### PR TITLE
Add "Error: " to the page title when there is an error on the form

### DIFF
--- a/app/views/claims/schools/users/new.html.erb
+++ b/app/views/claims/schools/users/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, sanitize(t(".page_title", school_name: @school.name)) %>
+<%= content_for :page_title, @user_form.errors.any? ? sanitize(t(".page_title_with_error", school_name: @school.name)) : sanitize(t(".page_title", school_name: @school.name)) %>
 <% render "claims/schools/primary_navigation", school: @school, current: :users %>
 
 <%= content_for(:before_content) do %>

--- a/app/views/claims/support/schools/new.html.erb
+++ b/app/views/claims/support/schools/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t(".title") %>
+<% content_for :page_title, @school_form.errors.any? ? t(".title_with_error") : t(".title") %>
 <% render "claims/support/primary_navigation", current: :organisations %>
 
 <%= content_for(:before_content) do %>

--- a/app/views/claims/support/schools/users/new.html.erb
+++ b/app/views/claims/support/schools/users/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, sanitize(t(".page_title", school_name: @school.name)) %>
+<% content_for :page_title, @user_form.errors.any? ? sanitize(t(".page_title_with_error", school_name: @school.name)) : sanitize(t(".page_title", school_name: @school.name)) %>
 <%= render "claims/support/primary_navigation", current: :organisations %>
 
 <%= content_for(:before_content) do %>

--- a/app/views/placements/support/organisations/new.html.erb
+++ b/app/views/placements/support/organisations/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t(".title") %>
+<% content_for :page_title, @organisation_form.errors.any? ? t(".title_with_error") : t(".title") %>
 <%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 
 <%= content_for(:before_content) do %>

--- a/app/views/placements/support/providers/new.html.erb
+++ b/app/views/placements/support/providers/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t(".title") %>
+<% content_for :page_title, @provider_form.errors.any? ? t(".title_with_error") : t(".title") %>
 <%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: new_placements_support_organisation_path) %>

--- a/app/views/placements/support/providers/users/new.html.erb
+++ b/app/views/placements/support/providers/users/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, sanitize(t(".page_title", provider_name: @provider.name)) %>
+<%= content_for :page_title, @user_form.errors.any? ? sanitize(t(".page_title_with_error", provider_name: @provider.name)) : sanitize(t(".page_title", provider_name: @provider.name)) %>
 <%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: placements_support_provider_users_path(@provider)) %>

--- a/app/views/placements/support/schools/new.html.erb
+++ b/app/views/placements/support/schools/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t(".title") %>
+<% content_for :page_title, @school_form.errors.any? ? t(".title_with_error") : t(".title") %>
 <%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: new_placements_support_organisation_path) %>

--- a/app/views/placements/support/schools/users/new.html.erb
+++ b/app/views/placements/support/schools/users/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, sanitize(t(".page_title", school_name: @school.name)) %>
+<%= content_for :page_title, @user_form.errors.any? ? sanitize(t(".page_title_with_error", school_name: @school.name)) : sanitize(t(".page_title", school_name: @school.name)) %>
 <%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 
 <%= content_for(:before_content) do %>

--- a/config/locales/en/claims/schools/users.yml
+++ b/config/locales/en/claims/schools/users.yml
@@ -7,6 +7,7 @@ en:
           add_user: Add user
           no_users: There are no users for %{school_name}.
         new:
+          page_title_with_error: "Error: Invite a new user"
           page_title: Invite a new user
           cancel: Cancel
           continue: Continue

--- a/config/locales/en/claims/support/schools.yml
+++ b/config/locales/en/claims/support/schools.yml
@@ -25,6 +25,7 @@ en:
           cancel: Cancel
           continue: Continue
           title: Enter a school name, URN or postcode
+          title_with_error: "Error: Enter a school name, URN or postcode"
         check:
           add_organisation: Add organisation
           address: Address

--- a/config/locales/en/claims/support/schools/users.yml
+++ b/config/locales/en/claims/support/schools/users.yml
@@ -21,6 +21,7 @@ en:
             title: Personal details
             caption: Add user - %{school_name}
             page_title: "Personal details - Add user - %{school_name}"
+            page_title_with_error: "Error: Personal details - Add user - %{school_name}"
           show:
             attributes:
               users:

--- a/config/locales/en/placements/support/organisations.yml
+++ b/config/locales/en/placements/support/organisations.yml
@@ -7,6 +7,7 @@ en:
           itt_provider: ITT provider
           school: School
           title: Organisation type
+          title_with_error: "Error: Organisation type"
           continue: Continue
           cancel: Cancel
         index:

--- a/config/locales/en/placements/support/providers.yml
+++ b/config/locales/en/placements/support/providers.yml
@@ -10,6 +10,7 @@ en:
           caption: Add organisation
           cancel: Cancel
           continue: Continue
+          title_with_error: "Error: Enter a provider name, UKPRN, URN or postcode"
           title: Enter a provider name, UKPRN, URN or postcode
         check:
           accredited_provider_id: Accredited provider ID

--- a/config/locales/en/placements/support/providers/users.yml
+++ b/config/locales/en/placements/support/providers/users.yml
@@ -15,6 +15,7 @@ en:
             user_added: User added
           new:
             page_title: "Personal details - Add user - %{provider_name}"
+            page_title_with_error: "Error: Personal details - Add user - %{provider_name}"
           check:
             page_title: "Check your answers - Add user - %{provider_name}"
             check_your_answers: Check your answers

--- a/config/locales/en/placements/support/schools.yml
+++ b/config/locales/en/placements/support/schools.yml
@@ -11,6 +11,7 @@ en:
           cancel: Cancel
           continue: Continue
           title: Enter a school name, URN or postcode
+          title_with_error: "Error: Enter a school name, URN or postcode"
         check:
           add_organisation: Add organisation
           address: Address

--- a/config/locales/en/placements/support/schools/users.yml
+++ b/config/locales/en/placements/support/schools/users.yml
@@ -15,6 +15,7 @@ en:
             user_added: User added
           new:
             page_title: "Personal details - Add user - %{school_name}"
+            page_title_with_error: "Error: Personal details - Add user - %{school_name}"
           check:
             page_title: "Check your answers - Add user - %{school_name}"
             caption: Add user - %{organisation_name}


### PR DESCRIPTION
## Context

The page titles should be prefixed with "Error: " when there is an error on the form. 

## Changes proposed in this pull request

As far as i could find, I have conditionally added "Error: " to the relevant page titles. 

I haven't added it to the Claims form  at all because there aren't page titles yet and I think this is very much in draft form. 

## Guidance to review

Sign in to on of the services as a support user
Whenever you create an error on a form you should see an the page title change to have the word "Error: " 
Do the same for the other service 
And then both again as a normal user

Let me know if I missed anything.

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots
before: 
<img width="956" alt="image" src="https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/97965edf-ecca-4322-aa5a-f09d9861802d">


after 
<img width="954" alt="image" src="https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/15742e49-8478-4adc-810d-65dbd4a14a78">

