### PR TITLE
Add DFE sign in integration for login 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,16 @@ POSTGRES_PASSWORD=password
 DATABASE_URL=postgres://postgres:$POSTGRES_PASSWORD@localhost:5432
 GOVUK_NOTIFY_API_KEY=
 SIGN_IN_METHOD=persona
-PLACEMENTS_HOST=placements.localhost
+DFE_SIGN_IN_ISSUER_URL=https://dev-oidc.signin.education.gov.uk
+
 CLAIMS_HOST=claims.localhost
+CLAIMS_DFE_SIGN_IN_CLIENT_ID=ittMentorTrackPay
+CLAIMS_DFE_SIGN_IN_SECRET=
+
+PLACEMENTS_HOST=placements.localhost
+PLACEMENTS_DFE_SIGN_IN_CLIENT_ID=
+PLACEMENTS_DFE_SIGN_IN_SECRET=
+
 GIAS_CSV_BASE_URL=https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public
 PUBLISH_BASE_URL=https://www.publish-teacher-training-courses.service.gov.uk
 RAILS_LOG_TO_STDOUT=true

--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,12 @@
 HOSTING_ENV=test
-PLACEMENTS_HOST=placements.localhost
-CLAIMS_HOST=claims.localhost
-SIGN_IN_METHOD=persona
 PUBLISH_BASE_URL=https://www.publish-teacher-training-courses.service.gov.uk
 GOVUK_NOTIFY_API_KEY=
+SIGN_IN_METHOD=persona
+
+CLAIMS_HOST=claims.localhost
+CLAIMS_DFE_SIGN_IN_CLIENT_ID=123
+CLAIMS_DFE_SIGN_IN_SECRET=secret
+
+PLACEMENTS_HOST=placements.localhost
+PLACEMENTS_DFE_SIGN_IN_CLIENT_ID=123
+PLACEMENTS_DFE_SIGN_IN_SECRET=secret

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ gem "propshaft"
 # Use postgresql as the database for Active Record
 gem "pg", "~> 1.1"
 
+gem "awesome_print"
+
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", "~> 6.4"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,7 @@ GEM
       rake (>= 10.4, < 14.0)
     ast (2.4.2)
     attr_required (1.0.1)
+    awesome_print (1.9.2)
     backport (1.2.0)
     base64 (0.2.0)
     benchmark (0.3.0)
@@ -546,6 +547,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate
+  awesome_print
   better_html
   bootsnap
   brakeman

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,22 +2,19 @@ class SessionsController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[new callback]
   before_action :redirect_to_after_sign_in_path, only: %i[new], if: :user_signed_in?
 
-  # setup inspired by register-trainee-teacher
-  # TODO: Replace with commented code when DfE Sign In implemented
-
   def new; end
 
   def callback
     DfESignInUser.begin_session!(session, request.env["omniauth.auth"])
 
     if current_user
-      # DfESignInUsers::Update.call(user: current_user, sign_in_user: sign_in_user)
+      DfESignIn::UserUpdate.call(current_user:, sign_in_user:)
 
       redirect_to after_sign_in_path
     else
-      # session.delete(:requested_path)
       DfESignInUser.end_session!(session)
-      # redirect_to(sign_in_user_not_found_path)
+      flash[:alert] = I18n.t(".you_do_not_have_access_to_this_service")
+      redirect_to after_sign_out_path
     end
   end
 

--- a/app/helpers/routes_helper.rb
+++ b/app/helpers/routes_helper.rb
@@ -112,4 +112,8 @@ module RoutesHelper
       new_placements_provider_user_path(organisation, params)
     end
   end
+
+  def omniauth_sign_in_path(provider)
+    "/auth/#{provider}"
+  end
 end

--- a/app/models/claims/support_user.rb
+++ b/app/models/claims/support_user.rb
@@ -2,13 +2,15 @@
 #
 # Table name: users
 #
-#  id         :uuid             not null, primary key
-#  email      :string           not null
-#  first_name :string           not null
-#  last_name  :string           not null
-#  type       :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id                :uuid             not null, primary key
+#  dfe_sign_in_uid   :string
+#  email             :string           not null
+#  first_name        :string           not null
+#  last_name         :string           not null
+#  last_signed_in_at :datetime
+#  type              :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
 #
 # Indexes
 #

