### PR TITLE
Rename Membership to UserMembership

### DIFF
--- a/app/controllers/placements/organisations_controller.rb
+++ b/app/controllers/placements/organisations_controller.rb
@@ -13,10 +13,10 @@ class Placements::OrganisationsController < ApplicationController
   end
 
   def set_memberships
-    @memberships = current_user.memberships.filter(&:placements_service).sort_by(&:name)
+    @memberships = current_user.user_memberships.filter(&:placements_service).sort_by(&:name)
   end
 
   def organisation
-    @organisation ||= current_user.memberships.first.organisation
+    @organisation ||= current_user.user_memberships.first.organisation
   end
 end

--- a/app/forms/user_invite_form.rb
+++ b/app/forms/user_invite_form.rb
@@ -44,7 +44,7 @@ class UserInviteForm < ApplicationForm
   end
 
   def membership
-    @membership ||= user.memberships.new(organisation:)
+    @membership ||= user.user_memberships.new(organisation:)
   end
 
   def user_klass

--- a/app/models/claims/school.rb
+++ b/app/models/claims/school.rb
@@ -55,7 +55,7 @@
 class Claims::School < School
   default_scope { claims_service }
 
-  has_many :users, through: :memberships
+  has_many :users, through: :user_memberships
   has_many :claims
   has_many :mentor_memberships
   has_many :mentors, through: :mentor_memberships

--- a/app/models/claims/user.rb
+++ b/app/models/claims/user.rb
@@ -20,7 +20,7 @@
 #
 class Claims::User < User
   has_many :schools,
-           through: :memberships,
+           through: :user_memberships,
            source: :organisation,
            source_type: "School"
 end

--- a/app/models/placements/provider.rb
+++ b/app/models/placements/provider.rb
@@ -31,5 +31,5 @@
 class Placements::Provider < Provider
   default_scope { placements_service }
 
-  has_many :users, through: :memberships
+  has_many :users, through: :user_memberships
 end

--- a/app/models/placements/school.rb
+++ b/app/models/placements/school.rb
@@ -55,7 +55,7 @@
 class Placements::School < School
   default_scope { placements_service }
 
-  has_many :users, through: :memberships
+  has_many :users, through: :user_memberships
   has_many :mentor_memberships
   has_many :mentors, through: :mentor_memberships
 end

--- a/app/models/placements/user.rb
+++ b/app/models/placements/user.rb
@@ -20,11 +20,11 @@
 #
 class Placements::User < User
   has_many :schools,
-           through: :memberships,
+           through: :user_memberships,
            source: :organisation,
            source_type: "School"
   has_many :providers,
-           through: :memberships,
+           through: :user_memberships,
            source: :organisation,
            source_type: "Provider"
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -33,8 +33,8 @@ class Provider < ApplicationRecord
 
   alias_attribute :organisation_type, :provider_type
 
-  has_many :memberships, as: :organisation
-  has_many :users, through: :memberships
+  has_many :user_memberships, as: :organisation
+  has_many :users, through: :user_memberships
   has_many :mentor_trainings
 
   enum :provider_type,

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -57,7 +57,7 @@ class School < ApplicationRecord
 
   belongs_to :region
 
-  has_many :memberships, as: :organisation
+  has_many :user_memberships, as: :organisation
   has_many :mentor_memberships
   has_many :mentors, through: :mentor_memberships
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@
 class User < ApplicationRecord
   include Discard::Model
 
-  has_many :memberships, dependent: :destroy
+  has_many :user_memberships, dependent: :destroy
 
   validates :first_name, presence: true
   validates :last_name, presence: true

--- a/app/models/user_membership.rb
+++ b/app/models/user_membership.rb
@@ -19,7 +19,7 @@
 #
 #  fk_rails_...  (user_id => users.id)
 #
-class Membership < ApplicationRecord
+class UserMembership < ApplicationRecord
   belongs_to :user
   belongs_to :organisation, polymorphic: true
 

--- a/app/services/remove_user_service.rb
+++ b/app/services/remove_user_service.rb
@@ -9,7 +9,7 @@ class RemoveUserService
   attr_reader :user, :organisation
 
   def call
-    membership = user.memberships.find_by(organisation:)
+    membership = user.user_memberships.find_by(organisation:)
     ActiveRecord::Base.transaction do
       membership.destroy!
       UserMailer.removal_email(user, organisation).deliver_later

