### PR TITLE
Gitignore all .env.*.local files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .env
 .env.local
+.env.*.local
 .envrc
 .idea
 .vscode


### PR DESCRIPTION
## Context

We want to add `.env.*.local` files for local configuration. This allows us to distinctly setup our development and test environments without a shared `.env.local`.

## Changes proposed in this pull request

Add `.env.*.local`

## Guidance to review

Replacing `.env` or `.env.local` with `.env.development.local` should work locally.
