### PR TITLE
Configure RuboCop to lint RSpec files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,3 +35,21 @@ RSpec/SpecFilePathFormat:
 
 RSpec/SpecFilePathSuffix:
   Enabled: true
+
+# The following cops are temporarily disabled so we can incrementally
+# introduce RSpec rules while incrementally fixing up the codebase.
+# They should eventually all be re-enabled.
+RSpec/VerifiedDoubles:
+  Enabled: false
+RSpec/ExpectInHook:
+  Enabled: false
+RSpec/StubbedMock:
+  Enabled: false
+RSpec/ContextWording:
+  Enabled: false
+RSpec/InstanceVariable:
+  Enabled: false
+RSpec/NamedSubject:
+  Enabled: false
+RSpec/LetSetup:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ inherit_gem:
   rubocop-govuk:
     - config/default.yml
     - config/rails.yml
+    - config/rspec.yml
 
 inherit_mode:
   merge:
@@ -16,3 +17,21 @@ Style/StringLiteralsInInterpolation:
 
 Layout/AccessModifierIndentation:
   EnforcedStyle: indent
+
+RSpec/Capybara/FeatureMethods:
+  EnabledMethods:
+    - scenario
+
+# Switch off deprecated cop
+RSpec/FilePath:
+  Enabled: false
+
+# And replace with the preferred cops
+RSpec/SpecFilePathFormat:
+  Enabled: true
+  CustomTransform:
+    DfESignInUser: dfe_sign_in_user
+    DfESignIn: dfe_sign_in
+
+RSpec/SpecFilePathSuffix:
+  Enabled: true

--- a/spec/decorators/provider_decorator_spec.rb
+++ b/spec/decorators/provider_decorator_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ProviderDecorator do
     end
 
     context "when attributes are missing" do
