### PR TITLE
Lb/current user method

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,10 +8,11 @@ class ApplicationController < ActionController::Base
   private
 
   def sign_in_user
+    session["service"] = current_service
     @sign_in_user ||= DfESignInUser.load_from_session(session)
   end
 
   def current_user
-    @current_user ||= sign_in_user
+    @current_user ||= sign_in_user&.user
   end
 end

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -2,19 +2,20 @@
 
 class DfESignInUser
   attr_reader :email, :dfe_sign_in_uid
-  attr_accessor :first_name, :last_name
+  attr_accessor :first_name, :last_name, :service
 
   # setup inspired by register-trainee-teacher
   # TODO: Replace with commented code when DfE Sign In implemented
 
-  # def initialize(email:, dfe_sign_in_uid:, first_name:, last_name:, id_token: nil, provider: "dfe")
-  def initialize(email:, first_name:, last_name:)
+  # def initialize(email:, dfe_sign_in_uid:, first_name:, last_name:, id_token: nil, provider: "dfe", service:)
+  def initialize(email:, first_name:, last_name:, service:)
     @email = email&.downcase
     # @dfe_sign_in_uid = dfe_sign_in_uid
     @first_name = first_name
     @last_name = last_name
     # @id_token = id_token
     # @provider = provider&.to_s
+    @service = service
   end
 
   def self.begin_session!(session, omniauth_payload)
@@ -37,13 +38,30 @@ class DfESignInUser
       email: dfe_sign_in_session["email"],
       # dfe_sign_in_uid: dfe_sign_in_session["dfe_sign_in_uid"],
       first_name: dfe_sign_in_session["first_name"],
-      last_name: dfe_sign_in_session["last_name"]
+      last_name: dfe_sign_in_session["last_name"],
       # id_token: dfe_sign_in_session["id_token"],
       # provider: dfe_sign_in_session["provider"],
+      service: session["service"]
     )
+  end
+
+  def user
+    # TODO: When dfe sign-in is fully implemented, we will be able to find the user by the id == id_token.
+    @user ||= user_klass.find_by(email:)
   end
 
   def self.end_session!(session)
     session.clear
+  end
+
+  private
+
+  def user_klass
+    case service
+    when :claims
+      Claims::User
+    when :placements
+      Placements::User
+    end
   end
 end

--- a/spec/features/personas/sign_in_as_persona_spec.rb
+++ b/spec/features/personas/sign_in_as_persona_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 feature "Sign In as Persona" do
   around do |example|
-    Capybara.app_host = "https://#{ENV["PLACEMENTS_HOST"]}"
+    Capybara.app_host = "https://#{ENV["CLAIMS_HOST"]}"
     example.run
     Capybara.app_host = nil
   end

--- a/spec/models/dfe_sign_in_user_spec.rb
+++ b/spec/models/dfe_sign_in_user_spec.rb
@@ -34,14 +34,55 @@ describe DfESignInUser do
           "first_name" => "Example",
           "last_name" => "User",
           "email" => "example_user@example.com"
-        }
+        },
+        "service" => :placements
       }
-      user = DfESignInUser.load_from_session(session)
+      dfe_sign_in_user = DfESignInUser.load_from_session(session)
 
-      expect(user).not_to be_nil
-      expect(user.first_name).to eq("Example")
-      expect(user.last_name).to eq("User")
-      expect(user.email).to eq("example_user@example.com")
+      expect(dfe_sign_in_user).not_to be_nil
+      expect(dfe_sign_in_user.first_name).to eq("Example")
+      expect(dfe_sign_in_user.last_name).to eq("User")
+      expect(dfe_sign_in_user.email).to eq("example_user@example.com")
+    end
+  end
+
+  describe "#user" do
+    describe "claims service" do
+      it "returns the claims user" do
+        claims_user = create(:claims_user)
+
+        session = {
+          "dfe_sign_in_user" => {
+            "first_name" => claims_user.first_name,
+            "last_name" => claims_user.last_name,
+            "email" => claims_user.email
+          },
+          "service" => :claims
+        }
+
+        dfe_sign_in_user = DfESignInUser.load_from_session(session)
+
+        expect(dfe_sign_in_user.user).to eq claims_user
+      end
+    end
+
+    describe "placements service" do
+      it "returns the placements user" do
+        placements_user = create(:placements_user)
+
+        session = {
+          "dfe_sign_in_user" => {
+            "first_name" => placements_user.first_name,
+            "last_name" => placements_user.last_name,
+            "email" => placements_user.email
+          },
+          "service" => :placements
+        }
+
+        dfe_sign_in_user = DfESignInUser.load_from_session(session)
+
+        expect(dfe_sign_in_user.user).to eq placements_user
+      end
     end
   end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Provider, type: :model do
     subject { create(:provider) }
 
     it { is_expected.to validate_presence_of(:provider_code) }
-    it { is_expected.to validate_uniqueness_of(:provider_code).case_insensitive }
+    it do
+      is_expected.to validate_uniqueness_of(:provider_code).case_insensitive
+    end
   end
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -9,11 +9,12 @@ RSpec.describe "Sessions", type: :request do
 
   describe "POST /auth/developer/callback" do
     it "returns http success" do
+      placements_user = create(:placements_user)
       post auth_developer_callback_path,
            params: {
-             first_name: "Anne",
-             last_name: "Wilson",
-             email: "anne_wilson@example.com"
+             first_name: placements_user.first_name,
+             last_name: placements_user.last_name,
+             email: placements_user.email
            }
       follow_redirect!
 


### PR DESCRIPTION
## Context

See slack thread: https://ukgovernmentdfe.slack.com/archives/C06962474AC/p1702994098513929

We need the `current_user` method to return a Service::User object, not a `DfeSignInUser` instance. 

I did this as part of the support_user journey work, it makes sense to implement it earlier as needed in other places. 

## Changes proposed in this pull request
When a user is logged in a service, the `current_user` method returns the appropriate user object - `Placements::User` for the placements service, `Claims::User` for the claims service

No UI changes. 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [NA] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [NA] This code does not rely on migrations in the same Pull Request
- [NA] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [NA] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [NA] API release notes have been updated if necessary
- [NA] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [NA] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots
