### PR TITLE
Import Gias

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,6 @@ POSTGRES_PASSWORD=password
 DATABASE_URL=postgres://postgres:$POSTGRES_PASSWORD@localhost:5432
 GOVUK_NOTIFY_API_KEY=
 SIGN_IN_METHOD=persona
-
 PLACEMENTS_HOST=placements.localhost
 CLAIMS_HOST=claims.localhost
+GIAS_CSV_BASE_URL=https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .envrc
 .idea
 .vscode
+.byebug_history
 config/master.key
 db/*.sqlite3
 node_modules

--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,9 @@ gem "omniauth-rails_csrf_protection"
 # Decorators
 gem "draper"
 
+# Download files safely
+gem "down", "~> 5.0"
+
 group :development do
   gem "annotate", require: false
   gem "prettier_print", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,8 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
+    down (5.4.1)
+      addressable (~> 2.8)
     draper (4.0.2)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -512,6 +514,7 @@ DEPENDENCIES
   cssbundling-rails
   debug
   dotenv-rails
+  down (~> 5.0)
   draper
   erb_lint
   factory_bot_rails

--- a/app/models/gias_school.rb
+++ b/app/models/gias_school.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: gias_schools
+#
+#  id         :uuid             not null, primary key
+#  address1   :string
+#  address2   :string
+#  address3   :string
+#  name       :string           not null
+#  postcode   :string
+#  telephone  :string
+#  town       :string
+#  ukprn      :string
+#  urn        :string           not null
+#  website    :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_gias_schools_on_urn  (urn) UNIQUE
+#
+class GiasSchool < ApplicationRecord
+  validates :urn, presence: true
+  validates :urn, uniqueness: { case_sensitive: false }
+  validates :name, presence: true
+end

--- a/app/services/gias_csv_importer.rb
+++ b/app/services/gias_csv_importer.rb
@@ -1,0 +1,56 @@
+require "csv"
+
+class GiasCsvImporter
+  include ServicePattern
+  OPEN_SCHOOL = "1".freeze
+  NON_ENGLISH_ESTABLISHMENTS = %w[8 10 25 24 26 27 29 30 32 37 49 56 57].freeze
+
+  attr_reader :csv_path, :logger
+
+  def initialize(csv_path)
+    @csv_path = csv_path
+    @logger = Logger.new($stdout)
+  end
+
+  def call
+    invalid_records = []
+    records = []
+
+    CSV
+      .foreach(csv_path, headers: true, encoding: "iso-8859-1:utf-8")
+      .with_index(2) do |school, row_number|
+        invalid_records << "Row #{row_number} is invalid" if invalid?(school)
+        next if school_excluded?(school) || invalid?(school)
+
+        records << {
+          urn: school["URN"],
+          name: school["EstablishmentName"],
+          town: school["Town"].presence,
+          postcode: school["Postcode"].presence,
+          ukprn: school["UKPRN"].presence,
+          address1: school["Street"].presence,
+          address2: school["Locality"].presence,
+          address3: school["Address3"].presence,
+          website: school["SchoolWebsite"].presence,
+          telephone: school["TelephoneNum"].presence
+        }
+      end
+
+    if invalid_records.any?
+      logger.info "Invalid rows - #{invalid_records.inspect}"
+    end
+    GiasSchool.upsert_all(records, unique_by: :urn)
+    logger.info "Done!"
+  end
+
+  private
+
+  def invalid?(school)
+    school["URN"].blank? || school["EstablishmentName"].blank?
+  end
+
+  def school_excluded?(school)
+    school["EstablishmentStatus (code)"] != OPEN_SCHOOL ||
+      NON_ENGLISH_ESTABLISHMENTS.include?(school["TypeOfEstablishment (code)"])
+  end
+end

--- a/app/services/service_pattern.rb
+++ b/app/services/service_pattern.rb
@@ -1,0 +1,16 @@
+module ServicePattern
+  def self.included(base)
+    base.extend ClassMethods
+    base.class_eval { private_class_method :new }
+  end
+
+  def call
+    raise NotImplementedError("#call must be implemented")
+  end
+
+  module ClassMethods
+    def call(...)
+      new(...).call
+    end
+  end
+end

--- a/db/migrate/20231213110952_create_gias_schools.rb
+++ b/db/migrate/20231213110952_create_gias_schools.rb
@@ -1,0 +1,18 @@
+class CreateGiasSchools < ActiveRecord::Migration[7.1]
+  def change
+    create_table :gias_schools, id: :uuid do |t|
+      t.string :urn, null: false, index: { unique: true }
+      t.string :name, null: false
+      t.string :postcode
+      t.string :town
+      t.string :ukprn
+      t.string :telephone
+      t.string :website
+      t.string :address1
+      t.string :address2
+      t.string :address3
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_12_161320) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_13_110952) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,22 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_12_161320) do
     t.boolean "enabled", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "gias_schools", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "urn", null: false
+    t.string "name", null: false
+    t.string "postcode"
+    t.string "town"
+    t.string "ukprn"
+    t.string "telephone"
+    t.string "website"
+    t.string "address1"
+    t.string "address2"
+    t.string "address3"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["urn"], name: "index_gias_schools_on_urn", unique: true
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/gias_update.rake
+++ b/lib/tasks/gias_update.rake
@@ -1,0 +1,15 @@
+desc "Upsert GIAS data into GiasSchool"
+task gias_update: :environment do
+  logger = Logger.new($stdout)
+  today = Time.zone.today.strftime("%Y%m%d")
+  gias_filename = "edubasealldata#{today}.csv"
+
+  logger.info "Downloading the new gias file for #{Time.zone.today}"
+  tempfile = Down.download("#{ENV["GIAS_CSV_BASE_URL"]}/#{gias_filename}")
+  logger.info "Done!"
+
+  logger.info "Importing data"
+  GiasCsvImporter.call(tempfile.path)
+
+  tempfile.unlink
+end

--- a/spec/factories/gias_schools.rb
+++ b/spec/factories/gias_schools.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: gias_schools
+#
+#  id         :uuid             not null, primary key
+#  address1   :string
+#  address2   :string
+#  address3   :string
+#  name       :string           not null
+#  postcode   :string
+#  telephone  :string
+#  town       :string
+#  ukprn      :string
+#  urn        :string           not null
+#  website    :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_gias_schools_on_urn  (urn) UNIQUE
+#
+FactoryBot.define do
+  factory :gias_school do
+    sequence(:urn) { _1 }
+    name { "Hogwarts" }
+  end
+end

--- a/spec/fixtures/test_gias_import.csv
+++ b/spec/fixtures/test_gias_import.csv
@@ -1,0 +1,5 @@
+URN,EstablishmentName,Town,Postcode,EstablishmentStatus (code),TypeOfEstablishment (code)
+123,School,Town,Postcode,1,7
+124,School,Town,Postcode,2,7
+124,School,Town,Postcode,1,8
+124,,Town,Postcode,1,7

--- a/spec/models/gias_school_spec.rb
+++ b/spec/models/gias_school_spec.rb
@@ -1,0 +1,33 @@
+# == Schema Information
+#
+# Table name: gias_schools
+#
+#  id         :uuid             not null, primary key
+#  address1   :string
+#  address2   :string
+#  address3   :string
+#  name       :string           not null
+#  postcode   :string
+#  telephone  :string
+#  town       :string
+#  ukprn      :string
+#  urn        :string           not null
+#  website    :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_gias_schools_on_urn  (urn) UNIQUE
+#
+require "rails_helper"
+
+RSpec.describe GiasSchool, type: :model do
+  subject { create(:gias_school) }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:urn) }
+    it { is_expected.to validate_uniqueness_of(:urn).case_insensitive }
+    it { is_expected.to validate_presence_of(:name) }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe User, type: :model do
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:email) }
-    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to validate_uniqueness_of(:email).case_insensitive }
     it { is_expected.to validate_presence_of(:first_name) }
     it { is_expected.to validate_presence_of(:last_name) }
   end

--- a/spec/services/gias_csv_importer_spec.rb
+++ b/spec/services/gias_csv_importer_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe GiasCsvImporter do
+  subject { described_class.call("spec/fixtures/test_gias_import.csv") }
+
+  it "inserts the correct schools" do
+    expect { subject }.to change(GiasSchool, :count).from(0).to(1)
+  end
+
+  it "updates the correct schools" do
+    school = create(:gias_school, urn: "123")
+    expect { subject }.to change { school.reload.name }.to "School"
+  end
+
+  it "logs messages to STDOUT" do
+    expect { subject }.to output(
+      match(/Done!/).and(match(/Invalid rows - /)).and(
+        match(/Row 5 is invalid/)
+      )
+    ).to_stdout
+  end
+end

--- a/spec/tasks/gias_update_spec.rb
+++ b/spec/tasks/gias_update_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+require "rake"
+
+describe "gias_update" do
+  Rails.application.load_tasks if Rake::Task.tasks.empty?
+  subject { Rake::Task["gias_update"].invoke }
+
+  it "calls GiasCsvImporter service" do
+    today = Time.zone.today.strftime("%Y%m%d")
+    gias_filename = "edubasealldata#{today}.csv"
+    tempfile = Tempfile.new("foo")
+
+    expect(Down).to receive(:download).with(
+      "#{ENV["GIAS_CSV_BASE_URL"]}/#{gias_filename}"
+    ).and_return(tempfile)
+
+    expect(GiasCsvImporter).to receive(:call).with(tempfile.path)
+    subject
+  end
+end


### PR DESCRIPTION
## Context

We need to import GIAS data into our app. The GIAS service does not have
an official API. What they do have is a CSV that they publish every day
and we can download this CSV and parse the data.

To do this, we have introduced a rake task `rake gias_update` which will
download the CSV file for that day in the tmp folder and upsert the data
into our DB. All in all we have about 24k GiasSchool records created
containing schools and MATS that are still open. The file will be removed
after the task is done.

## Changes proposed in this pull request

- New rake task
- New ENV variable to hold the GIAS URL
- CSV Import
- Generic Service pattern

## Guidance to review

To run this on local:
1. bundle install
2. copy `GIAS_CSV_BASE_URL` to your env file
3. rake gias_update

## Link to Trello card

https://trello.com/c/5t52nESP/53-import-gias-schools

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Change considerations
- The task takes about 20 seconds on my machine, so if we put this into production hopefully it won't take too long and there's only 1 db call.
- Rerunning the job after you import the data will not update any records in your db that have not changed. 
