### PR TITLE
Exclude auto_annotate_models.rake from coverage

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,9 @@ SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
 SimpleCov.start "rails" do
   enable_coverage :branch
 
+  # Ignore test coverage for these files
+  add_filter "lib/tasks/auto_annotate_models.rake"
+
   add_group "Components", "app/components"
   add_group "Decorators", "app/decorators"
   add_group "Forms", "app/forms"


### PR DESCRIPTION
I've configured SimpleCov to exclude the auto_annotate_models Rake task from code coverage reports.

This file was [auto-generated][1] by the [annotate_models][2] gem, and it's only used during development. So it seems unhelpful to include this in coverage reports.

[1]: https://github.com/ctran/annotate_models/blob/a7cc62be92b355b3215911b17200112802fa8816/lib/generators/annotate/templates/auto_annotate_models.rake
[2]: https://github.com/ctran/annotate_models