--- a/db/migrate/20240216100317_rename_memberships_to_user_memberships.rb
+++ b/db/migrate/20240216100317_rename_memberships_to_user_memberships.rb
@@ -1,0 +1,5 @@
+class RenameMembershipsToUserMemberships < ActiveRecord::Migration[7.1]
+  def change
+    rename_table :memberships, :user_memberships
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_14_093104) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_16_100317) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -36,17 +36,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_14_093104) do
     t.boolean "enabled", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-  end
-
-  create_table "memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "user_id", null: false
-    t.string "organisation_type", null: false
-    t.uuid "organisation_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["organisation_type", "organisation_id"], name: "index_memberships_on_organisation"
-    t.index ["user_id", "organisation_id"], name: "index_memberships_on_user_id_and_organisation_id", unique: true
-    t.index ["user_id"], name: "index_memberships_on_user_id"
   end
 
   create_table "mentor_memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -170,6 +159,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_14_093104) do
     t.index ["urn"], name: "index_schools_on_urn", unique: true
   end
 
+  create_table "user_memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.string "organisation_type", null: false
+    t.uuid "organisation_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["organisation_type", "organisation_id"], name: "index_memberships_on_organisation"
+    t.index ["user_id", "organisation_id"], name: "index_user_memberships_on_user_id_and_organisation_id", unique: true
+    t.index ["user_id"], name: "index_user_memberships_on_user_id"
+  end
+
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "first_name", null: false
     t.string "last_name", null: false
@@ -186,11 +186,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_14_093104) do
 
   add_foreign_key "claims", "providers"
   add_foreign_key "claims", "schools"
-  add_foreign_key "memberships", "users"
   add_foreign_key "mentor_memberships", "mentors"
   add_foreign_key "mentor_memberships", "schools"
   add_foreign_key "mentor_trainings", "claims"
   add_foreign_key "mentor_trainings", "mentors"
   add_foreign_key "mentor_trainings", "providers"
   add_foreign_key "schools", "regions"
+  add_foreign_key "user_memberships", "users"
 end

--- a/spec/factories/user_memberships.rb
+++ b/spec/factories/user_memberships.rb
@@ -20,7 +20,7 @@
 #  fk_rails_...  (user_id => users.id)
 #
 FactoryBot.define do
-  factory :membership do
+  factory :user_membership do
     association :user, factory: :claims_user
     association :organisation, factory: :school
   end

--- a/spec/forms/user_invite_form_spec.rb
+++ b/spec/forms/user_invite_form_spec.rb
@@ -83,7 +83,7 @@ describe UserInviteForm, type: :model do
         end
 
         it "returns membership error on the email attribute of the for and does not send invite" do
-          create(:membership, user:, organisation:)
+          create(:user_membership, user:, organisation:)
           expect(user_invite_form.valid?).to eq false
 
           expect(user_invite_form.errors.messages)
@@ -110,14 +110,14 @@ describe UserInviteForm, type: :model do
       end
 
       it "creates membership" do
-        expect { user_invite_form.save! }.to change(Membership, :count).by 1
+        expect { user_invite_form.save! }.to change(UserMembership, :count).by 1
       end
     end
 
     context "with user belonging to another organisation" do
       let(:organisation) { create(:placements_provider) }
       let(:user) { create(:placements_user) }
-      let(:membership) { create(:membership, organisation:, user:) }
+      let(:membership) { create(:user_membership, organisation:, user:) }
       let(:another_organisation) { create(:placements_provider) }
 
       let(:form_params) do
@@ -135,7 +135,7 @@ describe UserInviteForm, type: :model do
       end
 
       it "creates membership" do
-        expect { user_invite_form.save! }.to change(Membership, :count).by 1
+        expect { user_invite_form.save! }.to change(UserMembership, :count).by 1
       end
     end
   end

--- a/spec/models/claims/school_spec.rb
+++ b/spec/models/claims/school_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Claims::School do
     it { is_expected.to have_many(:mentors).through(:mentor_memberships) }
 
     describe "#users" do
-      it { is_expected.to have_many(:users).through(:memberships) }
+      it { is_expected.to have_many(:users).through(:user_memberships) }
 
       it "returns only Claims::User records" do
         claims_school = create(:claims_school)

