### PR TITLE
Claim belongs to provider

### DIFF
--- a/app/controllers/claims/schools/claims_controller.rb
+++ b/app/controllers/claims/schools/claims_controller.rb
@@ -37,6 +37,7 @@ class Claims::Schools::ClaimsController < ApplicationController
 
   def claim_params
     params.require(:claim).permit(
+      :provider_id,
       mentor_trainings_attributes: %i[provider_id mentor_id id],
     )
   end

--- a/app/decorators/claim_decorator.rb
+++ b/app/decorators/claim_decorator.rb
@@ -2,7 +2,7 @@ class ClaimDecorator < Draper::Decorator
   delegate_all
 
   def item_status_tag(association)
-    if claim.public_send(association).any?
+    if claim.public_send(association).present?
       { text: I18n.t("decorators.claim.completed"), colour: "green" }
     else
       { text: I18n.t("decorators.claim.not_started"), colour: "grey" }

--- a/app/forms/claim_form.rb
+++ b/app/forms/claim_form.rb
@@ -12,19 +12,16 @@ class ClaimForm
   end
 
   def valid?
-    claim.valid? && valid_providers? && valid_mentors?
+    claim.valid? && valid_provider? && valid_mentors?
   end
 
   private
 
-  def valid_providers?
+  def valid_provider?
     return true unless step == "providers"
 
-    claim.mentor_trainings.each do |mentor_training|
-      if mentor_training.provider_id.nil?
-        mentor_training.errors.add(:provider_id, :blank)
-        claim.errors.add(:base, :enter_provider_name)
-      end
+    if claim.provider_id.nil?
+      claim.errors.add(:provider_id)
     end
 
     claim.errors.blank?

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -2,26 +2,29 @@
 #
 # Table name: claims
 #
-#  id         :uuid             not null, primary key
-#  draft      :boolean          default(FALSE)
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  school_id  :uuid             not null
+#  id          :uuid             not null, primary key
+#  draft       :boolean          default(FALSE)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  provider_id :uuid
+#  school_id   :uuid             not null
 #
 # Indexes
 #
-#  index_claims_on_school_id  (school_id)
+#  index_claims_on_provider_id  (provider_id)
+#  index_claims_on_school_id    (school_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (provider_id => providers.id)
 #  fk_rails_...  (school_id => schools.id)
 #
 class Claim < ApplicationRecord
   belongs_to :school
+  belongs_to :provider, optional: true
 
   has_many :mentor_trainings
   has_many :mentors, through: :mentor_trainings
-  has_many :providers, through: :mentor_trainings
 
   accepts_nested_attributes_for :mentor_trainings
 end

--- a/app/views/claims/schools/claims/_mentors_form.html.erb
+++ b/app/views/claims/schools/claims/_mentors_form.html.erb
@@ -15,6 +15,7 @@
   <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 
   <%= f.fields_for :mentor_trainings do |mentor_form| %>
+    <%= mentor_form.hidden_field :provider_id, value: f.object.provider_id %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <div class="govuk-form-group">

--- a/app/views/claims/schools/claims/_providers_form.html.erb
+++ b/app/views/claims/schools/claims/_providers_form.html.erb
@@ -14,27 +14,25 @@
 
   <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 
-  <%= f.fields_for :mentor_trainings do |mentor_form| %>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <div class="govuk-form-group">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-form-group">
 
-          <%= mentor_form.govuk_collection_select(
-            :provider_id,
-            Provider.all, # Provider.accredited when we have accredited providers
-            :id,
-            :name,
-            data: {
-              controller: "select-autocomplete",
-              select_autocomplete_target: "input",
-            },
-            label: nil,
-            options: { include_blank: true },
-          ) %>
-        </div>
-
-        <%= f.govuk_submit t(".continue") %>
+        <%= f.govuk_collection_select(
+          :provider_id,
+          Provider.all, # Provider.accredited when we have accredited providers
+          :id,
+          :name,
+          data: {
+            controller: "select-autocomplete",
+            select_autocomplete_target: "input",
+          },
+          label: nil,
+          options: { include_blank: true },
+        ) %>
       </div>
+
+      <%= f.govuk_submit t(".continue") %>
     </div>
-  <% end %>
+  </div>
 <% end %>

--- a/app/views/claims/schools/claims/show.html.erb
+++ b/app/views/claims/schools/claims/show.html.erb
@@ -10,11 +10,11 @@
 
   <%= govuk_task_list(id_prefix: "providers", classes: "providers-task-list") do |task_list| %>
     <%= task_list.with_item(
-      title: t(".itt_providers"),
+      title: t(".itt_provider"),
       href: edit_claims_school_claim_path(@school, @claim, "providers"),
       status: govuk_tag(
-        text: @claim.item_status_tag("providers").fetch(:text),
-        colour: @claim.item_status_tag("providers").fetch(:colour),
+        text: @claim.item_status_tag("provider").fetch(:text),
+        colour: @claim.item_status_tag("provider").fetch(:colour),
       ),
     ) %>
   <% end %>

