### PR TITLE
Add GOV.UK to page titles

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
-    <title><%= [yield(:page_title).presence, service_name].compact.join(" - ") %></title>
+    <title><%= [yield(:page_title).presence, service_name, "GOV.UK"].compact.join(" - ") %></title>
 
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>


### PR DESCRIPTION
## Context

Our page titles should end with "GOV.UK"

## Changes proposed in this pull request

- Add a hardcoded "GOV.UK" string to the `application.html.erb` title tag.

## Guidance to review

- All pages should end in "GOV.UK"
