### PR TITLE
Jc/re enable removed support users

### DIFF
--- a/app/forms/support_user_invite_form.rb
+++ b/app/forms/support_user_invite_form.rb
@@ -1,0 +1,50 @@
+class SupportUserInviteForm < ApplicationForm
+  FORM_PARAMS = %i[first_name last_name email].freeze
+
+  attr_accessor :email, :first_name, :last_name, :service
+
+  validate :validate_support_user
+  validates :service, presence: true
+
+  def persist
+    save_support_user
+  end
+
+  def as_form_params
+    { "support_user" => slice(FORM_PARAMS) }
+  end
+
+  def support_user
+    @support_user ||=
+      begin
+        user = user_klass
+          .with_discarded
+          .discarded
+          .find_or_initialize_by(email:)
+        user.assign_attributes(first_name:, last_name:)
+        user
+      end
+  end
+
+  private
+
+  def save_support_user
+    ActiveRecord::Base.transaction do
+      support_user.undiscard! if support_user.discarded?
+      support_user.save!
+    end
+  end
+
+  def validate_support_user
+    if support_user.invalid?
+      support_user.errors.each do |err|
+        errors.add(err.attribute, err.message)
+      end
+    end
+  end
+
+  def user_klass
+    { claims: Claims::SupportUser,
+      placements: Placements::SupportUser }.fetch service
+  end
+end

--- a/app/services/support_user/invite.rb
+++ b/app/services/support_user/invite.rb
@@ -8,14 +8,6 @@ class SupportUser::Invite
   end
 
   def call
-    support_user.save!
-    send_email_notification
-    true
-  end
-
-  private
-
-  def send_email_notification
     SupportUserMailer.with(service: support_user.service).support_user_invitation(support_user).deliver_later
   end
 end

--- a/app/views/claims/support/support_users/check.html.erb
+++ b/app/views/claims/support/support_users/check.html.erb
@@ -1,7 +1,8 @@
 <% content_for(:page_title) { t(".page_title") } %>
+
 <% render "claims/support/primary_navigation", current: :users %>
 
-<% back_href = new_claims_support_support_user_path({ support_user: @support_user_params }) %>
+<% back_href = new_claims_support_support_user_path(@support_user_form.as_form_params) %>
 
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: back_href) %>
@@ -10,7 +11,7 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= form_with(model: @support_user, scope: :support_user, url: claims_support_support_users_path, method: :post) do |f| %>
+      <%= form_with(model: @support_user_form, scope: :support_user, url: claims_support_support_users_path, method: :post) do |f| %>
         <%= f.hidden_field :first_name, value: f.object.first_name %>
         <%= f.hidden_field :last_name, value: f.object.last_name %>
         <%= f.hidden_field :email, value: f.object.email %>

--- a/app/views/claims/support/support_users/new.html.erb
+++ b/app/views/claims/support/support_users/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { @support_user.errors.empty? ? t(".page_title") : t(".page_title_with_errors") } %>
+<% content_for(:page_title) { @support_user_form.errors.empty? ? t(".page_title") : t(".page_title_with_errors") } %>
 <% render "claims/support/primary_navigation", current: :users %>
 
 <%= content_for(:before_content) do %>
@@ -6,7 +6,7 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <%= form_with(model: @support_user, scope: :support_user, url: check_claims_support_support_users_path, method: "get") do |f| %>
+  <%= form_with(model: @support_user_form, scope: :support_user, url: check_claims_support_support_users_path, method: "get") do |f| %>
     <%= f.govuk_error_summary %>
 
     <div class="govuk-grid-row">

--- a/app/views/placements/support/support_users/check.html.erb
+++ b/app/views/placements/support/support_users/check.html.erb
@@ -2,7 +2,7 @@
 
 <%= render "placements/support/primary_navigation", current_navigation: :users %>
 
-<% back_href = new_placements_support_support_user_path({ support_user: @support_user_params }) %>
+<% back_href = new_placements_support_support_user_path(@support_user_form.as_form_params) %>
 
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: back_href) %>
@@ -11,7 +11,7 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= form_with(model: @support_user, scope: :support_user, url: placements_support_support_users_path, method: :post) do |f| %>
+      <%= form_with(model: @support_user_form, scope: :support_user, url: placements_support_support_users_path, method: :post) do |f| %>
         <%= f.hidden_field :first_name, value: f.object.first_name %>
         <%= f.hidden_field :last_name, value: f.object.last_name %>
         <%= f.hidden_field :email, value: f.object.email %>

--- a/app/views/placements/support/support_users/new.html.erb
+++ b/app/views/placements/support/support_users/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { @support_user.errors.empty? ? t(".page_title") : t(".page_title_with_errors") } %>
+<% content_for(:page_title) { @support_user_form.errors.empty? ? t(".page_title") : t(".page_title_with_errors") } %>
 
 <%= render "placements/support/primary_navigation", current_navigation: :users %>
 
