### PR TITLE
Redirect users to organisations index/show after sign in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,10 +25,8 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path
     if current_user.support_user?
       support_root_path
-    elsif current_user.memberships.many?
-      organisation_index_path
     else
-      root_path
+      organisations_path
     end
   end
 

--- a/app/controllers/claims/schools_controller.rb
+++ b/app/controllers/claims/schools_controller.rb
@@ -1,5 +1,15 @@
 class Claims::SchoolsController < ApplicationController
+  before_action :redirect_to_school_when_belongs_to_one_school, only: :index
+
   def index
     @schools = current_user.schools
+  end
+
+  private
+
+  def redirect_to_school_when_belongs_to_one_school
+    if current_user.schools.one?
+      redirect_to claims_school_path(current_user.schools.first)
+    end
   end
 end

--- a/app/helpers/routes_helper.rb
+++ b/app/helpers/routes_helper.rb
@@ -13,7 +13,7 @@ module RoutesHelper
     }.fetch current_service
   end
 
-  def organisation_index_path
+  def organisations_path
     {
       claims: claims_schools_path,
       placements: placements_organisations_path,

--- a/app/views/claims/schools/index.html.erb
+++ b/app/views/claims/schools/index.html.erb
@@ -6,7 +6,7 @@
       <ul class="govuk-list">
         <% @schools.each do |school| %>
           <li>
-           <%= govuk_link_to school.name, request.env["PATH_INFO"], no_visited_state: true %>
+           <%= govuk_link_to school.name, claims_school_path(school), no_visited_state: true %>
           </li>
         <% end %>
       </ul>

--- a/app/views/claims/support/schools/index.html.erb
+++ b/app/views/claims/support/schools/index.html.erb
@@ -9,7 +9,7 @@
       <ul class="govuk-list">
         <% @schools.each do |school| %>
         <li>
-          <%= govuk_link_to school.name, request.env["PATH_INFO"], no_visited_state: true %>
+          <%= govuk_link_to school.name, claims_school_path(school), no_visited_state: true %>
         </li>
         <% end %>
       </ul>

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Sessions", type: :request do
       expect(response).to have_http_status(:success)
       # TODO: Change render_template once redirect to service specific
       # roots implemented
-      expect(response).to render_template("claims/pages/index")
+      expect(response).to render_template("claims/schools/index")
     end
   end
 end

--- a/spec/system/claims/view_organisations_spec.rb
+++ b/spec/system/claims/view_organisations_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "View schools", type: :system do
     and_persona_has_multiple_schools(persona)
     when_i_visit_claims_personas
     when_i_click_sign_in(persona)
-    i_can_see_a_list_marys_claims_schools(persona)
+    i_am_redirected_to_organisation_index(persona)
   end
 
   scenario "I sign in as persona Anne with one school" do
@@ -20,7 +20,7 @@ RSpec.describe "View schools", type: :system do
     and_persona_has_one_school(persona)
     when_i_visit_claims_personas
     when_i_click_sign_in(persona)
-    i_am_redirected_to_the_root_path
+    i_am_redirected_to_organisation_index(persona)
   end
 
   private
@@ -48,13 +48,15 @@ RSpec.describe "View schools", type: :system do
     click_on "Sign In as #{persona.first_name}"
   end
 
-  def i_can_see_a_list_marys_claims_schools(persona)
-    expect(page).to have_content("Organisations")
-    expect(page).to have_content(persona.schools.first.name)
-    expect(page).to have_content(persona.schools.last.name)
-  end
-
   def i_am_redirected_to_the_root_path
     expect(page).to have_content("Claim Funding for General Mentors")
+  end
+
+  def i_am_redirected_to_organisation_index(persona)
+    expect(page).to have_content("Organisations")
+
+    persona.schools.each do |school|
+      expect(page).to have_content(school.name)
+    end
   end
 end

--- a/spec/system/placements/view_organisations_spec.rb
+++ b/spec/system/placements/view_organisations_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "View organisations", type: :system do
     and_persona_has_multiple_organisations(persona)
     when_i_visit_placements_personas
     when_i_click_sign_in(persona)
-    i_can_see_a_list_marys_placements_organisations(persona)
+    i_am_redirected_to_organisation_index(persona)
   end
 
   scenario "I sign in as persona Anne with one organisation" do
@@ -20,7 +20,7 @@ RSpec.describe "View organisations", type: :system do
     and_persona_has_one_organisation(persona)
     when_i_visit_placements_personas
     when_i_click_sign_in(persona)
-    i_am_redirected_to_the_root_path
+    i_am_redirected_to_organisation_index(persona)
   end
 
   private
@@ -48,15 +48,18 @@ RSpec.describe "View organisations", type: :system do
     click_on "Sign In as #{persona.first_name}"
   end
 
-  def i_can_see_a_list_marys_placements_organisations(persona)
+  def i_am_redirected_to_organisation_index(persona)
     expect(page).to have_content("Organisations")
     expect(page).to have_content("Schools")
-    expect(page).to have_content("Providers")
-    expect(page).to have_content(persona.schools.first.name)
-    expect(page).to have_content(persona.providers.first.provider_code)
-  end
 
-  def i_am_redirected_to_the_root_path
-    expect(page).to have_content("It works!")
+    persona.schools.each do |school|
+      expect(page).to have_content(school.name)
+    end
+
+    expect(page).to have_content("Providers") if persona.providers.any?
+
+    persona.providers.each do |provider|
+      expect(page).to have_content(provider.provider_code)
+    end
   end
 end


### PR DESCRIPTION
## Context

In claims we need to redirect our users to the organisations index page. Some users do have only one organisation(school) so for those users we will redirect them to the school show page, we do this via another redirect in the schools controller just to make sure a user with one school doesn't land on the organisation(school) index page.

This change also affects placements where we will always redirect the user after sign in to the organisations index page, allowing placements to add their logic in their controllers

Also I didn't want to add too much logic in the application controller.

## Changes proposed in this pull request

Application controller
Scholl Controller

## Guidance to review
Claims:
- Sign in as a user with one organisation
- You should be redirected to the org show page
- Sign in as a multiple school user like Mary
- Should be redirected to org index page

Placements:
- Sign in as any user
- You should be redirected to org index page

## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/469c53af-1f29-488f-82d0-d9a0cb2b3ab9


