### PR TITLE
lb/Allow non-support users to remove other users

### DIFF
--- a/app/controllers/placements/organisations/users_controller.rb
+++ b/app/controllers/placements/organisations/users_controller.rb
@@ -45,7 +45,7 @@ class Placements::Organisations::UsersController < ApplicationController
   end
 
   def redirect_if_not_allowed
-    if current_user == @user
+    unless policy(@user).destroy?
       redirect_to_index
       flash[:alert] = t(".you_cannot_perform_this_action")
     end

--- a/app/controllers/placements/organisations/users_controller.rb
+++ b/app/controllers/placements/organisations/users_controller.rb
@@ -1,13 +1,13 @@
 class Placements::Organisations::UsersController < ApplicationController
   before_action :set_organisation
+  before_action :set_user, only: %i[show remove destroy]
+  before_action :redirect_if_not_allowed, only: %i[remove destroy]
 
   def index
     users
   end
 
-  def show
-    @user = users.find(params.require(:id))
-  end
+  def show; end
 
   def new
     @user_form = params[:user_invite_form].present? ? user_form : UserInviteForm.new
@@ -26,10 +26,29 @@ class Placements::Organisations::UsersController < ApplicationController
     end
   end
 
+  def remove; end
+
+  def destroy
+    RemoveUserService.call(@user, @organisation)
+    redirect_to_index
+    flash[:success] = t(".user_removed")
+  end
+
   private
+
+  def set_user
+    @user = users.find(params.require(:id))
+  end
 
   def users
     @users = @organisation.users.order("LOWER(first_name)")
+  end
+
+  def redirect_if_not_allowed
+    if current_user == @user
+      redirect_to_index
+      flash[:alert] = t(".you_cannot_perform_this_action")
+    end
   end
 
   def user_params

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class ApplicationPolicy
   attr_reader :user, :record
 

--- a/app/policies/placements/user_policy.rb
+++ b/app/policies/placements/user_policy.rb
@@ -1,0 +1,5 @@
+class Placements::UserPolicy < ApplicationPolicy
+  def destroy?
+    user != record
+  end
+end

--- a/app/views/placements/_primary_navigation.html.erb
+++ b/app/views/placements/_primary_navigation.html.erb
@@ -1,4 +1,12 @@
 <%# locals: (current_navigation: nil, organisation:) -%>
+<% if current_user.organisation_count > 1 %>
+  <%= content_for(:header_content) do %>
+    <%= render(ContentHeaderComponent.new(
+      title: organisation.name,
+      actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
+    )) %>
+  <% end %>
+<% end %>
 
 <%= content_for(:primary_navigation_content) do %>
   <%= render PrimaryNavigationComponent.new do |component| %>

--- a/app/views/placements/providers/show.html.erb
+++ b/app/views/placements/providers/show.html.erb
@@ -1,13 +1,4 @@
 <%= content_for :page_title, t(".organisation_details") %>
-<% if current_user.memberships.many? %>
-  <%= content_for(:header_content) do %>
-    <%= render(ContentHeaderComponent.new(
-      title: @provider.name,
-      actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
-    )) %>
-  <% end %>
-<% end %>
-
 <%= render "placements/primary_navigation", organisation: @provider, current_navigation: :organisation_details %>
 
 <div class="govuk-width-container">

--- a/app/views/placements/providers/users/check.html.erb
+++ b/app/views/placements/providers/users/check.html.erb
@@ -1,12 +1,4 @@
 <%= content_for :page_title, t(".page_title") %>
