### PR TITLE
Jc/change links on org user check pages

### DIFF
--- a/app/controllers/claims/support/schools/users_controller.rb
+++ b/app/controllers/claims/support/schools/users_controller.rb
@@ -10,7 +10,7 @@ class Claims::Support::Schools::UsersController < Claims::Support::ApplicationCo
   end
 
   def new
-    @user = Claims::User.new
+    @user = params[:claims_user].present? ? user : Claims::User.new
   end
 
   def check

--- a/app/controllers/placements/support/organisations/users_controller.rb
+++ b/app/controllers/placements/support/organisations/users_controller.rb
@@ -14,7 +14,11 @@ class Placements::Support::Organisations::UsersController < Placements::Support:
   end
 
   def check
-    render :new unless user.valid?
+    if user.valid?
+      @user = user.decorate
+    else
+      render :new
+    end
   end
 
   def create

--- a/app/controllers/placements/support/organisations/users_controller.rb
+++ b/app/controllers/placements/support/organisations/users_controller.rb
@@ -10,7 +10,7 @@ class Placements::Support::Organisations::UsersController < Placements::Support:
   end
 
   def new
-    @user = Placements::User.new
+    @user = params[:placements_user].present? ? user : Placements::User.new
   end
 
   def check

--- a/app/decorators/claims/user_decorator.rb
+++ b/app/decorators/claims/user_decorator.rb
@@ -1,3 +1,3 @@
-class Claims::UserDecorator < Draper::Decorator
+class Claims::UserDecorator < UserDecorator
   delegate_all
 end

--- a/app/decorators/placements/user_decorator.rb
+++ b/app/decorators/placements/user_decorator.rb
@@ -1,0 +1,3 @@
+class Placements::UserDecorator < UserDecorator
+  delegate_all
+end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,0 +1,9 @@
+class UserDecorator < Draper::Decorator
+  delegate_all
+
+  FORM_PARAMS = %i[first_name last_name email].freeze
+
+  def as_form_params
+    { "#{service}_user" => slice(FORM_PARAMS) }
+  end
+end

--- a/app/views/claims/support/schools/users/check.html.erb
+++ b/app/views/claims/support/schools/users/check.html.erb
@@ -3,7 +3,7 @@
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(
     href: new_claims_support_school_user_path(
-      params.permit(claims_user: {}).merge(school_id: @school.id),
+      @user.as_form_params.merge(school_id: @school.id),
     ),
   ) %>
 <% end %>
@@ -32,7 +32,7 @@
                 <li class="govuk-summary-list__actions-list-item">
                   <%= govuk_link_to(t(".change"),
                     new_claims_support_school_user_path(
-                      params.permit(claims_user: {}).merge(school_id: @school.id),
+                      @user.as_form_params.merge(school_id: @school.id),
                     ),
                     no_visited_state: true) %>
                 </li>
@@ -49,7 +49,7 @@
                 <li class="govuk-summary-list__actions-list-item">
                   <%= govuk_link_to(t(".change"),
                     new_claims_support_school_user_path(
-                      params.permit(claims_user: {}).merge(school_id: @school.id),
+                      @user.as_form_params.merge(school_id: @school.id),
                     ),
                     no_visited_state: true) %>
                 </li>
@@ -66,7 +66,7 @@
                 <li class="govuk-summary-list__actions-list-item">
                   <%= govuk_link_to(t(".change"),
                     new_claims_support_school_user_path(
-                      params.permit(claims_user: {}).merge(school_id: @school.id),
+                      @user.as_form_params.merge(school_id: @school.id),
                     ),
                     no_visited_state: true) %>
                 </li>

--- a/app/views/claims/support/schools/users/check.html.erb
+++ b/app/views/claims/support/schools/users/check.html.erb
@@ -1,7 +1,11 @@
 <%= content_for :page_title, sanitize(t(".page_title", school_name: @school.name)) %>
 
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: new_claims_support_school_user_path(@school)) %>
+  <%= govuk_back_link(
+    href: new_claims_support_school_user_path(
+      params.permit(claims_user: {}).merge(school_id: @school.id),
+    ),
+  ) %>
 <% end %>
 
 <div class="govuk-width-container">
@@ -25,7 +29,13 @@
             </dd>
             <dd class="govuk-summary-list__actions">
               <ul class="govuk-summary-list__actions-list">
-                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="#">Change<span class="govuk-visually-hidden"></span></a></li>
+                <li class="govuk-summary-list__actions-list-item">
+                  <%= govuk_link_to("Change",
+                    new_claims_support_school_user_path(
+                      params.permit(claims_user: {}).merge(school_id: @school.id),
+                    ),
+                    no_visited_state: true) %>
+                </li>
               </ul>
             </dd>
           </div>
@@ -36,7 +46,13 @@
             </dd>
             <dd class="govuk-summary-list__actions">
               <ul class="govuk-summary-list__actions-list">
