### PR TITLE
Claims: Fix Primary Navigation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,9 @@ gem "pg_search"
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem "stimulus-rails"
 
+# User-Resource Permissions and Scoping
+gem "pundit"
+
 group :development do
   gem "annotate", require: false
   gem "prettier_print", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,6 +330,8 @@ GEM
     public_suffix (5.0.4)
     puma (6.4.2)
       nio4r (~> 2.0)
+    pundit (2.3.1)
+      activesupport (>= 3.0.0)
     racc (1.7.3)
     rack (3.0.8)
     rack-oauth2 (2.2.0)
@@ -592,6 +594,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma (~> 6.4)
+  pundit
   rails (~> 7.1.3)
   rails-controller-testing
   rails-erd

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   include ApplicationHelper
   include RoutesHelper
   include Pagy::Backend
+  include Pundit::Authorization
 
   before_action :authenticate_user!
 

--- a/app/controllers/claims/schools_controller.rb
+++ b/app/controllers/claims/schools_controller.rb
@@ -2,7 +2,7 @@ class Claims::SchoolsController < ApplicationController
   before_action :redirect_to_school_when_belongs_to_one_school, only: :index
 
   def index
-    @schools = current_user.schools
+    @schools = policy_scope(Claims::School)
   end
 
   def show
@@ -12,7 +12,7 @@ class Claims::SchoolsController < ApplicationController
   private
 
   def redirect_to_school_when_belongs_to_one_school
-    if current_user.schools.one?
+    if policy_scope(Claims::School).one?
       redirect_to claims_school_path(current_user.schools.first)
     end
   end

--- a/app/controllers/concerns/claims/belongs_to_school.rb
+++ b/app/controllers/concerns/claims/belongs_to_school.rb
@@ -5,15 +5,7 @@ module Claims::BelongsToSchool
     before_action :set_school
 
     def set_school
-      @school = scoped_schools.find(params.require(:school_id))
-    rescue ActiveRecord::RecordNotFound
-      redirect_to not_found_path
-    end
-
-    def scoped_schools
-      return Claims::School.all if current_user.support_user?
-
-      current_user.schools
+      @school = policy_scope(Claims::School).find(params.require(:school_id))
     end
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      raise NotImplementedError, "You must define #resolve in #{self.class}"
+    end
+
+    private
+
+    attr_reader :user, :scope
+  end
+end

--- a/app/policies/claims/school_policy.rb
+++ b/app/policies/claims/school_policy.rb
@@ -1,0 +1,11 @@
+class Claims::SchoolPolicy < ApplicationPolicy
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      if user.support_user?
+        scope.all
+      else
+        scope.joins(:users).where(users: { id: user })
+      end
+    end
+  end
+end