-<% if current_user.organisation_count > 1 %>
-  <%= content_for(:header_content) do %>
-    <%= render(ContentHeaderComponent.new(
-      title: @organisation.name,
-      actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
-    )) %>
-  <% end %>
-<% end %>
 <%= render "placements/primary_navigation", current_navigation: :users, organisation: @organisation %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: new_placements_provider_user_path(

--- a/app/views/placements/providers/users/index.html.erb
+++ b/app/views/placements/providers/users/index.html.erb
@@ -1,12 +1,4 @@
 <% content_for(:page_title) { t(".users") } %>
-<% if current_user.organisation_count > 1 %>
-  <%= content_for(:header_content) do %>
-    <%= render(ContentHeaderComponent.new(
-      title: @organisation.name,
-      actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
-    )) %>
-  <% end %>
-<% end %>
 <%= render "placements/primary_navigation", organisation: @organisation, current_navigation: :users %>
 
 <div class="govuk-width-container">

--- a/app/views/placements/providers/users/new.html.erb
+++ b/app/views/placements/providers/users/new.html.erb
@@ -1,14 +1,5 @@
 <%= content_for :page_title, @user_form.errors.any? ? t(".page_title_with_error") : t(".page_title") %>
 <%= render "placements/primary_navigation", current_navigation: :users, organisation: @organisation %>
-<% if current_user.organisation_count > 1 %>
-  <%= content_for(:header_content) do %>
-    <%= render(ContentHeaderComponent.new(
-      title: @organisation.name,
-      actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
-    )) %>
-  <% end %>
-<% end %>
-
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: placements_provider_users_path(@organisation)) %>
 <% end %>

--- a/app/views/placements/providers/users/remove.html.erb
+++ b/app/views/placements/providers/users/remove.html.erb
@@ -1,12 +1,4 @@
 <%= content_for :page_title, sanitize(t(".page_title", user_name: @user.full_name, organisation_name: @organisation.name)) %>
-<% if current_user.organisation_count > 1 %>
-  <%= content_for(:header_content) do %>
-    <%= render(ContentHeaderComponent.new(
-      title: @organisation.name,
-      actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
-    )) %>
-  <% end %>
-<% end %>
 <%= render "placements/primary_navigation", organisation: @organisation, current_navigation: :users %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: placements_provider_user_path(@organisation, @user)) %>

--- a/app/views/placements/providers/users/remove.html.erb
+++ b/app/views/placements/providers/users/remove.html.erb
@@ -1,0 +1,33 @@
+<%= content_for :page_title, sanitize(t(".page_title", user_name: @user.full_name, organisation_name: @organisation.name)) %>
+<% if current_user.organisation_count > 1 %>
+  <%= content_for(:header_content) do %>
+    <%= render(ContentHeaderComponent.new(
+      title: @organisation.name,
+      actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
+    )) %>
+  <% end %>
+<% end %>
+<%= render "placements/primary_navigation", organisation: @organisation, current_navigation: :users %>
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: placements_provider_user_path(@organisation, @user)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <label class="govuk-label govuk-label--l">
+        <span class="govuk-caption-l"><%= @user.full_name.to_s %></span>
+        <%= t(".are_you_sure") %>
+      </label>
+      <%= render GovukComponent::WarningTextComponent.new(
+        text: t(".user_will_be_sent_an_email", organisation_name: @organisation.name),
+      ) %>
+
+      <%= govuk_button_to t(".remove_user"), placements_provider_user_path(@organisation, @user), warning: true, method: :delete %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to(t(".cancel"), placements_provider_user_path(@organisation, @user)) %>
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/placements/providers/users/show.html.erb
+++ b/app/views/placements/providers/users/show.html.erb
@@ -1,13 +1,5 @@
-<% if current_user.organisation_count > 1 %>
-  <%= content_for(:header_content) do %>
-    <%= render(ContentHeaderComponent.new(
-      title: @organisation.name,
-      actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
-    )) %>
-  <% end %>
-<% end %>
-<%= render "placements/primary_navigation", organisation: @organisation, current_navigation: :users %>
 <%= content_for :page_title, sanitize(@user.full_name) %>
+<%= render "placements/primary_navigation", organisation: @organisation, current_navigation: :users %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: placements_provider_users_path(@organisation)) %>
 <% end %>

