### PR TITLE
Rework onboarding with form objects for schools and providers

### DIFF
--- a/app/controllers/claims/support/schools_controller.rb
+++ b/app/controllers/claims/support/schools_controller.rb
@@ -8,20 +8,19 @@ class Claims::Support::SchoolsController < Claims::Support::ApplicationControlle
   end
 
   def new
-    @school = Claims::School.new
+    @school_form = SchoolOnboardingForm.new
   end
 
   def check
-    if school.valid? && !school.claims?
-      @school = school.decorate
+    if school_form.valid?
+      @school = school
     else
-      school.errors.add(:urn, :already_added, school_name: school.name) if school.claims?
       render :new
     end
   end
 
   def create
-    if school.update(claims: true)
+    if school_form.onboard
       redirect_to claims_support_schools_path
     else
       render :new
@@ -30,11 +29,15 @@ class Claims::Support::SchoolsController < Claims::Support::ApplicationControlle
 
   private
 
+  def school_form
+    @school_form ||= SchoolOnboardingForm.new(urn: urn_param, service: :claims)
+  end
+
   def school
-    @school ||= School.find_by(urn: urn_param) || Claims::School.new
+    @school ||= school_form.school.decorate
   end
 
   def urn_param
-    params.dig(:selection, :urn) || params.dig(:school, :urn)
+    params.dig(:school, :search_urn)
   end
 end

--- a/app/controllers/placements/support/providers_controller.rb
+++ b/app/controllers/placements/support/providers_controller.rb
@@ -1,31 +1,32 @@
 class Placements::Support::ProvidersController < Placements::Support::ApplicationController
   def new
-    @provider = Provider.new
+    @provider_form = ProviderOnboardingForm.new
+  end
+
+  def check
+    if provider_form.valid?
+      provider
+    else
+      render :new
+    end
   end
 
   def create
-    if provider.update(placements: true)
+    if provider_form.onboard
       redirect_to placements_support_organisations_path
     else
       render :new
     end
   end
 
-  def check
-    @provider = provider.decorate
-    return if @provider.valid?
-
-    render :new
-  end
-
   private
 
-  def provider
-    @provider ||= Provider.find_by(code: provider_code, placements: false) || unknown_provider
+  def provider_form
+    @provider_form ||= ProviderOnboardingForm.new(code: provider_code)
   end
 
-  def unknown_provider
-    Provider.new(name: "Unknown Provider", provider_type: "university", code: provider_code)
+  def provider
+    @provider ||= provider_form.provider.decorate
   end
 
   def provider_code

--- a/app/controllers/placements/support/schools_controller.rb
+++ b/app/controllers/placements/support/schools_controller.rb
@@ -1,20 +1,18 @@
 class Placements::Support::SchoolsController < Placements::Support::ApplicationController
   def new
-    @school = Placements::School.new
+    @school_form = SchoolOnboardingForm.new
   end
 
   def check
-    if school.valid? && !school.placements?
-      @school = school.decorate
+    if school_form.valid?
+      @school = school
     else
-      school.errors.add(:urn, :already_added, school_name: school.name) if school.placements?
       render :new
     end
   end
 
   def create
-    school.placements = true
-    if school.save
+    if school_form.onboard
       redirect_to placements_support_organisations_path
     else
       render :new
@@ -27,11 +25,15 @@ class Placements::Support::SchoolsController < Placements::Support::ApplicationC
 
   private
 
+  def school_form
+    @school_form ||= SchoolOnboardingForm.new(urn: urn_param, service: :placements)
+  end
+
   def school
-    @school ||= School.find_by(urn: urn_param) || Placements::School.new
+    @school ||= school_form.school.decorate
   end
 
   def urn_param
-    params.dig(:selection, :urn) || params.dig(:school, :urn)
+    params.dig(:school, :search_urn)
   end
 end

