### PR TITLE
Lb/enable RSpec/VerifiedDoubles

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,7 +40,7 @@ RSpec/SpecFilePathSuffix:
 # introduce RSpec rules while incrementally fixing up the codebase.
 # They should eventually all be re-enabled.
 RSpec/VerifiedDoubles:
-  Enabled: false
+  Enabled: true
 RSpec/ExpectInHook:
   Enabled: false
 RSpec/StubbedMock:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,8 +39,6 @@ RSpec/SpecFilePathSuffix:
 # The following cops are temporarily disabled so we can incrementally
 # introduce RSpec rules while incrementally fixing up the codebase.
 # They should eventually all be re-enabled.
-RSpec/VerifiedDoubles:
-  Enabled: true
 RSpec/ExpectInHook:
   Enabled: false
 RSpec/StubbedMock:

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,6 +43,9 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  # Use the test adapter for ActiveJob
+  config.active_job.queue_adapter = :test
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/spec/forms/user_invite_form_spec.rb
+++ b/spec/forms/user_invite_form_spec.rb
@@ -71,10 +71,9 @@ describe UserInviteForm, type: :model do
         }
       end
 
-      before "it sends invitation" do
-        user_mailer = double(:user_mailer)
-        expect(UserMailer).to receive(:invitation_email) { user_mailer }
-        expect(user_mailer).to receive(:deliver_later)
+      it "sends invitation" do
+        user_invite_form = described_class.new(form_params)
+        expect { user_invite_form.invite }.to have_enqueued_mail(UserMailer, :invitation_email)
       end
 
       it "creates user" do
@@ -103,10 +102,9 @@ describe UserInviteForm, type: :model do
           service: :placements,
         }
 
-        before "it sends invitation" do
-          user_mailer = double(:user_mailer)
-          expect(UserMailer).to receive(:invitation_email) { user_mailer }
-          expect(user_mailer).to receive(:deliver_later)
+        it "sends invitation" do
+          user_invite_form = described_class.new(form_params)
+          expect { user_invite_form.invite }.to have_enqueued_mail(UserMailer, :invitation_email)
         end
 
         it "updates user first name" do

--- a/spec/lib/hosting_environment_spec.rb
+++ b/spec/lib/hosting_environment_spec.rb
@@ -126,12 +126,12 @@ RSpec.describe HostingEnvironment do
 
   describe ".current_service" do
     it "returns the current service for claims" do
-      request = double(host: ENV["CLAIMS_HOST"])
+      request = instance_double("Rack::Request", host: ENV["CLAIMS_HOST"])
       expect(described_class.current_service(request)).to eq(:claims)
     end
 
     it "returns the current service for placements" do
-      request = double(host: ENV["PLACEMENTS_HOST"])
+      request = instance_double("Rack::Request", host: ENV["PLACEMENTS_HOST"])
       expect(described_class.current_service(request)).to eq(:placements)
     end
   end

--- a/spec/services/remove_user_service_spec.rb
+++ b/spec/services/remove_user_service_spec.rb
@@ -10,11 +10,8 @@ RSpec.describe RemoveUserService do
       let!(:membership) { create(:membership, user:, organisation:) }
 
       it "calls mailer with correct params" do
-        user_mailer = double(:user_mailer)
-        expect(UserMailer).to receive(:removal_email).with(user, organisation) { user_mailer }
-        expect(user_mailer).to receive(:deliver_later)
+        expect { subject }.to have_enqueued_mail(UserMailer, :removal_email).with(user, organisation)
 
