### PR TITLE
Add placements mentor index pages

### DIFF
--- a/app/controllers/placements/schools/mentors_controller.rb
+++ b/app/controllers/placements/schools/mentors_controller.rb
@@ -2,6 +2,10 @@ class Placements::Schools::MentorsController < ApplicationController
   before_action :set_school
   before_action :set_mentor, only: [:show]
 
+  def index
+    @pagy, @mentors = pagy(@school.mentors.order(:first_name, :last_name))
+  end
+
   def show; end
 
   private

--- a/app/controllers/placements/support/schools/mentors_controller.rb
+++ b/app/controllers/placements/support/schools/mentors_controller.rb
@@ -2,6 +2,10 @@ class Placements::Support::Schools::MentorsController < Placements::Support::App
   before_action :set_school
   before_action :set_mentor, only: [:show]
 
+  def index
+    @pagy, @mentors = pagy(@school.mentors.order(:first_name, :last_name))
+  end
+
   def show; end
 
   private

--- a/app/views/placements/schools/_primary_navigation.html.erb
+++ b/app/views/placements/schools/_primary_navigation.html.erb
@@ -11,7 +11,7 @@
 <%= content_for(:primary_navigation_content) do %>
   <%= render PrimaryNavigationComponent.new do |component| %>
     <% component.with_navigation_item t(".placements"), "#", current: current_navigation == :placements %>
-    <% component.with_navigation_item t(".mentors"), "#", current: current_navigation == :mentors %>
+    <% component.with_navigation_item t(".mentors"), placements_school_mentors_path(school), current: current_navigation == :mentors %>
     <% component.with_navigation_item t(".users"), placements_school_users_path(school), current: current_navigation == :users %>
     <% component.with_navigation_item t(".organisation_details"),
                                       placements_school_path(school),

--- a/app/views/placements/schools/mentors/index.html.erb
+++ b/app/views/placements/schools/mentors/index.html.erb
@@ -1,0 +1,43 @@
+<% content_for :page_title, t(".heading") %>
+
+<%= render "placements/schools/primary_navigation", school: @school, current_navigation: :mentors %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= t(".heading") %></h2>
+
+      <% if @mentors.any? %>
+        <%= govuk_table do |table| %>
+          <% table.with_head do |head| %>
+            <% head.with_row do |row| %>
+              <% row.with_cell(header: true, text: Mentor.human_attribute_name(:name)) %>
+              <% row.with_cell(header: true, text: t(".trn")) %>
+            <% end %>
+          <% end %>
+
+          <% table.with_body do |body| %>
+            <% @mentors.each do |mentor| %>
+              <% body.with_row do |row| %>
+                <% row.with_cell(text: govuk_link_to(
+                  mentor.full_name,
+                  placements_school_mentor_path(school_id: @school.id, id: mentor.id),
+                )) %>
+                <% row.with_cell(text: mentor.trn) %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+
+        <%= govuk_pagination(pagy: @pagy) %>
+        <p>
+          <%= t("pagination_info", from: @pagy.from, to: @pagy.to, count: @pagy.count) %>
+        </p>
+      <% else %>
+        <p>
+          <%= t("no_records_for", records: "mentors", for: @school.name) %>
+        </p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/placements/support/_secondary_navigation.html.erb
+++ b/app/views/placements/support/_secondary_navigation.html.erb
@@ -1,7 +1,9 @@
 <%= render SecondaryNavigationComponent.new do |component| %>
   <% component.with_navigation_item t(".details"), placements_support_organisation_path(organisation) %>
   <% component.with_navigation_item t(".users"), placements_support_users_path(organisation) %>
-  <% component.with_navigation_item t(".mentors"), "#" %>
+  <% unless organisation.is_a?(Provider) %>
+    <% component.with_navigation_item t(".mentors"), placements_support_school_mentors_path(organisation) %>
+  <% end %>
   <% component.with_navigation_item t(".placements"), "#" %>
   <% component.with_navigation_item t(".providers"), "#" %>
 <% end %>

--- a/app/views/placements/support/schools/mentors/index.html.erb
+++ b/app/views/placements/support/schools/mentors/index.html.erb
@@ -1,4 +1,5 @@
-<% content_for :page_title, t(".heading") %>
+<%= content_for :page_title, sanitize(@school.name) %>
+
 <%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 
 <div class="govuk-width-container">

