### PR TITLE
Add update service page for both claims and placements

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,16 +30,16 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 20.9.0
-          cache: 'npm'
+          cache: "npm"
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get -yqq install libpq-dev
           bundle install --jobs 4 --retry 3
           bundle exec rails assets:precompile
         env:
-            DATABASE_URL: postgres://postgres:password@localhost:5432
-            GOVUK_NOTIFY_API_KEY: fake_key
-            SIGN_IN_METHOD: persona
+          DATABASE_URL: postgres://postgres:password@localhost:5432
+          GOVUK_NOTIFY_API_KEY: fake_key
+          SIGN_IN_METHOD: persona
       - name: ${{ matrix.tests }}
         run: ${{ env.COMMAND }}
         env:
@@ -52,16 +52,16 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     services:
-        postgres:
-          image: postgres:16
-          env:
-            POSTGRES_PASSWORD: password
-          ports: ['5432:5432']
-          options: >-
-            --health-cmd pg_isready
-            --health-interval 10s
-            --health-timeout 5s
-            --health-retries 5
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: password
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     strategy:
       fail-fast: false
     steps:
@@ -77,16 +77,16 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 20.9.0
-          cache: 'npm'
+          cache: "npm"
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get -yqq install libpq-dev
           bundle install --jobs 4 --retry 3
           bundle exec rails assets:precompile
         env:
-            DATABASE_URL: postgres://postgres:password@localhost:5432
-            GOVUK_NOTIFY_API_KEY: fake_key
-            SIGN_IN_METHOD: persona
+          DATABASE_URL: postgres://postgres:password@localhost:5432
+          GOVUK_NOTIFY_API_KEY: fake_key
+          SIGN_IN_METHOD: persona
       - name: Run Tests
         env:
           RAILS_ENV: test

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ gem "bootsnap", require: false
 # gem 'image_processing', '~> 1.2'
 
 gem "flipflop"
+gem "redcarpet", "~> 3.6"
 
 gem "govuk-components"
 gem "govuk_design_system_formbuilder", "~> 5.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
-    addressable (2.8.5)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     aes_key_wrap (1.1.0)
     annotate (3.2.0)
@@ -165,16 +165,16 @@ GEM
       terminal-table (>= 1.8)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    govuk-components (4.1.2)
+    govuk-components (5.0.0)
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (~> 6.0)
-      view_component (>= 3.3, < 3.7)
+      view_component (>= 3.3, < 3.8)
     govuk_design_system_formbuilder (5.0.0)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
       html-attributes-utils (~> 1)
-    haml (6.2.3)
+    haml (6.3.0)
       temple (>= 0.8.2)
       thor
       tilt
@@ -183,7 +183,7 @@ GEM
       activesupport (>= 6.1.4.4)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    io-console (0.7.0)
+    io-console (0.6.0)
     irb (1.10.1)
       rdoc
       reline (>= 0.3.8)
@@ -225,7 +225,7 @@ GEM
     minitest (5.20.0)
     msgpack (1.7.2)
     mutex_m (0.2.0)
-    net-imap (0.4.7)
+    net-imap (0.4.8)
       date
       net-protocol
     net-pop (0.1.2)
@@ -235,7 +235,7 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     nio4r (2.7.0)
-    nokogiri (1.15.5-arm64-darwin)
+    nokogiri (1.15.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.15.5-x86_64-linux)
       racc (~> 1.4)
@@ -290,7 +290,7 @@ GEM
     puma (6.4.0)
       nio4r (~> 2.0)
     racc (1.7.3)
-    rack (2.2.8)
+    rack (3.0.8)
     rack-oauth2 (2.2.0)
       activesupport
       attr_required
@@ -300,13 +300,13 @@ GEM
       rack (>= 2.1.0)
     rack-protection (3.0.6)
       rack
-    rack-session (1.0.2)
-      rack (< 3)
+    rack-session (2.0.0)
+      rack (>= 3.0.0)
     rack-test (2.1.0)
       rack (>= 1.3)
-    rackup (1.0.0)
-      rack (< 3)
-      webrick
+    rackup (2.1.0)
+      rack (>= 3)
+      webrick (~> 1.8)
     rails (7.1.2)
       actioncable (= 7.1.2)
       actionmailbox (= 7.1.2)
@@ -350,6 +350,7 @@ GEM
     rbs (2.8.4)
     rdoc (6.6.1)
       psych (>= 4.0.0)
+    redcarpet (3.6.0)
     regexp_parser (2.8.3)
     reline (0.4.1)
       io-console (~> 0.5)
@@ -475,7 +476,7 @@ GEM
     validate_url (1.0.15)
       activemodel (>= 3.0.0)
       public_suffix