--- a/spec/models/claims/user_spec.rb
+++ b/spec/models/claims/user_spec.rb
@@ -23,7 +23,7 @@ require "rails_helper"
 RSpec.describe Claims::User do
   describe "associations" do
     describe "#schools" do
-      it { is_expected.to have_many(:schools).through(:memberships).source(:organisation) }
+      it { is_expected.to have_many(:schools).through(:user_memberships).source(:organisation) }
 
       it "returns only Claims::School records" do
         claims_user = create(:claims_user)

--- a/spec/models/placements/provider_spec.rb
+++ b/spec/models/placements/provider_spec.rb
@@ -33,7 +33,7 @@ require "rails_helper"
 RSpec.describe Placements::Provider do
   context "with assocations" do
     describe "#users" do
-      it { is_expected.to have_many(:users).through(:memberships) }
+      it { is_expected.to have_many(:users).through(:user_memberships) }
 
       it "returns only Placements::User records" do
         placements_provider = create(:placements_provider)

--- a/spec/models/placements/school_spec.rb
+++ b/spec/models/placements/school_spec.rb
@@ -57,7 +57,7 @@ require "rails_helper"
 RSpec.describe Placements::School do
   context "with assocations" do
     describe "#users" do
-      it { is_expected.to have_many(:users).through(:memberships) }
+      it { is_expected.to have_many(:users).through(:user_memberships) }
 
       it "returns only Placements::User records" do
         placements_school = create(:placements_school)

--- a/spec/models/placements/user_spec.rb
+++ b/spec/models/placements/user_spec.rb
@@ -23,7 +23,7 @@ require "rails_helper"
 RSpec.describe Placements::User do
   describe "associations" do
     describe "#schools" do
-      it { is_expected.to have_many(:schools).through(:memberships).source(:organisation) }
+      it { is_expected.to have_many(:schools).through(:user_memberships).source(:organisation) }
 
       it "returns only Placements::School records" do
         placements_user = create(:placements_user)
@@ -62,15 +62,15 @@ RSpec.describe Placements::User do
         user = create(:placements_user)
         expect(user.organisation_count).to eq 0
 
-        create(:membership, user:, organisation: create(:claims_school))
+        create(:user_membership, user:, organisation: create(:claims_school))
         expect(user.organisation_count).to eq 0
       end
 
       it "returns combined provider and school count" do
         user = create(:placements_user)
-        create(:membership, user:, organisation: create(:placements_school))
-        create(:membership, user:, organisation: create(:placements_provider))
-        create(:membership, user:, organisation: create(:placements_provider))
+        create(:user_membership, user:, organisation: create(:placements_school))
+        create(:user_membership, user:, organisation: create(:placements_provider))
+        create(:user_membership, user:, organisation: create(:placements_provider))
 
         expect(user.organisation_count).to eq 3
       end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -32,8 +32,8 @@ require "rails_helper"
 
 RSpec.describe Provider, type: :model do
   context "with associations" do
-    it { is_expected.to have_many(:memberships) }
-    it { is_expected.to have_many(:users).through(:memberships) }
+    it { is_expected.to have_many(:user_memberships) }
+    it { is_expected.to have_many(:users).through(:user_memberships) }
     it { is_expected.to have_many(:mentor_trainings) }
   end
 

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -56,7 +56,7 @@ require "rails_helper"
 
 RSpec.describe School, type: :model do
   context "with associations" do
-    it { is_expected.to have_many(:memberships) }
+    it { is_expected.to have_many(:user_memberships) }
     it { is_expected.to have_many(:mentors) }
     it { is_expected.to belong_to(:region) }
   end

--- a/spec/models/user_membership_spec.rb
+++ b/spec/models/user_membership_spec.rb
@@ -21,8 +21,8 @@
 #
 require "rails_helper"
 
-RSpec.describe Membership, type: :model do
-  subject(:test_membership) { create(:membership) }
+RSpec.describe UserMembership, type: :model do
+  subject(:test_membership) { create(:user_membership) }
 
   context "with validations" do
     it do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe User, type: :model do
   subject(:test_user) { build(:user) }
 
   context "with associations" do
-    it { is_expected.to have_many(:memberships).dependent(:destroy) }
+    it { is_expected.to have_many(:user_memberships).dependent(:destroy) }
   end
 
   describe "validations" do

--- a/spec/services/remove_user_service_spec.rb
+++ b/spec/services/remove_user_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RemoveUserService do
     context "when the user is a placements user" do
       let(:user) { create(:placements_user) }
       let(:organisation) { create(:placements_school) }
