### PR TITLE
Remove temporary comment in RuboCop config file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,7 +35,3 @@ RSpec/SpecFilePathFormat:
 
 RSpec/SpecFilePathSuffix:
   Enabled: true
-
-# The following cops are temporarily disabled so we can incrementally
-# introduce RSpec rules while incrementally fixing up the codebase.
-# They should eventually all be re-enabled.


### PR DESCRIPTION
This is no longer needed since we've now fixed-up all the RuboCop failures.

This completes the work started in #227, and iteratively fixed-up in #233, #238, #239, #240, #241, #242, #243.