### PR TITLE
Update bundler platforms to include all versions of arm64-darwin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -504,7 +504,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
-  arm64-darwin-23
+  arm64-darwin
   x86_64-darwin-22
   x86_64-linux
 


### PR DESCRIPTION
## Context

Different Apple Silicon & MacOS versions have different platform versions. With the different machines we are working on as a team, conflicts often occur.

## Changes proposed in this pull request

Change the bundle platform to support all versions of `arm64-darwin`.

## Guidance to review

Try running `bundle install` on any Apple Silicon Mac and it should not error nor update the platforms list.

## Link to Trello card

https://trello.com/c/livsdvzX/84-update-gemfilelock-platforms-list-to-support-all-macs

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
