### PR TITLE
As a Support User, I should be able to see the details of a School

### DIFF
--- a/app/controllers/claims/support/schools_controller.rb
+++ b/app/controllers/claims/support/schools_controller.rb
@@ -5,7 +5,7 @@ class Claims::Support::SchoolsController < Claims::Support::ApplicationControlle
   end
 
   def show
-    @school = Claims::School.find(params.require(:id))
+    @school = Claims::School.find(params.require(:id)).decorate
   end
 
   def new

--- a/app/controllers/placements/support/schools_controller.rb
+++ b/app/controllers/placements/support/schools_controller.rb
@@ -20,7 +20,7 @@ class Placements::Support::SchoolsController < Placements::Support::ApplicationC
   end
 
   def show
-    @school = Placements::School.find(params[:id])&.decorate
+    @school = Placements::School.find(params[:id]).decorate
   end
 
   private

--- a/app/views/claims/support/schools/_additional_details.html.erb
+++ b/app/views/claims/support/schools/_additional_details.html.erb
@@ -1,0 +1,58 @@
+<%= govuk_summary_list(html_attributes: { id: "additional-details" }) do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.group")) %>
+    <% row.with_value(**details_field_args(@school.group)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.type")) %>
+    <% row.with_value(**details_field_args(@school.type_of_establishment)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.phase")) %>
+    <% row.with_value(**details_field_args(@school.phase)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.gender")) %>
+    <% row.with_value(**details_field_args(@school.gender)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.minimum_age")) %>
+    <% row.with_value(**details_field_args(@school.minimum_age)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.maximum_age")) %>
+    <% row.with_value(**details_field_args(@school.maximum_age)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.religious_character")) %>
+    <% row.with_value(**details_field_args(@school.religious_character)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.admissions_policy")) %>
+    <% row.with_value(**details_field_args(@school.admissions_policy)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.urban_or_rural")) %>
+    <% row.with_value(**details_field_args(@school.urban_or_rural)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.school_capacity")) %>
+    <% row.with_value(**details_field_args(@school.school_capacity)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.total_pupils")) %>
+    <% row.with_value(**details_field_args(@school.total_pupils)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.total_boys")) %>
+    <% row.with_value(**details_field_args(@school.total_boys)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.total_girls")) %>
+    <% row.with_value(**details_field_args(@school.total_girls)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.percentage_free_school_meals")) %>
+    <% row.with_value(**details_field_args(@school.percentage_free_school_meals)) %>
+  <% end %>
+<% end %>

--- a/app/views/claims/support/schools/_contact_details.html.erb
+++ b/app/views/claims/support/schools/_contact_details.html.erb
@@ -1,0 +1,33 @@
+<%= govuk_summary_list(html_attributes: { id: "contact-details" }) do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.email_address")) %>
+    <% if @school.email_address.present? %>
+      <% row.with_value do %>
+        <%= govuk_mail_to(@school.email_address, @school.email_address) %>
+      <% end %>
+    <% else %>
+      <% row.with_value(**details_field_args) %>
+    <% end %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.telephone_number")) %>
+    <% row.with_value(**details_field_args(@school.telephone)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.website")) %>
+    <% if @school.website.present? %>
+      <% row.with_value do %>
+        <%= govuk_link_to(@school.website,
+                          external_link(@school.website),
+                          target: "_blank",
+                          rel: "noopener noreferrer") %>
+      <% end %>
+    <% else %>
+      <% row.with_value(**details_field_args) %>
+    <% end %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.address")) %>
+    <% row.with_value(**details_field_args(@school.formatted_address)) %>
+  <% end %>
+<% end %>

--- a/app/views/claims/support/schools/_ofsted_details.html.erb
+++ b/app/views/claims/support/schools/_ofsted_details.html.erb
@@ -1,0 +1,10 @@
+<%= govuk_summary_list(html_attributes: { id: "ofsted-details" }) do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.rating")) %>
+    <% row.with_value(**ofsted_field_args(@school.rating)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.last_inspection_date")) %>
+    <% row.with_value(**ofsted_field_args(@school.formatted_inspection_date)) %>
+  <% end %>
+<% end %>

--- a/app/views/claims/support/schools/_school_details.html.erb
+++ b/app/views/claims/support/schools/_school_details.html.erb
@@ -1,0 +1,14 @@
+<%= govuk_summary_list(html_attributes: { id: "school-details" }) do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.organisation_name")) %>
+    <% row.with_value(**details_field_args(@school.name)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.ukprn")) %>
+    <% row.with_value(**details_field_args(@school.ukprn)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.urn")) %>
+    <% row.with_value(**details_field_args(@school.urn)) %>
+  <% end %>
+<% end %>

--- a/app/views/claims/support/schools/_send_details.html.erb
+++ b/app/views/claims/support/schools/_send_details.html.erb
@@ -1,0 +1,14 @@
+<%= govuk_summary_list(html_attributes: { id: "send-details" }) do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.special_classes")) %>
+    <% row.with_value(**details_field_args(@school.special_classes)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.send_provision")) %>
+    <% row.with_value(**details_field_args(@school.send_provision)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t("placements.support.schools.show.training_with_disabilities")) %>
+    <% row.with_value(**details_field_args(@school.training_with_disabilities)) %>
+  <% end %>
+<% end %>

--- a/app/views/claims/support/schools/show.html.erb
+++ b/app/views/claims/support/schools/show.html.erb
@@ -1,6 +1,6 @@
-<div class="govuk-width-container">
-  <h1 class="govuk-heading-l"><%= @school.name %></h1>
+<%= content_for :page_title, @school.name %>
 
+<div class="govuk-width-container">
   <%= render SecondaryNavigationComponent.new do |component| %>
     <% component.with_navigation_item t(".details"), claims_support_school_path(@school.id) %>
     <% component.with_navigation_item t(".users"), claims_support_school_users_path(@school.id) %>
@@ -10,23 +10,19 @@
   <% end %>
 
   <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h1 class="govuk-heading-l"><%= @school.name %></h1>
+    </div>
     <div class="govuk-grid-column-two-thirds">
-      <%= govuk_summary_list do |summary_list| %>
-        <% summary_list.with_row do |row| %>
-          <% row.with_key(text: t(".organisation_name")) %>
-          <% row.with_value(text: "Hogwarts") %>
-        <% end %>
-
-        <% summary_list.with_row do |row| %>
-          <% row.with_key(text: t(".uk_provider_reference_number")) %>
-          <% row.with_value(text: "fake_uprn") %>
-        <% end %>
-
-        <% summary_list.with_row do |row| %>
-          <% row.with_key(text: t(".unique_reference_number")) %>
-          <% row.with_value(text: 1) %>
-        <% end %>
-      <% end %>
+      <%= render "school_details", school: @school %>
+      <h2 class="govuk-heading-m govuk-!-margin-top-9"><%= t(".additional_details") %></h2>
+      <%= render "additional_details", school: @school %>
+      <h2 class="govuk-heading-m govuk-!-margin-top-9"><%= t(".send") %></h2>
+      <%= render "send_details", school: @school %>
+      <h2 class="govuk-heading-m govuk-!-margin-top-9"><%= t(".ofsted") %></h2>
+      <%= render "ofsted_details", school: @school %>
+      <h2 class="govuk-heading-m govuk-!-margin-top-9"><%= t(".contact_details") %></h2>
+      <%= render "contact_details", school: @school %>
     </div>
   </div>
 </div>

--- a/app/views/claims/support/users/index.html.erb
+++ b/app/views/claims/support/users/index.html.erb
@@ -1,6 +1,4 @@
 <div class="govuk-width-container">
-  <h1 class="govuk-heading-l"><%= @school.name %></h1>
-
   <%= render SecondaryNavigationComponent.new do |component| %>
     <% component.with_navigation_item t(".details"), claims_support_school_path(@school.id) %>
     <% component.with_navigation_item t(".users"), claims_support_school_users_path(@school.id) %>
@@ -9,6 +7,7 @@
     <% component.with_navigation_item t(".claims"), claims_support_school_claims_path(@school.id) %>
   <% end %>
 
+  <h1 class="govuk-heading-l"><%= @school.name %></h1>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m"><%= t(".heading") %></h2>

--- a/spec/system/claims/support/schools/view_a_school_spec.rb
+++ b/spec/system/claims/support/schools/view_a_school_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "View a school", type: :system do
     when_i_visit_the_school_page(school)
     i_see_the_school_details(school)
     and_i_see_the_secondary_navigation_links(school)
+    i_see_the_schools_details_sections
   end
 
   private
@@ -35,5 +36,12 @@ RSpec.describe "View a school", type: :system do
       expect(page).to have_link("Users", href: "/support/schools/#{school.id}/users")
       expect(page).to have_link("Claims", href: "/support/schools/#{school.id}/claims")
     end
+  end
+
+  def i_see_the_schools_details_sections
+    expect(page).to have_selector("h2", text: "Additional Details")
+    expect(page).to have_selector("h2", text: "Send")
+    expect(page).to have_selector("h2", text: "Ofsted")
+    expect(page).to have_selector("h2", text: "Contact Details")
   end
 end


### PR DESCRIPTION
## Context

Update the support schools page to show the schools details

## Changes proposed in this pull request

Add read only fields to show a schools details

## Guidance to review

- login as support user 
- Go to the support/schools url
- Select a school

## Link to Trello card

https://trello.com/c/4iG5S0cP/68-as-a-support-user-i-should-be-able-to-see-the-details-of-a-school-organisation

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<img width="943" alt="Screenshot 2024-01-12 at 08 57 18" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/38307d3e-0403-4039-a582-ead55da67a3b">