-      let!(:membership) { create(:membership, user:, organisation:) }
+      let!(:membership) { create(:user_membership, user:, organisation:) }
 
       it "calls mailer with correct params" do
         expect { remove_user_service }.to have_enqueued_mail(UserMailer, :removal_email).with(user, organisation)
@@ -19,7 +19,7 @@ RSpec.describe RemoveUserService do
     context "when the user is a claims user" do
       let(:user) { create(:claims_user) }
       let(:organisation) { create(:claims_school) }
-      let!(:membership) { create(:membership, user:, organisation:) }
+      let!(:membership) { create(:user_membership, user:, organisation:) }
 
       it "calls mailer with correct params" do
         expect { remove_user_service }.to have_enqueued_mail(UserMailer, :removal_email).with(user, organisation)

--- a/spec/system/claims/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/schools/claims/create_claim_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Create claim", type: :system, js: true, retry: 3, service: :clai
     create(
       :claims_user,
       :anne,
-      memberships: [create(:membership, organisation: school)],
+      user_memberships: [create(:user_membership, organisation: school)],
     )
   end
   let!(:provider) { create(:provider) }

--- a/spec/system/claims/schools/claims/view_claims_spec.rb
+++ b/spec/system/claims/schools/claims/view_claims_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "View claims", type: :system, service: :claims do
     create(
       :claims_user,
       :anne,
-      memberships: [create(:membership, organisation: school)],
+      user_memberships: [create(:user_membership, organisation: school)],
     )
   end
 

--- a/spec/system/claims/schools/users/invite_a_user_to_a_school_spec.rb
+++ b/spec/system/claims/schools/users/invite_a_user_to_a_school_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "Invite a user to a school", type: :system do
   private
 
   def setup_school_and_anne_membership
-    create(:membership, user: anne, organisation: school)
+    create(:user_membership, user: anne, organisation: school)
     user_exists_in_dfe_sign_in(user: anne)
   end
 
@@ -87,7 +87,7 @@ RSpec.describe "Invite a user to a school", type: :system do
   end
 
   def remove_all_users_from_school
-    school.users.each { |user| user.memberships.destroy_all }
+    school.users.each { |user| user.user_memberships.destroy_all }
   end
 
   def verify_i_cant_access_another_schools_users_list

--- a/spec/system/claims/schools/users/view_users_of_a_school_spec.rb
+++ b/spec/system/claims/schools/users/view_users_of_a_school_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "View users for school", type: :system do
 
   def setup_school_and_anne_membership
     user = create(:claims_user, :anne)
-    create(:membership, user:, organisation: school)
+    create(:user_membership, user:, organisation: school)
   end
 
   def sign_in_as_support_user

--- a/spec/system/claims/schools/users/view_users_spec.rb
+++ b/spec/system/claims/schools/users/view_users_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Invite and view a users details", type: :system do
   private
 
   def setup_school_and_anne_membership
-    create(:membership, user: anne, organisation: school)
+    create(:user_membership, user: anne, organisation: school)
     user_exists_in_dfe_sign_in(user: anne)
   end
 

--- a/spec/system/claims/schools/view_school_spec.rb
+++ b/spec/system/claims/schools/view_school_spec.rb
@@ -43,12 +43,12 @@ RSpec.describe "School Page", type: :system do
   end
 
   def and_user_has_multiple_schools(user)
-    create(:membership, user:, organisation: school2)
+    create(:user_membership, user:, organisation: school2)
   end
 
   def given_there_is_an_existing_user_for(user_name)
     user = create(:claims_user, user_name.downcase.to_sym)
-    create(:membership, user:, organisation: school1)
+    create(:user_membership, user:, organisation: school1)
     user
   end
 

--- a/spec/system/claims/sign_in_as_a_claims_user_spec.rb
+++ b/spec/system/claims/sign_in_as_a_claims_user_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "Sign In as a Claims User", type: :system, service: :claims do
   def given_there_is_an_existing_claims_user_with_a_school_for(user)
     user_exists_in_dfe_sign_in(user:)
     create(
-      :membership,
+      :user_membership,
       user:,
       organisation: create(:school, :claims),
     )

