### PR TITLE
Add district_admin_name and district_admin_code to Schools and importer

### DIFF
--- a/app/models/claims/school.rb
+++ b/app/models/claims/school.rb
@@ -8,6 +8,8 @@
 #  address3                     :string
 #  admissions_policy            :string
 #  claims_service               :boolean          default(FALSE)
+#  district_admin_code          :string
+#  district_admin_name          :string
 #  email_address                :string
 #  gender                       :string
 #  group                        :string

--- a/app/models/placements/school.rb
+++ b/app/models/placements/school.rb
@@ -8,6 +8,8 @@
 #  address3                     :string
 #  admissions_policy            :string
 #  claims_service               :boolean          default(FALSE)
+#  district_admin_code          :string
+#  district_admin_name          :string
 #  email_address                :string
 #  gender                       :string
 #  group                        :string

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -8,6 +8,8 @@
 #  address3                     :string
 #  admissions_policy            :string
 #  claims_service               :boolean          default(FALSE)
+#  district_admin_code          :string
+#  district_admin_name          :string
 #  email_address                :string
 #  gender                       :string
 #  group                        :string

--- a/app/services/gias_csv_importer.rb
+++ b/app/services/gias_csv_importer.rb
@@ -24,6 +24,8 @@ class GiasCsvImporter
         records << {
           urn: school["URN"],
           name: school["EstablishmentName"],
+          district_admin_name: school["DistrictAdministrative (name)"],
+          district_admin_code: school["DistrictAdministrative (code)"],
           town: school["Town"].presence,
           postcode: school["Postcode"].presence,
           ukprn: school["UKPRN"].presence,

--- a/db/migrate/20240201101735_add_district_admin_fields_to_schools.rb
+++ b/db/migrate/20240201101735_add_district_admin_fields_to_schools.rb
@@ -1,0 +1,8 @@
+class AddDistrictAdminFieldsToSchools < ActiveRecord::Migration[7.1]
+  def change
+    change_table :schools, bulk: true do |t|
+      t.string :district_admin_name
+      t.string :district_admin_code
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_26_114650) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_01_101735) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -140,6 +140,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_26_114650) do
     t.string "rating"
     t.date "last_inspection_date"
     t.string "email_address"
+    t.string "district_admin_name"
+    t.string "district_admin_code"
     t.index ["claims_service"], name: "index_schools_on_claims_service"
     t.index ["placements_service"], name: "index_schools_on_placements_service"
     t.index ["urn"], name: "index_schools_on_urn", unique: true

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -8,6 +8,8 @@
 #  address3                     :string
 #  admissions_policy            :string
 #  claims_service               :boolean          default(FALSE)
+#  district_admin_code          :string
+#  district_admin_name          :string
 #  email_address                :string
 #  gender                       :string
 #  group                        :string

--- a/spec/models/claims/school_spec.rb
+++ b/spec/models/claims/school_spec.rb
@@ -8,6 +8,8 @@
 #  address3                     :string
 #  admissions_policy            :string
 #  claims_service               :boolean          default(FALSE)
+#  district_admin_code          :string
+#  district_admin_name          :string
 #  email_address                :string
 #  gender                       :string
 #  group                        :string

--- a/spec/models/placements/school_spec.rb
+++ b/spec/models/placements/school_spec.rb
@@ -8,6 +8,8 @@
 #  address3                     :string
 #  admissions_policy            :string
 #  claims_service               :boolean          default(FALSE)
+#  district_admin_code          :string
+#  district_admin_name          :string
 #  email_address                :string
 #  gender                       :string
 #  group                        :string

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -8,6 +8,8 @@
 #  address3                     :string
 #  admissions_policy            :string
 #  claims_service               :boolean          default(FALSE)
+#  district_admin_code          :string
+#  district_admin_name          :string
 #  email_address                :string
 #  gender                       :string
 #  group                        :string


### PR DESCRIPTION
## Context

We need to import these two extra fields in order for us to calculate the hourly rate dependent on region

## Changes proposed in this pull request

Add the `district_admin_name` and `district_admin_code` to the importer and School model

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Qa8m6wD8/129-store-the-hourly-rate-for-each-region-school (will be multiple PR's)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
