### PR TITLE
Jc/add view mentor placements

### DIFF
--- a/app/controllers/placements/schools/mentors_controller.rb
+++ b/app/controllers/placements/schools/mentors_controller.rb
@@ -1,0 +1,16 @@
+class Placements::Schools::MentorsController < ApplicationController
+  before_action :set_school
+  before_action :set_mentor, only: [:show]
+
+  def show; end
+
+  private
+
+  def set_school
+    @school = current_user.schools.find(params.require(:school_id))
+  end
+
+  def set_mentor
+    @mentor = @school.mentors.find(params.require(:id))
+  end
+end

--- a/app/controllers/placements/support/schools/mentors_controller.rb
+++ b/app/controllers/placements/support/schools/mentors_controller.rb
@@ -1,0 +1,16 @@
+class Placements::Support::Schools::MentorsController < Placements::Support::ApplicationController
+  before_action :set_school
+  before_action :set_mentor, only: [:show]
+
+  def show; end
+
+  private
+
+  def set_school
+    @school = Placements::School.find(params.fetch(:school_id))
+  end
+
+  def set_mentor
+    @mentor = @school.mentors.find(params.fetch(:id))
+  end
+end

--- a/app/models/user_membership.rb
+++ b/app/models/user_membership.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: memberships
+# Table name: user_memberships
 #
 #  id                :uuid             not null, primary key
 #  organisation_type :string           not null
@@ -11,9 +11,9 @@
 #
 # Indexes
 #
-#  index_memberships_on_organisation                 (organisation_type,organisation_id)
-#  index_memberships_on_user_id                      (user_id)
-#  index_memberships_on_user_id_and_organisation_id  (user_id,organisation_id) UNIQUE
+#  index_memberships_on_organisation                      (organisation_type,organisation_id)
+#  index_user_memberships_on_user_id                      (user_id)
+#  index_user_memberships_on_user_id_and_organisation_id  (user_id,organisation_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/app/views/placements/schools/mentors/show.html.erb
+++ b/app/views/placements/schools/mentors/show.html.erb
@@ -1,0 +1,31 @@
+<%= content_for :page_title, sanitize("#{@mentor.full_name} - #{@school.name}") %>
+
+<%= render "placements/schools/primary_navigation", school: @school, current_navigation: :mentors %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: placements_school_mentors_path(school_id: @school.id)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= @school.name %></span>
+      <h2 class="govuk-heading-l"><%= @mentor.full_name %></h2>
+
+      <%= govuk_summary_list do |summary_list| %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".attributes.mentors.first_name")) %>
+          <% row.with_value(text: @mentor.first_name) %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".attributes.mentors.last_name")) %>
+          <% row.with_value(text: @mentor.last_name) %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".attributes.mentors.trn")) %>
+          <% row.with_value(text: @mentor.trn) %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/placements/schools/mentors/show.html.erb
+++ b/app/views/placements/schools/mentors/show.html.erb
@@ -14,11 +14,11 @@
 
       <%= govuk_summary_list do |summary_list| %>
         <% summary_list.with_row do |row| %>
-          <% row.with_key(text: t(".attributes.mentors.first_name")) %>
+          <% row.with_key(text: Mentor.human_attribute_name("first_name")) %>
           <% row.with_value(text: @mentor.first_name) %>
         <% end %>
         <% summary_list.with_row do |row| %>
-          <% row.with_key(text: t(".attributes.mentors.last_name")) %>
+          <% row.with_key(text: Mentor.human_attribute_name("last_name")) %>
           <% row.with_value(text: @mentor.last_name) %>
         <% end %>
         <% summary_list.with_row do |row| %>

--- a/app/views/placements/support/schools/mentors/show.html.erb
+++ b/app/views/placements/support/schools/mentors/show.html.erb
@@ -1,0 +1,31 @@
+<%= content_for :page_title, sanitize("#{@mentor.full_name} - #{@school.name}") %>
+
+<%= render "placements/support/primary_navigation", current_navigation: :organisations %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: placements_support_school_mentors_path) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= @school.name %></span>
+      <h2 class="govuk-heading-l"><%= @mentor.full_name %></h2>
+
+      <%= govuk_summary_list do |summary_list| %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".attributes.mentors.first_name")) %>
+          <% row.with_value(text: @mentor.first_name) %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".attributes.mentors.last_name")) %>
+          <% row.with_value(text: @mentor.last_name) %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".attributes.mentors.trn")) %>
+          <% row.with_value(text: @mentor.trn) %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/placements/support/schools/mentors/show.html.erb
+++ b/app/views/placements/support/schools/mentors/show.html.erb
@@ -9,16 +9,16 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-l"><%= @school.name %></span>
+      <span class="govuk-caption-l"><%= t(".caption", school_name: @school.name) %></span>
       <h2 class="govuk-heading-l"><%= @mentor.full_name %></h2>
 
       <%= govuk_summary_list do |summary_list| %>
         <% summary_list.with_row do |row| %>