--- a/app/views/claims/schools/_primary_navigation.html.erb
+++ b/app/views/claims/schools/_primary_navigation.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:primary_navigation_content) do %>
-  <% if current_user.schools.many? %>
+  <% if policy_scope(Claims::School.all).many? %>
     <%= content_for(:header_content) do %>
       <%= render(ContentHeaderComponent.new(
         title: @school.name,

--- a/app/views/claims/schools/_primary_navigation.html.erb
+++ b/app/views/claims/schools/_primary_navigation.html.erb
@@ -1,5 +1,20 @@
-<%= render PrimaryNavigationComponent.new do |component| %>
-  <% component.with_navigation_item t(".claims"), claims_school_claims_path(school) %>
-  <% component.with_navigation_item t(".users"), claims_school_users_path(school) %>
-  <% component.with_navigation_item t(".details"), claims_school_path(school) %>
+<% content_for(:primary_navigation_content) do %>
+  <% if current_user.schools.many? %>
+    <%= content_for(:header_content) do %>
+      <%= render(ContentHeaderComponent.new(
+        title: @school.name,
+        actions: [
+          govuk_link_to(t(".change_organisation"), claims_schools_path, no_visited_state: true),
+        ],
+      )) %>
+    <% end %>
+  <% else %>
+    <% content_for(:no_phase_banner_border, true) %>
+  <% end %>
+
+  <%= render PrimaryNavigationComponent.new do |component| %>
+    <% component.with_navigation_item t(".claims"), claims_school_claims_path(school), current: local_assigns[:current] == :claims %>
+    <% component.with_navigation_item t(".users"), claims_school_users_path(school), current: local_assigns[:current] == :users %>
+    <% component.with_navigation_item t(".details"), claims_school_path(school) %>
+  <% end %>
 <% end %>

--- a/app/views/claims/schools/claims/edit.html.erb
+++ b/app/views/claims/schools/claims/edit.html.erb
@@ -1,3 +1,5 @@
+<% render "claims/schools/primary_navigation", school: @school, current: :claims %>
+
 <div class="govuk-width-container">
   <%= render(
     partial: "#{step}_form",

--- a/app/views/claims/schools/claims/index.html.erb
+++ b/app/views/claims/schools/claims/index.html.erb
@@ -1,6 +1,4 @@
-<% content_for(:before_content) do %>
-  <%= render "claims/schools/primary_navigation", school: @school %>
-<% end %>
+<% render "claims/schools/primary_navigation", school: @school, current: :claims %>
 
 <div class="govuk-width-container">
   <h1 class="govuk-heading-l"><%= t(".heading") %></h1>

--- a/app/views/claims/schools/claims/show.html.erb
+++ b/app/views/claims/schools/claims/show.html.erb
@@ -1,6 +1,4 @@
-<% content_for(:before_content) do %>
-  <%= render "claims/schools/primary_navigation", school: @school %>
-<% end %>
+<% render "claims/schools/primary_navigation", school: @school, current: :claims %>
 
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: claims_school_claims_path) %>

--- a/app/views/claims/schools/show.html.erb
+++ b/app/views/claims/schools/show.html.erb
@@ -1,19 +1,5 @@
-<% if current_user.schools.many? %>
-  <%= content_for(:header_content) do %>
-    <%= render(ContentHeaderComponent.new(
-      title: @school.name,
-      actions: [
-        govuk_link_to(t(".change_organisation"), claims_schools_path, no_visited_state: true),
-      ],
-    )) %>
-  <% end %>
-<% end %>
-
 <% content_for :page_title, sanitize(@school.name) %>
-
-<% content_for(:before_content) do %>
-  <%= render "claims/schools/primary_navigation", school: @school %>
-<% end %>
+<% render "claims/schools/primary_navigation", school: @school %>
 
 <div class="govuk-width-container">
   <h1 class="govuk-heading-l"><%= t(".heading") %></h1>

--- a/app/views/claims/schools/users/check.html.erb
+++ b/app/views/claims/schools/users/check.html.erb
@@ -1,4 +1,5 @@
-<%= content_for :page_title, sanitize(t(".page_title", school_name: @school.name)) %>
+<% content_for :page_title, sanitize(t(".page_title", school_name: @school.name)) %>
+<% render "claims/schools/primary_navigation", school: @school, current: :users %>
 
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(

--- a/app/views/claims/schools/users/index.html.erb
+++ b/app/views/claims/schools/users/index.html.erb
@@ -1,6 +1,4 @@
-<% content_for(:before_content) do %>
-  <%= render "claims/schools/primary_navigation", school: @school %>
-<% end %>
+<% render "claims/schools/primary_navigation", school: @school, current: :users %>
 
 <div class="govuk-width-container">
   <h1 class="govuk-heading-l"><%= t(".heading") %></h1>

--- a/app/views/claims/schools/users/new.html.erb
+++ b/app/views/claims/schools/users/new.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, sanitize(t(".page_title", school_name: @school.name)) %>
+<% render "claims/schools/primary_navigation", school: @school, current: :users %>
 
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: claims_school_users_path(@school)) %>

--- a/app/views/claims/schools/users/show.html.erb
+++ b/app/views/claims/schools/users/show.html.erb
@@ -1,3 +1,5 @@
+<% render "claims/schools/primary_navigation", school: @school, current: :users %>
+
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: claims_school_users_path(@school)) %>
 <% end %>

--- a/app/views/claims/support/_primary_navigation.html.erb
+++ b/app/views/claims/support/_primary_navigation.html.erb
@@ -1,0 +1,9 @@
+<% content_for(:primary_navigation_content) do %>
+  <%= render PrimaryNavigationComponent.new do |component| %>
+    <% component.with_navigation_item t(".organisations"), claims_support_schools_path, current: local_assigns[:current] == :organisations %>
+    <% component.with_navigation_item t(".users"), claims_support_support_users_path, current: local_assigns[:current] == :users %>
+    <% component.with_navigation_item t(".claims"), claims_support_claims_path, current: local_assigns[:current] == :claims %>
+  <% end %>
+
+  <% content_for(:no_phase_banner_border, true) %>
+<% end %>

--- a/app/views/claims/support/claims/index.html.erb
+++ b/app/views/claims/support/claims/index.html.erb
@@ -1,3 +1,5 @@
+<%= render "claims/support/primary_navigation", current: :claims %>
+
 <div class="govuk-width-container">
   <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 </div>

--- a/app/views/claims/support/schools/check.html.erb
+++ b/app/views/claims/support/schools/check.html.erb
@@ -1,4 +1,5 @@
-<%= content_for(:before_content) do %>
+<% render "claims/support/primary_navigation", current: :organisations %>
+<% content_for(:before_content) do %>
   <%= govuk_back_link(href: new_claims_support_school_path(
     @school_form.as_form_params,
   )) %>

--- a/app/views/claims/support/schools/claims/index.html.erb
+++ b/app/views/claims/support/schools/claims/index.html.erb
@@ -1,3 +1,5 @@
+<% render "claims/support/primary_navigation", current: :organisations %>
+
 <div class="govuk-width-container">
   <h1 class="govuk-heading-l"><%= @school.name %></h1>
 

--- a/app/views/claims/support/schools/claims/show.html.erb
+++ b/app/views/claims/support/schools/claims/show.html.erb
@@ -1,3 +1,5 @@
+<% render "claims/support/primary_navigation", current: :organisations %>
+
 <div class="govuk-width-container">
   <h1 class="govuk-heading-l"><%= @school.name %></h1>
 

--- a/app/views/claims/support/schools/index.html.erb
+++ b/app/views/claims/support/schools/index.html.erb
@@ -1,4 +1,5 @@
-<%= content_for :page_title, t(".heading", records: @pagy.count) %>
+<% content_for :page_title, t(".heading", records: @pagy.count) %>
+<% render "claims/support/primary_navigation", current: :organisations %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">

--- a/app/views/claims/support/schools/mentors/index.html.erb
+++ b/app/views/claims/support/schools/mentors/index.html.erb
@@ -1,3 +1,5 @@
+<% render "claims/support/primary_navigation", current: :organisations %>
+
 <div class="govuk-width-container">
   <h1 class="govuk-heading-l"><%= @school.name %></h1>
 

--- a/app/views/claims/support/schools/new.html.erb
+++ b/app/views/claims/support/schools/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title, t(".title") %>
+<% render "claims/support/primary_navigation", current: :organisations %>
 
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: claims_support_schools_path) %>