--- a/app/views/placements/providers/users/show.html.erb
+++ b/app/views/placements/providers/users/show.html.erb
@@ -9,7 +9,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "placements/organisations/users/details", user: @user %>
-      <% unless current_user == @user %>
+      <% if policy(@user).destroy? %>
         <%= link_to(t(".remove_user"),
                     remove_placements_provider_user_path(@organisation, @user),
                     class: "govuk-link govuk-link--no-visited-state app-link--destructive") %>

--- a/app/views/placements/providers/users/show.html.erb
+++ b/app/views/placements/providers/users/show.html.erb
@@ -17,6 +17,11 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "placements/organisations/users/details", user: @user %>
+      <% unless current_user == @user %>
+        <%= link_to(t(".remove_user"),
+                    remove_placements_provider_user_path(@organisation, @user),
+                    class: "govuk-link govuk-link--no-visited-state app-link--destructive") %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/placements/schools/show.html.erb
+++ b/app/views/placements/schools/show.html.erb
@@ -1,13 +1,4 @@
 <%= content_for :page_title, t(".organisation_details") %>
-<% if current_user.organisation_count > 1 %>
-  <%= content_for(:header_content) do %>
-    <%= render(ContentHeaderComponent.new(
-      title: @school.name,
-      actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
-    )) %>
-  <% end %>
-<% end %>
-
 <%= render "placements/primary_navigation", organisation: @school, current_navigation: :organisation_details %>
 
 <div class="govuk-width-container">

--- a/app/views/placements/schools/users/check.html.erb
+++ b/app/views/placements/schools/users/check.html.erb
@@ -1,12 +1,4 @@
 <%= content_for :page_title, t(".page_title") %>
-<% if current_user.organisation_count > 1 %>
-  <%= content_for(:header_content) do %>
-    <%= render(ContentHeaderComponent.new(
-      title: @organisation.name,
-      actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
-    )) %>
-  <% end %>
-<% end %>
 <%= render "placements/primary_navigation", current_navigation: :users, organisation: @organisation %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: new_placements_school_user_path(

--- a/app/views/placements/schools/users/index.html.erb
+++ b/app/views/placements/schools/users/index.html.erb
@@ -1,13 +1,5 @@
-<% content_for(:page_title) { t(".users") } %>
-<% if current_user.organisation_count > 1 %>
-  <%= content_for(:header_content) do %>
-    <%= render(ContentHeaderComponent.new(
-      title: @organisation.name,
-      actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
-    )) %>
-  <% end %>
-<% end %>
 <%= render "placements/primary_navigation", organisation: @organisation, current_navigation: :users %>
+<% content_for(:page_title) { t(".users") } %>
 
 <div class="govuk-width-container">
   <h1 class="govuk-heading-l"><%= t(".users") %></h1>

--- a/app/views/placements/schools/users/new.html.erb
+++ b/app/views/placements/schools/users/new.html.erb
@@ -1,13 +1,5 @@
 <%= content_for :page_title, @user_form.errors.any? ? t(".page_title_with_error") : t(".page_title") %>
 <%= render "placements/primary_navigation", current_navigation: :users, organisation: @organisation %>
-<% if current_user.organisation_count > 1 %>
-  <%= content_for(:header_content) do %>
-    <%= render(ContentHeaderComponent.new(
-      title: @organisation.name,
-      actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
-    )) %>
-  <% end %>
-<% end %>
 
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: placements_school_users_path(@organisation)) %>

--- a/app/views/placements/schools/users/remove.html.erb
+++ b/app/views/placements/schools/users/remove.html.erb
@@ -1,12 +1,4 @@
 <%= content_for :page_title, sanitize(t(".page_title", user_name: @user.full_name, organisation_name: @organisation.name)) %>
