### PR TITLE
Lb/placements secondary nav bar

### DIFF
--- a/app/views/placements/support/schools/show.html.erb
+++ b/app/views/placements/support/schools/show.html.erb
@@ -4,7 +4,15 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-l"><%= @school.name %></h1>
+      <%= render SecondaryNavigationComponent.new do |component| %>
+        <% component.with_navigation_item t(".secondary_navigation.details"), placements_support_school_path(@school) %>
+        <% component.with_navigation_item t(".secondary_navigation.users"), "#" %>
+        <% component.with_navigation_item t(".secondary_navigation.mentors"), "#" %>
+        <% component.with_navigation_item t(".secondary_navigation.placements"), "#" %>
+        <% component.with_navigation_item t(".secondary_navigation.providers"), "#" %>
+      <% end %>
     </div>
+
     <div class="govuk-grid-column-two-thirds">
       <%= render "school_details", school: @school %>
       <h2 class="govuk-heading-m govuk-!-margin-top-9"><%= t(".additional_details") %></h2>

--- a/config/locales/placements/en/layouts/application.yml
+++ b/config/locales/placements/en/layouts/application.yml
@@ -55,6 +55,12 @@ en:
           urn: Unique reference number (URN)
           website: Website
         show:
+          secondary_navigation:
+            details: Details
+            users: Users
+            mentors: Mentors
+            placements: Placements
+            providers: Providers
           unknown: Unknown
           not_entered: Not entered
           not_applicable: Not applicable


### PR DESCRIPTION
## Context

As a support user viewing school details, I should see a secondary navigation bar (to match the prototype)

## Changes proposed in this pull request

- Add secondary navigation bar to school show page.

## Guidance to review

Login as a user, click on a school, and you'll see the secondary navigation

## Link to Trello card

https://trello.com/c/pAwpNGZQ

## Things to check

- [NA] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [NA] This code does not rely on migrations in the same Pull Request
- [NA] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [NA] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [NA] API release notes have been updated if necessary
- [NA] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [NA] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots
Before: 
<img width="1035" alt="image" src="https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/4e267bd4-3212-48dd-a1c2-544e3de612ea">


After: 
<img width="1079" alt="image" src="https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/ea3b0fa9-f5a0-4953-8b1a-f61772dd62f9">

