### PR TITLE
Create Claims support users index page

### DIFF
--- a/app/controllers/claims/support/schools_controller.rb
+++ b/app/controllers/claims/support/schools_controller.rb
@@ -1,2 +1,9 @@
 class Claims::Support::SchoolsController < Claims::Support::ApplicationController
+  def index
+    @schools = Claims::School.includes(:gias_school).order("gias_schools.name ASC")
+  end
+
+  def show
+    @school = Claims::School.find(params.require(:id))
+  end
 end

--- a/app/controllers/claims/support/users_controller.rb
+++ b/app/controllers/claims/support/users_controller.rb
@@ -1,2 +1,13 @@
 class Claims::Support::UsersController < Claims::Support::ApplicationController
+  before_action :set_school
+
+  def index
+    @users = @school.users
+  end
+
+  private
+
+  def set_school
+    @school = Claims::School.find(params[:school_id])
+  end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -18,6 +18,7 @@
 class School < ApplicationRecord
   belongs_to :gias_school, foreign_key: :urn, primary_key: :urn
   has_many :memberships, as: :organisation
+  has_many :users, through: :memberships
 
   validates :urn, presence: true
   validates :urn, uniqueness: { case_sensitive: false }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,4 +37,8 @@ class User < ApplicationRecord
   validates :email, uniqueness: { scope: :service, case_sensitive: false }
 
   scope :support_users, -> { where(support_user: true) }
+
+  def full_name
+    "#{first_name} #{last_name}".strip
+  end
 end

--- a/app/views/claims/support/schools/index.html.erb
+++ b/app/views/claims/support/schools/index.html.erb
@@ -1,5 +1,16 @@
-Support / Schools
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t("organisations") %></h1>
 
-<ul>
-  <li><%= link_to "School 1", claims_support_school_path(1) %></li>
-</ul>
+    <% if @schools.any? %>
+      <h2 class="govuk-heading-l"><%= t("schools") %></h2>
+      <ul class="govuk-list">
+        <% @schools.each do |school| %>
+        <li>
+          <%= govuk_link_to school.name, request.env["PATH_INFO"], no_visited_state: true %>
+        </li>
+        <% end %>
+      </ul>
+    <% end %>
+  </div>
+</div>

--- a/app/views/claims/support/users/index.html.erb
+++ b/app/views/claims/support/users/index.html.erb
@@ -1,1 +1,22 @@
-Support / Users
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+  </div>
+</div>
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header"><%= t(".attributes.users.name") %></th>
+      <th scope="col" class="govuk-table__header"><%= t(".attributes.users.email") %></th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% @users.each do |user| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><%= user.full_name %></td>
+        <td class="govuk-table__cell"><%= user.email %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,7 @@ en:
   add_organisation: Add organsiation
   organisations: Organisations
   schools: Schools
+  organisation_details: Organisation details
   providers: Providers
   account:
     index:
@@ -55,3 +56,12 @@ en:
     placements:
       heading: Placements news and updates
     contents: Contents
+  claims:
+    support:
+      users:
+        index:
+          heading: Users
+          attributes:
+            users:
+              name: Name
+              email: Email

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -6,9 +6,9 @@ scope module: :claims, as: :claims, constraints: { host: ENV["CLAIMS_HOST"] } do
   namespace :support do
     root to: redirect("/support/schools")
 
-    resources :schools do
+    resources :schools, only: %i[index show] do
       resources :claims
-      resources :users
+      resources :users, only: [:index]
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -40,4 +40,10 @@ FactoryBot.define do
           parent: :user do
     service { "placements" }
   end
+
+  factory :claims_support_user,
+          class: "Claims::SupportUser",
+          parent: :user do
+    service { "claims" }
+  end
 end

--- a/spec/system/claims/view_users_of_a_school_spec.rb
+++ b/spec/system/claims/view_users_of_a_school_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "View users for school", type: :system do
+  before do
+    setup_school_and_anne_membership
+  end
+
+  scenario "I sign in as a support user and view a schools users index page" do
+    sign_in_as_support_user
+    visit_claims_support_school_users_page
+    verify_users_list_for_school
+  end
+
+  private
+
+  def setup_school_and_anne_membership
+    @school = create(:school, :claims, urn: "123456")
+    @anne_persona = create(:persona, :anne, service: "claims")
+    create(:membership, user: @anne_persona, organisation: @school)
+  end
+
+  def sign_in_as_support_user
+    create(:persona, :colin, service: "claims")
+    visit personas_path
+    click_on "Sign In as Colin"
+  end
+
+  def visit_claims_support_school_users_page
+    visit claims_support_school_users_path(@school)
+  end
+
+  def verify_users_list_for_school
+    expect(page).to have_content("Anne Wilson")
+    expect(page).to have_content("anne_wilson@example.org")
+  end
+end


### PR DESCRIPTION
## Context

This change is to add a support users page for a school, so as a support user I can login go to a schools page then visit the users page to view all users for a given school example url: `http://claims.localhost:3000/support/schools/7911aadb-cd18-41de-a315-990e61890db0/users`

## Changes proposed in this pull request

<img width="1728" alt="Screenshot 2024-01-03 at 06 59 17" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/59a9ee63-95c8-45b2-a772-750c68bb4612">

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/PTkum8z5/52-as-a-support-user-i-should-be-able-to-see-the-list-of-users-within-a-school-organisation

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
