### PR TITLE
Refactor: Create a single source of truth for `current_service`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,11 +13,7 @@ class ApplicationController < ActionController::Base
   private
 
   def sign_in_user
-    @sign_in_user ||=
-      begin
-        session["service"] = current_service
-        DfESignInUser.load_from_session(session)
-      end
+    @sign_in_user ||= DfESignInUser.load_from_session(session, service: current_service)
   end
 
   def current_user

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,12 +2,7 @@ module ApplicationHelper
   include Pagy::Frontend
 
   def current_service
-    case request.host
-    when ENV["CLAIMS_HOST"]
-      :claims
-    when ENV["PLACEMENTS_HOST"]
-      :placements
-    end
+    HostingEnvironment.current_service(request)
   end
 
   def service_name

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -1,6 +1,5 @@
 class DfESignInUser
-  attr_reader :email, :dfe_sign_in_uid, :id_token, :provider
-  attr_accessor :first_name, :last_name, :service
+  attr_reader :email, :dfe_sign_in_uid, :id_token, :provider, :service, :first_name, :last_name
 
   def initialize(email:, dfe_sign_in_uid:, first_name:, last_name:, service:, id_token: nil, provider: nil)
     @email = email&.downcase
@@ -24,7 +23,7 @@ class DfESignInUser
     }
   end
 
-  def self.load_from_session(session)
+  def self.load_from_session(session, service:)
     dfe_sign_in_session = session["dfe_sign_in_user"]
     return unless dfe_sign_in_session
 
@@ -43,7 +42,7 @@ class DfESignInUser
       last_name: dfe_sign_in_session["last_name"],
       id_token: dfe_sign_in_session["id_token"],
       provider: dfe_sign_in_session["provider"],
-      service: session["service"],
+      service:,
     )
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ApplicationHelper do
-  describe "#external_link" do
+  describe ".external_link" do
     context "when value is blank" do
       it "returns nil" do
         value = ""
@@ -28,6 +28,16 @@ RSpec.describe ApplicationHelper do
         value = "https://www.google.com"
         expect(external_link(value)).to eq("https://www.google.com")
       end
+    end
+  end
+
+  describe ".current_service" do
+    it "delegates to HostingEnvironment.current_service" do
+      allow(HostingEnvironment).to receive(:current_service)
+                                   .with(kind_of(ActionDispatch::Request))
+                                   .and_return(:pineapple)
+
+      expect(current_service).to eq(:pineapple)
     end
   end
 end

--- a/spec/models/dfe_sign_in_user_spec.rb
+++ b/spec/models/dfe_sign_in_user_spec.rb
@@ -47,9 +47,8 @@ describe DfESignInUser do
           "id_token" => "123",
           "provider" => "dfe",
         },
-        "service" => :placements,
       }
-      dfe_sign_in_user = described_class.load_from_session(session)
+      dfe_sign_in_user = described_class.load_from_session(session, service: :placements)
 
       expect(dfe_sign_in_user).not_to be_nil
       expect(dfe_sign_in_user.first_name).to eq("Example")
@@ -67,7 +66,7 @@ describe DfESignInUser do
             "last_active_at" => 3.hours.ago,
           },
         }
-        dfe_sign_in_user = described_class.load_from_session(session)
+        dfe_sign_in_user = described_class.load_from_session(session, service: :placements)
 
         expect(dfe_sign_in_user).to be_nil
       end
@@ -89,10 +88,9 @@ describe DfESignInUser do
             "id_token" => "123",
             "provider" => nil,
           },
-          "service" => :claims,
         }
 
-        dfe_sign_in_user = described_class.load_from_session(session)
+        dfe_sign_in_user = described_class.load_from_session(session, service: :claims)
 
         expect(dfe_sign_in_user.user).to eq claims_user
         expect(dfe_sign_in_user.user).to be_a Claims::User
@@ -111,10 +109,9 @@ describe DfESignInUser do
             "id_token" => "123",
             "provider" => nil,
           },
-          "service" => :claims,
         }
 
-        dfe_sign_in_user = described_class.load_from_session(session)
+        dfe_sign_in_user = described_class.load_from_session(session, service: :claims)
 
         expect(dfe_sign_in_user.user.id).to eq support_user.id
         expect(dfe_sign_in_user.user).to be_a Claims::SupportUser
@@ -134,10 +131,9 @@ describe DfESignInUser do
               "id_token" => "123",
               "provider" => "dfe",
             },
-            "service" => :claims,
           }
 