--- a/app/views/claims/support/claims/show.html.erb
+++ b/app/views/claims/support/claims/show.html.erb
@@ -16,12 +16,10 @@
           <% row.with_value(text: render(Claim::StatusTagComponent.new(claim: @claim))) %>
         <% end %>
 
-        <% if @claim.providers.any? %>
-          <%= @claim.providers.each_with_index do |provider, index| %>
-            <% summary_list.with_row do |row| %>
-              <% row.with_key(text: t(".provider_with_index", index: index + 1)) %>
-              <% row.with_value(text: provider.name) %>
-            <% end %>
+        <% if @claim.provider %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".provider")) %>
+            <% row.with_value(text: @claim.provider.name) %>
           <% end %>
         <% else %>
           <% summary_list.with_row do |row| %>

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -13,8 +13,9 @@ en:
       models:
         claim:
           attributes:
+            provider_id: 
+              invalid: Enter a provider name
             base:
-              enter_provider_name: Enter a provider name 
               enter_mentor_name: Enter a mentor's name 
         mentor_training:
           attributes:

--- a/config/locales/en/claims/schools/claims.yml
+++ b/config/locales/en/claims/schools/claims.yml
@@ -9,9 +9,9 @@ en:
           claim_updated: Claim updated
         show:
           heading: Claim general mentor training funding
-          providers_heading: 1. ITT providers
+          providers_heading: 1. ITT provider
           mentors_heading: 2. General mentors
-          itt_providers: ITT providers
+          itt_provider: ITT provider
           general_mentors: General mentors
         edit:
           cancel: Cancel

--- a/config/locales/en/claims/support/claims.yml
+++ b/config/locales/en/claims/support/claims.yml
@@ -8,7 +8,6 @@ en:
         show:
           heading: Claim
           status: Status
-          provider_with_index: Provider %{index}
           provider: Provider
           mentor_with_index: Mentor %{index}
           mentor: Mentor

--- a/db/migrate/20240208141742_claim_belongs_to_provider.rb
+++ b/db/migrate/20240208141742_claim_belongs_to_provider.rb
@@ -1,0 +1,5 @@
+class ClaimBelongsToProvider < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :claims, :provider, null: true, foreign_key: true, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_02_070544) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_08_141742) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -26,6 +26,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_02_070544) do
     t.boolean "draft", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "provider_id"
+    t.index ["provider_id"], name: "index_claims_on_provider_id"
     t.index ["school_id"], name: "index_claims_on_school_id"
   end
 
@@ -170,6 +172,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_02_070544) do
     t.index ["type", "email"], name: "index_users_on_type_and_email", unique: true
   end
 
+  add_foreign_key "claims", "providers"
   add_foreign_key "claims", "schools"
   add_foreign_key "memberships", "users"
   add_foreign_key "mentor_trainings", "claims"

--- a/spec/decorators/claim_decorator_spec.rb
+++ b/spec/decorators/claim_decorator_spec.rb
@@ -3,20 +3,19 @@ require "rails_helper"
 RSpec.describe ClaimDecorator do
   describe "item_status_tag" do
     it "returns the completed status tag for a claim item" do
-      school = create(:school, :claims).becomes(Claims::School)
-      claim = create(:claim, school:)
-      create(:mentor_training, claim:)
+      school = create(:claims_school)
+      claim = create(:claim, school:, provider: create(:provider))
 
