### PR TITLE
Add missing CSS for autocomplete

### DIFF
--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -4,3 +4,4 @@
 @import "organisation_list_item";
 @import "primary_navigation";
 @import "secondary_navigation";
+@import "autocomplete";

--- a/app/assets/stylesheets/components/_autocomplete.scss
+++ b/app/assets/stylesheets/components/_autocomplete.scss
@@ -1,0 +1,24 @@
+.autocomplete__wrapper,
+.autocomplete__input,
+.autocomplete__hint {
+  font-family: $govuk-font-family;
+}
+
+.autocomplete__option {
+  color: $govuk-secondary-text-colour;
+}
+
+.govuk-form-group--error {
+  .autocomplete__input {
+    border-color: $govuk-error-colour;
+  }
+
+  .autocomplete__input--focused {
+    border-color: $govuk-input-border-colour;
+  }
+}
+
+.autocomplete__dropdown-arrow-down {
+  pointer-events: none;
+  z-index: 0;
+}

--- a/app/views/claims/support/schools/new.html.erb
+++ b/app/views/claims/support/schools/new.html.erb
@@ -13,7 +13,7 @@
         <%= content_tag(:div, class: class_names("govuk-form-group", "govuk-form-group--error": f.object.errors.present?)) do %>
           <%= f.govuk_text_field :urn, value: nil,
                                        label: { text: t(".title"), size: "l" },
-                                       caption: { text: t(".caption") },
+                                       caption: { text: t(".caption"), size: "l" },
                                        id: "school-search-form-query-field" %>
 
           <div id="school-autocomplete" class="govuk-!-margin-bottom-7"></div>

--- a/app/views/placements/support/providers/new.html.erb
+++ b/app/views/placements/support/providers/new.html.erb
@@ -13,7 +13,7 @@
         <%= content_tag(:div, class: class_names("govuk-form-group", "govuk-form-group--error": f.object.errors.present?)) do %>
           <%= f.govuk_text_field :code, value: nil,
                                         label: { text: t(".title"), size: "l" },
-                                        caption: { text: t(".caption") },
+                                        caption: { text: t(".caption"), size: "l" },
                                         id: "accredited-provider-search-form-query-field" %>
 
           <div id="accredited-provider-autocomplete" class="govuk-!-margin-bottom-7"></div>

--- a/app/views/placements/support/schools/new.html.erb
+++ b/app/views/placements/support/schools/new.html.erb
@@ -11,7 +11,7 @@
         <%= content_tag(:div, class: class_names("govuk-form-group", "govuk-form-group--error": f.object.errors.present?)) do %>
           <%= f.govuk_text_field :urn, value: nil,
                                        label: { text: t(".title"), size: "l" },
-                                       caption: { text: t(".caption") },
+                                       caption: { text: t(".caption"), size: "l" },
                                        id: "school-search-form-query-field" %>
 
           <div id="school-autocomplete" class="govuk-!-margin-bottom-7"></div>


### PR DESCRIPTION
## Context

The autocomplete dropdown is missing the font used by DfE GOV.UK.

## Changes proposed in this pull request

Added CSS to account for the missing font and styling on the autocomplete.

## Link to Trello card

https://trello.com/c/quVSHgvA/137-update-add-the-missing-autocomplete-component-fonts

## Screenshots

**Before**
<img width="1493" alt="Screenshot 2024-01-23 at 11 59 02" src="https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/69ad9fd8-01cd-4826-83de-c34f18177e85">

<img width="1492" alt="Screenshot 2024-01-23 at 11 59 27" src="https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/368c24e7-d18c-4317-9da4-62a3026a0931">

**After**
<img width="1491" alt="Screenshot 2024-01-23 at 11 56 22" src="https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/2abf90e6-8135-4e93-af23-02e054c50628">

<img width="1494" alt="Screenshot 2024-01-23 at 11 56 36" src="https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/0c43e8b8-349a-4992-8b16-6b7dc0d04c0a">



