### PR TITLE
Enable NamedSubject rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,5 +43,3 @@ RSpec/ExpectInHook:
   Enabled: false
 RSpec/InstanceVariable:
   Enabled: false
-RSpec/NamedSubject:
-  Enabled: false

--- a/spec/forms/organisation_onboarding_form_spec.rb
+++ b/spec/forms/organisation_onboarding_form_spec.rb
@@ -4,11 +4,7 @@ describe OrganisationOnboardingForm, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of(:organisation_type) }
 
-    it {
-      expect(subject).to validate_inclusion_of(:organisation_type).in_array(
-        described_class::ORGANISATION_TYPES,
-      )
-    }
+    it { is_expected.to validate_inclusion_of(:organisation_type).in_array(described_class::ORGANISATION_TYPES) }
   end
 
   describe "#options" do

--- a/spec/mailers/support_user_mailer_spec.rb
+++ b/spec/mailers/support_user_mailer_spec.rb
@@ -3,14 +3,14 @@ require "rails_helper"
 RSpec.describe SupportUserMailer, type: :mailer do
   describe "#support_user_invitation" do
     context "when inviting a user to the claims service" do
-      subject { described_class.with(service: "claims").support_user_invitation(user) }
+      subject(:invite_email) { described_class.with(service: "claims").support_user_invitation(user) }
 
       let(:user) { create(:claims_support_user, first_name: "John", last_name: "Doe") }
 
       it "is addressed to the user's email and contains a link to the claims sign in url" do
-        expect(subject.to).to contain_exactly(user.email)
-        expect(subject.subject).to eq("Invitation to join Claim funding for mentors")
-        expect(subject.body).to have_content <<~EMAIL
+        expect(invite_email.to).to contain_exactly(user.email)
+        expect(invite_email.subject).to eq("Invitation to join Claim funding for mentors")
+        expect(invite_email.body).to have_content <<~EMAIL
           Dear John Doe,
 
           You have been invited to join Claim funding for mentors.
@@ -21,14 +21,14 @@ RSpec.describe SupportUserMailer, type: :mailer do
     end
 
     context "when inviting a user to the placements service" do
-      subject { described_class.with(service: "placements").support_user_invitation(user) }
+      subject(:invite_email) { described_class.with(service: "placements").support_user_invitation(user) }
 
       let(:user) { create(:placements_support_user, first_name: "John", last_name: "Doe") }
 
       it "is addressed to the user's email and contains a link to the placements sign in url" do
-        expect(subject.to).to contain_exactly(user.email)
-        expect(subject.subject).to eq("Invitation to join Manage school placements")
-        expect(subject.body).to have_content <<~EMAIL
+        expect(invite_email.to).to contain_exactly(user.email)
+        expect(invite_email.subject).to eq("Invitation to join Manage school placements")
+        expect(invite_email.body).to have_content <<~EMAIL
           Dear John Doe,
 
           You have been invited to join Manage school placements.
@@ -40,15 +40,15 @@ RSpec.describe SupportUserMailer, type: :mailer do
   end
 
   describe "#support_user_removal_notification" do
-    context "when inviting a user to the claims service" do
-      subject { described_class.with(service: "claims").support_user_removal_notification(user) }
+    context "when removing a user from the claims service" do
+      subject(:removal_email) { described_class.with(service: "claims").support_user_removal_notification(user) }
 
       let(:user) { create(:claims_support_user, first_name: "John", last_name: "Doe") }
 
       it "is addressed to the user's email and contains a link to the claims sign in url" do
-        expect(subject.to).to contain_exactly(user.email)
-        expect(subject.subject).to eq("You have been removed from Claim funding for mentors")
-        expect(subject.body).to have_content <<~EMAIL
+        expect(removal_email.to).to contain_exactly(user.email)
+        expect(removal_email.subject).to eq("You have been removed from Claim funding for mentors")
+        expect(removal_email.body).to have_content <<~EMAIL
           Dear John Doe,
 
           You have been removed from Claim funding for mentors.
@@ -56,15 +56,15 @@ RSpec.describe SupportUserMailer, type: :mailer do
       end
     end
 
