### PR TITLE
Lb/make tests less flaky

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,6 +108,7 @@ group :test do
   gem "capybara-screenshot"
   gem "climate_control"
   gem "rails-controller-testing"
+  gem "rspec-retry"
   gem "selenium-webdriver"
   gem "shoulda-matchers"
   gem "simplecov", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -108,7 +108,7 @@ group :test do
   gem "capybara-screenshot"
   gem "climate_control"
   gem "rails-controller-testing"
-  gem "rspec-retry"
+  gem "rspec-retry", git: "https://github.com/DFE-Digital/rspec-retry.git", branch: "main"
   gem "selenium-webdriver"
   gem "shoulda-matchers"
   gem "simplecov", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -426,6 +426,8 @@ GEM
       rspec-expectations (~> 3.12)
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
+    rspec-retry (0.6.2)
+      rspec-core (> 3.3)
     rspec-support (3.13.0)
     rubocop (1.60.2)
       json (~> 2.3)
@@ -618,6 +620,7 @@ DEPENDENCIES
   rladr
   rspec
   rspec-rails
+  rspec-retry
   rubocop-govuk
   selenium-webdriver
   shoulda-matchers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/DFE-Digital/rspec-retry.git
+  revision: 306b42b8d5853303982e1a165e82d04744c20ea3
+  branch: main
+  specs:
+    rspec-retry (0.7.0)
+      rspec-core (> 3.3)
+
+GIT
   remote: https://github.com/citizensadvice/capybara_accessible_selectors
   revision: 8e9748e1655f8c51e9b6f914e630bb6415813a57
   branch: main
@@ -426,8 +434,6 @@ GEM
       rspec-expectations (~> 3.12)
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
-    rspec-retry (0.6.2)
-      rspec-core (> 3.3)
     rspec-support (3.13.0)
     rubocop (1.60.2)
       json (~> 2.3)
@@ -620,7 +626,7 @@ DEPENDENCIES
   rladr
   rspec
   rspec-rails
-  rspec-retry
+  rspec-retry!
   rubocop-govuk
   selenium-webdriver
   shoulda-matchers

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@
 # the additional setup, and require it from the spec files that actually need
 # it.
 
+require "rspec/retry"
 require "simplecov"
 require "simplecov-html"
 require "simplecov-lcov"
@@ -104,4 +105,11 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
+
+  # Configuration for re-trying flaky tests.
+  # See https://github.com/DFE-Digital/rspec-retry for documentation
+  # (Optional) show retry status in spec process
+  config.verbose_retry = true
+  # (Optional) show exception that triggers a retry if verbose_retry is set to true
+  config.display_try_failure_messages = true
 end