--- a/app/views/placements/support/schools/mentors/index.html.erb
+++ b/app/views/placements/support/schools/mentors/index.html.erb
@@ -1,0 +1,46 @@
+<% content_for :page_title, t(".heading") %>
+<%= render "placements/support/primary_navigation", current_navigation: :organisations %>
+
+<div class="govuk-width-container">
+  <h1 class="govuk-heading-l"><%= @school.name %></h1>
+
+  <%= render "placements/support/secondary_navigation", organisation: @school %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-m"><%= t(".heading") %></h2>
+
+      <% if @mentors.any? %>
+        <%= govuk_table do |table| %>
+          <% table.with_head do |head| %>
+            <% head.with_row do |row| %>
+              <% row.with_cell(header: true, text: Mentor.human_attribute_name(:name)) %>
+              <% row.with_cell(header: true, text: t(".trn")) %>
+            <% end %>
+          <% end %>
+
+          <% table.with_body do |body| %>
+            <% @mentors.each do |mentor| %>
+              <% body.with_row do |row| %>
+                <% row.with_cell(text: govuk_link_to(
+                  mentor.full_name,
+                  placements_support_school_mentor_path(school_id: @school.id, id: mentor.id),
+                )) %>
+                <% row.with_cell(text: mentor.trn) %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+
+        <%= govuk_pagination(pagy: @pagy) %>
+        <p>
+          <%= t("pagination_info", from: @pagy.from, to: @pagy.to, count: @pagy.count) %>
+        </p>
+      <% else %>
+        <p>
+          <%= t("no_records_for", records: "mentors", for: @school.name) %>
+        </p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/locales/en/placements/schools/mentors.yml
+++ b/config/locales/en/placements/schools/mentors.yml
@@ -2,6 +2,9 @@ en:
   placements:
     schools:
       mentors:
+        index:
+          heading: Mentors
+          trn: Teacher reference number (TRN)
         show:
           attributes:
             mentors:

--- a/config/locales/en/placements/support/schools/mentors.yml
+++ b/config/locales/en/placements/support/schools/mentors.yml
@@ -3,6 +3,9 @@ en:
     support:
       schools:
         mentors:
+          index:
+            heading: Mentors
+            trn: Teacher reference number (TRN)
           show:
             caption: "Mentors - %{school_name}"
             attributes:

--- a/spec/system/claims/support/schools/mentors/view_mentors_spec.rb
+++ b/spec/system/claims/support/schools/mentors/view_mentors_spec.rb
@@ -12,15 +12,15 @@ RSpec.describe "View a school's mentors", type: :system, service: :claims do
     user_exists_in_dfe_sign_in(user: colin)
     given_i_sign_in
     when_i_visit_the_support_school_mentors_page(school)
-    i_see_a_list_of_the_schools_mentors
-    i_dont_see_mentors_from_another_school
+    then_i_see_a_list_of_the_schools_mentors
+    and_i_dont_see_mentors_from_another_school
   end
 
   scenario "View a school's empty mentors list" do
     user_exists_in_dfe_sign_in(user: colin)
     given_i_sign_in
     when_i_visit_the_support_school_mentors_page(another_school)
-    i_see_no_results
+    then_i_see_no_results
   end
 
   private
@@ -34,7 +34,7 @@ RSpec.describe "View a school's mentors", type: :system, service: :claims do
     visit claims_support_school_mentors_path(school)
   end
 
-  def i_see_a_list_of_the_schools_mentors
+  def then_i_see_a_list_of_the_schools_mentors
     expect(page).to have_content("Name")
     expect(page).to have_content("Teacher reference number (TRN)")
 
@@ -49,12 +49,12 @@ RSpec.describe "View a school's mentors", type: :system, service: :claims do
     end
   end
 
-  def i_dont_see_mentors_from_another_school
+  def and_i_dont_see_mentors_from_another_school
     expect(page).not_to have_content(mentor3.full_name)
     expect(page).not_to have_content(mentor3.trn)
   end
 
-  def i_see_no_results
+  def then_i_see_no_results
     expect(page).to have_content("There are no mentors for #{another_school.name}")
   end
 end

