### PR TITLE
Update govuk_design_system_formbuilder to 5.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem "bootsnap", require: false
 # gem 'image_processing', '~> 1.2'
 
 gem "govuk-components"
-gem "govuk_design_system_formbuilder"
+gem "govuk_design_system_formbuilder", "~> 5.0.0"
 
 # DfE Sign-in
 gem "omniauth"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (~> 6.0)
       view_component (>= 3.3, < 3.7)
-    govuk_design_system_formbuilder (4.1.1)
+    govuk_design_system_formbuilder (5.0.0)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
@@ -491,7 +491,7 @@ DEPENDENCIES
   erb_lint
   factory_bot_rails
   govuk-components
-  govuk_design_system_formbuilder
+  govuk_design_system_formbuilder (~> 5.0.0)
   jsbundling-rails
   mail-notify
   omniauth


### PR DESCRIPTION
## Context

The `govuk_design_system_formbuilder` has a new version, 5.0.0. As we are spinning a new service probably better to start with most up to date tools.

## Changes proposed in this pull request

Update `govuk_design_system_formbuilder`

## Guidance to review

`bin/setup`
