### PR TITLE
Add production plaintext env vars

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,3 @@
+SIGN_IN_METHOD=persona
+GIAS_CSV_BASE_URL=https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public
+PUBLISH_BASE_URL=https://www.publish-teacher-training-courses.service.gov.uk


### PR DESCRIPTION
## Context

Terraform currently needs to add an ENV configuration file for these values. By adding the `.env.production`, we can avoid the need for terraform env var configuration for public static values.

## Changes proposed in this pull request

- Add an `.env.production` file.

## Guidance to review

Running the app with `RAILS_ENV=production` should populate the `ENV` values from `.env.production`.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
