### PR TITLE
Add CRU for Placement Support Users

### DIFF
--- a/app/controllers/placements/support/support_users_controller.rb
+++ b/app/controllers/placements/support/support_users_controller.rb
@@ -1,0 +1,51 @@
+class Placements::Support::SupportUsersController < Placements::Support::ApplicationController
+  before_action :set_support_user, only: %i[show]
+
+  def index
+    @support_users = Placements::SupportUser.order(created_at: :desc)
+  end
+
+  def new
+    @support_user = if params[:support_user].present?
+                      Placements::SupportUser.new(support_user_params)
+                    else
+                      Placements::SupportUser.new
+                    end
+  end
+
+  def check
+    @support_user = Placements::SupportUser.new(support_user_params)
+
+    render :new unless @support_user.valid?
+  end
+
+  def create
+    @support_user = Placements::SupportUser.new(support_user_params)
+
+    if SupportUser::Invite.call(support_user: @support_user)
+      redirect_to placements_support_support_users_path, flash: { success: t(".success") }
+    else
+      render :check
+    end
+  end
+
+  def show; end
+
+  def remove; end
+
+  def destroy
+    RemoveUserService.call(@user, @organisation)
+    redirect_to_index
+    flash[:success] = t(".user_removed")
+  end
+
+  private
+
+  def support_user_params
+    @support_user_params ||= params.require(:support_user).permit(:first_name, :last_name, :email)
+  end
+
+  def set_support_user
+    @support_user = Placements::SupportUser.find(params.require(:id))
+  end
+end

--- a/app/helpers/routes_helper.rb
+++ b/app/helpers/routes_helper.rb
@@ -23,7 +23,7 @@ module RoutesHelper
   def support_support_users_path
     {
       claims: claims_support_support_users_path,
-      placements: placements_support_root_path,
+      placements: placements_support_support_users_path,
     }.fetch current_service
   end
 

--- a/app/views/placements/support/support_users/check.html.erb
+++ b/app/views/placements/support/support_users/check.html.erb
@@ -1,0 +1,57 @@
+<% content_for(:page_title) { t(".page_title") } %>
+
+<%= render "placements/support/primary_navigation", current_navigation: :users %>
+
+<% back_href = new_placements_support_support_user_path({ support_user: @support_user_params }) %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: back_href) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= form_with(model: @support_user, scope: :support_user, url: placements_support_support_users_path, method: :post) do |f| %>
+        <%= f.hidden_field :first_name, value: f.object.first_name %>
+        <%= f.hidden_field :last_name, value: f.object.last_name %>
+        <%= f.hidden_field :email, value: f.object.email %>
+
+        <label class="govuk-label govuk-label--l">
+          <span class="govuk-caption-l"><%= t(".caption") %></span>
+          <%= t(".title") %>
+        </label>
+
+        <%= govuk_summary_list do |summary_list| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: User.human_attribute_name(:first_name)) %>
+            <% row.with_value(text: f.object.first_name) %>
+            <% row.with_action(text: t(".change"), href: back_href, visually_hidden_text: f.object.first_name) %>
+          <% end %>
+
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: User.human_attribute_name(:last_name)) %>
+            <% row.with_value(text: f.object.last_name) %>
+            <% row.with_action(text: t(".change"), href: back_href, visually_hidden_text: f.object.last_name) %>
+          <% end %>
+
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: User.human_attribute_name(:email)) %>
+            <% row.with_value(text: f.object.email) %>
+            <% row.with_action(text: t(".change"), href: back_href, visually_hidden_text: f.object.email) %>
+          <% end %>
+        <% end %>
+
+        <div class="govuk-warning-text">
+          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+          <strong class="govuk-warning-text__text"><%= t(".warning") %></strong>
+        </div>
+
+        <%= f.govuk_submit t(".submit") %>
+
+        <p class="govuk-body">
+          <%= govuk_link_to(t(".cancel"), placements_support_support_users_path) %>
+        </p>
+      <% end %>
+    <div>
+  <div>
+</div>

