### PR TITLE
Lb/remove mentors from provider primary nav

### DIFF
--- a/app/views/placements/providers/_primary_navigation.html.erb
+++ b/app/views/placements/providers/_primary_navigation.html.erb
@@ -1,8 +1,8 @@
-<%# locals: (current_navigation: nil, organisation:) -%>
+<%# locals: (current_navigation: nil, provider:) -%>
 <% if current_user.organisation_count > 1 %>
   <%= content_for(:header_content) do %>
     <%= render(ContentHeaderComponent.new(
-      title: organisation.name,
+      title: provider.name,
       actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
     )) %>
   <% end %>
@@ -11,10 +11,9 @@
 <%= content_for(:primary_navigation_content) do %>
   <%= render PrimaryNavigationComponent.new do |component| %>
     <% component.with_navigation_item t(".placements"), "#", current: current_navigation == :placements %>
-    <% component.with_navigation_item t(".mentors"), "#", current: current_navigation == :mentors %>
-    <% component.with_navigation_item t(".users"), organisation_users_path(organisation), current: current_navigation == :users %>
+    <% component.with_navigation_item t(".users"), placements_provider_users_path(provider), current: current_navigation == :users %>
     <% component.with_navigation_item t(".organisation_details"),
-                                      placements_organisation_path(organisation),
+                                      placements_provider_path(provider),
                                       current: current_navigation == :organisation_details %>
   <% end %>
 <% end %>

--- a/app/views/placements/providers/show.html.erb
+++ b/app/views/placements/providers/show.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :page_title, t(".organisation_details") %>
-<%= render "placements/primary_navigation", organisation: @provider, current_navigation: :organisation_details %>
+<%= render "placements/providers/primary_navigation", provider: @provider, current_navigation: :organisation_details %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">

--- a/app/views/placements/providers/users/check.html.erb
+++ b/app/views/placements/providers/users/check.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :page_title, t(".page_title") %>
-<%= render "placements/primary_navigation", current_navigation: :users, organisation: @organisation %>
+<%= render "placements/providers/primary_navigation", current_navigation: :users, provider: @organisation %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: new_placements_provider_user_path(
     @user_form.as_form_params.merge(provider_id: @organisation.id),

--- a/app/views/placements/providers/users/index.html.erb
+++ b/app/views/placements/providers/users/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_title) { t(".users") } %>
-<%= render "placements/primary_navigation", organisation: @organisation, current_navigation: :users %>
+<%= render "placements/providers/primary_navigation", provider: @organisation, current_navigation: :users %>
 
 <div class="govuk-width-container">
   <h1 class="govuk-heading-l"><%= t(".users") %></h1>

--- a/app/views/placements/providers/users/new.html.erb
+++ b/app/views/placements/providers/users/new.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :page_title, @user_form.errors.any? ? t(".page_title_with_error") : t(".page_title") %>
-<%= render "placements/primary_navigation", current_navigation: :users, organisation: @organisation %>
+<%= render "placements/providers/primary_navigation", current_navigation: :users, provider: @organisation %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: placements_provider_users_path(@organisation)) %>
 <% end %>

--- a/app/views/placements/providers/users/remove.html.erb
+++ b/app/views/placements/providers/users/remove.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :page_title, sanitize(t(".page_title", user_name: @user.full_name, organisation_name: @organisation.name)) %>
-<%= render "placements/primary_navigation", organisation: @organisation, current_navigation: :users %>
+<%= render "placements/providers/primary_navigation", provider: @organisation, current_navigation: :users %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: placements_provider_user_path(@organisation, @user)) %>
 <% end %>

--- a/app/views/placements/providers/users/show.html.erb
+++ b/app/views/placements/providers/users/show.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :page_title, sanitize(@user.full_name) %>
-<%= render "placements/primary_navigation", organisation: @organisation, current_navigation: :users %>
+<%= render "placements/providers/primary_navigation", provider: @organisation, current_navigation: :users %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: placements_provider_users_path(@organisation)) %>
 <% end %>

