### PR TITLE
Change publish API to use current year

### DIFF
--- a/app/services/provider/api.rb
+++ b/app/services/provider/api.rb
@@ -15,16 +15,6 @@ class Provider::Api
   private
 
   def all_providers_url
-    "#{ENV["PUBLISH_BASE_URL"]}/api/public/v1/recruitment_cycles/#{recruitment_cycle_year}/providers"
-  end
-
-  # Recruitment cycle year calculated based on the cycle timetime
-  # https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/app/services/cycle_timetable.rb
-  def recruitment_cycle_year
-    current_year = Time.current.year
-    next_year = current_year + 1
-    cycle_start =  Time.zone.local(current_year, 10, 1) # Start of October
-    cycle_start += 1.day until cycle_start.wday == 2 # First Tuesday of October
-    Time.current > cycle_start ? next_year : current_year
+    "#{ENV["PUBLISH_BASE_URL"]}/api/public/v1/recruitment_cycles/current/providers"
   end
 end

--- a/spec/services/accredited_provider/api_spec.rb
+++ b/spec/services/accredited_provider/api_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Provider::Api do
   before do
     stub_request(
       :get,
-      "https://www.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2024/providers",
+      "https://www.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/current/providers",
     ).to_return(
       status: 200,
       body: {
@@ -30,55 +30,25 @@ RSpec.describe Provider::Api do
 
   subject { described_class.call }
 
-  context "when the date is after between the first Tuesday in October (2023) and the end of the year" do
-    it "returns a list of providers from the next recruitment cycle (2024) publish-teacher-training-courses api" do
-      Timecop.freeze(Time.zone.local(2023, 10, 3, 1)) do # First Tuesday of October 2023
-        response = subject
-        expect(response.fetch("data")).to match_array(
-          [
-            {
-              "id" => 123,
-              "attributes" => {
-                "name" => "Provider 1",
-                "code" => "Prov1",
-              },
-            },
-            {
-              "id" => 234,
-              "attributes" => {
-                "name" => "Provider 2",
-                "code" => "Prov2",
-              },
-            },
-          ],
-        )
-      end
-    end
-  end
-
-  context "when the date is between the first day in the year (2024) and the first Tuesday in October (2024)" do
-    it "returns a list of providers from the current recruitment cycle (2024) publish-teacher-training-courses api" do
-      Timecop.freeze(Time.zone.local(2024, 1, 1, 1)) do
-        response = subject
-        expect(response.fetch("data")).to match_array(
-          [
-            {
-              "id" => 123,
-              "attributes" => {
-                "name" => "Provider 1",
-                "code" => "Prov1",
-              },
-            },
-            {
-              "id" => 234,
-              "attributes" => {
-                "name" => "Provider 2",
-                "code" => "Prov2",
-              },
-            },
-          ],
-        )
-      end
-    end
+  it "returns a list of providers from the current recruitment cycle publish-teacher-training-courses api" do
+    response = subject
+    expect(response.fetch("data")).to match_array(
+      [
+        {
+          "id" => 123,
+          "attributes" => {
+            "name" => "Provider 1",
+            "code" => "Prov1",
+          },
+        },
+        {
+          "id" => 234,
+          "attributes" => {
+            "name" => "Provider 2",
+            "code" => "Prov2",
+          },
+        },
+      ],
+    )
   end
 end

--- a/spec/services/accredited_provider/importer_spec.rb
+++ b/spec/services/accredited_provider/importer_spec.rb
@@ -7,11 +7,9 @@ RSpec.describe Provider::Importer do
   let(:changeable_provider) { create(:provider, name: "Changeable Provider") }
 
   before do
-    Timecop.freeze(Time.zone.local(2024, 1, 1, 1))
-
     stub_request(
       :get,
-      "https://www.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2024/providers",
+      "https://www.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/current/providers",
     ).to_return(
       status: 200,
       body: {
@@ -78,14 +76,14 @@ RSpec.describe Provider::Importer do
           },
         ],
         "links" => {
-          "next" => "https://www.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2024/providers?page=2",
+          "next" => "https://www.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/current/providers?page=2",
         },
       }.to_json,
     )
 
     stub_request(
       :get,
-      "https://www.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2024/providers?page=2",
+      "https://www.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/current/providers?page=2",
     ).to_return(
       status: 200,
       body: {
@@ -102,8 +100,6 @@ RSpec.describe Provider::Importer do
       }.to_json,
     )
   end
-
-  after { Timecop.return }
 
   it "creates new provider records for responses which don't already exist or are valid" do
     expect { subject }.to change(Provider, :count).by(4)


### PR DESCRIPTION
## Context

Since changes have been made to the Publish API (https://github.com/DFE-Digital/publish-teacher-training/pull/4011), use the "current" in place of an actual year, to acquire the Providers for the current year.

## Changes proposed in this pull request

Changes to API to swap out the calculated current year, with the word "current"

## Link to Trello card

https://trello.com/c/0JIgI5Nj/127-use-the-current-recruitment-cycle-when-retrieving-providers-from-the-api
