### PR TITLE
Store failure screenshots as test artifacts in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,3 +97,10 @@ jobs:
           bundle exec rake db:create
           bundle exec rails db:schema:load
           bundle exec rspec --format progress
+      - name: Upload failure screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: failure-screenshots
+          path: tmp/capybara/
+          if-no-files-found: ignore


### PR DESCRIPTION
## Context

When system tests fail, Capybara automatically takes a screenshot of the page to help developers debug the context of the failure. This was introduced in 6ca32a1c3189c480ffa589c6116c3ad8f0acbc9d.

## Changes proposed in this pull request

This commit configures the GitHub Actions CI job to store those screenshots as test artifacts. This makes them available to developers following a failed build.

This implementation was inspired by DFE-Digital/apply-for-teacher-training#8848 (thanks!)

## Guidance to review

1. Here's an example test failure:  
https://github.com/DFE-Digital/itt-mentor-services/actions/runs/7425203018
2. Scroll to the bottom of the page and you'll see an 'Artifacts' section with a 'failure-screenshots' file.
3. Download the file and open it to see the screenshots.

## Link to Trello card

https://trello.com/c/4UcgqmW7/100-store-failure-screenshots-as-test-artefacts-in-github-actions

## Screenshots

![Screenshot of the example test failure](https://github.com/DFE-Digital/itt-mentor-services/assets/7735945/c72fe845-d9a4-4c24-9035-b12586582bf9)

