### PR TITLE
Update importer to associate_schools_to_regions

### DIFF
--- a/app/services/gias_csv_importer.rb
+++ b/app/services/gias_csv_importer.rb
@@ -4,6 +4,80 @@ class GiasCsvImporter
   include ServicePattern
   OPEN_SCHOOL = "1".freeze
   NON_ENGLISH_ESTABLISHMENTS = %w[8 10 25 24 26 27 29 30 32 37 49 56 57].freeze
+  INNER_LONDON_AREAS = [
+    "E09000002", # Barking and Dagenham
+    "E09000005", # Brent
+    "E09000007", # Camden
+    "E09000001", # City of London
+    "E09000009", # Ealing
+    "E09000011", # Greenwhich
+    "E09000012", # Hackney
+    "E09000013", # Hammersmith and Fulham
+    "E09000014", # Haringey
+    "E09000019", # Islington
+    "E09000020", # Kensington and Chelsea
+    "E09000022", # Lambeth
+    "E09000023", # Lewisham
+    "E09000024", # Merton
+    "E09000025", # Newham
+    "E09000028", # Southwark
+    "E09000030", # Tower Hamlets
+    "E09000032", # Wandsworth
+    "E09000033", # Westminster
+  ].freeze
+
+  OUTER_LONDON_AREAS = [
+    "E09000003", # Barnet
+    "E09000004", # Bexley
+    "E09000006", # Bromley
+    "E09000008", # Croydon
+    "E09000010", # Enfield
+    "E09000015", # Harrow
+    "E09000016", # Havering
+    "E09000017", # Hillingdon
+    "E09000018", # Hounslow
+    "E09000021", # Kingston upon Thames
+    "E09000026", # Redbridge
+    "E09000027", # Richmond upon Thames
+    "E09000029", # Sutton
+    "E09000031", # Waltham Forest
+  ].freeze
+
+  FRINGE_AREAS = [
+    "E06000036", # Bracknell Forest
+    "E06000039", # Slough
+    "E06000040", # Windsor and Maidenhead
+    "E07000006", # South Bucks
+    "E07000005", # Chiltern
+    "E07000066", # Basildon
+    "E07000068", # Brentwood
+    "E07000072", # Epping Forest
+    "E07000073", # Harlow
+    "E06000034", # Thurrock
+    "E07000095", # Broxbourne
+    "E07000096", # Dacorum
+    "E07000242", # East Hertfordshire
+    "E07000098", # Hertsmere
+    "E07000240", # St Albans
+    "E07000102", # Three Rivers
+    "E07000103", # Watford
+    "E07000241", # Welwyn Hatfield
+    "E07000107", # Dartford
+    "E07000111", # Sevenoaks
+    "E07000226", # Crawley
+    # Surrey – the whole county below
+    "E07000227", # Reigate and Banstead
+    "E07000215", # Tandridge
+    "E07000212", # Mole Valley
+    "E07000211", # Guildford
+    "E07000210", # Epsom and Ewell
+    "E07000209", # Elmbridge
+    "E07000213", # Spelthorne
+    "E07000214", # Surrey Heath
+    "E07000216", # Waverley
+    "E07000217", # Woking
+    "E07000228", # Runnymede
+  ].freeze
 
   attr_reader :csv_path
 
@@ -60,12 +134,45 @@ class GiasCsvImporter
     end
     Rails.logger.silence do
       School.upsert_all(records, unique_by: :urn)
+      associate_schools_to_regions
     end
 
     Rails.logger.info "Done!"
   end
 
   private
