### PR TITLE
Allow non-support users to add other users to their organisation

### DIFF
--- a/app/controllers/placements/organisations/users_controller.rb
+++ b/app/controllers/placements/organisations/users_controller.rb
@@ -1,0 +1,44 @@
+class Placements::Organisations::UsersController < ApplicationController
+  before_action :set_organisation
+
+  def index
+    users
+  end
+
+  def show
+    @user = users.find(params.require(:id))
+  end
+
+  def new
+    @user_form = params[:user_invite_form].present? ? user_form : UserInviteForm.new
+  end
+
+  def check
+    render :new unless user_form.valid?
+  end
+
+  def create
+    if user_form.invite
+      redirect_to_index
+      flash[:success] = t(".user_added")
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def users
+    @users = @organisation.users.order("LOWER(first_name)")
+  end
+
+  def user_params
+    params.require(:user_invite_form)
+          .permit(:first_name, :last_name, :email)
+          .merge({ service: current_service, organisation: @organisation })
+  end
+
+  def user_form
+    @user_form ||= UserInviteForm.new(user_params)
+  end
+end

--- a/app/controllers/placements/providers/users_controller.rb
+++ b/app/controllers/placements/providers/users_controller.rb
@@ -1,0 +1,11 @@
+class Placements::Providers::UsersController < Placements::Organisations::UsersController
+  private
+
+  def set_organisation
+    @organisation = current_user.providers.find(params.fetch(:provider_id))
+  end
+
+  def redirect_to_index
+    redirect_to placements_provider_users_path(@organisation)
+  end
+end

--- a/app/controllers/placements/schools/users_controller.rb
+++ b/app/controllers/placements/schools/users_controller.rb
@@ -1,0 +1,11 @@
+class Placements::Schools::UsersController < Placements::Organisations::UsersController
+  private
+
+  def set_organisation
+    @organisation = current_user.schools.find(params.fetch(:school_id))
+  end
+
+  def redirect_to_index
+    redirect_to placements_school_users_path(@organisation)
+  end
+end

--- a/app/helpers/routes_helper.rb
+++ b/app/helpers/routes_helper.rb
@@ -34,12 +34,30 @@ module RoutesHelper
     }.fetch current_service
   end
 
+  def organisation_users_path(organisation)
+    case organisation
+    when School
+      placements_school_users_path(organisation)
+    when Provider
+      placements_provider_users_path(organisation)
+    end
+  end
+
   def placements_support_organisation_path(organisation)
     case organisation
     when School
       placements_support_school_path(organisation)
     when Provider
       placements_support_provider_path(organisation)
+    end
+  end
+
+  def placements_organisation_user_path(organisation, user)
+    case organisation
+    when School
+      placements_school_user_path(organisation, user)
+    when Provider
+      placements_provider_user_path(organisation, user)
     end
   end
 
@@ -58,6 +76,33 @@ module RoutesHelper
       placements_support_school_users_path(organisation)
     when Provider
       placements_support_provider_users_path(organisation)
+    end
+  end
+
+  def check_placements_organisation_users_path(organisation)
+    case organisation
+    when School
+      check_placements_school_users_path
+    when Provider
+      check_placements_provider_users_path
+    end
+  end
+
+  def placements_organisation_users_path(organisation)
+    case organisation
+    when School
+      placements_school_users_path(organisation)
+    when Provider
+      placements_provider_users_path(organisation)
+    end
+  end
+
+  def new_placements_organisation_user_path(organisation, params = {})
+    case organisation
+    when School
+      new_placements_school_user_path(organisation, params)
+    when Provider
+      new_placements_provider_user_path(organisation, params)
     end
   end
 end

--- a/app/models/placements/user.rb
+++ b/app/models/placements/user.rb
@@ -23,4 +23,11 @@ class Placements::User < User
            through: :memberships,
            source: :organisation,
            source_type: "Provider"
+  def service
+    :placements
+  end
+
+  def organisation_count
+    providers.count + schools.count
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,17 +60,16 @@
       <%= yield :before_content %>
     </div>
 
-    <div class="govuk-width-container">
-      <% flash.each do |key, message| %>
-        <div class="govuk-!-margin-top-6 govuk-!-margin-bottom-0">
-          <%= render(GovukComponent::NotificationBannerComponent.new(title_text: t(".success"), success: true)) do %>
-            <h3 class="govuk-heading-m"><%= message %></h3>
-          <% end %>
-        </div>
-      <% end %>
-    </div>
-
     <main class="govuk-main-wrapper" id="main-content" role="main">
