### PR TITLE
Run gias_update and limit to 1000 region associations

### DIFF
--- a/app/services/gias_csv_importer.rb
+++ b/app/services/gias_csv_importer.rb
@@ -134,28 +134,27 @@ class GiasCsvImporter
     end
     Rails.logger.silence do
       School.upsert_all(records, unique_by: :urn)
-      associate_schools_to_regions
     end
 
+    associate_schools_to_regions
     Rails.logger.info "Done!"
   end
 
   private
 
   def associate_schools_to_regions
-    Rails.logger.debug "Associating schools to regions... "
+    Rails.logger.info "Associating the first 1000 schools to regions"
 
-    Region.find_or_create_by!(name: "Inner London") { |region| region.claims_funding_available_per_hour = 53.60 }
-    Region.find_or_create_by!(name: "Outer London") { |region| region.claims_funding_available_per_hour = 48.25 }
-    Region.find_or_create_by!(name: "Fringe") { |region| region.claims_funding_available_per_hour = 45.10 }
-    Region.find_or_create_by!(name: "Rest of England") { |region| region.claims_funding_available_per_hour = 43.18 }
+    Rails.logger.silence do
+      Region.find_or_create_by!(name: "Inner London") { |region| region.claims_funding_available_per_hour = 53.60 }
+      Region.find_or_create_by!(name: "Outer London") { |region| region.claims_funding_available_per_hour = 48.25 }
+      Region.find_or_create_by!(name: "Fringe") { |region| region.claims_funding_available_per_hour = 45.10 }
+      Region.find_or_create_by!(name: "Rest of England") { |region| region.claims_funding_available_per_hour = 43.18 }
+    end
 
-    School.find_each do |school|
+    School.first(1000).each do |school|
       region = determine_region(school.district_admin_code)
-
-      unless school.update(region:)
-        Rails.logger.info "Failed to update region for school with ID #{school.id}"
-      end
+      school.update!(region:)
     end
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -42,10 +42,18 @@ Rails.logger.debug "Services added to schools"
 # Create Providers Imported from Publfish
 Rake::Task["provider_data:import"].invoke unless Provider.any?
 
+Rails.logger.debug "Importing schools from GIAS..."
+Rake::Task["gias_update"].invoke
+
 # Associate Placements Users with Organisations
 # Single School Anne
 placements_anne = Placements::User.find_by!(email: "anne_wilson@example.org")
 placements_anne.memberships.find_or_create_by!(organisation: Placements::School.first)
+
+# Associate Claims Users with Organisations
+# Single School Anne
+claims_anne = Claims::User.find_by!(email: "anne_wilson@example.org")
+claims_anne.memberships.find_or_create_by!(organisation: Claims::School.first)
 
 # Multi-school Mary
 placements_mary = Placements::User.find_by!(email: "mary@example.com")

--- a/spec/services/gias_csv_importer_spec.rb
+++ b/spec/services/gias_csv_importer_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe GiasCsvImporter do
 
   it "logs messages to STDOUT" do
     expect(Rails.logger).to receive(:info).with("Invalid rows - [\"Row 8 is invalid\"]")
+    expect(Rails.logger).to receive(:info).with("Associating the first 1000 schools to regions")
     expect(Rails.logger).to receive(:info).with("Done!")
 
     subject


### PR DESCRIPTION
## Context

The reason for this is when we want to populate data we need to run the seeds file and also run the importer. In addition to this we import all schools which is ALOT. With this change we add the importer call to the seeds file and we only add 1000 schools to a region to speed up this process.

## Changes proposed in this pull request

- Update seeds to run the gias_update importer
- Limit to 1000 region associations 
- Log out number of schools processed

## Guidance to review

- Run `rails db:seeds`

## Link to Trello card

https://trello.com/c/U6chEIcZ/176-update-seeds-file-to-also-run-gias-importer

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
