### PR TITLE
Add Anna Persona for Sign In

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,7 @@ end
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
+  gem "rails-controller-testing"
   gem "selenium-webdriver"
   gem "shoulda-matchers"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+  gem "shoulda-matchers"
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -402,6 +402,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    shoulda-matchers (5.3.0)
+      activesupport (>= 5.2.0)
     smart_properties (1.17.0)
     solargraph (0.49.0)
       backport (~> 1.2)
@@ -511,6 +513,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   selenium-webdriver
+  shoulda-matchers
   solargraph
   solargraph-rails
   syntax_tree

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,6 +307,10 @@ GEM
       activesupport (= 7.1.2)
       bundler (>= 1.15.0)
       railties (= 7.1.2)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -507,6 +511,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 6.3)
   rails (~> 7.1.2)
+  rails-controller-testing
   rails-erd
   rladr
   rspec

--- a/README.md
+++ b/README.md
@@ -89,3 +89,14 @@ To run the application locally:
 1. Run `yarn` to install dependencies for the web app to run
 2. Run `bin/setup` to setup the database
 3. Run `bin/dev` to launch the app on <http://localhost:3000>
+
+### Seed Data
+
+To run the seed data to generate the following:
+
+- Persona
+  - Anne Wilson
+
+```bash
+  bin/bundle exec rails db:seed
+```

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -1,0 +1,5 @@
+class AccountController < ApplicationController
+  def index
+    redirect_to root_path if current_user.blank?
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,15 @@
 class ApplicationController < ActionController::Base
   default_form_builder(GOVUKDesignSystemFormBuilder::FormBuilder)
+
+  helper_method :current_user
+
+  private
+
+  def sign_in_user
+    @sign_in_user ||= DfESignInUser.load_from_session(session)
+  end
+
+  def current_user
+    @current_user ||= sign_in_user
+  end
 end

--- a/app/controllers/personas_controller.rb
+++ b/app/controllers/personas_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PersonasController < ApplicationController
+  def index
+    @personas = Persona.all.order(:first_name)
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,22 @@
+class SessionsController < ApplicationController
+  # setup inspired by register-trainee-teacher
+  # TODO: Replace with commented code when DfE Sign In implemented
+  
+  def callback
+    DfESignInUser.begin_session!(session, request.env["omniauth.auth"])
+    if current_user
+      # DfESignInUsers::Update.call(user: current_user, sign_in_user: sign_in_user)
+
+      redirect_to(root_path)
+    else
+      # session.delete(:requested_path)
+      DfESignInUser.end_session!(session)
+      # redirect_to(sign_in_user_not_found_path)
+    end
+  end
+
+  def signout
+    DfESignInUser.end_session!(session)
+    redirect_to root_path
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,7 @@
 class SessionsController < ApplicationController
   # setup inspired by register-trainee-teacher
   # TODO: Replace with commented code when DfE Sign In implemented
-  
+
   def callback
     DfESignInUser.begin_session!(session, request.env["omniauth.auth"])
     if current_user

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class DfESignInUser
+  attr_reader :email, :dfe_sign_in_uid
+  attr_accessor :first_name, :last_name
+
+  # setup inspired by register-trainee-teacher
+  # TODO: Replace with commented code when DfE Sign In implemented
+
+  # def initialize(email:, dfe_sign_in_uid:, first_name:, last_name:, id_token: nil, provider: "dfe")
+  def initialize(email:, first_name:, last_name:)
+    @email = email&.downcase
+    # @dfe_sign_in_uid = dfe_sign_in_uid
+    @first_name = first_name
+    @last_name = last_name
+    # @id_token = id_token
+    # @provider = provider&.to_s
+  end
+
+  def self.begin_session!(session, omniauth_payload)
+    session["dfe_sign_in_user"] = {
+      "email" => omniauth_payload["info"]["email"],
+      # "dfe_sign_in_uid" => omniauth_payload["uid"],
+      "first_name" => omniauth_payload["info"]["first_name"],
+      "last_name" => omniauth_payload["info"]["last_name"]
+      # "last_active_at" => Time.zone.now,
+      # "id_token" => omniauth_payload["credentials"]["id_token"],
+      # "provider" => omniauth_payload["provider"],
+    }
+  end
+
+  def self.load_from_session(session)
+    dfe_sign_in_session = session["dfe_sign_in_user"]
+    return unless dfe_sign_in_session
+
+    new(
+      email: dfe_sign_in_session["email"],
+      # dfe_sign_in_uid: dfe_sign_in_session["dfe_sign_in_uid"],
+      first_name: dfe_sign_in_session["first_name"],
+      last_name: dfe_sign_in_session["last_name"]
+      # id_token: dfe_sign_in_session["id_token"],
+      # provider: dfe_sign_in_session["provider"],
+    )
+  end
+
+  def self.end_session!(session)
+    session.clear
+  end
+end

