### PR TITLE
Silence deprecation warning by monkey-patching Rack for Capybara

### DIFF
--- a/config/initializers/capybara.rb
+++ b/config/initializers/capybara.rb
@@ -1,0 +1,9 @@
+# https://github.com/teamcapybara/capybara/issues/2705#issuecomment-1752093026
+
+if Rails.env.test?
+  require "rackup"
+
+  module Rack
+    Handler = ::Rackup::Handler
+  end
+end


### PR DESCRIPTION
## Context

RSpec reports are currently interrupted by a deprecation warning coming from Capybara.

## Changes proposed in this pull request

Monkey-patch the `Rack::Handler` to `Rackup::Handler` when `Rails.env.test?` is `true`.

## Guidance to review

Try running `bundle exec rspec`. There should no longer be any logs interrupting the report.

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

Beautiful!

![CleanShot 2024-01-03 at 17 11 20@2x](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/5c62e989-50ea-468d-a9ea-9e57b4ee26a7)