+      <div class="govuk-width-container">
+        <% flash.each do |key, message| %>
+          <div class="govuk-!-margin-top-6 govuk-!-margin-bottom-0">
+            <%= render(GovukComponent::NotificationBannerComponent.new(title_text: t(".success"), success: true)) do %>
+              <h3 class="govuk-heading-m"><%= message %></h3>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
       <%= yield %>
     </main>
 

--- a/app/views/placements/_primary_navigation.html.erb
+++ b/app/views/placements/_primary_navigation.html.erb
@@ -4,7 +4,7 @@
   <%= render PrimaryNavigationComponent.new do |component| %>
     <% component.with_navigation_item t(".placements"), "#", current: current_navigation == :placements %>
     <% component.with_navigation_item t(".mentors"), "#", current: current_navigation == :mentors %>
-    <% component.with_navigation_item t(".users"), "#", current: current_navigation == :users %>
+    <% component.with_navigation_item t(".users"), organisation_users_path(organisation), current: current_navigation == :users %>
     <% component.with_navigation_item t(".organisation_details"),
                                       placements_organisation_path(organisation),
                                       current: current_navigation == :organisation_details %>

--- a/app/views/placements/organisations/users/_check_form.html.erb
+++ b/app/views/placements/organisations/users/_check_form.html.erb
@@ -1,0 +1,58 @@
+<%# locals: (user: nil, organisation: nil) -%>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= form_with(model: user, url: placements_organisation_users_path(organisation), method: :post) do |f| %>
+        <%= f.hidden_field :first_name, value: user.first_name %>
+        <%= f.hidden_field :last_name, value: user.last_name %>
+        <%= f.hidden_field :email, value: user.email %>
+
+        <label class="govuk-label govuk-label--l">
+          <span class="govuk-caption-l"><%= t(".add_user", organisation_name: organisation.name) %></span>
+          <%= t(".check_your_answers") %>
+        </label>
+
+        <%= govuk_summary_list do |summary_list| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: User.human_attribute_name(:first_name)) %>
+            <% row.with_value(text: user.first_name) %>
+            <% row.with_action(text: t(".change"),
+                               href: new_placements_organisation_user_path(organisation, user.as_form_params),
+                               html_attributes: {
+                                 class: "govuk-link--no-visited-state",
+                               }) %>
+          <% end %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: User.human_attribute_name(:last_name)) %>
+            <% row.with_value(text: user.last_name) %>
+            <% row.with_action(text: t(".change"),
+                               href: new_placements_organisation_user_path(organisation, user.as_form_params),
+                               html_attributes: {
+                                 class: "govuk-link--no-visited-state",
+                               }) %>
+          <% end %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: User.human_attribute_name(:email)) %>
+            <% row.with_value(text: user.email) %>
+            <% row.with_action(text: t(".change"),
+                               href: new_placements_organisation_user_path(organisation, user.as_form_params),
+                               html_attributes: {
+                                 class: "govuk-link--no-visited-state",
+                               }) %>
+          <% end %>
+        <% end %>
+
+        <div class="govuk-warning-text">
+          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+          <strong class="govuk-warning-text__text"><%= t(".warning", organisation_name: organisation.name) %></strong>
+        </div>
+
+        <%= f.govuk_submit t(".add_user") %>
+
+        <p class="govuk-body">
+          <%= govuk_link_to(t(".cancel"), placements_organisation_users_path(organisation)) %>
+        </p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/placements/organisations/users/_details.html.erb
+++ b/app/views/placements/organisations/users/_details.html.erb
@@ -1,0 +1,14 @@
+<%= govuk_summary_list do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: User.human_attribute_name(:first_name)) %>
+    <% row.with_value(text: @user.first_name) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: User.human_attribute_name(:last_name)) %>
+    <% row.with_value(text: @user.last_name) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: User.human_attribute_name(:email)) %>
+    <% row.with_value(text: @user.email) %>
+  <% end %>
+<% end %>

--- a/app/views/placements/organisations/users/_list.html.erb
+++ b/app/views/placements/organisations/users/_list.html.erb
@@ -1,0 +1,20 @@
+<% if users.any? %>
+  <%= govuk_table do |table| %>
+    <% table.with_head do |head| %>
+      <% head.with_row do |row| %>
+        <% row.with_cell(header: true, text: t(".name")) %>
+        <% row.with_cell(header: true, text: User.human_attribute_name(:email)) %>
+      <% end %>
+    <% end %>
+    <% table.with_body do |body| %>
+      <% users.each do |user| %>
+        <% body.with_row do |row| %>
+          <% row.with_cell(text: govuk_link_to(user.full_name, placements_organisation_user_path(organisation, user))) %>
+          <% row.with_cell(text: user.email) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% else %>
+  <p><%= t("no_users", organisation_name: organisation.name) %></p>
+<% end %>

