### PR TITLE
Detect code coverage regressions in CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -63,6 +65,13 @@ jobs:
         run: |
           bundle exec rails test:prepare db:test:prepare
           bundle exec rspec --format progress
+      - name: Upload code coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage
+          path: coverage/
+      - name: Detect missing code coverage
+        run: bundle exec undercover --compare origin/main
       - name: Upload failure screenshots
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ tmp/pids/*
 !tmp/pids/
 !tmp/pids/.keep
 
+coverage/
+
 .yarn/*
 # Ignore terraform files
 bin/terrafile

--- a/Gemfile
+++ b/Gemfile
@@ -111,9 +111,11 @@ group :test do
   gem "selenium-webdriver"
   gem "shoulda-matchers"
   gem "simplecov", require: false
+  gem "simplecov-lcov", require: false
   # launch browser when inspecting capybara specs
   gem "launchy"
   gem "timecop"
+  gem "undercover"
   gem "webmock"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -110,6 +110,7 @@ group :test do
   gem "rails-controller-testing"
   gem "selenium-webdriver"
   gem "shoulda-matchers"
+  gem "simplecov", require: false
   # launch browser when inspecting capybara specs
   gem "launchy"
   gem "timecop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,6 +208,8 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    imagen (0.1.8)
+      parser (>= 2.5, != 2.5.1.1)
     io-console (0.7.2)
     irb (1.11.1)
       rdoc
@@ -464,6 +466,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
+    rugged (1.7.1)
     selenium-webdriver (4.17.0)
       base64 (~> 0.2)
       rexml (~> 3.2, >= 3.2.5)
@@ -476,6 +479,7 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
+    simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.4)
     smart_properties (1.17.0)
     solargraph (0.50.0)
@@ -524,6 +528,11 @@ GEM
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    undercover (0.5.0)
+      bigdecimal
+      imagen (>= 0.1.8)
+      rainbow (>= 2.1, < 4.0)
+      rugged (>= 0.27, < 1.8)
     unicode-display_width (2.5.0)
     validate_email (0.1.6)
       activemodel (>= 3.0)
@@ -613,6 +622,7 @@ DEPENDENCIES
   selenium-webdriver
   shoulda-matchers
   simplecov
+  simplecov-lcov
   solargraph
   solargraph-rails
   stimulus-rails
@@ -621,6 +631,7 @@ DEPENDENCIES
   syntax_tree-rbs
   timecop
   tzinfo-data
+  undercover
   view_component
   web-console
   webmock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,7 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (1.5.1)
+    docile (1.4.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
@@ -470,6 +471,12 @@ GEM
       websocket (~> 1.0)
     shoulda-matchers (6.1.0)
       activesupport (>= 5.2.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     smart_properties (1.17.0)
     solargraph (0.50.0)
       backport (~> 1.2)
@@ -605,6 +612,7 @@ DEPENDENCIES
   rubocop-govuk
   selenium-webdriver
   shoulda-matchers
+  simplecov
   solargraph
   solargraph-rails
   stimulus-rails

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,12 @@
 # a separate helper file that requires the additional dependencies and performs
 # the additional setup, and require it from the spec files that actually need
 # it.
-#
+
+require "simplecov"
+SimpleCov.start "rails" do
+  enable_coverage :branch
+end
+
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,13 @@
 # it.
 
 require "simplecov"
+require "simplecov-html"
+require "simplecov-lcov"
+SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
+SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
+  SimpleCov::Formatter::HTMLFormatter,
+  SimpleCov::Formatter::LcovFormatter,
+])
 SimpleCov.start "rails" do
   enable_coverage :branch
 end


### PR DESCRIPTION
## Context

We've spotted a few cases of missing test coverage. While I'm not a "100% coverage" purist, I do think it's healthy for us to have access to coverage reports so we have an overall awareness of our test coverage.

## Changes proposed in this pull request

I've added two gems:

1. [SimpleCov](https://github.com/simplecov-ruby/simplecov) – the standard code coverage tool used in Ruby apps
2. [Undercover](https://github.com/grodowski/undercover) – a tool that will analyse the coverage report generated by SimpleCov, and produce friendly & readable warnings when we've forgotten to add test coverage in our branch

I've configured the CI workflow to upload the SimpleCov HTML code coverage report as a build artefact. This makes it really easy for us to see a detailed coverage report for our branches.

I've also added Undercover to the workflow so that PRs are blocked if they introduce untested code to the codebase. Admittedly this sounds like it could be annoying, because nobody wants _yet more_ things that can potentially block the CI pipeline. However in my experience of using this gem on other projects, I've rarely seen it produce false-positives or get in the way. It will merely hold us to account so we don't introduce new code without test coverage.

Error messages reported by Undercover aim to be friendly and helpful. For example, see [this output](https://github.com/DFE-Digital/itt-mentor-services/actions/runs/7789500838/job/21241267282#step:8:8) triggered by [this demo commit](https://github.com/DFE-Digital/itt-mentor-services/commit/d418fbd3089bc42470c0bf3b898cbe4582277981).

<img width="1077" alt="" src="https://github.com/DFE-Digital/itt-mentor-services/assets/7735945/d84f25ea-9830-43a9-b1dd-0b7500ca74e7">

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

No specific guidance. If you're feeling really keen, go ahead and push up a commit with some uncovered code to see how it works in practice.

## Link to Trello card

https://trello.com/c/LjtUzbiP/168-detect-code-coverage-regressions-in-ci