-    context "when inviting a user to the placements service" do
-      subject { described_class.with(service: "placements").support_user_removal_notification(user) }
+    context "when removing a user from the placements service" do
+      subject(:removal_email) { described_class.with(service: "placements").support_user_removal_notification(user) }
 
       let(:user) { create(:placements_support_user, first_name: "John", last_name: "Doe") }
 
       it "is addressed to the user's email and contains a link to the placements sign in url" do
-        expect(subject.to).to contain_exactly(user.email)
-        expect(subject.subject).to eq("You have been removed from Manage school placements")
-        expect(subject.body).to have_content <<~EMAIL
+        expect(removal_email.to).to contain_exactly(user.email)
+        expect(removal_email.subject).to eq("You have been removed from Manage school placements")
+        expect(removal_email.body).to have_content <<~EMAIL
           Dear John Doe,
 
           You have been removed from Manage school placements.

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -2,17 +2,17 @@ require "rails_helper"
 
 RSpec.describe UserMailer, type: :mailer do
   describe "#invitation_email" do
-    subject { described_class.invitation_email(user, organisation, "sign_in_url") }
+    subject(:invite_email) { described_class.invitation_email(user, organisation, "sign_in_url") }
 
     context "when user's service is Claims" do
       let(:user) { create(:claims_user) }
       let(:organisation) { create(:claims_school) }
 
       it "sends the invitation" do
-        expect(subject.to).to contain_exactly(user.email)
-        expect(subject.subject).to eq("You have been invited to #{organisation.name}")
+        expect(invite_email.to).to contain_exactly(user.email)
+        expect(invite_email.subject).to eq("You have been invited to #{organisation.name}")
 