--- a/app/views/placements/organisations/users/_new_form.html.erb
+++ b/app/views/placements/organisations/users/_new_form.html.erb
@@ -1,0 +1,33 @@
+<%# locals: (organisation: nil, user: nil) -%>
+<%= form_with(model: user, url: check_placements_organisation_users_path(organisation), method: "get") do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".add_user", organisation_name: organisation.name) %></span>
+      <h2 class="govuk-heading-l"><%= t(".personal_details") %></h2>
+
+      <div class="govuk-form-group">
+        <%= f.govuk_text_field :first_name,
+                               class: "govuk-input--width-20",
+                               label: { text: User.human_attribute_name(:first_name), size: "s" } %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= f.govuk_text_field :last_name,
+                               class: "govuk-input--width-20",
+                               label: { text: User.human_attribute_name(:last_name), size: "s" } %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= f.govuk_text_field :email, label: { text: User.human_attribute_name(:email), size: "s" } %>
+      </div>
+
+      <%= f.govuk_submit t(".continue") %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to(t(".cancel"), placements_organisation_users_path(organisation)) %>
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/placements/providers/users/check.html.erb
+++ b/app/views/placements/providers/users/check.html.erb
@@ -1,0 +1,17 @@
+<%= content_for :page_title, t(".page_title") %>
+<% if current_user.organisation_count > 1 %>
+  <%= content_for(:header_content) do %>
+    <%= render(ContentHeaderComponent.new(
+      title: @organisation.name,
+      actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
+    )) %>
+  <% end %>
+<% end %>
+<%= render "placements/primary_navigation", current_navigation: :users, organisation: @organisation %>
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: new_placements_provider_user_path(
+    @user_form.as_form_params.merge(provider_id: @organisation.id),
+  )) %>
+<% end %>
+
+<%= render "placements/organisations/users/check_form", user: @user_form, organisation: @organisation %>

--- a/app/views/placements/providers/users/index.html.erb
+++ b/app/views/placements/providers/users/index.html.erb
@@ -1,0 +1,20 @@
+<% content_for(:page_title) { t(".users") } %>
+<% if current_user.organisation_count > 1 %>
+  <%= content_for(:header_content) do %>
+    <%= render(ContentHeaderComponent.new(
+      title: @organisation.name,
+      actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
+    )) %>
+  <% end %>
+<% end %>
+<%= render "placements/primary_navigation", organisation: @organisation, current_navigation: :users %>
+
+<div class="govuk-width-container">
+  <h1 class="govuk-heading-l"><%= t(".users") %></h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= govuk_button_to(t(".add_user"), new_placements_provider_user_path, method: :get) %>
+      <%= render "placements/organisations/users/list", users: @users, organisation: @organisation %>
+    </div>
+  </div>
+</div>

--- a/app/views/placements/providers/users/new.html.erb
+++ b/app/views/placements/providers/users/new.html.erb
@@ -1,0 +1,18 @@
+<%= content_for :page_title, @user_form.errors.any? ? t(".page_title_with_error") : t(".page_title") %>
+<%= render "placements/primary_navigation", current_navigation: :users, organisation: @organisation %>
+<% if current_user.organisation_count > 1 %>
+  <%= content_for(:header_content) do %>
+    <%= render(ContentHeaderComponent.new(
+      title: @organisation.name,
+      actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
+    )) %>
+  <% end %>
+<% end %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: placements_provider_users_path(@organisation)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= render "placements/organisations/users/new_form", user: @user_form, organisation: @organisation %>
+</div>

--- a/app/views/placements/providers/users/show.html.erb
+++ b/app/views/placements/providers/users/show.html.erb
@@ -1,0 +1,22 @@
+<% if current_user.organisation_count > 1 %>
+  <%= content_for(:header_content) do %>
+    <%= render(ContentHeaderComponent.new(
+      title: @organisation.name,
+      actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
+    )) %>
+  <% end %>
+<% end %>
+<%= render "placements/primary_navigation", organisation: @organisation, current_navigation: :users %>
+<%= content_for :page_title, sanitize(@user.full_name) %>
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: placements_provider_users_path(@organisation)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <h1 class="govuk-heading-l"><%= @user.full_name %></h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "placements/organisations/users/details", user: @user %>
+    </div>
+  </div>
+</div>

