### PR TITLE
Update the Money configuration to silence deprecation warnings

### DIFF
--- a/config/initializers/money.rb
+++ b/config/initializers/money.rb
@@ -1,21 +1,26 @@
 MoneyRails.configure do |config|
-  Money.locale_backend = nil
-
   config.default_currency = :gbp
 
-  config.amount_column = { prefix: "",           # column name prefix
-                           postfix: "_pence",    # column name  postfix
-                           column_name: nil,     # full column name (overrides prefix, postfix and accessor name)
-                           type: :integer,       # column type
-                           present: true,        # column will be created
-                           null: false,          # other options will be treated as column options
-                           default: 0 }
+  config.amount_column = {
+    prefix: "",           # column name prefix
+    postfix: "_pence",    # column name  postfix
+    column_name: nil,     # full column name (overrides prefix, postfix and accessor name)
+    type: :integer,       # column type
+    present: true,        # column will be created
+    null: false,          # other options will be treated as column options
+    default: 0,
+  }
 
-  config.currency_column = { prefix: "",
-                             postfix: "_currency",
-                             column_name: nil,
-                             type: :string,
-                             present: true,
-                             null: false,
-                             default: "GBP" }
+  config.currency_column = {
+    prefix: "",
+    postfix: "_currency",
+    column_name: nil,
+    type: :string,
+    present: true,
+    null: false,
+    default: "GBP",
+  }
 end
+
+Money.locale_backend = nil
+Money.rounding_mode = BigDecimal::ROUND_HALF_UP


### PR DESCRIPTION
## Context

We currently see the following deprecation warning:

```
[WARNING] The default rounding mode will change from `ROUND_HALF_EVEN` to `ROUND_HALF_UP` in the next major release. Set it explicitly using `Money.rounding_mode=` to avoid potential problems.
```

We'd like to remove this warning.

## Changes proposed in this pull request

- Explicitly set the rounding mode of the Money objects to `HALF_UP`. Any partial "pence" amounts will be rounded up to a full pence.
  - This deviates from the existing default behaviour, but it will have no impact on our current logic.

## Guidance to review

The newly configured value now differs from the previous default. As we don't currently do any multiplication or division with money, there will be no changes in behaviour. Moving forward, decimal point subunits will be rounded up.