-                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="#">Change<span class="govuk-visually-hidden"></span></a></li>
+                <li class="govuk-summary-list__actions-list-item">
+                  <%= govuk_link_to("Change",
+                    new_claims_support_school_user_path(
+                      params.permit(claims_user: {}).merge(school_id: @school.id),
+                    ),
+                    no_visited_state: true) %>
+                </li>
               </ul>
             </dd>
           </div>
@@ -47,7 +63,13 @@
             </dd>
             <dd class="govuk-summary-list__actions">
               <ul class="govuk-summary-list__actions-list">
-                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="#">Change<span class="govuk-visually-hidden"></span></a></li>
+                <li class="govuk-summary-list__actions-list-item">
+                  <%= govuk_link_to("Change",
+                    new_claims_support_school_user_path(
+                      params.permit(claims_user: {}).merge(school_id: @school.id),
+                    ),
+                    no_visited_state: true) %>
+                </li>
               </ul>
             </dd>
           </div>

--- a/app/views/claims/support/schools/users/check.html.erb
+++ b/app/views/claims/support/schools/users/check.html.erb
@@ -30,7 +30,7 @@
             <dd class="govuk-summary-list__actions">
               <ul class="govuk-summary-list__actions-list">
                 <li class="govuk-summary-list__actions-list-item">
-                  <%= govuk_link_to("Change",
+                  <%= govuk_link_to(t(".change"),
                     new_claims_support_school_user_path(
                       params.permit(claims_user: {}).merge(school_id: @school.id),
                     ),
@@ -47,7 +47,7 @@
             <dd class="govuk-summary-list__actions">
               <ul class="govuk-summary-list__actions-list">
                 <li class="govuk-summary-list__actions-list-item">
-                  <%= govuk_link_to("Change",
+                  <%= govuk_link_to(t(".change"),
                     new_claims_support_school_user_path(
                       params.permit(claims_user: {}).merge(school_id: @school.id),
                     ),
@@ -64,7 +64,7 @@
             <dd class="govuk-summary-list__actions">
               <ul class="govuk-summary-list__actions-list">
                 <li class="govuk-summary-list__actions-list-item">
-                  <%= govuk_link_to("Change",
+                  <%= govuk_link_to(t(".change"),
                     new_claims_support_school_user_path(
                       params.permit(claims_user: {}).merge(school_id: @school.id),
                     ),

--- a/app/views/placements/support/organisations/users/_check_form.html.erb
+++ b/app/views/placements/support/organisations/users/_check_form.html.erb
@@ -16,7 +16,7 @@
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".first_name")) %>
             <% row.with_value(text: user.first_name) %>
-            <% row.with_action(text: "Change",
+            <% row.with_action(text: t(".change"),
                                href: change_url,
                                html_attributes: {
                                 class: "govuk-link--no-visited-state",
@@ -25,7 +25,7 @@
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".last_name")) %>
             <% row.with_value(text: user.last_name) %>
-            <% row.with_action(text: "Change",
+            <% row.with_action(text: t(".change"),
                                href: change_url,
                                html_attributes: {
                                 class: "govuk-link--no-visited-state",
@@ -34,7 +34,7 @@
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".email")) %>
             <% row.with_value(text: user.email) %>
-            <% row.with_action(text: "Change",
+            <% row.with_action(text: t(".change"),
                                href: change_url,
                                html_attributes: {
                                 class: "govuk-link--no-visited-state",

--- a/app/views/placements/support/organisations/users/_check_form.html.erb
+++ b/app/views/placements/support/organisations/users/_check_form.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (form_url: "", cancel_url: "", user: nil, organisation: nil) -%>
+<%# locals: (form_url: "", cancel_url: "", change_url: "", user: nil, organisation: nil) -%>
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -16,14 +16,29 @@
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".first_name")) %>
             <% row.with_value(text: user.first_name) %>
+            <% row.with_action(text: "Change",
+                               href: change_url,
+                               html_attributes: {
+                                class: "govuk-link--no-visited-state",
+            }) %>
           <% end %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".last_name")) %>
             <% row.with_value(text: user.last_name) %>
+            <% row.with_action(text: "Change",
+                               href: change_url,
+                               html_attributes: {
+                                class: "govuk-link--no-visited-state",
+            }) %>
           <% end %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".email")) %>
             <% row.with_value(text: user.email) %>
+            <% row.with_action(text: "Change",
+                               href: change_url,
+                               html_attributes: {
+                                class: "govuk-link--no-visited-state",
+            }) %>
           <% end %>
         <% end %>
 

--- a/app/views/placements/support/providers/users/check.html.erb
+++ b/app/views/placements/support/providers/users/check.html.erb
@@ -8,6 +8,9 @@
 
 <%= render "placements/support/organisations/users/check_form",
   form_url: placements_support_provider_users_path(@provider),
-  cancel_url: placements_support_school_users_path(@provider),
+  cancel_url: placements_support_provider_users_path(@provider),
+  change_url: new_placements_support_provider_user_path(
+    params.permit(placements_user: {}).merge(provider_id: @provider.id),
+  ),
   user: @user,
   organisation: @provider %>

--- a/app/views/placements/support/providers/users/check.html.erb
+++ b/app/views/placements/support/providers/users/check.html.erb
@@ -1,7 +1,9 @@
 <%= content_for :page_title, sanitize(t(".page_title", provider_name: @provider.name)) %>
 
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: new_placements_support_provider_user_path(@provider)) %>
+  <%= govuk_back_link(href: new_placements_support_provider_user_path(
+    @user.as_form_params.merge(provider_id: @provider.id),
+  )) %>
 <% end %>
 
 <%= content_for :page_title, sanitize(@provider.name) %>
@@ -10,7 +12,7 @@
   form_url: placements_support_provider_users_path(@provider),
   cancel_url: placements_support_provider_users_path(@provider),
   change_url: new_placements_support_provider_user_path(
-    params.permit(placements_user: {}).merge(provider_id: @provider.id),
+    @user.as_form_params.merge(provider_id: @provider.id),
   ),
   user: @user,
   organisation: @provider %>

--- a/app/views/placements/support/schools/users/check.html.erb
+++ b/app/views/placements/support/schools/users/check.html.erb
@@ -1,7 +1,9 @@
 <%= content_for :page_title, sanitize(t(".page_title", school_name: @school.name)) %>
 
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: new_placements_support_school_user_path(@school)) %>
+  <%= govuk_back_link(href: new_placements_support_school_user_path(
+    params.permit(placements_user: {}).merge(school_id: @school.id),
+  )) %>
 <% end %>
 
 <%= content_for :page_title, sanitize(@school.name) %>
@@ -9,5 +11,8 @@
 <%= render "placements/support/organisations/users/check_form",
   form_url: placements_support_school_users_path(@school),
   cancel_url: placements_support_school_users_path(@school),
+  change_url: new_placements_support_school_user_path(
+    params.permit(placements_user: {}).merge(school_id: @school.id),
+  ),
   user: @user,
   organisation: @school %>

--- a/app/views/placements/support/schools/users/check.html.erb
+++ b/app/views/placements/support/schools/users/check.html.erb
@@ -2,7 +2,7 @@
 
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: new_placements_support_school_user_path(
-    params.permit(placements_user: {}).merge(school_id: @school.id),
+    @user.as_form_params.merge(school_id: @school.id),
   )) %>
 <% end %>
 
