### PR TITLE
Jc/placements remove mentors from schools

### DIFF
--- a/app/controllers/placements/schools/mentors_controller.rb
+++ b/app/controllers/placements/schools/mentors_controller.rb
@@ -1,12 +1,22 @@
 class Placements::Schools::MentorsController < ApplicationController
   before_action :set_school
-  before_action :set_mentor, only: [:show]
+  before_action :set_mentor, only: %i[show remove destroy]
 
   def index
     @pagy, @mentors = pagy(@school.mentors.order(:first_name, :last_name))
   end
 
   def show; end
+
+  def remove; end
+
+  def destroy
+    mentor_membership = @mentor.mentor_memberships.find_by(school: @school)
+    mentor_membership.destroy!
+
+    redirect_to placements_school_mentors_path(@school)
+    flash[:success] = t(".mentor_removed")
+  end
 
   private
 

--- a/app/controllers/placements/support/schools/mentors_controller.rb
+++ b/app/controllers/placements/support/schools/mentors_controller.rb
@@ -1,6 +1,6 @@
 class Placements::Support::Schools::MentorsController < Placements::Support::ApplicationController
   before_action :set_school
-  before_action :set_mentor, only: [:show]
+  before_action :set_mentor, only: %i[show remove destroy]
 
   def index
     @pagy, @mentors = pagy(@school.mentors.order(:first_name, :last_name))
@@ -22,6 +22,16 @@ class Placements::Support::Schools::MentorsController < Placements::Support::App
     mentor_form.save!
 
     redirect_to placements_support_school_mentors_path(@school), flash: { success: t(".mentor_added") }
+  end
+
+  def remove; end
+
+  def destroy
+    mentor_membership = @mentor.mentor_memberships.find_by(school: @school)
+    mentor_membership.destroy!
+
+    redirect_to placements_support_school_mentors_path(@school)
+    flash[:success] = t(".mentor_removed")
   end
 
   private

--- a/app/views/placements/providers/users/remove.html.erb
+++ b/app/views/placements/providers/users/remove.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, sanitize(t(".page_title", user_name: @user.full_name, organisation_name: @organisation.name)) %>
+<%= content_for :page_title, sanitize(t(".page_title", user_name: @user.full_name)) %>
 <%= render "placements/providers/primary_navigation", provider: @organisation, current_navigation: :users %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: placements_provider_user_path(@organisation, @user)) %>

--- a/app/views/placements/schools/mentors/remove.html.erb
+++ b/app/views/placements/schools/mentors/remove.html.erb
@@ -1,0 +1,25 @@
+<%= content_for :page_title, sanitize(t(".page_title", user_name: @mentor.full_name)) %>
+<%= render "placements/schools/primary_navigation", school: @school, current_navigation: :mentors %>
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: placements_school_mentor_path(@school, @mentor)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <label class="govuk-label govuk-label--l">
+        <span class="govuk-caption-l"><%= @mentor.full_name %></span>
+        <%= t(".are_you_sure") %>
+      </label>
+
+      <%= govuk_button_to t(".remove_mentor"),
+        placements_school_mentor_path(@school, @mentor),
+        warning: true,
+        method: :delete %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to(t(".cancel"), placements_school_mentor_path(@school, @mentor)) %>
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/placements/schools/mentors/show.html.erb
+++ b/app/views/placements/schools/mentors/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, sanitize("#{@mentor.full_name} - #{@school.name}") %>
+<%= content_for :page_title, sanitize(@mentor.full_name) %>
 
 <%= render "placements/schools/primary_navigation", school: @school, current_navigation: :mentors %>
 
@@ -9,7 +9,6 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-l"><%= @school.name %></span>
       <h2 class="govuk-heading-l"><%= @mentor.full_name %></h2>
 
       <%= govuk_summary_list do |summary_list| %>
@@ -26,6 +25,10 @@
           <% row.with_value(text: @mentor.trn) %>
         <% end %>
       <% end %>
+
+      <%= govuk_link_to t(".remove_mentor"),
+        remove_placements_school_mentor_path(@school, @mentor),
+        class: "app-link app-link--destructive" %>
     </div>
   </div>
 </div>

--- a/app/views/placements/schools/users/remove.html.erb
+++ b/app/views/placements/schools/users/remove.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, sanitize(t(".page_title", user_name: @user.full_name, organisation_name: @organisation.name)) %>
+<%= content_for :page_title, sanitize(t(".page_title", user_name: @user.full_name)) %>
 <%= render "placements/schools/primary_navigation", school: @organisation, current_navigation: :users %>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: placements_school_user_path(@organisation, @user)) %>

