### PR TITLE
Resolve issue with autocomplete pre-filling back link

### DIFF
--- a/app/controllers/claims/support/schools_controller.rb
+++ b/app/controllers/claims/support/schools_controller.rb
@@ -11,7 +11,11 @@ class Claims::Support::SchoolsController < Claims::Support::ApplicationControlle
   end
 
   def new
-    @school_form = SchoolOnboardingForm.new
+    @school_form = if params[:school].present?
+                     school_form
+                   else
+                     SchoolOnboardingForm.new
+                   end
   end
 
   def school_options

--- a/app/controllers/placements/support/providers_controller.rb
+++ b/app/controllers/placements/support/providers_controller.rb
@@ -2,7 +2,11 @@ class Placements::Support::ProvidersController < Placements::Support::Applicatio
   before_action :redirect_to_provider_options, only: :check, if: -> { javascript_disabled? }
 
   def new
-    @provider_form = ProviderOnboardingForm.new
+    @provider_form = if params[:provider].present?
+                       provider_form
+                     else
+                       ProviderOnboardingForm.new
+                     end
   end
 
   def show

--- a/app/controllers/placements/support/schools_controller.rb
+++ b/app/controllers/placements/support/schools_controller.rb
@@ -2,7 +2,11 @@ class Placements::Support::SchoolsController < Placements::Support::ApplicationC
   before_action :redirect_to_school_options, only: :check, if: -> { javascript_disabled? }
 
   def new
-    @school_form = SchoolOnboardingForm.new
+    @school_form = if params[:school].present?
+                     school_form
+                   else
+                     SchoolOnboardingForm.new
+                   end
   end
 
   def school_options

--- a/app/forms/provider_onboarding_form.rb
+++ b/app/forms/provider_onboarding_form.rb
@@ -2,6 +2,7 @@ class ProviderOnboardingForm < ApplicationForm
   attr_accessor :id, :javascript_disabled
 
   validate :id_presence
+  validate :provider_exists?
   validate :provider_already_onboarded?
 
   def onboard
@@ -11,13 +12,18 @@ class ProviderOnboardingForm < ApplicationForm
   end
 
   def provider
-    @provider ||= Provider.find(id)
-  rescue ActiveRecord::RecordNotFound
-    errors.add(:id, :blank)
-    nil
+    @provider ||= Provider.find_by(id:)
+  end
+
+  def as_form_params
+    { "provider" => { id:, javascript_disabled: } }
   end
 
   private
+
+  def provider_exists?
+    errors.add(:id, :blank) if provider.blank?
+  end
 
   def provider_already_onboarded?
     if provider&.placements_service?

--- a/app/forms/school_onboarding_form.rb
+++ b/app/forms/school_onboarding_form.rb
@@ -3,6 +3,7 @@ class SchoolOnboardingForm < ApplicationForm
 
   validate :id_presence
   validates :service, presence: true, inclusion: { in: %i[placements claims] }
+  validate :school_exists?
   validate :school_already_onboarded?
 
   def onboard
@@ -12,13 +13,18 @@ class SchoolOnboardingForm < ApplicationForm
   end
 
   def school
-    @school ||= School.find(id)
-  rescue ActiveRecord::RecordNotFound
-    errors.add(:id, :blank)
-    nil
+    @school ||= School.find_by(id:)
+  end
+
+  def as_form_params
+    { "school" => { id:, service:, javascript_disabled: } }
   end
 
   private
