### PR TITLE
Change validation error from ActiveRecord::RecordInvalid to ActiveModel::ValidationError

### DIFF
--- a/app/forms/application_form.rb
+++ b/app/forms/application_form.rb
@@ -26,6 +26,6 @@ class ApplicationForm
   private
 
   def raise_validation_error
-    raise ActiveRecord::RecordInvalid, self
+    raise ActiveModel::ValidationError, self
   end
 end

--- a/spec/forms/support_user_invite_form_spec.rb
+++ b/spec/forms/support_user_invite_form_spec.rb
@@ -70,7 +70,7 @@ describe SupportUserInviteForm, type: :model do
             ],
           )
 
-          expect { support_user_invite_form.save! }.to raise_error ActiveRecord::RecordInvalid
+          expect { support_user_invite_form.save! }.to raise_error ActiveModel::ValidationError
         end
       end
     end

--- a/spec/forms/user_invite_form_spec.rb
+++ b/spec/forms/user_invite_form_spec.rb
@@ -65,7 +65,7 @@ describe UserInviteForm, type: :model do
             first_name: ["Enter a first name"],
             email: ["Enter an email address", "Enter an email address in the correct format, like name@example.com"],
           )
-          expect { user_invite_form.save! }.to raise_error ActiveRecord::RecordInvalid
+          expect { user_invite_form.save! }.to raise_error ActiveModel::ValidationError
         end
       end
 
@@ -88,7 +88,7 @@ describe UserInviteForm, type: :model do
 
           expect(user_invite_form.errors.messages)
             .to match(email: ["Email address already in use"])
-          expect { user_invite_form.save! }.to raise_error ActiveRecord::RecordInvalid
+          expect { user_invite_form.save! }.to raise_error ActiveModel::ValidationError
         end
       end
     end


### PR DESCRIPTION
## Context

As `ApplicationForm` only includes the `ActiveModel::Model` module, it makes more sense to avoid the external dependency of `ActiveRecord`.

## Changes proposed in this pull request

- Change the validation error from `ActiveRecord::RecordInvalid` to `ActiveModel::ValidationError`.
