### PR TITLE
Remove school name from search box and add to error

### DIFF
--- a/app/controllers/claims/support/schools_controller.rb
+++ b/app/controllers/claims/support/schools_controller.rb
@@ -15,7 +15,7 @@ class Claims::Support::SchoolsController < Claims::Support::ApplicationControlle
     if school.valid? && !school.claims?
       @school = school.decorate
     else
-      school.errors.add(:urn, :taken) if school.claims?
+      school.errors.add(:urn, :already_added, school_name: school.name) if school.claims?
       render :new
     end
   end

--- a/app/controllers/placements/support/schools_controller.rb
+++ b/app/controllers/placements/support/schools_controller.rb
@@ -7,7 +7,7 @@ class Placements::Support::SchoolsController < Placements::Support::ApplicationC
     if school.valid? && !school.placements?
       @school = school.decorate
     else
-      school.errors.add(:urn, :taken) if school.placements?
+      school.errors.add(:urn, :already_added, school_name: school.name) if school.placements?
       render :new
     end
   end

--- a/app/javascript/autocomplete.js
+++ b/app/javascript/autocomplete.js
@@ -16,7 +16,6 @@ const initAutocomplete = (elementId, inputId, options = {}) => {
         id: input.id,
         showNoOptionsFound: true,
         name: input.name,
-        defaultValue: input.value,
         minLength,
         source: debounce(request(path), 900),
         templates: {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,7 +22,7 @@ en:
         school:
           attributes:
             urn:
-              taken: This school has already been added. Try another school
+              already_added: "%{school_name} has already been added. Try another school"
               blank: Enter a school name, URN or postcode
         user:
           attributes:

--- a/spec/system/claims/schools/support_user_adds_a_school_spec.rb
+++ b/spec/system/claims/schools/support_user_adds_a_school_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Support User adds a School", type: :system do
     then_i_see_a_dropdown_item_for("Claims School")
     when_i_click_the_dropdown_item_for("Claims School")
     and_i_click_continue
-    then_i_see_an_error("This school has already been added. Try another school")
+    then_i_see_an_error("Claims School has already been added. Try another school")
   end
 
   scenario "Colin submits the search form without selecting a school", js: true do

--- a/spec/system/placements/schools/support_user_adds_a_school_spec.rb
+++ b/spec/system/placements/schools/support_user_adds_a_school_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Placements / Schools / Support User adds a School",
     then_i_see_a_dropdown_item_for("Placements School")
     when_i_click_the_dropdown_item_for("Placements School")
     and_i_click_continue
-    then_i_see_an_error("This school has already been added. Try another school")
+    then_i_see_an_error("Placements School has already been added. Try another school")
   end
 
   scenario "Colin submits the search form without selecting a school", js: true do


### PR DESCRIPTION
## Context

To recreate bug: 
Login as a support user (either claims or placements) and Click Add an organisation
Search for a school that has already been added.
Click “Continue”
Click into the search box
Then you see `undefined (undefined undefined)` in the drop down

## Changes proposed in this pull request

Remove the default text from the search box as it is not useable (the search isn't run by default when the page reloads), and 
Add the school name to the error so we don't lose the context about which schools has already been added. 

## ACs

AS a support user
GIVEN I am logged in and on the add a school page
WHEN I Add a school that has already onboarded
AND I click into the search box again
THEN I should see the selected school in the error message
AND the search box should be empty
AND I should not see any search results when I click there (ie, I should not see not `undefined (undefined undefined)`)

## Limitations / Scope

There is another ticket to deal with the erroneous "can't be blank" error that shows up when you click continue without selecting a school. 
There is also a ticket to refactor the logic for this, and providers, so that we use a Form object instead of managing the errors in the controller.

## Guidance to review

Follow the steps above to recreate. But instead, you should see an empty search box and a descriptive error. When you click on the box, you won't see 'undefined (undefined undefined)

## Link to Trello card

https://trello.com/c/CD7HrkDz

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [NA] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [NA] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [NA] API release notes have been updated if necessary
- [NA] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [NA] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

### Before

https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/ee0a75ab-db45-4e93-95e6-7c5613681520

### After

https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/985c5b4f-72f9-4ac3-ae5a-023c997172a0


