### PR TITLE
Default to "persona" sign in method

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,7 +1,7 @@
 OmniAuth.config.logger = Rails.logger
 
 # Implementation inspired by register-trainee-teachers repo
-case ENV.fetch("SIGN_IN_METHOD")
+case ENV.fetch("SIGN_IN_METHOD", "persona")
 when "persona"
   Rails
     .application

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,8 +11,7 @@ Rails.application.routes.draw do
   get "/sign-in", to: "sessions#new", as: :sign_in
 
   # Persona Sign In
-  case ENV.fetch("SIGN_IN_METHOD")
-  when "persona"
+  if ENV.fetch("SIGN_IN_METHOD", "persona") == "persona"
     get "/personas", to: "personas#index"
     get "/auth/developer/sign-out", to: "sessions#destroy", as: :sign_out
     post "/auth/developer/callback", to: "sessions#callback", as: :auth_callback


### PR DESCRIPTION
## Context

When the `SIGN_IN_METHOD` environment variable isn't set, fallback to persona based sign in.

This resolves an issue where the docker image could not be built because the `assets:precompile` step was failing with the error:

```
> [builder 10/11] RUN RAILS_ENV=production SECRET_KEY_BASE=required-to-run-but-not-used     bundle exec rails assets:precompile:
16 11.84 bin/rails aborted!
16 11.85 KeyError: key not found: "SIGN_IN_METHOD" (KeyError)
16 11.85 /app/config/initializers/omniauth.rb:4:in `fetch'
16 11.85 /app/config/initializers/omniauth.rb:4:in `<main>'
16 11.85 /app/config/environment.rb:5:in `<main>'
16 11.85 Tasks: TOP => assets:precompile => environment
16 11.85 (See full trace by running task with --trace)
```

## Guidance to review

1. Check out this branch.
2. Try building the app as a Docker image:
    ```
    docker build --platform linux/amd64 -t itt-mentor-services .
    ```
3. It should succeed without errors.