### PR TITLE
Enable RSpec/ContextWording rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,8 +45,6 @@ RSpec/ExpectInHook:
   Enabled: false
 RSpec/StubbedMock:
   Enabled: false
-RSpec/ContextWording:
-  Enabled: false
 RSpec/InstanceVariable:
   Enabled: false
 RSpec/NamedSubject:

--- a/spec/forms/user_invite_form_spec.rb
+++ b/spec/forms/user_invite_form_spec.rb
@@ -38,7 +38,7 @@ describe UserInviteForm, type: :model do
         end
       end
 
-      context "where membership already exists" do
+      context "when membership already exists" do
         it "returns membership error on the email attribute of the for and does not send invite" do
           user = create(:placements_user)
           organisation = create(:school, :placements)

--- a/spec/helpers/placements/support/schools_helper_spec.rb
+++ b/spec/helpers/placements/support/schools_helper_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 RSpec.describe Placements::Support::SchoolsHelper do
   describe "#ofsted_field_args" do
-    context "value is empty" do
+    context "when value is empty" do
       it "returns empty state and hint class" do
         value = ""
         expect(ofsted_field_args(value)).to match({ text: "Unknown", classes: "govuk-hint" })
       end
     end
 
-    context "value is not empty" do
+    context "when value is not empty" do
       it "returns just the text" do
         value = "Some value"
         expect(ofsted_field_args(value)).to match({ text: "Some value" })
@@ -18,14 +18,14 @@ RSpec.describe Placements::Support::SchoolsHelper do
   end
 
   describe "#details_field_args" do
-    context "value is empty" do
+    context "when value is empty" do
       it "returns empty state and hint class" do
         value = ""
         expect(details_field_args(value)).to match({ text: "Not entered", classes: "govuk-hint" })
       end
     end
 
-    context "value is not empty" do
+    context "when value is not empty" do
       it "returns just the text" do
         value = "Some value"
         expect(details_field_args(value)).to match({ text: "Some value" })

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe UserMailer, type: :mailer do
   describe "#invitation_email" do
     subject { described_class.invitation_email(user, organisation, "sign_in_url") }
 
-    context "user's service is Claims" do
+    context "when user's service is Claims" do
       let(:user) { create(:claims_user) }
       let(:organisation) { create(:claims_school) }
 
@@ -19,8 +19,8 @@ RSpec.describe UserMailer, type: :mailer do
       end
     end
 
-    context "user's service is Placements" do
-      context "organisation is school" do
+    context "when user's service is Placements" do
+      context "when organisation is school" do
         let(:user) { create(:placements_user) }
         let(:organisation) { create(:placements_school) }
 
@@ -34,7 +34,7 @@ RSpec.describe UserMailer, type: :mailer do
         end
       end
 
-      context "organisation is provider" do
+      context "when organisation is provider" do
         let(:user) { create(:placements_user) }
         let(:organisation) { create(:placements_provider) }
 
@@ -54,7 +54,7 @@ RSpec.describe UserMailer, type: :mailer do
     subject { described_class.removal_email(user, organisation) }
 
     context "when user's service is Placements" do
-      context "organisation is a school" do
+      context "when organisation is a school" do
         let(:user) { create(:placements_user) }
         let(:organisation) { create(:placements_school) }
 
@@ -66,7 +66,7 @@ RSpec.describe UserMailer, type: :mailer do
         end
       end
 
-      context "organisation is a provider" do
+      context "when organisation is a provider" do
         let(:user) { create(:placements_user) }
         let(:organisation) { create(:placements_provider) }
 

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -19,7 +19,7 @@
 require "rails_helper"
 
 RSpec.describe Claim, type: :model do
-  context "associations" do
+  context "with associations" do
     it { is_expected.to belong_to(:school) }
     it { is_expected.to have_many(:mentor_trainings) }
     it { is_expected.to have_many(:mentors).through(:mentor_trainings) }

--- a/spec/models/claims/school_spec.rb
+++ b/spec/models/claims/school_spec.rb
@@ -55,7 +55,7 @@
 require "rails_helper"
 
 RSpec.describe Claims::School do
-  context "associations" do
+  context "with associations" do
     it { is_expected.to have_many(:claims) }
 
     describe "#users" do

--- a/spec/models/claims/support_user_spec.rb
+++ b/spec/models/claims/support_user_spec.rb
@@ -19,7 +19,7 @@
 require "rails_helper"
 
 RSpec.describe Claims::SupportUser do
-  context "validations" do
+  context "with validations" do
     subject { build(:claims_support_user) }
 
     it { is_expected.to validate_presence_of(:email) }

--- a/spec/models/dfe_sign_in_user_spec.rb
+++ b/spec/models/dfe_sign_in_user_spec.rb
@@ -120,7 +120,7 @@ describe DfESignInUser do
         expect(dfe_sign_in_user.user).to be_a Claims::SupportUser
       end
 