--- a/spec/system/placements/schools/mentors/view_mentors_spec.rb
+++ b/spec/system/placements/schools/mentors/view_mentors_spec.rb
@@ -1,21 +1,21 @@
 require "rails_helper"
 
-RSpec.describe "View a school's mentors", type: :system, service: :claims do
+RSpec.describe "Placements / Schools / Mentors / View mentors", type: :system, service: :placements do
   let!(:mentor1) { create(:mentor, first_name: "Bilbo", last_name: "Baggins") }
   let!(:mentor2) { create(:mentor, first_name: "Bilbo", last_name: "Test") }
   let!(:mentor3) { create(:mentor, trn: "123") }
-  let!(:school) { create(:claims_school, mentors: [mentor1, mentor2]) }
-  let!(:another_school) { create(:claims_school) }
+  let!(:school) { create(:placements_school, mentors: [mentor1, mentor2]) }
+  let!(:another_school) { create(:placements_school) }
   let!(:anne) do
     create(
-      :claims_user,
+      :placements_user,
       :anne,
       user_memberships: [create(:user_membership, organisation: school)],
     )
   end
   let!(:mary) do
     create(
-      :claims_user,
+      :placements_user,
       :mary,
       user_memberships: [create(:user_membership, organisation: another_school)],
     )
@@ -44,7 +44,7 @@ RSpec.describe "View a school's mentors", type: :system, service: :claims do
   end
 
   def when_i_visit_the_school_mentors_page(school)
-    visit claims_school_mentors_path(school)
+    visit placements_school_mentors_path(school)
   end
 
   def then_i_see_a_list_of_the_schools_mentors

--- a/spec/system/placements/support/schools/mentors/support_user_views_mentors_spec.rb
+++ b/spec/system/placements/support/schools/mentors/support_user_views_mentors_spec.rb
@@ -1,38 +1,27 @@
 require "rails_helper"
 
-RSpec.describe "View a school's mentors", type: :system, service: :claims do
+RSpec.describe "Placements / Support / Schools / Mentor / Support User views mentors",
+               type: :system,
+               service: :placements do
   let!(:mentor1) { create(:mentor, first_name: "Bilbo", last_name: "Baggins") }
   let!(:mentor2) { create(:mentor, first_name: "Bilbo", last_name: "Test") }
   let!(:mentor3) { create(:mentor, trn: "123") }
-  let!(:school) { create(:claims_school, mentors: [mentor1, mentor2]) }
-  let!(:another_school) { create(:claims_school) }
-  let!(:anne) do
-    create(
-      :claims_user,
-      :anne,
-      user_memberships: [create(:user_membership, organisation: school)],
-    )
-  end
-  let!(:mary) do
-    create(
-      :claims_user,
-      :mary,
-      user_memberships: [create(:user_membership, organisation: another_school)],
-    )
-  end
+  let!(:school) { create(:placements_school, mentors: [mentor1, mentor2]) }
+  let!(:another_school) { create(:placements_school) }
+  let!(:colin) { create(:placements_support_user, :colin) }
 
-  scenario "View a school's mentors as a user" do
-    user_exists_in_dfe_sign_in(user: anne)
+  scenario "View a school's mentors as a support user" do
+    user_exists_in_dfe_sign_in(user: colin)
     given_i_sign_in
-    when_i_visit_the_school_mentors_page(school)
+    when_i_visit_the_support_school_mentors_page(school)
     then_i_see_a_list_of_the_schools_mentors
     and_i_dont_see_mentors_from_another_school
   end
 
   scenario "View a school's empty mentors list" do
-    user_exists_in_dfe_sign_in(user: mary)
+    user_exists_in_dfe_sign_in(user: colin)
     given_i_sign_in
-    when_i_visit_the_school_mentors_page(another_school)
+    when_i_visit_the_support_school_mentors_page(another_school)
     then_i_see_no_results
   end
 
@@ -43,8 +32,8 @@ RSpec.describe "View a school's mentors", type: :system, service: :claims do
     click_on "Sign in using DfE Sign In"
   end
 
-  def when_i_visit_the_school_mentors_page(school)
-    visit claims_school_mentors_path(school)
+  def when_i_visit_the_support_school_mentors_page(school)
+    visit placements_support_school_mentors_path(school)
   end
 
   def then_i_see_a_list_of_the_schools_mentors

