### PR TITLE
Fix error wrapper for autocomplete

### DIFF
--- a/app/views/claims/support/schools/new.html.erb
+++ b/app/views/claims/support/schools/new.html.erb
@@ -10,7 +10,7 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <div class="govuk-form-group">
+        <div class="govuk-form-group<%= " govuk-form-group--error" if f.object.errors.present? %>">
           <%= f.govuk_text_field :urn, value: nil,
                                        label: { text: t(".title"), size: "l" },
                                        caption: { text: t(".caption") },

--- a/app/views/claims/support/schools/new.html.erb
+++ b/app/views/claims/support/schools/new.html.erb
@@ -10,14 +10,14 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <div class="govuk-form-group<%= " govuk-form-group--error" if f.object.errors.present? %>">
+        <%= content_tag(:div, class: class_names("govuk-form-group", "govuk-form-group--error": f.object.errors.present?)) do %>
           <%= f.govuk_text_field :urn, value: nil,
                                        label: { text: t(".title"), size: "l" },
                                        caption: { text: t(".caption") },
                                        id: "school-search-form-query-field" %>
 
           <div id="school-autocomplete" class="govuk-!-margin-bottom-7"></div>
-        </div>
+        <% end %>
 
         <%= f.govuk_submit t(".continue") %>
 

--- a/app/views/placements/support/providers/new.html.erb
+++ b/app/views/placements/support/providers/new.html.erb
@@ -10,14 +10,14 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <div class="govuk-form-group<%= " govuk-form-group--error" if f.object.errors.present? %>">
+        <%= content_tag(:div, class: class_names("govuk-form-group", "govuk-form-group--error": f.object.errors.present?)) do %>
           <%= f.govuk_text_field :code, value: nil,
                                         label: { text: t(".title"), size: "l" },
                                         caption: { text: t(".caption") },
                                         id: "accredited-provider-search-form-query-field" %>
 
           <div id="accredited-provider-autocomplete" class="govuk-!-margin-bottom-7"></div>
-        </div>
+        <% end %>
 
         <%= f.govuk_submit t(".continue") %>
 

--- a/app/views/placements/support/providers/new.html.erb
+++ b/app/views/placements/support/providers/new.html.erb
@@ -10,7 +10,7 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <div class="govuk-form-group">
+        <div class="govuk-form-group<%= " govuk-form-group--error" if f.object.errors.present? %>">
           <%= f.govuk_text_field :code, value: nil,
                                         label: { text: t(".title"), size: "l" },
                                         caption: { text: t(".caption") },

--- a/app/views/placements/support/schools/new.html.erb
+++ b/app/views/placements/support/schools/new.html.erb
@@ -8,7 +8,7 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <div class="govuk-form-group">
+        <div class="govuk-form-group<%= " govuk-form-group--error" if f.object.errors.present? %>">
         <%= f.govuk_text_field :urn, value: nil,
                                      label: { text: t(".title"), size: "l" },
                                      caption: { text: t(".caption") },

--- a/app/views/placements/support/schools/new.html.erb
+++ b/app/views/placements/support/schools/new.html.erb
@@ -8,14 +8,14 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <div class="govuk-form-group<%= " govuk-form-group--error" if f.object.errors.present? %>">
-        <%= f.govuk_text_field :urn, value: nil,
-                                     label: { text: t(".title"), size: "l" },
-                                     caption: { text: t(".caption") },
-                                     id: "school-search-form-query-field" %>
+        <%= content_tag(:div, class: class_names("govuk-form-group", "govuk-form-group--error": f.object.errors.present?)) do %>
+          <%= f.govuk_text_field :urn, value: nil,
+                                       label: { text: t(".title"), size: "l" },
+                                       caption: { text: t(".caption") },
+                                       id: "school-search-form-query-field" %>
 
           <div id="school-autocomplete" class="govuk-!-margin-bottom-7"></div>
-        </div>
+        <% end %>
 
         <%= f.govuk_submit t(".continue") %>
 


### PR DESCRIPTION
## Context

Currently the error handling wrapper on the autocomplete forms (School/Provider on Claims/Placements) does not wrap around the input.

## Changes proposed in this pull request
**Before**
![screencapture-claims-localhost-3000-support-schools-check-2024-01-18-14_31_37](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/9e36e05e-d7f5-4125-a313-3e79e3ad61f9)

**After**
Claims/Schools
![screencapture-claims-localhost-3000-support-schools-check-2024-01-18-14_26_07](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/c831dd8f-ed00-484a-afee-0637196cda19)

Placements/Providers
![screencapture-placements-localhost-3000-support-providers-check-2024-01-18-14_25_40](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/888cb4e9-6bfe-457d-b799-c9aa82718447)

Placements/Schools
![screencapture-placements-localhost-3000-support-schools-check-2024-01-18-14_25_15](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/fe1f575c-8b43-4a4b-97ef-2a24977cfeac)


## Link to Trello card

https://trello.com/c/6KvckHhS/133-bug-error-formatting-on-organisation-search-box