-      context "DFE provider" do
+      context "with DFE provider" do
         it "returns the current Claims::User by dfe_sign_in_uid" do
           claims_user = create(:claims_user)
 
@@ -234,7 +234,7 @@ describe DfESignInUser do
         expect(dfe_sign_in_user.user).to be_a Placements::SupportUser
       end
 
-      context "DFE provider" do
+      context "with DFE provider" do
         it "returns the current Placements::User by dfe_sign_in_uid" do
           placements_user = create(:placements_user)
 

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -24,13 +24,13 @@ require "rails_helper"
 RSpec.describe Membership, type: :model do
   subject { create(:membership) }
 
-  context "validations" do
+  context "with validations" do
     it do
       expect(subject).to validate_uniqueness_of(:user).scoped_to(:organisation_id)
     end
   end
 
-  context "associations" do
+  context "with associations" do
     it do
       expect(subject).to belong_to(:user)
       expect(subject).to belong_to(:organisation)

--- a/spec/models/mentor_spec.rb
+++ b/spec/models/mentor_spec.rb
@@ -21,11 +21,11 @@
 require "rails_helper"
 
 RSpec.describe Mentor, type: :model do
-  context "associations" do
+  context "with associations" do
     it { is_expected.to belong_to(:school) }
   end
 
-  context "validations" do
+  context "with validations" do
     subject { build(:mentor) }
 
     it { is_expected.to validate_presence_of(:first_name) }

--- a/spec/models/mentor_training_spec.rb
+++ b/spec/models/mentor_training_spec.rb
@@ -27,7 +27,7 @@
 require "rails_helper"
 
 RSpec.describe MentorTraining, type: :model do
-  context "associations" do
+  context "with associations" do
     it { is_expected.to belong_to(:claim) }
     it { is_expected.to belong_to(:mentor).optional }
     it { is_expected.to belong_to(:provider).optional }

--- a/spec/models/placements/provider_spec.rb
+++ b/spec/models/placements/provider_spec.rb
@@ -31,7 +31,7 @@
 require "rails_helper"
 
 RSpec.describe Placements::Provider do
-  context "assocations" do
+  context "with assocations" do
     describe "#users" do
       it { is_expected.to have_many(:users).through(:memberships) }
 

--- a/spec/models/placements/school_spec.rb
+++ b/spec/models/placements/school_spec.rb
@@ -55,7 +55,7 @@
 require "rails_helper"
 
 RSpec.describe Placements::School do
-  context "assocations" do
+  context "with assocations" do
     describe "#users" do
       it { is_expected.to have_many(:users).through(:memberships) }
 

--- a/spec/models/placements/support_user_spec.rb
+++ b/spec/models/placements/support_user_spec.rb
@@ -19,7 +19,7 @@
 require "rails_helper"
 
 RSpec.describe Placements::SupportUser do
-  context "validations" do
+  context "with validations" do
     subject { build(:placements_support_user) }
 
     it { is_expected.to validate_presence_of(:email) }

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -31,13 +31,13 @@
 require "rails_helper"
 
 RSpec.describe Provider, type: :model do
-  context "associations" do
+  context "with associations" do
     it { is_expected.to have_many(:memberships) }
     it { is_expected.to have_many(:users).through(:memberships) }
     it { is_expected.to have_many(:mentor_trainings) }
   end
 
-  context "validations" do
+  context "with validations" do
     subject { build(:provider) }
 
     it { is_expected.to validate_presence_of(:code) }
@@ -52,7 +52,7 @@ RSpec.describe Provider, type: :model do
     it { is_expected.to allow_values("scitt", "lead_school", "university").for(:provider_type) }
   end
 
-  context "scopes" do
+  context "with scopes" do
     describe "#accredited" do
       let!(:accredited_provider) { create(:provider, accredited: true) }
       let!(:non_accredited_provider) { create(:provider) }

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -16,11 +16,11 @@
 require "rails_helper"
 
 RSpec.describe Region, type: :model do
-  context "associations" do
+  context "with associations" do
     it { is_expected.to have_many(:schools) }
   end
 
-  context "validations" do
+  context "with validations" do
     subject { create(:region) }
 
     it { is_expected.to validate_presence_of(:name) }

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -55,13 +55,13 @@
 require "rails_helper"
 
 RSpec.describe School, type: :model do
-  context "associations" do
+  context "with associations" do
     it { is_expected.to have_many(:memberships) }
     it { is_expected.to have_many(:mentors) }
     it { is_expected.to belong_to(:region) }
   end
 
-  context "scopes" do
+  context "with scopes" do
     describe "#placements_service" do
       it "only returns placements schools" do
         create(:school, :claims)
@@ -83,7 +83,7 @@ RSpec.describe School, type: :model do
     end
   end
 
