### PR TITLE
Update create_claim_spec and view_claims_spec to use service: configuration keyword

### DIFF
--- a/spec/system/claims/create_claim_spec.rb
+++ b/spec/system/claims/create_claim_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Create claim", type: :system, js: true do
+RSpec.describe "Create claim", type: :system, js: true, service: :claims do
   let!(:school) { create(:school, :claims) }
   let!(:anne) do
     create(
@@ -99,7 +99,6 @@ RSpec.describe "Create claim", type: :system, js: true do
   private
 
   def given_i_sign_in_as_anne
-    given_i_am_on_the_claims_site
     and_i_visit_the_personas_page
     and_i_click_sign_in_as("Anne")
   end

--- a/spec/system/claims/view_claims_spec.rb
+++ b/spec/system/claims/view_claims_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "View claims", type: :system do
+RSpec.describe "View claims", type: :system, service: :claims do
   let!(:school) { create(:school, :claims).becomes(Claims::School) }
   let!(:mentor_trainings) do
     [
@@ -39,7 +39,6 @@ RSpec.describe "View claims", type: :system do
   end
 
   def given_i_sign_in_as_anne
-    given_i_am_on_the_claims_site
     and_i_visit_the_personas_page
     and_i_click_sign_in_as("Anne")
   end


### PR DESCRIPTION
## Context

We recently added a change to how we can setup the host for system specs.

## Changes proposed in this pull request

Adopt the new method of setting up system specs for the claims service.

## Guidance to review

`bundle exec rspec` should pass.
