### PR TITLE
Lb/raise exceptions on create

### DIFF
--- a/app/controllers/claims/schools/users_controller.rb
+++ b/app/controllers/claims/schools/users_controller.rb
@@ -18,12 +18,9 @@ class Claims::Schools::UsersController < ApplicationController
   end
 
   def create
-    if user_form.invite
-      redirect_to claims_school_users_path(@school)
-      flash[:success] = t(".user_added")
-    else
-      render :new
-    end
+    user_form.invite!
+    redirect_to claims_school_users_path(@school)
+    flash[:success] = t(".user_added")
   end
 
   private

--- a/app/controllers/claims/schools/users_controller.rb
+++ b/app/controllers/claims/schools/users_controller.rb
@@ -19,8 +19,7 @@ class Claims::Schools::UsersController < ApplicationController
 
   def create
     user_form.invite!
-    redirect_to claims_school_users_path(@school)
-    flash[:success] = t(".user_added")
+    redirect_to claims_school_users_path(@school), flash: { success: t(".user_added") }
   end
 
   private

--- a/app/controllers/claims/support/schools/users_controller.rb
+++ b/app/controllers/claims/support/schools/users_controller.rb
@@ -18,12 +18,9 @@ class Claims::Support::Schools::UsersController < Claims::Support::ApplicationCo
   end
 
   def create
-    if user_form.invite
-      redirect_to claims_support_school_users_path(@school)
-      flash[:success] = t(".user_added")
-    else
-      render :new
-    end
+    user_form.invite!
+    redirect_to claims_support_school_users_path(@school)
+    flash[:success] = t(".user_added")
   end
 
   private

--- a/app/controllers/claims/support/schools_controller.rb
+++ b/app/controllers/claims/support/schools_controller.rb
@@ -49,12 +49,9 @@ class Claims::Support::SchoolsController < Claims::Support::ApplicationControlle
   end
 
   def create
-    if school_form.onboard
-      flash[:success] = I18n.t("claims.support.schools.create.organisation_added")
-      redirect_to claims_support_schools_path
-    else
-      render :new
-    end
+    school_form.onboard!
+    flash[:success] = I18n.t("claims.support.schools.create.organisation_added")
+    redirect_to claims_support_schools_path
   end
 
   private

--- a/app/controllers/claims/support/support_users_controller.rb
+++ b/app/controllers/claims/support/support_users_controller.rb
@@ -22,11 +22,8 @@ class Claims::Support::SupportUsersController < Claims::Support::ApplicationCont
   def create
     @support_user = Claims::SupportUser.new(support_user_params)
 
-    if SupportUser::Invite.call(support_user: @support_user)
-      redirect_to claims_support_support_users_path, flash: { success: t(".success") }
-    else
-      render :check
-    end
+    SupportUser::Invite.call(support_user: @support_user)
+    redirect_to claims_support_support_users_path, flash: { success: t(".success") }
   end
 
   def show; end

--- a/app/controllers/placements/organisations/users_controller.rb
+++ b/app/controllers/placements/organisations/users_controller.rb
@@ -18,12 +18,9 @@ class Placements::Organisations::UsersController < ApplicationController
   end
 
   def create
-    if user_form.invite
-      redirect_to_index
-      flash[:success] = t(".user_added")
-    else
-      render :new
-    end
+    user_form.invite!
+    redirect_to_index
+    flash[:success] = t(".user_added")
   end
 
   def remove; end

--- a/app/controllers/placements/support/organisations/users_controller.rb
+++ b/app/controllers/placements/support/organisations/users_controller.rb
@@ -17,12 +17,9 @@ class Placements::Support::Organisations::UsersController < Placements::Support:
   end
 
   def create
-    if user_form.invite
-      redirect_to_index
-      flash[:success] = t(".user_added")
-    else
-      render :new
-    end
+    user_form.invite!
+    redirect_to_index
+    flash[:success] = t(".user_added")
   end
 
   def remove; end

--- a/app/controllers/placements/support/providers_controller.rb
+++ b/app/controllers/placements/support/providers_controller.rb
@@ -44,12 +44,9 @@ class Placements::Support::ProvidersController < Placements::Support::Applicatio
   end
 
   def create
-    if provider_form.onboard
-      flash[:success] = I18n.t("placements.support.providers.create.organisation_added")
-      redirect_to placements_support_organisations_path
-    else
-      render :new
-    end
+    provider_form.onboard!
+    flash[:success] = I18n.t("placements.support.providers.create.organisation_added")
+    redirect_to placements_support_organisations_path
   end
 
   private

--- a/app/controllers/placements/support/schools_controller.rb
+++ b/app/controllers/placements/support/schools_controller.rb
@@ -40,12 +40,9 @@ class Placements::Support::SchoolsController < Placements::Support::ApplicationC
   end
 
   def create
-    if school_form.onboard
-      flash[:success] = I18n.t("placements.support.schools.create.organisation_added")
-      redirect_to placements_support_organisations_path
-    else
-      render :new
-    end
+    school_form.onboard!
+    flash[:success] = I18n.t("placements.support.schools.create.organisation_added")
+    redirect_to placements_support_organisations_path
   end
 
   def show