--- a/app/forms/provider_onboarding_form.rb
+++ b/app/forms/provider_onboarding_form.rb
@@ -1,0 +1,31 @@
+class ProviderOnboardingForm
+  include ActiveModel::Model
+
+  attr_accessor :code
+
+  validates :code, presence: true
+  validate :provider_exists?
+  validate :provider_already_onboarded?
+
+  def onboard
+    return false unless valid?
+
+    provider.update!(placements: true)
+  end
+
+  def provider
+    @provider ||= Provider.find_by(code:)
+  end
+
+  private
+
+  def provider_exists?
+    errors.add(:code, :blank) if provider.blank?
+  end
+
+  def provider_already_onboarded?
+    if provider&.placements?
+      errors.add(:code, :already_added, provider_name: provider.name)
+    end
+  end
+end

--- a/app/forms/school_onboarding_form.rb
+++ b/app/forms/school_onboarding_form.rb
@@ -1,0 +1,32 @@
+class SchoolOnboardingForm
+  include ActiveModel::Model
+
+  attr_accessor :urn, :service
+
+  validates :urn, presence: true
+  validates :service, presence: true, inclusion: { in: %i[placements claims] }
+  validate :school_exists?
+  validate :school_already_onboarded?
+
+  def onboard
+    return false unless valid?
+
+    school.update!(service => true)
+  end
+
+  def school
+    @school ||= School.find_by(urn:)
+  end
+
+  private
+
+  def school_exists?
+    errors.add(:urn, :blank) if school.blank?
+  end
+
+  def school_already_onboarded?
+    if school&.try(service.to_s)
+      errors.add(:urn, :already_added, school_name: school.name)
+    end
+  end
+end

--- a/app/javascript/school.js
+++ b/app/javascript/school.js
@@ -15,7 +15,7 @@ function init() {
       suggestion: providerSuggestionTemplate,
     },
     minLength: 2,
-    inputName: "selection[urn]",
+    inputName: "school[search_urn]",
     onConfirm,
   };
 

--- a/app/views/claims/support/schools/check.html.erb
+++ b/app/views/claims/support/schools/check.html.erb
@@ -5,7 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(model: @school, url: claims_support_schools_path, method: "post", data: { turbo: false }) do |f| %>
-      <%= f.hidden_field :urn, value: @school.urn %>
+      <%= f.hidden_field :search_urn, value: @school.urn %>
 
       <label class="govuk-label govuk-label--l">
         <span class="govuk-caption-l"><%= t(".add_organisation") %></span>

--- a/app/views/claims/support/schools/new.html.erb
+++ b/app/views/claims/support/schools/new.html.erb
@@ -2,13 +2,13 @@
   <%= govuk_back_link(href: claims_support_schools_path) %>
 <% end %>
 
-<%= form_with(model: @school, scope: :school, url: check_claims_support_schools_path, method: "get", data: { turbo: false }) do |f| %>
+<%= form_with(model: @school_form, scope: :school, url: check_claims_support_schools_path, method: "get", data: { turbo: false }) do |f| %>
   <%= f.govuk_error_summary %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-form-group">
-        <%= f.govuk_text_field :urn, value: @school.name,
+        <%= f.govuk_text_field :urn, value: nil,
                                      label: { text: t(".title"), size: "l" },
                                      caption: { text: t(".caption") },
                                      id: "school-search-form-query-field" %>

--- a/app/views/placements/support/providers/new.html.erb
+++ b/app/views/placements/support/providers/new.html.erb
@@ -2,13 +2,13 @@
   <%= govuk_back_link(href: new_placements_support_organisation_path) %>
 <% end %>
 
-<%= form_with(model: @provider, url: check_placements_support_providers_path, method: "get", data: { turbo: false }) do |f| %>
+<%= form_with(model: @provider_form, url: check_placements_support_providers_path, method: "get", data: { turbo: false }) do |f| %>
   <%= f.govuk_error_summary %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
        <div class="govuk-form-group">
-        <%= f.govuk_text_field :code, value: params[:code],
+        <%= f.govuk_text_field :code, value: nil,
                                       label: { text: t(".title"), size: "l" },
                                       caption: { text: t(".caption") },
                                       id: "accredited-provider-search-form-query-field" %>

