### PR TITLE
Add SupportUser class and use implicit association class casting

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,5 @@
 PLACEMENTS_HOST=placements.localhost
 CLAIMS_HOST=claims.localhost
+SIGN_IN_METHOD=persona
 PUBLISH_BASE_URL=https://www.publish-teacher-training-courses.service.gov.uk
+GOVUK_NOTIFY_API_KEY=

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,5 +1,5 @@
-name: Build and Deploy
-concurrency: build_and_deploy_${{ github.ref_name }}
+name: Build and Test
+concurrency: build_and_test_${{ github.ref_name }}
 
 on: push
 
@@ -24,27 +24,8 @@ jobs:
         with:
           ruby-version: 3.2.2
           bundler-cache: true
-      - name: Use Node.js 20.9.0
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20.9.0
-          cache: "npm"
-      - name: Install dependencies
-        run: |
-          sudo apt-get update && sudo apt-get -yqq install libpq-dev
-          bundle install --jobs 4 --retry 3
-          bundle exec rails assets:precompile
-        env:
-          DATABASE_URL: postgres://postgres:password@localhost:5432
-          GOVUK_NOTIFY_API_KEY: fake_key
-          SIGN_IN_METHOD: persona
       - name: ${{ matrix.tests }}
-        run: ${{ env.COMMAND }}
-        env:
-          COMMAND: ${{ matrix.command }}
-          DATABASE_URL: postgres://postgres:password@localhost:5432
-          GOVUK_NOTIFY_API_KEY: fake_key
-          SIGN_IN_METHOD: persona
+        run: ${{ matrix.COMMAND }}
 
   test:
     name: Test
@@ -62,10 +43,12 @@ jobs:
           --health-retries 5
     strategy:
       fail-fast: false
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: postgres://postgres:password@localhost:5432
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -76,26 +59,9 @@ jobs:
         with:
           node-version: 20.9.0
           cache: "npm"
-      - name: Install dependencies
-        run: |
-          sudo apt-get update && sudo apt-get -yqq install libpq-dev
-          bundle install --jobs 4 --retry 3
-          bundle exec rails assets:precompile
-        env:
-          DATABASE_URL: postgres://postgres:password@localhost:5432
-          GOVUK_NOTIFY_API_KEY: fake_key
-          SIGN_IN_METHOD: persona
       - name: Run Tests
-        env:
-          RAILS_ENV: test
-          PGHOST: localhost
-          DISABLE_SPRING: 1
-          DATABASE_URL: postgres://postgres:password@localhost:5432
-          GOVUK_NOTIFY_API_KEY: fake_key
-          SIGN_IN_METHOD: persona
         run: |
-          bundle exec rake db:create
-          bundle exec rails db:schema:load
+          bundle exec rails test:prepare db:test:prepare
           bundle exec rspec --format progress
       - name: Upload failure screenshots
         if: failure()

--- a/app/controllers/concerns/claims/belongs_to_school.rb
+++ b/app/controllers/concerns/claims/belongs_to_school.rb
@@ -5,7 +5,7 @@ module Claims::BelongsToSchool
     before_action :set_school
 
     def set_school
-      @school = scoped_schools.find(params.require(:school_id)).becomes(Claims::School)
+      @school = scoped_schools.find(params.require(:school_id))
     rescue ActiveRecord::RecordNotFound
       redirect_to not_found_path
     end

--- a/app/controllers/placements/support/organisations/users_controller.rb
+++ b/app/controllers/placements/support/organisations/users_controller.rb
@@ -29,7 +29,7 @@ class Placements::Support::Organisations::UsersController < Placements::Support:
   private
 
   def users
-    @users = @organisation.users.placements
+    @users = @organisation.users
   end
 
   def user_params

--- a/app/models/claims/school.rb
+++ b/app/models/claims/school.rb
@@ -47,6 +47,6 @@
 class Claims::School < School
   default_scope { claims_service }
 