--- a/app/controllers/placements/support/support_users_controller.rb
+++ b/app/controllers/placements/support/support_users_controller.rb
@@ -22,11 +22,8 @@ class Placements::Support::SupportUsersController < Placements::Support::Applica
   def create
     @support_user = Placements::SupportUser.new(support_user_params)
 
-    if SupportUser::Invite.call(support_user: @support_user)
-      redirect_to placements_support_support_users_path, flash: { success: t(".success") }
-    else
-      render :check
-    end
+    SupportUser::Invite.call(support_user: @support_user)
+    redirect_to placements_support_support_users_path, flash: { success: t(".success") }
   end
 
   def show; end

--- a/app/forms/provider_onboarding_form.rb
+++ b/app/forms/provider_onboarding_form.rb
@@ -5,9 +5,7 @@ class ProviderOnboardingForm < ApplicationForm
   validate :provider_exists?
   validate :provider_already_onboarded?
 
-  def onboard
-    return false unless valid?
-
+  def onboard!
     provider.update!(placements_service: true)
   end
 

--- a/app/forms/school_onboarding_form.rb
+++ b/app/forms/school_onboarding_form.rb
@@ -6,9 +6,7 @@ class SchoolOnboardingForm < ApplicationForm
   validate :school_exists?
   validate :school_already_onboarded?
 
-  def onboard
-    return false unless valid?
-
+  def onboard!
     school.update!("#{service}_service" => true)
   end
 

--- a/app/forms/user_invite_form.rb
+++ b/app/forms/user_invite_form.rb
@@ -8,10 +8,12 @@ class UserInviteForm
   validate :validate_membership
   validates :service, :organisation, presence: true
 
-  def invite
-    return false unless valid?
-
-    UserInviteService.call(user, organisation) if save_user
+  def invite!
+    ActiveRecord::Base.transaction do
+      user.save!
+      membership.save!
+    end
+    UserInviteService.call(user, organisation)
   end
 
   def as_form_params
@@ -27,13 +29,6 @@ class UserInviteForm
         user.assign_attributes(first_name:, last_name:)
         user
       end
-  end
-
-  def save_user
-    ActiveRecord::Base.transaction do
-      user.save!
-      membership.save!
-    end
   end
 
   def validate_user

--- a/app/services/support_user/invite.rb
+++ b/app/services/support_user/invite.rb
@@ -8,13 +8,9 @@ class SupportUser::Invite
   end
 
   def call
-    if support_user.save
-      send_email_notification
-
-      true
-    else
-      false
-    end
+    support_user.save!
+    send_email_notification
+    true
   end
 
   private

--- a/spec/forms/provider_onboarding_form_spec.rb
+++ b/spec/forms/provider_onboarding_form_spec.rb
@@ -56,7 +56,7 @@ describe ProviderOnboardingForm, type: :model do
     it "enables the boolean flag for placements" do
       provider = create(:provider)
       onboarding = expect do
-        described_class.new(id: provider.id).onboard
+        described_class.new(id: provider.id).onboard!
         provider.reload
       end
       onboarding.to change(provider, :placements_service).from(false).to(true)

--- a/spec/forms/school_onboarding_form_spec.rb
+++ b/spec/forms/school_onboarding_form_spec.rb
@@ -66,7 +66,7 @@ describe SchoolOnboardingForm, type: :model do
     it "enables the boolean flag for the given service" do
       school = create(:school)
       onboarding = expect do
-        described_class.new(id: school.id, service: :placements).onboard
+        described_class.new(id: school.id, service: :placements).onboard!
         school.reload
       end
       onboarding.to change(school, :placements_service).from(false).to(true)

--- a/spec/services/support_user/invite_spec.rb
+++ b/spec/services/support_user/invite_spec.rb
@@ -25,16 +25,8 @@ RSpec.describe SupportUser::Invite do
     context "when given an invalid Support User" do
       let(:support_user) { build(:claims_support_user, first_name: nil) }
 
-      it "returns false" do
-        expect(invite_support_user).to be(false)
-      end
-
-      it "does not create a user" do
-        expect { invite_support_user }.not_to(change(User, :count))
-      end
-
-      it "does not send an email" do
-        expect { invite_support_user }.not_to(change(enqueued_jobs, :size))
+      it "raises error" do
+        expect { invite_support_user }.to raise_error ActiveRecord::RecordInvalid
       end
     end
   end


### PR DESCRIPTION
## Context

Improving test coverage throughout

When we have a "check" method, we check validations have been confirmed before we reach the `create` method. So if the `create` method fails for some reason, we want an exception should be raised. Otherwise, potentially important errors get swallowed up by the application and we won't be aware of them. 

This is related to test coverage because all of our create methods had untested branches. We would have had to manufacture artificial / unrealistic test scenarios to test the branches. 

## Changes proposed in this pull request

- Change all "create" methods to remove branching, adding the bang (!) to the save methods (in relevant services or forms)
- Update test cases

## Guidance to review

Tests pass. 

## Link to Trello card

https://trello.com/c/rmWNKYnC


