### PR TITLE
Add phase banner to the app

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -3,3 +3,5 @@ $govuk-new-link-styles: true;
 $govuk-assets-path: "";
 
 @import "govuk-frontend/dist/govuk/all";
+
+@import "components/all";

--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -1,0 +1,1 @@
+@import "page_banner";

--- a/app/assets/stylesheets/components/_page_banner.scss
+++ b/app/assets/stylesheets/components/_page_banner.scss
@@ -1,0 +1,22 @@
+.app-phase-banner .govuk-tag {
+  color: govuk-colour("white");
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-weight: $govuk-font-weight-bold;
+}
+
+.app-phase-banner__env--development .govuk-tag {
+  background: govuk-colour("dark-grey");
+}
+
+.app-phase-banner__env--qa .govuk-tag {
+  background-color: govuk-colour("orange");
+}
+
+.app-phase-banner__env--staging .govuk-tag {
+  background-color: govuk-colour("red");
+}
+
+.app-phase-banner__env--beta .govuk-tag {
+  background: govuk-colour("blue");
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,6 +27,14 @@
 
     <%= govuk_header(homepage_url: "https://www.gov.uk", service_name: t(".#{current_service}.header.service_name"), service_url: "/") %>
 
+    <div class="app-phase-banner app-phase-banner__env--<%= HostingEnvironment.name(current_service) %>">
+      <div class="govuk-width-container">
+        <%= govuk_phase_banner(tag: { text: HostingEnvironment.name(current_service) }) do %>
+          <%= govuk_link_to HostingEnvironment.banner_description(current_service), request.env["PATH_INFO"], class: "govuk-link--no-visited-state" %>
+        <% end %>
+      </div>
+    </div>
+
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <%= yield %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,7 @@ module IttMentorServices
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.autoload_lib(ignore: %w[])
 
     config.assets.paths << Rails.root.join(
       "node_modules/govuk-frontend/dist/govuk/assets"

--- a/config/locales/claims/en/models/hosting_environment.yml
+++ b/config/locales/claims/en/models/hosting_environment.yml
@@ -1,0 +1,6 @@
+en:
+  models:
+    hosting_environment:
+      claims:
+        banner:
+          description: Make a complaint or give feedback

--- a/config/locales/placements/en/models/hosting_environment.yml
+++ b/config/locales/placements/en/models/hosting_environment.yml
@@ -1,0 +1,6 @@
+en:
+  models:
+    hosting_environment:
+      placements:
+        banner:
+          description: Make a complaint or give feedback

--- a/lib/hosting_environment.rb
+++ b/lib/hosting_environment.rb
@@ -1,0 +1,18 @@
+module HostingEnvironment
+  PRODUCTION_BANNER_NAME = {
+    claims: "beta",
+    placements: "beta"
+  }.with_indifferent_access.freeze
+
+  def self.name(current_service)
+    if Rails.env.production?
+      PRODUCTION_BANNER_NAME.fetch(current_service)
+    else
+      Rails.env
+    end
+  end
+
+  def self.banner_description(current_service)
+    I18n.t(".models.hosting_environment.#{current_service}.banner.description")
+  end
+end

--- a/spec/lib/hosting_environment_spec.rb
+++ b/spec/lib/hosting_environment_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe HostingEnvironment do
+  describe ".name" do
+    it "returns the name of the hosting environment" do
+      current_service = "claims"
+      expect(described_class.name(current_service)).to eq("test")
+    end
+
+    context "when environment is production" do
+      it "returns the name of the hosting environment for claims" do
+        allow(Rails.env).to receive(:production?).and_return(true)
+        current_service = "claims"
+        expect(described_class.name(current_service)).to eq("beta")
+      end
+
+      it "returns the name of the hosting environment for placements" do
+        allow(Rails.env).to receive(:production?).and_return(true)
+        current_service = "placements"
+        expect(described_class.name(current_service)).to eq("beta")
+      end
+    end
+  end
+
+  describe ".banner_description" do
+    it "returns the banner description of the hosting environment for claims" do
+      current_service = "claims"
+      expect(described_class.banner_description(current_service)).to eq(
+        "Make a complaint or give feedback"
+      )
+    end
+
+    it "returns the banner description of the hosting environment for placements" do
+      current_service = "placements"
+      expect(described_class.banner_description(current_service)).to eq(
+        "Make a complaint or give feedback"
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Context

We want to add a phase banner that will indicate to our users that this app is in Beta. The banner title is dynamic based on the environment we are in and both claims and placements can control the content of it.

## Changes proposed in this pull request

- Phase banner Styles
- Translations
- HostingEnvironment module

## Guidance to review

- The link in the banner only redirects to the current page, we need to talk to product about where we want that link to go. It was not in the scope of this story

Run the app on local and you should see the `Development` phase banner
![Screenshot from 2023-12-20 09-55-24](https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/7f1aff23-e379-401d-a592-6a7fb20ae831)


## Link to Trello card

https://trello.com/c/ivbin1aW/73-add-beta-banner-to-app

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->

Development:
![Screenshot from 2023-12-20 09-55-24](https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/d811256c-c75a-4c4b-987c-8dc97a66d72e)

Production:
![Screenshot from 2023-12-20 10-01-23](https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/c16816cc-de65-4e67-9e2c-09316aecd6c5)