-  context "validations" do
+  context "with validations" do
     subject { create(:school) }
 
     it { is_expected.to validate_presence_of(:urn) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,7 +21,7 @@ require "rails_helper"
 RSpec.describe User, type: :model do
   subject { build(:user) }
 
-  context "associations" do
+  context "with associations" do
     it { is_expected.to have_many(:memberships).dependent(:destroy) }
   end
 

--- a/spec/requests/heartbeat_spec.rb
+++ b/spec/requests/heartbeat_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Heartbeats", type: :request do
       end
     end
 
-    context "there's no db connection" do
+    context "when there's no db connection" do
       before do
         allow(ActiveRecord::Base).to receive(:connected?).and_return(false)
       end

--- a/spec/services/placements/organisation_finder_spec.rb
+++ b/spec/services/placements/organisation_finder_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Placements::OrganisationFinder do
     create(:school, :placements, name: "1 Primary", postcode: "SW12 H3B")
   end
 
-  context "no search or filter" do
+  context "with no search or filter" do
     subject { described_class.call }
 
     it "returns all placement schools and providers, ordered by name" do
@@ -25,7 +25,7 @@ RSpec.describe Placements::OrganisationFinder do
     end
   end
 
-  context "search without filters" do
+  context "with search without filters" do
     describe "search postcode" do
       subject { described_class.call(search_term: "HA4") }
 
@@ -58,7 +58,7 @@ RSpec.describe Placements::OrganisationFinder do
   end
 
   describe "filters without search" do
-    context "schools only" do
+    context "with schools only" do
       subject { described_class.call(filters: %w[school]) }
 
       it "returns only schools ordered by name" do
@@ -69,7 +69,7 @@ RSpec.describe Placements::OrganisationFinder do
       end
     end
 
-    context "school and provider" do
+    context "with school and provider" do
       subject { described_class.call(filters: %w[school university]) }
 
       it "returns only schools and specified provider type" do

--- a/spec/services/remove_user_service_spec.rb
+++ b/spec/services/remove_user_service_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RemoveUserService do
   subject { described_class.call(user, organisation) }
 
   describe "#call" do
-    context "the user is a placements user" do
+    context "when the user is a placements user" do
       let(:user) { create(:placements_user) }
       let(:organisation) { create(:placements_school) }
       let!(:membership) { create(:membership, user:, organisation:) }
@@ -19,7 +19,7 @@ RSpec.describe RemoveUserService do
       end
     end
 
-    context "the user is a claims user" do
+    context "when the user is a claims user" do
       let(:user) { create(:claims_user) }
       let(:organisation) { create(:claims_school) }
       let!(:membership) { create(:membership, user:, organisation:) }

--- a/spec/system/placements/organisations/add_users_spec.rb
+++ b/spec/system/placements/organisations/add_users_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Placements users invite other users to organisations", type: :sy
   let(:new_user) { create(:placements_user) }
 
   describe "Ann invites a member successfully " do
-    context "provider" do
+    context "with provider" do
       before "user is sent an invitation" do
         user_mailer = double(:user_mailer)
         expect(UserMailer).to receive(:invitation_email).with(kind_of(Placements::User), one_provider, "http://placements.localhost/sign-in") { user_mailer }
@@ -32,7 +32,7 @@ RSpec.describe "Placements users invite other users to organisations", type: :sy
       end
     end
 
-    context "school" do
+    context "with school" do
       before "user is sent an invitation" do
         user_mailer = double(:user_mailer)
         expect(UserMailer).to receive(:invitation_email).with(kind_of(Placements::User), one_school, "http://placements.localhost/sign-in") { user_mailer }

--- a/spec/system/placements/support/users/support_user_removes_a_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_removes_a_user_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
     end
   end
 
-  context "user is a member of more than one organisation" do
+  context "when user is a member of more than one organisation" do
     let(:school) { create(:placements_school) }
     let(:provider) { create(:placements_provider) }
     let(:user) { create(:placements_user) }

--- a/spec/system/service_updates_page_spec.rb
+++ b/spec/system/service_updates_page_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Service updates page", type: :system do
-  context "User is on the Claims site", service: :claims do
+  context "when user is on the Claims site", service: :claims do
     before do
       allow(YAML).to receive(:load_file).with(Rails.root.join("db/claims_service_updates.yml"), symbolize_names: true).and_return([
         {
@@ -19,7 +19,7 @@ RSpec.describe "Service updates page", type: :system do
     end
   end
 
-  context "User is on the Placements site", service: :placements do
+  context "when user is on the Placements site", service: :placements do
     before do
       allow(YAML).to receive(:load_file).with(Rails.root.join("db/placements_service_updates.yml"), symbolize_names: true).and_return([
         {


### PR DESCRIPTION
## Context

We want to enable all the rspec rules in rubocop that are not enabled https://github.com/DFE-Digital/itt-mentor-services/blob/main/.rubocop.yml#L42-L53

This PR enables `RSpec/ContextWording` which expects the context description to be like `Context description should match /^when\b/, /^with\b/, /^without\b/,
/^and\b/, or /^but\b/`

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Enable the rule
Change all specs that break this rule

## Guidance to review

Review
Do the tests pass?
Maybe have a brew after? 


