### PR TITLE
Update school links in Claims support schools index page

### DIFF
--- a/app/views/claims/support/schools/index.html.erb
+++ b/app/views/claims/support/schools/index.html.erb
@@ -18,7 +18,7 @@
         <% @schools.each do |school| %>
           <%= render(OrganisationListItem.new(
             organisation: school,
-            organisation_url: claims_school_path(school),
+            organisation_url: claims_support_school_path(school),
           )) %>
         <% end %>
 

--- a/spec/system/claims/support/schools/view_a_school_spec.rb
+++ b/spec/system/claims/support/schools/view_a_school_spec.rb
@@ -1,10 +1,12 @@
 require "rails_helper"
 
 RSpec.describe "View a school", type: :system do
+  let!(:support_user) { create(:persona, :colin, service: :claims) }
+  let!(:school) { create(:school, :claims) }
+
   scenario "View a school's details as a support user" do
-    when_i_sign_in_as_a_support_user
-    school = and_there_is_a_school
-    when_i_visit_the_school_page(school)
+    when_i_sign_in_as_a_support_user(support_user)
+    and_i_visit_the_school_page(school)
     i_see_the_school_details(school)
     and_i_see_the_secondary_navigation_links(school)
     i_see_the_schools_details_sections
@@ -12,18 +14,13 @@ RSpec.describe "View a school", type: :system do
 
   private
 
-  def when_i_sign_in_as_a_support_user
-    create(:persona, :colin, service: "claims")
-    visit personas_path
-    click_on "Sign In as Colin"
+  def when_i_sign_in_as_a_support_user(support_user)
+    visit claims_root_path
+    click_on "Sign In as #{support_user.first_name}"
   end
 
-  def and_there_is_a_school
-    create(:school, :claims, urn: "123456")
-  end
-
-  def when_i_visit_the_school_page(school)
-    visit "/support/schools/#{school.id}"
+  def and_i_visit_the_school_page(school)
+    click_on school.name
   end
 
   def i_see_the_school_details(school)


### PR DESCRIPTION
## Context

The links on the support schools page link to the non-support school pages.

## Changes proposed in this pull request

- Update links to support school page paths
- Update system spec to walk through the user journey to avoid regressions

## Guidance to review

- Sign in as support user
- Click on a school
- It should take you to the `/support/schools/{id}` page

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
