### PR TITLE
As a Support User, I should be able to see all Claims made by a School

### DIFF
--- a/app/components/claim/status_tag_component.rb
+++ b/app/components/claim/status_tag_component.rb
@@ -1,0 +1,16 @@
+class Claim::StatusTagComponent < ApplicationComponent
+  attr_reader :claim
+
+  def initialize(claim:, classes: [], html_attributes: {})
+    super(classes:, html_attributes:)
+
+    @claim = claim
+  end
+
+  def call
+    css_class = claim.draft ? "govuk-tag--grey" : "govuk-tag--blue"
+    text = claim.draft ? t(".draft") : t(".submitted")
+
+    content_tag(:p, text, class: "govuk-tag #{css_class}")
+  end
+end

--- a/app/controllers/claims/support/schools/claims_controller.rb
+++ b/app/controllers/claims/support/schools/claims_controller.rb
@@ -1,3 +1,7 @@
 class Claims::Support::Schools::ClaimsController < Claims::Support::ApplicationController
   include Claims::BelongsToSchool
+
+  def index
+    @claims = @school.claims.order("created_at DESC")
+  end
 end

--- a/app/views/claims/support/schools/claims/index.html.erb
+++ b/app/views/claims/support/schools/claims/index.html.erb
@@ -6,6 +6,23 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m"><%= t(".heading") %></h2>
+
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header"><%= t(".claim_id") %></th>
+            <th scope="col" class="govuk-table__header"></th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% @claims.each do |claim| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell"><%= govuk_link_to claim.id, claims_support_school_claim_path(id: claim) %></td>
+              <td class="govuk-table__cell"><%= render(Claim::StatusTagComponent.new(claim:)) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
     </div>
   </div>
 </div>

--- a/app/views/claims/support/schools/claims/show.html.erb
+++ b/app/views/claims/support/schools/claims/show.html.erb
@@ -1,0 +1,11 @@
+<div class="govuk-width-container">
+  <h1 class="govuk-heading-l"><%= @school.name %></h1>
+
+  <%= render "claims/support/schools/secondary_navigation", school: @school %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-m"><%= t(".heading") %></h2>
+    </div>
+  </div>
+</div>

--- a/config/locales/en/claims/support/schools/claims.yml
+++ b/config/locales/en/claims/support/schools/claims.yml
@@ -5,3 +5,4 @@ en:
         claims:
           index:
             heading: Claims
+            claim_id: ID

--- a/config/locales/en/components/claim/status_tag_component.yml
+++ b/config/locales/en/components/claim/status_tag_component.yml
@@ -1,0 +1,6 @@
+en:
+  components:
+    claim:
+      status_tag_component:
+        draft: Draft
+        submitted: Submitted

--- a/spec/system/claims/support/schools/claims/view_a_schools_claims_spec.rb
+++ b/spec/system/claims/support/schools/claims/view_a_schools_claims_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe "View a schools claims", type: :system, service: :claims do
+  let!(:school) { create(:school, :claims).becomes(Claims::School) }
+  let!(:another_school) { create(:school, :claims).becomes(Claims::School) }
+
+  let!(:colin) { create(:persona, :colin, service: "claims") }
+
+  let!(:submitted_claim) { create(:claim, school_id: school.id, draft: false) }
+  let!(:draft_claim) { create(:claim, school_id: school.id, draft: true) }
+  let!(:claim_from_another_school) { create(:claim, school_id: another_school.id, draft: true) }
+
+  scenario "View a school's claims as a support user" do
+    given_i_sign_in_as_colin
+    when_i_visit_the_claims_support_school_claims_page
+    i_see_a_list_of_the_schools_claims
+    i_dont_see_claims_from_other_schools
+  end
+
+  private
+
+  def given_i_sign_in_as_colin
+    and_i_visit_the_personas_page
+    and_i_click_sign_in_as("Colin")
+  end
+
+  def and_i_visit_the_personas_page
+    visit personas_path
+  end
+
+  def and_i_click_sign_in_as(persona_name)
+    click_on "Sign In as #{persona_name}"
+  end
+
+  def when_i_visit_the_claims_support_school_claims_page
+    visit claims_support_school_claims_path(school)
+  end
+
+  def i_see_a_list_of_the_schools_claims
+    expect(page).to have_content("#{draft_claim.id}\nDraft\n#{submitted_claim.id}\nSubmitted")
+  end
+
+  def i_dont_see_claims_from_other_schools
+    expect(page).not_to have_content("#{claim_from_another_school.id}\nDraft")
+  end
+end


### PR DESCRIPTION
## Context

This change allows a support user to view a list of all claims made by a school 

**Note: We don't have an example of this page in the prototype. Once updated I can update this PR..**

## Changes proposed in this pull request

Added content to the claims page

## Guidance to review

- Sign in as a support user
- Go to a school
- Click on the secondary navigation Claims link

## Link to Trello card

https://trello.com/c/ftOHgLbl/100-as-a-support-user-i-should-be-able-to-see-all-claims-made-by-a-school

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<img width="1018" alt="Screenshot 2024-01-27 at 17 05 14" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/24ad09bf-bf07-47f0-aae3-046e4ac0007c">
