### PR TITLE
sanitise html in page title

### DIFF
--- a/app/views/placements/support/schools/show.html.erb
+++ b/app/views/placements/support/schools/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, @school.name %>
+<%= content_for :page_title, sanitize(@school.name) %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">


### PR DESCRIPTION
## Context

Bug: School name in page title has escaped characters eg 
<img width="246" alt="image" src="https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/58b9c903-dda0-42ff-8c87-16d73eb48a24">

## Changes proposed in this pull request

sanitize school name in page title

## Guidance to review

Look at a school with an apostrophe in the title. The name should be rendered correctly in the page title

## Link to Trello card

https://trello.com/c/kbx9B460

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots
Before 
<img width="246" alt="image" src="https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/152efc51-f3b6-4609-a5ae-d6ff4735cb00">

After: 
<img width="244" alt="image" src="https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/3871c535-980a-40e1-a00d-2381060b6e2f">


<!-- Sceenshots to aid with reviewing if needed-->
