### PR TITLE
Claims / Sign in page should redirect to persona select

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,7 @@ end
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
+  gem "capybara-screenshot"
   gem "rails-controller-testing"
   gem "selenium-webdriver"
   gem "shoulda-matchers"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,9 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    capybara-screenshot (1.0.26)
+      capybara (>= 1.0, < 4)
+      launchy
     choice (0.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
@@ -529,6 +532,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   capybara
+  capybara-screenshot
   cssbundling-rails
   debug
   dotenv-rails

--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -1,1 +1,2 @@
+@import "header";
 @import "page_banner";

--- a/app/assets/stylesheets/components/_header.scss
+++ b/app/assets/stylesheets/components/_header.scss
@@ -1,0 +1,8 @@
+.govuk-header__logo,
+.govuk-header__content {
+  width: unset;
+}
+
+.govuk-header__content {
+  float: right;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@ class ApplicationController < ActionController::Base
   include ApplicationHelper
   include RoutesHelper
 
+  before_action :authenticate_user!
+
   default_form_builder(GOVUKDesignSystemFormBuilder::FormBuilder)
 
   helper_method :current_user

--- a/app/controllers/claims/pages_controller.rb
+++ b/app/controllers/claims/pages_controller.rb
@@ -1,2 +1,3 @@
 class Claims::PagesController < ApplicationController
+  before_action :authenticate_user!
 end

--- a/app/controllers/claims/pages_controller.rb
+++ b/app/controllers/claims/pages_controller.rb
@@ -1,3 +1,2 @@
 class Claims::PagesController < ApplicationController
-  before_action :authenticate_user!
 end

--- a/app/controllers/claims/support/application_controller.rb
+++ b/app/controllers/claims/support/application_controller.rb
@@ -1,13 +1,11 @@
 class Claims::Support::ApplicationController < ApplicationController
-  before_action :authenticate_support_user!
+  before_action :authenticate_user!, :authorize_user!
 
   private
 
-  def authenticate_support_user!
-    authenticate_user!
+  def authorize_user!
+    return if current_user.support_user?
 
-    unless current_user.support_user?
-      redirect_to claims_root_path, alert: "You cannot perform this action"
-    end
+    redirect_to claims_root_path, alert: "You cannot perform this action"
   end
 end

--- a/app/controllers/claims/support/application_controller.rb
+++ b/app/controllers/claims/support/application_controller.rb
@@ -1,0 +1,13 @@
+class Claims::Support::ApplicationController < ApplicationController
+  before_action :authenticate_support_user!
+
+  private
+
+  def authenticate_support_user!
+    authenticate_user!
+
+    unless current_user.support_user?
+      redirect_to claims_root_path, alert: "You cannot perform this action"
+    end
+  end
+end

--- a/app/controllers/claims/support/claims_controller.rb
+++ b/app/controllers/claims/support/claims_controller.rb
@@ -1,0 +1,2 @@
+class Claims::Support::ClaimsController < Claims::Support::ApplicationController
+end

--- a/app/controllers/claims/support/schools_controller.rb
+++ b/app/controllers/claims/support/schools_controller.rb
@@ -1,0 +1,2 @@
+class Claims::Support::SchoolsController < Claims::Support::ApplicationController
+end

--- a/app/controllers/claims/support/users_controller.rb
+++ b/app/controllers/claims/support/users_controller.rb
@@ -1,0 +1,2 @@
+class Claims::Support::UsersController < Claims::Support::ApplicationController
+end

--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -1,4 +1,6 @@
 class HeartbeatController < ApplicationController
+  skip_before_action :authenticate_user!
+
   def healthcheck
     checks = { database: database_alive? }
     status = checks.values.all? ? :ok : :service_unavailable

--- a/app/controllers/personas_controller.rb
+++ b/app/controllers/personas_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PersonasController < ApplicationController
+  skip_before_action :authenticate_user!, only: %i[index]
+
   def index
     @personas = Persona.public_send(current_service).decorate
   end

--- a/app/controllers/service_updates_controller.rb
+++ b/app/controllers/service_updates_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ServiceUpdatesController < ApplicationController
-  include ApplicationHelper
+  skip_before_action :authenticate_user!, only: %i[index]
 
   def index
     @service_name ||= current_service

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,5 @@
 class SessionsController < ApplicationController
+  skip_before_action :authenticate_user!, only: %i[new callback]
   before_action :redirect_to_personas, only: [:new]
 
   # setup inspired by register-trainee-teacher

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,9 +1,14 @@
 class SessionsController < ApplicationController
+  before_action :redirect_to_personas, only: [:new]
+
   # setup inspired by register-trainee-teacher
   # TODO: Replace with commented code when DfE Sign In implemented
 
+  def new; end
+
   def callback
     DfESignInUser.begin_session!(session, request.env["omniauth.auth"])
+
     if current_user
       # DfESignInUsers::Update.call(user: current_user, sign_in_user: sign_in_user)
 
@@ -15,8 +20,15 @@ class SessionsController < ApplicationController
     end
   end
 
-  def signout
+  def destroy
     DfESignInUser.end_session!(session)
-    redirect_to root_path
+
+    redirect_to after_sign_out_path
+  end
+
+  private
+
+  def redirect_to_personas
+    redirect_to personas_path if ENV["SIGN_IN_METHOD"] == "persona"
   end
 end

--- a/app/helpers/routes_helper.rb
+++ b/app/helpers/routes_helper.rb
@@ -8,7 +8,7 @@ module RoutesHelper
 
   def support_root_path
     {
-      claims: root_path, # TODO: claims support path in another PR
+      claims: claims_support_root_path,
       placements: placements_support_root_path,
     }.fetch current_service
   end

--- a/app/views/claims/pages/index.html.erb
+++ b/app/views/claims/pages/index.html.erb
@@ -9,6 +9,7 @@
     <%= govuk_summary_list(
       rows: [
         { key: { text: "Service" }, value: { text: "Claims" } },
+        { key: { text: "Signed in as" }, value: { text: current_user&.first_name } },
         { key: { text: "Rails version" }, value: { text: Rails.version } },
         { key: { text: "Ruby version" }, value: { text: RUBY_VERSION } },
         {

--- a/app/views/claims/support/claims/index.html.erb
+++ b/app/views/claims/support/claims/index.html.erb
@@ -1,0 +1,1 @@
+Support / Claims

--- a/app/views/claims/support/schools/index.html.erb
+++ b/app/views/claims/support/schools/index.html.erb
@@ -1,0 +1,5 @@
+Support / Schools
+
+<ul>
+  <li><%= link_to "School 1", claims_support_school_path(1) %></li>
+</ul>

--- a/app/views/claims/support/schools/show.html.erb
+++ b/app/views/claims/support/schools/show.html.erb
@@ -1,0 +1,7 @@
+Support / Schools / 1
+
+<ul>
+  <li><%= link_to "Organisation Details", claims_support_school_path(params[:id]) %></li>
+  <li><%= link_to "Users", claims_support_school_users_path(params[:id]) %></li>
+  <li><%= link_to "Claims", claims_support_school_claims_path(params[:id]) %></li>
+</ul>

--- a/app/views/claims/support/users/index.html.erb
+++ b/app/views/claims/support/users/index.html.erb
@@ -1,0 +1,1 @@
+Support / Users

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,9 @@
 
     <%= govuk_skip_link %>
 
-    <%= govuk_header(homepage_url: "https://www.gov.uk", service_name: t(".#{current_service}.header.service_name"), service_url: "/") do |header| %>
+    <%= govuk_header(homepage_url: "/") do |header| %>
+      <% header.with_product_name(name: t(".#{current_service}.header.service_name")) %>
+
       <% if current_user %>
         <% header.with_navigation_item(text: "Your Account", href: account_path) %>
         <% header.with_navigation_item(text: "Sign Out", href: sign_out_path) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
-    <title><%= [yield(:page_title).presence, t("service.name")].compact.join(" - ") %></title>
+    <title><%= [yield(:page_title).presence, t(".#{current_service}.header.service_name")].compact.join(" - ") %></title>
 
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -25,7 +25,12 @@
 
     <%= govuk_skip_link %>
 
-    <%= govuk_header(homepage_url: "https://www.gov.uk", service_name: t(".#{current_service}.header.service_name"), service_url: "/") %>
+    <%= govuk_header(homepage_url: "https://www.gov.uk", service_name: t(".#{current_service}.header.service_name"), service_url: "/") do |header| %>
+      <% if current_user %>
+        <% header.with_navigation_item(text: "Your Account", href: account_path) %>
+        <% header.with_navigation_item(text: "Sign Out", href: sign_out_path) %>
+      <% end %>
+    <% end %>
 
     <div class="app-phase-banner app-phase-banner__env--<%= HostingEnvironment.name(current_service) %>">
       <div class="govuk-width-container">

--- a/app/views/placements/pages/index.html.erb
+++ b/app/views/placements/pages/index.html.erb
@@ -9,6 +9,7 @@
     <%= govuk_summary_list(
       rows: [
         { key: { text: "Service" }, value: { text: "Placements" } },
+        { key: { text: "Signed in as" }, value: { text: current_user&.first_name } },
         { key: { text: "Rails version" }, value: { text: Rails.version } },
         { key: { text: "Ruby version" }, value: { text: RUBY_VERSION } },
         {

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,1 @@
+DfE Sign In button goes here.

--- a/config/initializers/persona.rb
+++ b/config/initializers/persona.rb
@@ -1,20 +1,60 @@
 # frozen_string_literal: true
 
-# any additional details should be added to en.yml (t.personas.index)
-PERSONAS = [
-  { first_name: "Anne", last_name: "Wilson", email: "anne_wilson@example.org" },
+CLAIMS_PERSONAS = [
   {
-    first_name: "Patricia",
-    last_name: "Adebayo",
-    email: "patricia@example.com",
+    first_name: "Anne",
+    last_name: "Wilson",
+    email: "anne_wilson@example.org",
+    service: :claims,
   },
-  { first_name: "Mary", last_name: "Lawson", email: "mary@example.com" },
+  {
+    first_name: "Mary",
+    last_name: "Lawson",
+    email: "mary@example.com",
+    service: :claims,
+  },
   {
     first_name: "Colin",
     last_name: "Chapman",
     email: "colin@example.com",
     support_user: true,
+    service: :claims,
   },
-].push((DEVELOPER_PERSONA if defined?(DEVELOPER_PERSONA))).compact.freeze
+].freeze
+
+PLACEMENTS_PERSONAS = [
+  {
+    first_name: "Anne",
+    last_name: "Wilson",
+    email: "anne_wilson@example.org",
+    service: :placements,
+  },
+  {
+    first_name: "Patricia",
+    last_name: "Adebayo",
+    email: "patricia@example.com",
+    service: :placements,
+  },
+  {
+    first_name: "Mary",
+    last_name: "Lawson",
+    email: "mary@example.com",
+    service: :placements,
+  },
+  {
+    first_name: "Colin",
+    last_name: "Chapman",
+    email: "colin@example.com",
+    support_user: true,
+    service: :placements,
+  },
+].freeze
+
+# any additional details should be added to en.yml (t.personas.index)
+PERSONAS = [
+  *CLAIMS_PERSONAS,
+  *PLACEMENTS_PERSONAS,
+  (DEVELOPER_PERSONA if defined?(DEVELOPER_PERSONA)),
+].compact.freeze
 
 PERSONA_EMAILS = PERSONAS.map { |persona| persona[:email] }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,14 +7,15 @@ Rails.application.routes.draw do
   end
 
   # User Account Details
-  get("/account", to: "account#index")
+  get "/account", to: "account#index"
+  get "/sign-in", to: "sessions#new", as: :sign_in
 
   # Persona Sign In
   case ENV.fetch("SIGN_IN_METHOD")
   when "persona"
-    get("/personas", to: "personas#index")
-    get("/auth/developer/sign-out", to: "sessions#signout")
-    post("/auth/developer/callback", to: "sessions#callback")
+    get "/personas", to: "personas#index"
+    get "/auth/developer/sign-out", to: "sessions#destroy", as: :sign_out
+    post "/auth/developer/callback", to: "sessions#callback", as: :auth_callback
   end
 
   resources :service_updates, only: %i[index]

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -2,4 +2,13 @@ scope module: :claims, as: :claims, constraints: { host: ENV["CLAIMS_HOST"] } do
   root to: "pages#index"
 
   resources :schools, only: [:index]
+
+  namespace :support do
+    root to: redirect("/support/schools")
+
+    resources :schools do
+      resources :claims
+      resources :users
+    end
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,10 +9,12 @@ SCHOOLS = [
 Rails.logger.debug "Creating Personas"
 
 # Create the same personas for each service
-%w[claims placements].each do |service|
-  PERSONAS.each do |persona_attributes|
-    Persona.find_or_create_by!(**persona_attributes, service:)
-  end
+CLAIMS_PERSONAS.each do |persona_attributes|
+  Persona.find_or_create_by!(**persona_attributes)
+end
+
+PLACEMENTS_PERSONAS.each do |persona_attributes|
+  Persona.find_or_create_by!(**persona_attributes)
 end
 
 Rails.logger.debug "Personas successfully created!"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,6 +66,18 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.around(:each, type: :request) do |example|
+    host! ENV["CLAIMS_HOST"]
+    example.run
+    host! nil
+  end
+
+  config.around(:each, type: :system) do |example|
+    Capybara.app_host = "http://#{ENV["CLAIMS_HOST"]}"
+    example.run
+    Capybara.app_host = nil
+  end
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,7 +35,10 @@ begin
 rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
+
 RSpec.configure do |config|
+  config.include ServicesTestHelper, type: :system
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   # config.fixture_paths = [Rails.root.join("spec/fixtures")]
 

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,27 +1,23 @@
 require "rails_helper"
 
 RSpec.describe "Sessions", type: :request do
-  around do |example|
-    host! ENV["PLACEMENTS_HOST"]
-    example.run
-    host! nil
-  end
-
   describe "POST /auth/developer/callback" do
     it "returns http success" do
-      placements_user = create(:placements_user)
-      post auth_developer_callback_path,
+      claims_user = create(:claims_user)
+
+      post "/auth/developer/callback",
            params: {
-             first_name: placements_user.first_name,
-             last_name: placements_user.last_name,
-             email: placements_user.email,
+             first_name: claims_user.first_name,
+             last_name: claims_user.last_name,
+             email: claims_user.email,
            }
+
       follow_redirect!
 
       expect(response).to have_http_status(:success)
       # TODO: Change render_template once redirect to service specific
       # roots implemented
-      expect(response).to render_template("placements/pages/index")
+      expect(response).to render_template("claims/pages/index")
     end
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,4 +1,5 @@
 require "capybara/rspec"
+require "capybara-screenshot/rspec"
 
 # Use different Capybara ports when running tests in parallel
 if ENV["TEST_ENV_NUMBER"]

--- a/spec/support/services_test_helper.rb
+++ b/spec/support/services_test_helper.rb
@@ -1,0 +1,9 @@
+module ServicesTestHelper
+  def given_i_am_on_the_claims_site
+    Capybara.app_host = "http://#{ENV["CLAIMS_HOST"]}"
+  end
+
+  def given_i_am_on_the_placements_site
+    Capybara.app_host = "http://#{ENV["PLACEMENTS_HOST"]}"
+  end
+end

--- a/spec/system/home_page_spec.rb
+++ b/spec/system/home_page_spec.rb
@@ -1,31 +1,19 @@
 require "rails_helper"
 
 RSpec.describe "Home Page", type: :system do
-  after { Capybara.app_host = nil }
-
   scenario "User visits the claims homepage" do
     given_i_am_on_the_claims_site
     and_i_am_on_the_start_page
     i_can_see_the_claims_service_name_in_the_header
-    and_i_can_see_the_claims_service_value_in_the_page
   end
 
   scenario "User visits the placements homepage" do
     given_i_am_on_the_placements_site
     and_i_am_on_the_start_page
     i_can_see_the_placements_service_name_in_the_header
-    and_i_can_see_the_placements_service_value_in_the_page
   end
 
   private
-
-  def given_i_am_on_the_claims_site
-    Capybara.app_host = "http://#{ENV["CLAIMS_HOST"]}"
-  end
-
-  def given_i_am_on_the_placements_site
-    Capybara.app_host = "http://#{ENV["PLACEMENTS_HOST"]}"
-  end
 
   def and_i_am_on_the_start_page
     visit "/"
@@ -41,13 +29,5 @@ RSpec.describe "Home Page", type: :system do
     within(".govuk-header") do
       expect(page).to have_content("Manage School Placements")
     end
-  end
-
-  def and_i_can_see_the_claims_service_value_in_the_page
-    expect(page).to have_css(".govuk-summary-list__value", text: "Claims")
-  end
-
-  def and_i_can_see_the_placements_service_value_in_the_page
-    expect(page).to have_css(".govuk-summary-list__value", text: "Placements")
   end
 end

--- a/spec/system/service_updates_page_spec.rb
+++ b/spec/system/service_updates_page_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "Service updates page", type: :system do
-  after { Capybara.app_host = nil }
-
   scenario "User visits the claims Service updates" do
     given_i_am_on_the_claims_site
     and_i_am_on_the_service_updates_page
@@ -16,14 +14,6 @@ RSpec.describe "Service updates page", type: :system do
   end
 
   private
-
-  def given_i_am_on_the_claims_site
-    Capybara.app_host = "http://#{ENV["CLAIMS_HOST"]}"
-  end
-
-  def given_i_am_on_the_placements_site
-    Capybara.app_host = "http://#{ENV["PLACEMENTS_HOST"]}"
-  end
 
   def and_i_am_on_the_service_updates_page
     visit "/service_updates"


### PR DESCRIPTION
## Context

We want to lay down the foundations of user pages and flows. There is no data added, just _blank_ pages to highlight routing structures.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

- Remove "University" persona from Claims personas
- Redirect Claims users to sign-in page when landing on service root url
- Add "account" and "sign out" navigation items to navbar when signed in

## Guidance to review

- Head to the Claims service
- Be redirected to the personas page
- Login as any of the personas
- Be redirected to their internal pages (General users pending)

## Link to Trello card

https://trello.com/c/ow40pfAm/75-update-landing-page-of-app-to-sign-in-or-persona-select

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots / Videos

https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/eb2fd6d8-ea62-4f6b-b7c7-90aef4f3016e