### PR TITLE
add-missing-school-user-navigation

### DIFF
--- a/app/views/placements/support/schools/users/show.html.erb
+++ b/app/views/placements/support/schools/users/show.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :page_title, sanitize("#{@user.full_name} - #{@school.name}") %>
-
+<%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: placements_support_school_users_path(@school)) %>
 <% end %>


### PR DESCRIPTION
## Context

A primary navigation was missing from the support user view of a school user

## Changes proposed in this pull request

adds primary navigation to support user view of a school user 

## Guidance to review

Sign in a placements support user. Navigate to a school that has users. Click on a user's name. The primary navigation should be there with "Organisations" shown as active.

## Link to Trello card

https://trello.com/c/bEiwUqo0

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

Before:
<img width="1133" alt="image" src="https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/23f3d418-a1d7-43fd-a43d-ce1d7a58d6fd">

After: 
<img width="1046" alt="image" src="https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/8cff0dad-903d-40bc-8b24-0941dbfcf4b6">