--- a/app/views/claims/support/schools/providers/index.html.erb
+++ b/app/views/claims/support/schools/providers/index.html.erb
@@ -1,3 +1,5 @@
+<% render "claims/support/primary_navigation", current: :organisations %>
+
 <div class="govuk-width-container">
   <h1 class="govuk-heading-l"><%= @school.name %></h1>
 

--- a/app/views/claims/support/schools/school_options.html.erb
+++ b/app/views/claims/support/schools/school_options.html.erb
@@ -1,4 +1,5 @@
-<%= content_for(:before_content) do %>
+<% render "claims/support/primary_navigation", current: :organisations %>
+<% content_for(:before_content) do %>
   <%= govuk_back_link(href: new_claims_support_school_path) %>
 <% end %>
 

--- a/app/views/claims/support/schools/show.html.erb
+++ b/app/views/claims/support/schools/show.html.erb
@@ -1,4 +1,5 @@
-<%= content_for :page_title, @school.name %>
+<% content_for :page_title, @school.name %>
+<% render "claims/support/primary_navigation", current: :organisations %>
 
 <div class="govuk-width-container">
   <h1 class="govuk-heading-l"><%= @school.name %></h1>

--- a/app/views/claims/support/schools/users/check.html.erb
+++ b/app/views/claims/support/schools/users/check.html.erb
@@ -1,4 +1,5 @@
-<%= content_for :page_title, sanitize(t(".page_title", school_name: @school.name)) %>
+<% content_for :page_title, sanitize(t(".page_title", school_name: @school.name)) %>
+<% render "claims/support/primary_navigation", current: :organisations %>
 
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(

--- a/app/views/claims/support/schools/users/index.html.erb
+++ b/app/views/claims/support/schools/users/index.html.erb
@@ -1,4 +1,5 @@
-<%= content_for :page_title, sanitize(@school.name) %>
+<% content_for :page_title, sanitize(@school.name) %>
+<% render "claims/support/primary_navigation", current: :organisations %>
 
 <div class="govuk-width-container">
   <h1 class="govuk-heading-l"><%= @school.name %></h1>

--- a/app/views/claims/support/schools/users/new.html.erb
+++ b/app/views/claims/support/schools/users/new.html.erb
@@ -1,4 +1,5 @@
-<%= content_for :page_title, sanitize(t(".page_title", school_name: @school.name)) %>
+<% content_for :page_title, sanitize(t(".page_title", school_name: @school.name)) %>
+<%= render "claims/support/primary_navigation", current: :organisations %>
 
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: claims_support_school_users_path(@school)) %>