--- a/app/views/placements/support/schools/check.html.erb
+++ b/app/views/placements/support/schools/check.html.erb
@@ -5,7 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(model: @school, url: placements_support_schools_path, method: "post", data: { turbo: false }) do |f| %>
-      <%= f.hidden_field :urn, value: @school.urn %>
+      <%= f.hidden_field :search_urn, value: @school.urn %>
 
       <label class="govuk-label govuk-label--l">
         <span class="govuk-caption-l"><%= t(".add_organisation") %></span>

--- a/app/views/placements/support/schools/new.html.erb
+++ b/app/views/placements/support/schools/new.html.erb
@@ -2,13 +2,13 @@
   <%= govuk_back_link(href: new_placements_support_organisation_path) %>
 <% end %>
 
-<%= form_with(model: @school, scope: :school, url: check_placements_support_schools_path, method: "get", data: { turbo: false }) do |f| %>
+<%= form_with(model: @school_form, scope: :school, url: check_placements_support_schools_path, method: "get", data: { turbo: false }) do |f| %>
   <%= f.govuk_error_summary %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-form-group">
-        <%= f.govuk_text_field :urn, value: @school.name,
+        <%= f.govuk_text_field :urn, value: nil,
                                      label: { text: t(".title"), size: "l" },
                                      caption: { text: t(".caption") },
                                      id: "school-search-form-query-field" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,19 @@ en:
       long: "%e %B %Y %H:%M"
       long_with_seconds: "%e %B %Y %H:%M:%S"
       time: "%H:%M"
+  activemodel:
+    errors:
+      models:
+        provider_onboarding_form:
+          attributes:
+            code:
+              already_added: "%{provider_name} has already been added. Try another provider"
+              blank: Enter a provider name, UKPRN, URN or postcode
+        school_onboarding_form:
+          attributes:
+            urn:
+              already_added: "%{school_name} has already been added. Try another school"
+              blank: Enter a school name, URN or postcode
   activerecord:
     errors:
       models:
@@ -14,16 +27,6 @@ en:
           attributes:
             type:
               blank: Select an organisation type
-        provider:
-          attributes:
-            code:
-              taken: This provider has already been added. Try another provider
-              blank: Enter a provider name, UKPRN, URN or postcode
-        school:
-          attributes:
-            urn:
-              already_added: "%{school_name} has already been added. Try another school"
-              blank: Enter a school name, URN or postcode
         user:
           attributes:
             first_name:

--- a/spec/forms/provider_onboarding_form_spec.rb
+++ b/spec/forms/provider_onboarding_form_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+describe ProviderOnboardingForm, type: :model do
+  describe "validations" do
+    it { should validate_presence_of(:code) }
+
+    context "when given a code not associated with a provider" do
+      it "returns invalid" do
+        form = described_class.new(code: "random")
+        expect(form.valid?).to eq(false)
+        expect(form.errors.messages[:code]).to include("Enter a provider name, UKPRN, URN or postcode")
+      end
+    end
+
+    context "when given a code for a provider already onboarded" do
+      it "returns invalid" do
+        provider = create(:placements_provider)
+        form = described_class.new(code: provider.code)
+        expect(form.valid?).to eq(false)
+        expect(form.errors.messages[:code]).to include("#{provider.name} has already been added. Try another provider")
+      end
+    end
+
+    context "when given a urn for a provider not onboarded" do
+      it "returns valid" do
+        provider = create(:provider)
+        form = described_class.new(code: provider.code)
+        expect(form.valid?).to eq(true)
+      end
+    end
+  end
+
+  describe "#provider" do
+    context "when given the urn of an existing provider" do
+      it "returns the provider associated with that urn" do
+        provider = create(:provider)
+        expect(described_class.new(code: provider.code).provider).to eq(provider)
+      end
+    end
+
+    context "when given a urn not associated with a provider" do
+      it "returns nil" do
+        expect(described_class.new(code: "random").provider).to eq(nil)
+      end
+    end
+  end
+
+  describe "onboard" do
+    it "enables the boolean flag for placements" do
+      provider = create(:provider)
+      onboarding = expect do
+        described_class.new(code: provider.code).onboard
+        provider.reload
+      end
+      onboarding.to change(provider, :placements).from(false).to(true)
+    end
+  end
+end