--- a/app/views/placements/schools/users/show.html.erb
+++ b/app/views/placements/schools/users/show.html.erb
@@ -10,9 +10,9 @@
     <div class="govuk-grid-column-two-thirds">
       <%= render "placements/organisations/users/details", user: @user %>
       <% if policy(@user).destroy? %>
-        <%= link_to(t(".remove_user"),
-                    remove_placements_school_user_path(@organisation, @user),
-                    class: "govuk-link govuk-link--no-visited-state app-link--destructive") %>
+        <%= govuk_link_to t(".remove_user"),
+          remove_placements_school_user_path(@organisation, @user),
+          class: "app-link app-link--destructive" %>
       <% end %>
     </div>
   </div>

--- a/app/views/placements/support/schools/mentors/remove.html.erb
+++ b/app/views/placements/support/schools/mentors/remove.html.erb
@@ -1,0 +1,25 @@
+<%= content_for :page_title, sanitize(t(".page_title", user_name: @mentor.full_name, school_name: @school.name)) %>
+<%= render "placements/support/primary_navigation", current_navigation: :organisations %>
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: placements_support_school_mentor_path(school_id: @school.id, id: @mentor.id)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <label class="govuk-label govuk-label--l">
+        <span class="govuk-caption-l"><%= "#{@mentor.full_name} - #{@school.name}" %></span>
+        <%= t(".are_you_sure") %>
+      </label>
+
+      <%= govuk_button_to t(".remove_mentor"),
+        placements_support_school_mentor_path(@school, @mentor),
+        warning: true,
+        method: :delete %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to(t(".cancel"), placements_support_school_mentor_path(@school, @mentor)) %>
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/placements/support/schools/mentors/show.html.erb
+++ b/app/views/placements/support/schools/mentors/show.html.erb
@@ -28,4 +28,6 @@
       <% end %>
     </div>
   </div>
+
+  <%= govuk_link_to t(".remove_mentor"), remove_placements_support_school_mentor_path(@school, @mentor), class: "app-link app-link--destructive" %>
 </div>

--- a/config/locales/en/placements/providers/users.yml
+++ b/config/locales/en/placements/providers/users.yml
@@ -24,7 +24,7 @@ en:
         destroy:
           user_removed: User removed
         remove:
-          page_title: Are you sure you want to remove this user? - %{user_name} - %{organisation_name}
+          page_title: Are you sure you want to remove this user? - %{user_name}
           are_you_sure: Are you sure you want to remove this user?
           remove_user: Remove user
           cancel: Cancel

--- a/config/locales/en/placements/schools/mentors.yml
+++ b/config/locales/en/placements/schools/mentors.yml
@@ -6,6 +6,15 @@ en:
           heading: Mentors
           trn: Teacher reference number (TRN)
         show:
+          remove_mentor: Remove mentor
           attributes:
             mentors:
               trn: Teacher reference number (TRN)
+        remove:
+          page_title: Are you sure you want to remove this mentor? - %{user_name}
+          are_you_sure: Are you sure you want to remove this mentor?
+          remove_mentor: Remove mentor
+          cancel: Cancel
+        destroy:
+            mentor_removed: Mentor removed
+      

--- a/config/locales/en/placements/schools/users.yml
+++ b/config/locales/en/placements/schools/users.yml
@@ -24,7 +24,7 @@ en:
         destroy:
           user_removed: User removed
         remove:
-          page_title: Are you sure you want to remove this user? - %{user_name} - %{organisation_name}
+          page_title: Are you sure you want to remove this user? - %{user_name}
           are_you_sure: Are you sure you want to remove this user?
           remove_user: Remove user
           cancel: Cancel

--- a/config/locales/en/placements/support/schools/mentors.yml
+++ b/config/locales/en/placements/support/schools/mentors.yml
@@ -10,6 +10,7 @@ en:
             page_title: Mentors
           show:
             caption: "Mentors - %{school_name}"
+            remove_mentor: Remove mentor
             attributes:
               mentors:
                 trn: Teacher reference number (TRN)
@@ -40,3 +41,10 @@ en:
             no_results_found: No results found for ‘%{trn}’
           create:
             mentor_added: Mentor added
