### PR TITLE
Lb/bug missing success flash when adding organisations

### DIFF
--- a/app/controllers/claims/support/schools_controller.rb
+++ b/app/controllers/claims/support/schools_controller.rb
@@ -22,6 +22,7 @@ class Claims::Support::SchoolsController < Claims::Support::ApplicationControlle
 
   def create
     if school_form.onboard
+      flash[:success] = I18n.t("claims.support.schools.create.organisation_added")
       redirect_to claims_support_schools_path
     else
       render :new

--- a/app/controllers/placements/support/providers_controller.rb
+++ b/app/controllers/placements/support/providers_controller.rb
@@ -13,6 +13,7 @@ class Placements::Support::ProvidersController < Placements::Support::Applicatio
 
   def create
     if provider_form.onboard
+      flash[:success] = I18n.t("placements.support.providers.create.organisation_added")
       redirect_to placements_support_organisations_path
     else
       render :new

--- a/app/controllers/placements/support/schools_controller.rb
+++ b/app/controllers/placements/support/schools_controller.rb
@@ -13,6 +13,7 @@ class Placements::Support::SchoolsController < Placements::Support::ApplicationC
 
   def create
     if school_form.onboard
+      flash[:success] = I18n.t("placements.support.schools.create.organisation_added")
       redirect_to placements_support_organisations_path
     else
       render :new

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,16 +55,18 @@
       <%= yield :before_content %>
     </div>
 
-    <% flash.each do |key, message| %>
-      <div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-top-6 govuk-!-margin-bottom-0" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-        <div class="govuk-notification-banner__header">
-          <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+    <div class="govuk-width-container">
+      <% flash.each do |key, message| %>
+        <div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-top-6 govuk-!-margin-bottom-0" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+          <div class="govuk-notification-banner__header">
+            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+          </div>
+          <div class="govuk-notification-banner__content">
+            <h3 class="govuk-notification-banner__heading"><%= message %></h3>
+          </div>
         </div>
-        <div class="govuk-notification-banner__content">
-          <h3 class="govuk-notification-banner__heading"><%= message %></h3>
-        </div>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
 
     <main class="govuk-main-wrapper" id="main-content" role="main">
       <%= yield %>

--- a/config/locales/claims/en/support/schools.yml
+++ b/config/locales/claims/en/support/schools.yml
@@ -8,6 +8,8 @@ en:
           mentors: Mentors
           providers: Providers
           claims: Claims
+        create:
+          organisation_added: Organisation added
         show:
           additional_details: Additional details
           send: Special educational needs and disabilities (SEND)

--- a/config/locales/placements/en/layouts/application.yml
+++ b/config/locales/placements/en/layouts/application.yml
@@ -39,6 +39,8 @@ en:
           no_organisations: There are no onboarded organisations
           organisation_type: Organisation type
       schools:
+        create:
+          organisation_added: Organisation added
         new:
           caption: Add organisation
           cancel: Cancel
@@ -95,6 +97,8 @@ en:
           website: Website
           address: Address
       providers:
+        create:
+          organisation_added: Organisation added
         new:
           caption: Add organisation
           cancel: Cancel

--- a/spec/system/claims/schools/support_user_adds_a_school_spec.rb
+++ b/spec/system/claims/schools/support_user_adds_a_school_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe "Support User adds a School", type: :system do
     when_i_click_add_organisation
     then_i_return_to_support_organisations_index
     and_a_school_is_listed(school_name: "School 1")
+    and_i_see_success_message
   end
 
   scenario "Colin adds a school which already exists", js: true do
@@ -112,5 +113,9 @@ RSpec.describe "Support User adds a School", type: :system do
 
   def and_a_school_is_listed(school_name:)
     expect(page).to have_content(school_name)
+  end
+
+  def and_i_see_success_message
+    expect(page).to have_content "Organisation added"
   end
 end

--- a/spec/system/placements/providers/support_user_adds_a_provider_spec.rb
+++ b/spec/system/placements/providers/support_user_adds_a_provider_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "Placements / Providers / Support User adds a Provider", type: :s
     when_i_click_add_organisation
     then_i_return_to_support_organisations_index
     and_a_provider_code_is_listed(code: "Provider 1")
+    and_i_see_success_message
   end
 
   scenario "Colin adds a Provider which already exists", js: true do
@@ -113,5 +114,9 @@ RSpec.describe "Placements / Providers / Support User adds a Provider", type: :s
 
   def and_a_provider_code_is_listed(code:)
     expect(page).to have_content(code)
+  end
+
+  def and_i_see_success_message
+    expect(page).to have_content "Organisation added"
   end
 end

--- a/spec/system/placements/schools/support_user_adds_a_school_spec.rb
+++ b/spec/system/placements/schools/support_user_adds_a_school_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe "Placements / Schools / Support User adds a School",
     when_i_click_add_organisation
     then_i_return_to_support_organisations_index
     and_a_school_is_listed(school_name: "School 1")
+    and_i_see_success_message
   end
 
   scenario "Colin adds a school which already exists", js: true do
@@ -115,5 +116,9 @@ RSpec.describe "Placements / Schools / Support User adds a School",
 
   def and_a_school_is_listed(school_name:)
     expect(page).to have_content(school_name)
+  end
+
+  def and_i_see_success_message
+    expect(page).to have_content "Organisation added"
   end
 end


### PR DESCRIPTION
## Context

The prototype has a flash success message when a support user adds an organisation (school or provider, claims or placements). 

## Changes proposed in this pull request

- Add success messages
- Wrap all flash messages in the width container so they are the same size as the rest of the page

## Guidance to review

Login as a colin in claims or support
Add an organisation
See a success message

## Link to Trello card

https://trello.com/c/WZPkPzcj

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<img width="1117" alt="image" src="https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/23157dbe-9a7a-4d6e-b59d-687403846253">

