### PR TITLE
Lb/placements support navigation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,6 +96,7 @@ end
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
+  # The accessible selectors gem is maintained by Citizens Advice, not yet a registered gem.
   gem "capybara_accessible_selectors", git: "https://github.com/citizensadvice/capybara_accessible_selectors", branch: "main"
   gem "capybara-screenshot"
   gem "rails-controller-testing"

--- a/Gemfile
+++ b/Gemfile
@@ -96,6 +96,7 @@ end
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
+  gem "capybara_accessible_selectors", git: "https://github.com/citizensadvice/capybara_accessible_selectors", branch: "main"
   gem "capybara-screenshot"
   gem "rails-controller-testing"
   gem "selenium-webdriver"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/citizensadvice/capybara_accessible_selectors
+  revision: 679abc42cce81b43ed81d31bbe7ad6a96dbe7fef
+  branch: main
+  specs:
+    capybara_accessible_selectors (0.11.0)
+      capybara (~> 3.36)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -541,6 +549,7 @@ DEPENDENCIES
   brakeman
   capybara
   capybara-screenshot
+  capybara_accessible_selectors!
   cssbundling-rails
   debug
   dotenv-rails

--- a/app/components/primary_navigation_component.rb
+++ b/app/components/primary_navigation_component.rb
@@ -2,19 +2,26 @@ class PrimaryNavigationComponent < ApplicationComponent
   renders_many :navigation_items, "NavigationItemComponent"
 
   class NavigationItemComponent < ApplicationComponent
-    attr_reader :name, :url
+    attr_reader :name, :url, :current
 
-    def initialize(name, url, classes: [], html_attributes: {})
+    def initialize(name, url, current: false, classes: [], html_attributes: {})
       @name = name
       @url = url
+      @current = current
 
       super(classes:, html_attributes:)
     end
 
     def call
       content_tag(:li, class: "app-primary-navigation__item") do
-        link_to name, url, class: "app-primary-navigation__link", aria: { current: current_page?(url) && "page" }
+        link_to name, url, class: "app-primary-navigation__link", aria: { current: show_as_current?(url) && "page" }
       end
+    end
+
+    private
+
+    def show_as_current?(url)
+      current || current_page?(url)
     end
   end
 end

--- a/app/components/primary_navigation_component.rb
+++ b/app/components/primary_navigation_component.rb
@@ -14,13 +14,13 @@ class PrimaryNavigationComponent < ApplicationComponent
 
     def call
       content_tag(:li, class: "app-primary-navigation__item") do
-        link_to name, url, class: "app-primary-navigation__link", aria: { current: show_as_current?(url) && "page" }
+        link_to name, url, class: "app-primary-navigation__link", aria: { current: current?(url) && "page" }
       end
     end
 
     private
 
-    def show_as_current?(url)
+    def current?(url)
       current || current_page?(url)
     end
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,12 +42,14 @@
       </div>
     </div>
 
-    <% if support_controller? %>
+    <% if support_controller? && current_service == :claims %>
       <%= render PrimaryNavigationComponent.new do |component| %>
-        <% component.with_navigation_item t(".#{current_service}.primary_navigation.organisations"), support_organisations_path %>
-        <% component.with_navigation_item t(".#{current_service}.primary_navigation.claims"), claims_support_claims_path if current_service == :claims %>
-        <% component.with_navigation_item t(".#{current_service}.primary_navigation.users"), support_users_path %>
+        <% component.with_navigation_item t(".claims.primary_navigation.organisations"), support_organisations_path %>
+        <% component.with_navigation_item t(".claims.primary_navigation.claims"), claims_support_claims_path %>
+        <% component.with_navigation_item t(".claims.primary_navigation.users"), support_users_path %>
       <% end %>
+    <% else %>
+      <%= yield :primary_navigation_content %>
     <% end %>
 
     <div class="govuk-width-container">

--- a/app/views/placements/support/_primary_navigation.html.erb
+++ b/app/views/placements/support/_primary_navigation.html.erb
@@ -1,0 +1,10 @@
+<%# locals: (current_navigation: nil) -%>
+
+<%= content_for(:primary_navigation_content) do %>
+  <%= render PrimaryNavigationComponent.new do |component| %>
+    <% component.with_navigation_item t(".organisations"),
+                                      support_organisations_path,
+                                      current: current_navigation == :organisations %>
+    <% component.with_navigation_item t(".users"), support_users_path, current: current_navigation == :users %>
+  <% end %>
+<% end %>

--- a/app/views/placements/support/organisations/index.html.erb
+++ b/app/views/placements/support/organisations/index.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, t(".title", organisation_count: @pagy.count) %>
+<%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/placements/support/organisations/new.html.erb
+++ b/app/views/placements/support/organisations/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title, t(".title") %>
+<%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: placements_support_organisations_path) %>