--- a/app/models/persona.rb
+++ b/app/models/persona.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id         :bigint           not null, primary key
+#  email      :string           not null
+#  first_name :string           not null
+#  last_name  :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email  (email) UNIQUE
+#
+class Persona < User
+  default_scope { where(email: PERSONA_EMAILS) }
+  validates :email, inclusion: { in: PERSONA_EMAILS }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id         :bigint           not null, primary key
+#  email      :string           not null
+#  first_name :string           not null
+#  last_name  :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email  (email) UNIQUE
+#
+class User < ApplicationRecord
+  validates :first_name, presence: true
+  validates :last_name, presence: true
+  validates :email, presence: true
+  validates :email, uniqueness: { case_sensitive: false }
+end

--- a/app/views/account/index.html.erb
+++ b/app/views/account/index.html.erb
@@ -1,11 +1,13 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Your account</h1>
+    <h1 class="govuk-heading-l">
+      <%= t(".title") %>
+    </h1>
 
     <dl class="govuk-summary-list">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          First name
+          <%= t(".first_name") %>
         </dt>
         <dd class="govuk-summary-list__value">
           <%= current_user.first_name %>
@@ -14,7 +16,7 @@
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Last name
+          <%= t(".last_name") %>
         </dt>
         <dd class="govuk-summary-list__value">
           <%= current_user.last_name %>
@@ -23,7 +25,7 @@
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Email Address
+          <%= t(".email_address") %>
         </dt>
         <dd class="govuk-summary-list__value">
           <%= current_user.email %>

--- a/app/views/account/index.html.erb
+++ b/app/views/account/index.html.erb
@@ -1,0 +1,34 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Your account</h1>
+
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          First name
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= current_user.first_name %>
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Last name
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= current_user.last_name %>
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Email Address
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= current_user.email %>
+        </dd>
+      </div>
+    </dl>
+  </div>
+</div>

--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -1,0 +1,34 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Test Users</h1>
+
+    <% @personas.each do |persona| %>
+      <h2 class="govuk-heading-m">
+        <%= persona.first_name %>
+      </h2>
+      <strong class="govuk-tag govuk-tag--turquoise govuk-!-margin-bottom-5">
+        <%= t(".#{persona.first_name.downcase}.persona_type") %>
+      </strong>
+      <p class="govuk-body">
+        <%= t(".#{persona.first_name.downcase}.description") %>
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <% t(".#{persona.first_name.downcase}.roles").each do |role| %>
+          <li><%= role %></li>
+        <% end %>
+      </ul>
+
+      <%= form_tag("/auth/developer/callback", method: "post", data: {turbo: false}) do %>
+        <%= hidden_field_tag "email", persona.email %>
+        <%= hidden_field_tag "first_name", persona.first_name %>
+        <%= hidden_field_tag "last_name", persona.last_name %>
+        <button type='submit' class="govuk-button govuk-!-margin-bottom-2">
+          Sign In as <%= persona.first_name %>
+        </button>
+      <% end %>
+
+      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
+    <% end %>
+  </div>
+
+</div>

--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Test Users</h1>
+    <h1 class="govuk-heading-l"><%= t(".title") %></h1>
 
     <% @personas.each do |persona| %>
       <h2 class="govuk-heading-m">
@@ -28,8 +28,8 @@
         <%= hidden_field_tag "email", persona.email %>
         <%= hidden_field_tag "first_name", persona.first_name %>
         <%= hidden_field_tag "last_name", persona.last_name %>
-        <button type='submit' class="govuk-button govuk-!-margin-bottom-2">
-          Sign In as <%= persona.first_name %>
+        <button type="submit" class="govuk-button govuk-!-margin-bottom-2">
+          <%= t(".sign_in_as", persona_name: persona.first_name) %>
         </button>
       <% end %>
 