-          dfe_sign_in_user = described_class.load_from_session(session)
+          dfe_sign_in_user = described_class.load_from_session(session, service: :claims)
 
           expect(dfe_sign_in_user.user).to eq claims_user
           expect(dfe_sign_in_user.user).to be_a Claims::User
@@ -156,10 +152,9 @@ describe DfESignInUser do
               "id_token" => "123",
               "provider" => nil,
             },
-            "service" => :claims,
           }
 
-          dfe_sign_in_user = described_class.load_from_session(session)
+          dfe_sign_in_user = described_class.load_from_session(session, service: :claims)
 
           expect(dfe_sign_in_user.user).to eq claims_user
           expect(dfe_sign_in_user.user).to be_a Claims::User
@@ -178,10 +173,9 @@ describe DfESignInUser do
               "id_token" => "123",
               "provider" => nil,
             },
-            "service" => :claims,
           }
 
-          dfe_sign_in_user = described_class.load_from_session(session)
+          dfe_sign_in_user = described_class.load_from_session(session, service: :claims)
 
           expect(dfe_sign_in_user.user.id).to eq support_user.id
           expect(dfe_sign_in_user.user).to be_a Claims::SupportUser
@@ -203,10 +197,9 @@ describe DfESignInUser do
             "id_token" => "123",
             "provider" => nil,
           },
-          "service" => :placements,
         }
 
-        dfe_sign_in_user = described_class.load_from_session(session)
+        dfe_sign_in_user = described_class.load_from_session(session, service: :placements)
 
         expect(dfe_sign_in_user.user).to eq placements_user
         expect(dfe_sign_in_user.user).to be_a Placements::User
@@ -225,10 +218,9 @@ describe DfESignInUser do
             "id_token" => "123",
             "provider" => nil,
           },
-          "service" => :placements,
         }
 
-        dfe_sign_in_user = described_class.load_from_session(session)
+        dfe_sign_in_user = described_class.load_from_session(session, service: :placements)
 
         expect(dfe_sign_in_user.user.id).to eq support_user.id
         expect(dfe_sign_in_user.user).to be_a Placements::SupportUser
@@ -248,10 +240,9 @@ describe DfESignInUser do
               "id_token" => "123",
               "provider" => "dfe",
             },
-            "service" => :placements,
           }
 
-          dfe_sign_in_user = described_class.load_from_session(session)
+          dfe_sign_in_user = described_class.load_from_session(session, service: :placements)
 
           expect(dfe_sign_in_user.user).to eq placements_user
           expect(dfe_sign_in_user.user).to be_a Placements::User
@@ -270,10 +261,9 @@ describe DfESignInUser do
               "id_token" => "123",
               "provider" => "dfe",
             },
-            "service" => :placements,
           }
 
-          dfe_sign_in_user = described_class.load_from_session(session)
+          dfe_sign_in_user = described_class.load_from_session(session, service: :placements)
 
           expect(dfe_sign_in_user.user).to eq placements_user
           expect(dfe_sign_in_user.user).to be_a Placements::User
@@ -292,10 +282,9 @@ describe DfESignInUser do
               "id_token" => "123",
               "provider" => "dfe",
             },
-            "service" => :placements,
           }
 
-          dfe_sign_in_user = described_class.load_from_session(session)
+          dfe_sign_in_user = described_class.load_from_session(session, service: :placements)
 
           expect(dfe_sign_in_user.user.id).to eq support_user.id
           expect(dfe_sign_in_user.user).to be_a Placements::SupportUser


### PR DESCRIPTION
## Context

This PR is a refactor which aims to clarify and simplify the way `current_service` is passed and defined within the app.

I'm doing this as a precursory refactor ahead of [setting up GoodJob](https://trello.com/c/9uy2ArZJ/217-draft-set-up-active-job). I'm doing this so I can access the current user within `routes.rb` – which has access to `request.session`, but cannot access the `current_user` controller helper method – so a suitable constraint can be applied for accessing the GoodJob admin dashboard.

## Changes proposed in this pull request

It makes two main changes:

1. Define a single source of truth – by removing a duplicate implementation of `current_service`.
2. Stop passing `current_service` into the user's session – it was unnecessary, and was the source of a potential bug.

## Guidance to review

This is a refactor with no functional changes, so there's not much to review. The most important thing is that tests still pass.

If you want more details about the changes made, I recommend reading the commit messages.

## Link to Trello card

This is a precursory refactor for: https://trello.com/c/9uy2ArZJ/217-draft-set-up-active-job