-  has_many :users, -> { claims }, through: :memberships
+  has_many :users, through: :memberships
   has_many :claims
 end

--- a/app/models/claims/support_user.rb
+++ b/app/models/claims/support_user.rb
@@ -16,8 +16,4 @@
 #
 class Claims::SupportUser < User
   include ActsAsSupportUser
-
-  def service
-    :claims
-  end
 end

--- a/app/models/claims/support_user.rb
+++ b/app/models/claims/support_user.rb
@@ -15,9 +15,7 @@
 #  index_users_on_type_and_email  (type,email) UNIQUE
 #
 class Claims::SupportUser < User
-  def support_user?
-    true
-  end
+  include ActsAsSupportUser
 
   def service
     :claims

--- a/app/models/claims/user.rb
+++ b/app/models/claims/user.rb
@@ -20,8 +20,4 @@ class Claims::User < User
            through: :memberships,
            source: :organisation,
            source_type: "School"
-
-  def service
-    :claims
-  end
 end

--- a/app/models/claims/user.rb
+++ b/app/models/claims/user.rb
@@ -16,7 +16,6 @@
 #
 class Claims::User < User
   has_many :schools,
-           -> { claims_service },
            through: :memberships,
            source: :organisation,
            source_type: "School"

--- a/app/models/concerns/acts_as_support_user.rb
+++ b/app/models/concerns/acts_as_support_user.rb
@@ -1,0 +1,9 @@
+module ActsAsSupportUser
+  extend ActiveSupport::Concern
+
+  included do
+    def support_user?
+      true
+    end
+  end
+end

--- a/app/models/placements/provider.rb
+++ b/app/models/placements/provider.rb
@@ -31,5 +31,5 @@
 class Placements::Provider < Provider
   default_scope { placements_service }
 
-  has_many :users, -> { placements }, through: :memberships
+  has_many :users, through: :memberships
 end

--- a/app/models/placements/school.rb
+++ b/app/models/placements/school.rb
@@ -47,5 +47,5 @@
 class Placements::School < School
   default_scope { placements_service }
 
-  has_many :users, -> { placements }, through: :memberships
+  has_many :users, through: :memberships
 end

--- a/app/models/placements/support_user.rb
+++ b/app/models/placements/support_user.rb
@@ -15,9 +15,7 @@
 #  index_users_on_type_and_email  (type,email) UNIQUE
 #
 class Placements::SupportUser < User
-  def support_user?
-    true
-  end
+  include ActsAsSupportUser
 
   def service
     :placements

--- a/app/models/placements/support_user.rb
+++ b/app/models/placements/support_user.rb
@@ -16,8 +16,4 @@
 #
 class Placements::SupportUser < User
   include ActsAsSupportUser
-
-  def service
-    :placements
-  end
 end

--- a/app/models/placements/user.rb
+++ b/app/models/placements/user.rb
@@ -16,12 +16,10 @@
 #
 class Placements::User < User
   has_many :schools,
-           -> { placements_service },
            through: :memberships,
            source: :organisation,
            source_type: "School"
   has_many :providers,
-           -> { placements_service },
            through: :memberships,
            source: :organisation,
            source_type: "Provider"

--- a/app/models/placements/user.rb
+++ b/app/models/placements/user.rb
@@ -25,8 +25,4 @@ class Placements::User < User
            through: :memberships,
            source: :organisation,
            source_type: "Provider"
-
-  def service
-    :placements
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,4 +33,12 @@ class User < ApplicationRecord
   def support_user?
     false
   end
+
+  # Extracts the namespace of the class as a symbol to determine the service
+  # e.g.
+  # - Placements::User => :placements
+  # - Claims::User => :claims
+  def service
+    self.class.name.deconstantize.downcase.to_sym
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,9 +23,6 @@ class User < ApplicationRecord
   validates :type, presence: true
   validates :email, uniqueness: { scope: :type, case_sensitive: false }
 