--- a/spec/system/claims/create_claim_spec.rb
+++ b/spec/system/claims/create_claim_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Create claim", type: :system, js: true, service: :claims do
+RSpec.describe "Create claim", type: :system, js: true, retry: 3, service: :claims do
   let!(:school) { create(:claims_school) }
   let!(:anne) do
     create(

--- a/spec/system/claims/support/schools/add_a_school_spec.rb
+++ b/spec/system/claims/support/schools/add_a_school_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Support User adds a School", type: :system, service: :claims do
 
   after { Capybara.app_host = nil }
 
-  scenario "Colin adds a new School", js: true do
+  scenario "Colin adds a new School", js: true, retry: 3 do
     when_i_visit_the_add_school_page
     and_i_enter_a_school_named("School 1")
     then_i_see_a_dropdown_item_for("School 1")
@@ -23,7 +23,7 @@ RSpec.describe "Support User adds a School", type: :system, service: :claims do
     and_i_see_success_message
   end
 
-  scenario "Colin adds a school which already exists", js: true do
+  scenario "Colin adds a school which already exists", js: true, retry: 3 do
     given_a_school_already_exists_for_claims
     when_i_visit_the_add_school_page
     and_i_enter_a_school_named("Claims School")
@@ -33,13 +33,13 @@ RSpec.describe "Support User adds a School", type: :system, service: :claims do
     then_i_see_an_error("Claims School has already been added. Try another school")
   end
 
-  scenario "Colin submits the search form without selecting a school", js: true do
+  scenario "Colin submits the search form without selecting a school", js: true, retry: 3 do
     when_i_visit_the_add_school_page
     and_i_click_continue
     then_i_see_an_error("Enter a school name, URN or postcode")
   end
 
-  scenario "Colin reconsiders onboarding a school", js: true do
+  scenario "Colin reconsiders onboarding a school", js: true, retry: 3 do
     given_i_have_completed_the_form_to_onboard(school:)
     when_i_click_back
     then_i_see_the_search_input_pre_filled_with("School 1")

--- a/spec/system/placements/support/providers/support_user_adds_a_provider_spec.rb
+++ b/spec/system/placements/support/providers/support_user_adds_a_provider_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Placements / Support / Providers / Support User adds a Provider"
   end
   after { Capybara.app_host = nil }
 
-  scenario "Colin adds a new Provider", js: true do
+  scenario "Colin adds a new Provider", js: true, retry: 3 do
     when_i_visit_the_add_provider_page
     then_i_see_support_navigation_with_organisation_selected
     and_i_enter_a_provider_named("Provider 1")
@@ -23,7 +23,7 @@ RSpec.describe "Placements / Support / Providers / Support User adds a Provider"
     and_i_see_success_message
   end
 
-  scenario "Colin adds a Provider which already exists", js: true do
+  scenario "Colin adds a Provider which already exists", js: true, retry: 3 do
     given_a_provider_already_as_already_been_onboarded
     when_i_visit_the_add_provider_page
     then_i_see_support_navigation_with_organisation_selected
@@ -34,14 +34,14 @@ RSpec.describe "Placements / Support / Providers / Support User adds a Provider"
     then_i_see_an_error("Provider 1 has already been added. Try another provider")
   end
 
-  scenario "Colin submits the search form without selecting a provider", js: true do
+  scenario "Colin submits the search form without selecting a provider", js: true, retry: 3 do
     when_i_visit_the_add_provider_page
     then_i_see_support_navigation_with_organisation_selected
     and_i_click_continue
     then_i_see_an_error("Enter a provider name, UKPRN, URN or postcode")
   end
 
-  scenario "Colin reconsiders onboarding a provider", js: true do
+  scenario "Colin reconsiders onboarding a provider", js: true, retry: 3 do
     given_i_have_completed_the_form_to_onboard(provider:)
     when_i_click_back
     then_i_see_the_search_input_pre_filled_with("Provider 1")

--- a/spec/system/placements/support/providers/support_user_adds_a_provider_without_javascript_spec.rb
+++ b/spec/system/placements/support/providers/support_user_adds_a_provider_without_javascript_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Support User adds a Provider without JavaScript", type: :system,
     then_i_see_an_error("Manchester 1 has already been added. Try another provider")
   end
 
-  scenario "Colin submits the search form without selecting a provider", js: true do
+  scenario "Colin submits the search form without selecting a provider" do
     when_i_visit_the_add_provider_page
     then_i_see_support_navigation_with_organisation_selected
     and_i_click_continue

--- a/spec/system/placements/support/schools/support_user_adds_a_school_spec.rb
+++ b/spec/system/placements/support/schools/support_user_adds_a_school_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Placements / Support / Schools / Support User adds a School",
 
   after { Capybara.app_host = nil }
 
-  scenario "Colin adds a new School", js: true do
+  scenario "Colin adds a new School", js: true, retry: 3 do
     when_i_visit_the_add_school_page
     and_i_enter_a_school_named("School 1")
     then_i_see_a_dropdown_item_for("School 1")
@@ -24,7 +24,7 @@ RSpec.describe "Placements / Support / Schools / Support User adds a School",
     and_i_see_success_message
   end
 
-  scenario "Colin adds a school which already exists", js: true do
+  scenario "Colin adds a school which already exists", js: true, retry: 3 do
     given_a_school_already_exists_for_placements
     when_i_visit_the_add_school_page
     and_i_enter_a_school_named("Placements School")
@@ -34,13 +34,13 @@ RSpec.describe "Placements / Support / Schools / Support User adds a School",
     then_i_see_an_error("Placements School has already been added. Try another school")
   end
 
-  scenario "Colin submits the search form without selecting a school", js: true do
+  scenario "Colin submits the search form without selecting a school", js: true, retry: 3 do
     when_i_visit_the_add_school_page
     and_i_click_continue
     then_i_see_an_error("Enter a school name, URN or postcode")
   end
 
-  scenario "Colin reconsiders onboarding a school", js: true do
+  scenario "Colin reconsiders onboarding a school", js: true, retry: 3 do
     given_i_have_completed_the_form_to_onboard(school:)
     when_i_click_back
     then_i_see_the_search_input_pre_filled_with("School 1")

--- a/spec/system/placements/support/schools/support_user_adds_a_school_without_javascript_spec.rb
+++ b/spec/system/placements/support/schools/support_user_adds_a_school_without_javascript_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Support User adds a School without JavaScript", type: :system, s
     then_i_see_an_error("Manchester 1 has already been added. Try another school")
   end
 
-  scenario "Colin submits the search form without selecting a school", js: true do
+  scenario "Colin submits the search form without selecting a school" do
     when_i_visit_the_add_school_page
     and_i_click_continue
     then_i_see_an_error("Enter a school name, URN or postcode")


### PR DESCRIPTION
## Context
Our tests where JS is enabled fail regularly. They pass locally though, so difficult to replicate

## Changes proposed in this pull request

- Remove `js: true` from two tests that were meant to test without JS enabled.
- Added rspec-retry gem (https://github.com/DFE-Digital/rspec-retry)
- Added a retry parameter to our tests that have js enabled

## Guidance to review

Difficult to review this locally as we aren't able to make them fail regularly locally. 

## Link to Trello card

https://trello.com/c/8iPfLU6U

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots
