### PR TITLE
Add coverage groups for Components, Decorators, Forms, Policies, and Services

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,13 +17,22 @@ require "pundit/rspec"
 require "simplecov"
 require "simplecov-html"
 require "simplecov-lcov"
+
 SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
+
 SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::HTMLFormatter,
   SimpleCov::Formatter::LcovFormatter,
 ])
+
 SimpleCov.start "rails" do
   enable_coverage :branch
+
+  add_group "Components", "app/components"
+  add_group "Decorators", "app/decorators"
+  add_group "Forms", "app/forms"
+  add_group "Policies", "app/policies"
+  add_group "Services", "app/services"
 end
 
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration


### PR DESCRIPTION
## Context

We have a few ungrouped types of files in our coverage report.

## Changes proposed in this pull request

- Add additional simple-cov coverage groups:
  - Components
  - Decorators
  - Forms
  - Policies
  - Services

## Guidance to review

- There should only be 1 remaining ungrouped file, [ServiceUpdate::View](https://github.com/DFE-Digital/itt-mentor-services/blob/main/app/assets/components/service_update/view.rb).
  - I've written up a ticket to move this file into the correct directory: https://trello.com/c/Q2xVj8lC/177-move-the-serviceupdateview-component-into-our-app-components-directory

## Screenshots

![CleanShot 2024-02-08 at 12 19 22@2x](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/8934322d-b0e2-4f2c-bfc3-2bd2bea3d233)