@@ -12,7 +12,7 @@
   form_url: placements_support_school_users_path(@school),
   cancel_url: placements_support_school_users_path(@school),
   change_url: new_placements_support_school_user_path(
-    params.permit(placements_user: {}).merge(school_id: @school.id),
+    @user.as_form_params.merge(school_id: @school.id),
   ),
   user: @user,
   organisation: @school %>

--- a/config/locales/en/claims/support/schools/users.yml
+++ b/config/locales/en/claims/support/schools/users.yml
@@ -37,3 +37,4 @@ en:
             email: Email address
             warning: "The user will be sent an email to tell them you’ve added them to %{school_name}."
             page_title: "Check your answers - Add user - %{school_name}"
+            change: Change

--- a/config/locales/placements/en/support/organisations/users.yml
+++ b/config/locales/placements/en/support/organisations/users.yml
@@ -28,3 +28,4 @@ en:
             last_name: Last name
             email: Email
             warning: "The user will be sent an email to tell them you’ve added them to %{organisation_name}."
+            change: Change

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe UserDecorator do
+  describe "#as_form_params" do
+    context "when the User's service is Claims" do
+      it "returns a hash of form values with a key 'claims_user'" do
+        user = create(:claims_user,
+                      first_name: "Claims",
+                      last_name: "User",
+                      email: "claims_user@example.com")
+        expect(user.decorate.as_form_params).to eq(
+          { "claims_user" => {
+            "first_name" => "Claims",
+            "last_name" => "User",
+            "email" => "claims_user@example.com",
+          } },
+        )
+      end
+    end
+
+    context "when the User's service is Placements" do
+      it "returns a hash of form values with a key 'placements_user'" do
+        user = create(:placements_user,
+                      first_name: "Placements",
+                      last_name: "User",
+                      email: "placements_user@example.com")
+        expect(user.decorate.as_form_params).to eq(
+          { "placements_user" => {
+            "first_name" => "Placements",
+            "last_name" => "User",
+            "email" => "placements_user@example.com",
+          } },
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Currently the "Change" links on Organisations(Schools/Providers)/Users/Check pages (Placements/Claims) don't work.

## Changes proposed in this pull request

"Change" and "Back" links on  Organisations(Schools/Providers)/Users/Check pages (Placements/Claims) now redirect back to the Organisations(Schools/Providers)/Users/New pages, AND repopulate the form with the User's inputs.

## Guidance to review

- Fill out the form to onboard a new user to an organisation
- Click the "Change" and "Back" links
- You should be redirected back to the New User form, with form pre(re)-filled

## Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/O3l6X9kG/131-fix-change-links-on-claims-org-users-check-page-and-implement-them-on-placements)

## Screenshots

https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/069c12e1-d39d-4ecb-a232-a470f23f758c