--- a/app/views/placements/support/providers/check.html.erb
+++ b/app/views/placements/support/providers/check.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, t(".title") %>
-
+<%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: new_placements_support_provider_path) %>
 <% end %>

--- a/app/views/placements/support/providers/new.html.erb
+++ b/app/views/placements/support/providers/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, t(".title") %>
-
+<%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: new_placements_support_organisation_path) %>
 <% end %>

--- a/app/views/placements/support/providers/show.html.erb
+++ b/app/views/placements/support/providers/show.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, sanitize(@provider.name) %>
+<%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">

--- a/app/views/placements/support/providers/users/check.html.erb
+++ b/app/views/placements/support/providers/users/check.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :page_title, sanitize(t(".page_title", provider_name: @provider.name)) %>
-
+<%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: new_placements_support_provider_user_path(
     @user_form.as_form_params.merge(provider_id: @provider.id),

--- a/app/views/placements/support/providers/users/index.html.erb
+++ b/app/views/placements/support/providers/users/index.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, sanitize(@provider.name) %>
+<%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">

--- a/app/views/placements/support/providers/users/new.html.erb
+++ b/app/views/placements/support/providers/users/new.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :page_title, sanitize(t(".page_title", provider_name: @provider.name)) %>
-
+<%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: placements_support_provider_users_path(@provider)) %>
 <% end %>

--- a/app/views/placements/support/providers/users/show.html.erb
+++ b/app/views/placements/support/providers/users/show.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :page_title, sanitize("#{@user.full_name} - #{@provider.name}") %>
-
+<%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: placements_support_provider_users_path(@provider)) %>
 <% end %>

--- a/app/views/placements/support/schools/check.html.erb
+++ b/app/views/placements/support/schools/check.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, t(".title") %>
-
+<%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: new_placements_support_provider_path) %>
 <% end %>

--- a/app/views/placements/support/schools/new.html.erb
+++ b/app/views/placements/support/schools/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, t(".title") %>
+<%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: new_placements_support_organisation_path) %>
 <% end %>

--- a/app/views/placements/support/schools/show.html.erb
+++ b/app/views/placements/support/schools/show.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, sanitize(@school.name) %>
+<%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">

--- a/app/views/placements/support/schools/users/check.html.erb
+++ b/app/views/placements/support/schools/users/check.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :page_title, sanitize(t(".page_title", school_name: @school.name)) %>
-
+<%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: new_placements_support_school_user_path(
     @user_form.as_form_params.merge(school_id: @school.id),

--- a/app/views/placements/support/schools/users/index.html.erb
+++ b/app/views/placements/support/schools/users/index.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, sanitize(@school.name) %>
+<%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">

--- a/app/views/placements/support/schools/users/new.html.erb
+++ b/app/views/placements/support/schools/users/new.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, sanitize(t(".page_title", school_name: @school.name)) %>
+<%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: placements_support_school_users_path(@school)) %>

--- a/config/locales/en/placements/layouts/application.yml
+++ b/config/locales/en/placements/layouts/application.yml
@@ -1,8 +1,0 @@
-en:
-  layouts:
-    application:
-      placements:
-        primary_navigation:
-          users: Users
-          placements: Placements
-          organisations: Organisations

--- a/config/locales/en/placements/support/primary_navigation.yml
+++ b/config/locales/en/placements/support/primary_navigation.yml
@@ -1,0 +1,6 @@
+en:
+  placements:
+    support:
+      primary_navigation:
+        users: Users
+        organisations: Organisations

--- a/spec/system/placements/support/organisations/support_filtering_and_searching_for_organisation_spec.rb
+++ b/spec/system/placements/support/organisations/support_filtering_and_searching_for_organisation_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "Support user filters and searches for organisations", type: :sys
   before do
     given_i_am_signed_in_as_a_support_user
     and_placement_schools_and_providers_exist
+    then_i_see_support_navigation_with_organisation_selected
   end
 
   after { Capybara.app_host = nil }
@@ -187,6 +188,13 @@ RSpec.describe "Support user filters and searches for organisations", type: :sys
     create(:persona, :colin, service: :placements)
     visit personas_path
     click_on "Sign In as Colin"
+  end
+
+  def then_i_see_support_navigation_with_organisation_selected
+    within(".app-primary-navigation__nav") do
+      expect(page).to have_link "Organisations", current: "page"
+      expect(page).to have_link "Users", current: "false"
+    end
   end
 
   def and_placement_schools_and_providers_exist