--- a/app/views/placements/schools/show.html.erb
+++ b/app/views/placements/schools/show.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :page_title, t(".organisation_details") %>
-<% if current_user.memberships.many? %>
+<% if current_user.organisation_count > 1 %>
   <%= content_for(:header_content) do %>
     <%= render(ContentHeaderComponent.new(
       title: @school.name,

--- a/app/views/placements/schools/users/check.html.erb
+++ b/app/views/placements/schools/users/check.html.erb
@@ -1,0 +1,17 @@
+<%= content_for :page_title, t(".page_title") %>
+<% if current_user.organisation_count > 1 %>
+  <%= content_for(:header_content) do %>
+    <%= render(ContentHeaderComponent.new(
+      title: @organisation.name,
+      actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
+    )) %>
+  <% end %>
+<% end %>
+<%= render "placements/primary_navigation", current_navigation: :users, organisation: @organisation %>
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: new_placements_school_user_path(
+    @user_form.as_form_params.merge(school_id: @organisation.id),
+  )) %>
+<% end %>
+
+<%= render "placements/organisations/users/check_form", user: @user_form, organisation: @organisation %>

--- a/app/views/placements/schools/users/index.html.erb
+++ b/app/views/placements/schools/users/index.html.erb
@@ -1,0 +1,20 @@
+<% content_for(:page_title) { t(".users") } %>
+<% if current_user.organisation_count > 1 %>
+  <%= content_for(:header_content) do %>
+    <%= render(ContentHeaderComponent.new(
+      title: @organisation.name,
+      actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
+    )) %>
+  <% end %>
+<% end %>
+<%= render "placements/primary_navigation", organisation: @organisation, current_navigation: :users %>
+
+<div class="govuk-width-container">
+  <h1 class="govuk-heading-l"><%= t(".users") %></h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= govuk_button_to(t(".add_user"), new_placements_school_user_path, method: :get) %>
+      <%= render "placements/organisations/users/list", users: @users, organisation: @organisation %>
+    </div>
+  </div>
+</div>

--- a/app/views/placements/schools/users/new.html.erb
+++ b/app/views/placements/schools/users/new.html.erb
@@ -1,0 +1,18 @@
+<%= content_for :page_title, @user_form.errors.any? ? t(".page_title_with_error") : t(".page_title") %>
+<%= render "placements/primary_navigation", current_navigation: :users, organisation: @organisation %>
+<% if current_user.organisation_count > 1 %>
+  <%= content_for(:header_content) do %>
+    <%= render(ContentHeaderComponent.new(
+      title: @organisation.name,
+      actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
+    )) %>
+  <% end %>
+<% end %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: placements_school_users_path(@organisation)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= render "placements/organisations/users/new_form", user: @user_form, organisation: @organisation %>
+</div>

--- a/app/views/placements/schools/users/show.html.erb
+++ b/app/views/placements/schools/users/show.html.erb
@@ -1,0 +1,22 @@
+<% if current_user.organisation_count > 1 %>
+  <%= content_for(:header_content) do %>
+    <%= render(ContentHeaderComponent.new(
+      title: @organisation.name,
+      actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
+    )) %>
+  <% end %>
+<% end %>
+<%= render "placements/primary_navigation", organisation: @organisation, current_navigation: :users %>
+<%= content_for :page_title, sanitize(@user.full_name) %>
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: placements_school_users_path(@organisation)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <h1 class="govuk-heading-l"><%= @user.full_name %></h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "placements/organisations/users/details", user: @user %>
+    </div>
+  </div>
+</div>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -5,7 +5,7 @@ en:
         user_invite_form:
           attributes:
             email:
-              taken: This email address is already in use. Try another email address
+              taken: Email address already in use
         organisation_onboarding_form:
           attributes:
             organisation_type:

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -28,5 +28,5 @@ en:
               blank: Enter a last name
             email:
               blank: Enter an email address
-              taken: This email address is already in use. Try another email address
+              taken: Email address already in use
               invalid: Enter an email address in the correct format, like name@example.com

--- a/config/locales/en/placements/organisations/users/check_form.yml
+++ b/config/locales/en/placements/organisations/users/check_form.yml
@@ -1,0 +1,11 @@
+en:
+  placements:
+    organisations:
+      users:
+        check_form:
+          add_user: Add user
+          check_your_answers: Check your answers
+          change: Change
+          continue: Continue
+          cancel: Cancel
+          warning: "The user will be sent an email to tell them you’ve added them to %{organisation_name}."

--- a/config/locales/en/placements/organisations/users/new_form.yml
+++ b/config/locales/en/placements/organisations/users/new_form.yml
@@ -1,0 +1,9 @@
+en:
+  placements:
+    organisations:
+      users:
+        new_form:
+          add_user: Add user
+          personal_details: Personal details
+          continue: Continue
+          cancel: Cancel

--- a/config/locales/en/placements/organisations/users/users_list.yml
+++ b/config/locales/en/placements/organisations/users/users_list.yml
@@ -1,0 +1,6 @@
+en:
+  placements:
+    organisations:
+      users:
+        list:
+          name: Name

--- a/config/locales/en/placements/providers/users.yml
+++ b/config/locales/en/placements/providers/users.yml
@@ -1,0 +1,22 @@
+en:
+  placements:
+    providers:
+      users:
+        index:
+          users: Users
+          add_user: Add user
+          change_organisation: Change organisation
+        new:
+          page_title_with_error: "Error: Personal details - Add user"
+          page_title: Personal details - Add user
+          change_organisation: Change organisation
+          add_user: Add user
+        check:
+          page_title: Check your answers - Add user
+          change_organisation: Change organisation
+          check_your_answers: Check your answers
+          add_user: Add user
+        show:
+          change_organisation: Change organisation
+        create:
+          user_added: User added

--- a/config/locales/en/placements/schools/users.yml
+++ b/config/locales/en/placements/schools/users.yml
@@ -1,0 +1,22 @@
+en:
+  placements:
+    schools:
+      users:
+        index:
+          users: Users
+          add_user: Add user
+          change_organisation: Change organisation
+        new:
+          page_title_with_error: "Error: Personal details - Add user"
+          page_title: Personal details - Add user
+          change_organisation: Change organisation
+          add_user: Add user
+        check:
+          change_organisation: Change organisation
+          page_title: Check your answers - Add user
+          check_your_answers: Check your answers
+          add_user: Add user
+        show:
+          change_organisation: Change organisation
+        create:
+          user_added: User added

--- a/config/locales/en/placements/support/providers/users.yml
+++ b/config/locales/en/placements/support/providers/users.yml
@@ -4,12 +4,6 @@ en:
       providers:
         users:
           index:
-            secondary_navigation:
-              details: Details
-              users: Users
-              mentors: Mentors
-              placements: Placements
-              providers: Providers
             add_user: Add user
             empty_state: There are no users for %{provider_name}.
             heading: Users
@@ -23,3 +17,4 @@ en:
             page_title: "Personal details - Add user - %{provider_name}"
           check:
             page_title: "Check your answers - Add user - %{provider_name}"
+            check_your_answers: Check your answers

--- a/config/locales/en/placements/support/schools/users.yml
+++ b/config/locales/en/placements/support/schools/users.yml
@@ -4,12 +4,6 @@ en:
       schools:
         users:
           index:
-            secondary_navigation:
-              details: Details
-              users: Users
-              mentors: Mentors
-              placements: Placements
-              providers: Providers
             add_user: Add user
             heading: Users
             attributes:
@@ -23,3 +17,5 @@ en:
             page_title: "Personal details - Add user - %{school_name}"
           check:
             page_title: "Check your answers - Add user - %{school_name}"
+            caption: Add user - %{organisation_name}
+            check_your_answers: Check your answers

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -42,6 +42,19 @@ scope module: :placements,
   end
 
   resources :organisations, only: [:index]
-  resources :schools, only: [:show]
-  resources :providers, only: [:show]
+  resources :schools, only: %i[show] do
+    scope module: :schools do
+      resources :users, only: %i[index new create show] do
+        get :check, on: :collection
+      end
+    end
+  end
+
+  resources :providers, only: [:show] do
+    scope module: :providers do
+      resources :users, only: %i[index new create show] do
+        get :check, on: :collection
+      end
+    end
+  end
 end

--- a/spec/forms/user_invite_form_spec.rb
+++ b/spec/forms/user_invite_form_spec.rb
@@ -54,7 +54,7 @@ describe UserInviteForm, type: :model do
           expect(user_invite_form.invite).to eq false
 
           expect(user_invite_form.errors.messages)
-            .to match(email: ["This email address is already in use. Try another email address"])
+            .to match(email: ["Email address already in use"])
         end
       end
     end

--- a/spec/models/placements/user_spec.rb
+++ b/spec/models/placements/user_spec.rb
@@ -50,4 +50,25 @@ RSpec.describe Placements::User do
       expect(described_class.new.service).to eq(:placements)
     end
   end
+
+  describe "#organisation_count" do
+    describe "returns the count of only placements organisations" do
+      it "returns 0 if user has no placement organisations" do
+        user = create(:placements_user)
+        expect(user.organisation_count).to eq 0
+
+        create(:membership, user:, organisation: create(:claims_school))
+        expect(user.organisation_count).to eq 0
+      end
+
+      it "returns combined provider and school count" do
+        user = create(:placements_user)
+        create(:membership, user:, organisation: create(:placements_school))
+        create(:membership, user:, organisation: create(:placements_provider))
+        create(:membership, user:, organisation: create(:placements_provider))
+
+        expect(user.organisation_count).to eq 3
+      end
+    end
+  end
 end

--- a/spec/system/claims/create_claim_spec.rb
+++ b/spec/system/claims/create_claim_spec.rb
@@ -102,10 +102,6 @@ RSpec.describe "Create claim", type: :system, js: true, service: :claims do
     and_i_click_sign_in_as("Anne")
   end
 
-  def and_there_is_an_existing_persona_for(persona_name)
-    create(:persona, persona_name.downcase.to_sym, service: :claims)
-  end
-
   def and_i_visit_the_personas_page
     visit personas_path
   end

--- a/spec/system/claims/invite_a_user_to_a_school_spec.rb
+++ b/spec/system/claims/invite_a_user_to_a_school_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe "Invite a user to a school", type: :system do
   end
 
   def then_see_error_message_for_existing_user
-    expect(page).to have_content("This email address is already in use. Try another email address").twice
+    expect(page).to have_content("Email address already in use").twice
   end
 
   def show_error_messages

--- a/spec/system/claims/support/schools/invite_a_user_to_a_school_spec.rb
+++ b/spec/system/claims/support/schools/invite_a_user_to_a_school_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe "Invite a user to a school", type: :system do
   end
 
   def then_see_error_message_for_existing_user
-    expect(page).to have_content("This email address is already in use. Try another email address").twice
+    expect(page).to have_content("Email address already in use").twice
   end
 
   def show_error_messages

--- a/spec/system/placements/organisations/add_users_spec.rb
+++ b/spec/system/placements/organisations/add_users_spec.rb
@@ -1,0 +1,248 @@
+require "rails_helper"
+
+RSpec.describe "Placements users invite other users to organisations", type: :system, service: :placements do
+  let(:anne) { create(:placements_user, :anne) }
+  let(:one_school) { create(:placements_school, name: "One School") }
+  let(:one_provider) { create(:placements_provider, name: "One Provider") }
+  let(:mary) { create(:placements_user, :mary) }
+  let(:another_school) { create(:placements_school, name: "Another School") }
+  let(:new_user) { create(:placements_user) }
+
+  describe "Ann invites a member successfully " do
+    context "provider" do
+      before "user is sent an invitation" do
+        notify_mailer = double(:notify_mailer)
+        expect(NotifyMailer).to receive(:send_organisation_invite_email).with(kind_of(Placements::User), one_provider, "http://placements.localhost/sign-in") { notify_mailer }
+        expect(notify_mailer).to receive(:deliver_later).and_return true
+      end
+
+      scenario "user invites a member to a provider" do
+        given_i_am_logged_in_as_a_user_with_one_organisation(one_provider)
+        when_i_click_users
+        then_i_see_the_users_page
+        when_i_click_add_user
+        and_i_enter_valid_user_details
+        then_i_can_check_my_answers(one_provider)
+        when_i_click_back
+        then_i_see_prepopulated_form
+        when_i_change_user_details
+        then_i_see_changes_in_check_form
+        when_i_click_add_user
+        then_the_user_is_added
+      end
+    end
+
+    context "school" do
+      before "user is sent an invitation" do
+        notify_mailer = double(:notify_mailer)
+        expect(NotifyMailer).to receive(:send_organisation_invite_email).with(kind_of(Placements::User), one_school, "http://placements.localhost/sign-in") { notify_mailer }
+        expect(notify_mailer).to receive(:deliver_later).and_return true
+      end
+
+      scenario "user invites a member to a school" do
+        given_i_am_logged_in_as_a_user_with_one_organisation(one_school)
+        when_i_click_users
+        then_i_see_the_users_page
+        when_i_click_add_user
+        and_i_enter_valid_user_details
+        then_i_can_check_my_answers(one_school)
+        when_i_click_back
+        then_i_see_prepopulated_form
+        when_i_change_user_details
+        then_i_see_changes_in_check_form
+        when_i_click_add_user
+        then_the_user_is_added
+      end
+    end
+  end
+
+  describe "Mary invites a members to second organisation" do
+    before "user is sent an invitation" do
+      create(:membership, user: mary, organisation: one_school)
+      create(:membership, user: mary, organisation: another_school)
+      create(:membership, user: mary, organisation: one_provider)
+
+      notify_mailer = double(:notify_mailer)
+      expect(NotifyMailer).to receive(:send_organisation_invite_email).with(kind_of(Placements::User), another_school, "http://placements.localhost/sign-in") { notify_mailer }
+      expect(notify_mailer).to receive(:deliver_later).and_return true
+
+      expect(NotifyMailer).to receive(:send_organisation_invite_email).with(kind_of(Placements::User), one_provider, "http://placements.localhost/sign-in") { notify_mailer }
+      expect(notify_mailer).to receive(:deliver_later).and_return true
+    end
+
+    scenario "user adds a user to multiple organisations" do
+      given_i_am_logged_in_as_a_user_with_multiple_organisations
+      and_user_is_already_assigned_to_a_school
+      when_i_navigate_to_that_schools_users
+      then_i_see_the_user_on_that_schools_user_list
+      when_i_change_organisation(another_school)
+      and_i_try_to_add_the_user
+      then_the_user_is_added_successfully
+      when_i_change_organisation(one_provider)
+      and_i_try_to_add_the_user
+      then_the_user_is_added_successfully
+    end
+  end
+
+  scenario "user tries to submit invalid form" do
+    given_i_am_logged_in_as_a_user_with_one_organisation(one_school)
+    when_i_click_users
+    then_i_see_the_users_page
+    when_i_click_add_user
+    and_try_to_submit_invalid_form_data
+    then_i_see_form_errors
+  end
+
+  scenario "user tries to add an existing user to the organisation" do
+    given_i_am_logged_in_as_a_user_with_one_organisation(one_school)
+    and_user_is_already_assigned_to_a_school
+    when_i_try_to_add_the_user_to_the_same_school
+    then_i_see_the_email_taken_error
+  end
+
+  private
+
+  def and_try_to_submit_invalid_form_data
+    fill_in "Email", with: "firsty_lasty"
+    click_on "Continue"
+  end
+
+  def then_i_see_form_errors
+    expect(page.find(".govuk-error-summary")).to have_content "There is a problem"
+    expect(page).to have_content("Enter a first name").twice
+    expect(page).to have_content("Enter a last name").twice
+    expect(page).to have_content("Enter an email address in the correct format, like name@example.com").twice
+  end
+
+  def then_i_see_the_email_taken_error
+    expect(page.find(".govuk-error-summary")).to have_content "There is a problem"
+    expect(page).to have_content("Email address already in use")
+  end
+
+  def given_i_am_logged_in_as_a_user_with_one_organisation(organisation)
+    create(:membership, user: anne, organisation:)
+    visit personas_path
+    click_on "Sign In as Anne"
+  end
+
+  def given_i_am_logged_in_as_a_user_with_multiple_organisations
+    visit personas_path
+    click_on "Sign In as Mary"
+  end
+
+  def and_user_is_already_assigned_to_a_school
+    create(:membership, user: new_user, organisation: one_school)
+  end
+
+  def when_i_try_to_add_the_user_to_the_same_school
+    click_on "Users"
+    click_on "Add user"
+    fill_in "First name", with: new_user.first_name
+    fill_in "Last name", with: new_user.last_name
+    fill_in "Email", with: new_user.email
+    click_on "Continue"
+  end
+
+  def when_i_navigate_to_that_schools_users
+    click_on "One School"
+    click_on "Users"
+  end
+
+  def then_i_see_the_user_on_that_schools_user_list
+    users_is_selected_in_navigation
+    expect(page).to have_content(new_user.full_name)
+    expect(page).to have_content(new_user.email)
+  end
+
+  def when_i_change_organisation(organisation)
+    click_on "Change organisation"
+    click_on organisation.name
+    click_on "Users"
+  end
+
+  def and_i_try_to_add_the_user
+    click_on "Add user"
+    fill_in "First name", with: new_user.first_name
+    fill_in "Last name", with: new_user.last_name
+    fill_in "Email", with: new_user.email
+    click_on "Continue"
+    click_on "Add user"
+  end
+
+  def then_the_user_is_added_successfully
+    users_is_selected_in_navigation
+
+    expect(page.find(".govuk-notification-banner__content")).to have_content("User added")
+    expect(page).to have_content new_user.full_name
+    expect(page).to have_content new_user.email
+  end
+
+  def when_i_click_users
+    click_on "Users"
+  end
+
+  def then_i_see_the_users_page
+    users_is_selected_in_navigation
+
+    expect(page).to have_content "Anne Wilson"
+    expect(page).to have_content "anne_wilson@example.org"
+  end
+
+  def when_i_click_add_user
+    click_on "Add user"
+  end
+
+  def and_i_enter_valid_user_details
+    users_is_selected_in_navigation
+    fill_in "First name", with: "First Namey"
+    fill_in "Last name", with: "Last Namey"
+    fill_in "Email", with: "firsty_lasty@email.co.uk"
+    click_on "Continue"
+  end
+
+  def then_i_can_check_my_answers(organisation)
+    users_is_selected_in_navigation
+    expect(page).to have_content "First Namey"
+    expect(page).to have_content "Last Namey"
+    expect(page).to have_content "firsty_lasty@email.co.uk"
+    expect(page).to have_content "The user will be sent an email to tell them you’ve added them to #{organisation.name}."
+  end
+
+  def when_i_click_back
+    click_on "Back"
+  end
+
+  def then_i_see_prepopulated_form
+    users_is_selected_in_navigation
+    expect(page).to have_field("First name", with: "First Namey")
+    expect(page).to have_field("Last name", with: "Last Namey")
+    expect(page).to have_field("Email", with: "firsty_lasty@email.co.uk")
+  end
+
+  def when_i_change_user_details
+    fill_in "First name", with: "New First Name"
+    click_on "Continue"
+  end
+
+  def then_i_see_changes_in_check_form
+    expect(page).to have_content "New First Name"
+    expect(page).to have_content "Last Namey"
+    expect(page).to have_content "firsty_lasty@email.co.uk"
+  end
+
+  def then_the_user_is_added
+    users_is_selected_in_navigation
+    expect(page.find(".govuk-notification-banner__content")).to have_content("User added")
+    expect(page).to have_content "New First Name Last Namey"
+    expect(page).to have_content "firsty_lasty@email.co.uk"
+  end
+
+  def users_is_selected_in_navigation
+    within(".app-primary-navigation__nav") do
+      expect(page).to have_link "Placements", current: "false"
+      expect(page).to have_link "Mentors", current: "false"
+      expect(page).to have_link "Users", current: "page"
+      expect(page).to have_link "Organisation details", current: "false"
+    end
+  end
+end

--- a/spec/system/placements/organisations/users/user_views_other_users_spec.rb
+++ b/spec/system/placements/organisations/users/user_views_other_users_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.describe "Placements user views other users in their organisation", type: :system, service: :placements do
+  let(:school) { create(:placements_school, name: "Placements School 1") }
+  let(:provider) { create(:placements_provider, name: "Placements Provider 1") }
+  let(:anne) { create(:placements_user, :anne) }
+  let(:mary) { create(:placements_user, :mary) }
+
+  describe "schools" do
+    scenario "user can view other school users" do
+      given_users_have_been_assigned_to_the(organisation: school)
+      when_i_visit_the_users_page
+      then_i_see_the_organisation_users
+      when_i_click_on_a_users_name(mary.full_name)
+      then_i_see_user_details(user: mary)
+    end
+  end
+
+  describe "providers" do
+    scenario "users can view other provider users" do
+      given_users_have_been_assigned_to_the(organisation: provider)
+      when_i_visit_the_users_page
+      then_i_see_the_organisation_users
+      when_i_click_on_a_users_name(anne.full_name)
+      then_i_see_user_details(user: anne)
+    end
+  end
+
+  private
+
+  def given_users_have_been_assigned_to_the(organisation:)
+    [mary, anne].each do |user|
+      create(:membership, user:, organisation:)
+    end
+  end
+
+  def when_i_visit_the_users_page
+    visit personas_path
+    click_on "Sign In as Anne"
+    within(".app-primary-navigation__nav") do
+      click_on "Users"
+    end
+  end
+
+  def then_i_see_the_organisation_users
+    users_is_selected_in_navigation
+    expect(page).to have_content anne.full_name
+    expect(page).to have_content anne.email
+
+    expect(page).to have_content mary.full_name
+    expect(page).to have_content mary.email
+  end
+
+  def when_i_click_on_a_users_name(user_name)
+    click_on user_name
+  end
+
+  def then_i_see_user_details(user:)
+    users_is_selected_in_navigation
+    expect(page).to have_content "First name"
+    expect(page).to have_content user.first_name
+
+    expect(page).to have_content "Last name"
+    expect(page).to have_content user.last_name
+
+    expect(page).to have_content "Email address"
+    expect(page).to have_content user.email
+  end
+
+  def users_is_selected_in_navigation
+    within(".app-primary-navigation__nav") do
+      expect(page).to have_link "Placements", current: "false"
+      expect(page).to have_link "Mentors", current: "false"
+      expect(page).to have_link "Users", current: "page"
+      expect(page).to have_link "Organisation details", current: "false"
+    end
+  end
+end

--- a/spec/system/placements/support/users/support_user_invites_a_new_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_invites_a_new_user_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
       and_i_click("Add user")
       and_i_enter_the_details_for_a_new_user
       and_i_click("Continue")
-      then_i_see_an_error("This email address is already in use. Try another email address")
+      then_i_see_an_error("Email address already in use")
     end
 
     scenario "Support User doesn't enter any user details" do


### PR DESCRIPTION
## Context

As a placements user, I should be able to add other users to my organisation(s).

## Changes proposed in this pull request

- Controllers and views for non-support users to add other users.

## Guidance to review

Login as any non-support placement user
Select an organisation (or not if user is only a member of one)
Add user
You should be able to add the same user to another organisation

## Link to Trello card

https://trello.com/c/JTRen6nD

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/8ede3d6a-a0fe-4215-b0b5-33966713f7c3


