### PR TITLE
lb/placements-non-support-user-add-a-mentor

### DIFF
--- a/app/views/placements/schools/mentors/check.html.erb
+++ b/app/views/placements/schools/mentors/check.html.erb
@@ -1,0 +1,47 @@
+<% content_for :page_title, t(".page_title") %>
+<%= render "placements/schools/primary_navigation", current_navigation: :mentors, school: @school %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: new_placements_school_mentor_path(@school, params: @mentor_form.as_form_params)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= form_with(model: @mentor_form, url: placements_school_mentors_path, method: :post) do |f| %>
+        <%= f.hidden_field :first_name, value: @mentor_form.mentor.first_name %>
+        <%= f.hidden_field :last_name, value: @mentor_form.mentor.last_name %>
+        <%= f.hidden_field :trn, value: @mentor_form.trn %>
+
+        <label class="govuk-label govuk-label--l">
+          <span class="govuk-caption-l"><%= t(".add_mentor") %></span>
+          <%= t(".check_your_answers") %>
+        </label>
+
+        <%= govuk_summary_list do |summary_list| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: Mentor.human_attribute_name("first_name")) %>
+            <% row.with_value(text: @mentor_form.mentor.first_name) %>
+          <% end %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: Mentor.human_attribute_name("last_name")) %>
+            <% row.with_value(text: @mentor_form.mentor.last_name) %>
+          <% end %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".trn")) %>
+            <% row.with_value(text: @mentor_form.trn) %>
+            <% row.with_action(text: t(".change"),
+                               href: new_placements_school_mentor_path(params: @mentor_form.as_form_params),
+                               html_attributes: {
+                                 class: "govuk-link--no-visited-state",
+                               }) %>
+          <% end %>
+        <% end %>
+        <%= f.govuk_submit t(".add_mentor") %>
+        <p class="govuk-body">
+          <%= govuk_link_to(t(".cancel"), placements_school_mentors_path(@school)) %>
+        </p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/placements/schools/mentors/index.html.erb
+++ b/app/views/placements/schools/mentors/index.html.erb
@@ -5,7 +5,9 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l"><%= t(".heading") %></h2>
+      <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+
+      <%= govuk_button_to(t(".add_mentor"), new_placements_school_mentor_path, method: :get) %>
 
       <% if @mentors.any? %>
         <%= govuk_table do |table| %>

--- a/app/views/placements/schools/mentors/new.html.erb
+++ b/app/views/placements/schools/mentors/new.html.erb
@@ -1,0 +1,41 @@
+<% content_for :page_title, @mentor_form.errors.any? ? t(".page_title_with_error") : t(".page_title") %>
+<%= render "placements/schools/primary_navigation", current_navigation: :mentors, school: @school %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: placements_school_mentors_path(@school)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= form_with(model: @mentor_form, url: check_placements_school_mentors_path, method: "get") do |f| %>
+    <%= f.govuk_error_summary %>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-form-group">
+          <%= f.govuk_text_field :trn, label: -> do %>
+            <span class="govuk-caption-l"><%= t(".add_mentor") %></span>
+            <h2 class="govuk-heading-l"><%= t(".enter_a_trn") %></h2>
+          <% end %>
+        </div>
+
+        <%= govuk_details(summary_text: t(".help_with_the_trn")) do %>
+          <p>
+            <%= t(".if_you_dont_have_a_trn") %>
+            <%= govuk_link_to(
+                  t(".trn_guidance"),
+                  "https://www.gov.uk/guidance/teacher-reference-number-trn",
+                  new_tab: true,
+                  no_visited_state: true,
+                ) %>
+            <%= t(".to_find_a_list_trn") %>
+          </p>
+        <% end %>
+
+        <%= f.govuk_submit t(".continue") %>
+        <p class="govuk-body">
+          <%= govuk_link_to(t(".cancel"), placements_school_mentors_path(@school)) %>
+        </p>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/placements/schools/mentors/no_results.html.erb
+++ b/app/views/placements/schools/mentors/no_results.html.erb
@@ -1,0 +1,19 @@
+<% content_for :page_title, t(".page_title", trn: @mentor_form.trn) %>
+<%= render "placements/schools/primary_navigation", current_navigation: :mentors, school: @school %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: new_placements_school_mentor_path(@school, params: @mentor_form.as_form_params)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <h1 class="govuk-heading-l">
+    <span class="govuk-caption-l"><%= t(".add_mentor") %></span>
+    <%= t(".no_results_found", trn: @mentor_form.trn) %>
+  </h1>
+  <p class="govuk-body">
+    <%= t(".help_text") %>
+  </p>
+  <p class="govuk-body">
+    <%= govuk_link_to(t(".change_your_search"), new_placements_school_mentor_path(@school, params: @mentor_form.as_form_params)) %>
+  </p>
+</div>

