### PR TITLE
Organisation index per service

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
           - tests: erblint
             command: bundle exec erblint app
           - tests: prettier
-            command: yarn prettier --check app
+            command: yarn prettier --check --ignore-unknown '**/*'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,8 @@ group :test do
   gem "rails-controller-testing"
   gem "selenium-webdriver"
   gem "shoulda-matchers"
+  # launch browser when inspecting capybara specs
+  gem "launchy"
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,6 +205,8 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
+    launchy (2.5.2)
+      addressable (~> 2.8)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -525,6 +527,7 @@ DEPENDENCIES
   govuk-components (~> 5.0.0)
   govuk_design_system_formbuilder (~> 5.0.0)
   jsbundling-rails
+  launchy
   mail-notify
   omniauth
   omniauth-rails_csrf_protection

--- a/adr/00003-testing-practices.md
+++ b/adr/00003-testing-practices.md
@@ -19,13 +19,13 @@ Use the following test types for our classes, modules, and functionalities.
   ```ruby
   RSpec.describe User, type: :model do
     subject { build(:user) }
-
+  
     describe ".class_method" do
       it "does something" do
         expect(User.class_method).to do_something
       end
     end
-
+  
     describe "#instance_method" do
       it "does something" do
         expect(subject.instance_method).to do_something
@@ -41,7 +41,7 @@ Use the following test types for our classes, modules, and functionalities.
         expect(User.class_method).to do_something
       end
     end
-
+  
     describe "#instance_method" do
       it "does something" do
         expect(subject.instance_method).to do_something
@@ -59,11 +59,11 @@ Use the following test types for our classes, modules, and functionalities.
       given_i_am_on_the_landing_page
       i_can_see_something
     end
-
+  
     def given_i_am_on_the_landing_page
       visit "/"
     end
-
+  
     def i_can_see_something
       expect(page).to have_content("Something")
     end
@@ -81,25 +81,19 @@ Use the following test types for our classes, modules, and functionalities.
       # Base happy path first
       it "returns a list of users" do
         get :index
-
-        expected_json = [
-          {
-            id: 1,
-            first_name: "John",
-            last_name: "Doe"
-          }
-        ]
-
+  
+        expected_json = [{ id: 1, first_name: "John", last_name: "Doe" }]
+  
         expect(response.body).to eq(expected_json)
       end
-
+  
       # Happy path variants next
       context "when given a 'name' query parameter" do
         it "returns a list of users filtered by name" do
           # Assertion
         end
       end
-
+  
       # Error paths
       context "without authentication" do
         it "returns a 401 error" do
@@ -107,7 +101,7 @@ Use the following test types for our classes, modules, and functionalities.
         end
       end
     end
-
+  
     context "POST /users" do
       it "returns a list of users" do
         get :index

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,9 +21,13 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path
-    return support_root_path if current_user.support_user?
-
-    root_path
+    if current_user.support_user?
+      support_root_path
+    elsif current_user.memberships.many?
+      organisation_index_path
+    else
+      root_path
+    end
   end
 
   def after_sign_out_path

--- a/app/controllers/claims/organisations_controller.rb
+++ b/app/controllers/claims/organisations_controller.rb
@@ -1,0 +1,5 @@
+class Claims::OrganisationsController < ApplicationController
+  def index
+    @schools = current_user.schools
+  end
+end

--- a/app/controllers/placements/organisations_controller.rb
+++ b/app/controllers/placements/organisations_controller.rb
@@ -1,0 +1,6 @@
+class Placements::OrganisationsController < ApplicationController
+  def index
+    @schools = current_user.schools
+    @providers = current_user.providers
+  end
+end

--- a/app/helpers/routes_helper.rb
+++ b/app/helpers/routes_helper.rb
@@ -2,14 +2,21 @@ module RoutesHelper
   def root_path
     {
       claims: claims_root_path,
-      placements: placements_root_path
+      placements: placements_root_path,
     }.fetch current_service
   end
 
   def support_root_path
     {
       claims: root_path, # TODO: claims support path in another PR
-      placements: placements_support_root_path
+      placements: placements_support_root_path,
+    }.fetch current_service
+  end
+
+  def organisation_index_path
+    {
+      claims: claims_organisations_path,
+      placements: placements_organisations_path,
     }.fetch current_service
   end
 end

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -21,7 +21,7 @@ class DfESignInUser
       "email" => omniauth_payload["info"]["email"],
       # "dfe_sign_in_uid" => omniauth_payload["uid"],
       "first_name" => omniauth_payload["info"]["first_name"],
-      "last_name" => omniauth_payload["info"]["last_name"]
+      "last_name" => omniauth_payload["info"]["last_name"],
       # "last_active_at" => Time.zone.now,
       # "id_token" => omniauth_payload["credentials"]["id_token"],
       # "provider" => omniauth_payload["provider"],
@@ -39,7 +39,7 @@ class DfESignInUser
       last_name: dfe_sign_in_session["last_name"],
       # id_token: dfe_sign_in_session["id_token"],
       # provider: dfe_sign_in_session["provider"],
-      service: session["service"]
+      service: session["service"],
     )
   end
 

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: memberships
+#
+#  id                :uuid             not null, primary key
+#  organisation_type :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  organisation_id   :uuid             not null
+#  user_id           :uuid             not null
+#
+# Indexes
+#
+#  index_memberships_on_organisation  (organisation_type,organisation_id)
+#  index_memberships_on_user_id       (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class Membership < ApplicationRecord
+  belongs_to :user
+  belongs_to :organisation, polymorphic: true
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -12,6 +12,8 @@
 #  index_providers_on_provider_code  (provider_code) UNIQUE
 #
 class Provider < ApplicationRecord
+  has_many :memberships, as: :organisation
+
   validates :provider_code, presence: true
   validates :provider_code, uniqueness: { case_sensitive: false }
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -17,6 +17,8 @@
 #
 class School < ApplicationRecord
   belongs_to :gias_school, foreign_key: :urn, primary_key: :urn
+  has_many :memberships, as: :organisation
+
   validates :urn, presence: true
   validates :urn, uniqueness: { case_sensitive: false }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,16 @@
 #  index_users_on_service_and_email  (service,email) UNIQUE
 #
 class User < ApplicationRecord
+  has_many :memberships
+  has_many :schools,
+           through: :memberships,
+           source: :organisation,
+           source_type: "School"
+  has_many :providers,
+           through: :memberships,
+           source: :organisation,
+           source_type: "Provider"
+
   enum :service,
        { no_service: "no_service", claims: "claims", placements: "placements" },
        validate: true

--- a/app/services/gias_csv_importer.rb
+++ b/app/services/gias_csv_importer.rb
@@ -32,7 +32,7 @@ class GiasCsvImporter
           address2: school["Locality"].presence,
           address3: school["Address3"].presence,
           website: school["SchoolWebsite"].presence,
-          telephone: school["TelephoneNum"].presence
+          telephone: school["TelephoneNum"].presence,
         }
       end
 

--- a/app/views/claims/organisations/index.html.erb
+++ b/app/views/claims/organisations/index.html.erb
@@ -1,0 +1,15 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t("organisations") %></h1>
+
+    <% if @schools.any? %>
+      <ul class="govuk-list">
+        <% @schools.each do |school| %>
+          <li>
+           <%= govuk_link_to school.name, request.env["PATH_INFO"], no_visited_state: true %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+  </div>
+</div>

--- a/app/views/placements/organisations/index.html.erb
+++ b/app/views/placements/organisations/index.html.erb
@@ -1,0 +1,27 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t("organisations") %></h1>
+
+    <% if @schools.any? %>
+      <h2 class="govuk-heading-l"><%= t("schools") %></h2>
+      <ul class="govuk-list">
+        <% @schools.each do |school| %>
+        <li>
+          <%= govuk_link_to school.name, request.env["PATH_INFO"], no_visited_state: true %>
+        </li>
+        <% end %>
+      </ul>
+    <% end %>
+
+    <% if @providers.any? %>
+      <h2 class="govuk-heading-l"><%= t("providers") %></h2>
+      <ul class="govuk-list">
+        <% @providers.each do |provider| %>
+          <li>
+            <%= govuk_link_to provider.provider_code, request.env["PATH_INFO"], no_visited_state: true %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+  </div>
+</div>

--- a/bin/bundle
+++ b/bin/bundle
@@ -102,7 +102,7 @@ m =
       require_error = activation_error_handling { require "bundler/version" }
       if require_error.nil? &&
            Gem::Requirement.new(bundler_requirement).satisfied_by?(
-             Gem::Version.new(Bundler::VERSION)
+             Gem::Version.new(Bundler::VERSION),
            )
         return
       end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,7 @@ module IttMentorServices
     config.autoload_lib(ignore: %w[])
 
     config.assets.paths << Rails.root.join(
-      "node_modules/govuk-frontend/dist/govuk/assets"
+      "node_modules/govuk-frontend/dist/govuk/assets",
     )
 
     config.autoload_paths += %W[#{config.root}/app/assets/components]

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      "Cache-Control" => "public, max-age=#{2.days.to_i}"
+      "Cache-Control" => "public, max-age=#{2.days.to_i}",
     }
   else
     config.action_controller.perform_caching = false
@@ -35,7 +35,7 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :notify
   config.action_mailer.notify_settings = {
-    api_key: ENV.fetch("GOVUK_NOTIFY_API_KEY")
+    api_key: ENV.fetch("GOVUK_NOTIFY_API_KEY"),
   }
 
   # Store uploaded files on the local file system (see config/storage.yml for options).

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    "Cache-Control" => "public, max-age=#{1.hour.to_i}"
+    "Cache-Control" => "public, max-age=#{1.hour.to_i}",
   }
 
   # Show full error reports and disable caching.

--- a/config/initializers/better_html.rb
+++ b/config/initializers/better_html.rb
@@ -3,7 +3,7 @@ return if Rails.env.production?
 
 BetterHtml.config =
   BetterHtml::Config.new(
-    YAML.safe_load(File.read(Rails.root.join(".better-html.yml")))
+    YAML.safe_load(File.read(Rails.root.join(".better-html.yml"))),
   )
 
 BetterHtml.configure do |config|

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -9,7 +9,7 @@ when "persona"
       provider(
         :developer,
         fields: %i[uid email first_name last_name],
-        uid_field: :uid
+        uid_field: :uid,
       )
     end
 when "dfe-sign-in"

--- a/config/initializers/persona.rb
+++ b/config/initializers/persona.rb
@@ -6,15 +6,15 @@ PERSONAS = [
   {
     first_name: "Patricia",
     last_name: "Adebayo",
-    email: "patricia@example.com"
+    email: "patricia@example.com",
   },
   { first_name: "Mary", last_name: "Lawson", email: "mary@example.com" },
   {
     first_name: "Colin",
     last_name: "Chapman",
     email: "colin@example.com",
-    support_user: true
-  }
+    support_user: true,
+  },
 ].push((DEVELOPER_PERSONA if defined?(DEVELOPER_PERSONA))).compact.freeze
 
 PERSONA_EMAILS = PERSONAS.map { |persona| persona[:email] }

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -1,3 +1,5 @@
 scope module: :claims, as: :claims, constraints: { host: ENV["CLAIMS_HOST"] } do
   root to: "pages#index"
+
+  resources :organisations, only: [:index]
 end

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -1,7 +1,7 @@
 scope module: :placements,
       as: :placements,
       constraints: {
-        host: ENV["PLACEMENTS_HOST"]
+        host: ENV["PLACEMENTS_HOST"],
       } do
   root to: "pages#index"
 

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -9,4 +9,6 @@ scope module: :placements,
     root to: redirect("/support/organisations")
     resources :organisations, only: :index
   end
+
+  resources :organisations, only: [:index]
 end

--- a/db/migrate/20231220143008_create_memberships.rb
+++ b/db/migrate/20231220143008_create_memberships.rb
@@ -1,0 +1,10 @@
+class CreateMemberships < ActiveRecord::Migration[7.1]
+  def change
+    create_table :memberships, id: :uuid do |t|
+      t.references :user, null: false, foreign_key: true, type: :uuid
+      t.references :organisation, polymorphic: true, null: false, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_16_102842) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_20_143008) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -39,6 +39,16 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_16_102842) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["urn"], name: "index_gias_schools_on_urn", unique: true
+  end
+
+  create_table "memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.string "organisation_type", null: false
+    t.uuid "organisation_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["organisation_type", "organisation_id"], name: "index_memberships_on_organisation"
+    t.index ["user_id"], name: "index_memberships_on_user_id"
   end
 
   create_table "providers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -70,4 +80,5 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_16_102842) do
     t.index ["service", "email"], name: "index_users_on_service_and_email", unique: true
   end
 
+  add_foreign_key "memberships", "users"
 end

--- a/lib/hosting_environment.rb
+++ b/lib/hosting_environment.rb
@@ -1,7 +1,7 @@
 module HostingEnvironment
   PRODUCTION_BANNER_NAME = {
     claims: "beta",
-    placements: "beta"
+    placements: "beta",
   }.with_indifferent_access.freeze
 
   def self.name(current_service)

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -52,7 +52,7 @@ if Rails.env.development?
       "trace" => "false",
       "wrapper_open" => nil,
       "wrapper_close" => nil,
-      "with_comment" => "true"
+      "with_comment" => "true",
     )
   end
 

--- a/spec/decorators/persona_decorator_spec.rb
+++ b/spec/decorators/persona_decorator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe PersonaDecorator do
     context "when the persona is Patricia" do
       it "returns orange" do
         expect(build(:persona, :patricia).decorate.type_tag_colour).to eq(
-          "orange"
+          "orange",
         )
       end
     end

--- a/spec/factories/memberships.rb
+++ b/spec/factories/memberships.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: memberships
+#
+#  id                :uuid             not null, primary key
+#  organisation_type :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  organisation_id   :uuid             not null
+#  user_id           :uuid             not null
+#
+# Indexes
+#
+#  index_memberships_on_organisation  (organisation_type,organisation_id)
+#  index_memberships_on_user_id       (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+FactoryBot.define do
+  factory :membership do
+    association :user
+    association :organisation, factory: :school
+  end
+end

--- a/spec/features/personas/sign_in_as_a_claims_user_persona_spec.rb
+++ b/spec/features/personas/sign_in_as_a_claims_user_persona_spec.rb
@@ -70,7 +70,7 @@ def then_i_see_persona_details_for_anne
   page_has_persona_content(
     first_name: "Anne",
     last_name: "Wilson",
-    email: "anne_wilson@example.org"
+    email: "anne_wilson@example.org",
   )
 end
 
@@ -78,7 +78,7 @@ def then_i_see_persona_details_for_patricia
   page_has_persona_content(
     first_name: "Patricia",
     last_name: "Adebayo",
-    email: "patricia@example.com"
+    email: "patricia@example.com",
   )
 end
 
@@ -86,7 +86,7 @@ def then_i_see_persona_details_for_mary
   page_has_persona_content(
     first_name: "Mary",
     last_name: "Lawson",
-    email: "mary@example.com"
+    email: "mary@example.com",
   )
 end
 
@@ -94,7 +94,7 @@ def then_i_see_persona_details_for_colin
   page_has_persona_content(
     first_name: "Colin",
     last_name: "Chapman",
-    email: "colin@example.com"
+    email: "colin@example.com",
   )
 end
 

--- a/spec/features/personas/sign_in_as_a_placements_user_persona_spec.rb
+++ b/spec/features/personas/sign_in_as_a_placements_user_persona_spec.rb
@@ -85,7 +85,7 @@ def then_i_see_persona_details_for_anne
   page_has_persona_content(
     first_name: "Anne",
     last_name: "Wilson",
-    email: "anne_wilson@example.org"
+    email: "anne_wilson@example.org",
   )
 end
 
@@ -93,7 +93,7 @@ def then_i_see_persona_details_for_patricia
   page_has_persona_content(
     first_name: "Patricia",
     last_name: "Adebayo",
-    email: "patricia@example.com"
+    email: "patricia@example.com",
   )
 end
 
@@ -101,7 +101,7 @@ def then_i_see_persona_details_for_mary
   page_has_persona_content(
     first_name: "Mary",
     last_name: "Lawson",
-    email: "mary@example.com"
+    email: "mary@example.com",
   )
 end
 
@@ -109,7 +109,7 @@ def then_i_see_persona_details_for_colin
   page_has_persona_content(
     first_name: "Colin",
     last_name: "Chapman",
-    email: "colin@example.com"
+    email: "colin@example.com",
   )
 end
 

--- a/spec/lib/hosting_environment_spec.rb
+++ b/spec/lib/hosting_environment_spec.rb
@@ -26,14 +26,14 @@ RSpec.describe HostingEnvironment do
     it "returns the banner description of the hosting environment for claims" do
       current_service = "claims"
       expect(described_class.banner_description(current_service)).to eq(
-        "Make a complaint or give feedback"
+        "Make a complaint or give feedback",
       )
     end
 
     it "returns the banner description of the hosting environment for placements" do
       current_service = "placements"
       expect(described_class.banner_description(current_service)).to eq(
-        "Make a complaint or give feedback"
+        "Make a complaint or give feedback",
       )
     end
   end

--- a/spec/models/dfe_sign_in_user_spec.rb
+++ b/spec/models/dfe_sign_in_user_spec.rb
@@ -8,8 +8,8 @@ describe DfESignInUser do
         "info" => {
           "first_name" => "Example",
           "last_name" => "User",
-          "email" => "example_user@example.com"
-        }
+          "email" => "example_user@example.com",
+        },
       }
       DfESignInUser.begin_session!(session, omniauth_payload)
 
@@ -18,9 +18,9 @@ describe DfESignInUser do
           "dfe_sign_in_user" => {
             "first_name" => "Example",
             "last_name" => "User",
-            "email" => "example_user@example.com"
-          }
-        }
+            "email" => "example_user@example.com",
+          },
+        },
       )
     end
   end
@@ -31,9 +31,9 @@ describe DfESignInUser do
         "dfe_sign_in_user" => {
           "first_name" => "Example",
           "last_name" => "User",
-          "email" => "example_user@example.com"
+          "email" => "example_user@example.com",
         },
-        "service" => :placements
+        "service" => :placements,
       }
       dfe_sign_in_user = DfESignInUser.load_from_session(session)
 
@@ -53,9 +53,9 @@ describe DfESignInUser do
           "dfe_sign_in_user" => {
             "first_name" => claims_user.first_name,
             "last_name" => claims_user.last_name,
-            "email" => claims_user.email
+            "email" => claims_user.email,
           },
-          "service" => :claims
+          "service" => :claims,
         }
 
         dfe_sign_in_user = DfESignInUser.load_from_session(session)
@@ -73,9 +73,9 @@ describe DfESignInUser do
           "dfe_sign_in_user" => {
             "first_name" => placements_user.first_name,
             "last_name" => placements_user.last_name,
-            "email" => placements_user.email
+            "email" => placements_user.email,
           },
-          "service" => :placements
+          "service" => :placements,
         }
 
         dfe_sign_in_user = DfESignInUser.load_from_session(session)
@@ -91,9 +91,9 @@ describe DfESignInUser do
           "dfe_sign_in_user" => {
             "first_name" => support_user.first_name,
             "last_name" => support_user.last_name,
-            "email" => support_user.email
+            "email" => support_user.email,
           },
-          "service" => :placements
+          "service" => :placements,
         }
 
         dfe_sign_in_user = DfESignInUser.load_from_session(session)
@@ -110,8 +110,8 @@ describe DfESignInUser do
         "dfe_sign_in_user" => {
           "first_name" => "Example",
           "last_name" => "User",
-          "email" => "example_user@example.com"
-        }
+          "email" => "example_user@example.com",
+        },
       }
 
       DfESignInUser.end_session!(session)

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -1,0 +1,32 @@
+# == Schema Information
+#
+# Table name: memberships
+#
+#  id                :uuid             not null, primary key
+#  organisation_type :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  organisation_id   :uuid             not null
+#  user_id           :uuid             not null
+#
+# Indexes
+#
+#  index_memberships_on_organisation  (organisation_type,organisation_id)
+#  index_memberships_on_user_id       (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+require "rails_helper"
+
+RSpec.describe Membership, type: :model do
+  subject { create(:membership) }
+
+  context "associations" do
+    it do
+      should belong_to(:user)
+      should belong_to(:organisation)
+    end
+  end
+end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -14,6 +14,10 @@
 require "rails_helper"
 
 RSpec.describe Provider, type: :model do
+  context "associations" do
+    it { should have_many(:memberships) }
+  end
+
   context "validations" do
     subject { create(:provider) }
 

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -21,8 +21,9 @@ RSpec.describe School, type: :model do
   context "associations" do
     it do
       should belong_to(:gias_school).with_foreign_key(:urn).with_primary_key(
-               :urn
+               :urn,
              )
+      should have_many(:memberships)
     end
   end
 
@@ -31,6 +32,10 @@ RSpec.describe School, type: :model do
 
     it { is_expected.to validate_presence_of(:urn) }
     it { is_expected.to validate_uniqueness_of(:urn).case_insensitive }
+  end
+
+  context "delegations" do
+    it { should delegate_method(:name).to(:gias_school) }
   end
 
   context "scopes" do

--- a/spec/models/service_update_spec.rb
+++ b/spec/models/service_update_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe ServiceUpdate do
             {
               date: "2023-12-14",
               title: "Claim Update",
-              content: "Some content"
-            }
-          ]
+              content: "Some content",
+            },
+          ],
         )
         updates = ServiceUpdate.where(service: :claims)
         expect(updates.length).to eq(1)
@@ -34,9 +34,9 @@ RSpec.describe ServiceUpdate do
             {
               date: "2023-12-14",
               title: "Placement Update",
-              content: "Some content"
-            }
-          ]
+              content: "Some content",
+            },
+          ],
         )
         updates = ServiceUpdate.where(service: :placements)
         expect(updates.length).to eq(1)
@@ -60,7 +60,7 @@ RSpec.describe ServiceUpdate do
     it "returns placements YAML file path" do
       file_path = ServiceUpdate.file_path(service: :placements)
       expect(file_path).to eq(
-        Rails.root.join("db/placements_service_updates.yml")
+        Rails.root.join("db/placements_service_updates.yml"),
       )
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -20,11 +20,19 @@ require "rails_helper"
 RSpec.describe User, type: :model do
   subject { create(:user) }
 
+  context "associations" do
+    it do
+      should have_many(:memberships)
+      should have_many(:schools).through(:memberships).source(:organisation)
+      should have_many(:providers).through(:memberships).source(:organisation)
+    end
+  end
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:email) }
     it do
       is_expected.to validate_uniqueness_of(:email).scoped_to(
-        :service
+        :service,
       ).case_insensitive
     end
     it { is_expected.to validate_presence_of(:first_name) }

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Sessions", type: :request do
            params: {
              first_name: placements_user.first_name,
              last_name: placements_user.last_name,
-             email: placements_user.email
+             email: placements_user.email,
            }
       follow_redirect!
 

--- a/spec/services/gias_csv_importer_spec.rb
+++ b/spec/services/gias_csv_importer_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe GiasCsvImporter do
   it "logs messages to STDOUT" do
     expect { subject }.to output(
       match(/Done!/).and(match(/Invalid rows - /)).and(
-        match(/Row 5 is invalid/)
-      )
+        match(/Row 5 is invalid/),
+      ),
     ).to_stdout
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,18 +1,18 @@
-require 'capybara/rspec'
+require "capybara/rspec"
 
 # Use different Capybara ports when running tests in parallel
-if ENV['TEST_ENV_NUMBER']
-  Capybara.server_port = 9887 + ENV['TEST_ENV_NUMBER'].to_i
+if ENV["TEST_ENV_NUMBER"]
+  Capybara.server_port = 9887 + ENV["TEST_ENV_NUMBER"].to_i
 end
 
 Capybara.register_driver :chrome_headless do |app|
   options = Selenium::WebDriver::Chrome::Options.new
 
-  options.add_argument('--headless') unless ENV['HEADLESS'] == 'false'
-  options.add_argument('--no-sandbox')
-  options.add_argument('--disable-dev-shm-usage')
-  options.add_argument('--disable-gpu')
-  options.add_argument('--window-size=1400,1400')
+  options.add_argument("--headless") unless ENV["HEADLESS"] == "false"
+  options.add_argument("--no-sandbox")
+  options.add_argument("--disable-dev-shm-usage")
+  options.add_argument("--disable-gpu")
+  options.add_argument("--window-size=1400,1400")
 
   Capybara::Selenium::Driver.new(app, browser: :chrome, options:)
 end

--- a/spec/system/claims/view_organisations_spec.rb
+++ b/spec/system/claims/view_organisations_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe "View organisations", type: :system do
+  around do |example|
+    Capybara.app_host = "https://#{ENV["CLAIMS_HOST"]}"
+    example.run
+    Capybara.app_host = nil
+  end
+
+  scenario "I sign in as persona Mary with multiple organistions" do
+    persona = given_the_claims_persona("Mary")
+    and_persona_has_multiple_organisations(persona)
+    when_i_visit_claims_personas
+    when_i_click_sign_in(persona)
+    i_can_see_a_list_marys_claims_organisations(persona)
+  end
+
+  scenario "I sign in as persona Anne with one organisation" do
+    persona = given_the_claims_persona("Anne")
+    and_persona_has_one_organisation(persona)
+    when_i_visit_claims_personas
+    when_i_click_sign_in(persona)
+    i_am_redirected_to_the_root_path
+  end
+end
+
+private
+
+def given_the_claims_persona(persona_name)
+  create(:persona, persona_name.downcase.to_sym, service: "claims")
+end
+
+def and_persona_has_multiple_organisations(persona)
+  school1 = create(:school)
+  school2 = create(:school)
+  create(:membership, user: persona, organisation: school1)
+  create(:membership, user: persona, organisation: school2)
+end
+
+def and_persona_has_one_organisation(persona)
+  create(:membership, user: persona, organisation: create(:school))
+end
+
+def when_i_visit_claims_personas
+  visit personas_path
+end
+
+def when_i_click_sign_in(persona)
+  click_on "Sign In as #{persona.first_name}"
+end
+
+def i_can_see_a_list_marys_claims_organisations(persona)
+  expect(page).to have_content("Organisations")
+  expect(page).to have_content(persona.schools.first.name)
+  expect(page).to have_content(persona.schools.last.name)
+end
+
+def i_am_redirected_to_the_root_path
+  expect(page).to have_content("It works!")
+end

--- a/spec/system/placements/view_organisations_spec.rb
+++ b/spec/system/placements/view_organisations_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe "View organisations", type: :system do
+  around do |example|
+    Capybara.app_host = "https://#{ENV["PLACEMENTS_HOST"]}"
+    example.run
+    Capybara.app_host = nil
+  end
+
+  scenario "I sign in as persona Mary with multiple organistions" do
+    persona = given_the_placements_persona("Mary")
+    and_persona_has_multiple_organisations(persona)
+    when_i_visit_placements_personas
+    when_i_click_sign_in(persona)
+    i_can_see_a_list_marys_placements_organisations(persona)
+  end
+
+  scenario "I sign in as persona Anne with one organisation" do
+    persona = given_the_placements_persona("Anne")
+    and_persona_has_one_organisation(persona)
+    when_i_visit_placements_personas
+    when_i_click_sign_in(persona)
+    i_am_redirected_to_the_root_path
+  end
+end
+
+private
+
+def given_the_placements_persona(persona_name)
+  create(:persona, persona_name.downcase.to_sym, service: "placements")
+end
+
+def and_persona_has_multiple_organisations(persona)
+  school1 = create(:school)
+  provider = create(:provider)
+  create(:membership, user: persona, organisation: school1)
+  create(:membership, user: persona, organisation: provider)
+end
+
+def and_persona_has_one_organisation(persona)
+  create(:membership, user: persona, organisation: create(:school))
+end
+
+def when_i_visit_placements_personas
+  visit personas_path
+end
+
+def when_i_click_sign_in(persona)
+  click_on "Sign In as #{persona.first_name}"
+end
+
+def i_can_see_a_list_marys_placements_organisations(persona)
+  expect(page).to have_content("Organisations")
+  expect(page).to have_content("Schools")
+  expect(page).to have_content("Providers")
+  expect(page).to have_content(persona.schools.first.name)
+  expect(page).to have_content(persona.providers.first.provider_code)
+end
+
+def i_am_redirected_to_the_root_path
+  expect(page).to have_content("It works!")
+end

--- a/spec/tasks/gias_update_spec.rb
+++ b/spec/tasks/gias_update_spec.rb
@@ -11,7 +11,7 @@ describe "gias_update" do
     tempfile = Tempfile.new("foo")
 
     expect(Down).to receive(:download).with(
-      "#{ENV["GIAS_CSV_BASE_URL"]}/#{gias_filename}"
+      "#{ENV["GIAS_CSV_BASE_URL"]}/#{gias_filename}",
     ).and_return(tempfile)
 
     expect(GiasCsvImporter).to receive(:call).with(tempfile.path)

--- a/spec/views/erb_safety_check_spec.rb
+++ b/spec/views/erb_safety_check_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "ERB Safety Check" do
 
   erb_glob =
     Rails.root.join(
-      "app/views/**/{*.htm,*.html,*.htm.erb,*.html.erb,*.html+*.erb}"
+      "app/views/**/{*.htm,*.html,*.htm.erb,*.html.erb,*.html+*.erb}",
     )
 
   Dir[erb_glob].each do |filename|


### PR DESCRIPTION
## Context

We want an organisation index for each service.
This index page will be shown to the user after he sigin in as a
persona only if the user has multiple organisations.

An organisation can be a school or a provider, the Membership
polymorphic table handles this.

The Placements service will show both schools and providers, the claims
only schools.

## Changes

Migrations to create the memberships table
Separate organisations controllers
Separate organisation index views
Update seed file

## Guidance for review

- The links on the org index pages don't go anywhere, they will probably be implemented when we have show pages for the organisations.
- The placements organisation index page shows providers, not sure if this is correct, someone from placements should tell us.
- If you want to pull this on local please run `bin/setup` or `rake db:seed` after.

## Link to Trello card

https://trello.com/c/1Wl6xPgw/76-if-a-user-belongs-to-multiple-organisations-they-should-be-redirected-to-a-list-of-their-organisations-after-sign-in

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/b9d79e61-637b-4238-99fc-e4829528a678