@@ -7,7 +7,7 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <%= form_with(model: @support_user, scope: :support_user, url: check_placements_support_support_users_path, method: "get") do |f| %>
+  <%= form_with(model: @support_user_form, scope: :support_user, url: check_placements_support_support_users_path, method: "get") do |f| %>
     <%= f.govuk_error_summary %>
 
     <div class="govuk-grid-row">

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -1,6 +1,8 @@
 en:
   activemodel:
     errors:
+      messages:
+        record_invalid: "Validation failed: %{errors}"
       models:
         user_invite_form:
           attributes:

--- a/spec/forms/support_user_invite_form_spec.rb
+++ b/spec/forms/support_user_invite_form_spec.rb
@@ -1,0 +1,169 @@
+require "rails_helper"
+
+describe SupportUserInviteForm, type: :model do
+  describe "#as_form_params" do
+    it "returns form params" do
+      expect(described_class.new(
+        first_name: "First",
+        last_name: "Last",
+        email: "email@education.gov.uk",
+      ).as_form_params).to eq({
+        "support_user" =>
+          {
+            "email" => "email@education.gov.uk",
+            "first_name" => "First",
+            "last_name" => "Last",
+          },
+      })
+    end
+  end
+
+  describe "#support_user" do
+    let(:form_params) do
+      {
+        first_name: "First name",
+        last_name: "Last name",
+        email: "validEmail@education.gov.uk",
+        service: :placements,
+      }
+    end
+    let(:support_user_invite_form) { described_class.new(form_params) }
+
+    context "when given attributes of a new support user" do
+      it "returns a new support user" do
+        expect(support_user_invite_form.support_user).to be_a_new(Placements::SupportUser)
+      end
+    end
+
+    context "when given attributes of an existing support user (not discarded)" do
+      it "returns a new support user" do
+        create(:placements_support_user, email: "validEmail@education.gov.uk")
+        expect(support_user_invite_form.support_user).to be_a_new(Placements::SupportUser)
+      end
+    end
+
+    context "when given attributes of an existing discarded support user" do
+      it "returns a new support user" do
+        support_user = create(:placements_support_user,
+                              :discarded,
+                              email: "validEmail@education.gov.uk")
+        expect(support_user_invite_form.support_user).to eq(support_user)
+      end
+    end
+  end
+
+  describe "#save!" do
+    let(:support_user_invite_form) { described_class.new(form_params) }
+
+    context "with invalid params" do
+      context "with invalid user params" do
+        let(:form_params) { { last_name: "Last Name", service: :placements } }
+
+        it "returns user errors on form and does not send invite" do
+          expect(support_user_invite_form.valid?).to eq(false)
+
+          expect(support_user_invite_form.errors.messages).to match(
+            first_name: ["Enter a first name"],
+            email: [
+              "Enter an email address",
+              "Enter a Department for Education email address in the correct format, like name@education.gov.uk",
+            ],
+          )
+
+          expect { support_user_invite_form.save! }.to raise_error ActiveRecord::RecordInvalid
+        end
+      end
+    end
+
+    context "with entirely new valid support user" do
+      let(:form_params) do
+        {
+          first_name: "First name",
+          last_name: "Last name",
+          email: "validEmail@education.gov.uk",
+          service: :placements,
+        }
+      end
+
+      it "creates user" do
+        expect { support_user_invite_form.save! }.to change(Placements::SupportUser, :count).by 1
+      end
+    end
+
+    context "with a discarded support user" do
+      before { discarded_support_user }
+
+      let(:discarded_support_user) do
+        create(:placements_support_user,
+               :discarded,
+               email: "validEmail@education.gov.uk",
+               first_name: "First name",
+               last_name: "Last name")
+      end
+
+      context "with the same params as the supports users attribute" do
+        let(:form_params) do
+          {
+            first_name: "First name",
+            last_name: "Last name",
+            email: "validEmail@education.gov.uk",
+            service: :placements,
+          }
+        end
+
+        it "does not create a new user" do
+          expect {
+            support_user_invite_form.save!
+          }.to change(Placements::SupportUser.with_discarded, :count).by(0)
+            .and change(Placements::SupportUser, :count).by(1)
+        end
+
+        it "undiscards the support user" do
+          expect {
+            support_user_invite_form.save!
+          }.to change { discarded_support_user.reload.discarded_at }
+            .to nil
+        end
+      end
+
+      context "with params different from the supports users attributes" do
+        let(:form_params) do
+          {
+            first_name: "New first name",
+            last_name: "New last name",
+            email: "validEmail@education.gov.uk",
+            service: :placements,
+          }
+        end
+
+        it "does not create a new user" do
+          expect {
+            support_user_invite_form.save!
+          }.to change(Placements::SupportUser.with_discarded, :count).by(0)
+            .and change(Placements::SupportUser, :count).by(1)
+        end
+
+        it "updates user first name" do
+          expect {
+            support_user_invite_form.save!
+          }.to change { discarded_support_user.reload.first_name }
+            .from("First name").to "New first name"
+        end
+
+        it "updates user last name" do
+          expect {
+            support_user_invite_form.save!
+          }.to change { discarded_support_user.reload.last_name }
+            .from("Last name").to "New last name"
+        end
+
+        it "undiscards the support user" do
+          expect {
+            support_user_invite_form.save!
+          }.to change { discarded_support_user.reload.discarded_at }
+            .to nil
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/user_invite_form_spec.rb
+++ b/spec/forms/user_invite_form_spec.rb
@@ -19,17 +19,20 @@ describe UserInviteForm, type: :model do
   end
 
   describe "#invite!" do