-      it "it returns a formatted address based on the present attributes" do
+      it "returns a formatted address based on the present attributes" do
         provider = create(:provider,
                           address1: "A School",
                           address2: "The School Road",

--- a/spec/decorators/school_decorator_spec.rb
+++ b/spec/decorators/school_decorator_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SchoolDecorator do
     end
 
     context "when attributes are missing" do
-      it "it returns a formatted address based on the present attributes" do
+      it "returns a formatted address based on the present attributes" do
         school = build(:school,
                        address1: "A School",
                        address2: "The School Road",

--- a/spec/forms/organisation_onboarding_form_spec.rb
+++ b/spec/forms/organisation_onboarding_form_spec.rb
@@ -2,9 +2,10 @@ require "rails_helper"
 
 describe OrganisationOnboardingForm, type: :model do
   describe "validations" do
-    it { should validate_presence_of(:organisation_type) }
+    it { is_expected.to validate_presence_of(:organisation_type) }
+
     it {
-      should validate_inclusion_of(:organisation_type).in_array(
+      expect(subject).to validate_inclusion_of(:organisation_type).in_array(
         described_class::ORGANISATION_TYPES,
       )
     }

--- a/spec/forms/school_onboarding_form_spec.rb
+++ b/spec/forms/school_onboarding_form_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 describe SchoolOnboardingForm, type: :model do
   describe "validations" do
-    it { should validate_presence_of(:service) }
-    it { should validate_inclusion_of(:service).in_array(%i[placements claims]) }
+    it { is_expected.to validate_presence_of(:service) }
+    it { is_expected.to validate_inclusion_of(:service).in_array(%i[placements claims]) }
 
     context "when id is not present" do
       it "returns invalid" do

--- a/spec/forms/user_invite_form_spec.rb
+++ b/spec/forms/user_invite_form_spec.rb
@@ -21,7 +21,7 @@ describe UserInviteForm, type: :model do
   describe "#invite" do
     context "with invalid params" do
       before "it does not send invitation" do
-        expect(UserMailer).to_not receive(:invitation_email)
+        expect(UserMailer).not_to receive(:invitation_email)
       end
 
       context "with invalid user params" do

--- a/spec/lib/hosting_environment_spec.rb
+++ b/spec/lib/hosting_environment_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.describe HostingEnvironment do
   before do
-    HostingEnvironment.instance_variable_set :@env, nil
-    HostingEnvironment.instance_variable_set :@phase, nil
+    described_class.instance_variable_set :@env, nil
+    described_class.instance_variable_set :@phase, nil
   end
 
   describe ".env" do

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -20,10 +20,10 @@ require "rails_helper"
 
 RSpec.describe Claim, type: :model do
   context "associations" do
-    it { should belong_to(:school) }
-    it { should have_many(:mentor_trainings) }
-    it { should have_many(:mentors).through(:mentor_trainings) }
-    it { should have_many(:providers).through(:mentor_trainings) }
-    it { should accept_nested_attributes_for(:mentor_trainings) }
+    it { is_expected.to belong_to(:school) }
+    it { is_expected.to have_many(:mentor_trainings) }
+    it { is_expected.to have_many(:mentors).through(:mentor_trainings) }
+    it { is_expected.to have_many(:providers).through(:mentor_trainings) }
+    it { is_expected.to accept_nested_attributes_for(:mentor_trainings) }
   end
 end

--- a/spec/models/claims/school_spec.rb
+++ b/spec/models/claims/school_spec.rb
@@ -56,10 +56,10 @@ require "rails_helper"
 
 RSpec.describe Claims::School do
   context "associations" do
-    it { should have_many(:claims) }
+    it { is_expected.to have_many(:claims) }
 
-    context "#users" do
-      it { should have_many(:users).through(:memberships) }
+    describe "#users" do
+      it { is_expected.to have_many(:users).through(:memberships) }
 
       it "returns only Claims::User records" do
         claims_school = create(:claims_school)

--- a/spec/models/claims/support_user_spec.rb
+++ b/spec/models/claims/support_user_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe Claims::SupportUser do
     it { is_expected.to validate_presence_of(:email) }
     it { is_expected.to validate_uniqueness_of(:email).scoped_to(:type).case_insensitive }
     it { is_expected.to allow_value("name@education.gov.uk").for(:email).with_message(:invalid_support_email) }
-    it { is_expected.to_not allow_value("name@example.com").for(:email).with_message(:invalid_support_email) }
-    it { is_expected.to_not allow_value("name@education.gov.ukk").for(:email).with_message(:invalid_support_email) }
+    it { is_expected.not_to allow_value("name@example.com").for(:email).with_message(:invalid_support_email) }
+    it { is_expected.not_to allow_value("name@education.gov.ukk").for(:email).with_message(:invalid_support_email) }
     it { is_expected.to validate_presence_of(:first_name) }
     it { is_expected.to validate_presence_of(:last_name) }
     it { is_expected.to validate_presence_of(:type) }

--- a/spec/models/claims/user_spec.rb
+++ b/spec/models/claims/user_spec.rb
@@ -20,8 +20,8 @@ require "rails_helper"
 
 RSpec.describe Claims::User do
   describe "associations" do
-    context "#schools" do
-      it { should have_many(:schools).through(:memberships).source(:organisation) }
+    describe "#schools" do
+      it { is_expected.to have_many(:schools).through(:memberships).source(:organisation) }
 
       it "returns only Claims::School records" do
         claims_user = create(:claims_user)

--- a/spec/models/dfe_sign_in_user_spec.rb
+++ b/spec/models/dfe_sign_in_user_spec.rb
@@ -16,7 +16,7 @@ describe DfESignInUser do
           "credentials" => { "id_token" => "123" },
           "provider" => "dfe",
         }
-        DfESignInUser.begin_session!(session, omniauth_payload)
+        described_class.begin_session!(session, omniauth_payload)
 
         expect(session).to eq(
           {
@@ -49,7 +49,7 @@ describe DfESignInUser do
         },
         "service" => :placements,
       }
-      dfe_sign_in_user = DfESignInUser.load_from_session(session)
+      dfe_sign_in_user = described_class.load_from_session(session)
 
       expect(dfe_sign_in_user).not_to be_nil
       expect(dfe_sign_in_user.first_name).to eq("Example")
@@ -67,7 +67,7 @@ describe DfESignInUser do
             "last_active_at" => 3.hours.ago,
           },
         }
-        dfe_sign_in_user = DfESignInUser.load_from_session(session)
+        dfe_sign_in_user = described_class.load_from_session(session)
 
         expect(dfe_sign_in_user).to be_nil
       end
@@ -92,7 +92,7 @@ describe DfESignInUser do
           "service" => :claims,
         }
 
-        dfe_sign_in_user = DfESignInUser.load_from_session(session)
+        dfe_sign_in_user = described_class.load_from_session(session)
 
         expect(dfe_sign_in_user.user).to eq claims_user
         expect(dfe_sign_in_user.user).to be_a Claims::User
@@ -114,7 +114,7 @@ describe DfESignInUser do
           "service" => :claims,
         }
 
-        dfe_sign_in_user = DfESignInUser.load_from_session(session)
+        dfe_sign_in_user = described_class.load_from_session(session)
 
         expect(dfe_sign_in_user.user.id).to eq support_user.id
         expect(dfe_sign_in_user.user).to be_a Claims::SupportUser