--- a/app/views/placements/schools/_primary_navigation.html.erb
+++ b/app/views/placements/schools/_primary_navigation.html.erb
@@ -1,0 +1,20 @@
+<%# locals: (current_navigation: nil, school:) -%>
+<% if current_user.organisation_count > 1 %>
+  <%= content_for(:header_content) do %>
+    <%= render(ContentHeaderComponent.new(
+      title: school.name,
+      actions: [govuk_link_to(t(".change_organisation"), placements_organisations_path, no_visited_state: true)],
+    )) %>
+  <% end %>
+<% end %>
+
+<%= content_for(:primary_navigation_content) do %>
+  <%= render PrimaryNavigationComponent.new do |component| %>
+    <% component.with_navigation_item t(".placements"), "#", current: current_navigation == :placements %>
+    <% component.with_navigation_item t(".mentors"), "#", current: current_navigation == :mentors %>
+    <% component.with_navigation_item t(".users"), placements_school_users_path(school), current: current_navigation == :users %>
+    <% component.with_navigation_item t(".organisation_details"),
+                                      placements_school_path(school),
+                                      current: current_navigation == :organisation_details %>
+  <% end %>
+<% end %>

--- a/app/views/placements/schools/show.html.erb
+++ b/app/views/placements/schools/show.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :page_title, t(".organisation_details") %>
-<%= render "placements/primary_navigation", organisation: @school, current_navigation: :organisation_details %>
+<%= render "placements/schools/primary_navigation", school: @school, current_navigation: :organisation_details %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">

--- a/app/views/placements/schools/users/check.html.erb
+++ b/app/views/placements/schools/users/check.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :page_title, t(".page_title") %>
-<%= render "placements/primary_navigation", current_navigation: :users, organisation: @organisation %>
+<%= render "placements/schools/primary_navigation", current_navigation: :users, school: @organisation %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: new_placements_school_user_path(
     @user_form.as_form_params.merge(school_id: @organisation.id),

--- a/app/views/placements/schools/users/index.html.erb
+++ b/app/views/placements/schools/users/index.html.erb
@@ -1,4 +1,4 @@
-<%= render "placements/primary_navigation", organisation: @organisation, current_navigation: :users %>
+<%= render "placements/schools/primary_navigation", school: @organisation, current_navigation: :users %>
 <% content_for(:page_title) { t(".users") } %>
 
 <div class="govuk-width-container">

--- a/app/views/placements/schools/users/new.html.erb
+++ b/app/views/placements/schools/users/new.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :page_title, @user_form.errors.any? ? t(".page_title_with_error") : t(".page_title") %>
-<%= render "placements/primary_navigation", current_navigation: :users, organisation: @organisation %>
+<%= render "placements/schools/primary_navigation", current_navigation: :users, school: @organisation %>
 
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: placements_school_users_path(@organisation)) %>

--- a/app/views/placements/schools/users/remove.html.erb
+++ b/app/views/placements/schools/users/remove.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :page_title, sanitize(t(".page_title", user_name: @user.full_name, organisation_name: @organisation.name)) %>
-<%= render "placements/primary_navigation", organisation: @organisation, current_navigation: :users %>
+<%= render "placements/schools/primary_navigation", school: @organisation, current_navigation: :users %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: placements_school_user_path(@organisation, @user)) %>
 <% end %>

--- a/app/views/placements/schools/users/show.html.erb
+++ b/app/views/placements/schools/users/show.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :page_title, sanitize(@user.full_name) %>
-<%= render "placements/primary_navigation", organisation: @organisation, current_navigation: :users %>
+<%= render "placements/schools/primary_navigation", school: @organisation, current_navigation: :users %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: placements_school_users_path(@organisation)) %>
 <% end %>

--- a/app/views/placements/support/support_users/remove.html.erb
+++ b/app/views/placements/support/support_users/remove.html.erb
@@ -22,6 +22,6 @@
           <%= govuk_link_to(t(".cancel"), placements_support_support_users_path) %>
         </p>
       <% end %>
