### PR TITLE
lb/Placements add in missing page titles

### DIFF
--- a/app/views/claims/schools/show.html.erb
+++ b/app/views/claims/schools/show.html.erb
@@ -9,7 +9,7 @@
   <% end %>
 <% end %>
 
-<% content_for :page_title, @school.name %>
+<% content_for :page_title, sanitize(@school.name) %>
 
 <% content_for(:before_content) do %>
   <%= render PrimaryNavigationComponent.new do |component| %>

--- a/app/views/claims/support/schools/new.html.erb
+++ b/app/views/claims/support/schools/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, t(".title") %>
+
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: claims_support_schools_path) %>
 <% end %>

--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, t(".title") %>
+
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/placements/support/organisations/new.html.erb
+++ b/app/views/placements/support/organisations/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, t(".title") %>
+
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: placements_support_organisations_path) %>
 <% end %>

--- a/app/views/placements/support/providers/check.html.erb
+++ b/app/views/placements/support/providers/check.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, t(".title") %>
+
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: new_placements_support_provider_path) %>
 <% end %>

--- a/app/views/placements/support/providers/new.html.erb
+++ b/app/views/placements/support/providers/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, t(".title") %>
+
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: new_placements_support_organisation_path) %>
 <% end %>

--- a/app/views/placements/support/schools/check.html.erb
+++ b/app/views/placements/support/schools/check.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, t(".title") %>
+
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: new_placements_support_provider_path) %>
 <% end %>


### PR DESCRIPTION
## Context

Page titles were missing from several pages in placements. 

## Changes proposed in this pull request

Added in page titles to match the prototype

## Guidance to review

Login to placements and navigate around -- the page titles should match the prototype now

## Link to Trello card

https://trello.com/c/yMouPrsn

## Things to check

- [NA] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [NA] This code does not rely on migrations in the same Pull Request
- [NA] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [NA] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [NA] API release notes have been updated if necessary
- [NA] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [NA] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

An example before: 
<img width="739" alt="image" src="https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/f94c6766-ffe2-4368-ad3c-785f89e6e222">


And after: 
<img width="681" alt="image" src="https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/687d6db6-a2fa-48f7-9a9b-0932fcb50b93">