--- a/app/views/placements/support/support_users/index.html.erb
+++ b/app/views/placements/support/support_users/index.html.erb
@@ -1,0 +1,30 @@
+<% content_for(:page_title) { t(".page_title") } %>
+<%= render "placements/support/primary_navigation", current_navigation: :users %>
+
+<div class="govuk-width-container">
+  <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+
+  <%= govuk_button_to t(".add_user"), new_placements_support_support_user_path, method: :get %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= govuk_table do |table| %>
+        <% table.with_head do |head| %>
+          <% head.with_row do |row| %>
+            <% row.with_cell(text: User.human_attribute_name(:name), width: "govuk-!-width-one-third") %>
+            <% row.with_cell(text: User.human_attribute_name(:email)) %>
+          <% end %>
+        <% end %>
+
+        <% table.with_body do |body| %>
+          <% @support_users.each do |user| %>
+            <% body.with_row do |row| %>
+              <% row.with_cell(text: link_to(user.full_name, placements_support_support_user_path(user), class: "govuk-link govuk-heading-s govuk-!-margin-bottom-0")) %>
+              <% row.with_cell(text: user.email) %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/placements/support/support_users/new.html.erb
+++ b/app/views/placements/support/support_users/new.html.erb
@@ -1,0 +1,44 @@
+<% content_for(:page_title) { @support_user.errors.empty? ? t(".page_title") : t(".page_title_with_errors") } %>
+
+<%= render "placements/support/primary_navigation", current_navigation: :users %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: placements_support_support_users_path) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= form_with(model: @support_user, scope: :support_user, url: check_placements_support_support_users_path, method: "get") do |f| %>
+    <%= f.govuk_error_summary %>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <span class="govuk-caption-l"><%= t(".caption") %></span>
+        <h2 class="govuk-heading-l"><%= t(".title") %></h2>
+
+        <div class="govuk-form-group">
+          <%= f.govuk_text_field :first_name,
+                                  class: "govuk-input--width-20",
+                                  label: { text: User.human_attribute_name(:first_name), size: "s" } %>
+        </div>
+
+        <div class="govuk-form-group">
+          <%= f.govuk_text_field :last_name,
+                                  class: "govuk-input--width-20",
+                                  label: { text: User.human_attribute_name(:last_name), size: "s" } %>
+        </div>
+
+        <div class="govuk-form-group">
+          <%= f.govuk_text_field :email,
+                                 label: { text: User.human_attribute_name(:email), size: "s" },
+                                 hint: { text: t(".attributes.email.hint") } %>
+        </div>
+
+        <%= f.govuk_submit t(".submit") %>
+
+        <p class="govuk-body">
+          <%= govuk_link_to(t(".cancel"), placements_support_support_users_path) %>
+        </p>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/placements/support/support_users/show.html.erb
+++ b/app/views/placements/support/support_users/show.html.erb
@@ -1,0 +1,32 @@
+<% content_for(:page_title) { @support_user.full_name } %>
+
+<%= render "placements/support/primary_navigation", current_navigation: :users %>
+
+<% content_for(:before_content) do %>
+  <%= govuk_back_link href: placements_support_support_users_path %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= @support_user.full_name %></h1>
+
+      <%= govuk_summary_list do |summary_list| %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: User.human_attribute_name(:first_name)) %>
+          <% row.with_value(text: @support_user.first_name) %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: User.human_attribute_name(:last_name)) %>
+          <% row.with_value(text: @support_user.last_name) %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: User.human_attribute_name(:email)) %>
+          <% row.with_value(text: @support_user.email) %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/locales/en/placements/support/support_users.yml
+++ b/config/locales/en/placements/support/support_users.yml
@@ -1,0 +1,30 @@
+en:
+  placements:
+    support:
+      support_users:
+        index:
+          page_title: Users
+          add_user: Add user
+          heading: Users
+        new:
+          page_title: Personal details - Add user
+          page_title_with_errors: "Error: Personal details - Add user"
+          caption: Add user
+          title: Personal details
+          submit: Continue
+          cancel: Cancel
+          attributes:
+            email:
+              hint: Email must be a valid Department for Education address, like name@education.gov.uk
+        check:
+          page_title: Check your answers - Add user
+          caption: Add user
+          title: Check your answers
+          submit: Add user
+          cancel: Cancel
+          change: Change
+          warning: The user will be sent an email to tell them you’ve added them to Manage school placements.
+        create:
+          success: User added
+        show:
+          change: Change

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -12,6 +12,10 @@ scope module: :placements,
   namespace :support do
     root to: redirect("/support/organisations")
 
+    resources :support_users do
+      collection { get :check }
+    end
+
     resources :organisations, only: %i[index new] do
       collection { get :select_type }
     end