--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -7,16 +7,22 @@
         <%= persona.first_name %>
       </h2>
       <strong class="govuk-tag govuk-tag--turquoise govuk-!-margin-bottom-5">
-        <%= t(".#{persona.first_name.downcase}.persona_type") %>
+        <%= t(".#{persona.first_name.downcase}.persona_type", default: "") %>
       </strong>
       <p class="govuk-body">
-        <%= t(".#{persona.first_name.downcase}.description") %>
+        <%= t(".#{persona.first_name.downcase}.description", default: "") %>
       </p>
-      <ul class="govuk-list govuk-list--bullet">
-        <% t(".#{persona.first_name.downcase}.roles").each do |role| %>
-          <li><%= role %></li>
-        <% end %>
-      </ul>
+
+      <% if t(".#{persona.first_name.downcase}.roles", default: "").present? %>
+        <p class="govuk-body">
+          <%= t(".roles_include", persona_name: persona.first_name, default: "") %>
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <% t(".#{persona.first_name.downcase}.roles").each do |role| %>
+            <li><%= role %></li>
+          <% end %>
+        </ul>
+      <% end %>
 
       <%= form_tag("/auth/developer/callback", method: "post", data: {turbo: false}) do %>
         <%= hidden_field_tag "email", persona.email %>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -11,6 +11,4 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym "RESTful"
-# end
+ActiveSupport::Inflector.inflections(:en) { |inflect| inflect.acronym "DfE" }

--- a/config/initializers/persona.rb
+++ b/config/initializers/persona.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# any additional details should be added to en.yml (t.personas.index)
+PERSONAS = [
+  { first_name: "Anne", last_name: "Wilson", email: "anne_wilson@example.org" }
+].push((DEVELOPER_PERSONA if defined?(DEVELOPER_PERSONA))).compact.freeze
+
+PERSONA_EMAILS = PERSONAS.map { |persona| persona[:email] }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,3 +2,12 @@ en:
   service:
     name: GOV.UK Frontend on Rails
     email: my-service@email
+  personas:
+    index:
+      anne:
+        persona_type: School
+        description: Anne is a lead mentor within a school.
+        roles:
+          - "setting timetables for mentors within the school"
+          - "being the main point of contact for providers"
+          - "ensuring mentors’ training is up-to-date"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,10 +1,15 @@
 en:
+  account:
+    index:
+      email_address: Email address
+      first_name: First name
+      last_name: Last name
+      title: Your account
   service:
     name: GOV.UK Frontend on Rails
     email: my-service@email
   personas:
     index:
-      roles_include: "%{persona_name}’s role includes:"
       anne:
         persona_type: School
         description: Anne is a lead mentor within a school.
@@ -12,3 +17,6 @@ en:
           - "setting timetables for mentors within the school"
           - "being the main point of contact for providers"
           - "ensuring mentors’ training is up-to-date"
+      roles_include: "%{persona_name}’s role includes:"
+      sign_in_as: "Sign In as %{persona_name}"
+      title: Test users

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,7 @@ en:
     email: my-service@email
   personas:
     index:
+      roles_include: "%{persona_name}’s role includes:"
       anne:
         persona_type: School
         description: Anne is a lead mentor within a school.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,11 @@ Rails.application.routes.draw do
     get "/500", to: "errors#internal_server_error"
   end
 
+  # User Account Details
+  get("/account", to: "account#index")
+
   # Persona Sign In
+  get("/personas", to: "personas#index")
   get("/auth/developer/sign-out", to: "sessions#signout")
   post("/auth/developer/callback", to: "sessions#callback")
 end

--- a/db/migrate/20231208153214_create_users.rb
+++ b/db/migrate/20231208153214_create_users.rb
@@ -1,0 +1,10 @@
+class CreateUsers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :users do |t|
+      t.string :first_name, null: false
+      t.string :last_name, null: false
+      t.string :email, null: false, index: { unique: true }
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 0) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_08_153214) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.string "first_name", null: false
+    t.string "last_name", null: false
+    t.string "email", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,17 @@
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 #
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
+# Persona Creation (Dummy User Creation)
+Rails.logger.debug "Creating Personas"
+
+# For each persona...
+PERSONAS.each do |persona_attributes|
+  # Create the persona
+  Persona.find_or_create_by!(
+    first_name: persona_attributes[:first_name],
+    last_name: persona_attributes[:last_name],
+    email: persona_attributes[:email]
+  )
+end
+
+Rails.logger.debug "Personas successfully created!"

