### PR TITLE
Add UI for the sign in page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,6 +10,10 @@ module ApplicationHelper
     end
   end
 
+  def service_name
+    t("#{current_service}.service_name")
+  end
+
   def external_link(link)
     return if link.blank?
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
-    <title><%= [yield(:page_title).presence, t("#{current_service}.service_name")].compact.join(" - ") %></title>
+    <title><%= [yield(:page_title).presence, service_name].compact.join(" - ") %></title>
 
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -26,7 +26,7 @@
     <%= govuk_skip_link %>
 
     <%= govuk_header(homepage_url: "/") do |header| %>
-      <% header.with_product_name(name: t("#{current_service}.service_name")) %>
+      <% header.with_product_name(name: service_name) %>
 
       <% if current_user %>
         <% header.with_navigation_item(text: "Your Account", href: account_path) %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,1 +1,15 @@
-DfE Sign In button goes here.
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= t(".heading", service_name:) %></h1>
+
+      <p class="govuk-body"><%= t(".description") %></p>
+
+      <%= govuk_button_to t(".sign_in"), "#" %>
+
+      <p class="govuk-body">
+        <%= sanitize t(".disclaimer", service_name:, support_email: mail_to("becomingateacher@digital.education.gov.uk")) %>
+      </p>
+    </div>
+  </div>
+</div>

--- a/config/locales/en/sessions.yml
+++ b/config/locales/en/sessions.yml
@@ -1,0 +1,7 @@
+en:
+  sessions:
+    new:
+      heading: Sign in to %{service_name}
+      description: Use DfE Sign-in to access your account.
+      sign_in: Sign in using DfE Sign In
+      disclaimer: If you do not have a DfE Sign-in account but need access to %{service_name}, email %{support_email}.


### PR DESCRIPTION
## Context

We want to add in DfE Sign In. Whilst the external setup is still pending, here is the UI.

## Changes proposed in this pull request

- Update `/sign_in` page UI.
- Add `service_name` helper for convenience.

## Guidance to review

- You'll need to comment out the `before_action :redirect_to_personas, only: [:new]` line in the `SessionsController` to view the page.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

![CleanShot 2024-01-19 at 14 53 52](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/9dbc6184-541f-4b73-8411-448e9133a5b4)

![CleanShot 2024-01-19 at 14 55 21](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/3d849b97-a695-4cc7-93fb-af7b8c204883)