@@ -137,7 +137,7 @@ describe DfESignInUser do
             "service" => :claims,
           }
 
-          dfe_sign_in_user = DfESignInUser.load_from_session(session)
+          dfe_sign_in_user = described_class.load_from_session(session)
 
           expect(dfe_sign_in_user.user).to eq claims_user
           expect(dfe_sign_in_user.user).to be_a Claims::User
@@ -159,7 +159,7 @@ describe DfESignInUser do
             "service" => :claims,
           }
 
-          dfe_sign_in_user = DfESignInUser.load_from_session(session)
+          dfe_sign_in_user = described_class.load_from_session(session)
 
           expect(dfe_sign_in_user.user).to eq claims_user
           expect(dfe_sign_in_user.user).to be_a Claims::User
@@ -181,7 +181,7 @@ describe DfESignInUser do
             "service" => :claims,
           }
 
-          dfe_sign_in_user = DfESignInUser.load_from_session(session)
+          dfe_sign_in_user = described_class.load_from_session(session)
 
           expect(dfe_sign_in_user.user.id).to eq support_user.id
           expect(dfe_sign_in_user.user).to be_a Claims::SupportUser
@@ -206,7 +206,7 @@ describe DfESignInUser do
           "service" => :placements,
         }
 
-        dfe_sign_in_user = DfESignInUser.load_from_session(session)
+        dfe_sign_in_user = described_class.load_from_session(session)
 
         expect(dfe_sign_in_user.user).to eq placements_user
         expect(dfe_sign_in_user.user).to be_a Placements::User
@@ -228,7 +228,7 @@ describe DfESignInUser do
           "service" => :placements,
         }
 
-        dfe_sign_in_user = DfESignInUser.load_from_session(session)
+        dfe_sign_in_user = described_class.load_from_session(session)
 
         expect(dfe_sign_in_user.user.id).to eq support_user.id
         expect(dfe_sign_in_user.user).to be_a Placements::SupportUser
@@ -251,7 +251,7 @@ describe DfESignInUser do
             "service" => :placements,
           }
 
-          dfe_sign_in_user = DfESignInUser.load_from_session(session)
+          dfe_sign_in_user = described_class.load_from_session(session)
 
           expect(dfe_sign_in_user.user).to eq placements_user
           expect(dfe_sign_in_user.user).to be_a Placements::User
@@ -273,7 +273,7 @@ describe DfESignInUser do
             "service" => :placements,
           }
 
-          dfe_sign_in_user = DfESignInUser.load_from_session(session)
+          dfe_sign_in_user = described_class.load_from_session(session)
 
           expect(dfe_sign_in_user.user).to eq placements_user
           expect(dfe_sign_in_user.user).to be_a Placements::User
@@ -295,7 +295,7 @@ describe DfESignInUser do
             "service" => :placements,
           }
 
-          dfe_sign_in_user = DfESignInUser.load_from_session(session)
+          dfe_sign_in_user = described_class.load_from_session(session)
 
           expect(dfe_sign_in_user.user.id).to eq support_user.id
           expect(dfe_sign_in_user.user).to be_a Placements::SupportUser
@@ -318,7 +318,7 @@ describe DfESignInUser do
         },
       }
 
-      DfESignInUser.end_session!(session)
+      described_class.end_session!(session)
 
       expect(session).to eq({})
     end

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -26,14 +26,14 @@ RSpec.describe Membership, type: :model do
 
   context "validations" do
     it do
-      is_expected.to validate_uniqueness_of(:user).scoped_to(:organisation_id)
+      expect(subject).to validate_uniqueness_of(:user).scoped_to(:organisation_id)
     end
   end
 
   context "associations" do
     it do
-      should belong_to(:user)
-      should belong_to(:organisation)
+      expect(subject).to belong_to(:user)
+      expect(subject).to belong_to(:organisation)
     end
   end
 end

--- a/spec/models/mentor_spec.rb
+++ b/spec/models/mentor_spec.rb
@@ -22,7 +22,7 @@ require "rails_helper"
 
 RSpec.describe Mentor, type: :model do
   context "associations" do
-    it { should belong_to(:school) }
+    it { is_expected.to belong_to(:school) }
   end
 
   context "validations" do

--- a/spec/models/mentor_training_spec.rb
+++ b/spec/models/mentor_training_spec.rb
@@ -28,8 +28,8 @@ require "rails_helper"
 
 RSpec.describe MentorTraining, type: :model do
   context "associations" do