--- a/spec/factories/persona.rb
+++ b/spec/factories/persona.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :persona do
+    email { "anne_wilson@example.org" }
+    first_name { "Persona" }
+    sequence(:last_name)
+
+    trait :anne do
+      first_name { "Anne" }
+      last_name { "Wilson" }
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -15,5 +15,8 @@
 #
 FactoryBot.define do
   factory :user do
+    sequence(:email) { |n| "user#{n}@example.com" }
+    first_name { "User" }
+    sequence(:last_name)
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id         :bigint           not null, primary key
+#  email      :string           not null
+#  first_name :string           not null
+#  last_name  :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email  (email) UNIQUE
+#
+FactoryBot.define do
+  factory :user do
+  end
+end

--- a/spec/features/personas/sign_in_as_persona_spec.rb
+++ b/spec/features/personas/sign_in_as_persona_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Sign In as Persona" do
+  scenario "I sign in as persona Anne" do
+    given_there_is_an_existing_persona_for("Anne")
+    when_i_visit_the_personas_page
+    then_i_see_the_persona_for("Anne")
+    when_i_click_sign_in_as("Anne")
+    and_i_visit_my_account_page
+    then_i_see_persona_details_for_anne
+  end
+end
+
+private
+
+def given_there_is_an_existing_persona_for(persona_name)
+  create(:persona, persona_name.downcase.to_sym)
+end
+
+def when_i_visit_the_personas_page
+  visit personas_path
+end
+
+def then_i_see_the_persona_for(persona_name)
+  expect(page).to have_content(persona_name)
+end
+
+def when_i_click_sign_in_as(persona_name)
+  click_on "Sign In as #{persona_name}"
+end
+
+def and_i_visit_my_account_page
+  visit account_path
+end
+
+def then_i_see_persona_details_for_anne
+  page_has_persona_content(
+    first_name: "Anne",
+    last_name: "Wilson",
+    email: "anne_wilson@example.org"
+  )
+end
+
+def page_has_persona_content(first_name:, last_name:, email:)
+  expect(page).to have_content(first_name)
+  expect(page).to have_content(last_name)
+  expect(page).to have_content(email)
+end

--- a/spec/models/dfe_sign_in_user_spec.rb
+++ b/spec/models/dfe_sign_in_user_spec.rb
@@ -15,26 +15,29 @@ describe DfESignInUser do
       }
       DfESignInUser.begin_session!(session, omniauth_payload)
 
