### PR TITLE
Don't use the frozen_string_literal magic comment

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,10 @@ Style/NumericLiterals:
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
 
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: never
+
 Layout/AccessModifierIndentation:
   EnforcedStyle: indent
 


### PR DESCRIPTION
The `frozen_string_literal` was introduced in Ruby 2.3 to prepare codebases for an anticipated breaking change in Ruby 3, where String objects would be frozen by default.

However [that decision was reverted ahead][1] of the release of Ruby 3. So the change never happened, and the magic comment is mostly considered to be 'code cruft' nowadays.

Some IDEs and tools are still configured to automatically add the `frozen_string_literal` magic comment, so I've enabled this RuboCop rule to ensure they don't accidentally sneak in to the codebase.  This will avoid the need for PRs like #245 in future.

[1]: https://bugs.ruby-lang.org/issues/11473#note-53
