### PR TITLE
Lb/add sentry setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,8 @@ gem "stimulus-rails"
 # User-Resource Permissions and Scoping
 gem "pundit"
 
+gem "sentry-rails"
+
 group :development do
   gem "annotate", require: false
   gem "prettier_print", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -480,6 +480,11 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    sentry-rails (5.14.0)
+      railties (>= 5.0)
+      sentry-ruby (~> 5.14.0)
+    sentry-ruby (5.14.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
     shoulda-matchers (6.1.0)
       activesupport (>= 5.2.0)
     simplecov (0.22.0)
@@ -629,6 +634,7 @@ DEPENDENCIES
   rspec-retry!
   rubocop-govuk
   selenium-webdriver
+  sentry-rails
   shoulda-matchers
   simplecov
   simplecov-lcov

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,18 @@
+Sentry.init do |config|
+  # Sentry config here is mostly copied from apply-for-teacher-training
+  # https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/config/initializers/sentry.rb
+  config.environment = ActiveSupport::EnvironmentInquirer.new(ENV.fetch("HOSTING_ENV", "development"))
+  config.release = ENV["SHA"]
+  config.dsn = ENV.fetch("SENTRY_DSN", "")
+
+  config.inspect_exception_causes_for_exclusion = true
+
+  config.excluded_exceptions += [
+    # Google cloud (ie Bigquery) errors are usually caused by transient network
+    # issues. If there's a genuine problem the queues will stack up and the Sidekiq
+    # latency check will alert. That takes at most 100 seconds to happen, so if
+    # something is actually wrong it's not meaningfully less useful than hearing about
+    # it via Sentry.
+    "Google::Cloud::Error",
+  ]
+end


### PR DESCRIPTION
## Context

We want to have a sentry integration so that we are aware of things when they go wrong. 

## Changes proposed in this pull request

- Add relevant sentry gems
- Sentry configuration

### Not in this PR, but related:
- [itt-mentor-services](https://dfe-teacher-services.sentry.io/settings/projects/itt-mentor-services/) has been set up as a project in the becoming-a-teacher 'team' in sentry
- Everyone has been added as a user and admin of the becoming-a-teacher team
- SENTRY_DNS environment variables have been added to review and qa -- we'll need to add it to the higher environments when they become available. 

## Guidance to review

- Login to the rails console for this review app (things have changed a bit since we all did this, so there is some new documentation coming, see Ollie's PR https://github.com/DFE-Digital/itt-mentor-services/pull/226)
- Manually send something to sentry, eg `Sentry.capture_message "This is a test"`
- Go to the [issues log for the project on Sentry](https://dfe-teacher-services.sentry.io/issues/?project=4506705538056192&referrer=sidebar&statsPeriod=14d)
- You should see the message you've sent.
- Please resolve the issue so we don't have issues hanging around unresolved. 


## Link to Trello card

https://trello.com/c/DFJaBFsv

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

![image](https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/5903be80-1376-4a2b-b447-c8462755a0f2)

