### PR TITLE
As a Support User, I want to remove a Mentor from a School

### DIFF
--- a/app/controllers/claims/support/schools/mentors_controller.rb
+++ b/app/controllers/claims/support/schools/mentors_controller.rb
@@ -1,7 +1,26 @@
 class Claims::Support::Schools::MentorsController < Claims::Support::ApplicationController
   include Claims::BelongsToSchool
+  before_action :set_mentor, only: %i[show remove destroy]
 
   def index
     @pagy, @mentors = pagy(@school.mentors.order(:first_name, :last_name))
+  end
+
+  def show; end
+
+  def remove; end
+
+  def destroy
+    mentor_membership = @mentor.mentor_memberships.find_by(school: @school)
+    mentor_membership.destroy!
+
+    redirect_to claims_support_school_mentors_path(@school)
+    flash[:success] = t(".mentor_removed")
+  end
+
+  private
+
+  def set_mentor
+    @mentor = @school.mentors.find(params.require(:id))
   end
 end

--- a/app/views/claims/support/schools/mentors/index.html.erb
+++ b/app/views/claims/support/schools/mentors/index.html.erb
@@ -1,4 +1,5 @@
-<% content_for :page_title, t(".heading") %>
+<% content_for :page_title, "#{@school.name} - #{t(".heading")}" %>
+
 <% render "claims/support/primary_navigation", current: :organisations %>
 
 <div class="govuk-width-container">
@@ -22,7 +23,7 @@
           <% table.with_body do |body| %>
             <% @mentors.each do |mentor| %>
               <% body.with_row do |row| %>
-                <% row.with_cell(text: govuk_link_to(mentor.full_name, "#")) %>
+                <% row.with_cell(text: govuk_link_to(mentor.full_name, claims_support_school_mentor_path(id: mentor.id))) %>
                 <% row.with_cell(text: mentor.trn) %>
               <% end %>
             <% end %>

--- a/app/views/claims/support/schools/mentors/remove.html.erb
+++ b/app/views/claims/support/schools/mentors/remove.html.erb
@@ -1,0 +1,19 @@
+<% content_for :page_title, "#{t(".header_info")} - #{@mentor.full_name} - #{@school.name}" %>
+
+<% render "claims/support/primary_navigation", current: :organisations %>
+<% content_for(:before_content) do %>
+  <%= govuk_back_link(href: claims_support_school_mentor_path(id: @mentor.id)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= @mentor.full_name %> - <%= @school.name %></span>
+      <h1 class="govuk-heading-l"><%= t(".confirm_removal") %></h1>
+    </div>
+  </div>
+
+  <%= govuk_button_to(t(".remove_mentor"), claims_support_school_mentor_path(@school, @mentor), warning: true, method: :delete, class: "govuk-button govuk-button--warning") %>
+
+  <%= govuk_link_to t(".cancel"), claims_support_school_mentors_path(@school) %>
+</div>

--- a/app/views/claims/support/schools/mentors/show.html.erb
+++ b/app/views/claims/support/schools/mentors/show.html.erb
@@ -1,0 +1,32 @@
+<% content_for :page_title, "#{@mentor.full_name} - #{t(".heading")} - #{@school.name}" %>
+
+<% render "claims/support/primary_navigation", current: :organisations %>
+<% content_for(:before_content) do %>
+  <%= govuk_back_link(href: claims_support_school_mentors_path(@school)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".heading") %> <%= @school.name %></span>
+      <h2 class="govuk-heading-l"><%= @mentor.full_name %></h2>
+
+        <%= govuk_summary_list do |summary_list| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: Mentor.human_attribute_name(:first_name)) %>
+            <% row.with_value(text: @mentor.first_name) %>
+          <% end %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: Mentor.human_attribute_name(:last_name)) %>
+            <% row.with_value(text: @mentor.last_name) %>
+          <% end %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".attributes.mentors.trn")) %>
+            <% row.with_value(text: @mentor.trn) %>
+          <% end %>
+        <% end %>
+    </div>
+  </div>
+
+  <%= govuk_link_to t(".remove_mentor"), remove_claims_support_school_mentor_path, class: "app-link app-link--destructive" %>
+</div>

