### PR TITLE
Improve test coverage for claims/schools/users_controller.rb

### DIFF
--- a/spec/system/claims/schools/view_users_spec.rb
+++ b/spec/system/claims/schools/view_users_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe "Invite and view a users details", type: :system do
+  let(:school) { create(:claims_school, :claims, urn: "123456") }
+  let(:anne) { create(:claims_user, :anne) }
+  let(:another_school) { create(:claims_school, :claims) }
+
+  before do
+    setup_school_and_anne_membership
+  end
+
+  scenario "I sign in as a lead mentor user and invite a user to a school and view that users details" do
+    sign_in_as_lead_mentor_user
+    visit_claims_school_users_page
+    click_on_add_user
+    fill_in_user_details
+    click_on_add_user
+    show_user_details
+  end
+
+  private
+
+  def setup_school_and_anne_membership
+    create(:membership, user: anne, organisation: school)
+    user_exists_in_dfe_sign_in(user: anne)
+  end
+
+  def sign_in_as_lead_mentor_user
+    user_exists_in_dfe_sign_in(user: anne)
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def visit_claims_school_users_page
+    visit claims_school_users_path(school)
+  end
+
+  def fill_in_user_details
+    fill_in "First name", with: "Barry"
+    fill_in "Last name", with: "Garlow"
+    fill_in "Email", with: "barry.garlow@eduction.gov.uk"
+    click_on "Continue"
+  end
+
+  def show_user_details
+    click_on "Barry Garlow"
+    expect(page).to have_content("\nFirst nameBarry")
+    expect(page).to have_content("\nLast nameGarlow")
+    expect(page).to have_content("\nEmail addressbarry.garlow@eduction.gov.uk")
+  end
+
+  def click_on_add_user
+    click_on "Add user"
+  end
+end


### PR DESCRIPTION
## Context

Improve test coverage for claims/schools/users_controller.rb to 100%

## Changes proposed in this pull request

To add a test around showing of a users details as this was missed 

## Guidance to review

Run tests to see claims/schools/users_controller.rb be at 100% test coverage

## Link to Trello card

https://trello.com/c/4NTkY3Iw/208-improve-test-coverage-for-claims-schools-userscontrollerrb

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
<img width="565" alt="Screenshot 2024-02-15 at 13 13 08" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/121dbf09-0623-4f59-8408-7eeaf8267e17">