-<% if current_user.organisation_count > 1 %>
-  <%= content_for(:header_content) do %>
-    <%= render(ContentHeaderComponent.new(
-      title: @organisation.name,
-      actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
-    )) %>
-  <% end %>
-<% end %>
 <%= render "placements/primary_navigation", organisation: @organisation, current_navigation: :users %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: placements_school_user_path(@organisation, @user)) %>

--- a/app/views/placements/schools/users/remove.html.erb
+++ b/app/views/placements/schools/users/remove.html.erb
@@ -1,0 +1,33 @@
+<%= content_for :page_title, sanitize(t(".page_title", user_name: @user.full_name, organisation_name: @organisation.name)) %>
+<% if current_user.organisation_count > 1 %>
+  <%= content_for(:header_content) do %>
+    <%= render(ContentHeaderComponent.new(
+      title: @organisation.name,
+      actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
+    )) %>
+  <% end %>
+<% end %>
+<%= render "placements/primary_navigation", organisation: @organisation, current_navigation: :users %>
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: placements_school_user_path(@organisation, @user)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <label class="govuk-label govuk-label--l">
+        <span class="govuk-caption-l"><%= @user.full_name.to_s %></span>
+        <%= t(".are_you_sure") %>
+      </label>
+      <%= render GovukComponent::WarningTextComponent.new(
+        text: t(".user_will_be_sent_an_email", organisation_name: @organisation.name),
+      ) %>
+
+      <%= govuk_button_to t(".remove_user"), placements_school_user_path(@organisation, @user), warning: true, method: :delete %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to(t(".cancel"), placements_school_user_path(@organisation, @user)) %>
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/placements/schools/users/show.html.erb
+++ b/app/views/placements/schools/users/show.html.erb
@@ -9,7 +9,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "placements/organisations/users/details", user: @user %>
-      <% unless current_user == @user %>
+      <% if policy(@user).destroy? %>
         <%= link_to(t(".remove_user"),
                     remove_placements_school_user_path(@organisation, @user),
                     class: "govuk-link govuk-link--no-visited-state app-link--destructive") %>

--- a/app/views/placements/schools/users/show.html.erb
+++ b/app/views/placements/schools/users/show.html.erb
@@ -1,13 +1,5 @@
-<% if current_user.organisation_count > 1 %>
-  <%= content_for(:header_content) do %>
-    <%= render(ContentHeaderComponent.new(
-      title: @organisation.name,
-      actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
-    )) %>
-  <% end %>
-<% end %>
-<%= render "placements/primary_navigation", organisation: @organisation, current_navigation: :users %>
 <%= content_for :page_title, sanitize(@user.full_name) %>
+<%= render "placements/primary_navigation", organisation: @organisation, current_navigation: :users %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: placements_school_users_path(@organisation)) %>
 <% end %>

--- a/app/views/placements/schools/users/show.html.erb
+++ b/app/views/placements/schools/users/show.html.erb
@@ -17,6 +17,11 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "placements/organisations/users/details", user: @user %>
+      <% unless current_user == @user %>
+        <%= link_to(t(".remove_user"),
+                    remove_placements_school_user_path(@organisation, @user),
+                    class: "govuk-link govuk-link--no-visited-state app-link--destructive") %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/config/locales/en/placements/primary_navigation.yml
+++ b/config/locales/en/placements/primary_navigation.yml
@@ -1,6 +1,7 @@
 en:
   placements:
     primary_navigation:
+      change_organisation: Change organisation
       placements: Placements
       mentors: Mentors
       users: Users

--- a/config/locales/en/placements/providers/users.yml
+++ b/config/locales/en/placements/providers/users.yml
@@ -18,5 +18,16 @@ en:
           add_user: Add user
         show:
           change_organisation: Change organisation
+          remove_user: Remove user
         create:
           user_added: User added
+        destroy:
+          user_removed: User removed
+        remove:
+          page_title: Are you sure you want to remove this user? - %{user_name} - %{organisation_name}
+          are_you_sure: Are you sure you want to remove this user?
+          remove_user: Remove user
+          cancel: Cancel
+          change_organisation: Change organisation
+          user_will_be_sent_an_email: The user will be sent an email to tell them you removed them from %{organisation_name}
+        you_cannot_perform_this_action: You cannot perform this action

--- a/config/locales/en/placements/schools/users.yml
+++ b/config/locales/en/placements/schools/users.yml
@@ -18,5 +18,16 @@ en:
           add_user: Add user
         show:
           change_organisation: Change organisation
+          remove_user: Remove user
         create:
           user_added: User added
+        destroy:
+          user_removed: User removed
+        remove:
+          page_title: Are you sure you want to remove this user? - %{user_name} - %{organisation_name}
+          are_you_sure: Are you sure you want to remove this user?
+          remove_user: Remove user
+          cancel: Cancel
+          change_organisation: Change organisation
+          user_will_be_sent_an_email: The user will be sent an email to tell them you removed them from %{organisation_name}
+        you_cannot_perform_this_action: You cannot perform this action

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -54,16 +54,18 @@ scope module: :placements,
   resources :organisations, only: [:index]
   resources :schools, only: %i[show] do
     scope module: :schools do
-      resources :users, only: %i[index new create show] do
-        get :check, on: :collection
+      resources :users, only: %i[index new create show destroy] do
+        member { get :remove }
+        collection { get :check }
       end
     end
   end
 
   resources :providers, only: [:show] do
     scope module: :providers do
-      resources :users, only: %i[index new create show] do
-        get :check, on: :collection
+      resources :users, only: %i[index new create show destroy] do
+        member { get :remove }
+        collection { get :check }
       end
     end
   end

--- a/spec/policies/placements/user_policy_spec.rb
+++ b/spec/policies/placements/user_policy_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Placements::UserPolicy do
+  subject { described_class.new(current_user, user).destroy? }
+
+  context "where current user and user are the the same user" do
+    let(:current_user) { create(:placements_user) }
+    let(:user) { current_user }
+
+    it "returns false, user cannot destroy themselves" do
+      expect(subject).to eq false
+    end
+  end
+
+  context "where current user and user are different users" do
+    let(:current_user) { create(:placements_user) }
+    let(:user) { create(:placements_user) }
+
+    it "returns true, user can destroy other users" do
+      expect(subject).to eq true
+    end
+  end
+end

--- a/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
+++ b/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
 
     scenario "I try to remove myself from a school" do
       given_i_am_signed_in_as_mary
-      when_i_try_to_visit_the_remove_path_form_myself(mary, school)
+      when_i_try_to_visit_the_remove_path_for(mary, school)
       then_i_am_redirected_to_the_index_page(school)
     end
   end
@@ -60,7 +60,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
 
     scenario "I try to remove myself from a school" do
       given_i_am_signed_in_as_mary
-      when_i_try_to_visit_the_remove_path_form_myself(mary, provider)
+      when_i_try_to_visit_the_remove_path_for(mary, provider)
       then_i_am_redirected_to_the_index_page(provider)
     end
   end
@@ -90,7 +90,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
     click_on user.full_name
   end
 
-  def when_i_try_to_visit_the_remove_path_form_myself(user, organisation)
+  def when_i_try_to_visit_the_remove_path_for(user, organisation)
     case organisation
     when School
       visit remove_placements_school_user_path(organisation, user)

--- a/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
+++ b/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
@@ -68,8 +68,9 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
   private
 
   def given_i_am_signed_in_as_mary
-    visit personas_path
-    click_on "Sign In as Mary"
+    user_exists_in_dfe_sign_in(user: mary)
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
   end
 
   def and_message_is_sent_to_user(user, organisation)

