### PR TITLE
Update the Crown logo - Update govuk gems to 5.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,8 +50,8 @@ gem "bootsnap", require: false
 gem "flipflop"
 gem "redcarpet", "~> 3.6"
 
-gem "govuk-components", "~> 5.0.2"
-gem "govuk_design_system_formbuilder", "~> 5.0.0"
+gem "govuk-components", "~> 5.1"
+gem "govuk_design_system_formbuilder", "~> 5.1"
 
 # DfE Sign-in
 gem "omniauth"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,11 +199,11 @@ GEM
       terminal-table (>= 1.8)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    govuk-components (5.0.2)
+    govuk-components (5.1.0)
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (~> 6.0)
-      view_component (>= 3.9, < 3.10)
-    govuk_design_system_formbuilder (5.0.0)
+      view_component (>= 3.9, < 3.11)
+    govuk_design_system_formbuilder (5.1.0)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
@@ -318,7 +318,7 @@ GEM
       validate_email
       validate_url
       webfinger (~> 2.0)
-    pagy (6.4.3)
+    pagy (6.5.0)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
@@ -558,7 +558,7 @@ GEM
     validate_url (1.0.15)
       activemodel (>= 3.0.0)
       public_suffix
-    view_component (3.9.0)
+    view_component (3.10.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
@@ -612,8 +612,8 @@ DEPENDENCIES
   factory_bot_rails
   faker
   flipflop
-  govuk-components (~> 5.0.2)
-  govuk_design_system_formbuilder (~> 5.0.0)
+  govuk-components (~> 5.1)
+  govuk_design_system_formbuilder (~> 5.1)
   httparty
   jsbundling-rails
   launchy


### PR DESCRIPTION
## Context

We need to update the crown logo.

> Why the GOV.UK crown is changing
> Following the coronation of King Charles III, the royal cypher has been updated by the Royal Household. Announced in September 2022, this means many logos, crests and other symbols of state are being updated in line with the new design.
> Within government, this work is led by the Government Communications Service, who are liaising with the Royal Household. In line with wider changes to government symbols, the GOV.UK crown will be updated to reflect the new royal cypher and we have partnered with GCS to plan and deliver the changes.

## Changes proposed in this pull request

Update the govuk gems and receive the updates to the crown logo.

## Screenshots

![CleanShot 2024-02-19 at 13 04 06](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/146dbe14-79e0-48be-b5c5-64919fce9384)

![CleanShot 2024-02-19 at 13 04 17](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/40fbdbb7-327a-484c-9801-c1b6b2bd0cb5)