-    view_component (3.6.0)
+    view_component (3.7.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
@@ -501,6 +502,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
@@ -533,6 +535,7 @@ DEPENDENCIES
   rails (~> 7.1.2)
   rails-controller-testing
   rails-erd
+  redcarpet (~> 3.6)
   rladr
   rspec
   rspec-rails

--- a/app/assets/components/service_update/view.html.erb
+++ b/app/assets/components/service_update/view.html.erb
@@ -1,0 +1,5 @@
+<section id="<%= service_update.id %>">
+  <%= title_element %>
+  <p class="govuk-body govuk-!-margin-bottom-2"><%= date_pretty %></p>
+  <div class="govuk-body"><%= content_html %></div>
+</section>

--- a/app/assets/components/service_update/view.rb
+++ b/app/assets/components/service_update/view.rb
@@ -1,0 +1,26 @@
+class ServiceUpdate::View < GovukComponent::Base
+  attr_reader :service_update
+
+  delegate :title, :content, :date, to: :service_update
+
+  TITLE_CLASS = "govuk-heading-m govuk-!-margin-bottom-2"
+
+  def initialize(service_update:)
+    @service_update = service_update
+  end
+
+  def title_element
+    tag.h2(title, class: TITLE_CLASS)
+  end
+
+  def date_pretty
+    date.to_date.strftime("%e %B %Y")
+  end
+
+  def content_html
+    custom_render =
+      Redcarpet::Render::HTML.new(link_attributes: { class: "govuk-link" })
+    markdown = Redcarpet::Markdown.new(custom_render)
+    markdown.render(content).html_safe
+  end
+end

--- a/app/controllers/service_updates_controller.rb
+++ b/app/controllers/service_updates_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ServiceUpdatesController < ApplicationController
+  include ApplicationHelper
+
+  def index
+    @service_name ||= current_service
+    @service_updates = ServiceUpdate.where(service: @service_name)
+  end
+end

--- a/app/models/service_update.rb
+++ b/app/models/service_update.rb
@@ -1,0 +1,34 @@
+class ServiceUpdate
+  CLAIMS_SERVICE_UPDATES_YAML_FILE =
+    Rails.root.join("db/claims_service_updates.yml").freeze
+  PLACEMENTS_SERVICE_UPDATES_YAML_FILE =
+    Rails.root.join("db/placements_service_updates.yml").freeze
+
+  attr_accessor :date, :title, :content
+
+  def initialize(title:, date:, content:)
+    @title = title
+    @date = date
+    @content = content
+  end
+
+  def id
+    title.parameterize
+  end
+
+  def self.where(service:)
+    path = file_path(service:)
+    updates = YAML.load_file(path, symbolize_names: true) || []
+
+    updates.map { |service_update| new(**service_update) }
+  end
+
+  def self.file_path(service:)
+    case service
+    when :claims
+      CLAIMS_SERVICE_UPDATES_YAML_FILE
+    when :placements
+      PLACEMENTS_SERVICE_UPDATES_YAML_FILE
+    end
+  end
+end

--- a/app/views/service_updates/index.html.erb
+++ b/app/views/service_updates/index.html.erb
@@ -1,0 +1,17 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-xl"><%= t("service_updates.#{@service_name}.heading") %></h1>
+
+    <h2 class="govuk-heading-m"><%= t("service_updates.contents") %></h2>
+    <ul class="govuk-list app-list--dash govuk-!-margin-bottom-8 govuk-!-margin-left-3">
+      <% @service_updates.each do |service_update| %>
+        <li><a class="govuk-link" href="#<%= service_update.id %>"><%= service_update.title %></a></li>
+      <% end %>
+    </ul>
+
+    <% @service_updates.each do |service_update| %>
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      <%= render ServiceUpdate::View.new(service_update:) %>
+    <% end %>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,6 +35,7 @@ module IttMentorServices
       "node_modules/govuk-frontend/govuk/assets"
     )
 