--- a/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
+++ b/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
@@ -1,0 +1,150 @@
+require "rails_helper"
+
+RSpec.describe "Placements support user removes a user from an organisation", type: :system, service: :placements do
+  describe "schools" do
+    let(:school) { create(:placements_school) }
+    let(:anne) { create(:placements_user, :anne) }
+    let(:mary) { create(:placements_user, :mary) }
+
+    before do
+      [anne, mary].each do |user|
+        create(:membership, user:, organisation: school)
+      end
+    end
+
+    scenario "user is removed from a school" do
+      given_i_am_signed_in_as_mary
+      and_i_visit_the_user_page(anne)
+      when_i_click_on("Remove user")
+      then_i_am_asked_to_confirm(anne, school)
+      when_i_click_on("Cancel")
+      then_i_return_to_user_page(anne, school)
+      when_i_click_on("Remove user")
+      then_i_am_asked_to_confirm(anne, school)
+      when_i_click_on("Remove user")
+      then_the_the_user_is_removed_from_the_organisation(anne, school)
+      and_message_is_sent_to_user(anne, school)
+    end
+
+    scenario "I try to remove myself from a school" do
+      given_i_am_signed_in_as_mary
+      when_i_try_to_visit_the_remove_path_form_myself(mary, school)
+      then_i_am_redirected_to_the_index_page(school)
+    end
+  end
+
+  describe "providers" do
+    let(:provider) { create(:placements_provider) }
+    let(:anne) { create(:placements_user, :anne) }
+    let(:mary) { create(:placements_user, :mary) }
+
+    before "message is sent to user" do
+      [anne, mary].each do |user|
+        create(:membership, user:, organisation: provider)
+      end
+    end
+
+    scenario "user is removed from a school" do
+      given_i_am_signed_in_as_mary
+      and_i_visit_the_user_page(anne)
+      when_i_click_on("Remove user")
+      then_i_am_asked_to_confirm(anne, provider)
+      when_i_click_on("Cancel")
+      then_i_return_to_user_page(anne, provider)
+      when_i_click_on("Remove user")
+      then_i_am_asked_to_confirm(anne, provider)
+      when_i_click_on("Remove user")
+      then_the_the_user_is_removed_from_the_organisation(anne, provider)
+      and_message_is_sent_to_user(anne, provider)
+    end
+
+    scenario "I try to remove myself from a school" do
+      given_i_am_signed_in_as_mary
+      when_i_try_to_visit_the_remove_path_form_myself(mary, provider)
+      then_i_am_redirected_to_the_index_page(provider)
+    end
+  end
+
+  private
+
+  def given_i_am_signed_in_as_mary
+    visit personas_path
+    click_on "Sign In as Mary"
+  end
+
+  def and_message_is_sent_to_user(user, organisation)
+    email = ActionMailer::Base.deliveries.find do |delivery|
+      delivery.to.include?(user.email) && delivery.subject == "You have been removed from #{organisation.name}"
+    end
+
+    expect(email).to_not be_nil
+  end
+
+  def when_i_click_on(text)
+    click_on text
+  end
+
+  def and_i_visit_the_user_page(user)
+    click_on "Users"
+    click_on user.full_name
+  end
+
+  def when_i_try_to_visit_the_remove_path_form_myself(user, organisation)
+    case organisation
+    when School
+      visit remove_placements_school_user_path(organisation, user)
+    when Provider
+      visit remove_placements_provider_user_path(organisation, user)
+    end
+  end
+
+  def then_i_am_redirected_to_the_index_page(organisation)
+    case organisation
+    when School
+      expect(current_path).to eq placements_school_users_path(organisation)
+    when Provider
+      expect(current_path).to eq placements_provider_users_path(organisation)
+    end
+
+    expect(page).to have_content "You cannot perform this action"
+  end
+
+  def then_i_am_asked_to_confirm(user, organisation)
+    users_is_selected_in_primary_nav
+    expect(page).to have_title(
+      "Are you sure you want to remove this user? - #{user.full_name} - #{organisation.name} - Manage school placements",
+    )
+    expect(page).to have_content user.full_name.to_s
+    expect(page).to have_content "Are you sure you want to remove this user?"
+    expect(page).to have_content "The user will be sent an email to tell them you removed them from #{organisation.name}"
+  end
+
+  def users_is_selected_in_primary_nav
+    within(".app-primary-navigation__nav") do
+      expect(page).to have_link "Placements", current: "false"
+      expect(page).to have_link "Mentors", current: "false"
+      expect(page).to have_link "Users", current: "page"
+      expect(page).to have_link "Organisation details", current: "false"
+    end
+  end
+
+  def then_i_return_to_user_page(user, organisation)
+    users_is_selected_in_primary_nav
+    case organisation
+    when School
+      expect(current_path).to eq placements_school_user_path(organisation, user)
+    when Provider
+      expect(current_path).to eq placements_provider_user_path(organisation, user)
+    end
+  end
+
+  def then_the_the_user_is_removed_from_the_organisation(user, organisation)
+    users_is_selected_in_primary_nav
+    expect(user.memberships.find_by(organisation:)).to eq nil
+    within(".govuk-notification-banner__content") do
+      expect(page).to have_content "User removed"
+    end
+
+    expect(page).to_not have_content user.full_name
+  end
+end

