### PR TITLE
Remove Action Cable boilerplate code

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,4 +1,0 @@
-module ApplicationCable
-  class Channel < ActionCable::Channel::Base
-  end
-end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,4 +1,0 @@
-module ApplicationCable
-  class Connection < ActionCable::Connection::Base
-  end
-end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ require "action_mailer/railtie"
 # require "action_mailbox/engine"
 # require "action_text/engine"
 require "action_view/railtie"
-require "action_cable/engine"
+# require "action_cable/engine"
 require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems


### PR DESCRIPTION
## What

This project doesn't use Action Cable, so I've removed the boilerplate code. We can always add it again later if we find a need for Action Cable.

## Why

It's unused and untested code.

When I generate a code coverage report locally, these files are flagged as untested. For some reason, code coverage reports generated in CI consider these files to be covered, although I'm not sure why because there are no tests which exercise it. 🤷🏻