+    let(:user_invite_form) { described_class.new(form_params) }
+
     context "with invalid params" do
       it "does not send invitation" do
         expect(UserMailer).not_to receive(:invitation_email)
       end
 
       context "with invalid user params" do
+        let(:organisation) { create(:school, :placements) }
+        let(:form_params) { { last_name: "Last Name", organisation:, service: :placements } }
+
         it "returns user errors on form and does not send invite" do
-          organisation = create(:school, :placements)
-          form_params = { last_name: "Last Name", organisation:, service: :placements }
-          user_invite_form = described_class.new(form_params)
           expect(user_invite_form.valid?).to eq false
+
           expect(user_invite_form.errors.messages).to match(
             first_name: ["Enter a first name"],
             email: ["Enter an email address", "Enter an email address in the correct format, like name@example.com"],
@@ -39,19 +42,22 @@ describe UserInviteForm, type: :model do
       end
 
       context "when membership already exists" do
-        it "returns membership error on the email attribute of the for and does not send invite" do
-          user = create(:placements_user)
-          organisation = create(:school, :placements)
-          create(:membership, user:, organisation:)
-          form_params = {
+        let(:user) { create(:placements_user) }
+        let(:organisation) { create(:school, :placements) }
+        let(:form_params) do
+          {
             first_name: user.first_name,
             last_name: user.last_name,
             email: user.email,
             organisation:,
             service: :placements,
           }
-          user_invite_form = described_class.new(form_params)
+        end
+
+        it "returns membership error on the email attribute of the for and does not send invite" do
+          create(:membership, user:, organisation:)
           expect(user_invite_form.valid?).to eq false
+
           expect(user_invite_form.errors.messages)
             .to match(email: ["Email address already in use"])
           expect { user_invite_form.invite! }.to raise_error ActiveRecord::RecordInvalid
@@ -72,17 +78,14 @@ describe UserInviteForm, type: :model do
       end
 
       it "sends invitation" do
-        user_invite_form = described_class.new(form_params)
         expect { user_invite_form.invite! }.to have_enqueued_mail(UserMailer, :invitation_email)
       end
 
       it "creates user" do
-        user_invite_form = described_class.new(form_params)
         expect { user_invite_form.invite! }.to change(User, :count).by 1
       end
 
       it "creates membership" do
-        user_invite_form = described_class.new(form_params)
         expect { user_invite_form.invite! }.to change(Membership, :count).by 1
       end
     end
@@ -104,18 +107,14 @@ describe UserInviteForm, type: :model do
       end
 
       it "sends invitation" do
-        user_invite_form = described_class.new(form_params)
         expect { user_invite_form.invite! }.to have_enqueued_mail(UserMailer, :invitation_email)
       end
 
       it "updates user first name" do
-        user_invite_form = described_class.new(form_params)
-        user_invite_form.invite!
-        expect(user.reload.first_name).to eq "New first name"
+        expect { user_invite_form.invite! }.to change { user.reload.first_name }.to "New first name"
       end
 
       it "creates membership" do
-        user_invite_form = described_class.new(form_params)
         expect { user_invite_form.invite! }.to change(Membership, :count).by 1
       end
     end

--- a/spec/services/support_user/invite_spec.rb
+++ b/spec/services/support_user/invite_spec.rb
@@ -6,27 +6,21 @@ RSpec.describe SupportUser::Invite do
   describe ".call" do
     subject(:invite_support_user) { described_class.call(support_user:) }
 
-    context "when given a valid Support User" do
-      let(:support_user) { build(:claims_support_user) }
-
-      it "returns true" do
-        expect(invite_support_user).to be(true)
-      end
-
-      it "creates a user" do
-        expect { invite_support_user }.to change(User, :count).by(1)
-      end
+    context "when given a valid Claims Support User" do
+      let(:support_user) { create(:claims_support_user) }
 
       it "enqueues an invitation email" do
-        expect { invite_support_user }.to change(enqueued_jobs, :size).by(1)
+        expect { invite_support_user }.to have_enqueued_mail(SupportUserMailer, :support_user_invitation)
+          .with(params: { service: :claims }, args: [support_user])
       end
     end
 
-    context "when given an invalid Support User" do
-      let(:support_user) { build(:claims_support_user, first_name: nil) }
+    context "when given a valid Placements Support User" do
+      let(:support_user) { create(:placements_support_user) }
 
-      it "raises error" do
-        expect { invite_support_user }.to raise_error ActiveRecord::RecordInvalid
+      it "enqueues an invitation email" do
+        expect { invite_support_user }.to have_enqueued_mail(SupportUserMailer, :support_user_invitation)
+          .with(params: { service: :placements }, args: [support_user])
       end
     end
   end

--- a/spec/system/claims/support/support_users/add_a_support_user_spec.rb
+++ b/spec/system/claims/support/support_users/add_a_support_user_spec.rb
@@ -10,49 +10,45 @@ RSpec.describe "Add a support user", type: :system do
   let!(:support_user) { create(:claims_support_user, :colin) }
 
   scenario "Add a support user" do
-    user_exists_in_dfe_sign_in(user: support_user)
     when_i_sign_in_as_a_support_user
     and_i_visit_the_support_users_page
     and_i_click_on_add_a_support_user
-    then_i_fill_in_the_support_user_form(email_address: "john.doe@education.gov.uk")
-    i_am_redirected_to_check_the_support_user_details
-    then_i_click_on_add_user
-    i_see_the_support_user_has_been_added(email_address: "john.doe@education.gov.uk")
+    and_i_fill_in_the_support_user_form(email_address: "john.doe@education.gov.uk")
+    then_i_am_redirected_to_check_the_support_user_details
+    when_i_click_on_add_user
+    then_i_see_the_support_user_has_been_added(email_address: "john.doe@education.gov.uk")
     and_an_email_is_sent_to_the_support_user(email_address: "john.doe@education.gov.uk")
   end
 
   scenario "Attempt to add a support user without an @education.gov.uk email address" do
-    user_exists_in_dfe_sign_in(user: support_user)
     when_i_sign_in_as_a_support_user
     and_i_visit_the_support_users_page
     and_i_click_on_add_a_support_user
-    then_i_fill_in_the_support_user_form(email_address: "john.doe@example.com")
+    and_i_fill_in_the_support_user_form(email_address: "john.doe@example.com")
     then_i_see_an_error("Enter a Department for Education email address in the correct format, like name@education.gov.uk")
     and_the_page_title_is("Error: Personal details - Add user - Claim funding for mentors")
   end
 
   scenario "Attempt to add a support user with an email that already exists in the system" do
-    user_exists_in_dfe_sign_in(user: support_user)
     given_there_is_a_support_user_with(email_address: "john.doe@education.gov.uk")
     when_i_sign_in_as_a_support_user
     and_i_visit_the_support_users_page
     and_i_click_on_add_a_support_user
-    then_i_fill_in_the_support_user_form(email_address: "john.doe@education.gov.uk")
+    and_i_fill_in_the_support_user_form(email_address: "john.doe@education.gov.uk")
     then_i_see_an_error("Email address already in use")
     and_the_page_title_is("Error: Personal details - Add user - Claim funding for mentors")
   end
 
   scenario "Make changes while adding a support user" do
-    user_exists_in_dfe_sign_in(user: support_user)
     when_i_sign_in_as_a_support_user
     and_i_visit_the_support_users_page
     and_i_click_on_add_a_support_user
-    then_i_fill_in_the_support_user_form(email_address: "john.doe@education.gov.uk")
-    then_i_click_on_a_change_link
-    i_should_see_the_support_user_form_with(email_address: "john.doe@education.gov.uk")
-    then_i_fill_in_the_support_user_form(email_address: "jane.doe@education.gov.uk")
-    then_i_click_on_add_user
-    i_see_the_support_user_has_been_added(email_address: "jane.doe@education.gov.uk")
+    and_i_fill_in_the_support_user_form(email_address: "john.doe@education.gov.uk")
+    and_i_click_on_a_change_link
+    then_i_should_see_the_support_user_form_with(email_address: "john.doe@education.gov.uk")
+    when_i_fill_in_the_support_user_form(email_address: "jane.doe@education.gov.uk")
+    and_i_click_on_add_user
+    then_i_see_the_support_user_has_been_added(email_address: "jane.doe@education.gov.uk")
     and_an_email_is_sent_to_the_support_user(email_address: "jane.doe@education.gov.uk")
   end
 
@@ -63,6 +59,7 @@ RSpec.describe "Add a support user", type: :system do
   end
 
   def when_i_sign_in_as_a_support_user
+    user_exists_in_dfe_sign_in(user: support_user)
     visit claims_root_path
     click_on "Sign in using DfE Sign In"
   end
@@ -77,15 +74,16 @@ RSpec.describe "Add a support user", type: :system do
     click_on "Add user"
   end
 
-  def then_i_fill_in_the_support_user_form(email_address:)
+  def when_i_fill_in_the_support_user_form(email_address:)
     fill_in "First name", with: "John"
     fill_in "Last name", with: "Doe"
     fill_in "Email address", with: email_address
 
     click_on "Continue"
   end
+  alias_method :and_i_fill_in_the_support_user_form, :when_i_fill_in_the_support_user_form
 
-  def i_am_redirected_to_check_the_support_user_details
+  def then_i_am_redirected_to_check_the_support_user_details
     expect(page).to have_content "Check your answers"
 
     expect(page).to have_content "John"
@@ -93,11 +91,12 @@ RSpec.describe "Add a support user", type: :system do
     expect(page).to have_content "john.doe@education.gov.uk"
   end
 
-  def then_i_click_on_add_user
+  def when_i_click_on_add_user
     click_on "Add user"
   end
+  alias_method :and_i_click_on_add_user, :when_i_click_on_add_user
 
-  def i_see_the_support_user_has_been_added(email_address:)
+  def then_i_see_the_support_user_has_been_added(email_address:)
     expect(page).to have_content "User added"
     expect(page).to have_content email_address
   end
@@ -110,11 +109,11 @@ RSpec.describe "Add a support user", type: :system do
     expect(email).not_to be_nil
   end
 
-  def then_i_click_on_a_change_link
+  def and_i_click_on_a_change_link
     click_on "Change", match: :first
   end
 
-  def i_should_see_the_support_user_form_with(email_address:)
+  def then_i_should_see_the_support_user_form_with(email_address:)
     within("form") do
       expect(page).to have_field("support_user[email]", with: email_address)
     end

--- a/spec/system/claims/support/support_users/re_add_a_discarded_support_user_spec.rb
+++ b/spec/system/claims/support/support_users/re_add_a_discarded_support_user_spec.rb
@@ -1,0 +1,151 @@
+require "rails_helper"
+
+RSpec.describe "Re-add a discarded support user", type: :system do
+  include ActiveJob::TestHelper
+
+  around do |example|
+    perform_enqueued_jobs { example.run }
+  end
+
+  let!(:support_user) { create(:claims_support_user, :colin) }
+
+  scenario "Re-add a discarded support user" do
+    given_a_discarded_support_user_with(
+      email_address: "john.doe@education.gov.uk",
+      first_name: "John",
+      last_name: "Doe",
+    )
+    when_i_sign_in_as_a_support_user(support_user)
+    and_i_visit_the_support_users_page
+    and_i_click_on_add_a_support_user
+    and_i_fill_in_the_support_user_form(
+      email_address: "john.doe@education.gov.uk",
+      first_name: "John",
+      last_name: "Doe",
+    )
+    then_i_am_redirected_to_check_the_support_user_details
+    and_the_support_user_details_displayed_are(
+      email_address: "john.doe@education.gov.uk",
+      first_name: "John",
+      last_name: "Doe",
+    )
+    when_i_click_on_add_user
+    i_see_the_support_user_has_been_added(email_address: "john.doe@education.gov.uk")
+    and_an_email_is_sent_to_the_support_user(email_address: "john.doe@education.gov.uk")
+  end
+
+  scenario "Re-add a discareded support user and change their details" do
+    given_a_discarded_support_user_with(
+      email_address: "john.doe@education.gov.uk",
+      first_name: "John",
+      last_name: "Doe",
+    )
+    when_i_sign_in_as_a_support_user(support_user)
+    and_i_visit_the_support_users_page
+    and_i_click_on_add_a_support_user
+    and_i_fill_in_the_support_user_form(
+      email_address: "john.doe@education.gov.uk",
+      first_name: "Johnny",
+      last_name: "Dorian",
+    )
+    then_i_am_redirected_to_check_the_support_user_details
+    and_the_support_user_details_displayed_are(
+      email_address: "john.doe@education.gov.uk",
+      first_name: "Johnny",
+      last_name: "Dorian",
+    )
+    when_i_click_on_add_user
+    i_see_the_support_user_has_been_added(email_address: "john.doe@education.gov.uk")
+    and_an_email_is_sent_to_the_support_user(email_address: "john.doe@education.gov.uk")
+  end
+
+  scenario "Re-add a discarded support user with empty details" do
+    given_a_discarded_support_user_with(
+      email_address: "john.doe@education.gov.uk",
+      first_name: "John",
+      last_name: "Doe",
+    )
+    when_i_sign_in_as_a_support_user(support_user)
+    and_i_visit_the_support_users_page
+    and_i_click_on_add_a_support_user
+    and_i_fill_in_the_support_user_form(
+      email_address: "john.doe@education.gov.uk",
+      first_name: "",
+      last_name: "",
+    )
+    then_i_see_an_error("Enter a first name")
+    and_i_see_an_error("Enter a last name")
+  end
+
+  private
+
+  def given_a_discarded_support_user_with(email_address:, first_name:, last_name:)
+    create(:claims_support_user, :discarded, email: email_address, first_name:, last_name:)
+  end
+
+  def when_i_sign_in_as_a_support_user(support_user)
+    user_exists_in_dfe_sign_in(user: support_user)
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def and_i_visit_the_support_users_page
+    within(".app-primary-navigation nav") do
+      click_on "Users"
+    end
+  end
+
+  def and_i_click_on_add_a_support_user
+    click_on "Add user"
+  end
+
+  def and_i_fill_in_the_support_user_form(email_address:, first_name:, last_name:)
+    fill_in "First name", with: first_name
+    fill_in "Last name", with: last_name
+    fill_in "Email address", with: email_address
+
+    click_on "Continue"
+  end
+
+  def then_i_am_redirected_to_check_the_support_user_details
+    expect(page).to have_content "Check your answers"
+  end
+
+  def and_the_support_user_details_displayed_are(email_address:, first_name:, last_name:)
+    expect(page).to have_content email_address
+    expect(page).to have_content first_name
+    expect(page).to have_content last_name
+  end
+
+  def when_i_click_on_add_user
+    click_on "Add user"
+  end
+
+  def i_see_the_support_user_has_been_added(email_address:)
+    expect(page).to have_content "User added"
+    expect(page).to have_content email_address
+  end
+
+  def and_an_email_is_sent_to_the_support_user(email_address:)
+    email = ActionMailer::Base.deliveries.find do |delivery|
+      delivery.to.include?(email_address) &&
+        delivery.subject == "Invitation to join Claim funding for mentors"
+    end
+
+    expect(email).not_to be_nil
+  end
+
+  def then_i_click_on_a_change_link
+    click_on "Change", match: :first
+  end
+
+  def then_i_see_an_error(message)
+    expect(page).to have_content "There is a problem"
+    expect(page).to have_content message, count: 2
+  end
+  alias_method :and_i_see_an_error, :then_i_see_an_error
+
+  def and_the_page_title_is(title)
+    expect(page).to have_title title
+  end
+end

--- a/spec/system/placements/support/support_users/support_user_adds_a_support_user_spec.rb
+++ b/spec/system/placements/support/support_users/support_user_adds_a_support_user_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe "Placements / Support Users / Support user adds a support user",
     when_i_sign_in_as_a_support_user(support_user)
     and_i_visit_the_support_users_page
     and_i_click_on_add_a_support_user
-    then_i_fill_in_the_support_user_form(email_address: "john.doe@education.gov.uk")
-    i_am_redirected_to_check_the_support_user_details
-    then_i_click_on_add_user
-    i_see_the_support_user_has_been_added(email_address: "john.doe@education.gov.uk")
+    and_i_fill_in_the_support_user_form(email_address: "john.doe@education.gov.uk")
+    then_i_am_redirected_to_check_the_support_user_details
+    when_i_click_on_add_user
+    then_i_see_the_support_user_has_been_added(email_address: "john.doe@education.gov.uk")
     and_an_email_is_sent_to_the_support_user(email_address: "john.doe@education.gov.uk")
   end
 
@@ -26,7 +26,7 @@ RSpec.describe "Placements / Support Users / Support user adds a support user",
     when_i_sign_in_as_a_support_user(support_user)
     and_i_visit_the_support_users_page
     and_i_click_on_add_a_support_user
-    then_i_fill_in_the_support_user_form(email_address: "john.doe@example.com")
+    and_i_fill_in_the_support_user_form(email_address: "john.doe@example.com")
     then_i_see_an_error("Enter a Department for Education email address in the correct format, like name@education.gov.uk")
     and_the_page_title_is("Error: Personal details - Add user - Manage school placements")
   end
@@ -36,7 +36,7 @@ RSpec.describe "Placements / Support Users / Support user adds a support user",
     when_i_sign_in_as_a_support_user(support_user)
     and_i_visit_the_support_users_page
     and_i_click_on_add_a_support_user
-    then_i_fill_in_the_support_user_form(email_address: "john.doe@education.gov.uk")
+    and_i_fill_in_the_support_user_form(email_address: "john.doe@education.gov.uk")
     then_i_see_an_error("Email address already in use")
     and_the_page_title_is("Error: Personal details - Add user - Manage school placements")
   end
@@ -45,12 +45,12 @@ RSpec.describe "Placements / Support Users / Support user adds a support user",
     when_i_sign_in_as_a_support_user(support_user)
     and_i_visit_the_support_users_page
     and_i_click_on_add_a_support_user
-    then_i_fill_in_the_support_user_form(email_address: "john.doe@education.gov.uk")
-    then_i_click_on_a_change_link
-    i_should_see_the_support_user_form_with(email_address: "john.doe@education.gov.uk")
-    then_i_fill_in_the_support_user_form(email_address: "jane.doe@education.gov.uk")
-    then_i_click_on_add_user
-    i_see_the_support_user_has_been_added(email_address: "jane.doe@education.gov.uk")
+    and_i_fill_in_the_support_user_form(email_address: "john.doe@education.gov.uk")
+    and_i_click_on_a_change_link
+    then_i_should_see_the_support_user_form_with(email_address: "john.doe@education.gov.uk")
+    when_i_fill_in_the_support_user_form(email_address: "jane.doe@education.gov.uk")
+    and_i_click_on_add_user
+    then_i_see_the_support_user_has_been_added(email_address: "jane.doe@education.gov.uk")
     and_an_email_is_sent_to_the_support_user(email_address: "jane.doe@education.gov.uk")
   end
 
@@ -76,15 +76,16 @@ RSpec.describe "Placements / Support Users / Support user adds a support user",
     click_on "Add user"
   end
 
-  def then_i_fill_in_the_support_user_form(email_address:)
+  def when_i_fill_in_the_support_user_form(email_address:)
     fill_in "First name", with: "John"
     fill_in "Last name", with: "Doe"
     fill_in "Email address", with: email_address
 
     click_on "Continue"
   end
+  alias_method :and_i_fill_in_the_support_user_form, :when_i_fill_in_the_support_user_form
 
-  def i_am_redirected_to_check_the_support_user_details
+  def then_i_am_redirected_to_check_the_support_user_details
     expect(page).to have_content "Check your answers"
 
     expect(page).to have_content "John"
@@ -92,11 +93,12 @@ RSpec.describe "Placements / Support Users / Support user adds a support user",
     expect(page).to have_content "john.doe@education.gov.uk"
   end
 
-  def then_i_click_on_add_user
+  def when_i_click_on_add_user
     click_on "Add user"
   end
+  alias_method :and_i_click_on_add_user, :when_i_click_on_add_user
 
-  def i_see_the_support_user_has_been_added(email_address:)
+  def then_i_see_the_support_user_has_been_added(email_address:)
     expect(page).to have_content "User added"
     expect(page).to have_content email_address
   end
@@ -109,11 +111,11 @@ RSpec.describe "Placements / Support Users / Support user adds a support user",
     expect(email).not_to be_nil
   end
 
-  def then_i_click_on_a_change_link
+  def and_i_click_on_a_change_link
     click_on "Change", match: :first
   end
 
-  def i_should_see_the_support_user_form_with(email_address:)
+  def then_i_should_see_the_support_user_form_with(email_address:)
     within("form") do
       expect(page).to have_field("support_user[email]", with: email_address)
     end

--- a/spec/system/placements/support/support_users/support_user_re_adds_a_discarded_support_user_spec.rb
+++ b/spec/system/placements/support/support_users/support_user_re_adds_a_discarded_support_user_spec.rb
@@ -1,0 +1,153 @@
+require "rails_helper"
+
+RSpec.describe "Placements / Support Users / Support user re-adds a discarded support user",
+               type: :system,
+               service: :placements do
+  include ActiveJob::TestHelper
+
+  around do |example|
+    perform_enqueued_jobs { example.run }
+  end
+
+  let!(:support_user) { create(:placements_support_user, :colin) }
+
+  scenario "Re-add a discarded support user" do
+    given_a_discarded_support_user_with(
+      email_address: "john.doe@education.gov.uk",
+      first_name: "John",
+      last_name: "Doe",
+    )
+    when_i_sign_in_as_a_support_user(support_user)
+    and_i_visit_the_support_users_page
+    and_i_click_on_add_a_support_user
+    and_i_fill_in_the_support_user_form(
+      email_address: "john.doe@education.gov.uk",
+      first_name: "John",
+      last_name: "Doe",
+    )
+    then_i_am_redirected_to_check_the_support_user_details
+    and_the_support_user_details_displayed_are(
+      email_address: "john.doe@education.gov.uk",
+      first_name: "John",
+      last_name: "Doe",
+    )
+    when_i_click_on_add_user
+    i_see_the_support_user_has_been_added(email_address: "john.doe@education.gov.uk")
+    and_an_email_is_sent_to_the_support_user(email_address: "john.doe@education.gov.uk")
+  end
+
+  scenario "Re-add a discareded support user and change their details" do
+    given_a_discarded_support_user_with(
+      email_address: "john.doe@education.gov.uk",
+      first_name: "John",
+      last_name: "Doe",
+    )
+    when_i_sign_in_as_a_support_user(support_user)
+    and_i_visit_the_support_users_page
+    and_i_click_on_add_a_support_user
+    and_i_fill_in_the_support_user_form(
+      email_address: "john.doe@education.gov.uk",
+      first_name: "Johnny",
+      last_name: "Dorian",
+    )
+    then_i_am_redirected_to_check_the_support_user_details
+    and_the_support_user_details_displayed_are(
+      email_address: "john.doe@education.gov.uk",
+      first_name: "Johnny",
+      last_name: "Dorian",
+    )
+    when_i_click_on_add_user
+    i_see_the_support_user_has_been_added(email_address: "john.doe@education.gov.uk")
+    and_an_email_is_sent_to_the_support_user(email_address: "john.doe@education.gov.uk")
+  end
+
+  scenario "Re-add a discarded support user with empty details" do
+    given_a_discarded_support_user_with(
+      email_address: "john.doe@education.gov.uk",
+      first_name: "John",
+      last_name: "Doe",
+    )
+    when_i_sign_in_as_a_support_user(support_user)
+    and_i_visit_the_support_users_page
+    and_i_click_on_add_a_support_user
+    and_i_fill_in_the_support_user_form(
+      email_address: "john.doe@education.gov.uk",
+      first_name: "",
+      last_name: "",
+    )
+    then_i_see_an_error("Enter a first name")
+    and_i_see_an_error("Enter a last name")
+  end
+
+  private
+
+  def given_a_discarded_support_user_with(email_address:, first_name:, last_name:)
+    create(:placements_support_user, :discarded, email: email_address, first_name:, last_name:)
+  end
+
+  def when_i_sign_in_as_a_support_user(support_user)
+    user_exists_in_dfe_sign_in(user: support_user)
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def and_i_visit_the_support_users_page
+    within(".app-primary-navigation nav") do
+      click_on "Users"
+    end
+  end
+
+  def and_i_click_on_add_a_support_user
+    click_on "Add user"
+  end
+
+  def and_i_fill_in_the_support_user_form(email_address:, first_name:, last_name:)
+    fill_in "First name", with: first_name
+    fill_in "Last name", with: last_name
+    fill_in "Email address", with: email_address
+
+    click_on "Continue"
+  end
+
+  def then_i_am_redirected_to_check_the_support_user_details
+    expect(page).to have_content "Check your answers"
+  end
+
+  def and_the_support_user_details_displayed_are(email_address:, first_name:, last_name:)
+    expect(page).to have_content email_address
+    expect(page).to have_content first_name
+    expect(page).to have_content last_name
+  end
+
+  def when_i_click_on_add_user
+    click_on "Add user"
+  end
+
+  def i_see_the_support_user_has_been_added(email_address:)
+    expect(page).to have_content "User added"
+    expect(page).to have_content email_address
+  end
+
+  def and_an_email_is_sent_to_the_support_user(email_address:)
+    email = ActionMailer::Base.deliveries.find do |delivery|
+      delivery.to.include?(email_address) &&
+        delivery.subject == "Invitation to join Manage school placements"
+    end
+
+    expect(email).not_to be_nil
+  end
+
+  def then_i_click_on_a_change_link
+    click_on "Change", match: :first
+  end
+
+  def then_i_see_an_error(message)
+    expect(page).to have_content "There is a problem"
+    expect(page).to have_content message, count: 2
+  end
+  alias_method :and_i_see_an_error, :then_i_see_an_error
+
+  def and_the_page_title_is(title)
+    expect(page).to have_title title
+  end
+end


### PR DESCRIPTION
## Context

Add the ability for Support users to re-onboard/re-enable discarded/removed support users.

## Changes proposed in this pull request

- Introduced a SupportUserInviteForm to handle the interactions necessary with onboarding and re-onboarding support users.

## Guidance to review
_Add a support user_
- Onboard a Support user (ensure nothing has broken from the existing functionality)

_Re-add a discarded support user_
- Remove Support User (you may need to create and then remove a support user to test this functionality)
- From the Support User index page, Click "Add user"
- Enter the details of the removed/discarded Support User into the form
- Click "Continue"
- Check your answers (at the very least the email address must match the removed/discarded user)
- Click "Add user"
- Then the removed user should appear in the Support User index list


## Link to Trello card

https://trello.com/c/zVIa51uZ/174-re-enabling-removed-support-users

## Screenshots

https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/8a59d1a3-8882-40a3-a604-fde437c4e313


