### PR TITLE
Configure Capybara to use rack_test driver by default in system specs

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,30 @@
+require 'capybara/rspec'
+
+# Use different Capybara ports when running tests in parallel
+if ENV['TEST_ENV_NUMBER']
+  Capybara.server_port = 9887 + ENV['TEST_ENV_NUMBER'].to_i
+end
+
+Capybara.register_driver :chrome_headless do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+
+  options.add_argument('--headless') unless ENV['HEADLESS'] == 'false'
+  options.add_argument('--no-sandbox')
+  options.add_argument('--disable-dev-shm-usage')
+  options.add_argument('--disable-gpu')
+  options.add_argument('--window-size=1400,1400')
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options:)
+end
+
+Capybara.javascript_driver = :chrome_headless
+
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    if self.class.metadata[:js] == true
+      driven_by(:chrome_headless)
+    else
+      driven_by(:rack_test)
+    end
+  end
+end


### PR DESCRIPTION
## Context

We want to configure Capybara to use the `:rack_test` driver by default and the `:chrome_headless` driver when js is required.

## Changes proposed in this pull request

Add Capybara configuration.

## Guidance to review

BAT reference can be found here: https://github.com/DFE-Digital/apply-for-teacher-training/blob/dd2212514ff076ddb6b423bdfac31615a7013406/spec/support/capybara.rb

## Link to Trello card

https://trello.com/c/Bq7BJB6G/85-add-capybara-configuration?filter=label:Dev

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
