### PR TITLE
As a Support User, I should be able to see the details of an individual user within a School Org

### DIFF
--- a/app/controllers/claims/support/users_controller.rb
+++ b/app/controllers/claims/support/users_controller.rb
@@ -5,6 +5,10 @@ class Claims::Support::UsersController < Claims::Support::ApplicationController
     @users = @school.users
   end
 
+  def show
+    @user = Claims::User.find(params.require(:id))
+  end
+
   def new
     @user = Claims::User.new
   end

--- a/app/views/claims/support/users/index.html.erb
+++ b/app/views/claims/support/users/index.html.erb
@@ -15,7 +15,7 @@
   <tbody class="govuk-table__body">
     <% @users.each do |user| %>
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell"><%= user.full_name %></td>
+        <td class="govuk-table__cell"><%= govuk_link_to user.full_name, claims_support_school_user_path(id: user.id) %></td>
         <td class="govuk-table__cell"><%= user.email %></td>
       </tr>
     <% end %>

--- a/app/views/claims/support/users/show.html.erb
+++ b/app/views/claims/support/users/show.html.erb
@@ -1,0 +1,25 @@
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: claims_support_school_users_path(@school)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h2 class="govuk-heading-l"><%= @user.full_name %></h2>
+
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"><%= t(".attributes.users.first_name") %></dt>
+        <dd class="govuk-summary-list__value"><%= @user.first_name %></dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"><%= t(".attributes.users.last_name") %></dt>
+        <dd class="govuk-summary-list__value"><%= @user.last_name %></dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"><%= t(".attributes.users.email") %></dt>
+        <dd class="govuk-summary-list__value"><%= @user.email %></dd>
+      </div>
+    </dl>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,6 +116,12 @@ en:
           title: Invite a new user
           caption: Add user
           description: Personal details
+        show:
+          attributes:
+            users:
+              first_name: First name
+              last_name: Last name
+              email: Email
         check:
           title: Check your answers
           caption: Add user

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -10,7 +10,7 @@ scope module: :claims, as: :claims, constraints: { host: ENV["CLAIMS_HOST"] } do
       collection { get :check }
 
       resources :claims
-      resources :users, only: %i[index new create] do
+      resources :users, only: %i[index new create show] do
         collection { get :check }
       end
     end

--- a/spec/system/claims/view_a_users_details.rb
+++ b/spec/system/claims/view_a_users_details.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe "View a users details", type: :system do
+  before do
+    setup_school
+    create_user
+    attach_user_to_school
+  end
+
+  scenario "I sign in as a support user and invite a user to a school" do
+    sign_in_as_support_user
+    visit_claims_support_school_users_page
+    verify_user_details
+  end
+
+  private
+
+  def setup_school
+    @school = create(:school, :claims, urn: "123456", name: "Test School")
+  end
+
+  def create_user
+    @user = create(:user, :claims, first_name: "Barry", last_name: "Garlow", email: "barry.garlow@gmail.com")
+  end
+
+  def attach_user_to_school
+    create(:membership, user: @user, organisation: @school)
+  end
+
+  def sign_in_as_support_user
+    create(:persona, :colin, service: "claims")
+    visit personas_path
+    click_on "Sign In as Colin"
+  end
+
+  def visit_claims_support_school_users_page
+    visit claims_support_school_user_path(id: @user.id, school_id: @school.id)
+  end
+
+  def verify_user_details
+    expect(page).to have_content("Test School")
+    expect(page).to have_content("First name Barry")
+    expect(page).to have_content("Last name Garlow")
+    expect(page).to have_content("Email barry.garlow@gmail.com")
+  end
+end


### PR DESCRIPTION
## Context

So we can view a users details

## Changes proposed in this pull request

We have added a new view so when you click on the user you can see a users details

## Guidance to review

- login as support user
- go to a school
- go to users page
- click on user

## Link to Trello card

https://trello.com/c/rvsFeMpl/62-as-a-support-user-i-should-be-able-to-see-the-details-of-an-individual-user-within-a-school-org

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots
<img width="1727" alt="Screenshot 2024-01-10 at 09 33 45" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/edc8d133-e131-44c7-bf01-e7ce40bded8b">

