### PR TITLE
Use Rails.logger instead of Logger

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ PLACEMENTS_HOST=placements.localhost
 CLAIMS_HOST=claims.localhost
 GIAS_CSV_BASE_URL=https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public
 PUBLISH_BASE_URL=https://www.publish-teacher-training-courses.service.gov.uk
+RAILS_LOG_TO_STDOUT=true

--- a/app/services/gias_csv_importer.rb
+++ b/app/services/gias_csv_importer.rb
@@ -5,11 +5,10 @@ class GiasCsvImporter
   OPEN_SCHOOL = "1".freeze
   NON_ENGLISH_ESTABLISHMENTS = %w[8 10 25 24 26 27 29 30 32 37 49 56 57].freeze
 
-  attr_reader :csv_path, :logger
+  attr_reader :csv_path
 
   def initialize(csv_path)
     @csv_path = csv_path
-    @logger = Logger.new($stdout)
   end
 
   def call
@@ -37,10 +36,13 @@ class GiasCsvImporter
       end
 
     if invalid_records.any?
-      logger.info "Invalid rows - #{invalid_records.inspect}"
+      Rails.logger.info "Invalid rows - #{invalid_records.inspect}"
     end
-    GiasSchool.upsert_all(records, unique_by: :urn)
-    logger.info "Done!"
+    Rails.logger.silence do
+      GiasSchool.upsert_all(records, unique_by: :urn)
+    end
+
+    Rails.logger.info "Done!"
   end
 
   private

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -64,4 +64,10 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+  #
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger = ActiveSupport::Logger.new($stdout)
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
 end

--- a/lib/tasks/gias_update.rake
+++ b/lib/tasks/gias_update.rake
@@ -1,14 +1,13 @@
 desc "Upsert GIAS data into GiasSchool"
 task gias_update: :environment do
-  logger = Logger.new($stdout)
   today = Time.zone.today.strftime("%Y%m%d")
   gias_filename = "edubasealldata#{today}.csv"
 
-  logger.info "Downloading the new gias file for #{Time.zone.today}"
+  Rails.logger.info "Downloading the new gias file for #{Time.zone.today}"
   tempfile = Down.download("#{ENV["GIAS_CSV_BASE_URL"]}/#{gias_filename}")
-  logger.info "Done!"
+  Rails.logger.info "Done!"
 
-  logger.info "Importing data"
+  Rails.logger.info "Importing data"
   GiasCsvImporter.call(tempfile.path)
 
   tempfile.unlink

--- a/spec/services/gias_csv_importer_spec.rb
+++ b/spec/services/gias_csv_importer_spec.rb
@@ -13,10 +13,9 @@ RSpec.describe GiasCsvImporter do
   end
 
   it "logs messages to STDOUT" do
-    expect { subject }.to output(
-      match(/Done!/).and(match(/Invalid rows - /)).and(
-        match(/Row 5 is invalid/),
-      ),
-    ).to_stdout
+    expect(Rails.logger).to receive(:info).with("Invalid rows - [\"Row 5 is invalid\"]")
+    expect(Rails.logger).to receive(:info).with("Done!")
+
+    subject
   end
 end


### PR DESCRIPTION
## Context

Previously with `Logger`, there was noise added to the terminal when running the specs. Because of this we want to use Rails.logger instead, in production and development

## Changes proposed in this pull request

- New env variable to print logs to STDOUT
- Dev env logger in line with production
- Temporarily silent the Active Record logger when upserting all the GiasSchools, This only adds noise to the logs when running the `gias_update` task in production.

## Guidance to review

Run rspec on local and there should be no logs from the Gias Import

## Link to Trello card

https://trello.com/c/HWeQQRQT/94-user-rails-logger

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots


- Ignore the auth logs

- Before:
![Screenshot from 2024-01-02 17-27-30](https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/b757fe1b-dff6-46a7-9a38-af1fb8ccadc6)


- After:
![Screenshot from 2024-01-02 17-26-09](https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/b800206e-cdf8-45be-ada0-8584215cbb8e)