-    it { should belong_to(:claim) }
-    it { should belong_to(:mentor).optional }
-    it { should belong_to(:provider).optional }
+    it { is_expected.to belong_to(:claim) }
+    it { is_expected.to belong_to(:mentor).optional }
+    it { is_expected.to belong_to(:provider).optional }
   end
 end

--- a/spec/models/placements/provider_spec.rb
+++ b/spec/models/placements/provider_spec.rb
@@ -32,8 +32,8 @@ require "rails_helper"
 
 RSpec.describe Placements::Provider do
   context "assocations" do
-    context "#users" do
-      it { should have_many(:users).through(:memberships) }
+    describe "#users" do
+      it { is_expected.to have_many(:users).through(:memberships) }
 
       it "returns only Placements::User records" do
         placements_provider = create(:placements_provider)

--- a/spec/models/placements/school_spec.rb
+++ b/spec/models/placements/school_spec.rb
@@ -56,8 +56,8 @@ require "rails_helper"
 
 RSpec.describe Placements::School do
   context "assocations" do
-    context "#users" do
-      it { should have_many(:users).through(:memberships) }
+    describe "#users" do
+      it { is_expected.to have_many(:users).through(:memberships) }
 
       it "returns only Placements::User records" do
         placements_school = create(:placements_school)

--- a/spec/models/placements/support_user_spec.rb
+++ b/spec/models/placements/support_user_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe Placements::SupportUser do
     it { is_expected.to validate_presence_of(:email) }
     it { is_expected.to validate_uniqueness_of(:email).scoped_to(:type).case_insensitive }
     it { is_expected.to allow_value("name@education.gov.uk").for(:email).with_message(:invalid_support_email) }
-    it { is_expected.to_not allow_value("name@example.com").for(:email).with_message(:invalid_support_email) }
-    it { is_expected.to_not allow_value("name@education.gov.ukk").for(:email).with_message(:invalid_support_email) }
+    it { is_expected.not_to allow_value("name@example.com").for(:email).with_message(:invalid_support_email) }
+    it { is_expected.not_to allow_value("name@education.gov.ukk").for(:email).with_message(:invalid_support_email) }
     it { is_expected.to validate_presence_of(:first_name) }
     it { is_expected.to validate_presence_of(:last_name) }
     it { is_expected.to validate_presence_of(:type) }

--- a/spec/models/placements/user_spec.rb
+++ b/spec/models/placements/user_spec.rb
@@ -20,8 +20,8 @@ require "rails_helper"
 
 RSpec.describe Placements::User do
   describe "associations" do
-    context "#schools" do
-      it { should have_many(:schools).through(:memberships).source(:organisation) }
+    describe "#schools" do
+      it { is_expected.to have_many(:schools).through(:memberships).source(:organisation) }
 
       it "returns only Placements::School records" do
         placements_user = create(:placements_user)

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -32,9 +32,9 @@ require "rails_helper"
 
 RSpec.describe Provider, type: :model do
   context "associations" do
-    it { should have_many(:memberships) }
-    it { should have_many(:users).through(:memberships) }
-    it { should have_many(:mentor_trainings) }
+    it { is_expected.to have_many(:memberships) }
+    it { is_expected.to have_many(:users).through(:memberships) }
+    it { is_expected.to have_many(:mentor_trainings) }
   end
 
   context "scopes" do
@@ -53,11 +53,13 @@ RSpec.describe Provider, type: :model do
 
     it { is_expected.to validate_presence_of(:code) }
     it { is_expected.to validate_presence_of(:name) }
+
     it do