+    config.autoload_paths += %W[#{config.root}/app/assets/components]
     config.exceptions_app = routes
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,3 +38,9 @@ en:
       roles_include: "%{persona_name}’s role includes:"
       sign_in_as: "Sign In as %{persona_name}"
       title: Test users
+  service_updates:
+    claims:
+      heading: Claims news and updates
+    placements:
+      heading: Placements news and updates
+    contents: Contents

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
   get("/auth/developer/sign-out", to: "sessions#signout")
   post("/auth/developer/callback", to: "sessions#callback")
 
+  resources :service_updates, only: %i[index]
+
   draw :placements
   draw :claims
 end

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -1,3 +1,7 @@
-scope module: :placements, as: :placements, constraints: { host: ENV["PLACEMENTS_HOST"] } do
+scope module: :placements,
+      as: :placements,
+      constraints: {
+        host: ENV["PLACEMENTS_HOST"]
+      } do
   root to: "pages#index"
 end

--- a/db/claims_service_updates.yml
+++ b/db/claims_service_updates.yml
@@ -1,0 +1,11 @@
+# Example structure for adding service updates
+
+# - date:
+#     type: String
+#     format: YYYY-MM-DD
+#   title:
+#     type: String
+#     format: Short text
+#   content:
+#     type: String
+#     format: Multi-line text

--- a/db/placements_service_updates.yml
+++ b/db/placements_service_updates.yml
@@ -1,0 +1,11 @@
+# Example structure for adding service updates
+
+# - date:
+#     type: String
+#     format: YYYY-MM-DD
+#   title:
+#     type: String
+#     format: Short text
+#   content:
+#     type: String
+#     format: Multi-line text

--- a/spec/models/service_update_spec.rb
+++ b/spec/models/service_update_spec.rb
@@ -1,0 +1,72 @@
+# spec/models/service_update_spec.rb
+
+require "rails_helper"
+
+RSpec.describe ServiceUpdate do
+  describe ".where" do
+    context "when service is :claims" do
+      it "returns updates for claims" do
+        allow(YAML).to receive(:load_file).and_return(
+          [
+            {
+              date: "2023-12-14",
+              title: "Claim Update",
+              content: "Some content"
+            }
+          ]
+        )
+        updates = ServiceUpdate.where(service: :claims)
+        expect(updates.length).to eq(1)
+        expect(updates.first.title).to eq("Claim Update")
+      end
+
+      it "returns an empty hash when no updates for claims" do
+        allow(YAML).to receive(:load_file).and_return(nil)
+        updates = ServiceUpdate.where(service: :claims)
+        expect(updates).to eq([])
+      end
+    end
+
+    context "when service is :placements" do
+      it "returns updates for placements" do
+        allow(YAML).to receive(:load_file).and_return(
+          [
+            {
+              date: "2023-12-14",
+              title: "Placement Update",
+              content: "Some content"
+            }
+          ]
+        )
+        updates = ServiceUpdate.where(service: :placements)
+        expect(updates.length).to eq(1)
+        expect(updates.first.title).to eq("Placement Update")
+      end
+
+      it "returns an empty hash when no updates for placements" do
+        allow(YAML).to receive(:load_file).and_return(nil)
+        updates = ServiceUpdate.where(service: :placements)
+        expect(updates).to eq([])
+      end
+    end
+  end
+
+  describe ".yaml_file" do
+    it "returns claims YAML file path" do
+      file_path = ServiceUpdate.file_path(service: :claims)
+      expect(file_path).to eq(Rails.root.join("db/claims_service_updates.yml"))
+    end
+
+    it "returns placements YAML file path" do
+      file_path = ServiceUpdate.file_path(service: :placements)
+      expect(file_path).to eq(
+        Rails.root.join("db/placements_service_updates.yml")
+      )
+    end
+
+    it "returns nil for unknown service" do
+      file_path = ServiceUpdate.file_path(service: :some_other_random_service)
+      expect(file_path).to be_nil
+    end
+  end
+end

--- a/spec/system/home_page_spec.rb
+++ b/spec/system/home_page_spec.rb
@@ -1,9 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Home Page" do
-  after do
-    Capybara.app_host = nil
-  end
+  after { Capybara.app_host = nil }
 
   scenario "User visits the claims homepage" do
     given_i_am_on_the_claims_site

--- a/spec/system/service_updates_page_spec.rb
+++ b/spec/system/service_updates_page_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.feature "Service updates page" do
+  after { Capybara.app_host = nil }
+
+  scenario "User visits the claims Service updates" do
+    given_i_am_on_the_claims_site
+    and_i_am_on_the_service_updates_page
+    i_can_see_the_claims_service_title
+  end
+
+  scenario "User visits the placements Service updates" do
+    given_i_am_on_the_placements_site
+    and_i_am_on_the_service_updates_page
+    i_can_see_the_placements_service_title
+  end
+
+  private
+
+  def given_i_am_on_the_claims_site
+    Capybara.app_host = "http://#{ENV["CLAIMS_HOST"]}"
+  end
+
+  def given_i_am_on_the_placements_site
+    Capybara.app_host = "http://#{ENV["PLACEMENTS_HOST"]}"
+  end
+
+  def and_i_am_on_the_service_updates_page
+    visit "/service_updates"
+  end
+
+  def i_can_see_the_claims_service_title
+    within(".govuk-heading-xl") do
+      expect(page).to have_content("Claims news and updates")
+    end
+  end
+
+  def i_can_see_the_placements_service_title
+    within(".govuk-heading-xl") do
+      expect(page).to have_content("Placements news and updates")
+    end
+  end
+end


### PR DESCRIPTION
## Context

We are making this change to allow us to update users for each service with news

## Changes proposed in this pull request

Add MVC for this

## Guidance to review

Run tests and or run app loccally

## Link to Trello card

https://trello.com/c/1qgE9sRc/44-news-and-updates-list-page

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots
<img width="1728" alt="Screenshot 2023-12-14 at 15 02 11" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/60d8a086-73bb-4d0c-890f-934dede0a6d8">
<img width="1728" alt="Screenshot 2023-12-14 at 15 18 44" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/ed470774-5600-40a9-ae65-8a7804aafc6a">