--- a/app/views/claims/support/schools/users/show.html.erb
+++ b/app/views/claims/support/schools/users/show.html.erb
@@ -1,4 +1,5 @@
-<%= content_for(:before_content) do %>
+<% render "claims/support/primary_navigation", current: :organisations %>
+<% content_for(:before_content) do %>
   <%= govuk_back_link(href: claims_support_school_users_path(@school)) %>
 <% end %>
 

--- a/app/views/claims/support/support_users/check.html.erb
+++ b/app/views/claims/support/support_users/check.html.erb
@@ -1,4 +1,6 @@
 <% content_for(:page_title) { t(".page_title") } %>
+<% render "claims/support/primary_navigation", current: :users %>
+
 <% back_href = new_claims_support_support_user_path({ support_user: @support_user_params }) %>
 
 <%= content_for(:before_content) do %>

--- a/app/views/claims/support/support_users/index.html.erb
+++ b/app/views/claims/support/support_users/index.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:page_title) { t(".page_title") } %>
+<% render "claims/support/primary_navigation", current: :users %>
 
 <div class="govuk-width-container">
   <h1 class="govuk-heading-l"><%= t(".heading") %></h1>

--- a/app/views/claims/support/support_users/new.html.erb
+++ b/app/views/claims/support/support_users/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:page_title) { @support_user.errors.empty? ? t(".page_title") : t(".page_title_with_errors") } %>
+<% render "claims/support/primary_navigation", current: :users %>
 
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: claims_support_support_users_path) %>

--- a/app/views/claims/support/support_users/show.html.erb
+++ b/app/views/claims/support/support_users/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:page_title) { @support_user.full_name } %>
+<% render "claims/support/primary_navigation", current: :users %>
 
 <% content_for(:before_content) do %>
   <%= govuk_back_link href: claims_support_support_users_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,22 +35,14 @@
     <% end %>
 
     <div class="govuk-width-container">
-      <%= govuk_phase_banner(tag: { text: hosting_environment_phase(current_service), colour: hosting_environment_color }, classes: [class_names("app-phase-banner", "app-phase-banner__env--#{HostingEnvironment.env}", "app-phase-banner--no-border-bottom": support_controller?)]) do %>
+      <%= govuk_phase_banner(tag: { text: hosting_environment_phase(current_service), colour: hosting_environment_color }, classes: [class_names("app-phase-banner", "app-phase-banner__env--#{HostingEnvironment.env}", "app-phase-banner--no-border-bottom": content_for(:no_phase_banner_border) || support_controller?)]) do %>
         <%== t(".#{current_service}.phase_banner.description", feedback_link: govuk_link_to(t(".#{current_service}.phase_banner.feedback"), feedback_path, class: "govuk-link--no-visited-state")) %>
       <% end %>
 
       <%= yield :header_content %>
     </div>
 
-    <% if support_controller? && current_service == :claims %>
-      <%= render PrimaryNavigationComponent.new do |component| %>
-        <% component.with_navigation_item t(".claims.primary_navigation.organisations"), support_organisations_path %>
-        <% component.with_navigation_item t(".claims.primary_navigation.users"), support_support_users_path %>
-        <% component.with_navigation_item t(".claims.primary_navigation.claims"), claims_support_claims_path %>
-      <% end %>
-    <% else %>
-      <%= yield :primary_navigation_content %>
-    <% end %>
+    <%= yield :primary_navigation_content %>
 
     <div class="govuk-width-container">
       <%= yield :before_content %>
@@ -59,13 +51,14 @@
     <main class="govuk-main-wrapper" id="main-content" role="main">
       <div class="govuk-width-container">
         <% flash.each do |key, message| %>
-          <div class="govuk-!-margin-top-6 govuk-!-margin-bottom-0">
+          <div class="govuk-!-margin-bottom-0">
             <%= render(GovukComponent::NotificationBannerComponent.new(title_text: t(".#{key}"), success: key == "success")) do %>
               <h3 class="govuk-heading-m"><%= message %></h3>
             <% end %>
           </div>
         <% end %>
       </div>