-    <div>
-  <div>
+    </div>
+  </div>
 </div>

--- a/config/locales/en/placements/primary_navigation.yml
+++ b/config/locales/en/placements/primary_navigation.yml
@@ -1,8 +1,0 @@
-en:
-  placements:
-    primary_navigation:
-      change_organisation: Change organisation
-      placements: Placements
-      mentors: Mentors
-      users: Users
-      organisation_details: Organisation details

--- a/config/locales/en/placements/providers/primary_navigation.yml
+++ b/config/locales/en/placements/providers/primary_navigation.yml
@@ -1,0 +1,8 @@
+en:
+  placements:
+    providers:
+      primary_navigation:
+        change_organisation: Change organisation
+        placements: Placements
+        users: Users
+        organisation_details: Organisation details

--- a/config/locales/en/placements/schools/primary_navigation.yml
+++ b/config/locales/en/placements/schools/primary_navigation.yml
@@ -1,0 +1,9 @@
+en:
+  placements:
+    schools:
+      primary_navigation:
+        change_organisation: Change organisation
+        placements: Placements
+        mentors: Mentors
+        users: Users
+        organisation_details: Organisation details

--- a/spec/system/placements/organisations/add_users_spec.rb
+++ b/spec/system/placements/organisations/add_users_spec.rb
@@ -22,13 +22,16 @@ RSpec.describe "Placements users invite other users to organisations", type: :sy
         then_i_see_the_users_page
         when_i_click_add_user
         and_i_enter_valid_user_details
+        and_user_is_selected_in_provider_primary_navigation
         then_i_can_check_my_answers(one_provider)
         when_i_click_back
         then_i_see_prepopulated_form
         when_i_change_user_details
         then_i_see_changes_in_check_form
+        and_user_is_selected_in_provider_primary_navigation
         when_i_click_add_user
         then_the_user_is_added(one_provider)
+        and_user_is_selected_in_provider_primary_navigation
       end
     end
 
@@ -37,13 +40,17 @@ RSpec.describe "Placements users invite other users to organisations", type: :sy
         given_i_am_logged_in_as_a_user_with_one_organisation(one_school)
         when_i_click_users
         then_i_see_the_users_page
+        and_user_is_selected_in_school_primary_navigation
         when_i_click_add_user
+        and_user_is_selected_in_school_primary_navigation
         and_i_enter_valid_user_details
         then_i_can_check_my_answers(one_school)
         when_i_click_back
         then_i_see_prepopulated_form
+        and_user_is_selected_in_school_primary_navigation
         when_i_change_user_details
         then_i_see_changes_in_check_form
+        and_user_is_selected_in_school_primary_navigation
         when_i_click_add_user
         then_the_user_is_added(one_school)
       end
@@ -138,7 +145,6 @@ RSpec.describe "Placements users invite other users to organisations", type: :sy
   end
 
   def then_i_see_the_user_on_that_schools_user_list
-    users_is_selected_in_navigation
     expect(page).to have_content(new_user.full_name)
     expect(page).to have_content(new_user.email)
   end
@@ -160,7 +166,6 @@ RSpec.describe "Placements users invite other users to organisations", type: :sy
 
   def then_the_user_is_added_successfully(organisation)
     email_is_sent(new_user.email, organisation)
-    users_is_selected_in_navigation
 
     expect(page.find(".govuk-notification-banner__content")).to have_content("User added")
     expect(page).to have_content new_user.full_name
@@ -172,8 +177,6 @@ RSpec.describe "Placements users invite other users to organisations", type: :sy
   end
 
   def then_i_see_the_users_page
-    users_is_selected_in_navigation
-
     expect(page).to have_content "Anne Wilson"
     expect(page).to have_content "anne_wilson@example.org"
   end
@@ -183,7 +186,6 @@ RSpec.describe "Placements users invite other users to organisations", type: :sy
   end
 
   def and_i_enter_valid_user_details
