### PR TITLE
Redirect placements service root to sign in page

### DIFF
--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -3,7 +3,7 @@ scope module: :placements,
       constraints: {
         host: ENV["PLACEMENTS_HOST"],
       } do
-  root to: "pages#index"
+  root to: redirect("/sign-in")
 
   scope module: :pages do
     get :feedback


### PR DESCRIPTION
## Context

Placements should also redirect away from the "pages#index" page as it is a placeholder.

https://github.com/DFE-Digital/itt-mentor-services/pull/195 fails due to Placements not being redirected away from the "pages#index" page.

## Changes proposed in this pull request

- `/` should redirect to `/sign-in`

## Guidance to review

You should no longer be able to access the `pages#index` page.