-      is_expected.to validate_uniqueness_of(
+      expect(subject).to validate_uniqueness_of(
         :code,
       ).case_insensitive
     end
+
     it { is_expected.to allow_values("scitt", "lead_school", "university").for(:provider_type) }
   end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -37,17 +37,6 @@ RSpec.describe Provider, type: :model do
     it { is_expected.to have_many(:mentor_trainings) }
   end
 
-  context "scopes" do
-    describe "#placements_service" do
-      it "only returns placements providers" do
-        create(:provider)
-        placements_provider = create(:provider, :placements)
-
-        expect(described_class.placements_service).to contain_exactly(placements_provider)
-      end
-    end
-  end
-
   context "validations" do
     subject { build(:provider) }
 
@@ -70,6 +59,15 @@ RSpec.describe Provider, type: :model do
 
       it "only returns the providers which have been onboarded (placements: true)" do
         expect(described_class.accredited).to contain_exactly(accredited_provider)
+      end
+    end
+
+    describe "#placements_service" do
+      it "only returns placements providers" do
+        create(:provider)
+        placements_provider = create(:provider, :placements)
+
+        expect(described_class.placements_service).to contain_exactly(placements_provider)
       end
     end
   end

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -17,7 +17,7 @@ require "rails_helper"
 
 RSpec.describe Region, type: :model do
   context "associations" do
-    it { should have_many(:schools) }
+    it { is_expected.to have_many(:schools) }
   end
 
   context "validations" do

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -56,9 +56,9 @@ require "rails_helper"
 
 RSpec.describe School, type: :model do
   context "associations" do
-    it { should have_many(:memberships) }
-    it { should have_many(:mentors) }
-    it { should belong_to(:region) }
+    it { is_expected.to have_many(:memberships) }
+    it { is_expected.to have_many(:mentors) }
+    it { is_expected.to belong_to(:region) }
   end
 
   context "scopes" do
@@ -80,9 +80,6 @@ RSpec.describe School, type: :model do
 
         expect(described_class.claims_service).to contain_exactly(claims_school)
       end
-    end
-
-    describe "#claims_service" do
     end
   end
 

--- a/spec/models/service_update_spec.rb
+++ b/spec/models/service_update_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe ServiceUpdate do
             },
           ],
         )
-        updates = ServiceUpdate.where(service: :claims)
+        updates = described_class.where(service: :claims)
         expect(updates.length).to eq(1)
         expect(updates.first.title).to eq("Claim Update")
       end
 
       it "returns an empty hash when no updates for claims" do
         allow(YAML).to receive(:load_file).and_return(nil)
-        updates = ServiceUpdate.where(service: :claims)
+        updates = described_class.where(service: :claims)
         expect(updates).to eq([])
       end
     end
@@ -38,14 +38,14 @@ RSpec.describe ServiceUpdate do
             },
           ],
         )
-        updates = ServiceUpdate.where(service: :placements)
+        updates = described_class.where(service: :placements)
         expect(updates.length).to eq(1)
         expect(updates.first.title).to eq("Placement Update")
       end
 
       it "returns an empty hash when no updates for placements" do
         allow(YAML).to receive(:load_file).and_return(nil)
-        updates = ServiceUpdate.where(service: :placements)
+        updates = described_class.where(service: :placements)
         expect(updates).to eq([])
       end
     end
@@ -53,19 +53,19 @@ RSpec.describe ServiceUpdate do
 
   describe ".yaml_file" do
     it "returns claims YAML file path" do
-      file_path = ServiceUpdate.file_path(service: :claims)
+      file_path = described_class.file_path(service: :claims)
       expect(file_path).to eq(Rails.root.join("db/claims_service_updates.yml"))
     end
 
     it "returns placements YAML file path" do
-      file_path = ServiceUpdate.file_path(service: :placements)
+      file_path = described_class.file_path(service: :placements)
       expect(file_path).to eq(
         Rails.root.join("db/placements_service_updates.yml"),
       )
     end
 
     it "returns nil for unknown service" do
-      file_path = ServiceUpdate.file_path(service: :some_other_random_service)
+      file_path = described_class.file_path(service: :some_other_random_service)
       expect(file_path).to be_nil
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe User, type: :model do
   subject { build(:user) }
 
   context "associations" do
-    it { should have_many(:memberships).dependent(:destroy) }
+    it { is_expected.to have_many(:memberships).dependent(:destroy) }
   end
 
   describe "validations" do

--- a/spec/services/accredited_provider/api_spec.rb
+++ b/spec/services/accredited_provider/api_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Provider::Api do
+  subject { described_class.call }
+
   before do
     stub_request(
       :get,
@@ -27,8 +29,6 @@ RSpec.describe Provider::Api do
       }.to_json,
     )
   end
-
-  subject { described_class.call }
 
   it "returns a list of providers from the current recruitment cycle publish-teacher-training-courses api" do
     response = subject

--- a/spec/services/dfe_sign_in/user_update_spec.rb
+++ b/spec/services/dfe_sign_in/user_update_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe DfESignIn::UserUpdate do
+  subject { described_class.call(current_user:, sign_in_user:) }
+
   let(:current_user) { create(:claims_user) }
   let(:sign_in_user) do
     instance_double(
@@ -12,13 +14,11 @@ RSpec.describe DfESignIn::UserUpdate do
     )
   end
 
-  subject { described_class.call(current_user:, sign_in_user:) }
-
   it "updates the user's sign in attributes" do
     expect { subject }.to change(current_user, :email).to("test@gmail.com")
       .and change(current_user, :first_name).to("John")
       .and change(current_user, :last_name).to("Doe")
       .and change(current_user, :dfe_sign_in_uid).to("123")