-    users_is_selected_in_navigation
     fill_in "First name", with: "First Namey"
     fill_in "Last name", with: "Last Namey"
     fill_in "Email", with: "firsty_lasty@email.co.uk"
@@ -191,7 +193,6 @@ RSpec.describe "Placements users invite other users to organisations", type: :sy
   end
 
   def then_i_can_check_my_answers(organisation)
-    users_is_selected_in_navigation
     expect(page).to have_content "First Namey"
     expect(page).to have_content "Last Namey"
     expect(page).to have_content "firsty_lasty@email.co.uk"
@@ -203,7 +204,6 @@ RSpec.describe "Placements users invite other users to organisations", type: :sy
   end
 
   def then_i_see_prepopulated_form
-    users_is_selected_in_navigation
     expect(page).to have_field("First name", with: "First Namey")
     expect(page).to have_field("Last name", with: "Last Namey")
     expect(page).to have_field("Email", with: "firsty_lasty@email.co.uk")
@@ -222,16 +222,23 @@ RSpec.describe "Placements users invite other users to organisations", type: :sy
 
   def then_the_user_is_added(organisation)
     email_is_sent("firsty_lasty@email.co.uk", organisation)
-    users_is_selected_in_navigation
     expect(page.find(".govuk-notification-banner__content")).to have_content("User added")
     expect(page).to have_content "New First Name Last Namey"
     expect(page).to have_content "firsty_lasty@email.co.uk"
   end
 
-  def users_is_selected_in_navigation
+  def and_user_is_selected_in_school_primary_navigation
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Placements", current: "false"
       expect(page).to have_link "Mentors", current: "false"
+      expect(page).to have_link "Users", current: "page"
+      expect(page).to have_link "Organisation details", current: "false"
+    end
+  end
+
+  def and_user_is_selected_in_provider_primary_navigation
+    within(".app-primary-navigation__nav") do
+      expect(page).to have_link "Placements", current: "false"
       expect(page).to have_link "Users", current: "page"
       expect(page).to have_link "Organisation details", current: "false"
     end

--- a/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
+++ b/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
@@ -117,7 +117,13 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
   end
 
   def then_i_am_asked_to_confirm(user, organisation)
-    users_is_selected_in_primary_nav
+    case organisation
+    when School
+      users_is_selected_in_schools_primary_nav
+    when Provider
+      users_is_selected_in_providers_primary_nav
+    end
+
     expect(page).to have_title(
       "Are you sure you want to remove this user? - #{user.full_name} - #{organisation.name} - Manage school placements",
     )
@@ -126,7 +132,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
     expect(page).to have_content "The user will be sent an email to tell them you removed them from #{organisation.name}"
   end
 
-  def users_is_selected_in_primary_nav
+  def users_is_selected_in_schools_primary_nav
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Placements", current: "false"
       expect(page).to have_link "Mentors", current: "false"
@@ -135,18 +141,33 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
     end
   end
 
+  def users_is_selected_in_providers_primary_nav
+    within(".app-primary-navigation__nav") do
+      expect(page).to have_link "Placements", current: "false"
+      expect(page).to have_link "Users", current: "page"
+      expect(page).to have_link "Organisation details", current: "false"
+    end
+  end
+
   def then_i_return_to_user_page(user, organisation)
-    users_is_selected_in_primary_nav
     case organisation
     when School
+      users_is_selected_in_schools_primary_nav
       expect(page).to have_current_path placements_school_user_path(organisation, user), ignore_query: true
     when Provider
+      users_is_selected_in_providers_primary_nav
       expect(page).to have_current_path placements_provider_user_path(organisation, user), ignore_query: true
     end
   end
 
   def then_the_the_user_is_removed_from_the_organisation(user, organisation)
-    users_is_selected_in_primary_nav
+    case organisation
+    when School
+      users_is_selected_in_schools_primary_nav
+    when Provider
+      users_is_selected_in_providers_primary_nav
+    end
+
     expect(user.memberships.find_by(organisation:)).to eq nil
     within(".govuk-notification-banner__content") do
       expect(page).to have_content "User removed"

