### PR TITLE
Basic Support Claims index and show page

### DIFF
--- a/app/controllers/claims/support/claims_controller.rb
+++ b/app/controllers/claims/support/claims_controller.rb
@@ -1,2 +1,9 @@
 class Claims::Support::ClaimsController < Claims::Support::ApplicationController
+  def index
+    @pagy, @claims = pagy(Claim.all.order(created_at: :desc))
+  end
+
+  def show
+    @claim = Claim.find(params.require(:id))
+  end
 end

--- a/app/models/mentor.rb
+++ b/app/models/mentor.rb
@@ -22,4 +22,8 @@ class Mentor < ApplicationRecord
   belongs_to :school
 
   validates :first_name, :last_name, :trn, presence: true
+
+  def full_name
+    "#{first_name} #{last_name}".strip
+  end
 end

--- a/app/views/claims/support/claims/index.html.erb
+++ b/app/views/claims/support/claims/index.html.erb
@@ -1,5 +1,38 @@
 <%= render "claims/support/primary_navigation", current: :claims %>
+<%= content_for :page_title, t(".heading") %>
 
 <div class="govuk-width-container">
-  <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+
+    <% if @claims.any? %>
+      <%= govuk_table do |table| %>
+        <% table.with_head do |head| %>
+          <% head.with_row do |row| %>
+            <% row.with_cell(header: true, text: Claim.human_attribute_name(:id)) %>
+            <% row.with_cell(header: true, text: t(".status")) %>
+          <% end %>
+        <% end %>
+
+        <% table.with_body do |body| %>
+          <% @claims.each do |claim| %>
+            <% body.with_row do |row| %>
+              <% row.with_cell(text: govuk_link_to(claim.id, claims_support_claim_path(claim))) %>
+              <% row.with_cell(text: render(Claim::StatusTagComponent.new(claim:))) %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <%= govuk_pagination(pagy: @pagy) %>
+      <p>
+        <%= t("pagination_info", from: @pagy.from, to: @pagy.to, count: @pagy.count) %>
+      </p>
+    <% else %>
+      <p>
+        <%= t("no_records", records: "claims") %>
+      </p>
+    <% end %>
+  </div>
 </div>

--- a/app/views/claims/support/claims/show.html.erb
+++ b/app/views/claims/support/claims/show.html.erb
@@ -1,0 +1,49 @@
+<%= render "claims/support/primary_navigation", current: :claims %>
+<% content_for(:page_title) { t(".heading") } %>
+
+<% content_for(:before_content) do %>
+  <%= govuk_back_link href: claims_support_claims_path %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= t(".heading") %> <%= @claim.id %></h1>
+
+      <%= govuk_summary_list do |summary_list| %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".status")) %>
+          <% row.with_value(text: render(Claim::StatusTagComponent.new(claim: @claim))) %>
+        <% end %>
+
+        <% if @claim.providers.any? %>
+          <%= @claim.providers.each_with_index do |provider, index| %>
+            <% summary_list.with_row do |row| %>
+              <% row.with_key(text: t(".provider_with_index", index: index + 1)) %>
+              <% row.with_value(text: provider.name) %>
+            <% end %>
+          <% end %>
+        <% else %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".provider")) %>
+            <% row.with_value(text: t("none")) %>
+          <% end %>
+        <% end %>
+
+        <% if @claim.mentors.any? %>
+          <%= @claim.mentors.each_with_index do |mentor, index| %>
+            <% summary_list.with_row do |row| %>
+              <% row.with_key(text: t(".mentor_with_index", index: index + 1)) %>
+              <% row.with_value(text: mentor.full_name) %>
+            <% end %>
+          <% end %>
+        <% else %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".mentor")) %>
+            <% row.with_value(text: t("none")) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,10 +1,12 @@
 en:
   pagination_info: Showing %{from} to %{to} of %{count} results
   no_results: There are no results for '%{for}'.
+  no_records: There are no %{records}
   no_results_with_filter_and_search: There are no results for '%{for}' and the selected filter.
   no_results_with_filter: There are no results for the selected filter.
   you_cannot_perform_this_action: You cannot perform this action
   you_do_not_have_access_to_this_service: You do not have access to this service
+  none: None
   date:
     formats:
       long: "%e %B %Y"

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -6,6 +6,8 @@ en:
         last_name: Last name
         full_name: Full name
         email: Email address
+      claim:
+          id: ID
 
     errors:
       models:

--- a/config/locales/en/claims/support/claims.yml
+++ b/config/locales/en/claims/support/claims.yml
@@ -4,3 +4,11 @@ en:
       claims:
         index:
           heading: Claims
+          status: Status
+        show:
+          heading: Claim
+          status: Status
+          provider_with_index: Provider %{index}
+          provider: Provider
+          mentor_with_index: Mentor %{index}
+          mentor: Mentor

--- a/spec/models/mentor_spec.rb
+++ b/spec/models/mentor_spec.rb
@@ -32,4 +32,11 @@ RSpec.describe Mentor, type: :model do
     it { is_expected.to validate_presence_of(:last_name) }
     it { is_expected.to validate_presence_of(:trn) }
   end
