### PR TITLE
Erb linting implementation

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,0 +1,26 @@
+---
+EnableDefaultLinters: true
+linters:
+  Rubocop:
+    enabled: true
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml
+      Layout/ArgumentAlignment:
+        Enabled: false
+      Layout/CommentIndentation:
+        Enabled: false
+      Layout/FirstArgumentIndentation:
+        Enabled: false
+      Layout/FirstArrayElementIndentation:
+        Enabled: false
+      Layout/FirstHashElementIndentation:
+        Enabled: false
+      Layout/InitialIndentation:
+        Enabled: false
+      Layout/LineLength:
+        Enabled: false
+      Layout/TrailingEmptyLines:
+        Enabled: false
+      Lint/UselessAssignment:
+        Enabled: false

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -24,3 +24,6 @@ linters:
         Enabled: false
       Lint/UselessAssignment:
         Enabled: false
+      Style/StringLiterals:
+        Enabled: true
+        EnforcedStyle: double_quotes

--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,7 @@ group :test, :development do
   gem "brakeman"
   gem "debug", platforms: %i[mri mingw x64_mingw]
   gem "dotenv-rails"
+  gem "erb_lint", require: false
   gem "factory_bot_rails"
   gem "pry"
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -387,6 +387,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,13 @@ GEM
     backport (1.2.0)
     base64 (0.2.0)
     benchmark (0.3.0)
+    better_html (2.0.2)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bigdecimal (3.1.4)
     bindex (0.8.1)
     bootsnap (1.17.0)
@@ -119,6 +126,13 @@ GEM
     drb (2.2.0)
       ruby2_keywords
     e2mmap (0.1.0)
+    erb_lint (0.5.0)
+      activesupport
+      better_html (>= 2.0.1)
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop
+      smart_properties
     erubi (1.12.0)
     factory_bot (6.4.2)
       activesupport (>= 5.0.0)
@@ -329,6 +343,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    smart_properties (1.17.0)
     solargraph (0.49.0)
       backport (~> 1.2)
       benchmark
@@ -398,6 +413,7 @@ DEPENDENCIES
   cssbundling-rails
   debug
   dotenv-rails
+  erb_lint
   factory_bot_rails
   govuk-components
   govuk_design_system_formbuilder

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -12,7 +12,7 @@
     </p>
     <p class="govuk-body">
       If you have any questions, please email us at <a class="govuk-link"
-        href="mailto:<%= t('service.email') %>"><%= t('service.email') %></a>.
+        href="mailto:<%= t("service.email") %>"><%= t("service.email") %></a>.
     </p>
   </div>
 </div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -11,9 +11,9 @@
     </p>
     <p class="govuk-body">
       If the web address is correct or you selected a link or button and you
-      need to speak to someone about this problem, contact the <%= t('service.name') %> team:
-      <a class="govuk-link" href="mailto:<%= t('service.email') %>">
-        <%= t('service.email') %></a>.
+      need to speak to someone about this problem, contact the <%= t("service.name") %> team:
+      <a class="govuk-link" href="mailto:<%= t("service.email") %>">
+        <%= t("service.email") %></a>.
     </p>
   </div>
 </div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -11,9 +11,9 @@
     </p>
     <p class="govuk-body">
       If the web address is correct or you selected a link or button and you
-      need to speak to someone about this problem, contact the <%=
-      t('service.name') %> team: <a class="govuk-link" href="mailto:<%=
-      t('service.email') %>"><%= t('service.email') %></a>.
+      need to speak to someone about this problem, contact the <%= t('service.name') %> team:
+      <a class="govuk-link" href="mailto:<%= t('service.email') %>">
+        <%= t('service.email') %></a>.
     </p>
   </div>
 </div>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, 'Sorry, there’s a problem with the service' %>
+<%= content_for :page_title, "Sorry, there’s a problem with the service" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -7,8 +7,8 @@
     <p class="govuk-body">Try again later.</p>
 
     <p class="govuk-body">
-      If you continue to see this error contact the <%= t('service.name') %> team:
-      <a class="govuk-link" href="mailto:<%= t('service.email') %>"><%= t('service.email') %></a>.
+      If you continue to see this error contact the <%= t("service.name") %> team:
+      <a class="govuk-link" href="mailto:<%= t("service.email") %>"><%= t("service.email") %></a>.
     </p>
   </div>
 </div>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -7,9 +7,8 @@
     <p class="govuk-body">Try again later.</p>
 
     <p class="govuk-body">