+
+  def school_exists?
+    errors.add(:id, :blank) if school.blank?
+  end
 
   def school_already_onboarded?
     if school&.try("#{service}_service?")

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -19,6 +19,7 @@ export default class extends Controller {
      id: this.serverInputTarget.id,
      showNoOptionsFound: true,
      name: this.inputTarget.dataset.inputName,
+     defaultValue: this.serverInputTarget.value,
      minLength,
      source: debounce(request(this.pathValue), 900),
      templates: {
@@ -33,16 +34,33 @@ export default class extends Controller {
     // Hijack the original input to submit the selected value.
     this.serverInputTarget.id = `old-${this.serverInputTarget.id}`;
     this.serverInputTarget.type = "hidden";
+    this.serverInputTarget.value = this.serverInputTarget.dataset.previousSearch || '';
+  }
+
+  clearUndefinedSuggestions() {
+    const autocompleteElement = this.element.getElementsByClassName("autocomplete__wrapper")[0];
+    if (autocompleteElement) {
+      const autocompleteOptions = autocompleteElement.getElementsByClassName("autocomplete__option");
+      for (const option of autocompleteOptions) {
+        if ( option.innerHTML === ""){
+          option.remove();
+        }
+      }
+    }
   }
 
   private
 
   inputValueTemplate(result) {
-    if (result) return result.name;
+    if (result && typeof result === "object") {
+      return result.name;
+    } else {
+      return ""
+    }
   }
 
   resultTemplate(result) {
-    if (result) {
+    if (result && typeof result === "object") {
       var returnString = `${result.name}`
       var attributesString = ''
       this.returnAttributesValue.forEach(function(attribute) {
@@ -50,6 +68,8 @@ export default class extends Controller {
       });
 
       return returnString.concat(` (${attributesString.trim()})`)
+    } else {
+      return ""
     }
   }
 

--- a/app/views/claims/support/schools/check.html.erb
+++ b/app/views/claims/support/schools/check.html.erb
@@ -1,5 +1,7 @@
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: new_claims_support_school_path) %>
+  <%= govuk_back_link(href: new_claims_support_school_path(
+    @school_form.as_form_params,
+  )) %>
 <% end %>
 
 <div class="govuk-width-container">

--- a/app/views/claims/support/schools/new.html.erb
+++ b/app/views/claims/support/schools/new.html.erb
@@ -23,12 +23,15 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <%= content_tag(:div, class: class_names("govuk-form-group", "govuk-form-group--error": f.object.errors.present?)) do %>
-          <%= f.govuk_text_field :id, value: nil,
+          <%= f.govuk_text_field :id, value: @school_form&.school&.name,
                                       label: { text: t(".title"), size: "l" },
                                       caption: { text: t(".caption"), size: "l" },
-                                      data: { autocomplete_target: "serverInput" } %>
+                                      data: { autocomplete_target: "serverInput",
+                                              previous_search: @school_form&.school&.id } %>
 
-          <div class="govuk-!-margin-bottom-7" data-autocomplete-target="input" data-input-name="school[name]"></div>
+          <div class="govuk-!-margin-bottom-7" data-autocomplete-target="input" data-input-name="school[name]"
+            data-action="focusin->autocomplete#clearUndefinedSuggestions click->autocomplete#clearUndefinedSuggestions">
+          </div>
         <% end %>
 
         <%= f.govuk_submit t(".continue") %>

--- a/app/views/placements/support/providers/check.html.erb
+++ b/app/views/placements/support/providers/check.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, t(".title") %>
 <%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: new_placements_support_provider_path) %>
+  <%= govuk_back_link(href: new_placements_support_provider_path(@provider_form.as_form_params)) %>
 <% end %>
 
 <div class="govuk-width-container">

--- a/app/views/placements/support/providers/new.html.erb
+++ b/app/views/placements/support/providers/new.html.erb
@@ -22,12 +22,15 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <%= content_tag(:div, class: class_names("govuk-form-group", "govuk-form-group--error": f.object.errors.present?)) do %>
-          <%= f.govuk_text_field :id, value: nil,
+          <%= f.govuk_text_field :id, value: @provider_form&.provider&.name,
                                       label: { text: t(".title"), size: "l" },
                                       caption: { text: t(".caption"), size: "l" },
-                                      data: { autocomplete_target: "serverInput" } %>
+                                      data: { autocomplete_target: "serverInput",
+                                              previous_search: @provider_form&.provider&.id } %>
 
-          <div class="govuk-!-margin-bottom-7" data-autocomplete-target="input" data-input-name="provider[name]"></div>
+          <div class="govuk-!-margin-bottom-7" data-autocomplete-target="input"
+            data-input-name="provider[name]"
+            data-action="focusin->autocomplete#clearUndefinedSuggestions click->autocomplete#clearUndefinedSuggestions"></div>
         <% end %>
 
         <%= f.govuk_submit t(".continue") %>

--- a/app/views/placements/support/schools/check.html.erb
+++ b/app/views/placements/support/schools/check.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, t(".title") %>
 <%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: new_placements_support_school_path) %>
+  <%= govuk_back_link(href: new_placements_support_school_path(@school_form.as_form_params)) %>
 <% end %>
 
 <div class="govuk-width-container">

--- a/app/views/placements/support/schools/new.html.erb
+++ b/app/views/placements/support/schools/new.html.erb
@@ -22,12 +22,15 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <%= content_tag(:div, class: class_names("govuk-form-group", "govuk-form-group--error": f.object.errors.present?)) do %>
-          <%= f.govuk_text_field :id, value: nil,
+          <%= f.govuk_text_field :id, value: @school_form&.school&.name,
                                       label: { text: t(".title"), size: "l" },
                                       caption: { text: t(".caption"), size: "l" },
-                                      data: { autocomplete_target: "serverInput" } %>
+                                      data: { autocomplete_target: "serverInput",
+                                              previous_search: @school_form&.school&.id } %>
 
-          <div class="govuk-!-margin-bottom-7" data-autocomplete-target="input" data-input-name="school[name]"></div>
+          <div class="govuk-!-margin-bottom-7" data-autocomplete-target="input" data-input-name="school[name]"
+            data-action="focusin->autocomplete#clearUndefinedSuggestions click->autocomplete#clearUndefinedSuggestions">
+          </div>
         <% end %>
 
         <%= f.govuk_submit t(".continue") %>

--- a/spec/forms/provider_onboarding_form_spec.rb
+++ b/spec/forms/provider_onboarding_form_spec.rb
@@ -62,4 +62,19 @@ describe ProviderOnboardingForm, type: :model do
       onboarding.to change(provider, :placements_service).from(false).to(true)
     end
   end
+
+  describe "as_form_params" do
+    it "returns form params" do
+      expect(described_class.new(
+        id: "1234",
+        javascript_disabled: true,
+      ).as_form_params).to eq({
+        "provider" =>
+          {
+            id: "1234",
+            javascript_disabled: true,
+          },
+      })
+    end
+  end
 end

--- a/spec/forms/school_onboarding_form_spec.rb
+++ b/spec/forms/school_onboarding_form_spec.rb
@@ -72,4 +72,21 @@ describe SchoolOnboardingForm, type: :model do
       onboarding.to change(school, :placements_service).from(false).to(true)
     end
   end
+
+  describe "as_form_params" do
+    it "returns form params" do
+      expect(described_class.new(
+        id: "1234",
+        javascript_disabled: true,
+        service: "claims",
+      ).as_form_params).to eq({
+        "school" =>
+          {
+            id: "1234",
+            javascript_disabled: true,
+            service: "claims",
+          },
+      })
+    end
+  end
 end

--- a/spec/system/claims/support/schools/add_a_school_spec.rb
+++ b/spec/system/claims/support/schools/add_a_school_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe "Support User adds a School", type: :system, service: :claims do
     then_i_see_an_error("Enter a school name, URN or postcode")
   end
 
+  scenario "Colin reconsiders onboarding a school", js: true do
+    given_i_have_completed_the_form_to_onboard(school:)
+    when_i_click_back
+    then_i_see_the_search_input_pre_filled_with("School 1")
+    and_i_click_continue
+    then_i_see_the_check_details_page_for_school("School 1")
+  end
+
   private
 
   def and_there_is_an_existing_persona_for(persona_name)
@@ -79,6 +87,10 @@ RSpec.describe "Support User adds a School", type: :system, service: :claims do
     click_on "Continue"
   end
 
+  def when_i_click_back
+    click_on "Back"
+  end
+
   def then_i_see_the_check_details_page_for_school(school_name)
     expect(page).to have_css(".govuk-caption-l", text: "Add organisation")
     expect(page).to have_content("Check your answers")
@@ -112,5 +124,16 @@ RSpec.describe "Support User adds a School", type: :system, service: :claims do
 
   def and_i_see_success_message
     expect(page).to have_content "Organisation added"
+  end
+
+  def given_i_have_completed_the_form_to_onboard(school:)
+    params = { school: { id: school.id, name: school.name } }
+    visit check_claims_support_schools_path(params)
+  end
+
+  def then_i_see_the_search_input_pre_filled_with(school_name)
+    within(".autocomplete__wrapper") do
+      expect(page.find("#school-id-field").value).to eq(school_name)
+    end
   end
 end

--- a/spec/system/claims/support/schools/add_a_school_without_javascript_spec.rb
+++ b/spec/system/claims/support/schools/add_a_school_without_javascript_spec.rb
@@ -52,6 +52,17 @@ RSpec.describe "Support User adds a School without JavaScript", type: :system, s
     then_i_see_an_error("Select a school")
   end
 
+  scenario "Colin reconsiders onboarding a school" do
+    given_i_have_completed_the_form_to_onboard("Manchester 1")
+    when_i_click_back
+    then_i_see_the_search_input_pre_filled_with("Manchester 1")
+    and_i_click_continue
+    then_i_see_list_of_schools
+    then_i_choose("Manchester 1")
+    and_i_click_continue
+    then_i_see_the_check_details_page_for_school("Manchester 1")
+  end
+
   private
 
   def and_there_is_an_existing_persona_for(persona_name)
@@ -82,6 +93,10 @@ RSpec.describe "Support User adds a School without JavaScript", type: :system, s
 
   def and_i_click_continue
     click_on "Continue"
+  end
+
+  def when_i_click_back
+    click_on "Back"
   end
 
   def then_i_see_list_of_schools
@@ -123,5 +138,15 @@ RSpec.describe "Support User adds a School without JavaScript", type: :system, s
 
   def and_a_school_is_listed(school_name:)
     expect(page).to have_content(school_name)
+  end
+
+  def given_i_have_completed_the_form_to_onboard(school_name)
+    school = School.find_by(name: school_name)
+    params = { school: { id: school.id, name: school.name } }
+    visit check_placements_support_schools_path(params)
+  end
+
+  def then_i_see_the_search_input_pre_filled_with(school_name)
+    expect(page.find("#school-id-field").value).to eq(school_name)
   end
 end

--- a/spec/system/placements/support/providers/support_user_adds_a_provider_spec.rb
+++ b/spec/system/placements/support/providers/support_user_adds_a_provider_spec.rb
@@ -41,6 +41,14 @@ RSpec.describe "Placements / Support / Providers / Support User adds a Provider"
     then_i_see_an_error("Enter a provider name, UKPRN, URN or postcode")
   end
 
+  scenario "Colin reconsiders onboarding a provider", js: true do
+    given_i_have_completed_the_form_to_onboard(provider:)
+    when_i_click_back
+    then_i_see_the_search_input_pre_filled_with("Provider 1")
+    and_i_click_continue
+    then_i_see_the_check_details_page_for_provider("Provider 1")
+  end
+
   private
 
   def and_there_is_an_existing_persona_for(persona_name)
@@ -88,6 +96,10 @@ RSpec.describe "Placements / Support / Providers / Support User adds a Provider"
     click_on "Continue"
   end
 
+  def when_i_click_back
+    click_on "Back"
+  end
+
   def then_i_see_the_check_details_page_for_provider(provider_name)
     expect(page).to have_css(".govuk-caption-l", text: "Add organisation")
     expect(page).to have_content("Check your answers")
@@ -123,5 +135,16 @@ RSpec.describe "Placements / Support / Providers / Support User adds a Provider"
 
   def and_i_see_success_message
     expect(page).to have_content "Organisation added"
+  end
+
+  def given_i_have_completed_the_form_to_onboard(provider:)
+    params = { provider: { id: provider.id, name: provider.name } }
+    visit check_placements_support_providers_path(params)
+  end
+
+  def then_i_see_the_search_input_pre_filled_with(provider_name)
+    within(".autocomplete__wrapper") do
+      expect(page.find("#provider-id-field").value).to eq(provider_name)
+    end
   end
 end

--- a/spec/system/placements/support/providers/support_user_adds_a_provider_without_javascript_spec.rb
+++ b/spec/system/placements/support/providers/support_user_adds_a_provider_without_javascript_spec.rb
@@ -56,6 +56,17 @@ RSpec.describe "Support User adds a Provider without JavaScript", type: :system,
     then_i_see_an_error("Select a provider")
   end
 
+  scenario "Colin reconsiders onboarding a provider" do
+    given_i_have_completed_the_form_to_onboard("Manchester 1")
+    when_i_click_back
+    then_i_see_the_search_input_pre_filled_with("Manchester 1")
+    and_i_click_continue
+    then_i_see_list_of_providers
+    then_i_choose("Manchester 1")
+    and_i_click_continue
+    then_i_see_the_check_details_page_for_provider("Manchester 1")
+  end
+
   private
 
   def and_there_is_an_existing_persona_for(persona_name)
@@ -93,6 +104,10 @@ RSpec.describe "Support User adds a Provider without JavaScript", type: :system,
 
   def and_i_click_continue
     click_on "Continue"
+  end
+
+  def when_i_click_back
+    click_on "Back"
   end
 
   def then_i_see_list_of_providers
@@ -134,5 +149,15 @@ RSpec.describe "Support User adds a Provider without JavaScript", type: :system,
 
   def and_a_provider_is_listed(provider_name:)
     expect(page).to have_content(provider_name)
+  end
+
+  def given_i_have_completed_the_form_to_onboard(provider_name)
+    provider = Provider.find_by(name: provider_name)
+    params = { provider: { id: provider.id, name: provider.name } }
+    visit check_placements_support_providers_path(params)
+  end
+
+  def then_i_see_the_search_input_pre_filled_with(provider_name)
+    expect(page.find("#provider-id-field").value).to eq(provider_name)
   end
 end

--- a/spec/system/placements/support/schools/support_user_adds_a_school_spec.rb
+++ b/spec/system/placements/support/schools/support_user_adds_a_school_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe "Placements / Support / Schools / Support User adds a School",
     then_i_see_an_error("Enter a school name, URN or postcode")
   end
 
+  scenario "Colin reconsiders onboarding a school", js: true do
+    given_i_have_completed_the_form_to_onboard(school:)
+    when_i_click_back
+    then_i_see_the_search_input_pre_filled_with("School 1")
+    and_i_click_continue
+    then_i_see_the_check_details_page_for_school("School 1")
+  end
+
   private
 
   def and_there_is_an_existing_persona_for(persona_name)
@@ -91,6 +99,10 @@ RSpec.describe "Placements / Support / Schools / Support User adds a School",
     click_on "Add organisation"
   end
 
+  def when_i_click_back
+    click_on "Back"
+  end
+
   def then_i_return_to_support_organisations_index
     expect(page).to have_content("Organisations")
   end
@@ -115,5 +127,16 @@ RSpec.describe "Placements / Support / Schools / Support User adds a School",
 
   def and_i_see_success_message
     expect(page).to have_content "Organisation added"
+  end
+
+  def given_i_have_completed_the_form_to_onboard(school:)
+    params = { school: { id: school.id, name: school.name } }
+    visit check_placements_support_schools_path(params)
+  end
+
+  def then_i_see_the_search_input_pre_filled_with(school_name)
+    within(".autocomplete__wrapper") do
+      expect(page.find("#school-id-field").value).to eq(school_name)
+    end
   end
 end

--- a/spec/system/placements/support/schools/support_user_adds_a_school_without_javascript_spec.rb
+++ b/spec/system/placements/support/schools/support_user_adds_a_school_without_javascript_spec.rb
@@ -52,6 +52,17 @@ RSpec.describe "Support User adds a School without JavaScript", type: :system, s
     then_i_see_an_error("Select a school")
   end
 
+  scenario "Colin reconsiders onboarding a school" do
+    given_i_have_completed_the_form_to_onboard("Manchester 1")
+    when_i_click_back
+    then_i_see_the_search_input_pre_filled_with("Manchester 1")
+    and_i_click_continue
+    then_i_see_list_of_schools
+    then_i_choose("Manchester 1")
+    and_i_click_continue
+    then_i_see_the_check_details_page_for_school("Manchester 1")
+  end
+
   private
 
   def and_there_is_an_existing_persona_for(persona_name)
@@ -82,6 +93,10 @@ RSpec.describe "Support User adds a School without JavaScript", type: :system, s
 
   def and_i_click_continue
     click_on "Continue"
+  end
+
+  def when_i_click_back
+    click_on "Back"
   end
 
   def then_i_see_list_of_schools
@@ -123,5 +138,15 @@ RSpec.describe "Support User adds a School without JavaScript", type: :system, s
 
   def and_a_school_is_listed(school_name:)
     expect(page).to have_content(school_name)
+  end
+
+  def given_i_have_completed_the_form_to_onboard(school_name)
+    school = School.find_by(name: school_name)
+    params = { school: { id: school.id, name: school.name } }
+    visit check_placements_support_schools_path(params)
+  end
+
+  def then_i_see_the_search_input_pre_filled_with(school_name)
+    expect(page.find("#school-id-field").value).to eq(school_name)
   end
 end


### PR DESCRIPTION
## Context

Back links on the Provider and School onboarding (Claims and Placements) "Check your answers" pages need to redirect back to the "New" onboarding forms, with the user's selection pre-filled. 
Once directed back, and the form is pre-filled, clicking continue should submit the form and take the user back to the "Check your answers" page.

## Developer Insight
Due to an issue with the [accessible-autocomplete](https://github.com/alphagov/accessible-autocomplete), additional javascript and changes to how options are rendered needed to be added to `app/javascript/controllers/autocomplete_controller.js`. Otherwise, the result of using `defaultValue` results in an `undefined` option appearing in the dropdown.
See https://github.com/alphagov/accessible-autocomplete/issues/424 for more details.

## Changes proposed in this pull request

- Back links on the "Check your answers" pages for Schools and Providers (Claims and Placements) redirect back to the "New" onboarding forms, with pre-filled user input (School or Provider name).
- `PreviousSearch` tag added to html, to allow stimulus to assign the Provider/School name and id to the correct inputs.
- Methods added to Provider/School Onboarding Form classes to easily assign back params.

## Guidance to review

- Follow steps to onboard to a school/provider until you reach the "Check your answers" page.
- Once on the "Check your answers" page, Click the "back" link at the top of the page.
- You should be redirected back to the "New" onboarding form for the school/provider.
- The user input for the "New" onboarding form should be pre-filled with the school/provider name.
- Clicking "Continue", without searching should return the user to the "Check your answers" page for the same school/provider.

## Link to Trello card

https://trello.com/c/e5SwYKuK/138-fix-back-links-on-providers-schools-onboarding-pages-to-pre-fill-the-search-input-new-page-with-users-input

## Screenshots

https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/449970bc-1a48-4e7e-873d-7710525f56b9

