### PR TITLE
Set HOSTING_ENV for QA

### DIFF
--- a/terraform/application/config/qa_app_env.yml
+++ b/terraform/application/config/qa_app_env.yml
@@ -2,3 +2,4 @@
 SIGN_IN_METHOD: persona
 GIAS_CSV_BASE_URL: https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public
 PUBLISH_BASE_URL: https://qa.api.publish-teacher-training-courses.service.gov.uk
+HOSTING_ENV: qa


### PR DESCRIPTION
## Context

QA currently doesn't set the `HOSTING_ENV` during deployment.

## Changes proposed in this pull request

Add `HOSTING_ENV=qa` to the QA deployment environment variables.

## Guidance to review

Hmm, trust that QA picks up its environment variables from `qa_app_env.yml`, like review does from `review_app_env.yml`?