### PR TITLE
Implement basic feature flag and documentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,8 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem 'image_processing', '~> 1.2'
 
+gem "flipflop"
+
 gem "govuk-components"
 gem "govuk_design_system_formbuilder", "~> 5.0.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,9 @@ GEM
     faraday-follow_redirects (0.3.0)
       faraday (>= 1, < 3)
     faraday-net_http (3.0.2)
+    flipflop (2.7.1)
+      activesupport (>= 4.0)
+      terminal-table (>= 1.8)
     globalid (1.2.1)
       activesupport (>= 6.1)
     govuk-components (4.1.2)
@@ -458,6 +461,8 @@ GEM
       rbs
       syntax_tree (>= 2.0.1)
     temple (0.10.3)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     thor (1.3.0)
     tilt (2.3.0)
     timeout (0.4.1)
@@ -510,6 +515,7 @@ DEPENDENCIES
   draper
   erb_lint
   factory_bot_rails
+  flipflop
   govuk-components
   govuk_design_system_formbuilder (~> 5.0.0)
   jsbundling-rails

--- a/config/features.rb
+++ b/config/features.rb
@@ -1,0 +1,6 @@
+Flipflop.configure do
+  strategy :active_record
+  strategy :default
+
+  feature :test_feature, description: "This is a test feature"
+end

--- a/db/migrate/20231212134422_create_features.rb
+++ b/db/migrate/20231212134422_create_features.rb
@@ -1,0 +1,10 @@
+class CreateFeatures < ActiveRecord::Migration[7.1]
+  def change
+    create_table :flipflop_features do |t|
+      t.string :key, null: false
+      t.boolean :enabled, null: false, default: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,6 +14,13 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_12_161320) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "flipflop_features", force: :cascade do |t|
+    t.string "key", null: false
+    t.boolean "enabled", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "first_name", null: false
     t.string "last_name", null: false

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,0 +1,43 @@
+# Feature flags
+
+## General principles
+
+- We use the gem [Flipflop](https://github.com/voormedia/flipflop) to manage feature flags
+- Developers are responsible for changing / maintaining feature flags using rake tasks
+
+## How to
+
+### Create a feature flag
+
+- Add the feature to `features.rb` There is a basic example in the comments of that doc. See [Flipflop](https://github.com/voormedia/flipflop) docs for more detail.
+- The feature will be turned off by default.
+- Start using it in your code
+- Use Rake tasks (see below) to enable / disable feature flags.
+
+### Use in the codebase
+
+Anywhere in the codebase, you can check to see if a feature is enabled.
+For example, to check if a feature called `test_feature` is enabled you could use:
+
+`Flipflop.test_feature?` or `Flipflop.enabled?(:test_feature)`
+
+### Remove a feature flag
+
+Once a feature flag has been turned on globally and everyone is happy that it should be a permanent feature the developer should:
+
+- Remove all uses from the codebase
+- Clear the feature flag from Active Record using the `flipflop:clear` rake task below in all environments.
+- Delete the feature flag from `features.rb`
+
+### Rake tasks
+
+| Command                                                                                                    | Description                                                                                                                                   |
+| ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rake flipflop:features`                                                                                   | Shows features table                                                                                                                          |
+| `rake "flipflop:turn_on[feature,strategy]"`<br/> eg `rake "flipflop:turn_on[test_feature,active_record]"`  | Enables a feature with the specified strategy<br/>Creates a record in the database if it does not exist already.<br/>Sets `enabled` to true   |
+| `rake "flipflop:turn_on[feature,strategy]"`<br/> eg `rake "flipflop:turn_off[test_feature,active_record]"` | Disables a feature with the specified strategy<br/>Creates a record in the database if it does not exist already.<br/>Sets `enabled` to false |
+| `rake "flipflop:clear[feature,strategy]"`<br/> eg `rake "flipflop:clear[test_feature,active_record]"`      | Clears a feature with the specified strategy<br/>Removes record from the database if it exists.                                               |
+
+## Last reviewed
+
+12-12-2023


### PR DESCRIPTION
## Context

This work comes after the [investigation ticket](https://trello.com/c/j2HF4dBc). Based on that work, the following specification was agreed:

- Use [Flipflop gem](https://github.com/voormedia/flipflop) instead of home rolling a solution
- Feature flags will be stored in the database (ie, the :active_record Flipflop strategy), not in Redis.
- As we do not know the specific requirements for the UI (eg who will use it, what authentication is required, how it will look), we will not implement at this stage.
- Feature flags will be turned on / off via rake tasks

## Changes proposed in this pull request

Implementation of the feature flag gem [Flipflop](https://github.com/voormedia/flipflop)

## Guidance to review

Read the instructions  in `feature-flags.md`. Does it make sense and can you make it work on your machine as expected?

## Link to Trello card

[Trello card](https://trello.com/c/8OKXtOO4)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/06c90cef-a824-48df-8fa0-213dcd907516