+
+  def associate_schools_to_regions
+    Rails.logger.debug "Associating schools to regions... "
+
+    Region.find_or_create_by!(name: "Inner London") { |region| region.claims_funding_available_per_hour = 53.60 }
+    Region.find_or_create_by!(name: "Outer London") { |region| region.claims_funding_available_per_hour = 48.25 }
+    Region.find_or_create_by!(name: "Fringe") { |region| region.claims_funding_available_per_hour = 45.10 }
+    Region.find_or_create_by!(name: "Rest of England") { |region| region.claims_funding_available_per_hour = 43.18 }
+
+    School.find_each do |school|
+      region = determine_region(school.district_admin_code)
+
+      unless school.update(region:)
+        Rails.logger.info "Failed to update region for school with ID #{school.id}"
+      end
+    end
+  end
+
+  def determine_region(district_admin_code)
+    @regions_hash ||= Region.all.index_by(&:name)
+
+    case district_admin_code
+    when *INNER_LONDON_AREAS
+      @regions_hash["Inner London"]
+    when *OUTER_LONDON_AREAS
+      @regions_hash["Outer London"]
+    when *FRINGE_AREAS
+      @regions_hash["Fringe"]
+    else
+      @regions_hash["Rest of England"]
+    end
+  end
 
   def invalid?(school)
     school["URN"].blank? || school["EstablishmentName"].blank?

--- a/spec/fixtures/test_gias_import.csv
+++ b/spec/fixtures/test_gias_import.csv
@@ -1,5 +1,8 @@
-URN,EstablishmentName,Town,Postcode,EstablishmentStatus (code),TypeOfEstablishment (code)
-123,School,Town,Postcode,1,7
-124,School,Town,Postcode,2,7
-124,School,Town,Postcode,1,8
-124,,Town,Postcode,1,7
+URN,EstablishmentName,Town,Postcode,EstablishmentStatus (code),TypeOfEstablishment (code),DistrictAdministrative (code)
+130,InnerLondonSchool,InnerLondonTown,Postcode,1,7,E09000007
+131,OuterLondonSchool,OuterLondonTown,Postcode,1,7,E09000004
+123,FringeSchool,FringeTown,Postcode,1,7,E06000039
+132,RestOfEnglandSchool,RestOfEnglandTown,Postcode,1,7,E09000099
+124,School,Town,Postcode,2,7,E06000031
+124,School,Town,Postcode,1,8,E06000031
+124,,Town,Postcode,1,7,E06000031

--- a/spec/services/gias_csv_importer_spec.rb
+++ b/spec/services/gias_csv_importer_spec.rb
@@ -4,18 +4,32 @@ RSpec.describe GiasCsvImporter do
   subject { described_class.call("spec/fixtures/test_gias_import.csv") }
 
   it "inserts the correct schools" do
-    expect { subject }.to change(School, :count).from(0).to(1)
+    expect { subject }.to change(School, :count).from(0).to(4)
   end
 
   it "updates the correct schools" do
     school = create(:school, urn: "123")
-    expect { subject }.to change { school.reload.name }.to "School"
+    expect { subject }.to change { school.reload.name }.to "FringeSchool"
   end
 
   it "logs messages to STDOUT" do
-    expect(Rails.logger).to receive(:info).with("Invalid rows - [\"Row 5 is invalid\"]")
+    expect(Rails.logger).to receive(:info).with("Invalid rows - [\"Row 8 is invalid\"]")
     expect(Rails.logger).to receive(:info).with("Done!")
 
     subject
+  end
+
+  it "associates schools to regions" do
+    subject
+
+    inner_london_school = School.find_by(urn: "130")
+    outer_london_school = School.find_by(urn: "131")
+    fringe_school = School.find_by(urn: "123")
+    rest_of_england_school = School.find_by(urn: "132")
+
+    expect(inner_london_school.region.name).to eq("Inner London")
+    expect(outer_london_school.region.name).to eq("Outer London")
+    expect(fringe_school.region.name).to eq("Fringe")
+    expect(rest_of_england_school.region.name).to eq("Rest of England")
   end
 end


### PR DESCRIPTION
## Context

This follows on from #201 where we now associate schools to regions

## Changes proposed in this pull request

Change updates the importer to now associate schools to regions

## Guidance to review

- Create the necessary regions
- Run the importer `rails gias_update RAILS_ENV=development `

## Link to Trello card

https://trello.com/c/Qa8m6wD8/129-store-the-hourly-rate-for-each-region-school

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