-        subject
         expect { membership.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
@@ -25,11 +22,7 @@ RSpec.describe RemoveUserService do
       let!(:membership) { create(:membership, user:, organisation:) }
 
       it "calls mailer with correct params" do
-        user_mailer = double(:user_mailer)
-        expect(UserMailer).to receive(:removal_email).with(user, organisation) { user_mailer }
-        expect(user_mailer).to receive(:deliver_later)
-
-        subject
+        expect { subject }.to have_enqueued_mail(UserMailer, :removal_email).with(user, organisation)
 
         expect { membership.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end

--- a/spec/services/user_invite_service_spec.rb
+++ b/spec/services/user_invite_service_spec.rb
@@ -11,10 +11,7 @@ RSpec.describe UserInviteService do
         let(:service) { "claims" }
 
         it "calls mailer with correct prams" do
-          user_mailer = double(:user_mailer)
-          expect(UserMailer).to receive(:invitation_email).with(user, organisation, "http://claims.localhost/sign-in") { user_mailer }
-          expect(user_mailer).to receive(:deliver_later)
-          subject
+          expect { subject }.to have_enqueued_mail(UserMailer, :invitation_email).with(user, organisation, "http://claims.localhost/sign-in")
         end
       end
     end
@@ -27,10 +24,7 @@ RSpec.describe UserInviteService do
         let(:organisation) { create(:school, :placements) }
 
         it "calls mailer with correct prams" do
-          user_mailer = double(:user_mailer)
-          expect(UserMailer).to receive(:invitation_email).with(user, organisation, "http://placements.localhost/sign-in") { user_mailer }
-          expect(user_mailer).to receive(:deliver_later)
-          subject
+          expect { subject }.to have_enqueued_mail(UserMailer, :invitation_email).with(user, organisation, "http://placements.localhost/sign-in")
         end
       end
 
@@ -39,10 +33,7 @@ RSpec.describe UserInviteService do
         let(:organisation) { create(:placements_provider) }
 
         it "calls mailer with correct prams" do
-          user_mailer = double(:user_mailer)
-          expect(UserMailer).to receive(:invitation_email).with(user, organisation, "http://placements.localhost/sign-in") { user_mailer }
-          expect(user_mailer).to receive(:deliver_later)
-          subject
+          expect { subject }.to have_enqueued_mail(UserMailer, :invitation_email).with(user, organisation, "http://placements.localhost/sign-in")
         end
       end
     end

--- a/spec/system/claims/support/schools/invite_a_user_to_a_school_spec.rb
+++ b/spec/system/claims/support/schools/invite_a_user_to_a_school_spec.rb
@@ -1,11 +1,14 @@
 require "rails_helper"
 
 RSpec.describe "Invite a user to a school", type: :system do
+  include ActiveJob::TestHelper
+
+  around do |example|
+    perform_enqueued_jobs { example.run }
+  end
+
   before do
     setup_school
-    mailer_double = double(:mailer_double)
-    allow(mailer_double).to receive(:deliver_later).and_return true
-    allow(UserMailer).to receive(:invitation_email).and_return(mailer_double)
   end
 
   scenario "I sign in as a support user and invite a user to a school" do
@@ -159,6 +162,7 @@ RSpec.describe "Invite a user to a school", type: :system do
   end
 
   def verify_user_added
+    email_is_sent("barry.garlow@eduction.gov.uk", @school)
     visit_claims_support_school_users_page
     check_user_details
   end
@@ -168,7 +172,16 @@ RSpec.describe "Invite a user to a school", type: :system do
   end
 
   def verify_user_added_to_another_school
+    email_is_sent("barry.garlow@eduction.gov.uk", @another_school)
     visit_another_claims_support_school_users_page
     check_user_details
+  end
+
+  def email_is_sent(email, school)
+    email = ActionMailer::Base.deliveries.find do |delivery|
+      delivery.to.include?(email) && delivery.subject == "You have been invited to #{school.name}"
+    end
+
+    expect(email).not_to be_nil
   end
 end

--- a/spec/system/claims/support/support_users/remove_a_support_user_spec.rb
+++ b/spec/system/claims/support/support_users/remove_a_support_user_spec.rb
@@ -1,14 +1,16 @@
 require "rails_helper"
 
 RSpec.describe "Remove a support user", type: :system do
+  include ActiveJob::TestHelper
+
+  around do |example|
+    perform_enqueued_jobs { example.run }
+  end
+
   let!(:support_user) { create(:claims_support_user, :colin) }
   let!(:support_user_to_be_removed) { create(:claims_support_user) }
 
   scenario "Remove a support user" do
-    support_user_mailer = double(:support_user_mailer)
-    expect(SupportUserMailer).to receive(:support_user_removal_notification).with(support_user_to_be_removed) { support_user_mailer }
-    expect(support_user_mailer).to receive(:deliver_later)
-
     when_i_sign_in_as_a_support_user(support_user)
     and_i_visit_the_support_users_page
     and_i_click_on_a_support_user(support_user_to_be_removed)
@@ -16,6 +18,7 @@ RSpec.describe "Remove a support user", type: :system do
     then_i_see_the_support_user_removal_confirmation(support_user_to_be_removed)
     when_i_click_on_remove
     then_i_see_the_support_user_has_been_removed(support_user_to_be_removed)
+    then_an_email_is_sent(support_user_to_be_removed.email)
   end
 
   scenario "A support user can not remove themselves as a support user" do
@@ -60,5 +63,13 @@ RSpec.describe "Remove a support user", type: :system do
 
   def then_i_can_not_see_a_remove_link
     expect(page).not_to have_content("Remove user")
+  end
+
+  def then_an_email_is_sent(email)
+    email = ActionMailer::Base.deliveries.find do |delivery|
+      delivery.to.include?(email) && delivery.subject == "You have been removed from Claim funding for mentors"
+    end
+
+    expect(email).not_to be_nil
   end
 end

--- a/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
+++ b/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 RSpec.describe "Placements support user removes a user from an organisation", type: :system, service: :placements do
+  include ActiveJob::TestHelper
+
+  around do |example|
+    perform_enqueued_jobs { example.run }
+  end
+
   describe "schools" do
     let(:school) { create(:placements_school) }
     let(:anne) { create(:placements_user, :anne) }
@@ -44,7 +50,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
       end
     end
 
-    scenario "user is removed from a school" do
+    scenario "user is removed from a provider" do
       given_i_am_signed_in_as_mary
       and_i_visit_the_user_page(anne)
       when_i_click_on("Remove user")

--- a/spec/system/placements/support/support_users/support_user_removes_a_support_user_spec.rb
+++ b/spec/system/placements/support/support_users/support_user_removes_a_support_user_spec.rb
@@ -3,14 +3,16 @@ require "rails_helper"
 RSpec.describe "Placements / Support Users / Support users removes a support user",
                type: :system,
                service: :placements do
+  include ActiveJob::TestHelper
+
+  around do |example|
+    perform_enqueued_jobs { example.run }
+  end
+
   let!(:support_user) { create(:placements_support_user, :colin) }
   let!(:support_user_to_be_removed) { create(:placements_support_user) }
 
   scenario "Remove a support user" do
-    support_user_mailer = double(:support_user_mailer)
-    expect(SupportUserMailer).to receive(:support_user_removal_notification).with(support_user_to_be_removed) { support_user_mailer }
-    expect(support_user_mailer).to receive(:deliver_later)
-
     when_i_sign_in_as_a_support_user(support_user)
     and_i_visit_the_support_users_page
     and_i_click_on_a_support_user(support_user_to_be_removed)
@@ -18,6 +20,7 @@ RSpec.describe "Placements / Support Users / Support users removes a support use
     then_i_see_the_support_user_removal_confirmation(support_user_to_be_removed)
     when_i_click_on_remove
     then_i_see_the_support_user_has_been_removed(support_user_to_be_removed)
+    then_an_email_is_sent(support_user_to_be_removed.email)
   end
 
   scenario "A support user can not remove themselves as a support user" do
@@ -58,6 +61,14 @@ RSpec.describe "Placements / Support Users / Support users removes a support use
   def then_i_see_the_support_user_has_been_removed(support_user)
     expect(page).not_to have_content support_user.full_name
     expect(page).to have_content "User removed"
+  end
+
+  def then_an_email_is_sent(email)
+    email = ActionMailer::Base.deliveries.find do |delivery|
+      delivery.to.include?(email) && delivery.subject == "You have been removed from Manage school placements"
+    end
+
+    expect(email).not_to be_nil
   end
 
   def then_i_can_not_see_a_remove_link


### PR DESCRIPTION
## Context
We ant to enable all the rspec rules for rubocop.

## Changes proposed in this pull request
This PR removes unverified doubles

## Guidance to review
Have a loop
The tests should pass!

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