--- a/spec/forms/school_onboarding_form_spec.rb
+++ b/spec/forms/school_onboarding_form_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+describe SchoolOnboardingForm, type: :model do
+  describe "validations" do
+    it { should validate_presence_of(:urn) }
+    it { should validate_presence_of(:service) }
+    it { should validate_inclusion_of(:service).in_array(%i[placements claims]) }
+
+    context "when given a urn not associated with a school" do
+      it "returns invalid" do
+        form = described_class.new(urn: "random", service: :placements)
+        expect(form.valid?).to eq(false)
+        expect(form.errors.messages[:urn]).to include("Enter a school name, URN or postcode")
+      end
+    end
+
+    context "when given a urn for a school already onboarded onto the given service" do
+      it "returns invalid" do
+        school = create(:school, :placements)
+        form = described_class.new(urn: school.urn, service: :placements)
+        expect(form.valid?).to eq(false)
+        expect(form.errors.messages[:urn]).to include("#{school.name} has already been added. Try another school")
+      end
+    end
+
+    context "when given a urn for a school not onboarded onto the given service" do
+      it "returns valid" do
+        school = create(:school, :claims)
+        form = described_class.new(urn: school.urn, service: :placements)
+        expect(form.valid?).to eq(true)
+      end
+    end
+  end
+
+  describe "#school" do
+    context "when given the urn of an existing school" do
+      it "returns the school associated with that urn" do
+        school = create(:school)
+        expect(described_class.new(urn: school.urn).school).to eq(school)
+      end
+    end
+
+    context "when given a urn not associated with a school" do
+      it "returns nil" do
+        expect(described_class.new(urn: "random").school).to eq(nil)
+      end
+    end
+  end
+
+  describe "onboard" do
+    it "enables the boolean flag for the given service" do
+      school = create(:school)
+      onboarding = expect do
+        described_class.new(urn: school.urn, service: :placements).onboard
+        school.reload
+      end
+      onboarding.to change(school, :placements).from(false).to(true)
+    end
+  end
+end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Provider, type: :model do
     it do
       is_expected.to validate_uniqueness_of(
         :code,
-      ).case_insensitive.with_message("This provider has already been added. Try another provider")
+      ).case_insensitive
     end
     it { is_expected.to allow_values("scitt", "lead_school", "university").for(:provider_type) }
   end

--- a/spec/system/placements/providers/support_user_adds_a_provider_spec.rb
+++ b/spec/system/placements/providers/support_user_adds_a_provider_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Placements / Providers / Support User adds a Provider", type: :s
     then_i_see_a_dropdown_item_for("Provider 1")
     when_i_click_the_dropdown_item_for("Provider 1")
     and_i_click_continue
-    then_i_see_an_error("This provider has already been added. Try another provider")
+    then_i_see_an_error("Provider 1 has already been added. Try another provider")
   end
 
   scenario "Colin submits the search form without selecting a provider", js: true do


### PR DESCRIPTION
## Context

Currently we are seeing a number of issues with forcing ourselves to use a CRU/D for onboarding Providers and Schools onto the different services.
Replacing the models used in the different controllers with form objects standardises the approach to onboarding external records, and reduces unwanted validating errors appearing when completing the onboarding form.

## Changes proposed in this pull request

- Introduces form objects (ProviderForm, SchoolForm) for onboarding (flipping the relevant service flag to `true`)
 of Provider and School records.

## Guidance to review

[ ] Test onboarding a provider on the `Placements` service.
[ ] Test onboarding a school on the `Placements` service.
[ ] Test onboarding a school on the `Claims` service.

## Link to Trello card

https://trello.com/c/xg3Ylg0f/104-refactor-school-provider-onboarding-journeys-to-use-form-objects-pattern
https://trello.com/c/ornOs5qW/103-bug-in-school-search-error-messages-placements-and-claims