--- a/app/models/claims/user.rb
+++ b/app/models/claims/user.rb
@@ -2,13 +2,15 @@
 #
 # Table name: users
 #
-#  id         :uuid             not null, primary key
-#  email      :string           not null
-#  first_name :string           not null
-#  last_name  :string           not null
-#  type       :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id                :uuid             not null, primary key
+#  dfe_sign_in_uid   :string
+#  email             :string           not null
+#  first_name        :string           not null
+#  last_name         :string           not null
+#  last_signed_in_at :datetime
+#  type              :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
 #
 # Indexes
 #

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -1,30 +1,26 @@
 class DfESignInUser
-  attr_reader :email, :dfe_sign_in_uid
+  attr_reader :email, :dfe_sign_in_uid, :id_token, :provider
   attr_accessor :first_name, :last_name, :service
 
-  # setup inspired by register-trainee-teacher
-  # TODO: Replace with commented code when DfE Sign In implemented
-
-  # def initialize(email:, dfe_sign_in_uid:, first_name:, last_name:, id_token: nil, provider: "dfe", service:)
-  def initialize(email:, first_name:, last_name:, service:)
+  def initialize(email:, dfe_sign_in_uid:, first_name:, last_name:, service:, id_token: nil, provider: nil)
     @email = email&.downcase
-    # @dfe_sign_in_uid = dfe_sign_in_uid
+    @dfe_sign_in_uid = dfe_sign_in_uid
     @first_name = first_name
     @last_name = last_name
-    # @id_token = id_token
-    # @provider = provider&.to_s
+    @id_token = id_token
+    @provider = provider&.to_s
     @service = service
   end
 
   def self.begin_session!(session, omniauth_payload)
     session["dfe_sign_in_user"] = {
       "email" => omniauth_payload["info"]["email"],
-      # "dfe_sign_in_uid" => omniauth_payload["uid"],
+      "dfe_sign_in_uid" => omniauth_payload["uid"],
       "first_name" => omniauth_payload["info"]["first_name"],
       "last_name" => omniauth_payload["info"]["last_name"],
-      # "last_active_at" => Time.zone.now,
-      # "id_token" => omniauth_payload["credentials"]["id_token"],
-      # "provider" => omniauth_payload["provider"],
+      "last_active_at" => Time.current,
+      "id_token" => omniauth_payload["credentials"]["id_token"],
+      "provider" => omniauth_payload["provider"],
     }
   end
 
@@ -32,20 +28,27 @@ class DfESignInUser
     dfe_sign_in_session = session["dfe_sign_in_user"]
     return unless dfe_sign_in_session
 
+    # Users who signed in before session expiry was implemented will not have
+    # `last_active_at` set. In that case, force them to sign in again.
+    return unless dfe_sign_in_session["last_active_at"]
+
+    return if dfe_sign_in_session.fetch("last_active_at") < 2.hours.ago
+
+    dfe_sign_in_session["last_active_at"] = Time.current
+
     new(
       email: dfe_sign_in_session["email"],
-      # dfe_sign_in_uid: dfe_sign_in_session["dfe_sign_in_uid"],
+      dfe_sign_in_uid: dfe_sign_in_session["dfe_sign_in_uid"],
       first_name: dfe_sign_in_session["first_name"],
       last_name: dfe_sign_in_session["last_name"],
-      # id_token: dfe_sign_in_session["id_token"],
-      # provider: dfe_sign_in_session["provider"],
+      id_token: dfe_sign_in_session["id_token"],
+      provider: dfe_sign_in_session["provider"],
       service: session["service"],
     )
   end
 
   def user
-    # TODO: When dfe sign-in is fully implemented, we will be able to find the user by the id == id_token.
-    @user ||= user_for_service
+    @user ||= user_by_uid || user_by_email
   end
 
   def self.end_session!(session)
@@ -54,12 +57,35 @@ class DfESignInUser
 
   private
 
