### PR TITLE
Add Live Environments to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@ This application has two main services:
 - A service where schools or training providers can claim funding for internal teacher training.
 - TODO: Add description for the other service
 
+## Live Environments
+
+| Name       | URL | Purpose | AKS Namespace |
+| ---------- | --- | ------- | ------------- |
+| Production | *pending* | Public site | bat-production |
+| Sandbox    | *pending* | Demo environment for end-users | bat-production |
+| Staging    | *pending* | For internal use by DfE for testing - Production-like environment | bat-staging |
+| QA         | [Track & Pay](https://track-and-pay-qa.test.teacherservices.cloud) / [School Placements](https://manage-school-placements-qa.test.teacherservices.cloud) | For internal use by DfE for testing - Automatically deployed from main | bat-qa |
+
 ## Setup
 
 ### Prerequisites


### PR DESCRIPTION
## Context

We currently do not have a list of our live environments documented.

## Changes proposed in this pull request

Add "Live Environments" section to `README.md`.

## Guidance to review

See rendered markdown here: https://github.com/DFE-Digital/itt-mentor-services/blob/dd/add-live-environments-to-readme/README.md

or view copy below:

## Live Environments

| Name       | URL | Purpose | AKS Namespace |
| ---------- | --- | ------- | ------------- |
| Production | *pending* | Public site | bat-production |
| Sandbox    | *pending* | Demo environment for end-users | bat-production |
| Staging    | *pending* | For internal use by DfE for testing - Production-like environment | bat-staging |
| QA         | [Track & Pay](https://track-and-pay-qa.test.teacherservices.cloud) / [School Placements](https://manage-school-placements-qa.test.teacherservices.cloud) | For internal use by DfE for testing - Automatically deployed from main | bat-qa |
