### PR TITLE
Enable cop RSpec/LetSetup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,5 +51,3 @@ RSpec/InstanceVariable:
   Enabled: false
 RSpec/NamedSubject:
   Enabled: false
-RSpec/LetSetup:
-  Enabled: false

--- a/spec/models/claims/school_spec.rb
+++ b/spec/models/claims/school_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe Claims::School do
     it "is scoped to schools using the claims service" do
       school = described_class.find(school_with_claims.id)
       expect(described_class.all).to contain_exactly(school)
+      expect(described_class.all).not_to include(school_without_claims)
     end
   end
 end

--- a/spec/models/claims/user_spec.rb
+++ b/spec/models/claims/user_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Claims::User do
     it "is scoped to users of the claims service" do
       user = described_class.find(user_with_claims_service.id)
       expect(described_class.all).to contain_exactly(user)
+      expect(described_class.all).not_to include(user_with_placements_service)
     end
   end
 

--- a/spec/models/placements/provider_spec.rb
+++ b/spec/models/placements/provider_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe Placements::Provider do
     it "is scoped to providers using the placement service" do
       provider = described_class.find(provider_with_placements.id)
       expect(described_class.all).to contain_exactly(provider)
+      expect(described_class.all).not_to include(provider_without_placements)
     end
   end
 end

--- a/spec/models/placements/school_spec.rb
+++ b/spec/models/placements/school_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe Placements::School do
     it "is scoped to schools using the placement service" do
       school = described_class.find(school_with_placements.id)
       expect(described_class.all).to contain_exactly(school)
+      expect(described_class.all).not_to include(school_without_placements)
     end
   end
 end

--- a/spec/models/placements/user_spec.rb
+++ b/spec/models/placements/user_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Placements::User do
     it "is scoped to placement service users" do
       user = described_class.find(user_with_placements_service.id)
       expect(described_class.all).to contain_exactly(user)
+      expect(described_class.all).not_to include(user_with_claims_service)
     end
   end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -55,10 +55,11 @@ RSpec.describe Provider, type: :model do
   context "scopes" do
     describe "#accredited" do
       let!(:accredited_provider) { create(:provider, accredited: true) }
-      let!(:provider) { create(:provider) }
+      let!(:non_accredited_provider) { create(:provider) }
 
       it "only returns the providers which have been onboarded (placements: true)" do
         expect(described_class.accredited).to contain_exactly(accredited_provider)
+        expect(described_class.accredited).not_to include(non_accredited_provider)
       end
     end
 

--- a/spec/system/claims/support/schools/add_a_school_without_javascript_spec.rb
+++ b/spec/system/claims/support/schools/add_a_school_without_javascript_spec.rb
@@ -1,15 +1,11 @@
 require "rails_helper"
 
 RSpec.describe "Support User adds a School without JavaScript", type: :system, service: :claims do
-  let!(:schools) do
-    [
-      create(:school, name: "Manchester 1"),
-      create(:school, name: "Manchester 2"),
-      create(:school, name: "London"),
-    ]
-  end
-
   before do
+    create(:school, name: "Manchester 1")
+    create(:school, name: "Manchester 2")
+    create(:school, name: "London")
+
     given_i_sign_in_as_colin
   end
 

--- a/spec/system/claims/view_claims_spec.rb
+++ b/spec/system/claims/view_claims_spec.rb
@@ -2,9 +2,6 @@ require "rails_helper"
 
 RSpec.describe "View claims", type: :system, service: :claims do
   let!(:school) { create(:claims_school) }
-  let!(:mentor_trainings) do
-    2.times.map { create(:mentor_training, claim: create(:claim, school:)) }
-  end
   let!(:anne) do
     create(
       :claims_user,

--- a/spec/system/placements/support/providers/support_user_adds_a_provider_without_javascript_spec.rb
+++ b/spec/system/placements/support/providers/support_user_adds_a_provider_without_javascript_spec.rb
@@ -1,15 +1,11 @@
 require "rails_helper"
 
 RSpec.describe "Support User adds a Provider without JavaScript", type: :system, service: :placements do
-  let!(:schools) do
-    [
-      create(:provider, name: "Manchester 1"),
-      create(:provider, name: "Manchester 2"),
-      create(:provider, name: "London"),
-    ]
-  end
-
   before do
+    create(:provider, name: "Manchester 1")
+    create(:provider, name: "Manchester 2")
+    create(:provider, name: "London")
+
     given_i_sign_in_as_colin
   end
 

--- a/spec/system/placements/support/schools/support_user_adds_a_school_without_javascript_spec.rb
+++ b/spec/system/placements/support/schools/support_user_adds_a_school_without_javascript_spec.rb
@@ -1,15 +1,11 @@
 require "rails_helper"
 
 RSpec.describe "Support User adds a School without JavaScript", type: :system, service: :placements do
-  let!(:schools) do
-    [
-      create(:school, name: "Manchester 1"),
-      create(:school, name: "Manchester 2"),
-      create(:school, name: "London"),
-    ]
-  end
-
   before do
+    create(:school, name: "Manchester 1")
+    create(:school, name: "Manchester 2")
+    create(:school, name: "London")
+
     given_i_sign_in_as_colin
   end
 


### PR DESCRIPTION
## Context

This PR follows on from #227, which configured RuboCop to use rules from the [rubocop-govuk](https://github.com/alphagov/rubocop-govuk) gem.

Some rules which couldn't be autocorrected were disabled, to be fixed in follow-up PRs.

## Changes proposed in this pull request

This PR enables the `RSpec/LetSetup` cop and fixes linting failures.

## Link to Trello card

https://trello.com/c/IzTz6Nvs/170-add-linter-rules-for-rspec
