### PR TITLE
Align sign-in flows for DfE Sign In and Persona

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ErrorsController < ApplicationController
-  skip_before_action :verify_authenticity_token
+  skip_before_action :verify_authenticity_token, :authenticate_user!
 
   def not_found
     render "not_found", status: :not_found

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,5 @@
 class SessionsController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[new callback]
-  before_action :redirect_to_personas, only: [:new]
 
   # setup inspired by register-trainee-teacher
   # TODO: Replace with commented code when DfE Sign In implemented
@@ -25,11 +24,5 @@ class SessionsController < ApplicationController
     DfESignInUser.end_session!(session)
 
     redirect_to after_sign_out_path
-  end
-
-  private
-
-  def redirect_to_personas
-    redirect_to personas_path if ENV["SIGN_IN_METHOD"] == "persona"
   end
 end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -5,7 +5,11 @@
 
       <p class="govuk-body"><%= t(".description") %></p>
 
-      <%= govuk_button_to t(".sign_in"), "#" %>
+      <% if ENV["SIGN_IN_METHOD"] == "persona" %>
+        <%= govuk_button_to t(".sign_in_with_persona"), personas_path, method: :get %>
+      <% else %>
+        <%= govuk_button_to t(".sign_in_with_dsi"), "#" %>
+      <% end %>
 
       <p class="govuk-body">
         <%= sanitize t(".disclaimer", service_name:, support_email: mail_to("becomingateacher@digital.education.gov.uk")) %>

--- a/config/locales/en/sessions.yml
+++ b/config/locales/en/sessions.yml
@@ -3,5 +3,6 @@ en:
     new:
       heading: Sign in to %{service_name}
       description: Use DfE Sign-in to access your account.
-      sign_in: Sign in using DfE Sign In
+      sign_in_with_dsi: Sign in using DfE Sign In
+      sign_in_with_persona: Sign in using a Persona
       disclaimer: If you do not have a DfE Sign-in account but need access to %{service_name}, email %{support_email}.

--- a/spec/system/claims/support/schools/view_a_school_spec.rb
+++ b/spec/system/claims/support/schools/view_a_school_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "View a school", type: :system do
 
   def when_i_sign_in_as_a_support_user(support_user)
     visit claims_root_path
+    click_on "Sign in using a Persona"
     click_on "Sign In as #{support_user.first_name}"
   end
 

--- a/spec/system/placements/support/users/support_user_invites_a_new_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_invites_a_new_user_spec.rb
@@ -113,8 +113,12 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
     create(:persona, persona_name.downcase.to_sym, service: :placements)
   end
 
-  def and_i_visit_the_personas_page
-    visit personas_path
+  def and_i_visit_root_path
+    visit placements_root_path
+  end
+
+  def and_i_click_on_sign_in
+    click_on "Sign in using a Persona"
   end
 
   def and_i_click_sign_in_as(persona_name)
@@ -123,7 +127,8 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
 
   def given_i_am_signed_in_as_a_support_user
     and_there_is_an_existing_persona_for("Colin")
-    and_i_visit_the_personas_page
+    and_i_visit_root_path
+    and_i_click_on_sign_in
     and_i_click_sign_in_as("Colin")
   end
 


### PR DESCRIPTION
## Context

Right now, we skip a step from our intended production flow by redirecting to the `/personas` page. If we are to treat persona selection as an OmniAuth method, we should mirror the sign-in flows.

## Changes proposed in this pull request

- Stop redirecting to `/personas` automatically.
- Skip authentication when rendering error pages.

## Guidance to review

- You should be able to access the `/sign-in` path.

## Screenshots

| DfE Sign In | Persona |
| ----------- | -------- |
| ![CleanShot 2024-01-26 at 13 38 37](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/2081e760-85db-4c40-a708-0a3ffc6a5fa1) | ![CleanShot 2024-01-26 at 13 39 04](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/39a24fb1-cc89-47e6-9581-ddbf540cb2d0) |