-      expect(claim.decorate.item_status_tag("providers")).to eq(
+      expect(claim.decorate.item_status_tag("provider")).to eq(
         { text: "Completed", colour: "green" },
       )
     end
 
     it "returns the not_started status tag for a claim item" do
-      school = create(:school, :claims).becomes(Claims::School)
+      school = create(:claims_school)
       claim = create(:claim, school:)
 
-      expect(claim.decorate.item_status_tag("providers")).to eq(
+      expect(claim.decorate.item_status_tag("provider")).to eq(
         { text: "Not started", colour: "grey" },
       )
     end

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -2,18 +2,21 @@
 #
 # Table name: claims
 #
-#  id         :uuid             not null, primary key
-#  draft      :boolean          default(FALSE)
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  school_id  :uuid             not null
+#  id          :uuid             not null, primary key
+#  draft       :boolean          default(FALSE)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  provider_id :uuid
+#  school_id   :uuid             not null
 #
 # Indexes
 #
-#  index_claims_on_school_id  (school_id)
+#  index_claims_on_provider_id  (provider_id)
+#  index_claims_on_school_id    (school_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (provider_id => providers.id)
 #  fk_rails_...  (school_id => schools.id)
 #
 FactoryBot.define do

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -2,18 +2,21 @@
 #
 # Table name: claims
 #
-#  id         :uuid             not null, primary key
-#  draft      :boolean          default(FALSE)
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  school_id  :uuid             not null
+#  id          :uuid             not null, primary key
+#  draft       :boolean          default(FALSE)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  provider_id :uuid
+#  school_id   :uuid             not null
 #
 # Indexes
 #
-#  index_claims_on_school_id  (school_id)
+#  index_claims_on_provider_id  (provider_id)
+#  index_claims_on_school_id    (school_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (provider_id => providers.id)
 #  fk_rails_...  (school_id => schools.id)
 #
 require "rails_helper"
@@ -21,9 +24,9 @@ require "rails_helper"
 RSpec.describe Claim, type: :model do
   context "associations" do
     it { is_expected.to belong_to(:school) }
+    it { is_expected.to belong_to(:provider).optional }
     it { is_expected.to have_many(:mentor_trainings) }
     it { is_expected.to have_many(:mentors).through(:mentor_trainings) }
-    it { is_expected.to have_many(:providers).through(:mentor_trainings) }
     it { is_expected.to accept_nested_attributes_for(:mentor_trainings) }
   end
 end

--- a/spec/system/claims/create_claim_spec.rb
+++ b/spec/system/claims/create_claim_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Create claim", type: :system, js: true, retry: 3, service: :clai
       providers_status: "Not started",
       mentors_status: "Not started",
     )
-    and_i_click("ITT providers")
+    and_i_click("ITT provider")
     and_i_input_a_provider(provider.name.first(3))
     then_i_see_a_dropdown_item_for(provider.name)
     when_i_click_the_dropdown_item_for(provider.name)
@@ -52,7 +52,7 @@ RSpec.describe "Create claim", type: :system, js: true, retry: 3, service: :clai
       providers_status: "Not started",
       mentors_status: "Not started",
     )
-    and_i_click("ITT providers")
+    and_i_click("ITT provider")
     and_i_click_continue
     then_i_see_an_error_message("Enter a provider name")
   end
@@ -64,7 +64,7 @@ RSpec.describe "Create claim", type: :system, js: true, retry: 3, service: :clai
       providers_status: "Not started",
       mentors_status: "Not started",
     )
-    and_i_click("ITT providers")
+    and_i_click("ITT provider")
     and_i_input_a_provider("non existent")
     and_i_click_continue
     then_i_see_an_error_message("Enter a provider name")
@@ -113,9 +113,9 @@ RSpec.describe "Create claim", type: :system, js: true, retry: 3, service: :clai
 
   def then_i_see_my_claim_check_list(providers_status:, mentors_status:)
     expect(page).to have_content("Claim general mentor training funding")
-    expect(page).to have_content("1. ITT providers")
+    expect(page).to have_content("1. ITT provider")
     within(".providers-task-list") do
-      expect(page).to have_content("ITT providers")
+      expect(page).to have_content("ITT provider")
       expect(page).to have_content(providers_status)
     end
 
@@ -127,7 +127,7 @@ RSpec.describe "Create claim", type: :system, js: true, retry: 3, service: :clai
   end
 
   def and_i_input_a_provider(string)
-    fill_in("claim-mentor-trainings-attributes-0-provider-id-field", with: string)
+    fill_in("claim-provider-id-field", with: string)
   end
 
   def and_i_input_a_mentor(string)

--- a/spec/system/claims/support/claims/view_a_claim_spec.rb
+++ b/spec/system/claims/support/claims/view_a_claim_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "View claims", type: :system, service: :claims do
     create(
       :claim,
       draft: false,
-      providers: [provider],
+      provider:,
       mentors: [mentor],
     )
   end
@@ -74,7 +74,7 @@ RSpec.describe "View claims", type: :system, service: :claims do
     end
 
     within(".govuk-summary-list__row:nth-child(2)") do
-      expect(page).to have_content("Provider 1")
+      expect(page).to have_content("Provider")
       expect(page).to have_content(provider.name)
     end
 


### PR DESCRIPTION
## Context

We decided that a claim can only have one provider. This PR changes the form and the db relation to be a belongs_to, optional because of the way the form works now, we create a claim when landing on on providers form.


## Changes proposed in this pull request

Claim has_one mentor_training
Claim has_one provider
Change claim form
Change suppport claim show  

## Guidance to review

Go onto the review app and create a claim
Then view that claim as a support user


## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/5a14e3ff-5119-4c6b-963c-558c59c01347


