### PR TITLE
Add link to Add Organisation

### DIFF
--- a/app/views/placements/support/organisations/index.html.erb
+++ b/app/views/placements/support/organisations/index.html.erb
@@ -1,6 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t("organisations") %></h1>
+    <%= govuk_button_to(t("add_organisation"), new_placements_support_provider_path, method: :get) %>
 
     <% if @schools.any? %>
       <h2 class="govuk-heading-l"><%= t("schools") %></h2>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,7 @@ en:
           attributes:
             provider_code:
               taken: Provider already exists
+  add_organisation: Add organsiation
   organisations: Organisations
   schools: Schools
   providers: Providers


### PR DESCRIPTION
## Context

Currently Support Users (Placements) can't access the Provider search/add pages unless the know the URL.

## Changes proposed in this pull request

Add a button to the Placements Support Organisation page, to allow Users to easily access the Provider pages.

## Guidance to review

Click the "Add Organisation" button. This should redirect the user to the Provider Search page.

## Link to Trello card

https://trello.com/c/kbAPMIAD/86-add-links-for-add-organisation-to-support-user-homepage

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots
![screencapture-placements-localhost-3000-support-organisations-2024-01-02-11_22_45](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/6981e9d0-1478-4cc0-88eb-7dc729e597ee)