--- a/spec/system/placements/support/support_users/support_user_adds_a_support_user_spec.rb
+++ b/spec/system/placements/support/support_users/support_user_adds_a_support_user_spec.rb
@@ -1,0 +1,130 @@
+require "rails_helper"
+
+RSpec.describe "Placements / Support Users / Support user adds a support user",
+               type: :system,
+               service: :placements do
+  include ActiveJob::TestHelper
+
+  around do |example|
+    perform_enqueued_jobs { example.run }
+  end
+
+  let!(:support_user) { create(:placements_support_user, :colin) }
+
+  scenario "Add a support user" do
+    when_i_sign_in_as_a_support_user(support_user)
+    and_i_visit_the_support_users_page
+    and_i_click_on_add_a_support_user
+    then_i_fill_in_the_support_user_form(email_address: "john.doe@education.gov.uk")
+    i_am_redirected_to_check_the_support_user_details
+    then_i_click_on_add_user
+    i_see_the_support_user_has_been_added(email_address: "john.doe@education.gov.uk")
+    and_an_email_is_sent_to_the_support_user(email_address: "john.doe@education.gov.uk")
+  end
+
+  scenario "Attempt to add a support user without an @education.gov.uk email address" do
+    when_i_sign_in_as_a_support_user(support_user)
+    and_i_visit_the_support_users_page
+    and_i_click_on_add_a_support_user
+    then_i_fill_in_the_support_user_form(email_address: "john.doe@example.com")
+    then_i_see_an_error("Enter a Department for Education email address in the correct format, like name@education.gov.uk")
+    and_the_page_title_is("Error: Personal details - Add user - Manage school placements")
+  end
+
+  scenario "Attempt to add a support user with an email that already exists in the system" do
+    given_there_is_a_support_user_with(email_address: "john.doe@education.gov.uk")
+    when_i_sign_in_as_a_support_user(support_user)
+    and_i_visit_the_support_users_page
+    and_i_click_on_add_a_support_user
+    then_i_fill_in_the_support_user_form(email_address: "john.doe@education.gov.uk")
+    then_i_see_an_error("Email address already in use")
+    and_the_page_title_is("Error: Personal details - Add user - Manage school placements")
+  end
+
+  scenario "Make changes while adding a support user" do
+    when_i_sign_in_as_a_support_user(support_user)
+    and_i_visit_the_support_users_page
+    and_i_click_on_add_a_support_user
+    then_i_fill_in_the_support_user_form(email_address: "john.doe@education.gov.uk")
+    then_i_click_on_a_change_link
+    i_should_see_the_support_user_form_with(email_address: "john.doe@education.gov.uk")
+    then_i_fill_in_the_support_user_form(email_address: "jane.doe@education.gov.uk")
+    then_i_click_on_add_user
+    i_see_the_support_user_has_been_added(email_address: "jane.doe@education.gov.uk")
+    and_an_email_is_sent_to_the_support_user(email_address: "jane.doe@education.gov.uk")
+  end
+
+  private
+
+  def given_there_is_a_support_user_with(email_address:)
+    create(:placements_support_user, email: email_address)
+  end
+
+  def when_i_sign_in_as_a_support_user(support_user)
+    visit placements_root_path
+    click_on "Sign in using a Persona"
+    click_on "Sign In as #{support_user.first_name}"
+  end
+
+  def and_i_visit_the_support_users_page
+    within(".app-primary-navigation nav") do
+      click_on "Users"
+    end
+  end
+
+  def and_i_click_on_add_a_support_user
+    click_on "Add user"
+  end
+
+  def then_i_fill_in_the_support_user_form(email_address:)
+    fill_in "First name", with: "John"
+    fill_in "Last name", with: "Doe"
+    fill_in "Email address", with: email_address
+
+    click_on "Continue"
+  end
+
+  def i_am_redirected_to_check_the_support_user_details
+    expect(page).to have_content "Check your answers"
+
+    expect(page).to have_content "John"
+    expect(page).to have_content "Doe"
+    expect(page).to have_content "john.doe@education.gov.uk"
+  end
+
+  def then_i_click_on_add_user
+    click_on "Add user"
+  end
+
+  def i_see_the_support_user_has_been_added(email_address:)
+    expect(page).to have_content "User added"
+    expect(page).to have_content email_address
+  end
+
+  def and_an_email_is_sent_to_the_support_user(email_address:)
+    email = ActionMailer::Base.deliveries.find do |delivery|
+      delivery.to.include?(email_address) && delivery.subject == "Invitation to join Manage school placements"
+    end
+
+    expect(email).to_not be_nil
+  end
+
+  def then_i_click_on_a_change_link
+    click_on "Change", match: :first
+  end
+
+  def i_should_see_the_support_user_form_with(email_address:)
+    within("form") do
+      expect(page).to have_field("support_user[email]", with: email_address)
+    end
+  end
+
+  def then_i_see_an_error(message)
+    expect(page).to have_content "There is a problem"
+    expect(page).to have_content message, count: 2
+  end
+
+  def and_the_page_title_is(title)
+    expect(page).to have_title title
+  end
+end