-          <% row.with_key(text: t(".attributes.mentors.first_name")) %>
+          <% row.with_key(text: Mentor.human_attribute_name("first_name")) %>
           <% row.with_value(text: @mentor.first_name) %>
         <% end %>
         <% summary_list.with_row do |row| %>
-          <% row.with_key(text: t(".attributes.mentors.last_name")) %>
+          <% row.with_key(text: Mentor.human_attribute_name("last_name")) %>
           <% row.with_value(text: @mentor.last_name) %>
         <% end %>
         <% summary_list.with_row do |row| %>

--- a/config/locales/en/placements/schools/mentors.yml
+++ b/config/locales/en/placements/schools/mentors.yml
@@ -1,0 +1,10 @@
+en:
+  placements:
+    schools:
+      mentors:
+        show:
+          attributes:
+            mentors:
+              first_name: First name
+              last_name: Last name
+              trn: Teacher reference number (TRN)

--- a/config/locales/en/placements/schools/mentors.yml
+++ b/config/locales/en/placements/schools/mentors.yml
@@ -5,6 +5,4 @@ en:
         show:
           attributes:
             mentors:
-              first_name: First name
-              last_name: Last name
               trn: Teacher reference number (TRN)

--- a/config/locales/en/placements/support/schools/mentors.yml
+++ b/config/locales/en/placements/support/schools/mentors.yml
@@ -4,6 +4,7 @@ en:
       schools:
         mentors:
           show:
+            caption: "Mentors - %{school_name}"
             attributes:
               mentors:
                 first_name: First name

--- a/config/locales/en/placements/support/schools/mentors.yml
+++ b/config/locales/en/placements/support/schools/mentors.yml
@@ -1,0 +1,11 @@
+en:
+  placements:
+    support:
+      schools:
+        mentors:
+          show:
+            attributes:
+              mentors:
+                first_name: First name
+                last_name: Last name
+                trn: Teacher reference number (TRN)

--- a/config/locales/en/placements/support/schools/mentors.yml
+++ b/config/locales/en/placements/support/schools/mentors.yml
@@ -7,6 +7,4 @@ en:
             caption: "Mentors - %{school_name}"
             attributes:
               mentors:
-                first_name: First name
-                last_name: Last name
                 trn: Teacher reference number (TRN)

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -33,6 +33,8 @@ scope module: :placements,
           member { get :remove }
           collection { get :check }
         end
+
+        resources :mentors
       end
     end
 
@@ -59,6 +61,8 @@ scope module: :placements,
         member { get :remove }
         collection { get :check }
       end
+
+      resources :mentors
     end
   end
 

--- a/spec/factories/user_memberships.rb
+++ b/spec/factories/user_memberships.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: memberships
+# Table name: user_memberships
 #
 #  id                :uuid             not null, primary key
 #  organisation_type :string           not null
@@ -11,9 +11,9 @@
 #
 # Indexes
 #
-#  index_memberships_on_organisation                 (organisation_type,organisation_id)
-#  index_memberships_on_user_id                      (user_id)
-#  index_memberships_on_user_id_and_organisation_id  (user_id,organisation_id) UNIQUE
+#  index_memberships_on_organisation                      (organisation_type,organisation_id)
+#  index_user_memberships_on_user_id                      (user_id)
+#  index_user_memberships_on_user_id_and_organisation_id  (user_id,organisation_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/spec/models/user_membership_spec.rb
+++ b/spec/models/user_membership_spec.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: memberships
+# Table name: user_memberships
 #
 #  id                :uuid             not null, primary key
 #  organisation_type :string           not null
@@ -11,9 +11,9 @@
 #
 # Indexes
 #