-  scope :claims, -> { where(type: "Claims::User") }
-  scope :placements, -> { where(type: "Placements::User") }
-
   def full_name
     "#{first_name} #{last_name}".strip
   end

--- a/spec/models/claims/school_spec.rb
+++ b/spec/models/claims/school_spec.rb
@@ -49,6 +49,21 @@ require "rails_helper"
 RSpec.describe Claims::School do
   context "associations" do
     it { should have_many(:claims) }
+
+    context "#users" do
+      it { should have_many(:users).through(:memberships) }
+
+      it "returns only Claims::User records" do
+        claims_school = create(:claims_school)
+        claims_user = create(:claims_user)
+
+        claims_school.users << claims_user
+        claims_school.users << create(:placements_user)
+
+        expect(claims_school.users).to contain_exactly(claims_user)
+        expect(claims_school.users).to all(be_a(Claims::User))
+      end
+    end
   end
 
   describe "default scope" do

--- a/spec/models/claims/user_spec.rb
+++ b/spec/models/claims/user_spec.rb
@@ -18,12 +18,19 @@ require "rails_helper"
 
 RSpec.describe Claims::User do
   describe "associations" do
-    it { should have_many(:schools).through(:memberships).source(:organisation) }
+    context "#schools" do
+      it { should have_many(:schools).through(:memberships).source(:organisation) }
 
-    it "association returns Claims::Schools objects" do
-      claims_user = create(:claims_user)
-      claims_user.memberships.create!(organisation: create(:school, :claims))
-      expect(claims_user.schools.first.class.name).to eq "Claims::School"
+      it "returns only Claims::School records" do
+        claims_user = create(:claims_user)
+        claims_school = create(:claims_school)
+
+        claims_user.schools << claims_school
+        claims_user.schools << create(:placements_school)
+
+        expect(claims_user.schools).to contain_exactly(claims_school)
+        expect(claims_user.schools).to all(be_a(Claims::School))
+      end
     end
   end
 

--- a/spec/models/placements/provider_spec.rb
+++ b/spec/models/placements/provider_spec.rb
@@ -31,8 +31,21 @@
 require "rails_helper"
 
 RSpec.describe Placements::Provider do
-  describe "#assocations" do
-    it { should have_many(:users).through(:memberships) }
+  context "assocations" do
+    context "#users" do
+      it { should have_many(:users).through(:memberships) }
+
+      it "returns only Placements::User records" do
+        placements_provider = create(:placements_provider)
+        placements_user = create(:placements_user)
+
+        placements_provider.users << create(:claims_user)
+        placements_provider.users << placements_user
+
+        expect(placements_provider.users).to contain_exactly(placements_user)
+        expect(placements_provider.users).to all(be_a(Placements::User))
+      end
+    end
   end
 
   describe "default scope" do

--- a/spec/models/placements/school_spec.rb
+++ b/spec/models/placements/school_spec.rb
@@ -47,8 +47,21 @@
 require "rails_helper"
 
 RSpec.describe Placements::School do
-  describe "#assocations" do
-    it { should have_many(:users).through(:memberships) }
+  context "assocations" do
+    context "#users" do
+      it { should have_many(:users).through(:memberships) }
+
+      it "returns only Placements::User records" do
+        placements_school = create(:placements_school)
+        placements_user = create(:placements_user)
+
+        placements_school.users << create(:claims_user)
+        placements_school.users << placements_user
+
+        expect(placements_school.users).to contain_exactly(placements_user)
+        expect(placements_school.users).to all(be_a(Placements::User))
+      end
+    end
   end
 
   describe "default scope" do

--- a/spec/models/placements/user_spec.rb
+++ b/spec/models/placements/user_spec.rb
@@ -18,12 +18,19 @@ require "rails_helper"
 
 RSpec.describe Placements::User do
   describe "associations" do
-    it { should have_many(:schools).through(:memberships).source(:organisation) }
+    context "#schools" do
+      it { should have_many(:schools).through(:memberships).source(:organisation) }
 