--- a/spec/system/claims/sign_out_as_claims_user_spec.rb
+++ b/spec/system/claims/sign_out_as_claims_user_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Sign out as a Claims User", type: :system, service: :claims do
   def given_there_is_an_existing_claims_user_with_a_school_for(user)
     user_exists_in_dfe_sign_in(user:)
     create(
-      :membership,
+      :user_membership,
       user:,
       organisation: create(:school, :claims),
     )

--- a/spec/system/claims/support/schools/users/view_a_users_details_spec.rb
+++ b/spec/system/claims/support/schools/users/view_a_users_details_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "View a users details", type: :system do
   private
 
   def attach_user_to_school
-    create(:membership, user:, organisation: school)
+    create(:user_membership, user:, organisation: school)
   end
 
   def sign_in_as_support_user

--- a/spec/system/claims/view_support_console_as_non_support_user_spec.rb
+++ b/spec/system/claims/view_support_console_as_non_support_user_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "View support console as a non support user", type: :system, serv
 
   def given_there_is_an_existing_user_for(user_name)
     user = create(:claims_user, user_name.downcase.to_sym)
-    create(:membership, user:, organisation: school1)
+    create(:user_membership, user:, organisation: school1)
     user
   end
 

--- a/spec/system/placements/organisations/users/add_users_spec.rb
+++ b/spec/system/placements/organisations/users/add_users_spec.rb
@@ -59,9 +59,9 @@ RSpec.describe "Placements users invite other users to organisations", type: :sy
 
   describe "Mary invites a members to second organisation" do
     before "user is sent an invitation" do
-      create(:membership, user: mary, organisation: one_school)
-      create(:membership, user: mary, organisation: another_school)
-      create(:membership, user: mary, organisation: one_provider)
+      create(:user_membership, user: mary, organisation: one_school)
+      create(:user_membership, user: mary, organisation: another_school)
+      create(:user_membership, user: mary, organisation: one_provider)
     end
 
     scenario "user adds a user to multiple organisations" do
@@ -115,7 +115,7 @@ RSpec.describe "Placements users invite other users to organisations", type: :sy
 
   def given_i_am_logged_in_as_a_user_with_one_organisation(organisation)
     user_exists_in_dfe_sign_in(user: anne)
-    create(:membership, user: anne, organisation:)
+    create(:user_membership, user: anne, organisation:)
     visit sign_in_path
     click_on "Sign in using DfE Sign In"
   end
@@ -127,7 +127,7 @@ RSpec.describe "Placements users invite other users to organisations", type: :sy
   end
 
   def and_user_is_already_assigned_to_a_school
-    create(:membership, user: new_user, organisation: one_school)
+    create(:user_membership, user: new_user, organisation: one_school)
   end
 
   def when_i_try_to_add_the_user_to_the_same_school

--- a/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
+++ b/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
 
     before do
       [anne, mary].each do |user|
-        create(:membership, user:, organisation: school)
+        create(:user_membership, user:, organisation: school)
       end
     end
 
@@ -46,7 +46,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
 
     before "message is sent to user" do
       [anne, mary].each do |user|
-        create(:membership, user:, organisation: provider)
+        create(:user_membership, user:, organisation: provider)
       end
     end
 
@@ -168,7 +168,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
       users_is_selected_in_providers_primary_nav
     end
 
-    expect(user.memberships.find_by(organisation:)).to eq nil
+    expect(user.user_memberships.find_by(organisation:)).to eq nil
     within(".govuk-notification-banner__content") do
       expect(page).to have_content "User removed"
     end

--- a/spec/system/placements/organisations/users/user_views_other_users_spec.rb
+++ b/spec/system/placements/organisations/users/user_views_other_users_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Placements user views other users in their organisation", type: 
 
   def given_users_have_been_assigned_to_the(organisation:)
     [mary, anne].each do |user|
-      create(:membership, user:, organisation:)
+      create(:user_membership, user:, organisation:)
     end
   end
 

--- a/spec/system/placements/organisations/view_organisations_spec.rb
+++ b/spec/system/placements/organisations/view_organisations_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe "View organisations", type: :system, service: :placements do
   end
 
   def and_user_has_a_school_without_a_service(user:)
-    create(:membership, user:, organisation: create(:school, :placements))
-    create(:membership, user:, organisation: school_without_placement)
+    create(:user_membership, user:, organisation: create(:school, :placements))
+    create(:user_membership, user:, organisation: school_without_placement)
   end
 
   def then_i_am_redirected_to_404_when_i_visit_the_school
