### PR TITLE
Add foundational CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+app/*/claims @DFE-Digital/track-pay
+spec/*/claims @DFE-Digital/track-pay
+
+app/*/placements  @DFE-Digital/school-placements
+spec/*/placements @DFE-Digital/school-placements


### PR DESCRIPTION
## Context

- We want to reduce manual effort required from developers when requesting reviews.
- We also want to ensure that the relevant parties are notified about PRs that are ready for review.

## Changes proposed in this pull request

Add a foundational `CODEOWNERS` file to kick off ownership of files we know to belong to a specific team. Shared code is still in limbo.

## Guidance to review

![CleanShot 2024-01-04 at 15 19 42](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/0a018225-49bd-4867-b674-24393736877b)

This will need to be merged in before GitHub will start automatically requesting reviews as it needs to be on the base branch of the PR.

> If you create a pull request from a fork, and the base branch is in the upstream repository, then the pull request will use the CODEOWNERS file from that branch in the upstream repository. If the base branch is a branch within your fork, then the pull request will use the CODEOWNERS file from that branch in your fork, but this will only trigger review requests if the code owners are added to your fork specifically with write access.
> -- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-and-forks

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Next Steps

We can check the option in branch protection settings if we want to enforce CODEOWNER reviews.

![CleanShot 2024-01-04 at 15 18 43](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/ab9f2e81-a7e9-42e6-9998-6acd99634d3b)