-      expect(session).to eq({
-        "dfe_sign_in_user" => {
-          "first_name" => "Example",
-          "last_name" => "User",
-          "email" => "example_user@example.com"
+      expect(session).to eq(
+        {
+          "dfe_sign_in_user" => {
+            "first_name" => "Example",
+            "last_name" => "User",
+            "email" => "example_user@example.com"
+          }
         }
-      })
+      )
     end
   end
 
   describe ".load_from_session" do
     it "returns a DfESignInUser with details stored in the session" do
-      session = { "dfe_sign_in_user" => {
+      session = {
+        "dfe_sign_in_user" => {
           "first_name" => "Example",
           "last_name" => "User",
           "email" => "example_user@example.com"
         }
       }
       user = DfESignInUser.load_from_session(session)
-      
+
       expect(user).not_to be_nil
       expect(user.first_name).to eq("Example")
       expect(user.last_name).to eq("User")
@@ -44,7 +47,8 @@ describe DfESignInUser do
 
   describe ".end_session" do
     it "clears the session" do
-      session = { "dfe_sign_in_user" => {
+      session = {
+        "dfe_sign_in_user" => {
           "first_name" => "Example",
           "last_name" => "User",
           "email" => "example_user@example.com"

--- a/spec/models/dfe_sign_in_user_spec.rb
+++ b/spec/models/dfe_sign_in_user_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe DfESignInUser do
+  describe ".begin_session!" do
+    it "creates a new session for dfe user details" do
+      session = {}
+      omniauth_payload = {
+        "info" => {
+          "first_name" => "Example",
+          "last_name" => "User",
+          "email" => "example_user@example.com"
+        }
+      }
+      DfESignInUser.begin_session!(session, omniauth_payload)
+
+      expect(session).to eq({
+        "dfe_sign_in_user" => {
+          "first_name" => "Example",
+          "last_name" => "User",
+          "email" => "example_user@example.com"
+        }
+      })
+    end
+  end
+
+  describe ".load_from_session" do
+    it "returns a DfESignInUser with details stored in the session" do
+      session = { "dfe_sign_in_user" => {
+          "first_name" => "Example",
+          "last_name" => "User",
+          "email" => "example_user@example.com"
+        }
+      }
+      user = DfESignInUser.load_from_session(session)
+      
+      expect(user).not_to be_nil
+      expect(user.first_name).to eq("Example")
+      expect(user.last_name).to eq("User")
+      expect(user.email).to eq("example_user@example.com")
+    end
+  end
+
+  describe ".end_session" do
+    it "clears the session" do
+      session = { "dfe_sign_in_user" => {
+          "first_name" => "Example",
+          "last_name" => "User",
+          "email" => "example_user@example.com"
+        }
+      }
+
+      DfESignInUser.end_session!(session)
+
+      expect(session).to eq({})
+    end
+  end
+end

--- a/spec/models/persona_spec.rb
+++ b/spec/models/persona_spec.rb
@@ -13,15 +13,9 @@
 #
 #  index_users_on_email  (email) UNIQUE
 #
-require "rails_helper"
-
-RSpec.describe User, type: :model do
-  subject { create(:user) }
-
+RSpec.describe Persona, type: :model do
   describe "validations" do
-    it { is_expected.to validate_presence_of(:email) }
-    it { is_expected.to validate_presence_of(:email) }
-    it { is_expected.to validate_presence_of(:first_name) }
-    it { is_expected.to validate_presence_of(:last_name) }
+    subject { create(:persona) }
+    it { is_expected.to validate_inclusion_of(:email).in_array(PERSONA_EMAILS) }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id         :bigint           not null, primary key
+#  email      :string           not null
+#  first_name :string           not null
+#  last_name  :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email  (email) UNIQUE
+#
+require "rails_helper"
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -64,3 +64,10 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end

--- a/spec/requests/personas_spec.rb
+++ b/spec/requests/personas_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe "Personas", type: :request do
+  describe "GET /personas" do
+    it "returns http success" do
+      get personas_path
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -3,11 +3,12 @@ require "rails_helper"
 RSpec.describe "Sessions", type: :request do
   describe "POST /auth/developer/callback" do
     it "returns http success" do
-      post auth_developer_callback_path, params: {
-        first_name: "Anne", 
-        last_name: "Wilson",
-        email: "anne_wilson@example.com"
-      }
+      post auth_developer_callback_path,
+           params: {
+             first_name: "Anne",
+             last_name: "Wilson",
+             email: "anne_wilson@example.com"
+           }
       follow_redirect!
 
       expect(response).to have_http_status(:success)

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe "Sessions", type: :request do
+  describe "POST /auth/developer/callback" do
+    it "returns http success" do
+      post auth_developer_callback_path, params: {
+        first_name: "Anne", 
+        last_name: "Wilson",
+        email: "anne_wilson@example.com"
+      }
+      follow_redirect!
+
+      expect(response).to have_http_status(:success)
+      # TODO: Change render_template once redirect to service specific
+      # roots implemented
+      expect(response).to render_template("pages/home")
+    end
+  end
+end


### PR DESCRIPTION
## Context

Adding the "Anne" persona for User login without DfE Sign In

## Running

- run `bundle exec rake db:seed` to generate the Persona/User for Anne

## Changes proposed in this pull request

- Add `User` and `Persona` models
- Migration to add `users` to the database
- Create `personas` index page
- Create `account` page

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/yZSxLwtM/17-set-up-persona-based-login

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots
![screencapture-localhost-3000-personas-2023-12-11-16_34_30](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/e72941f5-d7d3-4ddc-bdb0-e8304e1cf8fa)
![screencapture-localhost-3000-account-2023-12-11-16_34_07](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/00b1f636-2329-4d39-920e-22c43119d4a4)

https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/a67d9294-ebfa-4c9f-bf0e-2ede9d3d2573

