### PR TITLE
Test unhappy path for sign in placements support user

### DIFF
--- a/spec/features/personas/sign_in_as_a_placements_user_persona_spec.rb
+++ b/spec/features/personas/sign_in_as_a_placements_user_persona_spec.rb
@@ -12,6 +12,7 @@ feature "Sign In as a Placements User Persona" do
     when_i_visit_the_personas_page
     then_i_see_the_persona_for("Anne")
     when_i_click_sign_in_as("Anne")
+    then_i_dont_get_redirected_to_support_organisations
     and_i_visit_my_account_page
     then_i_see_persona_details_for_anne
   end
@@ -30,6 +31,7 @@ feature "Sign In as a Placements User Persona" do
     when_i_visit_the_personas_page
     then_i_see_the_persona_for("Mary")
     when_i_click_sign_in_as("Mary")
+    then_i_dont_get_redirected_to_support_organisations
     and_i_visit_my_account_page
     then_i_see_persona_details_for_mary
   end
@@ -79,6 +81,10 @@ def then_i_see_a_list_of_organisations
   expect(current_path).to eq placements_support_organisations_path
   expect(page).to have_content("Placement School")
   expect(page).to have_content("PROVIDER_CODE")
+end
+
+def then_i_dont_get_redirected_to_support_organisations
+  expect(current_path).not_to eq placements_support_organisations_path
 end
 
 def then_i_see_persona_details_for_anne


### PR DESCRIPTION
## Context

This follows on from:
https://trello.com/c/9QbPxRYT/65-login-as-a-support-user-and-see-organisations

That card introduced the concept of authorising users to make sure they’re allowed to access the support pages.

Test coverage was added for the ‘happy path’ here:
https://github.com/DFE-Digital/itt-mentor-services/pull/42/files#diff-16ef8afeb06e825ad8f0273956ec59c3b035897c63887ee09dfc5635b2becad8

However the ‘unhappy path’ has not been covered yet.

## Changes proposed in this pull request

Change sign_in_as_a_placements_user_persona_spec.rb file

## Guidance to review

Review changes

## Link to Trello card

https://trello.com/c/BTZ50gR8/83-add-test-coverage-for-unauthorised-users-trying-to-access-the-placements-support-area

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