-    expect(current_user.last_signed_in_at).to_not be_nil
+    expect(current_user.last_signed_in_at).not_to be_nil
   end
 end

--- a/spec/services/support_user/invite_spec.rb
+++ b/spec/services/support_user/invite_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe SupportUser::Invite do
       end
 
       it "creates a user" do
-        expect { subject }.to change { User.count }.by(1)
+        expect { subject }.to change(User, :count).by(1)
       end
 
       it "enqueues an invitation email" do
-        expect { subject }.to change { enqueued_jobs.size }.by(1)
+        expect { subject }.to change(enqueued_jobs, :size).by(1)
       end
     end
 
@@ -30,11 +30,11 @@ RSpec.describe SupportUser::Invite do
       end
 
       it "does not create a user" do
-        expect { subject }.to_not(change { User.count })
+        expect { subject }.not_to(change(User, :count))
       end
 
       it "does not send an email" do
-        expect { subject }.to_not(change { enqueued_jobs.size })
+        expect { subject }.not_to(change(enqueued_jobs, :size))
       end
     end
   end

--- a/spec/system/claims/support/support_users/add_a_support_user_spec.rb
+++ b/spec/system/claims/support/support_users/add_a_support_user_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe "Add a support user", type: :system do
       delivery.to.include?(email_address) && delivery.subject == "Invitation to join Claim funding for mentors"
     end
 
-    expect(email).to_not be_nil
+    expect(email).not_to be_nil
   end
 
   def then_i_click_on_a_change_link

--- a/spec/system/claims/view_claims_spec.rb
+++ b/spec/system/claims/view_claims_spec.rb
@@ -3,10 +3,7 @@ require "rails_helper"
 RSpec.describe "View claims", type: :system, service: :claims do
   let!(:school) { create(:claims_school) }
   let!(:mentor_trainings) do
