### PR TITLE
Update text for organisation details link

### DIFF
--- a/config/locales/en/claims/schools/primary_navigation.yml
+++ b/config/locales/en/claims/schools/primary_navigation.yml
@@ -5,5 +5,5 @@ en:
         users: Users
         claims: Claims
         mentors: Mentors
-        details: Details
+        details: Organisation details
         change_organisation: Change organisation

--- a/spec/system/claims/authenticate_user_spec.rb
+++ b/spec/system/claims/authenticate_user_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Authentication", type: :system, service: :claims do
   end
 
   def and_i_click_on_school_details
-    click_on "Details"
+    click_on "Organisation details"
   end
 
   def given_there_is_an_existing_claims_user_with_a_school_for(user)

--- a/spec/system/claims/schools/view_school_spec.rb
+++ b/spec/system/claims/schools/view_school_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "School Page", type: :system do
   end
 
   def when_i_click_on_school_details
-    click_on "Details"
+    click_on "Organisation details"
   end
 
   def given_the_claims_persona(persona_name)


### PR DESCRIPTION
## Context

The prototype has since been updated to show "Organisation details" instead of "Details".

## Changes proposed in this pull request

- Update User's school primary navigation item text to "Organisation details".

## Guidance to review

- Visit `/schools/:school_id/*` and see "Organisation details" in the primary navigation.

## Screenshots

|        | Screenshot |
| ------ | ---------- |
| Before | ![CleanShot 2024-02-22 at 12 52 06](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/c414e13d-d82a-430d-b3e5-c2fb4cc3c664) |
| After  | ![CleanShot 2024-02-22 at 12 52 58](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/0c1e4dcf-b40f-43ba-be5a-9c1fdf3ef9e4) |