### PR TITLE
Default most of the project to shared code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,25 @@
-app/*/claims @DFE-Digital/track-pay
-spec/*/claims @DFE-Digital/track-pay
-config/locales/en/claims.yml @DFE-Digital/track-pay
-config/locales/en/claims/* @DFE-Digital/track-pay
+adr                               @DFE-Digital/school-placements  @DFE-Digital/track-pay
+app                               @DFE-Digital/school-placements  @DFE-Digital/track-pay
+bin                               @DFE-Digital/school-placements  @DFE-Digital/track-pay
+config                            @DFE-Digital/school-placements  @DFE-Digital/track-pay
+db                                @DFE-Digital/school-placements  @DFE-Digital/track-pay
+docs                              @DFE-Digital/school-placements  @DFE-Digital/track-pay
+lib                               @DFE-Digital/school-placements  @DFE-Digital/track-pay
+log                               @DFE-Digital/school-placements  @DFE-Digital/track-pay
+public                            @DFE-Digital/school-placements  @DFE-Digital/track-pay
+spec                              @DFE-Digital/school-placements  @DFE-Digital/track-pay
+storage                           @DFE-Digital/school-placements  @DFE-Digital/track-pay
+tmp                               @DFE-Digital/school-placements  @DFE-Digital/track-pay
+vendor                            @DFE-Digital/school-placements  @DFE-Digital/track-pay
 
-app/*/placements  @DFE-Digital/school-placements
-spec/*/placements @DFE-Digital/school-placements
-config/locales/en/placements.yml @DFE-Digital/school-placements
-config/locales/en/placements/* @DFE-Digital/school-placements
+app/*/claims                      @DFE-Digital/track-pay
+spec/*/claims                     @DFE-Digital/track-pay
+config/locales/*/claims           @DFE-Digital/track-pay
+config/locales/*/claims.yml       @DFE-Digital/track-pay
+config/routes/claims.rb           @DFE-Digital/track-pay
 
-config/locales/en.yml @DFE-Digital/track-pay @DFE-Digital/school-placements
+app/*/placements                  @DFE-Digital/school-placements
+spec/*/placements                 @DFE-Digital/school-placements
+config/locales/en/placements      @DFE-Digital/school-placements
+config/locales/en/placements.yml  @DFE-Digital/school-placements
+config/routes/placements.rb       @DFE-Digital/school-placements


### PR DESCRIPTION
## Context

Most non-namespaced files typically warrant a review from both teams. We want to make it implicit that a review is requested by default.

## Changes proposed in this pull request

- Update CODEOWNERS

This may be radical blanket approach that covers a lot of unnecessary directories, but I've included them for good measure. For example, the tmp and log directories.

To remove a team, add a row explicitly assigning ownership to the correct team.

## Guidance to review

- If you're using VS Code, [this extension](https://marketplace.visualstudio.com/items?itemName=jasonnutter.vscode-codeowners) helps with previewing code ownership quite a bit.
