### PR TITLE
Add Search capabilities to claims/support/schools

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ gem "omniauth"
 gem "omniauth_openid_connect"
 gem "omniauth-rails_csrf_protection"
 
+# Pagination
+gem "pagy", "~> 6.3"
+
 # Decorators
 gem "draper"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,7 +283,7 @@ GEM
       validate_email
       validate_url
       webfinger (~> 2.0)
-    pagy (6.2.0)
+    pagy (6.3.0)
     parallel (1.24.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -556,6 +556,7 @@ DEPENDENCIES
   omniauth
   omniauth-rails_csrf_protection
   omniauth_openid_connect
+  pagy (~> 6.3)
   pg (~> 1.1)
   pg_search
   prettier_print

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,3 +5,4 @@ $govuk-assets-path: "";
 @import "govuk-frontend/dist/govuk/all";
 @import "components/all";
 @import "accessible-autocomplete/dist/accessible-autocomplete.min";
+@import "search-form"

--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -2,3 +2,4 @@
 @import "page_banner";
 @import "navigation_bar";
 @import "content_header";
+@import "organisation_list_item";

--- a/app/assets/stylesheets/components/_organisation_list_item.scss
+++ b/app/assets/stylesheets/components/_organisation_list_item.scss
@@ -1,0 +1,81 @@
+.organisation-search-results {
+  @include govuk-responsive-padding(4, "top");
+  margin: 0;
+  padding-left: 0;
+  border-top: 1px solid $govuk-border-colour;
+}
+
+.organisation-search-results__item {
+  @include govuk-responsive-margin(4, "bottom");
+  border-bottom: 1px solid $govuk-border-colour;
+  display: block;
+}
+
+.organisation-search-result__item-title {
+  @include govuk-font($size: 19, $weight: bold);
+  @include govuk-responsive-margin(4, "bottom");
+  margin-top: 0;
+}
+
+.organisation-search-results-header {
+  border-top: 1px solid $govuk-border-colour;
+  padding: govuk-spacing(2) 0;
+
+  @include govuk-media-query($from: "desktop") {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+  }
+}
+
+.app-result-detail {
+  @include govuk-font($size: 19);
+  @include govuk-text-colour;
+  @include govuk-responsive-margin(4, "bottom");
+  @include govuk-media-query($from: tablet) {
+    display: table;
+    width: 100%;
+    table-layout: fixed; // Required to allow us to wrap words that overflow.
+  }
+  margin: 0; // Reset default user agent styles
+}
+
+.app-result-detail__row {
+  @include govuk-media-query($until: tablet) {
+    margin-bottom: govuk-spacing(1);
+  }
+  @include govuk-media-query($from: tablet) {
+    display: table-row;
+  }
+}
+
+.app-result-detail__key,
+.app-result-detail__value {
+  margin: 0; // Reset default user agent styles
+  padding-bottom: govuk-spacing(1);
+
+  @include govuk-media-query($from: tablet) {
+    display: table-cell;
+    padding-top: 0;
+    padding-right: govuk-spacing(4);
+  }
+
+  .govuk-body {
+    margin-bottom: govuk-spacing(1);
+  }
+
+  .govuk-hint {
+    @include govuk-font($size: 16);
+    margin-bottom: govuk-spacing(1);
+  }
+}
+
+.app-result-detail__key {
+  font-weight: bold;
+
+  @include govuk-media-query($from: tablet) {
+    color: $govuk-secondary-text-colour;
+    font-weight: normal;
+    width: 200px;
+  }
+}

--- a/app/assets/stylesheets/search-form.scss
+++ b/app/assets/stylesheets/search-form.scss
@@ -1,0 +1,18 @@
+.search-form {
+  display: flex;
+}
+
+.search-form .govuk-form-group{
+  flex: 1;
+}
+
+.search-form button {
+  margin-top: auto;
+  top: -2px;
+  margin-bottom: 0;
+  margin-left: govuk-spacing(2);
+}
+
+.clear-search {
+  margin-top: -20px;
+}

--- a/app/components/organisation_list_item.html.erb
+++ b/app/components/organisation_list_item.html.erb
@@ -1,0 +1,11 @@
+<li class="organisation-search-results__item">
+  <h2 class="organisation-search-result__item-title">
+    <%= govuk_link_to organisation.name, organisation_url, no_visited_state: true %>
+  </h2>
+  <dl class="app-result-detail">
+    <div class="app-result-detail__row">
+      <dt class="app-result-detail__key"><%= t("components.organisation_list_item.organisation_type") %></dt>
+      <dd class="app-result-detail__value"><%= t("components.organisation_list_item.#{organisation_type}") %></dd>
+    </div>
+  </dl>
+</li>

--- a/app/components/organisation_list_item.rb
+++ b/app/components/organisation_list_item.rb
@@ -1,0 +1,17 @@
+class OrganisationListItem < ApplicationComponent
+  attr_reader :organisation, :organisation_type, :organisation_url
+
+  def initialize(
+    organisation:,
+    organisation_type:,
+    organisation_url:,
+    classes: [],
+    html_attributes: {}
+  )
+    super(classes:, html_attributes:)
+
+    @organisation = organisation
+    @organisation_type = organisation_type
+    @organisation_url = organisation_url
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   include ApplicationHelper
   include RoutesHelper
+  include Pagy::Backend
 
   before_action :authenticate_user!
 

--- a/app/controllers/claims/support/schools_controller.rb
+++ b/app/controllers/claims/support/schools_controller.rb
@@ -1,6 +1,7 @@
 class Claims::Support::SchoolsController < Claims::Support::ApplicationController
   def index
-    @schools = Claims::School.order(:name)
+    @pagy, @schools = pagy(schools)
+    @search_param = params[:name_or_postcode]
   end
 
   def show
@@ -32,6 +33,14 @@ class Claims::Support::SchoolsController < Claims::Support::ApplicationControlle
 
   def school
     @school ||= School.find_by(urn: urn_param) || Claims::School.new
+  end
+
+  def schools
+    @schools ||= if params[:name_or_postcode].blank?
+                   Claims::School.order(:name)
+                 else
+                   Claims::School.search_name_postcode(params[:name_or_postcode]).order(:name)
+                 end
   end
 
   def urn_param

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,6 @@
 module ApplicationHelper
+  include Pagy::Frontend
+
   def current_service
     case request.host
     when ENV["CLAIMS_HOST"]

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -60,4 +60,8 @@ class School < ApplicationRecord
   pg_search_scope :search_name_urn_postcode,
                   against: %i[name postcode urn],
                   using: { trigram: { word_similarity: true } }
+
+  pg_search_scope :search_name_postcode,
+                  against: %i[name postcode],
+                  using: { trigram: { word_similarity: true } }
 end

--- a/app/views/claims/support/schools/index.html.erb
+++ b/app/views/claims/support/schools/index.html.erb
@@ -1,18 +1,36 @@
+<%= content_for :page_title, t(".heading", records: @pagy.count) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
+    <h1 class="govuk-heading-l"><%= t(".heading", records: @pagy.count) %></h1>
 
     <%= govuk_button_to(t("add_organisation"), new_claims_support_school_path, method: :get) %>
 
+    <%= render partial: "shared/search_form", locals: {
+      url: claims_support_schools_path,
+      search_param: @search_param,
+      clear_search_url: claims_support_schools_path,
+    } %>
+
     <% if @schools.any? %>
-      <h2 class="govuk-heading-l"><%= t("schools") %></h2>
-      <ul class="govuk-list">
+      <ul class="organisation-search-results">
         <% @schools.each do |school| %>
-        <li>
-          <%= govuk_link_to school.name, claims_school_path(school), no_visited_state: true %>
-        </li>
+          <%= render(OrganisationListItem.new(
+            organisation: school,
+            organisation_type: "school",
+            organisation_url: claims_school_path(school),
+          )) %>
         <% end %>
+
+        <%= govuk_pagination(pagy: @pagy) %>
+        <p>
+          <%= t("pagination_info", from: @pagy.from, to: @pagy.to, count: @pagy.count) %>
+        </p>
       </ul>
+    <% else %>
+      <p>
+        <%= t("no_results", for: @search_param) %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,0 +1,18 @@
+<div class="govuk-form-group">
+  <%= form_with(
+    url:,
+    method: "get",
+    class: "search-form",
+    data: { turbo: false },
+  ) do |f| %>
+    <%= f.govuk_text_field :name_or_postcode, type: :search, value: search_param, label: { text: t(".search-header"), size: "m" } %>
+
+    <%= f.govuk_submit t(".search") %>
+  <% end %>
+</div>
+
+<% unless search_param.blank? %>
+  <p class="clear-search">
+    <%= govuk_link_to t(".clear_search"), clear_search_url, no_visited_state: true %>
+  </p>
+<% end %>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,238 @@
+# Pagy initializer file (6.3.0)
+# Customize only what you really need and notice that the core Pagy works also without any of the following lines.
+# Should you just cherry pick part of this file, please maintain the require-order of the extras
+
+# Pagy DEFAULT Variables
+# See https://ddnexus.github.io/pagy/docs/api/pagy#variables
+# All the Pagy::DEFAULT are set for all the Pagy instances but can be overridden per instance by just passing them to
+# Pagy.new|Pagy::Countless.new|Pagy::Calendar::*.new or any of the #pagy* controller methods
+
+# Instance variables
+# See https://ddnexus.github.io/pagy/docs/api/pagy#instance-variables
+# Pagy::DEFAULT[:page]   = 1                                  # default
+Pagy::DEFAULT[:items] = 25 # default
+# Pagy::DEFAULT[:outset] = 0                                  # default
+
+# Other Variables
+# See https://ddnexus.github.io/pagy/docs/api/pagy#other-variables
+# Pagy::DEFAULT[:size]       = [1,4,4,1]                       # default
+# Pagy::DEFAULT[:page_param] = :page                           # default
+# The :params can be also set as a lambda e.g ->(params){ params.exclude('useless').merge!('custom' => 'useful') }
+# Pagy::DEFAULT[:params]     = {}                              # default
+# Pagy::DEFAULT[:fragment]   = '#fragment'                     # example
+# Pagy::DEFAULT[:link_extra] = 'data-remote="true"'            # example
+# Pagy::DEFAULT[:i18n_key]   = 'pagy.item_name'                # default
+# Pagy::DEFAULT[:cycle]      = true                            # example
+# Pagy::DEFAULT[:request_path] = "/foo"                        # example
+
+# Extras
+# See https://ddnexus.github.io/pagy/categories/extra
+
+# Backend Extras
+
+# Arel extra: For better performance utilizing grouped ActiveRecord collections:
+# See: https://ddnexus.github.io/pagy/docs/extras/arel
+# require 'pagy/extras/arel'
+
+# Array extra: Paginate arrays efficiently, avoiding expensive array-wrapping and without overriding
+# See https://ddnexus.github.io/pagy/docs/extras/array
+# require 'pagy/extras/array'
+
+# Calendar extra: Add pagination filtering by calendar time unit (year, quarter, month, week, day)
+# See https://ddnexus.github.io/pagy/docs/extras/calendar
+# require 'pagy/extras/calendar'
+# Default for each unit
+# Pagy::Calendar::Year::DEFAULT[:order]     = :asc        # Time direction of pagination
+# Pagy::Calendar::Year::DEFAULT[:format]    = '%Y'        # strftime format
+#
+# Pagy::Calendar::Quarter::DEFAULT[:order]  = :asc        # Time direction of pagination
+# Pagy::Calendar::Quarter::DEFAULT[:format] = '%Y-Q%q'    # strftime format
+#
+# Pagy::Calendar::Month::DEFAULT[:order]    = :asc        # Time direction of pagination
+# Pagy::Calendar::Month::DEFAULT[:format]   = '%Y-%m'     # strftime format
+#
+# Pagy::Calendar::Week::DEFAULT[:order]     = :asc        # Time direction of pagination
+# Pagy::Calendar::Week::DEFAULT[:format]    = '%Y-%W'     # strftime format
+#
+# Pagy::Calendar::Day::DEFAULT[:order]      = :asc        # Time direction of pagination
+# Pagy::Calendar::Day::DEFAULT[:format]     = '%Y-%m-%d'  # strftime format
+#
+# Uncomment the following lines, if you need calendar localization without using the I18n extra
+# module LocalizePagyCalendar
+#   def localize(time, opts)
+#     ::I18n.l(time, **opts)
+#   end
+# end
+# Pagy::Calendar.prepend LocalizePagyCalendar
+
+# Countless extra: Paginate without any count, saving one query per rendering
+# See https://ddnexus.github.io/pagy/docs/extras/countless
+# require 'pagy/extras/countless'
+# Pagy::DEFAULT[:countless_minimal] = false   # default (eager loading)
+
+# Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects
+# See https://ddnexus.github.io/pagy/docs/extras/elasticsearch_rails
+# Default :pagy_search method: change only if you use also
+# the searchkick or meilisearch extra that defines the same
+# Pagy::DEFAULT[:elasticsearch_rails_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:elasticsearch_rails_search] = :search
+# require 'pagy/extras/elasticsearch_rails'
+
+# Headers extra: http response headers (and other helpers) useful for API pagination
+# See http://ddnexus.github.io/pagy/extras/headers
+# require 'pagy/extras/headers'
+# Pagy::DEFAULT[:headers] = { page: 'Current-Page',
+#                            items: 'Page-Items',
+#                            count: 'Total-Count',
+#                            pages: 'Total-Pages' }     # default
+
+# Meilisearch extra: Paginate `Meilisearch` result objects
+# See https://ddnexus.github.io/pagy/docs/extras/meilisearch
+# Default :pagy_search method: change only if you use also
+# the elasticsearch_rails or searchkick extra that define the same method
+# Pagy::DEFAULT[:meilisearch_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:meilisearch_search] = :ms_search
+# require 'pagy/extras/meilisearch'
+
+# Metadata extra: Provides the pagination metadata to Javascript frameworks like Vue.js, react.js, etc.
+# See https://ddnexus.github.io/pagy/docs/extras/metadata
+# you must require the frontend helpers internal extra (BEFORE the metadata extra) ONLY if you need also the :sequels
+# require 'pagy/extras/frontend_helpers'
+# require 'pagy/extras/metadata'
+# For performance reasons, you should explicitly set ONLY the metadata you use in the frontend
+# Pagy::DEFAULT[:metadata] = %i[scaffold_url page prev next last]   # example
+
+# Searchkick extra: Paginate `Searchkick::Results` objects
+# See https://ddnexus.github.io/pagy/docs/extras/searchkick
+# Default :pagy_search method: change only if you use also
+# the elasticsearch_rails or meilisearch extra that defines the same
+# DEFAULT[:searchkick_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:searchkick_search] = :search
+# require 'pagy/extras/searchkick'
+# uncomment if you are going to use Searchkick.pagy_search
+# Searchkick.extend Pagy::Searchkick
+
+# Frontend Extras
+
+# Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
+# See https://ddnexus.github.io/pagy/docs/extras/bootstrap
+# require 'pagy/extras/bootstrap'
+
+# Bulma extra: Add nav, nav_js and combo_nav_js helpers and templates for Bulma pagination
+# See https://ddnexus.github.io/pagy/docs/extras/bulma
+# require 'pagy/extras/bulma'
+
+# Foundation extra: Add nav, nav_js and combo_nav_js helpers and templates for Foundation pagination
+# See https://ddnexus.github.io/pagy/docs/extras/foundation
+# require 'pagy/extras/foundation'
+
+# Materialize extra: Add nav, nav_js and combo_nav_js helpers for Materialize pagination
+# See https://ddnexus.github.io/pagy/docs/extras/materialize
+# require 'pagy/extras/materialize'
+
+# Navs extra: Add nav_js and combo_nav_js javascript helpers
+# Notice: the other frontend extras add their own framework-styled versions,
+# so require this extra only if you need the unstyled version
+# See https://ddnexus.github.io/pagy/docs/extras/navs
+# require 'pagy/extras/navs'
+
+# Semantic extra: Add nav, nav_js and combo_nav_js helpers for Semantic UI pagination
+# See https://ddnexus.github.io/pagy/docs/extras/semantic
+# require 'pagy/extras/semantic'
+
+# UIkit extra: Add nav helper and templates for UIkit pagination
+# See https://ddnexus.github.io/pagy/docs/extras/uikit
+# require 'pagy/extras/uikit'
+
+# Multi size var used by the *_nav_js helpers
+# See https://ddnexus.github.io/pagy/docs/extras/navs#steps
+# Pagy::DEFAULT[:steps] = { 0 => [2,3,3,2], 540 => [3,5,5,3], 720 => [5,7,7,5] }   # example
+
+# Feature Extras
+
+# Gearbox extra: Automatically change the number of items per page depending on the page number
+# See https://ddnexus.github.io/pagy/docs/extras/gearbox
+# require 'pagy/extras/gearbox'
+# set to false only if you want to make :gearbox_extra an opt-in variable
+# Pagy::DEFAULT[:gearbox_extra] = false               # default true
+# Pagy::DEFAULT[:gearbox_items] = [15, 30, 60, 100]   # default
+
+# Items extra: Allow the client to request a custom number of items per page with an optional selector UI
+# See https://ddnexus.github.io/pagy/docs/extras/items
+# require 'pagy/extras/items'
+# set to false only if you want to make :items_extra an opt-in variable
+# Pagy::DEFAULT[:items_extra] = false    # default true
+# Pagy::DEFAULT[:items_param] = :items   # default
+# Pagy::DEFAULT[:max_items]   = 100      # default
+
+# Overflow extra: Allow for easy handling of overflowing pages
+# See https://ddnexus.github.io/pagy/docs/extras/overflow
+# require 'pagy/extras/overflow'
+# Pagy::DEFAULT[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
+
+# Support extra: Extra support for features like: incremental, infinite, auto-scroll pagination
+# See https://ddnexus.github.io/pagy/docs/extras/support
+# require 'pagy/extras/support'
+
+# Trim extra: Remove the page=1 param from links
+# See https://ddnexus.github.io/pagy/docs/extras/trim
+# require 'pagy/extras/trim'
+# set to false only if you want to make :trim_extra an opt-in variable
+# Pagy::DEFAULT[:trim_extra] = false # default true
+
+# Standalone extra: Use pagy in non Rack environment/gem
+# See https://ddnexus.github.io/pagy/docs/extras/standalone
+# require 'pagy/extras/standalone'
+# Pagy::DEFAULT[:url] = 'http://www.example.com/subdir'  # optional default
+
+# Rails
+# Enable the .js file required by the helpers that use javascript
+# (pagy*_nav_js, pagy*_combo_nav_js, and pagy_items_selector_js)
+# See https://ddnexus.github.io/pagy/docs/api/javascript
+
+# With the asset pipeline
+# Sprockets need to look into the pagy javascripts dir, so add it to the assets paths
+# Rails.application.config.assets.paths << Pagy.root.join('javascripts')
+
+# I18n
+
+# Pagy internal I18n: ~18x faster using ~10x less memory than the i18n gem
+# See https://ddnexus.github.io/pagy/docs/api/i18n
+# Notice: No need to configure anything in this section if your app uses only "en"
+# or if you use the i18n extra below
+#
+# Examples:
+# load the "de" built-in locale:
+# Pagy::I18n.load(locale: 'de')
+#
+# load the "de" locale defined in the custom file at :filepath:
+# Pagy::I18n.load(locale: 'de', filepath: 'path/to/pagy-de.yml')
+#
+# load the "de", "en" and "es" built-in locales:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({ locale: 'de' },
+#                 { locale: 'en' },
+#                 { locale: 'es' })
+#
+# load the "en" built-in locale, a custom "es" locale,
+# and a totally custom locale complete with a custom :pluralize proc:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({ locale: 'en' },
+#                 { locale: 'es', filepath: 'path/to/pagy-es.yml' },
+#                 { locale: 'xyz',  # not built-in
+#                   filepath: 'path/to/pagy-xyz.yml',
+#                   pluralize: lambda{ |count| ... } )
+
+# I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
+# than the default pagy internal i18n (see above)
+# See https://ddnexus.github.io/pagy/docs/extras/i18n
+# require 'pagy/extras/i18n'
+
+# Default i18n key
+# Pagy::DEFAULT[:i18n_key] = 'pagy.item_name'   # default
+
+# When you are done setting your own default freeze it, so it will not get changed accidentally
+Pagy::DEFAULT.freeze

--- a/config/locales/claims/en/support/schools.yml
+++ b/config/locales/claims/en/support/schools.yml
@@ -3,7 +3,7 @@ en:
     support:
       schools:
         index:
-          heading: Organisations
+          heading: Organisations (%{records})
         new:
           caption: Add organisation
           cancel: Cancel

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,15 @@
 en:
+  shared:
+    search_form:
+      search-header: Search by organisation name or postcode
+      search: Search
+      clear_search: Clear search
+  components:
+    organisation_list_item:
+      organisation_type: Organisation Type
+      school: School
+  pagination_info: Showing %{from} to %{to} of %{count} results
+  no_results: There are no results for '%{for}'.
   date:
     formats:
       long: "%e %B %Y"

--- a/spec/system/claims/view_schools_as_support_user_spec.rb
+++ b/spec/system/claims/view_schools_as_support_user_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe "View schools as support user", type: :system do
+  before do
+    schools
+  end
+
+  scenario "I sign in as a support user to view schools and search by name" do
+    given_i_am_signed_in_as_support_user
+    then_i_see_all_schools_in_claims
+    when_i_search_for_school("Manchester")
+    then_i_see_only_the_manchester_school
+    when_i_clear_search
+    then_i_see_all_schools_in_claims
+    when_i_search_for_school("Wrong search")
+    then_i_see_no_results_page("Wrong search")
+  end
+
+  scenario "I sign in as a support user to view schools and search by postcode" do
+    given_i_am_signed_in_as_support_user
+    then_i_see_all_schools_in_claims
+    when_i_search_for_school("M12")
+    then_i_see_only_the_manchester_school
+    when_i_clear_search
+    then_i_see_all_schools_in_claims
+    when_i_search_for_school("Wrong search")
+    then_i_see_no_results_page("Wrong search")
+  end
+
+  private
+
+  def schools
+    @schools ||= [
+      create(:school, :claims, name: "Manchester School", postcode: "M1234"),
+      create(:school, :claims, name: "London School", postcode: "L5678"),
+    ]
+  end
+
+  def given_i_am_signed_in_as_support_user
+    create(:persona, :colin, service: "claims")
+    visit personas_path
+    click_on "Sign In as Colin"
+  end
+
+  def then_i_see_all_schools_in_claims
+    expect(page).to have_content("Organisations (#{@schools.count})")
+
+    @schools.each do |school|
+      expect(page).to have_content(school.name)
+    end
+  end
+
+  def when_i_search_for_school(school_name)
+    fill_in "Search by organisation name or postcode", with: school_name
+    click_on "Search"
+  end
+
+  def then_i_see_only_the_manchester_school
+    expect(page).to have_content("Manchester School")
+    expect(page).not_to have_content("London School")
+  end
+
+  def when_i_clear_search
+    click_on "Clear search"
+  end
+
+  def then_i_see_no_results_page(search_string)
+    expect(page).to have_content("There are no results for '#{search_string}'")
+  end
+end


### PR DESCRIPTION
## Context

We need to allow our support users to search schools by their names or postcodes. This commit adds this functionality with pg search.

It also adds pagy, for pagination and a search form partial that can be reused in other places.

We won't be implementing filters in this PR.

## Changes proposed in this pull request

- New pg search scope
- Refactored the support/schools controller a bit
- search form partial
- pagy gem

## Guidance to review

- Sign in as Colin in claims
- Search for a school by its name or postcode
- Clear the search by using the small `X` icon or by clicking `Clear search`
- Search for a school that doesn't exist.

## Screenshots

Prototype;
https://itt-mentoring-beta-94341ca35a2c.herokuapp.com/support/organisations
![CleanShot_2024-01-03_at_14 26 29](https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/08d13e31-ec67-4fa7-8552-56a6f416b28b)




https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/9d47c063-0560-43b5-ac04-957fd73f0c86