-#  index_memberships_on_organisation                 (organisation_type,organisation_id)
-#  index_memberships_on_user_id                      (user_id)
-#  index_memberships_on_user_id_and_organisation_id  (user_id,organisation_id) UNIQUE
+#  index_memberships_on_organisation                      (organisation_type,organisation_id)
+#  index_user_memberships_on_user_id                      (user_id)
+#  index_user_memberships_on_user_id_and_organisation_id  (user_id,organisation_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/spec/system/placements/schools/mentors/view_a_mentor_spec.rb
+++ b/spec/system/placements/schools/mentors/view_a_mentor_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe "Placements / Schools / Mentors / View a mentor", type: :system, service: :placements do
+  let(:school) { create(:placements_school, name: "School 1") }
+  let(:mentor) do
+    create(:placements_mentor,
+           first_name: "John",
+           last_name: "Doe",
+           trn: "1234567")
+  end
+
+  before do
+    school
+    given_i_sign_in_as_anne
+  end
+
+  scenario "Support User views a school mentor's details" do
+    given_a_mentor_exists_in(school:)
+    when_i_visit_the_show_page_for(school, mentor)
+    then_i_see_the_mentor_details(
+      school_name: "School 1",
+      first_name: "John",
+      last_name: "Doe",
+      trn: "1234567",
+    )
+  end
+
+  private
+
+  def and_there_is_an_existing_user_for(user_name)
+    user = create(:placements_user, user_name.downcase.to_sym)
+    user_exists_in_dfe_sign_in(user:)
+    and_user_has_one_school(user:)
+  end
+
+  def and_i_visit_the_sign_in_path
+    visit sign_in_path
+  end
+
+  def and_i_click_sign_in
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def given_i_sign_in_as_anne
+    and_there_is_an_existing_user_for("Anne")
+    and_i_visit_the_sign_in_path
+    and_i_click_sign_in
+  end
+
+  def given_a_mentor_exists_in(school:)
+    create(:placements_mentor_membership, school:, mentor:)
+  end
+
+  def when_i_visit_the_show_page_for(school, mentor)
+    visit placements_school_mentor_path(
+      school_id: school.id,
+      id: mentor.id,
+    )
+  end
+
+  def then_i_see_the_mentor_details(school_name:, first_name:, last_name:, trn:)
+    expect(page).to have_content(school_name)
+    expect(page).to have_content("#{first_name} #{last_name}")
+
+    within(".govuk-summary-list") do
+      expect(page).to have_content(first_name)
+      expect(page).to have_content(last_name)
+      expect(page).to have_content(trn)
+    end
+  end
+
+  def and_user_has_one_school(user:)
+    create(:user_membership, user:, organisation: school)
+  end
+end

--- a/spec/system/placements/support/schools/mentors/support_user_views_a_mentor_spec.rb
+++ b/spec/system/placements/support/schools/mentors/support_user_views_a_mentor_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe "Placements / Support / Schools / Mentor / Support User views a mentor",
+               type: :system, service: :placements do
+  let(:school) { create(:placements_school, name: "School 1") }
+  let(:mentor) do
+    create(:placements_mentor,
+           first_name: "John",
+           last_name: "Doe",
+           trn: "1234567")
+  end
+
+  before do
+    school
+    given_i_sign_in_as_colin
+  end
+
+  scenario "Support User views a school mentor's details" do
+    given_a_mentor_exists_in(school:)
+    when_i_visit_the_support_show_page_for(school, mentor)
+    then_i_see_the_mentor_details(
+      school_name: "School 1",
+      first_name: "John",
+      last_name: "Doe",
+      trn: "1234567",
+    )
+  end
+
+  private
+
+  def and_there_is_an_existing_user_for(user_name)
+    user = create(:placements_support_user, user_name.downcase.to_sym)
+    user_exists_in_dfe_sign_in(user:)
+  end
+
+  def and_i_visit_the_sign_in_path
+    visit sign_in_path
+  end
+
+  def and_i_click_sign_in
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def given_i_sign_in_as_colin
+    and_there_is_an_existing_user_for("Colin")
+    and_i_visit_the_sign_in_path
+    and_i_click_sign_in
+  end
+
+  def given_a_mentor_exists_in(school:)
+    create(:placements_mentor_membership, school:, mentor:)
+  end
+
+  def when_i_visit_the_support_show_page_for(school, mentor)
+    visit placements_support_school_mentor_path(
+      school_id: school.id,
+      id: mentor.id,
+    )
+  end
+
+  def then_i_see_the_mentor_details(school_name:, first_name:, last_name:, trn:)
+    expect(page).to have_content(school_name)
+    expect(page).to have_content("#{first_name} #{last_name}")
+
+    within(".govuk-summary-list") do
+      expect(page).to have_content(first_name)
+      expect(page).to have_content(last_name)
+      expect(page).to have_content(trn)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Add show pages for mentors.

## Changes proposed in this pull request

_Placements_
- Views/Controllers/Routes/etc. for Support Users to view School Mentors
- Views/Controllers/Routes/etc. for School Users to view Mentors

## Guidance to review
_Placements_
- Sign in as Anne
- visit http://placements.localhost:3000/schools/:school_id/mentors/:id
- Check mentors `first_name`, `last_name`, `trn` are displayed

- Sign in as Colin
- visit http://placements.localhost:3000/support/schools/:school_id/mentors/:id
- Check mentors `first_name`, `last_name`, `trn` are displayed

## Link to Trello card

https://trello.com/c/z6xJxOoz/196-as-a-support-user-i-want-to-view-the-details-of-a-mentor
https://trello.com/c/oPOYv499/215-as-a-user-i-want-to-view-the-details-of-a-mentor

## Screenshots
_School User (Anne)_
<img width="1450" alt="Screenshot 2024-02-16 at 13 45 30" src="https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/18532428-3234-4db9-8f97-ec69acecf1eb">

_Support User (Colin)_
<img width="727" alt="Screenshot 2024-02-16 at 14 19 54" src="https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/a0aad200-9fcd-4827-add3-1f80e4ba46f3">



