### PR TITLE
Lb/fix error summary navigation

### DIFF
--- a/app/javascript/autocomplete.js
+++ b/app/javascript/autocomplete.js
@@ -8,12 +8,12 @@ const initAutocomplete = (elementId, inputId, options = {}) => {
     const input = document.getElementById(inputId);
 
     if (element && input) {
-      const { path, template, minLength, onConfirm, inputName } = options;
+      const { path, template, minLength, onConfirm, inputName, errorId = null } = options;
       const { inputValue, suggestion } = template;
 
       accessibleAutocomplete({
         element,
-        id: input.id,
+        id: errorId || input.id,
         showNoOptionsFound: true,
         name: input.name,
         minLength,

--- a/app/javascript/provider.js
+++ b/app/javascript/provider.js
@@ -16,6 +16,7 @@ function init() {
     minLength: 2,
     inputName: "provider[search_code]",
     onConfirm,
+    errorId: "provider-onboarding-form-code-field-error"
   };
 
   initAutocomplete(

--- a/app/javascript/school.js
+++ b/app/javascript/school.js
@@ -17,6 +17,7 @@ function init() {
     minLength: 2,
     inputName: "school[search_urn]",
     onConfirm,
+    errorId: "school-urn-field-error"
   };
 
   initAutocomplete(

--- a/spec/system/claims/schools/support_user_adds_a_school_spec.rb
+++ b/spec/system/claims/schools/support_user_adds_a_school_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "Support User adds a School", type: :system do
   end
 
   def and_i_enter_a_school_named(school_name)
-    fill_in "school-search-form-query-field", with: school_name
+    fill_in "school-urn-field-error", with: school_name
   end
 
   def then_i_see_a_dropdown_item_for(school_name)

--- a/spec/system/placements/providers/support_user_adds_a_provider_spec.rb
+++ b/spec/system/placements/providers/support_user_adds_a_provider_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Placements / Providers / Support User adds a Provider", type: :s
   end
 
   def and_i_enter_a_provider_named(provider_name)
-    fill_in "accredited-provider-search-form-query-field", with: provider_name
+    fill_in "provider-onboarding-form-code-field-error", with: provider_name
   end
 
   def then_i_see_a_dropdown_item_for(provider_name)

--- a/spec/system/placements/schools/support_user_adds_a_school_spec.rb
+++ b/spec/system/placements/schools/support_user_adds_a_school_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Placements / Schools / Support User adds a School",
   end
 
   def and_i_enter_a_school_named(school_name)
-    fill_in "school-search-form-query-field", with: school_name
+    fill_in "school-urn-field-error", with: school_name
   end
 
   def then_i_see_a_dropdown_item_for(school_name)


### PR DESCRIPTION
## Context

When there are errors in the error summary, we should be able to use those to navigate to the field where the error is. The ids were not correct for the provider and school inputs when adding a new organisation

## Changes proposed in this pull request

Add error id to autocomplete.

## Guidance to review

Login as colin and go to add organisation. 
Click continue without entering an organisation. 
Click on (or use the keyboard to navigate to) the error in the error summary, 
The focus should then be on the required input field

## Link to Trello card

https://trello.com/c/n4gsEQRz

## Things to check

- [NA] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [NA] This code does not rely on migrations in the same Pull Request
- [NA] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [NA] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [NA] API release notes have been updated if necessary
- [NA] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [NA] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

Before

https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/4172bd1c-bce2-485c-a0db-070dc3003309

After

https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/1457782d-4aad-4725-a410-c9b078b93259