-    [
-      create(:mentor_training, claim: create(:claim, school:)),
-      create(:mentor_training, claim: create(:claim, school:)),
-    ]
+    2.times.map { create(:mentor_training, claim: create(:claim, school:)) }
   end
   let!(:anne) do
     create(

--- a/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
+++ b/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
       delivery.to.include?(user.email) && delivery.subject == "You have been removed from #{organisation.name}"
     end
 
-    expect(email).to_not be_nil
+    expect(email).not_to be_nil
   end
 
   def when_i_click_on(text)
@@ -102,9 +102,9 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
   def then_i_am_redirected_to_the_index_page(organisation)
     case organisation
     when School
-      expect(current_path).to eq placements_school_users_path(organisation)
+      expect(page).to have_current_path placements_school_users_path(organisation), ignore_query: true
     when Provider
-      expect(current_path).to eq placements_provider_users_path(organisation)
+      expect(page).to have_current_path placements_provider_users_path(organisation), ignore_query: true
     end
 
     expect(page).to have_content "You cannot perform this action"
@@ -133,9 +133,9 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
     users_is_selected_in_primary_nav
     case organisation
     when School
-      expect(current_path).to eq placements_school_user_path(organisation, user)
+      expect(page).to have_current_path placements_school_user_path(organisation, user), ignore_query: true
     when Provider
-      expect(current_path).to eq placements_provider_user_path(organisation, user)
+      expect(page).to have_current_path placements_provider_user_path(organisation, user), ignore_query: true
     end
   end
 
@@ -146,6 +146,6 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
       expect(page).to have_content "User removed"
     end
 
-    expect(page).to_not have_content user.full_name
+    expect(page).not_to have_content user.full_name
   end
 end

--- a/spec/system/placements/organisations/users/user_views_other_users_spec.rb
+++ b/spec/system/placements/organisations/users/user_views_other_users_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "Placements user views other users in their organisation", type: 
   end
 
   def and_i_do_not_see_the_remove_user_link
-    expect(page).to_not have_link "Remove user"
+    expect(page).not_to have_link "Remove user"
   end
 
   def users_is_selected_in_navigation

--- a/spec/system/placements/sign_in_as_a_placements_user_spec.rb
+++ b/spec/system/placements/sign_in_as_a_placements_user_spec.rb
@@ -69,13 +69,13 @@ def and_i_visit_my_account_page
 end
 
 def then_i_see_a_list_of_organisations
-  expect(current_path).to eq placements_support_organisations_path
+  expect(page).to have_current_path placements_support_organisations_path, ignore_query: true
   expect(page).to have_content("Placement School")
   expect(page).to have_content("Provider 1")
 end
 
 def then_i_dont_get_redirected_to_support_organisations
-  expect(current_path).not_to eq placements_support_organisations_path
+  expect(page).to have_no_current_path placements_support_organisations_path, ignore_query: true
 end
 
 def then_i_see_user_details_for_anne

--- a/spec/system/placements/support/organisations/support_filtering_and_searching_for_organisation_spec.rb
+++ b/spec/system/placements/support/organisations/support_filtering_and_searching_for_organisation_spec.rb
@@ -92,18 +92,18 @@ RSpec.describe "Support user filters and searches for organisations", type: :sys
     expect(page).to have_content("A School")
     expect(page).to have_content("University of Westminster")
 
-    expect(page).to_not have_content("Lead Partner London")
-    expect(page).to_not have_content("School London")
-    expect(page).to_not have_content("1 Primary")
+    expect(page).not_to have_content("Lead Partner London")
+    expect(page).not_to have_content("School London")
+    expect(page).not_to have_content("1 Primary")
   end
 
   def then_i_see_only_the_organisation_with_lead_partner_as_provider_type
     expect(page).to have_content("Lead Partner London")
 
-    expect(page).to_not have_content("School London")
-    expect(page).to_not have_content("University of Westminster")
-    expect(page).to_not have_content("A School")
-    expect(page).to_not have_content("1 Primary")
+    expect(page).not_to have_content("School London")
+    expect(page).not_to have_content("University of Westminster")
+    expect(page).not_to have_content("A School")
+    expect(page).not_to have_content("1 Primary")
   end
 
   def then_i_see_the_no_results_message(message)
@@ -135,7 +135,7 @@ RSpec.describe "Support user filters and searches for organisations", type: :sys
       expect(page).to have_content "SCITT"
       expect(page).to have_content "University"
 
-      expect(page).to_not have_content "School"
+      expect(page).not_to have_content "School"
     end
   end
 
@@ -143,9 +143,9 @@ RSpec.describe "Support user filters and searches for organisations", type: :sys
     expect(page).to have_content("University of Westminster")
     expect(page).to have_content("Lead Partner London")
 
-    expect(page).to_not have_content("School London")
-    expect(page).to_not have_content("A School")
-    expect(page).to_not have_content("1 Primary")
+    expect(page).not_to have_content("School London")
+    expect(page).not_to have_content("A School")
+    expect(page).not_to have_content("1 Primary")
   end
 
   def then_i_see_all_organisations
@@ -159,19 +159,19 @@ RSpec.describe "Support user filters and searches for organisations", type: :sys
   def then_i_see_the_london_school_only
     expect(page).to have_content("School London")
 
-    expect(page).to_not have_content("University of Westminster")
-    expect(page).to_not have_content("Lead Partner London")
-    expect(page).to_not have_content("A School")
-    expect(page).to_not have_content("1 Primary")
+    expect(page).not_to have_content("University of Westminster")
+    expect(page).not_to have_content("Lead Partner London")
+    expect(page).not_to have_content("A School")
+    expect(page).not_to have_content("1 Primary")
   end
 
   def then_i_see_all_london_organisations
     expect(page).to have_content("School London")
     expect(page).to have_content("Lead Partner London")
 
-    expect(page).to_not have_content("University of Westminster")
-    expect(page).to_not have_content("A School")
-    expect(page).to_not have_content("1 Primary")
+    expect(page).not_to have_content("University of Westminster")
+    expect(page).not_to have_content("A School")
+    expect(page).not_to have_content("1 Primary")
   end
 
   def then_i_see_all_schools
@@ -179,8 +179,8 @@ RSpec.describe "Support user filters and searches for organisations", type: :sys
     expect(page).to have_content("1 Primary")
     expect(page).to have_content("A School")
 
-    expect(page).to_not have_content("University of Westminster")
-    expect(page).to_not have_content("Lead Partner London")
+    expect(page).not_to have_content("University of Westminster")
+    expect(page).not_to have_content("Lead Partner London")
   end
 
   def given_i_am_signed_in_as_a_support_user

--- a/spec/system/placements/support/providers/support_user_adds_a_provider_spec.rb
+++ b/spec/system/placements/support/providers/support_user_adds_a_provider_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Placements / Support / Providers / Support User adds a Provider"
     given_i_sign_in_as_colin
     provider
   end
+
   after { Capybara.app_host = nil }
 
   scenario "Colin adds a new Provider", js: true, retry: 3 do

--- a/spec/system/placements/support/support_users/support_user_adds_a_support_user_spec.rb
+++ b/spec/system/placements/support/support_users/support_user_adds_a_support_user_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe "Placements / Support Users / Support user adds a support user",
       delivery.to.include?(email_address) && delivery.subject == "Invitation to join Manage school placements"
     end
 
-    expect(email).to_not be_nil
+    expect(email).not_to be_nil
   end
 
   def then_i_click_on_a_change_link

--- a/spec/system/placements/support/users/support_user_removes_a_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_removes_a_user_spec.rb
@@ -140,9 +140,9 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
     organisations_is_selected_in_primary_nav
     case organisation
     when School
-      expect(current_path).to eq placements_support_school_user_path(organisation, user)
+      expect(page).to have_current_path placements_support_school_user_path(organisation, user), ignore_query: true
     when Provider
-      expect(current_path).to eq placements_support_provider_user_path(organisation, user)
+      expect(page).to have_current_path placements_support_provider_user_path(organisation, user), ignore_query: true
     end
   end
 
@@ -154,6 +154,6 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
       expect(page).to have_content "User removed"
     end
 
-    expect(page).to_not have_content user.full_name
+    expect(page).not_to have_content user.full_name
   end
 end

--- a/spec/system/placements/view_organisations_spec.rb
+++ b/spec/system/placements/view_organisations_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "View organisations", type: :system, service: :placements do
   end
 
   def then_i_see_the_school_page(school)
-    expect(current_path).to eq placements_school_path(school)
+    expect(page).to have_current_path placements_school_path(school), ignore_query: true
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Organisation details", current: "page"
       expect(page).to have_link "Users", current: "false"
@@ -116,7 +116,7 @@ RSpec.describe "View organisations", type: :system, service: :placements do
   end
 
   def then_i_see_provider_page(provider)
-    expect(current_path).to eq placements_provider_path(provider)
+    expect(page).to have_current_path placements_provider_path(provider), ignore_query: true
     within(".govuk-main-wrapper") do
       expect(page).to have_content provider.name
       expect(page).to have_content "Organisation details"
@@ -135,12 +135,12 @@ RSpec.describe "View organisations", type: :system, service: :placements do
   end
 
   def then_i_see_the_one_school
-    expect(page).to_not have_content "Change organisation"
+    expect(page).not_to have_content "Change organisation"
     then_i_see_the_school_page(@school)
   end
 
   def then_i_see_the_one_provider
-    expect(page).to_not have_content "Change organisation"
+    expect(page).not_to have_content "Change organisation"
     then_i_see_provider_page(@provider)
   end
 
@@ -156,12 +156,12 @@ RSpec.describe "View organisations", type: :system, service: :placements do
     expect(page).to have_content "Placements School"
     expect(page).to have_content "Provider 1"
 
-    expect(page).to_not have_content "Claims School"
-    expect(page).to_not have_content "No service school"
+    expect(page).not_to have_content "Claims School"
+    expect(page).not_to have_content "No service school"
   end
 
   def i_am_redirected_to_organisation_index
     expect(page).to have_content("Organisations")
-    expect(current_path).to eq placements_organisations_path
+    expect(page).to have_current_path placements_organisations_path, ignore_query: true
   end
 end


### PR DESCRIPTION
## Context

Our RuboCop config inherits from the `rubocop-govuk` gem, but it didn't enable the RSpec cops. Therefore we don't currently have any opinionated linter rules to standardise the way we write specs.

## Changes proposed in this pull request

- Include `config/rspec.yml` from `rubocop-govuk`
- Autocorrect lint errors
- Fix a couple more types of error manually
- Disable cops which violate the rules so we can manually fix them up in subsequent PRs

### Why not use a `.rubocop_todo.yml` file?

RuboCop can automatically generate a 'todo' config to ignore failures only in specific files. It'll produce [something like this](https://github.com/DFE-Digital/register-trainee-teachers/blob/main/.rubocop_todo.yml).

I've deliberately decided not to use this, instead opting to disable the affected cops across the entire codebase. I've done this to avoid any confusing situations where RuboCop inconsistently applies rules and it's not clear why. For example, we wouldn't want to find ourselves falling foul of RuboCop when creating new spec files that copy & paste from existing specs.

This seems like a reasonable decision to make while we have the capacity and momentum to fix-up errors and re-enable those cops.

## Guidance to review

I'd advise reviewing commit by commit, and skipping the "autocorrect" commit because that was autogenerated by RuboCop and is pretty hefty 😅

## Link to Trello card

https://trello.com/c/IzTz6Nvs/170-add-linter-rules-for-rspec