-  def user_for_service
+  def user_by_uid
+    return if dfe_sign_in_uid.blank?
+
+    support_user_klass.find_by(dfe_sign_in_uid:) ||
+      user_klass.find_by(dfe_sign_in_uid:)
+  end
+
+  def user_by_email
+    return if email.blank?
+
+    support_user_klass.find_by(email:) ||
+      user_klass.find_by(email:)
+  end
+
+  def support_user_klass
     case service
-    when :claims
-      Claims::SupportUser.find_by(email:) || Claims::User.find_by(email:)
     when :placements
-      Placements::SupportUser.find_by(email:) || Placements::User.find_by(email:)
+      Placements::SupportUser
+    when :claims
+      Claims::SupportUser
+    end
+  end
+
+  def user_klass
+    case service
+    when :placements
+      Placements::User
+    when :claims
+      Claims::User
     end
   end
 end

--- a/app/models/placements/support_user.rb
+++ b/app/models/placements/support_user.rb
@@ -2,13 +2,15 @@
 #
 # Table name: users
 #
-#  id         :uuid             not null, primary key
-#  email      :string           not null
-#  first_name :string           not null
-#  last_name  :string           not null
-#  type       :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id                :uuid             not null, primary key
+#  dfe_sign_in_uid   :string
+#  email             :string           not null
+#  first_name        :string           not null
+#  last_name         :string           not null
+#  last_signed_in_at :datetime
+#  type              :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
 #
 # Indexes
 #

--- a/app/models/placements/user.rb
+++ b/app/models/placements/user.rb
@@ -2,13 +2,15 @@
 #
 # Table name: users
 #
-#  id         :uuid             not null, primary key
-#  email      :string           not null
-#  first_name :string           not null
-#  last_name  :string           not null
-#  type       :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id                :uuid             not null, primary key
+#  dfe_sign_in_uid   :string
+#  email             :string           not null
+#  first_name        :string           not null
+#  last_name         :string           not null
+#  last_signed_in_at :datetime
+#  type              :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
 #
 # Indexes
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,13 +2,15 @@
 #
 # Table name: users
 #
-#  id         :uuid             not null, primary key
-#  email      :string           not null
-#  first_name :string           not null
-#  last_name  :string           not null
-#  type       :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id                :uuid             not null, primary key
+#  dfe_sign_in_uid   :string
+#  email             :string           not null
+#  first_name        :string           not null
+#  last_name         :string           not null
+#  last_signed_in_at :datetime
+#  type              :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
 #
 # Indexes
 #

--- a/app/services/dfe_sign_in/user_update.rb
+++ b/app/services/dfe_sign_in/user_update.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DfESignIn
+  class UserUpdate
+    include ServicePattern
+
+    attr_reader :current_user, :successful
+    alias_method :successful?, :successful
+
+    def initialize(current_user:, sign_in_user:)
+      @current_user = current_user
+
+      attributes = {
+        last_signed_in_at: Time.current,
+        email: sign_in_user.email,
+        dfe_sign_in_uid: sign_in_user.dfe_sign_in_uid,
+      }
+
+      attributes[:first_name] = sign_in_user.first_name if sign_in_user.first_name.present?
+      attributes[:last_name] = sign_in_user.last_name if sign_in_user.last_name.present?
+
+      current_user.assign_attributes(attributes)
+    end
+
+    def call
+      @successful = current_user.valid? && current_user.save!
+
+      self
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,7 +60,7 @@
       <div class="govuk-width-container">
         <% flash.each do |key, message| %>
           <div class="govuk-!-margin-top-6 govuk-!-margin-bottom-0">
-            <%= render(GovukComponent::NotificationBannerComponent.new(title_text: t(".success"), success: true)) do %>
+            <%= render(GovukComponent::NotificationBannerComponent.new(title_text: t(".#{key}"), success: key == "success")) do %>
               <h3 class="govuk-heading-m"><%= message %></h3>
             <% end %>
           </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -8,7 +8,7 @@
       <% if ENV["SIGN_IN_METHOD"] == "persona" %>
         <%= govuk_button_to t(".sign_in_with_persona"), personas_path, method: :get %>
       <% else %>
