### PR TITLE
Remove authentication from feedback pages

### DIFF
--- a/app/controllers/claims/pages_controller.rb
+++ b/app/controllers/claims/pages_controller.rb
@@ -1,2 +1,3 @@
 class Claims::PagesController < ApplicationController
+  skip_before_action :authenticate_user!
 end

--- a/app/controllers/placements/pages_controller.rb
+++ b/app/controllers/placements/pages_controller.rb
@@ -1,2 +1,3 @@
 class Placements::PagesController < ApplicationController
+  skip_before_action :authenticate_user!
 end


### PR DESCRIPTION
## Context

The feedback page currently requires authentication. It should not.

## Changes proposed in this pull request

Skip user authentication on the `PagesController`s.

## Guidance to review

- Sign out
- Visit `/feedback`.
