### PR TITLE
Add test to View support console as a non support user

### DIFF
--- a/spec/system/claims/support/claims/view_support_console_as_non_support_user_spec.rb
+++ b/spec/system/claims/support/claims/view_support_console_as_non_support_user_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "View support console as a non support user", type: :system, service: :claims do
-  let(:school1) { create(:school, :claims, name: "School1") }
+  let(:school1) { create(:claims_school, name: "School1") }
 
   scenario "As a non support user I cant access a support page" do
     user_exists_in_dfe_sign_in(


### PR DESCRIPTION
## Context

We needed to add a test to check that a user who is a non support user cant access the support console

## Changes proposed in this pull request

Add a spec to test a non support user cant access a support 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