--- a/spec/system/placements/organisations/users/user_views_other_users_spec.rb
+++ b/spec/system/placements/organisations/users/user_views_other_users_spec.rb
@@ -12,12 +12,15 @@ RSpec.describe "Placements user views other users in their organisation", type: 
       given_users_have_been_assigned_to_the(organisation: school)
       when_i_visit_the_users_page
       then_i_see_the_organisation_users
+      and_users_is_selected_in_schools_primary_nav
       when_i_click_on_a_users_name(mary.full_name)
-      then_i_see_user_details(user: mary)
+      then_i_see_user_details(:school, user: mary)
+      and_users_is_selected_in_schools_primary_nav
       and_i_do_not_see_the_remove_user_link
       when_i_click_back
       when_i_click_on_a_users_name(anne.full_name)
-      then_i_see_user_details(user: anne)
+      then_i_see_user_details(:school, user: anne)
+      and_users_is_selected_in_schools_primary_nav
       and_i_see_the_remove_user_link
     end
   end
@@ -28,12 +31,15 @@ RSpec.describe "Placements user views other users in their organisation", type: 
       given_users_have_been_assigned_to_the(organisation: provider)
       when_i_visit_the_users_page
       then_i_see_the_organisation_users
+      and_users_is_selected_in_providers_primary_nav
       when_i_click_on_a_users_name(mary.full_name)
-      then_i_see_user_details(user: mary)
+      then_i_see_user_details(:provider, user: mary)
+      and_users_is_selected_in_providers_primary_nav
       and_i_see_the_remove_user_link
       when_i_click_back
       when_i_click_on_a_users_name(anne.full_name)
-      then_i_see_user_details(user: anne)
+      then_i_see_user_details(:provider, user: anne)
+      and_users_is_selected_in_providers_primary_nav
       and_i_do_not_see_the_remove_user_link
     end
   end
@@ -55,7 +61,6 @@ RSpec.describe "Placements user views other users in their organisation", type: 
   end
 
   def then_i_see_the_organisation_users
-    users_is_selected_in_navigation
     expect(page).to have_content anne.full_name
     expect(page).to have_content anne.email
 
@@ -71,8 +76,7 @@ RSpec.describe "Placements user views other users in their organisation", type: 
     click_on "Back"
   end
 
-  def then_i_see_user_details(user:)
-    users_is_selected_in_navigation
+  def then_i_see_user_details(_organisation_type, user:)
     expect(page).to have_content "First name"
     expect(page).to have_content user.first_name
 
@@ -91,10 +95,18 @@ RSpec.describe "Placements user views other users in their organisation", type: 
     expect(page).not_to have_link "Remove user"
   end
 
-  def users_is_selected_in_navigation
+  def and_users_is_selected_in_schools_primary_nav
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Placements", current: "false"
       expect(page).to have_link "Mentors", current: "false"
+      expect(page).to have_link "Users", current: "page"
+      expect(page).to have_link "Organisation details", current: "false"
+    end
+  end
+
+  def and_users_is_selected_in_providers_primary_nav
+    within(".app-primary-navigation__nav") do
+      expect(page).to have_link "Placements", current: "false"
       expect(page).to have_link "Users", current: "page"
       expect(page).to have_link "Organisation details", current: "false"
     end


### PR DESCRIPTION
## Context

We are removing "Mentors" from the primary navigation for provider users because we do not have a use case for when provider users will view mentors.

## Changes proposed in this pull request

- Separate schools / provider primary navigation into different components.

## Guidance to review

Sign on as a user who belongs to a provider. 
click around and make sure you never see "Mentors" in the primary nav

## Link to Trello card

https://trello.com/c/gkGzwwrD

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

Before:
<img width="1047" alt="image" src="https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/0beab3e9-6cf5-45fc-b9bc-fd995f5bd9cb">


After:
<img width="1100" alt="image" src="https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/d06a2b29-95eb-4f05-b4a7-a4fdde769b21">