--- a/config/locales/en/placements/schools/mentors.yml
+++ b/config/locales/en/placements/schools/mentors.yml
@@ -5,6 +5,8 @@ en:
         index:
           heading: Mentors
           trn: Teacher reference number (TRN)
+          add_mentor: Add mentor
+          page_title: Mentors
         show:
           remove_mentor: Remove mentor
           attributes:
@@ -16,5 +18,34 @@ en:
           remove_mentor: Remove mentor
           cancel: Cancel
         destroy:
-            mentor_removed: Mentor removed
-      
+          mentor_removed: Mentor removed
+          caption: "Mentors - %{school_name}"
+          attributes:
+            mentors:
+              trn: Teacher reference number (TRN)
+        new:
+          page_title: Enter a teacher reference number (TRN) - Add mentor
+          page_title_with_error: "Error: Enter a teacher reference number (TRN) - Add mentor"
+          add_mentor: Add mentor
+          cancel: Cancel
+          continue: Continue
+          enter_a_trn: Enter a teacher reference number (TRN)
+          if_you_dont_have_a_trn: If you don’t have a TRN, read the
+          trn_guidance: Teacher reference number (TRN) guidance
+          to_find_a_list_trn: to find a lost TRN, or apply for one.
+          help_with_the_trn: Help with the teacher reference number (TRN)
+        check:
+          page_title: Check your answers - Add mentor
+          add_mentor: Add mentor
+          cancel: Cancel
+          change: Change
+          check_your_answers: Check your answers
+          trn: Teacher reference number (TRN)
+        no_results:
+          page_title: No results found for ‘%{trn}’ - Add mentor
+          add_mentor: Add mentor
+          change_your_search: Change your search
+          help_text: Check that you typed in the teacher reference number (TRN) correctly.
+          no_results_found: No results found for ‘%{trn}’
+        create:
+          mentor_added: Mentor added

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -67,6 +67,7 @@ scope module: :placements,
 
       resources :mentors, only: %i[index new create show destroy] do
         member { get :remove }
+        collection { get :check }
       end
     end
   end