--- a/config/locales/en/claims/support/schools/mentors.yml
+++ b/config/locales/en/claims/support/schools/mentors.yml
@@ -6,3 +6,17 @@ en:
           index:
             heading: Mentors
             trn: Teacher reference number (TRN)
+          show:
+            heading: Mentors
+            remove_mentor: Remove mentor
+            attributes:
+              mentors:
+                trn: Teacher reference number (TRN)
+          remove:
+            confirm_removal: Are you sure you want to remove this mentor?
+            cancel: Cancel
+            remove_mentor: Remove mentor
+            header_info: Are you sure you want to remove this mentor?
+          destroy:
+            mentor_removed: Mentor removed
+

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -38,7 +38,9 @@ scope module: :claims, as: :claims, constraints: { host: ENV["CLAIMS_HOST"] } do
 
       scope module: :schools do
         resources :claims
-        resources :mentors, only: %i[index]
+        resources :mentors, only: %i[index show destroy] do
+          get :remove, on: :member
+        end
         resources :providers, only: %i[index]
         resources :users, only: %i[index new create show] do
           get :check, on: :collection

--- a/spec/system/claims/support/schools/mentors/remove_mentor_spec.rb
+++ b/spec/system/claims/support/schools/mentors/remove_mentor_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe "Remove a mentor from a school", type: :system, service: :claims do
+  let!(:mentor1) { create(:mentor, first_name: "Bilbo", last_name: "Baggins") }
+  let!(:mentor2) { create(:mentor, first_name: "Bilbo", last_name: "Test") }
+  let!(:school) { create(:claims_school, mentors: [mentor1, mentor2]) }
+  let!(:colin) { create(:claims_support_user, :colin) }
+
+  scenario "View a school's mentors as a support user" do
+    user_exists_in_dfe_sign_in(user: colin)
+    given_i_sign_in
+    when_i_visit_the_support_school_mentors_page(school)
+    when_i_see_a_list_of_the_schools_mentors
+    when_i_select_a_mentor_to_remove
+    when_i_click_on_remove_mentor
+    when_i_confirm_removal
+    then_i_expect_to_see_the_mentor_has_been_removed
+  end
+
+  private
+
+  def given_i_sign_in
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def then_i_expect_to_see_the_mentor_has_been_removed
+    expect(page).not_to have_content("Bilbo Baggins\n1")
+  end
+
+  def when_i_confirm_removal
+    expect(page).to have_content("Are you sure you want to remove this mentor?")
+    click_on "Remove mentor"
+    expect(page).to have_content("Mentor removed")
+  end
+
+  def when_i_click_on_remove_mentor
+    click_on "Remove mentor"
+  end
+
+  def when_i_select_a_mentor_to_remove
+    click_on "Bilbo Baggins"
+  end
+
+  def when_i_visit_the_support_school_mentors_page(school)
+    visit claims_support_school_mentors_path(school)
+  end
+
+  def when_i_see_a_list_of_the_schools_mentors
+    expect(page).to have_content("Name")
+    expect(page).to have_content("Teacher reference number (TRN)")
+
+    within("tbody tr:nth-child(1)") do
+      expect(page).to have_content(mentor1.full_name)
+      expect(page).to have_content(mentor1.trn)
+    end
+
+    within("tbody tr:nth-child(2)") do
+      expect(page).to have_content(mentor2.full_name)
+      expect(page).to have_content(mentor2.trn)
+    end
+  end
+end


### PR DESCRIPTION
## Context

To allow a support user to remove a mentor

## Changes proposed in this pull request

To add the remove mentor flow for a support user

## Guidance to review

- Sign in as support user
- navigate to a schools mentor page
- Select a mentor
- Follow the remove mentor flow

## Link to Trello card

https://trello.com/c/x5M4tRwJ/159-as-a-support-user-i-want-to-remove-a-mentor-from-a-school

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