-        <%= govuk_button_to t(".sign_in_with_dsi"), "#" %>
+        <%= govuk_button_to t(".sign_in_with_dsi"), omniauth_sign_in_path("dfe") %>
       <% end %>
 
       <p class="govuk-body">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,7 @@ en:
   no_results_with_filter_and_search: There are no results for '%{for}' and the selected filter.
   no_results_with_filter: There are no results for the selected filter.
   you_cannot_perform_this_action: You cannot perform this action
+  you_do_not_have_access_to_this_service: You do not have access to this service
   date:
     formats:
       long: "%e %B %Y"

--- a/config/locales/en/layouts/application.yml
+++ b/config/locales/en/layouts/application.yml
@@ -2,6 +2,7 @@ en:
   layouts:
     application:
       success: Success
+      alert: Important
       your_account: Your account
       sign_out: Sign out
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,9 @@ Rails.application.routes.draw do
     get "/personas", to: "personas#index"
     get "/auth/developer/sign-out", to: "sessions#destroy", as: :sign_out
     post "/auth/developer/callback", to: "sessions#callback", as: :auth_callback
+  else
+    get("/auth/dfe/callback" => "sessions#callback")
+    get("/auth/dfe/sign-out" => "sessions#destroy", as: :sign_out)
   end
 
   resources :service_updates, only: %i[index]

--- a/db/migrate/20240129164009_add_dfe_sign_in_columns.rb
+++ b/db/migrate/20240129164009_add_dfe_sign_in_columns.rb
@@ -1,0 +1,8 @@
+class AddDfESignInColumns < ActiveRecord::Migration[7.1]
+  def change
+    change_table(:users, bulk: true) do |t|
+      t.column :dfe_sign_in_uid, :string
+      t.column :last_signed_in_at, :datetime
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -154,6 +154,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_01_101735) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "type"
+    t.string "dfe_sign_in_uid"
+    t.datetime "last_signed_in_at"
     t.index ["type", "email"], name: "index_users_on_type_and_email", unique: true
   end
 

--- a/lib/hosting_environment.rb
+++ b/lib/hosting_environment.rb
@@ -4,6 +4,21 @@ module HostingEnvironment
     placements: "beta",
   }.with_indifferent_access.freeze
 
+  DFE_SIGN_IN_CLIENT_IDS = {
+    claims: ENV["CLAIMS_DFE_SIGN_IN_CLIENT_ID"],
+    placements: ENV["PLACEMENTS_DFE_SIGN_IN_CLIENT_ID"],
+  }.with_indifferent_access.freeze
+
+  DFE_SIGN_IN_CLIENT_SECRETS = {
+    claims: ENV["CLAIMS_DFE_SIGN_IN_SECRET"],
+    placements: ENV["PLACEMENTS_DFE_SIGN_IN_SECRET"],
+  }.with_indifferent_access.freeze
+
+  SERVICE_HOST = {
+    claims: ENV["CLAIMS_HOST"],
+    placements: ENV["PLACEMENTS_HOST"],
+  }.with_indifferent_access.freeze
+
   def self.env
     @env ||= ActiveSupport::EnvironmentInquirer.new(ENV["HOSTING_ENV"].presence || "development")
   end
@@ -14,5 +29,30 @@ module HostingEnvironment
                else
                  env
                end
+  end
+
+  def self.dfe_sign_in_client_id(current_service)
+    DFE_SIGN_IN_CLIENT_IDS.fetch(current_service)
+  end
+
+  def self.dfe_sign_in_secret(current_service)
+    DFE_SIGN_IN_CLIENT_SECRETS.fetch(current_service)
+  end
+
+  def self.application_url(current_service)
+    if Rails.env.development?
+      "http://#{SERVICE_HOST.fetch(current_service)}:#{ENV.fetch("PORT", 3000)}"
+    else
+      "https://#{SERVICE_HOST.fetch(current_service)}"
+    end
+  end
+
+  def self.current_service(request)
+    case request.host
+    when ENV["CLAIMS_HOST"]
+      :claims
+    when ENV["PLACEMENTS_HOST"]
+      :placements
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,13 +2,15 @@
 #
 # Table name: users
 #