+
+  describe "#full_name" do
+    it "returns the mentors full name" do
+      mentor = build(:mentor, first_name: "Jane", last_name: "Doe")
+      expect(mentor.full_name).to eq("Jane Doe")
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -41,4 +41,11 @@ RSpec.describe User, type: :model do
       expect(subject.support_user?).to eq(false)
     end
   end
+
+  describe "#full_name" do
+    it "returns the users full name" do
+      user = build(:user, first_name: "Jane", last_name: "Doe")
+      expect(user.full_name).to eq("Jane Doe")
+    end
+  end
 end

--- a/spec/system/claims/support/claims/view_a_claim_spec.rb
+++ b/spec/system/claims/support/claims/view_a_claim_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+RSpec.describe "View claims", type: :system, service: :claims do
+  let!(:support_user) { create(:claims_support_user) }
+  let(:provider) { create(:provider) }
+  let(:mentor) { create(:mentor) }
+  let!(:claim_1) { create(:claim, draft: true) }
+  let!(:claim_2) do
+    create(
+      :claim,
+      draft: false,
+      providers: [provider],
+      mentors: [mentor],
+    )
+  end
+
+  before do
+    user_exists_in_dfe_sign_in(user: support_user)
+    given_i_sign_in
+  end
+
+  scenario "Support user visists a draft claims show page" do
+    when_i_visit_claim_index_page
+    and_i_click_on_claim(claim_1)
+    i_can_see_the_details_of_a_draft_claim
+  end
+
+  scenario "Support user visists a submitted claims show page" do
+    when_i_visit_claim_index_page
+    and_i_click_on_claim(claim_2)
+    i_can_see_the_details_of_a_submitted_claim
+  end
+
+  private
+
+  def given_i_sign_in
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def when_i_visit_claim_index_page
+    click_on("Claims")
+  end
+
+  def and_i_click_on_claim(claim)
+    click_on(claim.id)
+  end
+
+  def i_can_see_the_details_of_a_draft_claim
+    expect(page).to have_content("Claims")
+
+    within(".govuk-summary-list__row:nth-child(1)") do
+      expect(page).to have_content("Status")
+      expect(page).to have_content("Draft")
+    end
+
+    within(".govuk-summary-list__row:nth-child(2)") do
+      expect(page).to have_content("Provider")
+      expect(page).to have_content("None")
+    end
+
+    within(".govuk-summary-list__row:nth-child(3)") do
+      expect(page).to have_content("Mentor")
+      expect(page).to have_content("None")
+    end
+  end
+
+  def i_can_see_the_details_of_a_submitted_claim
+    expect(page).to have_content("Claims")
+
+    within(".govuk-summary-list__row:nth-child(1)") do
+      expect(page).to have_content("Status")
+      expect(page).to have_content("Submitted")
+    end
+
+    within(".govuk-summary-list__row:nth-child(2)") do
+      expect(page).to have_content("Provider 1")
+      expect(page).to have_content(provider.name)
+    end
+
+    within(".govuk-summary-list__row:nth-child(3)") do
+      expect(page).to have_content("Mentor 1")
+      expect(page).to have_content(mentor.full_name)
+    end
+  end
+end

--- a/spec/system/claims/support/claims/view_claims_spec.rb
+++ b/spec/system/claims/support/claims/view_claims_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe "View claims", type: :system, service: :claims do
+  let!(:support_user) { create(:claims_support_user) }
+  let!(:claim_2) { create(:claim, draft: false) }
+  let!(:claim_1) { create(:claim, draft: true) }
+
+  before do
+    user_exists_in_dfe_sign_in(user: support_user)
+    given_i_sign_in
+  end
+
+  scenario "Support user visits the claims index page" do
+    when_i_visit_claim_index_page
+    i_see_a_list_of_claims
+  end
+
+  private
+
+  def given_i_sign_in
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def when_i_visit_claim_index_page
+    click_on("Claims")
+  end
+
+  def i_see_a_list_of_claims
+    expect(page).to have_content("ID")
+    expect(page).to have_content("Status")
+    expect(page).to have_selector("tbody tr", count: 2)
+
+    within("tbody tr:nth-child(1)") do
+      expect(page).to have_selector("td", text: claim_1.id)
+      expect(page).to have_selector("td", text: "Draft")
+    end
+
+    within("tbody tr:nth-child(2)") do
+      expect(page).to have_selector("td", text: claim_2.id)
+      expect(page).to have_selector("td", text: "Submitted")
+    end
+  end
+end


### PR DESCRIPTION
## Context

This is more of a proof of concept, we don't have a claims index and show page designs yet.

## Changes proposed in this pull request

- Support Claims index and show
- Support claims controller methods

## Guidance to review

- Go onto the review app
- Sign in as support user
- Go to claims tab
- View the claims
- Click on a claim
- Click the back button


## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/4fd8f297-f7ef-4321-a3cc-4635b5b29f32