--- a/spec/system/placements/schools/mentors/user_adds_mentor_spec.rb
+++ b/spec/system/placements/schools/mentors/user_adds_mentor_spec.rb
@@ -1,0 +1,224 @@
+require "rails_helper"
+
+RSpec.describe "Placements school user adds mentors to schools", type: :system, service: :placements do
+  let!(:school) { create(:placements_school, name: "School") }
+  let(:another_school) { create(:placements_school, name: "Another School") }
+  let(:claims_mentor) { create(:claims_mentor) }
+  let(:placements_mentor) { create(:placements_mentor) }
+  let(:new_mentor) { build(:placements_mentor) }
+
+  before { given_i_sign_in_as_anne }
+
+  scenario "I can navigate back to the index page" do
+    given_i_navigate_to_schools_mentors_list
+    and_i_click_on("Add mentor")
+    when_i_click_on("Back")
+    then_i_see_the_index_page(school)
+    when_i_click_on("Add mentor")
+    and_i_click_on("Cancel")
+    then_i_see_the_index_page(school)
+  end
+
+  scenario "I can view help with the trn" do
+    given_i_navigate_to_schools_mentors_list
+    and_i_click_on "Add mentor"
+    when_i_click_on_help_text
+    then_i_see_link_to_trn_guidance
+  end
+
+  scenario "I do not enter a trn" do
+    given_i_navigate_to_schools_mentors_list
+    and_i_click_on("Add mentor")
+    when_i_click_on("Continue")
+    then_i_see_the_error("Enter a teacher reference number (TRN)")
+  end
+
+  scenario "I enter an invalid trn" do
+    given_i_navigate_to_schools_mentors_list
+    and_i_click_on("Add mentor")
+    when_i_enter_trn("12a")
+    and_i_click_on("Continue")
+    then_i_see_the_error("Enter a valid teacher reference number (TRN)")
+  end
+
+  scenario "I enter a trn of mentor who already exists for this school" do
+    given_a_placements_mentor_exists(school, placements_mentor)
+    given_i_navigate_to_schools_mentors_list
+    and_i_click_on("Add mentor")
+    when_i_enter_trn(placements_mentor.trn)
+    and_i_click_on("Continue")
+    then_i_see_the_error("The mentor has already been added")
+  end
+
+  scenario "I enter the trn of an existing claims mentor" do
+    given_a_claims_mentor_exists
+    given_i_navigate_to_schools_mentors_list
+    and_i_click_on("Add mentor")
+    when_i_enter_trn(claims_mentor.trn)
+    and_i_click_on("Continue")
+    then_i_see_check_page_for(claims_mentor)
+    when_i_click_on("Back")
+    then_i_see_form_with_trn(claims_mentor.trn)
+    when_i_click_on("Continue")
+    then_i_see_check_page_for(claims_mentor)
+    when_i_click_on("Change")
+    then_i_see_form_with_trn(claims_mentor.trn)
+    when_i_click_on("Continue")
+    then_i_see_check_page_for(claims_mentor)
+    when_i_click_on("Add mentor")
+    then_mentor_is_added(claims_mentor.full_name)
+  end
+
+  scenario "I enter the trn of an existing placements mentor from another school" do
+    given_a_placements_mentor_exists(another_school, placements_mentor)
+    given_i_navigate_to_schools_mentors_list
+    and_i_click_on("Add mentor")
+    when_i_enter_trn(placements_mentor.trn)
+    and_i_click_on("Continue")
+    then_i_see_check_page_for(placements_mentor)
+    when_i_click_on("Back")
+    then_i_see_form_with_trn(placements_mentor.trn)
+    when_i_click_on("Continue")
+    then_i_see_check_page_for(placements_mentor)
+    when_i_click_on("Add mentor")
+    then_mentor_is_added(placements_mentor.full_name)
+  end
+
+  describe "when trn is valid-looking, but does not exists in Teaching Record Service" do
+    before do
+      allow(TeachingRecord::GetTeacher).to receive(:call)
+                                             .with(trn: new_mentor.trn)
+                                             .and_raise TeachingRecord::RestClient::TeacherNotFoundError
+    end
+
+    scenario "I enter a a valid-looking trn that does not exist in the Teaching Record service" do
+      given_i_navigate_to_schools_mentors_list
+      and_i_click_on("Add mentor")
+      when_i_enter_trn(new_mentor.trn)
+      and_i_click_on("Continue")
+      then_i_see_no_results_page(school.name, new_mentor.trn)
+      when_i_click_on "Change your search"
+      then_i_see_form_with_trn(new_mentor.trn)
+    end
+  end
+
+  describe "when trn is valid-looking and mentor is found on Teaching Record Service" do
+    before do
+      allow(TeachingRecord::GetTeacher).to receive(:call)
+                                             .with(trn: new_mentor.trn)
+                                             .and_return teaching_record_valid_response(new_mentor)
+    end
+
+    scenario "I enter a valid-looking trn that does exist on the Teaching Record Service" do
+      given_i_navigate_to_schools_mentors_list
+      and_i_click_on("Add mentor")
+      when_i_enter_trn(new_mentor.trn)
+      and_i_click_on("Continue")
+      then_i_see_check_page_for(new_mentor)
+      when_i_click_on("Add mentor")
+      then_mentor_is_added(new_mentor.full_name)
+    end
+  end
+
+  def given_i_sign_in_as_anne
+    user = create(:placements_user, :anne)
+    create(:user_membership, user:, organisation: school)
+    user_exists_in_dfe_sign_in(user:)
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def given_a_claims_mentor_exists
+    create(:claims_mentor_membership, school: another_school, mentor: claims_mentor)
+  end
+
+  def given_a_placements_mentor_exists(school, mentor)
+    create(:placements_mentor_membership, school:, mentor:)
+  end
+
+  def given_i_navigate_to_schools_mentors_list
+    within(".app-primary-navigation__nav") do
+      click_on "Mentors"
+    end
+  end
+
+  def when_i_click_on(text)
+    click_on text
+  end
+
+  def when_i_click_on_help_text
+    find("span", text: "Help with the teacher reference number (TRN)").click
+  end
+
+  def then_i_see_check_page_for(mentor)
+    expect_organisations_to_be_selected_in_primary_navigation
+    expect(page).to have_content "Add mentor"
+    expect(page).to have_content "Check your answers"
+    name_row = page.all(".govuk-summary-list__row")[0]
+    within(name_row) do
+      expect(page).to have_content "First name"
+      expect(page).to have_content mentor.first_name
+    end
+  end
+
+  def expect_organisations_to_be_selected_in_primary_navigation
+    within(".app-primary-navigation__nav") do
+      expect(page).to have_link "Placements", current: "false"
+      expect(page).to have_link "Mentors", current: "page"
+      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Organisation details", current: "false"
+    end
+  end
+
+  def then_mentor_is_added(mentor_name)
+    within(".govuk-notification-banner--success") do
+      expect(page).to have_content "Mentor added"
+    end
+    expect(page).to have_content mentor_name
+  end
+
+  def when_i_enter_trn(trn)
+    fill_in "mentor-form-trn-field", with: trn
+  end
+
+  def then_i_see_the_index_page(school)
+    expect(page).to have_current_path placements_school_mentors_path(school), ignore_query: true
+  end
+
+  def then_i_see_the_error(message)
+    expect(page).to have_title "Error: Enter a teacher reference number (TRN)"
+    within(".govuk-error-summary") do
+      expect(page).to have_content message
+    end
+
+    within(".govuk-form-group--error") do
+      expect(page).to have_content message
+    end
+  end
+
+  def then_i_see_form_with_trn(trn)
+    expect(page.find("#mentor-form-trn-field").value).to eq(trn)
+  end
+
+  def then_i_see_no_results_page(_school_name, trn)
+    expect(page).to have_title "No results found for ‘#{trn}’"
+    expect(page).to have_content "Add mentor"
+    expect(page).to have_content "No results found for ‘#{trn}’"
+  end
+
+  def teaching_record_valid_response(mentor)
+    {
+      "trn" => mentor.trn.to_s,
+      "firstName" => mentor.first_name.to_s,
+      "middleName" => "",
+      "lastName" => mentor.last_name.to_s,
+    }
+  end
+
+  def then_i_see_link_to_trn_guidance
+    expect(page).to have_content "If you don’t have a TRN, read the Teacher reference number (TRN) guidance (opens in new tab) to find a lost TRN, or apply for one."
+    expect(page).to have_link("Teacher reference number (TRN) guidance (opens in new tab)", href: "https://www.gov.uk/guidance/teacher-reference-number-trn")
+  end
+
+  alias_method :and_i_click_on, :when_i_click_on
+end


### PR DESCRIPTION
## Context

School users (non-support) also need to be able to add mentors to the service.

## Changes proposed in this pull request

Views / controllers / routes and specs for adding a mentor. The form and mentor builder object are re-used from the support user implementation. 

## Guidance to review

Login as someone with a school
Navigate to the school
Add mentors

## Link to Trello card

https://trello.com/c/7Jobwhp3

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/856b4276-2576-47a4-b975-e603b0d35059