--- a/spec/system/placements/support/support_users/support_user_views_a_support_user_spec.rb
+++ b/spec/system/placements/support/support_users/support_user_views_a_support_user_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe "Placements / Support Users / Support user views a support user", type: :system, service: :placements do
+  let!(:support_user) { create(:placements_support_user, :colin) }
+
+  scenario "View a support user" do
+    when_i_sign_in_as_a_support_user(support_user)
+    and_i_visit_the_support_users_page
+    and_i_click_on_a_support_user(support_user)
+    i_see_the_details_of_the_support_user(support_user)
+  end
+
+  private
+
+  def when_i_sign_in_as_a_support_user(support_user)
+    visit placements_root_path
+    click_on "Sign in using a Persona"
+    click_on "Sign In as #{support_user.first_name}"
+  end
+
+  def and_i_visit_the_support_users_page
+    within(".app-primary-navigation nav") do
+      click_on "Users"
+    end
+  end
+
+  def and_i_click_on_a_support_user(_support_user)
+    click_on "Colin Chapman"
+  end
+
+  def i_see_the_details_of_the_support_user(_support_user)
+    expect(page).to have_selector("h1", text: "Colin Chapman")
+
+    expect(page).to have_content "Colin"
+    expect(page).to have_content "Chapman"
+    expect(page).to have_content "colin.chapman@education.gov.uk"
+  end
+end

--- a/spec/system/placements/support/support_users/support_user_views_support_users_spec.rb
+++ b/spec/system/placements/support/support_users/support_user_views_support_users_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe "Placements / Support Users / Support user views support users",
+               type: :system,
+               service: :placements do
+  let!(:support_user) { create(:placements_support_user, :colin, created_at: "2024-02-01") }
+  let!(:support_user_2) { create(:placements_support_user, created_at: "2024-01-01") }
+
+  scenario "View list of all support users" do
+    when_i_sign_in_as_a_support_user(support_user)
+    and_i_visit_the_support_users_page
+    i_see_the_list_of_all_support_users_ordered_by_latest_created_at_first
+  end
+
+  private
+
+  def when_i_sign_in_as_a_support_user(support_user)
+    visit placements_root_path
+    click_on "Sign in using a Persona"
+    click_on "Sign In as #{support_user.first_name}"
+  end
+
+  def and_i_visit_the_support_users_page
+    within(".app-primary-navigation nav") do
+      click_on "Users"
+    end
+  end
+
+  def i_see_the_list_of_all_support_users_ordered_by_latest_created_at_first
+    expect(page).to have_selector("tbody tr", count: 2)
+
+    within("tbody tr:nth-child(1)") do
+      expect(page).to have_selector("td", text: support_user.full_name)
+      expect(page).to have_selector("td", text: support_user.email)
+    end
+
+    within("tbody tr:nth-child(2)") do
+      expect(page).to have_selector("td", text: support_user_2.full_name)
+      expect(page).to have_selector("td", text: support_user_2.email)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Support Users will be able to onboard other support users (placements).

## Changes proposed in this pull request

- Add the controllers/views/routes to allow Placement Support Users to add other Support Users.

## Guidance to review

(On Placements Service)
- Login in as Support User Colin
- Click "Users" in the navigation
- This will display a list of Support Users (including Colin)
- Click "Add user"
- Fill in the form, using an email address ending in "@education.gov.uk"
- (Feel free to test form validation)
- Click "Continue"
- This will direct you to the "Check your answers" page
- Click "Add user"
- User should be added successfully
- Click on the name of the new Support User you have added
- This will direct you the the Support User show page.
- You should see the User's details here.

## Link to Trello card

https://trello.com/c/qmhJnd3t/143-support-user-crud

## Screenshots

https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/d78ec1b8-1161-49ac-b090-cacf7217ff41