--- a/spec/system/placements/support/organisations/support_user_selects_an_organisation_type_to_add_spec.rb
+++ b/spec/system/placements/support/organisations/support_user_selects_an_organisation_type_to_add_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Placements / Support / Organisations / Support User Selects An O
   before do
     given_i_sign_in_as_colin
     when_i_click_add_organisation
+    then_i_see_support_navigation_with_organisation_selected
   end
 
   after { Capybara.app_host = nil }
@@ -57,6 +58,13 @@ RSpec.describe "Placements / Support / Organisations / Support User Selects An O
 
   def when_i_click_add_organisation
     click_on "Add organisation"
+  end
+
+  def then_i_see_support_navigation_with_organisation_selected
+    within(".app-primary-navigation__nav") do
+      expect(page).to have_link "Organisations", current: "page"
+      expect(page).to have_link "Users", current: "false"
+    end
   end
 
   def when_i_select_the_radio_option(organisation_type)

--- a/spec/system/placements/support/providers/support_user_adds_a_provider_spec.rb
+++ b/spec/system/placements/support/providers/support_user_adds_a_provider_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Placements / Support / Providers / Support User adds a Provider"
 
   scenario "Colin adds a new Provider", js: true do
     when_i_visit_the_add_provider_page
+    then_i_see_support_navigation_with_organisation_selected
     and_i_enter_a_provider_named("Provider 1")
     then_i_see_a_dropdown_item_for("Provider 1")
     when_i_click_the_dropdown_item_for("Provider 1")
@@ -25,6 +26,7 @@ RSpec.describe "Placements / Support / Providers / Support User adds a Provider"
   scenario "Colin adds a Provider which already exists", js: true do
     given_a_provider_already_as_already_been_onboarded
     when_i_visit_the_add_provider_page
+    then_i_see_support_navigation_with_organisation_selected
     and_i_enter_a_provider_named("Provider 1")
     then_i_see_a_dropdown_item_for("Provider 1")
     when_i_click_the_dropdown_item_for("Provider 1")
@@ -34,6 +36,7 @@ RSpec.describe "Placements / Support / Providers / Support User adds a Provider"
 
   scenario "Colin submits the search form without selecting a provider", js: true do
     when_i_visit_the_add_provider_page
+    then_i_see_support_navigation_with_organisation_selected
     and_i_click_continue
     then_i_see_an_error("Enter a provider name, UKPRN, URN or postcode")
   end
@@ -58,6 +61,13 @@ RSpec.describe "Placements / Support / Providers / Support User adds a Provider"
 
   def when_i_visit_the_add_provider_page
     visit new_placements_support_provider_path
+  end
+
+  def then_i_see_support_navigation_with_organisation_selected
+    within(".app-primary-navigation__nav") do
+      expect(page).to have_link "Organisations", current: "page"
+      expect(page).to have_link "Users", current: "false"
+    end
   end
 
   def given_i_sign_in_as_colin

--- a/spec/system/placements/support/providers/support_user_adds_a_provider_without_javascript_spec.rb
+++ b/spec/system/placements/support/providers/support_user_adds_a_provider_without_javascript_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "Support User adds a Provider without JavaScript", type: :system 
 
   scenario "Colin adds a new Provider" do
     when_i_visit_the_add_provider_page
+    then_i_see_support_navigation_with_organisation_selected
     and_i_enter_a_provider_named("Manch")
     and_i_click_continue
     then_i_see_list_of_providers
@@ -29,6 +30,7 @@ RSpec.describe "Support User adds a Provider without JavaScript", type: :system 
   scenario "Colin adds a provider which already exists" do
     given_a_provider_already_exists_for_placements
     when_i_visit_the_add_provider_page
+    then_i_see_support_navigation_with_organisation_selected
     and_i_enter_a_provider_named("Manch")
     and_i_click_continue
     then_i_see_list_of_providers
@@ -39,12 +41,14 @@ RSpec.describe "Support User adds a Provider without JavaScript", type: :system 
 
   scenario "Colin submits the search form without selecting a provider", js: true do
     when_i_visit_the_add_provider_page
+    then_i_see_support_navigation_with_organisation_selected
     and_i_click_continue
     then_i_see_an_error("Enter a provider name, UKPRN, URN or postcode")
   end
 
   scenario "Colin submits the options form without selecting a provider" do
     when_i_visit_the_add_provider_page
+    then_i_see_support_navigation_with_organisation_selected
     and_i_enter_a_provider_named("Manch")
     and_i_click_continue
     then_i_see_list_of_providers
@@ -75,6 +79,13 @@ RSpec.describe "Support User adds a Provider without JavaScript", type: :system 
 
   def when_i_visit_the_add_provider_page
     visit new_placements_support_provider_path