-        expect(subject.body.encoded).to eq(
+        expect(invite_email.body.encoded).to eq(
           "Dear #{user.full_name} \r\n\r\n You have been invited to join the claims" \
             " service for #{organisation.name}.\r\n\r\n Sign in here sign_in_url",
         )
@@ -25,9 +25,9 @@ RSpec.describe UserMailer, type: :mailer do
         let(:organisation) { create(:placements_school) }
 
         it "sends invitation email" do
-          expect(subject.to).to contain_exactly(user.email)
-          expect(subject.subject).to eq("You have been invited to #{organisation.name}")
-          expect(subject.body.encoded).to eq(
+          expect(invite_email.to).to contain_exactly(user.email)
+          expect(invite_email.subject).to eq("You have been invited to #{organisation.name}")
+          expect(invite_email.body.encoded).to eq(
             "Dear #{user.full_name} \r\n\r\n You have been invited to join the school placements" \
             " service for #{organisation.name}.\r\n\r\n Sign in here sign_in_url",
           )
@@ -39,9 +39,9 @@ RSpec.describe UserMailer, type: :mailer do
         let(:organisation) { create(:placements_provider) }
 
         it "sends invitation email" do
-          expect(subject.to).to contain_exactly(user.email)
-          expect(subject.subject).to eq("You have been invited to #{organisation.name}")
-          expect(subject.body.encoded).to eq(
+          expect(invite_email.to).to contain_exactly(user.email)
+          expect(invite_email.subject).to eq("You have been invited to #{organisation.name}")
+          expect(invite_email.body.encoded).to eq(
             "Dear #{user.full_name} \r\n\r\n You have been invited to join the school placements" \
               " service for #{organisation.name}.\r\n\r\n Sign in here sign_in_url",
           )
@@ -51,7 +51,7 @@ RSpec.describe UserMailer, type: :mailer do
   end
 
   describe "#removal_email" do
-    subject { described_class.removal_email(user, organisation) }
+    subject(:removal_email) { described_class.removal_email(user, organisation) }
 
     context "when user's service is Placements" do
       context "when organisation is a school" do
@@ -59,9 +59,9 @@ RSpec.describe UserMailer, type: :mailer do
         let(:organisation) { create(:placements_school) }
 
         it "sends expected message to user" do
-          expect(subject.to).to contain_exactly user.email
-          expect(subject.subject).to eq "You have been removed from #{organisation.name}"
-          expect(subject.body.encoded).to eq("Dear #{user.full_name} \r\n\r\n You have been removed from the " \
+          expect(removal_email.to).to contain_exactly user.email
+          expect(removal_email.subject).to eq "You have been removed from #{organisation.name}"
+          expect(removal_email.body.encoded).to eq("Dear #{user.full_name} \r\n\r\n You have been removed from the " \
                                          "school placements service for #{organisation.name}.")
         end
       end
@@ -71,9 +71,9 @@ RSpec.describe UserMailer, type: :mailer do
         let(:organisation) { create(:placements_provider) }
 
         it "sends expected message to user" do
-          expect(subject.to).to contain_exactly user.email
-          expect(subject.subject).to eq "You have been removed from #{organisation.name}"
-          expect(subject.body.encoded).to eq("Dear #{user.full_name} \r\n\r\n You have been removed from the " \
+          expect(removal_email.to).to contain_exactly user.email
+          expect(removal_email.subject).to eq "You have been removed from #{organisation.name}"
+          expect(removal_email.body.encoded).to eq("Dear #{user.full_name} \r\n\r\n You have been removed from the " \
             "school placements service for #{organisation.name}.")
         end
       end
@@ -84,9 +84,9 @@ RSpec.describe UserMailer, type: :mailer do
       let(:organisation) { create(:claims_school) }
 
       it "sends expected message to user" do
-        expect(subject.to).to contain_exactly user.email
-        expect(subject.subject).to eq "You have been removed from #{organisation.name}"
-        expect(subject.body.encoded).to eq("Dear #{user.full_name} \r\n\r\n You have been removed from the claims" \
+        expect(removal_email.to).to contain_exactly user.email
+        expect(removal_email.subject).to eq "You have been removed from #{organisation.name}"
+        expect(removal_email.body.encoded).to eq("Dear #{user.full_name} \r\n\r\n You have been removed from the claims" \
           " service for #{organisation.name}.")
       end
     end

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -22,18 +22,18 @@
 require "rails_helper"
 
 RSpec.describe Membership, type: :model do
-  subject { create(:membership) }
+  subject(:test_membership) { create(:membership) }
 
   context "with validations" do
     it do
-      expect(subject).to validate_uniqueness_of(:user).scoped_to(:organisation_id)
+      expect(test_membership).to validate_uniqueness_of(:user).scoped_to(:organisation_id)
     end
   end
 
   context "with associations" do
     it do
-      expect(subject).to belong_to(:user)
-      expect(subject).to belong_to(:organisation)
+      expect(test_membership).to belong_to(:user)
+      expect(test_membership).to belong_to(:organisation)
     end
   end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -38,13 +38,13 @@ RSpec.describe Provider, type: :model do
   end
 
   context "with validations" do
-    subject { build(:provider) }
+    subject(:test_provider) { build(:provider) }
 
     it { is_expected.to validate_presence_of(:code) }
     it { is_expected.to validate_presence_of(:name) }
 
     it do
-      expect(subject).to validate_uniqueness_of(
+      expect(test_provider).to validate_uniqueness_of(
         :code,
       ).case_insensitive
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,7 +21,7 @@
 require "rails_helper"
 
 RSpec.describe User, type: :model do
-  subject { build(:user) }
+  subject(:test_user) { build(:user) }
 
   context "with associations" do
     it { is_expected.to have_many(:memberships).dependent(:destroy) }
@@ -65,7 +65,7 @@ RSpec.describe User, type: :model do
 
   describe "#support_user?" do
     it "returns false" do
-      expect(subject.support_user?).to eq(false)
+      expect(test_user.support_user?).to eq(false)
     end
   end
 

--- a/spec/policies/claims/school_policy/scope_spec.rb
+++ b/spec/policies/claims/school_policy/scope_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Claims::SchoolPolicy::Scope do
-  subject { described_class.new(user, Claims::School).resolve }
+  subject(:school_policy) { described_class.new(user, Claims::School).resolve }
 
   let!(:non_associated_school) { create(:claims_school) }
   let!(:associated_school) { create(:claims_school) }
@@ -10,7 +10,7 @@ RSpec.describe Claims::SchoolPolicy::Scope do
     let(:user) { create(:claims_support_user) }
 
     it "returns all schools" do
-      expect(subject).to match_array([non_associated_school, associated_school])
+      expect(school_policy).to match_array([non_associated_school, associated_school])
     end
   end
 
@@ -22,7 +22,7 @@ RSpec.describe Claims::SchoolPolicy::Scope do
     end
 
     it "returns schools that the user is associated with" do
-      expect(subject).to match_array([associated_school])
+      expect(school_policy).to match_array([associated_school])
     end
   end
 end

--- a/spec/policies/claims/support_user_policy_spec.rb
+++ b/spec/policies/claims/support_user_policy_spec.rb
@@ -1,18 +1,18 @@
 require "rails_helper"
 
 describe Claims::SupportUserPolicy do
-  subject { described_class }
+  subject(:support_user_policy) { described_class }
 
   let(:support_user_1) { create(:claims_support_user) }
   let(:support_user_2) { create(:claims_support_user) }
 
   permissions :destroy? do
     it "denies access current_user is the support_user" do
-      expect(subject).not_to permit(support_user_1, support_user_1)
+      expect(support_user_policy).not_to permit(support_user_1, support_user_1)
     end
 
     it "grants access current_user is not the support_user" do
-      expect(subject).to permit(support_user_1, support_user_2)
+      expect(support_user_policy).to permit(support_user_1, support_user_2)
     end
   end
 end

--- a/spec/policies/placements/support_user_policy_spec.rb
+++ b/spec/policies/placements/support_user_policy_spec.rb
@@ -1,18 +1,18 @@
 require "rails_helper"
 
 describe Placements::SupportUserPolicy do
-  subject { described_class }
+  subject(:support_user_policy) { described_class }
 
   let(:support_user_1) { create(:placements_support_user) }
   let(:support_user_2) { create(:placements_support_user) }
 
   permissions :destroy? do
     it "denies access current_user is the support_user" do
-      expect(subject).not_to permit(support_user_1, support_user_1)
+      expect(support_user_policy).not_to permit(support_user_1, support_user_1)
     end
 
     it "grants access current_user is not the support_user" do
-      expect(subject).to permit(support_user_1, support_user_2)
+      expect(support_user_policy).to permit(support_user_1, support_user_2)
     end
   end
 end

--- a/spec/policies/placements/user_policy_spec.rb
+++ b/spec/policies/placements/user_policy_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Placements::UserPolicy do
-  subject { described_class }
+  subject(:user_policy) { described_class }
 
   permissions :destroy? do
     context "when current user and user are the the same user" do
@@ -9,7 +9,7 @@ RSpec.describe Placements::UserPolicy do
       let(:user) { current_user }
 
       it "denies access" do
-        expect(subject).not_to permit(current_user, user)
+        expect(user_policy).not_to permit(current_user, user)
       end
     end
 
@@ -18,7 +18,7 @@ RSpec.describe Placements::UserPolicy do
       let(:user) { create(:placements_user) }
 
       it "grants access" do
-        expect(subject).to permit(current_user, user)
+        expect(user_policy).to permit(current_user, user)
       end
     end
   end

--- a/spec/services/accredited_provider/api_spec.rb
+++ b/spec/services/accredited_provider/api_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Provider::Api do
-  subject { described_class.call }
+  subject(:provider_api) { described_class.call }
 
   before do
     stub_request(
@@ -31,7 +31,7 @@ RSpec.describe Provider::Api do
   end
 
   it "returns a list of providers from the current recruitment cycle publish-teacher-training-courses api" do
-    response = subject
+    response = provider_api
     expect(response.fetch("data")).to match_array(
       [
         {

--- a/spec/services/accredited_provider/importer_spec.rb
+++ b/spec/services/accredited_provider/importer_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Provider::Importer do
-  subject { described_class.call }
+  subject(:importer) { described_class.call }
 
   let(:existing_provider) { create(:provider) }
   let(:changeable_provider) { create(:provider, name: "Changeable Provider") }
@@ -102,7 +102,7 @@ RSpec.describe Provider::Importer do
   end
 
   it "creates new provider records for responses which don't already exist or are valid" do
-    expect { subject }.to change(Provider, :count).by(4)
+    expect { importer }.to change(Provider, :count).by(4)
     expect(Provider.find_by(name: "Provider 1", code: "Prov1", provider_type: "scitt")).to be_present
     expect(Provider.find_by(name: "Provider 2", code: "Prov2", provider_type: "university")).to be_present
     expect(Provider.find_by(name: "Provider 3", code: "Prov3", provider_type: "lead_school")).to be_present

--- a/spec/services/dfe_sign_in/user_update_spec.rb
+++ b/spec/services/dfe_sign_in/user_update_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe DfESignIn::UserUpdate do
-  subject { described_class.call(current_user:, sign_in_user:) }
+  subject(:dfe_sign_in) { described_class.call(current_user:, sign_in_user:) }
 
   let(:current_user) { create(:claims_user) }
   let(:sign_in_user) do
@@ -15,7 +15,7 @@ RSpec.describe DfESignIn::UserUpdate do
   end
 
   it "updates the user's sign in attributes" do
-    expect { subject }.to change(current_user, :email).to("test@gmail.com")
+    expect { dfe_sign_in }.to change(current_user, :email).to("test@gmail.com")
       .and change(current_user, :first_name).to("John")
       .and change(current_user, :last_name).to("Doe")
       .and change(current_user, :dfe_sign_in_uid).to("123")

--- a/spec/services/gias_csv_importer_spec.rb
+++ b/spec/services/gias_csv_importer_spec.rb
@@ -1,26 +1,26 @@
 require "rails_helper"
 
 RSpec.describe GiasCsvImporter do
-  subject { described_class.call("spec/fixtures/test_gias_import.csv") }
+  subject(:gias_importer) { described_class.call("spec/fixtures/test_gias_import.csv") }
 
   it "inserts the correct schools" do
-    expect { subject }.to change(School, :count).from(0).to(4)
+    expect { gias_importer }.to change(School, :count).from(0).to(4)
   end
 
   it "updates the correct schools" do
     school = create(:school, urn: "123")
-    expect { subject }.to change { school.reload.name }.to "FringeSchool"
+    expect { gias_importer }.to change { school.reload.name }.to "FringeSchool"
   end
 
   it "logs messages to STDOUT" do
     expect(Rails.logger).to receive(:info).with("Invalid rows - [\"Row 8 is invalid\"]")
     expect(Rails.logger).to receive(:info).with("Done!")
 
-    subject
+    gias_importer
   end
 
   it "associates schools to regions" do
-    subject
+    gias_importer
 
     inner_london_school = School.find_by(urn: "130")
     outer_london_school = School.find_by(urn: "131")

--- a/spec/services/placements/organisation_finder_spec.rb
+++ b/spec/services/placements/organisation_finder_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe Placements::OrganisationFinder do
   end
 
   context "with no search or filter" do
-    subject { described_class.call }
+    subject(:organisations_finder) { described_class.call }
 
     it "returns all placement schools and providers, ordered by name" do
-      results = subject
+      results = organisations_finder
       expect(results.pluck(:content))
         .to eq ["1 Primary SW12 H3B",
                 "A School HA4 2FW",
@@ -27,30 +27,30 @@ RSpec.describe Placements::OrganisationFinder do
 
   context "with search without filters" do
     describe "search postcode" do
-      subject { described_class.call(search_term: "HA4") }
+      subject(:organisations_finder) { described_class.call(search_term: "HA4") }
 
       it "returns a provider and school matching the search term" do
-        results = subject
+        results = organisations_finder
         expect(results.pluck(:content))
           .to match_array ["A School HA4 2FW", "University of Westminster HA4 9JZ"]
       end
     end
 
     describe "search name" do
-      subject { described_class.call(search_term: "London") }
+      subject(:organisations_finder) { described_class.call(search_term: "London") }
 
       it "returns a provider and school with 'London' in the name" do
-        results = subject
+        results = organisations_finder
         expect(results.pluck(:content))
           .to match_array ["School London EC12 5BN", "Provider London SE3 5SL"]
       end
     end
 
     describe "search partial name" do
-      subject { described_class.call(search_term: "Lond") }
+      subject(:organisations_finder) { described_class.call(search_term: "Lond") }
 
       it "returns a provider and school with 'London' in the name" do
-        results = subject
+        results = organisations_finder
         expect(results.pluck(:content))
           .to match_array ["School London EC12 5BN", "Provider London SE3 5SL"]
       end
@@ -59,10 +59,10 @@ RSpec.describe Placements::OrganisationFinder do
 
   describe "filters without search" do
     context "with schools only" do
-      subject { described_class.call(filters: %w[school]) }
+      subject(:organisations_finder) { described_class.call(filters: %w[school]) }
 
       it "returns only schools ordered by name" do
-        results = subject
+        results = organisations_finder
         expect(results.pluck(:content)).to eq ["1 Primary SW12 H3B",
                                                "A School HA4 2FW",
                                                "School London EC12 5BN"]
@@ -70,10 +70,10 @@ RSpec.describe Placements::OrganisationFinder do
     end
 
     context "with school and provider" do
-      subject { described_class.call(filters: %w[school university]) }
+      subject(:organisations_finder) { described_class.call(filters: %w[school university]) }
 
       it "returns only schools and specified provider type" do
-        results = subject
+        results = organisations_finder
         expect(results.pluck(:content)).to eq ["1 Primary SW12 H3B",
                                                "A School HA4 2FW",
                                                "School London EC12 5BN",
@@ -83,10 +83,10 @@ RSpec.describe Placements::OrganisationFinder do
   end
 
   describe "filters and search" do
-    subject { described_class.call(filters: %w[school], search_term: "HA4") }
+    subject(:organisations_finder) { described_class.call(filters: %w[school], search_term: "HA4") }
 
     it "only returns school (not provider) with the given postcode" do
-      results = subject
+      results = organisations_finder
       expect(results.pluck(:content)).to eq ["A School HA4 2FW"]
     end
   end

--- a/spec/services/remove_user_service_spec.rb
+++ b/spec/services/remove_user_service_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe RemoveUserService do
-  subject { described_class.call(user, organisation) }
+  subject(:remove_user_service) { described_class.call(user, organisation) }
 
   describe "#call" do
     context "when the user is a placements user" do
@@ -10,7 +10,7 @@ RSpec.describe RemoveUserService do
       let!(:membership) { create(:membership, user:, organisation:) }
 
       it "calls mailer with correct params" do
-        expect { subject }.to have_enqueued_mail(UserMailer, :removal_email).with(user, organisation)
+        expect { remove_user_service }.to have_enqueued_mail(UserMailer, :removal_email).with(user, organisation)
 
         expect { membership.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
@@ -22,7 +22,7 @@ RSpec.describe RemoveUserService do
       let!(:membership) { create(:membership, user:, organisation:) }
 
       it "calls mailer with correct params" do
-        expect { subject }.to have_enqueued_mail(UserMailer, :removal_email).with(user, organisation)
+        expect { remove_user_service }.to have_enqueued_mail(UserMailer, :removal_email).with(user, organisation)
 
         expect { membership.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end

--- a/spec/services/support_user/invite_spec.rb
+++ b/spec/services/support_user/invite_spec.rb
@@ -4,21 +4,21 @@ RSpec.describe SupportUser::Invite do
   include ActiveJob::TestHelper
 
   describe ".call" do
-    subject { described_class.call(support_user:) }
+    subject(:invite_support_user) { described_class.call(support_user:) }
 
     context "when given a valid Support User" do
       let(:support_user) { build(:claims_support_user) }
 
       it "returns true" do
-        expect(subject).to be(true)
+        expect(invite_support_user).to be(true)
       end
 
       it "creates a user" do
-        expect { subject }.to change(User, :count).by(1)
+        expect { invite_support_user }.to change(User, :count).by(1)
       end
 
       it "enqueues an invitation email" do
-        expect { subject }.to change(enqueued_jobs, :size).by(1)
+        expect { invite_support_user }.to change(enqueued_jobs, :size).by(1)
       end
     end
 
@@ -26,15 +26,15 @@ RSpec.describe SupportUser::Invite do
       let(:support_user) { build(:claims_support_user, first_name: nil) }
 
       it "returns false" do
-        expect(subject).to be(false)
+        expect(invite_support_user).to be(false)
       end
 
       it "does not create a user" do
-        expect { subject }.not_to(change(User, :count))
+        expect { invite_support_user }.not_to(change(User, :count))
       end
 
       it "does not send an email" do
-        expect { subject }.not_to(change(enqueued_jobs, :size))
+        expect { invite_support_user }.not_to(change(enqueued_jobs, :size))
       end
     end
   end

--- a/spec/services/support_user/remove_spec.rb
+++ b/spec/services/support_user/remove_spec.rb
@@ -4,21 +4,21 @@ RSpec.describe SupportUser::Remove do
   include ActiveJob::TestHelper
 
   describe ".call" do
-    subject { described_class.call(support_user:) }
+    subject(:remove_support_user) { described_class.call(support_user:) }
 
     context "when given a valid Support User" do
       let(:support_user) { build(:claims_support_user) }
 
       it "returns true" do
-        expect(subject).to be(true)
+        expect(remove_support_user).to be(true)
       end
 
       it "removes a user" do
-        expect { subject }.to change { User.with_discarded.discarded.count }.by(1)
+        expect { remove_support_user }.to change { User.with_discarded.discarded.count }.by(1)
       end
 
       it "enqueues an invitation email" do
-        expect { subject }.to change(enqueued_jobs, :size).by(1)
+        expect { remove_support_user }.to change(enqueued_jobs, :size).by(1)
       end
     end
 
@@ -26,15 +26,15 @@ RSpec.describe SupportUser::Remove do
       let(:support_user) { build(:claims_support_user, :discarded) }
 
       it "returns true" do
-        expect(subject).to be(nil)
+        expect(remove_support_user).to be(nil)
       end
 
       it "removes a user" do
-        expect { subject }.to change { User.with_discarded.discarded.count }.by(0)
+        expect { remove_support_user }.to change { User.with_discarded.discarded.count }.by(0)
       end
 
       it "enqueues an invitation email" do
-        expect { subject }.to change(enqueued_jobs, :size).by(0)
+        expect { remove_support_user }.to change(enqueued_jobs, :size).by(0)
       end
     end
   end

--- a/spec/services/user_invite_service_spec.rb
+++ b/spec/services/user_invite_service_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe UserInviteService do
-  subject { described_class.call(user, organisation) }
+  subject(:user_invite_service) { described_class.call(user, organisation) }
 
   describe "call" do
     context "when the user's service is Claims" do
@@ -11,7 +11,7 @@ RSpec.describe UserInviteService do
         let(:service) { "claims" }
 
         it "calls mailer with correct prams" do
-          expect { subject }.to have_enqueued_mail(UserMailer, :invitation_email).with(user, organisation, "http://claims.localhost/sign-in")
+          expect { user_invite_service }.to have_enqueued_mail(UserMailer, :invitation_email).with(user, organisation, "http://claims.localhost/sign-in")
         end
       end
     end
@@ -24,7 +24,7 @@ RSpec.describe UserInviteService do
         let(:organisation) { create(:school, :placements) }
 
         it "calls mailer with correct prams" do
-          expect { subject }.to have_enqueued_mail(UserMailer, :invitation_email).with(user, organisation, "http://placements.localhost/sign-in")
+          expect { user_invite_service }.to have_enqueued_mail(UserMailer, :invitation_email).with(user, organisation, "http://placements.localhost/sign-in")
         end
       end
 
@@ -33,7 +33,7 @@ RSpec.describe UserInviteService do
         let(:organisation) { create(:placements_provider) }
 
         it "calls mailer with correct prams" do
-          expect { subject }.to have_enqueued_mail(UserMailer, :invitation_email).with(user, organisation, "http://placements.localhost/sign-in")
+          expect { user_invite_service }.to have_enqueued_mail(UserMailer, :invitation_email).with(user, organisation, "http://placements.localhost/sign-in")
         end
       end
     end

--- a/spec/tasks/gias_update_spec.rb
+++ b/spec/tasks/gias_update_spec.rb
@@ -3,7 +3,7 @@ require "rake"
 
 describe "gias_update" do
   Rails.application.load_tasks if Rake::Task.tasks.empty?
-  subject { Rake::Task["gias_update"].invoke }
+  subject(:gias_update) { Rake::Task["gias_update"].invoke }
 
   it "calls GiasCsvImporter service" do
     today = Time.zone.today.strftime("%Y%m%d")
@@ -15,6 +15,6 @@ describe "gias_update" do
     ).and_return(tempfile)
 
     expect(GiasCsvImporter).to receive(:call).with(tempfile.path)
-    subject
+    gias_update
   end
 end


### PR DESCRIPTION
## Context

Enabling more rubocop rules.

## Changes proposed in this pull request

Enabling the NamedSubject rule for rubocop and fixing tests that were violating the rule

## Guidance to review

passing tests