+          remove:
+            page_title: Are you sure you want to remove this mentor? - %{user_name} - %{school_name}
+            are_you_sure: Are you sure you want to remove this mentor?
+            cancel: Cancel
+            remove_mentor: Remove mentor
+          destroy:
+            mentor_removed: Mentor removed

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -34,7 +34,8 @@ scope module: :placements,
           collection { get :check }
         end
 
-        resources :mentors, only: %i[index new create show] do
+        resources :mentors, only: %i[index new create show destroy] do
+          member { get :remove }
           collection { get :check }
         end
       end
@@ -64,7 +65,9 @@ scope module: :placements,
         collection { get :check }
       end
 
-      resources :mentors
+      resources :mentors, only: %i[index new create show destroy] do
+        member { get :remove }
+      end
     end
   end
 

--- a/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
+++ b/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
     end
 
     expect(page).to have_title(
-      "Are you sure you want to remove this user? - #{user.full_name} - #{organisation.name} - Manage school placements",
+      "Are you sure you want to remove this user? - #{user.full_name} - Manage school placements",
     )
     expect(page).to have_content user.full_name.to_s
     expect(page).to have_content "Are you sure you want to remove this user?"

--- a/spec/system/placements/schools/mentors/remove_a_mentor_spec.rb
+++ b/spec/system/placements/schools/mentors/remove_a_mentor_spec.rb
@@ -1,0 +1,112 @@
+require "rails_helper"
+
+RSpec.describe "Placements / Schools / Mentors / Remove a mentor", type: :system, service: :placements do
+  let(:school) { create(:placements_school, name: "School 1") }
+  let(:mentor_1) do
+    create(:placements_mentor,
+           first_name: "John",
+           last_name: "Doe")
+  end
+  let(:mentor_2) do
+    create(:placements_mentor,
+           first_name: "Agatha",
+           last_name: "Christie")
+  end
+
+  before do
+    given_the_school_has_mentors(school:, mentors: [mentor_1, mentor_2])
+    given_i_sign_in_as_anne
+  end
+
+  scenario "Support User removes a mentor from a school" do
+    when_i_visit_the_show_page_for(school, mentor_1)
+    and_i_click_on("Remove mentor")
+    then_i_am_asked_to_confirm(school, mentor_1)
+    when_i_click_on("Cancel")
+    then_i_return_to_mentor_page(school, mentor_1)
+    when_i_click_on("Remove mentor")
+    then_i_am_asked_to_confirm(school, mentor_1)
+    when_i_click_on("Remove mentor")
+    then_the_mentor_is_removed_from_the_school(school, mentor_1)
+    and_a_school_mentor_remains_called("Agatha Christie")
+  end
+
+  private
+
+  def and_there_is_an_existing_user_for(user_name)
+    user = create(:placements_user, user_name.downcase.to_sym)
+    user_exists_in_dfe_sign_in(user:)
+    and_user_has_one_school(user:)
+  end
+
+  def and_i_visit_the_sign_in_path
+    visit sign_in_path
+  end
+
+  def and_i_click_sign_in
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def given_i_sign_in_as_anne
+    and_there_is_an_existing_user_for("Anne")
+    and_i_visit_the_sign_in_path
+    and_i_click_sign_in
+  end
+
+  def and_user_has_one_school(user:)
+    create(:user_membership, user:, organisation: school)
+  end
+
+  def given_the_school_has_mentors(school:, mentors:)
+    mentors.each do |mentor|
+      create(:placements_mentor_membership, school:, mentor:)
+    end
+  end
+
+  def when_i_visit_the_show_page_for(school, mentor)
+    visit placements_school_mentor_path(school, mentor)
+  end
+
+  def when_i_click_on(text)
+    click_on text
+  end
+  alias_method :and_i_click_on, :when_i_click_on
+
+  def then_i_am_asked_to_confirm(_school, mentor)
+    mentors_is_selected_in_primary_nav
+    expect(page).to have_title(
+      "Are you sure you want to remove this mentor? - #{mentor.full_name} - Manage school placements",
+    )
+    expect(page).to have_content mentor.full_name
+    expect(page).to have_content "Are you sure you want to remove this mentor?"
+  end
+
+  def mentors_is_selected_in_primary_nav
+    within(".app-primary-navigation__nav") do
+      expect(page).to have_link "Placements", current: "false"
+      expect(page).to have_link "Mentors", current: "page"
+      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Organisation details", current: "false"
+    end
+  end
+
+  def then_i_return_to_mentor_page(school, mentor)
+    mentors_is_selected_in_primary_nav
+    expect(page).to have_current_path placements_school_mentor_path(school, mentor),
+                                      ignore_query: true
+  end
+
+  def then_the_mentor_is_removed_from_the_school(school, mentor)
+    mentors_is_selected_in_primary_nav
+    expect(mentor.mentor_memberships.find_by(school:)).to eq nil
+    within(".govuk-notification-banner__content") do
+      expect(page).to have_content "Mentor removed"
+    end
+
+    expect(page).not_to have_content mentor.full_name
+  end
+
+  def and_a_school_mentor_remains_called(mentor_name)
+    expect(page).to have_content(mentor_name)
+  end
+end