-      If you continue to see this error contact the <%= t('service.name')
-      %> team: <a class="govuk-link" href="mailto:<%= t('service.email') %>"><%=
-      t('service.email') %></a>.
+      If you continue to see this error contact the <%= t('service.name') %> team:
+      <a class="govuk-link" href="mailto:<%= t('service.email') %>"><%= t('service.email') %></a>.
     </p>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,9 +6,9 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
-    <%= tag :meta, property: 'og:image', content: asset_path('images/govuk-opengraph-image.png') %>
-    <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
+    <%= tag.meta(name: 'viewport', content: 'width=device-width, initial-scale=1') %>
+    <%= tag.meta(property: 'og:image', content: asset_path('images/govuk-opengraph-image.png')) %>
+    <%= tag.meta(name: 'theme-color', content: '#0b0c0c') %>
     <%= favicon_link_tag asset_path('images/favicon.ico') %>
     <%= favicon_link_tag asset_path('images/govuk-mask-icon.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
     <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon.png'), rel: 'apple-touch-icon', type: 'image/png' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,20 +1,20 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
-    <title><%= [yield(:page_title).presence, t('service.name')].compact.join(' - ') %></title>
+    <title><%= [yield(:page_title).presence, t("service.name")].compact.join(" - ") %></title>
 
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= tag.meta(name: 'viewport', content: 'width=device-width, initial-scale=1') %>
-    <%= tag.meta(property: 'og:image', content: asset_path('images/govuk-opengraph-image.png')) %>
-    <%= tag.meta(name: 'theme-color', content: '#0b0c0c') %>
-    <%= favicon_link_tag asset_path('images/favicon.ico') %>
-    <%= favicon_link_tag asset_path('images/govuk-mask-icon.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
-    <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon.png'), rel: 'apple-touch-icon', type: 'image/png' %>
-    <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-152x152.png'), rel: 'apple-touch-icon', type: 'image/png', size: '152x152' %>
-    <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
-    <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
+    <%= tag.meta(name: "viewport", content: "width=device-width, initial-scale=1") %>
+    <%= tag.meta(property: "og:image", content: asset_path("images/govuk-opengraph-image.png")) %>
+    <%= tag.meta(name: "theme-color", content: "#0b0c0c") %>
+    <%= favicon_link_tag asset_path("images/favicon.ico") %>
+    <%= favicon_link_tag asset_path("images/govuk-mask-icon.svg"), rel: "mask-icon", type: "image/svg", color: "#0b0c0c" %>
+    <%= favicon_link_tag asset_path("images/govuk-apple-touch-icon.png"), rel: "apple-touch-icon", type: "image/png" %>
+    <%= favicon_link_tag asset_path("images/govuk-apple-touch-icon-152x152.png"), rel: "apple-touch-icon", type: "image/png", size: "152x152" %>
+    <%= favicon_link_tag asset_path("images/govuk-apple-touch-icon-167x167.png"), rel: "apple-touch-icon", type: "image/png", size: "167x167" %>
+    <%= favicon_link_tag asset_path("images/govuk-apple-touch-icon-180x180.png"), rel: "apple-touch-icon", type: "image/png", size: "180x180" %>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>

--- a/bin/lint
+++ b/bin/lint
@@ -2,3 +2,4 @@
 
 bin/bundle exec rubocop --autocorrect-all
 yarn prettier --write --ignore-unknown '**/*'
+bin/bundle exec erblint --lint-all --autocorrect


### PR DESCRIPTION
# What
- Added erb linting to the `bin/lint` script

# Change considerations
- The configuration in `.erb-lint.yml` largely mirrors that in [register](https://github.com/DFE-Digital/register-trainee-teachers/blob/main/.erb-lint.yml) and [publish](https://github.com/DFE-Digital/publish-teacher-training/blob/main/.erb-lint.yml) 
- I've disabled `Layout/LineLength` -- I think this this is restrictive in `erb` files where there is often a lot of text and indentation. But I'm happy to change this if other disagree. Or we could change the acceptable line length for erb files to something longer than the standard 140 characters. 
- Publish enforces double quotes in `erb` files, and I've gone with that for our codebase as well for consistency. (publish does not do this)
- I haven't included `better_html` because I'm following the existing patterns in other code bases, but it is part of the recommended `erb_lint` configuration and if others agree, we could include it as well. 