-#  id         :uuid             not null, primary key
-#  email      :string           not null
-#  first_name :string           not null
-#  last_name  :string           not null
-#  type       :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id                :uuid             not null, primary key
+#  dfe_sign_in_uid   :string
+#  email             :string           not null
+#  first_name        :string           not null
+#  last_name         :string           not null
+#  last_signed_in_at :datetime
+#  type              :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
 #
 # Indexes
 #
@@ -19,6 +21,7 @@ FactoryBot.define do
     sequence(:email) { |n| "user#{n}@example.com" }
     first_name { "User" }
     sequence(:last_name)
+    sequence(:dfe_sign_in_uid) { _1 }
 
     trait :anne do
       first_name { "Anne" }

--- a/spec/lib/hosting_environment_spec.rb
+++ b/spec/lib/hosting_environment_spec.rb
@@ -63,4 +63,76 @@ RSpec.describe HostingEnvironment do
       end
     end
   end
+
+  describe ".dfe_sign_in_client_id" do
+    it "returns the dfe sign in client id for claims" do
+      current_service = "claims"
+      expect(described_class.dfe_sign_in_client_id(current_service)).to eq("123")
+    end
+
+    it "returns the dfe sign in client id for placements" do
+      current_service = "placements"
+      expect(described_class.dfe_sign_in_client_id(current_service)).to eq("123")
+    end
+  end
+
+  describe ".dfe_sign_in_secret" do
+    it "returns the dfe sign in secret for claims" do
+      current_service = "claims"
+      expect(described_class.dfe_sign_in_secret(current_service)).to eq("secret")
+    end
+
+    it "returns the dfe sign in secret for placements" do
+      current_service = "placements"
+      expect(described_class.dfe_sign_in_secret(current_service)).to eq("secret")
+    end
+  end
+
+  describe ".application_url" do
+    it "returns the application url for claims" do
+      current_service = "claims"
+      expect(described_class.application_url(current_service)).to eq(
+        "https://claims.localhost",
+      )
+    end
+
+    it "returns the application url for placements" do
+      current_service = "placements"
+      expect(described_class.application_url(current_service)).to eq(
+        "https://placements.localhost",
+      )
+    end
+
+    context "when env is development" do
+      it "returns the application url for claims with port" do
+        allow(Rails.env).to receive(:development?).and_return(true)
+        current_service = "claims"
+
+        expect(described_class.application_url(current_service)).to eq(
+          "http://claims.localhost:3000",
+        )
+      end
+
+      it "returns the application url for placements with port" do
+        allow(Rails.env).to receive(:development?).and_return(true)
+        current_service = "placements"
+
+        expect(described_class.application_url(current_service)).to eq(
+          "http://placements.localhost:3000",
+        )
+      end
+    end
+  end
+
+  describe ".current_service" do
+    it "returns the current service for claims" do
+      request = double(host: ENV["CLAIMS_HOST"])
+      expect(described_class.current_service(request)).to eq(:claims)
+    end
+
+    it "returns the current service for placements" do
+      request = double(host: ENV["PLACEMENTS_HOST"])
+      expect(described_class.current_service(request)).to eq(:placements)
+    end
+  end
 end

--- a/spec/models/claims/support_user_spec.rb
+++ b/spec/models/claims/support_user_spec.rb
@@ -2,13 +2,15 @@
 #
 # Table name: users
 #
-#  id         :uuid             not null, primary key
-#  email      :string           not null
-#  first_name :string           not null
-#  last_name  :string           not null
-#  type       :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id                :uuid             not null, primary key
+#  dfe_sign_in_uid   :string
+#  email             :string           not null
+#  first_name        :string           not null
+#  last_name         :string           not null
+#  last_signed_in_at :datetime
+#  type              :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
 #
 # Indexes
 #

--- a/spec/models/claims/user_spec.rb
+++ b/spec/models/claims/user_spec.rb
@@ -2,13 +2,15 @@
 #
 # Table name: users
 #
-#  id         :uuid             not null, primary key
-#  email      :string           not null
-#  first_name :string           not null
-#  last_name  :string           not null
-#  type       :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id                :uuid             not null, primary key
+#  dfe_sign_in_uid   :string
+#  email             :string           not null
+#  first_name        :string           not null
+#  last_name         :string           not null
+#  last_signed_in_at :datetime
+#  type              :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
 #
 # Indexes
 #