--- a/spec/system/placements/schools/mentors/view_a_mentor_spec.rb
+++ b/spec/system/placements/schools/mentors/view_a_mentor_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe "Placements / Schools / Mentors / View a mentor", type: :system, 
     given_a_mentor_exists_in(school:)
     when_i_visit_the_show_page_for(school, mentor)
     then_i_see_the_mentor_details(
-      school_name: "School 1",
       first_name: "John",
       last_name: "Doe",
       trn: "1234567",
@@ -58,8 +57,7 @@ RSpec.describe "Placements / Schools / Mentors / View a mentor", type: :system, 
     )
   end
 
-  def then_i_see_the_mentor_details(school_name:, first_name:, last_name:, trn:)
-    expect(page).to have_content(school_name)
+  def then_i_see_the_mentor_details(first_name:, last_name:, trn:)
     expect(page).to have_content("#{first_name} #{last_name}")
 
     within(".govuk-summary-list") do

--- a/spec/system/placements/support/schools/mentors/support_user_removes_a_mentor_spec.rb
+++ b/spec/system/placements/support/schools/mentors/support_user_removes_a_mentor_spec.rb
@@ -1,0 +1,117 @@
+require "rails_helper"
+
+RSpec.describe "Placements / Support / Schools / Mentor / Support User removes a mentor",
+               type: :system, service: :placements do
+  let(:school) { create(:placements_school, name: "School 1") }
+  let(:mentor_1) do
+    create(:placements_mentor,
+           first_name: "John",
+           last_name: "Doe")
+  end
+  let(:mentor_2) do
+    create(:placements_mentor,
+           first_name: "Agatha",
+           last_name: "Christie")
+  end
+
+  before do
+    given_the_school_has_mentors(school:, mentors: [mentor_1, mentor_2])
+    given_i_sign_in_as_colin
+  end
+
+  scenario "Support User removes a mentor from a school" do
+    when_i_visit_the_support_show_page_for(school, mentor_1)
+    and_i_click_on("Remove mentor")
+    then_i_am_asked_to_confirm(school, mentor_1)
+    when_i_click_on("Cancel")
+    then_i_return_to_mentor_page(school, mentor_1)
+    when_i_click_on("Remove mentor")
+    then_i_am_asked_to_confirm(school, mentor_1)
+    when_i_click_on("Remove mentor")
+    then_the_mentor_is_removed_from_the_school(school, mentor_1)
+    and_a_school_mentor_remains_called("Agatha Christie")
+  end
+
+  private
+
+  def and_there_is_an_existing_user_for(user_name)
+    user = create(:placements_support_user, user_name.downcase.to_sym)
+    user_exists_in_dfe_sign_in(user:)
+  end
+
+  def and_i_visit_the_sign_in_path
+    visit sign_in_path
+  end
+
+  def and_i_click_sign_in
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def given_i_sign_in_as_colin
+    and_there_is_an_existing_user_for("Colin")
+    and_i_visit_the_sign_in_path
+    and_i_click_sign_in
+  end
+
+  def given_the_school_has_mentors(school:, mentors:)
+    mentors.each do |mentor|
+      create(:placements_mentor_membership, school:, mentor:)
+    end
+  end
+
+  def when_i_visit_the_support_show_page_for(school, mentor)
+    visit placements_support_school_mentor_path(school, mentor)
+  end
+
+  def when_i_click_on(text)
+    click_on text
+  end
+  alias_method :and_i_click_on, :when_i_click_on
+
+  def then_i_am_asked_to_confirm(school, mentor)
+    organisations_is_selected_in_primary_nav
+    expect(page).to have_title(
+      "Are you sure you want to remove this mentor? - #{mentor.full_name} - #{school.name} - Manage school placements",
+    )
+    expect(page).to have_content "#{mentor.full_name} - #{school.name}"
+    expect(page).to have_content "Are you sure you want to remove this mentor?"
+  end
+
+  def organisations_is_selected_in_primary_nav
+    within(".app-primary-navigation__nav") do
+      expect(page).to have_link "Organisations", current: "page"
+      expect(page).to have_link "Users", current: "false"
+    end
+  end
+
+  def then_i_return_to_mentor_page(school, mentor)
+    organisations_is_selected_in_primary_nav
+    expect(page).to have_current_path placements_support_school_mentor_path(school, mentor),
+                                      ignore_query: true
+  end
+
+  def then_the_mentor_is_removed_from_the_school(school, mentor)
+    organisations_is_selected_in_primary_nav
+    mentors_is_selected_in_secondary_nav
+    expect(mentor.mentor_memberships.find_by(school:)).to eq nil
+    within(".govuk-notification-banner__content") do
+      expect(page).to have_content "Mentor removed"
+    end
+
+    expect(page).not_to have_content mentor.full_name
+  end
+
+  def mentors_is_selected_in_secondary_nav
+    within(".app-secondary-navigation__list") do
+      expect(page).to have_link "Details", current: "false"
+      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Mentors", current: "page"
+      expect(page).to have_link "Placements", current: "false"
+      expect(page).to have_link "Providers", current: "false"
+    end
+  end
+
+  def and_a_school_mentor_remains_called(mentor_name)
+    expect(page).to have_content(mentor_name)
+  end
+end