+
       <%= yield %>
     </main>
 

--- a/config/locales/en/claims/schools.yml
+++ b/config/locales/en/claims/schools.yml
@@ -4,13 +4,7 @@ en:
       index:
         organisations: Organisations
       show:
-        primary_navigation:
-          users: Users
-          claims: Claims
-          organisations: Organisations
-          details: Details
         heading: Organisation details
-        change_organisation: Change organisation
         unknown: Unknown
         not_entered: Not entered
         not_applicable: Not applicable
@@ -37,7 +31,3 @@ en:
         rating: Rating
         last_inspection_date: Last inspection date
         contact_details: Contact details
-      primary_navigation:
-        claims: Claims
-        users: Users
-        details: Details

--- a/config/locales/en/claims/schools/primary_navigation.yml
+++ b/config/locales/en/claims/schools/primary_navigation.yml
@@ -1,0 +1,8 @@
+en:
+  claims:
+    schools:
+      primary_navigation:
+        users: Users
+        claims: Claims
+        details: Details
+        change_organisation: Change organisation

--- a/config/locales/en/claims/support/primary_navigation.yml
+++ b/config/locales/en/claims/support/primary_navigation.yml
@@ -1,0 +1,7 @@
+en:
+  claims:
+    support:
+      primary_navigation:
+        claims: Claims
+        organisations: Organisations
+        users: Users

--- a/config/locales/en/layouts/application.yml
+++ b/config/locales/en/layouts/application.yml
@@ -7,10 +7,6 @@ en:
       sign_out: Sign out
 
       claims:
-        primary_navigation:
-          claims: Claims
-          organisations: Organisations
-          users: Users
         phase_banner:
           description: This is a new service &ndash; your %{feedback_link} will help us to improve it.
           feedback: feedback

--- a/spec/policies/claims/school_policy/scope_spec.rb
+++ b/spec/policies/claims/school_policy/scope_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe Claims::SchoolPolicy::Scope do
+  subject { described_class.new(user, Claims::School).resolve }
+
+  let!(:non_associated_school) { create(:claims_school) }
+  let!(:associated_school) { create(:claims_school) }
+
+  context "when user is a support user" do
+    let(:user) { create(:claims_support_user) }
+
+    it "returns all schools" do
+      expect(subject).to match_array([non_associated_school, associated_school])
+    end
+  end
+
+  context "when user is not a support user" do
+    let(:user) { create(:claims_user) }
+
+    before do
+      user.schools << associated_school
+    end
+
+    it "returns schools that the user is associated with" do
+      expect(subject).to match_array([associated_school])
+    end
+  end
+end

--- a/spec/system/claims/invite_a_user_to_a_school_spec.rb
+++ b/spec/system/claims/invite_a_user_to_a_school_spec.rb
@@ -95,8 +95,7 @@ RSpec.describe "Invite a user to a school", type: :system do
   end
 
   def verify_i_cant_access_another_schools_users_list
-    visit claims_school_users_path(@another_school)
-    expect(page).to have_content("Page not found")
+    expect { visit claims_school_users_path(@another_school) }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
   def sign_in_as_lead_mentor_user


### PR DESCRIPTION
## Context

- We want to ensure that the Primary Navigation is always full screen width.
- When the Primary Navigation immediately follows the Phase Banner, the Phase Banner's bottom border should be hidden.
- When browsing nested paths, the top-level Primary Navigation Item should be active.

## Changes proposed in this pull request

- I've had to update the school scoping, as we've updated `SupportUser` models to no longer have the `#schools` association - which was admittedly wrong anyway. A support user does not belong to a school, they manage _all_ schools.
  - This allows support users to view all user-facing school pages.
  - Uses the https://github.com/varvet/pundit gem.

## Guidance to review

- Visit as many pages as you can as a single-org User
- Visit as many pages as you can as a multi-org User (phase banner border should be present)
- Visit as many pages as you can as a Support User

## Screenshots

| Type            | Screenshot |
| --------------- | ---------- |
| Single-org User | ![CleanShot 2024-02-01 at 17 01 25](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/1d06d5e6-ebc6-468f-803f-3d364f0553ed) |
| Multi-org User  | ![CleanShot 2024-02-01 at 17 01 35](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/bd515975-9f82-43ef-8e79-4cfb7f3ac5d7) |
| Support User    | ![CleanShot 2024-02-02 at 15 24 07](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/b4d9afb9-a16a-43c2-b2ac-bf9824b1d78d) |

