### PR TITLE
Ensure no fixup commits are merged into main

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,14 @@
+name: Git Checks
+
+on: [pull_request]
+
+jobs:
+  block-fixup:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Block Fixup Commit Merge
+        uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
## Context

As a developer that frequently uses the `git commit --fixup` command. I don't want these commits to ever be merged into `main`.

## Changes proposed in this pull request

- Add a GitHub action to prevent "fixup" commits from being merged into `main`.

## Guidance to review

- You could branch off of this branch and create a fixup commit by adding a change and committing with `git commit --fixup @` (`@` is an alias for `HEAD`)