### PR TITLE
Fill in the show page of a school.

### DIFF
--- a/app/controllers/claims/schools_controller.rb
+++ b/app/controllers/claims/schools_controller.rb
@@ -6,7 +6,7 @@ class Claims::SchoolsController < ApplicationController
   end
 
   def show
-    @school = Claims::School.find(params.require(:id))
+    @school = Claims::School.find(params.require(:id))&.decorate
   end
 
   private

--- a/app/views/claims/schools/_additional_details.html.erb
+++ b/app/views/claims/schools/_additional_details.html.erb
@@ -1,0 +1,58 @@
+<%= govuk_summary_list(html_attributes: { id: "additional-details" }) do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.group")) %>
+    <% row.with_value(**details_field_args(@school.group)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.type")) %>
+    <% row.with_value(**details_field_args(@school.type_of_establishment)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.phase")) %>
+    <% row.with_value(**details_field_args(@school.phase)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.gender")) %>
+    <% row.with_value(**details_field_args(@school.gender)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.minimum_age")) %>
+    <% row.with_value(**details_field_args(@school.minimum_age)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.maximum_age")) %>
+    <% row.with_value(**details_field_args(@school.maximum_age)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.religious_character")) %>
+    <% row.with_value(**details_field_args(@school.religious_character)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.admissions_policy")) %>
+    <% row.with_value(**details_field_args(@school.admissions_policy)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.urban_or_rural")) %>
+    <% row.with_value(**details_field_args(@school.urban_or_rural)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.school_capacity")) %>
+    <% row.with_value(**details_field_args(@school.school_capacity)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.total_pupils")) %>
+    <% row.with_value(**details_field_args(@school.total_pupils)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.total_boys")) %>
+    <% row.with_value(**details_field_args(@school.total_boys)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.total_girls")) %>
+    <% row.with_value(**details_field_args(@school.total_girls)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.percentage_free_school_meals")) %>
+    <% row.with_value(**details_field_args(@school.percentage_free_school_meals)) %>
+  <% end %>
+<% end %>

--- a/app/views/claims/schools/_contact_details.html.erb
+++ b/app/views/claims/schools/_contact_details.html.erb
@@ -1,0 +1,33 @@
+<%= govuk_summary_list(html_attributes: { id: "contact-details" }) do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.email_address")) %>
+    <% if @school.email_address.present? %>
+      <% row.with_value do %>
+        <%= govuk_mail_to(@school.email_address, @school.email_address) %>
+      <% end %>
+    <% else %>
+      <% row.with_value(**details_field_args) %>
+    <% end %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.telephone_number")) %>
+    <% row.with_value(**details_field_args(@school.telephone)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.website")) %>
+    <% if @school.website.present? %>
+      <% row.with_value do %>
+        <%= govuk_link_to(@school.website,
+                          external_link(@school.website),
+                          target: "_blank",
+                          rel: "noopener noreferrer") %>
+      <% end %>
+    <% else %>
+      <% row.with_value(**details_field_args) %>
+    <% end %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.address")) %>
+    <% row.with_value(**details_field_args(@school.formatted_address)) %>
+  <% end %>
+<% end %>

--- a/app/views/claims/schools/_ofsted_details.html.erb
+++ b/app/views/claims/schools/_ofsted_details.html.erb
@@ -1,0 +1,10 @@
+<%= govuk_summary_list(html_attributes: { id: "ofsted-details" }) do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.rating")) %>
+    <% row.with_value(**ofsted_field_args(@school.rating)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.last_inspection_date")) %>
+    <% row.with_value(**ofsted_field_args(@school.formatted_inspection_date)) %>
+  <% end %>
+<% end %>

--- a/app/views/claims/schools/_school_details.html.erb
+++ b/app/views/claims/schools/_school_details.html.erb
@@ -1,0 +1,14 @@
+<%= govuk_summary_list(html_attributes: { id: "school-details" }) do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.organisation_name")) %>
+    <% row.with_value(**details_field_args(@school.name)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.ukprn")) %>
+    <% row.with_value(**details_field_args(@school.ukprn)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.urn")) %>
+    <% row.with_value(**details_field_args(@school.urn)) %>
+  <% end %>
+<% end %>

--- a/app/views/claims/schools/_send_details.html.erb
+++ b/app/views/claims/schools/_send_details.html.erb
@@ -1,0 +1,14 @@
+<%= govuk_summary_list(html_attributes: { id: "send-details" }) do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.special_classes")) %>
+    <% row.with_value(**details_field_args(@school.special_classes)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.send_provision")) %>
+    <% row.with_value(**details_field_args(@school.send_provision)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("claims.schools.show.training_with_disabilities")) %>
+    <% row.with_value(**details_field_args(@school.training_with_disabilities)) %>
+  <% end %>
+<% end %>

--- a/app/views/claims/schools/show.html.erb
+++ b/app/views/claims/schools/show.html.erb
@@ -9,57 +9,23 @@
   <% end %>
 <% end %>
 
+<%= content_for :page_title, @school.name %>
 <%= navigation_bar %>
-<div class="govuk-grid-row">
-<br><br>
-    <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= t("claims.schools.show.heading") %></h1>
-    <%= govuk_summary_list do |summary_list|
-          summary_list.with_row do |row|
-            row.with_key(text: t("claims.schools.show.organisation_name"))
-            row.with_value(text: "Hogwarts")
-          end
-          summary_list.with_row do |row|
-            row.with_key(text: t("claims.schools.show.uk_provider_reference_number"))
-            row.with_value(text: "fake_uprn")
-          end
-          summary_list.with_row do |row|
-            row.with_key(text: t("claims.schools.show.unique_reference_number"))
-            row.with_value(text: 1)
-          end
-        end %>
 
-    <h2 class="govuk-heading-m govuk-!-margin-top-9">Contact details</h2>
-    <%= govuk_summary_list do |summary_list|
-        summary_list.with_row do |row|
-            row.with_key(text: t("claims.schools.show.email_address"))
-        row.with_value do %>
-        <a href="contact@example.com"><%= "mary@example.com" %></a>
-        <% end %>
-        <% row.with_action(text: t('claims.schools.show.change'), visually_hidden_text:  t("claims.schools.show.email_address"), href: '/contact-details')
-        end %>
-        <% summary_list.with_row do |row|
-             row.with_key(text: "Telephone number")
-             row.with_value(text: "0123456789")
-             row.with_action(text: t("claims.schools.show.change"), visually_hidden_text: t("claims.schools.show.email_address"), href: "/contact-details")
-           end %>
-        <% summary_list.with_row do |row|
-            row.with_key(text: 'Website')
-            row.with_value do %>
-            <a href="<%= "www.hogwarts.com" %>"><%= "www.hogwarts.com" %></a>
-            <% end;row.with_action(text: t('claims.schools.show.change'), visually_hidden_text:  t('claims.schools.show.email_address'), href: '/contact-details')
-            end %>
-            <% summary_list.with_row do |row|
-            row.with_key(text: t('claims.schools.show.address'))
-            row.with_value do %>
-            <p class="govuk-body">
-                <%= "Hogwarts Castle" %><br>
-                <%= "Scotland" %><br>
-                <%= "United Kingdom" %><br>
-            </p>
-            <% end %>
-            <% row.with_action(text:  t('claims.schools.show.change'), visually_hidden_text:  t('claims.schools.show.email_address'), href: '/contact-details')
-            end %>
-        <% end %>
-    </div>
+<div class="govuk-grid-row govuk-!-margin-top-7">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l"><%= t("claims.schools.show.heading") %></h1>
+  </div>
+
+    <div class="govuk-grid-column-two-thirds">
+    <%= render "school_details", school: @school %>
+    <h2 class="govuk-heading-m govuk-!-margin-top-9"><%= t(".additional_details") %></h2>
+    <%= render "additional_details", school: @school %>
+    <h2 class="govuk-heading-m govuk-!-margin-top-9"><%= t(".send") %></h2>
+    <%= render "send_details", school: @school %>
+    <h2 class="govuk-heading-m govuk-!-margin-top-9"><%= t(".ofsted") %></h2>
+    <%= render "ofsted_details", school: @school %>
+    <h2 class="govuk-heading-m govuk-!-margin-top-9"><%= t(".contact_details") %></h2>
+    <%= render "contact_details", school: @school %>
+  </div>
 </div>

--- a/config/locales/claims/en.yml
+++ b/config/locales/claims/en.yml
@@ -1,0 +1,39 @@
+en:
+  claims:
+    schools:
+      show:
+        heading: Organisation details
+        change_organisation: Change organisation
+        unknown: Unknown
+        not_entered: Not entered
+        not_applicable: Not applicable
+        additional_details: Additional details
+        organisation_name: Organisation name
+        ukprn: UK provider reference number (UKPRN)
+        urn: Unique reference number (URN)
+        group: Group
+        type: Type
+        phase: Phase
+        gender: Gender
+        minimum_age: Minimum age
+        maximum_age: Maximum age
+        religious_character: Religious character
+        admissions_policy: Admissions policy
+        urban_or_rural: Urban or rural
+        school_capacity: School capacity
+        total_pupils: Total pupils
+        total_boys: Total boys
+        total_girls: Total girls
+        percentage_free_school_meals: Percentage free school meals
+        send: Special educational needs and disabilities (SEND)
+        special_classes: Special classes
+        send_provision: SEND provision
+        training_with_disabilities: Training with disabilities
+        ofsted: Ofsted
+        rating: Rating
+        last_inspection_date: Last inspection date
+        contact_details: Contact details
+        email_address: Email address
+        telephone_number: Telephone number
+        website: Website
+        address: Address

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,16 +89,6 @@ en:
   claims:
     notify_message:
       invite_user_to_school: "Dear %{user_name} \n\n You have been invited to join the claims service for %{school_name}.\n\n Sign in here %{sign_in_url}"
-    schools:
-      show:
-        change_organisation: Change organisation
-        heading: Organisation details
-        organisation_name: Organisation name
-        uk_provider_reference_number: UK provider reference number (UKPRN)
-        unique_reference_number: Unique reference number (URN)
-        email_address: email address
-        change: Change
-        address: address
     support:
       users:
         index:

--- a/spec/system/claims/view_school_spec.rb
+++ b/spec/system/claims/view_school_spec.rb
@@ -1,12 +1,14 @@
 require "rails_helper"
 
 RSpec.describe "School Page", type: :system do
+  let(:school1) { create(:school, :claims, name: "School1") }
+  let(:school2) { create(:school, :claims, name: "School2") }
+
   scenario "User visits his school" do
     persona = given_there_is_an_existing_persona_for("Anne")
     when_i_visit_claims_personas
     when_i_click_sign_in(persona)
-    i_can_see_organisation_details
-    i_can_see_contact_details
+    then_i_see_the_school_details
   end
 
   scenario "User with multiple schools changes between them" do
@@ -16,13 +18,11 @@ RSpec.describe "School Page", type: :system do
     when_i_click_sign_in(persona)
 
     i_go_to_school_details_page("School1")
-    i_can_see_organisation_details
-    i_can_see_contact_details
+    then_i_see_the_school_details
 
     i_click_on_change_organisation
     i_go_to_school_details_page("School2")
-    i_can_see_organisation_details
-    i_can_see_contact_details
+    then_i_see_the_school_details
   end
 
   private
@@ -40,31 +40,66 @@ RSpec.describe "School Page", type: :system do
   end
 
   def and_persona_has_multiple_schools(persona)
-    school1 = create(:school, :claims, name: "School1")
-    school2 = create(:school, :claims, name: "School2")
     create(:membership, user: persona, organisation: school1)
     create(:membership, user: persona, organisation: school2)
   end
 
   def given_there_is_an_existing_persona_for(persona_name)
     user = create(:persona, persona_name.downcase.to_sym, service: "claims")
-    create(:membership, user:, organisation: create(:school, :claims))
+    create(:membership, user:, organisation: school1)
     user
   end
 
-  def i_can_see_organisation_details
-    expect(page).to have_css(".govuk-summary-list__value", text: "Hogwarts")
-    expect(page).to have_css(".govuk-summary-list__value", text: "fake_uprn")
-    expect(page).to have_css(".govuk-summary-list__value", text: 1)
-  end
+  def then_i_see_the_school_details
+    within(".govuk-heading-l") do
+      expect(page).to have_content "Organisation details"
+    end
 
-  def i_can_see_contact_details
-    expect(page).to have_css(".govuk-summary-list__value", text: "mary@example.com")
-    expect(page).to have_css(".govuk-summary-list__value", text: "0123456789")
-    expect(page).to have_css(".govuk-summary-list__value", text: "www.hogwarts.com")
-    expect(page).to have_css(".govuk-summary-list__value", text: "Hogwarts Castle")
-    expect(page).to have_css(".govuk-summary-list__value", text: "Scotland")
-    expect(page).to have_css(".govuk-summary-list__value", text: "United Kingdom")
+    expect(page).to have_content "Additional details"
+    expect(page).to have_content "Special educational needs and disabilities (SEND)"
+    expect(page).to have_content "Ofsted"
+    expect(page).to have_content "Contact details"
+
+    within("#school-details") do
+      expect(page).to have_content "Organisation name"
+      expect(page).to have_content "UK provider reference number (UKPRN)"
+      expect(page).to have_content "Unique reference number (URN)"
+    end
+
+    within("#additional-details") do
+      expect(page).to have_content "Group"
+      expect(page).to have_content "Type"
+      expect(page).to have_content "Phase"
+      expect(page).to have_content "Gender"
+      expect(page).to have_content "Minimum age"
+      expect(page).to have_content "Maximum age"
+      expect(page).to have_content "Religious character"
+      expect(page).to have_content "Admissions policy"
+      expect(page).to have_content "Urban or rural"
+      expect(page).to have_content "School capacity"
+      expect(page).to have_content "Total pupils"
+      expect(page).to have_content "Total girls"
+      expect(page).to have_content "Total boys"
+      expect(page).to have_content "Percentage free school meals"
+    end
+
+    within("#send-details") do
+      expect(page).to have_content "Special classes"
+      expect(page).to have_content "SEND provision"
+      expect(page).to have_content "Training with disabilities"
+    end
+
+    within("#ofsted-details") do
+      expect(page).to have_content "Rating"
+      expect(page).to have_content "Last inspection date"
+    end
+
+    within("#contact-details") do
+      expect(page).to have_content "Email address"
+      expect(page).to have_content "Telephone number"
+      expect(page).to have_content "Website"
+      expect(page).to have_content "Address"
+    end
   end
 
   def i_go_to_school_details_page(school_name)


### PR DESCRIPTION
## Context

Previously the show page of a school was populated with static data, this commit uses the school record to populate the page.

## Changes proposed in this pull request

Updated show view and added a few partials similar to placements

## Guidance to review

Sign in as any user
Go to the school show page

## Screenshots

![Screenshot from 2024-01-10 10-58-00](https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/87dcc1af-2fa5-43b1-8ce1-a506c62bd542)

