### PR TITLE
Make `current_user` return a `Placements::SupportUser` for support users

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,6 +237,8 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     nio4r (2.7.0)
+    nokogiri (1.15.5-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.15.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.15.5-x86_64-linux)
@@ -502,7 +504,6 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
-  arm64-darwin-22
   arm64-darwin-23
   x86_64-darwin-22
   x86_64-linux

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,8 +8,11 @@ class ApplicationController < ActionController::Base
   private
 
   def sign_in_user
-    session["service"] = current_service
-    @sign_in_user ||= DfESignInUser.load_from_session(session)
+    @sign_in_user ||=
+      begin
+        session["service"] = current_service
+        DfESignInUser.load_from_session(session)
+      end
   end
 
   def current_user

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -47,7 +47,16 @@ class DfESignInUser
 
   def user
     # TODO: When dfe sign-in is fully implemented, we will be able to find the user by the id == id_token.
-    @user ||= user_klass.find_by(email:)
+    @user ||=
+      begin
+        user = user_klass.find_by(email:)
+
+        if service == :placements && user&.support_user?
+          user = user.becomes(Placements::SupportUser)
+        end
+
+        user
+      end
   end
 
   def self.end_session!(session)

--- a/spec/models/dfe_sign_in_user_spec.rb
+++ b/spec/models/dfe_sign_in_user_spec.rb
@@ -48,7 +48,7 @@ describe DfESignInUser do
 
   describe "#user" do
     describe "claims service" do
-      it "returns the claims user" do
+      it "returns the current Claims::User" do
         claims_user = create(:claims_user)
 
         session = {
@@ -63,11 +63,12 @@ describe DfESignInUser do
         dfe_sign_in_user = DfESignInUser.load_from_session(session)
 
         expect(dfe_sign_in_user.user).to eq claims_user
+        expect(dfe_sign_in_user.user).to be_a Claims::User
       end
     end
 
     describe "placements service" do
-      it "returns the placements user" do
+      it "returns the current Placements::User" do
         placements_user = create(:placements_user)
 
         session = {
@@ -82,6 +83,25 @@ describe DfESignInUser do
         dfe_sign_in_user = DfESignInUser.load_from_session(session)
 
         expect(dfe_sign_in_user.user).to eq placements_user
+        expect(dfe_sign_in_user.user).to be_a Placements::User
+      end
+
+      it "returns a Placements::SupportUser for support users" do
+        support_user = create(:placements_user, :support)
+
+        session = {
+          "dfe_sign_in_user" => {
+            "first_name" => support_user.first_name,
+            "last_name" => support_user.last_name,
+            "email" => support_user.email
+          },
+          "service" => :placements
+        }
+
+        dfe_sign_in_user = DfESignInUser.load_from_session(session)
+
+        expect(dfe_sign_in_user.user.id).to eq support_user.id
+        expect(dfe_sign_in_user.user).to be_a Placements::SupportUser
       end
     end
   end


### PR DESCRIPTION
## Context

The School Placements service has two user models: `Placements::User` and `Placements::SupportUser < Placements::User`. We decided that support users will need slightly different behaviour from 'regular' users – for example, they'll need access to _all_ Organisations rather than only those they have Memberships to.

## Changes proposed in this pull request

I've updated the `current_user` method so that it returns the most appropriate User type for the circumstances. If the user is in the Placements service and is a Support User, then we'll return a `Placements::SupportUser` object.

I'm implementing in the hope that it'll simplify the implementation of PR #42 which needs to distinguish between regular users and support users. For more context, see this comment thread: https://github.com/DFE-Digital/itt-mentor-services/pull/42#discussion_r1432836796

## Guidance to review

I'd recommend reviewing commit-by-commit (and focussing primarily on the final commit).

1. The first commit was an unrelated change that `bundle` decided to make to `Gemfile.lock`. It seemed insistent on making this change, so I've just rolled with it.
2. The second commit is a micro-optimisation, but one which I thought I'd make while I was in the area. It should avoid unnecessary updates to the session object when calling `sign_in_user`.
3. This is the meat of the PR. Hopefully the tests explain what's changed.

## Link to Trello card

https://trello.com/c/9QbPxRYT/65-login-as-a-support-user-and-see-organisations