--- a/spec/system/placements/support/users/support_user_invites_a_new_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_invites_a_new_user_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
   describe "School" do
     scenario "Support User invites a new user to a school" do
       when_i_visit_the_users_page_for(organisation: school)
-      then_i_see_the_navigation_bars_with_organisations_and_users_selected
+      then_i_see_the_navigation_bars_with_organisations_and_users_selected(school)
       and_i_click("Add user")
       then_i_see_support_navigation_with_organisation_selected
       and_i_enter_the_details_for_a_new_user
@@ -54,7 +54,7 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
   describe "Provider" do
     scenario "Support User invites a new user to a school" do
       when_i_visit_the_users_page_for(organisation: provider)
-      then_i_see_the_navigation_bars_with_organisations_and_users_selected
+      then_i_see_the_navigation_bars_with_organisations_and_users_selected(provider)
       and_i_click("Add user")
       then_i_see_support_navigation_with_organisation_selected
       and_i_enter_the_details_for_a_new_user
@@ -154,7 +154,7 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
     fill_in "user-invite-form-email-field", with: "test@example.com"
   end
 
-  def then_i_see_the_navigation_bars_with_organisations_and_users_selected
+  def then_i_see_the_navigation_bars_with_organisations_and_users_selected(organisation)
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Organisations", current: "page"
       expect(page).to have_link "Users", current: "false"
@@ -163,7 +163,9 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
     within(".app-secondary-navigation") do
       expect(page).to have_link "Details", current: "false"
       expect(page).to have_link "Users", current: "page"
-      expect(page).to have_link "Mentors", current: "false"
+      unless organisation.is_a?(Provider)
+        expect(page).to have_link "Mentors", current: "false"
+      end
       expect(page).to have_link "Placements", current: "false"
       expect(page).to have_link "Providers", current: "false"
     end

--- a/spec/system/placements/support/users/support_user_removes_a_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_removes_a_user_spec.rb
@@ -120,11 +120,13 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
     end
   end
 
-  def users_is_selected_in_secondary_nav
+  def users_is_selected_in_secondary_nav(organisation)
     within(".app-secondary-navigation__list") do
       expect(page).to have_link "Details", current: "false"
       expect(page).to have_link "Users", current: "page"
-      expect(page).to have_link "Mentors", current: "false"
+      unless organisation.is_a?(Provider)
+        expect(page).to have_link "Mentors", current: "false"
+      end
       expect(page).to have_link "Placements", current: "false"
       expect(page).to have_link "Providers", current: "false"
     end
@@ -143,7 +145,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
   def then_the_the_user_is_removed_from_the_organisation(organisation)
     email_is_sent(user.email, organisation)
     organisations_is_selected_in_primary_nav
-    users_is_selected_in_secondary_nav
+    users_is_selected_in_secondary_nav(organisation)
     expect(user.user_memberships.find_by(organisation:)).to eq nil
     within(".govuk-notification-banner__content") do
       expect(page).to have_content "User removed"


### PR DESCRIPTION
## Context

- Add Mentor index page for Placements Support Users
- Add Mentor index page for Placements School Users

## Changes proposed in this pull request

- Controllers/Views/etc for Placements Support Users to view a list of mentors for a school
- Controllers/Views/etc for Placements School Users to view a list of their schools mentors

## Guidance to review

(Placements service only)
- Sign in as Support User Colin
- Click to view a school (with mentors)
- Click the "Mentors" tab in the secondary nav
- This should show the index page for Mentors on that school.

- Sign in as School User Anne
- Click the "Mentors" tab in the primary nav
- This should show the index page for Mentors for Anne's school.

## Link to Trello card

- https://trello.com/c/RJuJqfy0/222-as-a-support-user-i-want-to-see-a-list-of-all-mentors-belonging-to-a-school
- https://trello.com/c/5zA37IEv/223-as-a-user-i-want-to-see-a-list-of-all-mentors-belonging-to-a-school

## Screenshots

_Anne_
<img width="727" alt="Screenshot 2024-02-19 at 15 06 27" src="https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/01501993-7195-43b5-a8f1-31e2ca19bd34">

_Colin_
<img width="1453" alt="Screenshot 2024-02-19 at 15 07 20" src="https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/be53afa9-db46-4d67-864a-e37439fd4d11">

