### PR TITLE
Ot/jc/lb/scope user memberships to service for organisations

### DIFF
--- a/app/controllers/placements/providers_controller.rb
+++ b/app/controllers/placements/providers_controller.rb
@@ -1,13 +1,5 @@
 class Placements::ProvidersController < ApplicationController
-  before_action :set_providers
-
   def show
-    @provider = @providers.find(params.require(:id))&.decorate
-  end
-
-  private
-
-  def set_providers
-    @providers = current_user.providers.where(placements_service: true)
+    @provider = current_user.providers.find(params.require(:id))&.decorate
   end
 end

--- a/app/controllers/placements/schools_controller.rb
+++ b/app/controllers/placements/schools_controller.rb
@@ -1,12 +1,5 @@
 class Placements::SchoolsController < ApplicationController
-  before_action :set_schools
   def show
-    @school = @schools.find(params.require(:id))&.decorate
-  end
-
-  private
-
-  def set_schools
-    @schools = current_user.schools.where(placements_service: true)
+    @school = current_user.schools.find(params.require(:id))&.decorate
   end
 end

--- a/app/models/claims/school.rb
+++ b/app/models/claims/school.rb
@@ -45,7 +45,7 @@
 #  index_schools_on_urn                 (urn) UNIQUE
 #
 class Claims::School < School
-  default_scope { where claims_service: true }
+  default_scope { claims_service }
 
   has_many :users, -> { claims }, through: :memberships
   has_many :claims

--- a/app/models/claims/user.rb
+++ b/app/models/claims/user.rb
@@ -17,4 +17,10 @@
 #
 class Claims::User < User
   default_scope { claims }
+
+  has_many :schools,
+           -> { claims_service },
+           through: :memberships,
+           source: :organisation,
+           source_type: "School"
 end

--- a/app/models/placements/provider.rb
+++ b/app/models/placements/provider.rb
@@ -29,5 +29,7 @@
 #  index_providers_on_placements_service  (placements_service)
 #
 class Placements::Provider < Provider
-  default_scope { where placements_service: true }
+  default_scope { placements_service }
+
+  has_many :users, -> { placements }, through: :memberships
 end

--- a/app/models/placements/school.rb
+++ b/app/models/placements/school.rb
@@ -45,5 +45,7 @@
 #  index_schools_on_urn                 (urn) UNIQUE
 #
 class Placements::School < School
-  default_scope { where placements_service: true }
+  default_scope { placements_service }
+
+  has_many :users, -> { placements }, through: :memberships
 end

--- a/app/models/placements/user.rb
+++ b/app/models/placements/user.rb
@@ -17,4 +17,15 @@
 #
 class Placements::User < User
   default_scope { placements }
+
+  has_many :schools,
+           -> { placements_service },
+           through: :memberships,
+           source: :organisation,
+           source_type: "School"
+  has_many :providers,
+           -> { placements_service },
+           through: :memberships,
+           source: :organisation,
+           source_type: "Provider"
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -45,6 +45,7 @@ class Provider < ApplicationRecord
   validates :code, uniqueness: { case_sensitive: false }
 
   scope :accredited, -> { where accredited: true }
+  scope :placements_service, -> { where placements_service: true }
 
   multisearchable against: %i[name postcode],
                   if: :placements_service?,

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -48,12 +48,14 @@ class School < ApplicationRecord
   include PgSearch::Model
 
   has_many :memberships, as: :organisation
-  has_many :users, through: :memberships
   has_many :mentors
 
   validates :urn, presence: true
   validates :urn, uniqueness: { case_sensitive: false }
   validates :name, presence: true
+
+  scope :placements_service, -> { where placements_service: true }
+  scope :claims_service, -> { where claims_service: true }
 
   multisearchable against: %i[name postcode],
                   if: :placements_service?,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,14 +17,6 @@
 #
 class User < ApplicationRecord
   has_many :memberships
-  has_many :schools,
-           through: :memberships,
-           source: :organisation,
-           source_type: "School"
-  has_many :providers,
-           through: :memberships,
-           source: :organisation,
-           source_type: "Provider"
 
   enum :service,
        { no_service: "no_service", claims: "claims", placements: "placements" },

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -56,5 +56,13 @@ FactoryBot.define do
     trait :placements do
       placements_service { true }
     end
