### PR TITLE
Rework Placements Support Org Controller to work with form objects

### DIFF
--- a/app/controllers/placements/support/organisations_controller.rb
+++ b/app/controllers/placements/support/organisations_controller.rb
@@ -5,39 +5,27 @@ class Placements::Support::OrganisationsController < Placements::Support::Applic
   end
 
   def new
-    organisation
-    organisation_types
+    @organisation_form = OrganisationOnboardingForm.new
   end
 
   def select_type
-    if params_organisation_type == "school"
-      redirect_to new_placements_support_school_path
-    elsif params_organisation_type == "itt_provider"
-      redirect_to new_placements_support_provider_path
+    @organisation_form = OrganisationOnboardingForm.new(
+      organisation_type: organisation_type_param,
+    )
+    if @organisation_form.valid?
+      redirect_to @organisation_form.onboarding_url
     else
-      organisation.errors.add(
-        :organisation_type,
-        t("activerecord.errors.models.organisation.attributes.type.blank"),
-      )
-      organisation_types
       render :new
     end
   end
 
   private
 
-  def organisation_types
-    @organisation_types ||= [
-      OpenStruct.new(id: "itt_provider", name: t("itt_provider")),
-      OpenStruct.new(id: "school", name: t("school")),
-    ]
-  end
-
   def organisation
     @organisation ||= Placements::School.new
   end
 
-  def params_organisation_type
-    params.dig(:placements_school, :organisation_type)
+  def organisation_type_param
+    params.dig(:organisation, :organisation_type)
   end
 end

--- a/app/controllers/placements/support/organisations_controller.rb
+++ b/app/controllers/placements/support/organisations_controller.rb
@@ -21,10 +21,6 @@ class Placements::Support::OrganisationsController < Placements::Support::Applic
 
   private
 
-  def organisation
-    @organisation ||= Placements::School.new
-  end
-
   def organisation_type_param
     params.dig(:organisation, :organisation_type)
   end

--- a/app/forms/organisation_onboarding_form.rb
+++ b/app/forms/organisation_onboarding_form.rb
@@ -1,0 +1,28 @@
+class OrganisationOnboardingForm
+  include ActiveModel::Model
+  include Rails.application.routes.url_helpers
+
+  attr_accessor :organisation_type
+
+  ITT_PROVIDER = "itt_provider".freeze
+  SCHOOL = "school".freeze
+  ORGANISATION_TYPES = [ITT_PROVIDER, SCHOOL].freeze
+
+  validates :organisation_type, presence: true, inclusion: { in: ORGANISATION_TYPES }
+
+  def onboarding_url
+    return unless valid?
+
+    if organisation_type == ITT_PROVIDER
+      new_placements_support_provider_path
+    else
+      new_placements_support_school_path
+    end
+  end
+
+  def options
+    ORGANISATION_TYPES.map do |org_type|
+      OpenStruct.new(id: org_type, name: I18n.t(org_type))
+    end
+  end
+end

--- a/app/views/placements/support/organisations/new.html.erb
+++ b/app/views/placements/support/organisations/new.html.erb
@@ -2,13 +2,16 @@
   <%= govuk_back_link(href: placements_support_organisations_path) %>
 <% end %>
 
-<%= form_with(model: @organisation, url: select_type_placements_support_organisations_path, method: "get", data: { turbo: false }) do |f| %>
+<%= form_with(model: @organisation_form, scope: :organisation,
+              url: select_type_placements_support_organisations_path,
+              method: "get", data: { turbo: false }) do |f| %>
   <%= f.govuk_error_summary %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l"><%= t(".caption") %></span>
-      <%= f.govuk_collection_radio_buttons :organisation_type, @organisation_types, :id, :name, legend: { text: t(".title"), size: "l" } %>
+      <%= f.govuk_collection_radio_buttons :organisation_type, @organisation_form.options, :id,
+        :name, legend: { text: t(".title"), size: "l" } %>
 
       <%= f.govuk_submit t("continue") %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,10 @@ en:
   activemodel:
     errors:
       models:
+        organisation_onboarding_form:
+          attributes:
+            organisation_type:
+              blank: Select an organisation type
         provider_onboarding_form:
           attributes:
             code:
@@ -23,10 +27,6 @@ en:
   activerecord:
     errors:
       models:
-        organisation:
-          attributes:
-            type:
-              blank: Select an organisation type
         user:
           attributes:
             first_name:

--- a/spec/forms/organisation_onboarding_form_spec.rb
+++ b/spec/forms/organisation_onboarding_form_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+describe OrganisationOnboardingForm, type: :model do
+  describe "validations" do
+    it { should validate_presence_of(:organisation_type) }
+    it {
+      should validate_inclusion_of(:organisation_type).in_array(
+        described_class::ORGANISATION_TYPES,
+      )
+    }
+  end
+
+  describe "#options" do
+    it "returns an array of organisation types as open structs" do
+      expect(described_class.new.options).to match_array(
+        [
+          OpenStruct.new(
+            id: described_class::ITT_PROVIDER,
+            name: I18n.t(described_class::ITT_PROVIDER),
+          ),
+          OpenStruct.new(
+            id: described_class::SCHOOL,
+            name: I18n.t(described_class::SCHOOL),
+          ),
+        ],
+      )
+    end
+  end
+
+  describe "#onboarding_url" do
+    context "when the organisation type is an ITT Provider" do
+      it "returns the URL for onboarding a provider" do
+        expect(
+          described_class.new(
+            organisation_type: described_class::ITT_PROVIDER,
+          ).onboarding_url,
+        ).to eq("/support/providers/new")
+      end
+    end
+
+    context "when the organisation type is a school" do
+      it "returns the URL for onboarding a school" do
+        expect(
+          described_class.new(
+            organisation_type: described_class::SCHOOL,
+          ).onboarding_url,
+        ).to eq("/support/schools/new")
+      end
+    end
+
+    context "when the organisation type isn't a valid type" do
+      it "returns nil" do
+        expect(
+          described_class.new(
+            organisation_type: "random",
+          ).onboarding_url,
+        ).to eq(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

To continue with our mindset of using form objects when not working with actual models/records, refactor the `Placements::Support::OrganisationsController` to work an `OrganisationOnboardingForm`

## Changes proposed in this pull request

Introduce an `OrganisationOnboardingForm` to work when selecting the type on organisation which is being on boarded.

## Guidance to review

- [ ] Selecting "ITT Provider" should redirect the user to the Provider onboarding page.
- [ ] Selecting "School" should redirect the user to the School onboarding page.
- [ ] Not selection an Organisation Type should show the error "Select an organisation type"

![Screenshot 2024-01-11 at 13 07 22](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/3097f0a3-8262-46c6-995a-5d19b5a2999a)

## Link to Trello card

https://trello.com/c/Z0wd50sA/113-refactor-support-organisation-controller-to-use-organisationonboardingform-object
