### PR TITLE
Revert "WIP: list currently installed gems"

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -59,8 +59,6 @@ jobs:
         with:
           node-version: 20.9.0
           cache: "npm"
-      - name: List gems
-        run: bundle list
       - name: Run Tests
         run: |
           bundle exec rails test:prepare db:test:prepare


### PR DESCRIPTION
This reverts commit 929aeb4b0a3d3aa6c4f129f1050a28917c3c865c.

I accidentally committed this to the `main` branch rather than my feature branch – oops!

I've now configured the branch protection rules to block pushing directly to `main`.