+  end
+
+  def then_i_see_support_navigation_with_organisation_selected
+    within(".app-primary-navigation__nav") do
+      expect(page).to have_link "Organisations", current: "page"
+      expect(page).to have_link "Users", current: "false"
+    end
   end
 
   def and_i_enter_a_provider_named(provider_name)

--- a/spec/system/placements/support/users/support_user_invites_a_new_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_invites_a_new_user_spec.rb
@@ -20,11 +20,15 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
   describe "School" do
     scenario "Support User invites a new user to a school" do
       when_i_visit_the_users_page_for(organisation: school)
+      then_i_see_the_navigation_bars_with_organisations_and_users_selected
       and_i_click("Add user")
+      then_i_see_support_navigation_with_organisation_selected
       and_i_enter_the_details_for_a_new_user
       and_i_click("Continue")
+      then_i_see_support_navigation_with_organisation_selected
       then_i_see_the_new_users_details
       and_i_click("Add user")
+      then_i_see_support_navigation_with_organisation_selected
       then_i_see_the_new_user_has_been_added
     end
 
@@ -47,11 +51,15 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
   describe "Provider" do
     scenario "Support User invites a new user to a school" do
       when_i_visit_the_users_page_for(organisation: provider)
+      then_i_see_the_navigation_bars_with_organisations_and_users_selected
       and_i_click("Add user")
+      then_i_see_support_navigation_with_organisation_selected
       and_i_enter_the_details_for_a_new_user
       and_i_click("Continue")
+      then_i_see_support_navigation_with_organisation_selected
       then_i_see_the_new_users_details
       and_i_click("Add user")
+      then_i_see_support_navigation_with_organisation_selected
       then_i_see_the_new_user_has_been_added
     end
   end
@@ -143,6 +151,21 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
     fill_in "user-invite-form-email-field", with: "test@example.com"
   end
 
+  def then_i_see_the_navigation_bars_with_organisations_and_users_selected
+    within(".app-primary-navigation__nav") do
+      expect(page).to have_link "Organisations", current: "page"
+      expect(page).to have_link "Users", current: "false"
+    end
+
+    within(".app-secondary-navigation") do
+      expect(page).to have_link "Details", current: "false"
+      expect(page).to have_link "Users", current: "page"
+      expect(page).to have_link "Mentors", current: "false"
+      expect(page).to have_link "Placements", current: "false"
+      expect(page).to have_link "Providers", current: "false"
+    end
+  end
+
   def then_i_see_a_populated_form
     expect(page).to have_field("First name", with: "New")
     expect(page).to have_field("Last name", with: "User")
@@ -176,6 +199,7 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
 
   def then_i_see_the_new_user_has_been_added
     expect(page.find(".govuk-notification-banner__content")).to have_content("User added")
+    then_i_see_support_navigation_with_organisation_selected
     and_i_see_the_new_users_details
   end
 
@@ -198,5 +222,12 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
     # Error above input
     input_error_messages = page.all(".govuk-error-message")
     expect(input_error_messages[error_index]).to have_content(error_message)
+  end
+
+  def then_i_see_support_navigation_with_organisation_selected
+    within(".app-primary-navigation__nav") do
+      expect(page).to have_link "Organisations", current: "page"
+      expect(page).to have_link "Users", current: "false"
+    end
   end
 end


### PR DESCRIPTION
## Context
The current implementation of the `PrimaryNavigation` component only showed a nav item as current if it matched the url. This is not how it is used in the prototype, where it is at times more like a bread crumb

## Changes proposed in this pull request
- Add a optional `current` arg to the `PrimaryNavigation` component, so that we can show the nav as current even though the path does not match the `current_url?`
- Add accessible selectors for capaybara. See [here for details](https://github.com/citizensadvice/capybara_accessible_selectors)
- For placements only, I've added the appropriate primary navigation to each support page. 
- I'm *not* doing this for existing claims pages. But the tools / a pattern is there now so they can pick it up when it's a priority. 
- I'm also *not* adding the primary navigation for non-support users in placements. When we start building those pages, we will need to add navigation, page titles, etc etc.

## Guidance to review

- Login as a placements support user. 
- View an organisation. Make sure "Organisations" stays current when you click on 'Details' or 'Users' in the secondary navigation
- Add a user to the organisation. Make sure "Organisation" stays current when you click through the form. 
- Add organisations (schools or providers), make sure "Organisations" stays current as you click through the form. 

Login as a claims user -- make sure everything is how it has always been. (should be no changes for claims users)

## Link to Trello card

https://trello.com/c/v4CUXP3m

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots
Before
<img width="915" alt="image" src="https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/c07c6c4c-cd3d-4af5-9159-80cdb37a1115">


After 
<img width="934" alt="image" src="https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/6715317d-473e-417d-b974-ef0d87eb5ac4">