@@ -78,10 +78,10 @@ RSpec.describe "View organisations", type: :system, service: :placements do
   end
 
   def and_user_has_multiple_organisations(user:)
-    create(:membership, user:, organisation: multi_org_school)
-    create(:membership, user:, organisation: multi_org_provider)
-    create(:membership, user:, organisation: claims_school)
-    create(:membership, user:, organisation: no_service_school)
+    create(:user_membership, user:, organisation: multi_org_school)
+    create(:user_membership, user:, organisation: multi_org_provider)
+    create(:user_membership, user:, organisation: claims_school)
+    create(:user_membership, user:, organisation: no_service_school)
   end
 
   def when_i_click_on_school_name
@@ -125,11 +125,11 @@ RSpec.describe "View organisations", type: :system, service: :placements do
   end
 
   def and_user_has_one_school(user:)
-    create(:membership, user:, organisation: one_school)
+    create(:user_membership, user:, organisation: one_school)
   end
 
   def and_user_has_one_provider(user:)
-    create(:membership, user:, organisation: one_provider)
+    create(:user_membership, user:, organisation: one_provider)
   end
 
   def then_i_see_the_one_school(school)

--- a/spec/system/placements/sign_out_as_a_placements_user_spec.rb
+++ b/spec/system/placements/sign_out_as_a_placements_user_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Sign out as a Placements User", type: :system, service: :placeme
   def given_there_is_an_existing_placements_user_with_a_school_for(user)
     user_exists_in_dfe_sign_in(user:)
     create(
-      :membership,
+      :user_membership,
       user:,
       organisation: create(:school, :placements),
     )

--- a/spec/system/placements/support/users/support_user_invites_a_new_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_invites_a_new_user_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
   end
 
   def given_a_user_has_been_assigned_to_the(organisation:)
-    create(:membership, user: new_user, organisation:)
+    create(:user_membership, user: new_user, organisation:)
   end
 
   def then_i_see_an_error(error_message, error_index = 0)

--- a/spec/system/placements/support/users/support_user_removes_a_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_removes_a_user_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
     let(:user) { create(:placements_user) }
 
     before do
-      create(:membership, user:, organisation: school)
+      create(:user_membership, user:, organisation: school)
     end
 
     scenario "user is removed from a school" do
@@ -34,7 +34,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
     let(:user) { create(:placements_user) }
 
     before do
-      create(:membership, user:, organisation: provider)
+      create(:user_membership, user:, organisation: provider)
     end
 
     scenario "user is removed from a provider" do
@@ -57,8 +57,8 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
     let(:user) { create(:placements_user) }
 
     before do
-      create(:membership, user:, organisation: school)
-      create(:membership, user:, organisation: provider)
+      create(:user_membership, user:, organisation: school)
+      create(:user_membership, user:, organisation: provider)
     end
 
     scenario "user is removed from one organisation but when other memberships exist" do
@@ -75,7 +75,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
     click_on "Remove user"
     click_on "Remove user"
     expect(page).to have_content "User removed"
-    expect(user.memberships.find_by(organisation: school)).to eq nil
+    expect(user.user_memberships.find_by(organisation: school)).to eq nil
   end
 
   def then_user_is_still_member_of_provider
@@ -144,7 +144,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
     email_is_sent(user.email, organisation)
     organisations_is_selected_in_primary_nav
     users_is_selected_in_secondary_nav
-    expect(user.memberships.find_by(organisation:)).to eq nil
+    expect(user.user_memberships.find_by(organisation:)).to eq nil
     within(".govuk-notification-banner__content") do
       expect(page).to have_content "User removed"
     end

--- a/spec/system/placements/support/users/support_user_views_a_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_views_a_user_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "Placements / Support / Users / Support User Views A User", type:
 
   def given_users_have_been_assigned_to_the(organisation:)
     [mary, anne].each do |user|
-      create(:membership, user:, organisation:)
+      create(:user_membership, user:, organisation:)
     end
   end
 


### PR DESCRIPTION
## Context

To differentiate user memberships from mentor memberships by adding an explicit prefix.

## Changes proposed in this pull request

Rename Membership to UserMembership

## Guidance to review

- Run tests
- Navigate around the application to ensure no weird behaviour since the change

## Link to Trello card

https://trello.com/c/2QTUYofP/211-rename-membership-to-usermembership

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