--- a/spec/system/placements/organisations/users/user_views_other_users_spec.rb
+++ b/spec/system/placements/organisations/users/user_views_other_users_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe "Placements user views other users in their organisation", type: 
       then_i_see_the_organisation_users
       when_i_click_on_a_users_name(mary.full_name)
       then_i_see_user_details(user: mary)
+      and_i_do_not_see_the_remove_user_link
+      when_i_click_back
+      when_i_click_on_a_users_name(anne.full_name)
+      then_i_see_user_details(user: anne)
+      and_i_see_the_remove_user_link
     end
   end
 
@@ -23,8 +28,13 @@ RSpec.describe "Placements user views other users in their organisation", type: 
       given_users_have_been_assigned_to_the(organisation: provider)
       when_i_visit_the_users_page
       then_i_see_the_organisation_users
+      when_i_click_on_a_users_name(mary.full_name)
+      then_i_see_user_details(user: mary)
+      and_i_see_the_remove_user_link
+      when_i_click_back
       when_i_click_on_a_users_name(anne.full_name)
       then_i_see_user_details(user: anne)
+      and_i_do_not_see_the_remove_user_link
     end
   end
 
@@ -57,6 +67,10 @@ RSpec.describe "Placements user views other users in their organisation", type: 
     click_on user_name
   end
 
+  def when_i_click_back
+    click_on "Back"
+  end
+
   def then_i_see_user_details(user:)
     users_is_selected_in_navigation
     expect(page).to have_content "First name"
@@ -67,6 +81,14 @@ RSpec.describe "Placements user views other users in their organisation", type: 
 
     expect(page).to have_content "Email address"
     expect(page).to have_content user.email
+  end
+
+  def and_i_see_the_remove_user_link
+    expect(page).to have_link "Remove user"
+  end
+
+  def and_i_do_not_see_the_remove_user_link
+    expect(page).to_not have_link "Remove user"
   end
 
   def users_is_selected_in_navigation


### PR DESCRIPTION
## Context

Users should be allowed to remove other users from their organisations
They should *not* be allowed to remove themselves.

## Changes proposed in this pull request

Controllers, views, specs for users 
Also moved the "Change organisation" component to the primary nav for non-support users. So the views are just a little cleaner and less repetitive.

## Guidance to review

Login as a placements user (non support)
View the user you are logged in as 
You should *not* see the Remove user link
Go back

View a user that is not you.
You should see the Remove user link
And you should be able to remove the user.

Do this all for both providers and schools.


## Link to Trello card

https://trello.com/c/294x8A8L

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/c8419fb7-59b5-48af-9bdf-b2e204e0c2ea