--- a/spec/models/placements/support_user_spec.rb
+++ b/spec/models/placements/support_user_spec.rb
@@ -2,13 +2,15 @@
 #
 # Table name: users
 #
-#  id         :uuid             not null, primary key
-#  email      :string           not null
-#  first_name :string           not null
-#  last_name  :string           not null
-#  type       :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id                :uuid             not null, primary key
+#  dfe_sign_in_uid   :string
+#  email             :string           not null
+#  first_name        :string           not null
+#  last_name         :string           not null
+#  last_signed_in_at :datetime
+#  type              :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
 #
 # Indexes
 #

--- a/spec/models/placements/user_spec.rb
+++ b/spec/models/placements/user_spec.rb
@@ -2,13 +2,15 @@
 #
 # Table name: users
 #
-#  id         :uuid             not null, primary key
-#  email      :string           not null
-#  first_name :string           not null
-#  last_name  :string           not null
-#  type       :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id                :uuid             not null, primary key
+#  dfe_sign_in_uid   :string
+#  email             :string           not null
+#  first_name        :string           not null
+#  last_name         :string           not null
+#  last_signed_in_at :datetime
+#  type              :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
 #
 # Indexes
 #

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,13 +2,15 @@
 #
 # Table name: users
 #
-#  id         :uuid             not null, primary key
-#  email      :string           not null
-#  first_name :string           not null
-#  last_name  :string           not null
-#  type       :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id                :uuid             not null, primary key
+#  dfe_sign_in_uid   :string
+#  email             :string           not null
+#  first_name        :string           not null
+#  last_name         :string           not null
+#  last_signed_in_at :datetime
+#  type              :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
 #
 # Indexes
 #

--- a/spec/services/dfe_sign_in/user_update_spec.rb
+++ b/spec/services/dfe_sign_in/user_update_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe DfESignIn::UserUpdate do
+  let(:current_user) { create(:claims_user) }
+  let(:sign_in_user) do
+    instance_double(
+      DfESignInUser,
+      email: "test@gmail.com",
+      first_name: "John",
+      last_name: "Doe",
+      dfe_sign_in_uid: 123,
+    )
+  end
+
+  subject { described_class.call(current_user:, sign_in_user:) }
+
+  it "updates the user's sign in attributes" do
+    expect { subject }.to change(current_user, :email).to("test@gmail.com")
+      .and change(current_user, :first_name).to("John")
+      .and change(current_user, :last_name).to("Doe")
+      .and change(current_user, :dfe_sign_in_uid).to("123")
+    expect(current_user.last_signed_in_at).to_not be_nil
+  end
+end


### PR DESCRIPTION
## Context

We need to allow our users to login into our service using DFE sign in.

This PR adds the configuration to accommodate this, we find the user by the `dfe_sign_in_uid` or `email`. This should work for placements and claims through env variables. And for different env, production, staging, local etc.

We need to create users with dfe sign in emails so that they can login in our app using dfe sign in. This can be done by a support persona now.

There is no system test for the dfe sign in path, this is because we need to refactor most of our tests as they use persona sign in, they cannot work together because the omniauth config loads only once

Dfe sign-in works with localhost even if their documentation says it doesn't 😄. There is a bit of service configuration that needs to happen in here https://dev-manage.signin.education.gov.uk, mainly the url of the app, the redirect path and the log out path

## Changes proposed in this pull request

- Added [awesome_print](https://github.com/awesome-print/awesome_print) Helps me a lot when debugging
- Migrations to user table, `dfe sign in uid and last_signed_at`
- omniauth.rb
- Sessions controller
- DFE sign in user file
- Update user after sign in service
- Updated the Notice banner to allow other messages beside success ones

## Guidance to review

- Have a dfe sign in account
- Login as a support user using persona sign in, `SIGN_IN_METHOD=persona`
- Create a new user in an organisation with your dfe sign in email, `@education.gov.uk`
- Restart the app with `SIGN_IN_METHOD=dfe-sign-in`
- Login with the new user created in our app
- You should be successfully logged in


## Screenshots




https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/1f1751f6-0c7d-4192-84ad-0161e28fc7a9




