### PR TITLE
Restrict login path based on SIGN_IN_METHOD

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,9 +10,12 @@ Rails.application.routes.draw do
   get("/account", to: "account#index")
 
   # Persona Sign In
-  get("/personas", to: "personas#index")
-  get("/auth/developer/sign-out", to: "sessions#signout")
-  post("/auth/developer/callback", to: "sessions#callback")
+  case ENV.fetch("SIGN_IN_METHOD")
+  when "persona"
+    get("/personas", to: "personas#index")
+    get("/auth/developer/sign-out", to: "sessions#signout")
+    post("/auth/developer/callback", to: "sessions#callback")
+  end
 
   draw :placements
   draw :claims


### PR DESCRIPTION
## Context

We want to control the sign-in path based on the `SIGN_IN_METHOD` env variable. This will allow us to have a different sign-in path in production and staging to the one on dev and QA.

## Changes proposed in this pull request

SIGN_IN_METHOD logic in routes file 

## Guidance to review

- Pull on local
- CHANGE `SIGN_IN_METHOD` value to anything but `persona`
- Go to `/personas` or the `/auth/developer` paths

## Link to Trello card

https://trello.com/c/Df7kSskC/72-persona-select-page-should-only-be-accessible-in-the-qa-and-development-environments

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

![Screenshot from 2023-12-18 12-10-51](https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/a1abcb27-51fa-4e95-9a3e-fda684da3f5b)