-    it "association returns Placements::Schools objects" do
-      placements_user = create(:placements_user)
-      placements_user.memberships.create!(organisation: create(:school, :placements))
-      expect(placements_user.schools.first.class.name).to eq "Placements::School"
+      it "returns only Placements::School records" do
+        placements_user = create(:placements_user)
+        placements_school = create(:placements_school)
+
+        placements_user.schools << placements_school
+        placements_user.schools << create(:claims_school)
+
+        expect(placements_user.schools).to contain_exactly(placements_school)
+        expect(placements_user.schools).to all(be_a(Placements::School))
+      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -35,30 +35,6 @@ RSpec.describe User, type: :model do
     it { is_expected.to validate_presence_of(:type) }
   end
 
-  context "scopes" do
-    describe "#claims" do
-      it "only returns users of type Claims::User" do
-        claims_user = create(:claims_user)
-        create(:claims_support_user)
-        create(:placements_user)
-        create(:placements_support_user)
-
-        expect(described_class.claims).to contain_exactly(claims_user)
-      end
-    end
-
-    describe "#placements" do
-      it "only returns users of type Placements::User" do
-        create(:claims_user)
-        create(:claims_support_user)
-        create(:placements_support_user)
-        placements_user = create(:placements_user)
-
-        expect(described_class.placements).to contain_exactly(placements_user)
-      end
-    end
-  end
-
   describe "#support_user?" do
     it "returns false" do
       expect(subject.support_user?).to eq(false)

--- a/spec/system/claims/create_claim_spec.rb
+++ b/spec/system/claims/create_claim_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Create claim", type: :system, js: true, service: :claims do
-  let!(:school) { create(:school, :claims) }
+  let!(:school) { create(:claims_school) }
   let!(:anne) do
     create(
       :claims_user,

--- a/spec/system/claims/view_claims_spec.rb
+++ b/spec/system/claims/view_claims_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "View claims", type: :system, service: :claims do
-  let!(:school) { create(:school, :claims).becomes(Claims::School) }
+  let!(:school) { create(:claims_school) }
   let!(:mentor_trainings) do
     [
       create(:mentor_training, claim: create(:claim, school:)),


### PR DESCRIPTION
## Context

As [STI has been adopted for the User class](https://github.com/DFE-Digital/itt-mentor-services/pull/168), we can now fully lean into the practice of using only namespaced models and with Rails' _magic_ ✨, implicit namespaces for associations.

## Changes proposed in this pull request

- Drop `.claims` and `.placements` scopes from User. A User can be one or the other, never both, therefore we can rely on calling `Claims::User` and `Placements::User` for `User.claims` and `User.placements`.

## Guidance to review

  ```ruby
  class Claims::User < User
    has_many :schools # This will use the current namespace and look for Claims::School by default.
  end
  ```

- Try going through flows. Nothing should break.
- Try the following in your console:

  ```ruby
  # To silence SQL query logs
  ApplicationRecord.logger.silence do
    [
      Claims::User.all.flat_map(&:schools).all? { _1.class == Claims::School },
      Claims::School.all.flat_map(&:users).all? { _1.class == Claims::User },
      Placements::User.all.flat_map(&:schools).all? { _1.class == Placements::School },
      Placements::User.all.flat_map(&:providers).all? { _1.class == Placements::Provider },
      Placements::School.all.flat_map(&:users).all? { _1.class == Placements::User },
      Placements::Provider.all.flat_map(&:users).all? { _1.class == Placements::User },
    ]
  end
  ```

-----

Whilst trying to fix the `config/initializers/preload_stis.rb` code running without a database, I stumbled on optimising our GitHub workflow. Lint is around 50% faster without setting up Node and more.

| Before | After |
| ------ | ----- |
| ![CleanShot 2024-01-29 at 15 30 05](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/a6407d01-1cd4-4c38-947f-2a4a6d32c775) | ![CleanShot 2024-01-29 at 15 31 36](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/de577bfc-8c58-49b3-9caa-8744e8420358) |