### PR TITLE
Update Capybara

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,3 +1,5 @@
+OmniAuth.config.logger = Rails.logger
+
 # Implementation inspired by register-trainee-teachers repo
 case ENV.fetch("SIGN_IN_METHOD")
 when "persona"

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -7,26 +7,22 @@ end
 
 Capybara.always_include_port = true
 
-Capybara.register_driver :chrome_headless do |app|
-  options = Selenium::WebDriver::Chrome::Options.new
-
-  options.add_argument("--headless") unless ENV["HEADLESS"] == "false"
-  options.add_argument("--no-sandbox")
-  options.add_argument("--disable-dev-shm-usage")
-  options.add_argument("--disable-gpu")
-  options.add_argument("--window-size=1400,1400")
+Capybara.register_driver :selenium_chrome_headless do |app|
+  options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
+    opts.add_argument("--headless=new")
+    opts.add_argument("--no-sandbox")
+    opts.add_argument("--disable-dev-shm-usage")
+    opts.add_argument("--disable-gpu")
+    opts.add_argument("--window-size=1400,1400")
+  end
 
   Capybara::Selenium::Driver.new(app, browser: :chrome, options:)
 end
 
-Capybara.javascript_driver = :chrome_headless
+Capybara.javascript_driver = :selenium_chrome_headless
 
 RSpec.configure do |config|
   config.before(:each, type: :system) do
-    if self.class.metadata[:js] == true
-      driven_by(:chrome_headless)
-    else
-      driven_by(:rack_test)
-    end
+    driven_by Capybara.current_driver
   end
 end

--- a/spec/system/claims/view_organisations_spec.rb
+++ b/spec/system/claims/view_organisations_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "View organisations", type: :system do
   around do |example|
-    Capybara.app_host = "https://#{ENV["CLAIMS_HOST"]}"
+    Capybara.app_host = "http://#{ENV["CLAIMS_HOST"]}"
     example.run
     Capybara.app_host = nil
   end

--- a/spec/system/placements/providers/support_user_adds_a_provider_spec.rb
+++ b/spec/system/placements/providers/support_user_adds_a_provider_spec.rb
@@ -1,9 +1,6 @@
 require "rails_helper"
 
-# Changing type from feature => system stops the javascript working.
-# Will attempt to resolve in another PR.
-RSpec.describe "Placements / Providers / Support User adds a Provider",
-               type: :feature do
+RSpec.describe "Placements / Providers / Support User adds a Provider", type: :system, js: true do
   before do
     next_year = Time.current.next_year.year
 

--- a/spec/system/placements/view_organisations_spec.rb
+++ b/spec/system/placements/view_organisations_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "View organisations", type: :system do
   around do |example|
-    Capybara.app_host = "https://#{ENV["PLACEMENTS_HOST"]}"
+    Capybara.app_host = "http://#{ENV["PLACEMENTS_HOST"]}"
     example.run
     Capybara.app_host = nil
   end


### PR DESCRIPTION
## Context

In preparation for the `capybara-screenshot` gem, I found that the screenshot gem was not taking image screenshots. Ref: https://github.com/mattheworiordan/capybara-screenshot/issues/211#issuecomment-321857907

Upon investigation, I also found that we had a system spec not running javascript. This PR also addresses this issue.

## Changes proposed in this pull request

- Setup RSpec to refer to Capybara's current driver
- Configure OmniAuth to use Rails' default logger and avoid RSpec results clutter
- Add `js: true` in Javascript-dependent system specs
- Use the `--headless=new` argument in the Selenium Chrome driver based on https://developer.chrome.com/docs/chromium/new-headless
- Change `https` to `http` in Capybara host in system specs

## Guidance to review

Try running `bundle exec rspec` locally.

## Link to Trello card

https://trello.com/c/mzC6njCy/95-fix-javascript-dependent-system-specs

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

![CleanShot 2024-01-02 at 17 12 24@2x](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/8ebd1d5a-f829-476f-8a96-ce3f1ac63d98)