+
+    factory :claims_school,
+            class: "Claims::School",
+            parent: :school, traits: %i[claims]
+
+    factory :placements_school,
+            class: "Placements::School",
+            parent: :school, traits: %i[placements]
   end
 end

--- a/spec/models/claims/user_spec.rb
+++ b/spec/models/claims/user_spec.rb
@@ -18,6 +18,16 @@
 require "rails_helper"
 
 RSpec.describe Claims::User do
+  describe "associations" do
+    it { should have_many(:schools).through(:memberships).source(:organisation) }
+
+    it "association returns Claims::Schools objects" do
+      claims_user = create(:claims_user)
+      claims_user.memberships.create!(organisation: create(:school, :claims))
+      expect(claims_user.schools.first.class.name).to eq "Claims::School"
+    end
+  end
+
   describe "default scope" do
     let(:email) { "same_email@email.co.uk" }
     let!(:user_with_claims_service) { create(:claims_user, email:) }

--- a/spec/models/placements/provider_spec.rb
+++ b/spec/models/placements/provider_spec.rb
@@ -31,6 +31,10 @@
 require "rails_helper"
 
 RSpec.describe Placements::Provider do
+  describe "#assocations" do
+    it { should have_many(:users).through(:memberships) }
+  end
+
   describe "default scope" do
     let!(:provider_with_placements) { create(:provider, :placements) }
     let!(:provider_without_placements) { create(:provider) }

--- a/spec/models/placements/school_spec.rb
+++ b/spec/models/placements/school_spec.rb
@@ -47,6 +47,10 @@
 require "rails_helper"
 
 RSpec.describe Placements::School do
+  describe "#assocations" do
+    it { should have_many(:users).through(:memberships) }
+  end
+
   describe "default scope" do
     let!(:school_with_placements) { create(:school, :placements) }
     let!(:school_without_placements) { create(:school) }

--- a/spec/models/placements/user_spec.rb
+++ b/spec/models/placements/user_spec.rb
@@ -18,6 +18,16 @@
 require "rails_helper"
 
 RSpec.describe Placements::User do
+  describe "associations" do
+    it { should have_many(:schools).through(:memberships).source(:organisation) }
+
+    it "association returns Placements::Schools objects" do
+      placements_user = create(:placements_user)
+      placements_user.memberships.create!(organisation: create(:school, :placements))
+      expect(placements_user.schools.first.class.name).to eq "Placements::School"
+    end
+  end
+
   describe "default scope" do
     let(:email) { "same_email@email.co.uk" }
     let!(:user_with_placements_service) { create(:placements_user, email:) }

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -37,6 +37,17 @@ RSpec.describe Provider, type: :model do
     it { should have_many(:mentor_trainings) }
   end
 
+  context "scopes" do
+    describe "#placements_service" do
+      it "only returns placements providers" do
+        create(:provider)
+        placements_provider = create(:provider, :placements)
+
+        expect(described_class.placements_service).to contain_exactly(placements_provider)
+      end
+    end
+  end
+
   context "validations" do
     subject { build(:provider) }
 

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -49,8 +49,32 @@ require "rails_helper"
 RSpec.describe School, type: :model do
   context "associations" do
     it { should have_many(:memberships) }
-    it { should have_many(:users).through(:memberships) }
     it { should have_many(:mentors) }
+  end
+
+  context "scopes" do
+    describe "#placements_service" do
+      it "only returns placements schools" do
+        create(:school, :claims)
+        create(:school)
+        placements_school = create(:school, :placements)
+
+        expect(described_class.placements_service).to contain_exactly(placements_school)
+      end
+    end
+
+    describe "#claims_school" do
+      it "only returns claims schools" do
+        create(:school, :placements)
+        create(:school)
+        claims_school = create(:school, :claims)
+
+        expect(described_class.claims_service).to contain_exactly(claims_school)
+      end
+    end
+
+    describe "#claims_service" do
+    end
   end
 
   context "validations" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,11 +21,7 @@ RSpec.describe User, type: :model do
   subject { create(:user) }
 
   context "associations" do
-    it do
-      should have_many(:memberships)
-      should have_many(:schools).through(:memberships).source(:organisation)
-      should have_many(:providers).through(:memberships).source(:organisation)
-    end
+    it { should have_many(:memberships) }
   end
 
   describe "validations" do