--- a/spec/system/placements/support/users/support_user_removes_a_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_removes_a_user_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
       when_i_click_on("Remove user")
       then_i_am_asked_to_confirm(school)
       when_i_click_on("Remove user")
-      then_the_the_user_is_removed_from_the_organisation(school)
+      then_the_user_is_removed_from_the_organisation(school)
     end
   end
 
@@ -47,7 +47,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
       when_i_click_on("Remove user")
       then_i_am_asked_to_confirm(provider)
       when_i_click_on("Remove user")
-      then_the_the_user_is_removed_from_the_organisation(provider)
+      then_the_user_is_removed_from_the_organisation(provider)
     end
   end
 
@@ -142,7 +142,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
     end
   end
 
-  def then_the_the_user_is_removed_from_the_organisation(organisation)
+  def then_the_user_is_removed_from_the_organisation(organisation)
     email_is_sent(user.email, organisation)
     organisations_is_selected_in_primary_nav
     users_is_selected_in_secondary_nav(organisation)


### PR DESCRIPTION
## Context

- Support Users can remove mentors from a school
- School Users can remove mentors from their school

## Changes proposed in this pull request

- Controllers/Views/etc. to allow Support Users to remove mentors from a school
- Controllers/Views/etc. to allow School Users to remove mentors from their school

## Guidance to review

(on placements service)
_Colin_
- Sign in as Support User Colin
- Click an Organisation (which is a school)
- Click "Mentors" in the secondary nav
- Click the name of a mentor you wish to remove (if none exist reseed your database)
- This will redirect you to the mentor's show page
- Click the "Remove mentor" link
- Check the text to make sure the user wants to remove the mentor
- Click the "Remove mentor" button
- You should be redirected to the mentors index page, and the name of the removed mentor should no longer appear
- and a success flash message should appear saying "Mentor removed"

_Anne_
- Sign in as School User Anne
- Click "Mentors" in the primary nav
- Click the name of a mentor you wish to remove (if none exist reseed your database)
- This will redirect you to the mentor's show page
- Click the "Remove mentor" link
- Check the text to make sure the user wants to remove the mentor
- Click the "Remove mentor" button
- You should be redirected to the mentors index page, and the name of the removed mentor should no longer appear
- and a success flash message should appear saying "Mentor removed"

## Link to Trello card

https://trello.com/c/5q3kTeLh/224-as-a-support-user-i-want-to-remove-a-mentor-from-a-school
https://trello.com/c/HBOfalY4/225-as-a-user-i-want-to-remove-a-mentor-from-a-school

## Screenshots

_Anne_
https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/5015a284-a115-4060-bb89-f06a5697c0fb

_Colin_
https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/703d12a8-3a90-4cc1-8b42-a8489db46485


