### PR TITLE
Empty state for user lists in placements

### DIFF
--- a/app/views/placements/support/providers/users/index.html.erb
+++ b/app/views/placements/support/providers/users/index.html.erb
@@ -12,21 +12,25 @@
       <h2 class="govuk-heading-m"><%= t(".heading") %></h2>
       <%= govuk_button_to(t(".add_user"), new_placements_support_provider_user_path(@provider), method: :get) %>
 
-      <%= govuk_table do |table| %>
-        <% table.with_head do |head| %>
-          <% head.with_row do |row| %>
-            <% row.with_cell(header: true, text: t(".attributes.users.name")) %>
-            <% row.with_cell(header: true, text: t(".attributes.users.email")) %>
+      <% if @users.any? %>
+        <%= govuk_table do |table| %>
+          <% table.with_head do |head| %>
+            <% head.with_row do |row| %>
+              <% row.with_cell(header: true, text: t(".attributes.users.name")) %>
+              <% row.with_cell(header: true, text: t(".attributes.users.email")) %>
+            <% end %>
           <% end %>
-        <% end %>
-        <% table.with_body do |body| %>
-          <% @users.each do |user| %>
-            <% body.with_row do |row| %>
-              <% row.with_cell(text: govuk_link_to(user.full_name, placements_support_provider_user_path(id: user.id))) %>
-              <% row.with_cell(text: user.email) %>
+          <% table.with_body do |body| %>
+            <% @users.each do |user| %>
+              <% body.with_row do |row| %>
+                <% row.with_cell(text: govuk_link_to(user.full_name, placements_support_provider_user_path(id: user.id))) %>
+                <% row.with_cell(text: user.email) %>
+              <% end %>
             <% end %>
           <% end %>
         <% end %>
+      <% else %>
+        <p><%= t(".empty_state", provider_name: @provider.name) %></p>
       <% end %>
     </div>
   </div>

--- a/app/views/placements/support/schools/users/index.html.erb
+++ b/app/views/placements/support/schools/users/index.html.erb
@@ -12,21 +12,25 @@
       <h2 class="govuk-heading-m"><%= t(".heading") %></h2>
       <%= govuk_button_to(t(".add_user"), new_placements_support_school_user_path(@school), method: :get) %>
 
-      <%= govuk_table do |table| %>
-        <% table.with_head do |head| %>
-          <% head.with_row do |row| %>
-            <% row.with_cell(header: true, text: t(".attributes.users.name")) %>
-            <% row.with_cell(header: true, text: t(".attributes.users.email")) %>
+      <% if @users.any? %>
+        <%= govuk_table do |table| %>
+          <% table.with_head do |head| %>
+            <% head.with_row do |row| %>
+              <% row.with_cell(header: true, text: t(".attributes.users.name")) %>
+              <% row.with_cell(header: true, text: t(".attributes.users.email")) %>
+            <% end %>
           <% end %>
-        <% end %>
-        <% table.with_body do |body| %>
-          <% @users.each do |user| %>
-            <% body.with_row do |row| %>
-              <% row.with_cell(text: govuk_link_to(user.full_name, placements_support_school_user_path(id: user.id))) %>
-              <% row.with_cell(text: user.email) %>
+          <% table.with_body do |body| %>
+            <% @users.each do |user| %>
+              <% body.with_row do |row| %>
+                <% row.with_cell(text: govuk_link_to(user.full_name, placements_support_school_user_path(id: user.id))) %>
+                <% row.with_cell(text: user.email) %>
+              <% end %>
             <% end %>
           <% end %>
         <% end %>
+      <% else %>
+        <p><%= t(".empty_state", school_name: @school.name) %></p>
       <% end %>
     </div>
   </div>

--- a/config/locales/en/placements/support/providers/users.yml
+++ b/config/locales/en/placements/support/providers/users.yml
@@ -11,6 +11,7 @@ en:
               placements: Placements
               providers: Providers
             add_user: Add user
+            empty_state: There are no users for %{provider_name}.
             heading: Users
             attributes:
               users:

--- a/config/locales/en/placements/support/schools/users.yml
+++ b/config/locales/en/placements/support/schools/users.yml
@@ -16,6 +16,7 @@ en:
               users:
                 name: Name
                 email: Email
+            empty_state: There are no users for %{school_name}.
           create:
             user_added: User added
           new:


### PR DESCRIPTION
## Context

Support users in placements should see an empty state when viewing an organisation with no users

## Changes proposed in this pull request

adds empty state to user lists (providers and schools)

## Guidance to review

Sign in as placements Colin
Add an organisation
Look at that organisation's users list
You should see the empty state "There are no users for..." instead of an empyt table.

## Link to Trello card

None

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<img width="957" alt="image" src="https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/4472575d-3b68-4095-af2d-207fff323ce2">

