### PR TITLE
Add docker-compose.yml file for database dependency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+POSTGRES_PASSWORD=password
+DATABASE_URL=postgres://postgres:$POSTGRES_PASSWORD@localhost:5432

--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,7 @@ end
 group :test, :development do
   gem "brakeman"
   gem "debug", platforms: %i[mri mingw x64_mingw]
+  gem "dotenv-rails"
   gem "factory_bot_rails"
   gem "pry"
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,10 @@ GEM
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     diff-lcs (1.5.0)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     drb (2.2.0)
       ruby2_keywords
     e2mmap (0.1.0)
@@ -392,6 +396,7 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   debug
+  dotenv-rails
   factory_bot_rails
   govuk-components
   govuk_design_system_formbuilder

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  db:
+    image: postgres:16
+    environment:
+      - POSTGRES_PASSWORD=$POSTGRES_PASSWORD
+    ports:
+      - 5432:5432


### PR DESCRIPTION
## Context

To avoid using bare metal dependencies or dependency managers, such as `brew`, add PostgreSQL to a `docker-compose.yml` file which can be spun up in docker containers using `docker-compose up`.

## Changes

- Add `docker-compose.yml` file to configure software dependencies, such as PostgreSQL.
- Add `dotenv-rails` gem to configure environment variables in `.env` files.