--- a/spec/system/claims/invite_a_user_to_a_school_spec.rb
+++ b/spec/system/claims/invite_a_user_to_a_school_spec.rb
@@ -70,11 +70,11 @@ RSpec.describe "Invite a user to a school", type: :system do
   private
 
   def setup_school
-    @school = create(:school, :claims, urn: "123456")
+    @school = create(:claims_school, :claims, urn: "123456")
   end
 
   def another_school_exists
-    @another_school = create(:school, :claims)
+    @another_school = create(:claims_school, :claims)
   end
 
   def setup_school_and_anne_membership

--- a/spec/system/claims/view_organisations_spec.rb
+++ b/spec/system/claims/view_organisations_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "View schools", type: :system do
     and_persona_has_multiple_schools(persona)
     when_i_visit_claims_personas
     when_i_click_sign_in(persona)
-    i_am_redirected_to_organisation_index(persona)
+    and_i_see_marys_schools
   end
 
   scenario "I sign in as persona Anne with one school" do
@@ -20,7 +20,7 @@ RSpec.describe "View schools", type: :system do
     and_persona_has_one_school(persona)
     when_i_visit_claims_personas
     when_i_click_sign_in(persona)
-    i_am_redirected_to_organisation_index(persona)
+    and_i_see_annes_schools
   end
 
   private
@@ -30,10 +30,16 @@ RSpec.describe "View schools", type: :system do
   end
 
   def and_persona_has_multiple_schools(persona)
-    school1 = create(:school)
-    school2 = create(:school)
-    create(:membership, user: persona, organisation: school1)
-    create(:membership, user: persona, organisation: school2)
+    @school1 = create(:claims_school)
+    @school2 = create(:claims_school)
+    create(:membership, user: persona, organisation: @school1)
+    create(:membership, user: persona, organisation: @school2)
+  end
+
+  def and_i_see_marys_schools
+    expect(page).to have_content "Organisations"
+    expect(page).to have_content @school1.name
+    expect(page).to have_content @school2.name
   end
 
   def and_persona_has_one_school(persona)
@@ -42,6 +48,11 @@ RSpec.describe "View schools", type: :system do
       user: persona,
       organisation: create(:school, :claims, name: "Hogwarts"),
     )
+  end
+
+  def and_i_see_annes_schools
+    expect(page).to have_content "Organisation details"
+    expect(page).to have_content "Hogwarts"
   end
 
   def when_i_visit_claims_personas
@@ -54,14 +65,5 @@ RSpec.describe "View schools", type: :system do
 
   def i_am_redirected_to_the_root_path
     expect(page).to have_content("Claim Funding for General Mentors")
-  end
-
-  def i_am_redirected_to_organisation_index(persona)
-    expected_content = persona.schools.many? ? "Organisations" : "Organisation details"
-    expect(page).to have_content(expected_content)
-
-    persona.schools.each do |school|
-      expect(page).to have_content(school.name)
-    end
   end
 end

--- a/spec/system/placements/support/users/support_user_invites_a_new_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_invites_a_new_user_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Placements / Support / Users / Support User Invites A New User", type: :system, service: :placements do
-  let!(:school) { create(:school, :placements, name: "School 1") }
+  let!(:school) { create(:placements_school) }
   let!(:provider) { create(:placements_provider, name: "Provider 1") }
   let(:new_user) do
     create(:placements_user,


### PR DESCRIPTION
## Context

In our controllers, we are currently having to do a bit of gymnastics to ensure we are limiting our organisations to those that not only belong to a particular service user, but that are organisations with the service == true. Eg:

`current_user.schools.where(placements_service: true).first.becomes(Placements::School)`

after this pr, you can just call:`current_user.schools.first` it will be a `Placements::School` if the current_user is a `Placements::User`. It will be a `Claims::School` if the current_user is a `Claims::User`

## Changes proposed in this pull request

Moved the association to the child classes. 
Added back scopes to parent models since we are using them in multiple places

## Guidance to review

You shouldn't need to reseed the database. 
Mess about with it on the command line.
None of the functionality should change, so just click around and make sure everything is as it should be. 

## Link to Trello card

https://trello.com/c/sHJqWuJ9

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<img width="961" alt="image" src="https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/1593c2b0-9882-4fc2-bb65-be0df4ffe2f2">

