### PR TITLE
Remove deprecation notice from tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,7 +34,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = Rails.root.join("spec/fixtures")
+  # config.fixture_paths = [Rails.root.join("spec/fixtures")]
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
The following deprecation notice was being shown when running the RSpec test suite:

```
Rails 7.1 has deprecated the singular fixture_path in favour of an array
```

We should set `config.fixture_paths = []` instead of `config.fixture_path`.

However, we don't actually use ActiveRecord fixtures. We prefer to use FactoryBot. So I've fixed the deprecation, but then have commented out the line since it's not something we use.

If we need to enable it in the future, I've fixed the deprecation notice so we should be able to simply uncomment the line.