### PR TITLE
Set up GoodJob for Active Job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,9 @@ gem "bootsnap", require: false
 gem "flipflop"
 gem "redcarpet", "~> 3.6"
 
+# GoodJob backend for Active Job
+gem "good_job", "~> 3.24"
+
 gem "govuk-components", "~> 5.1"
 gem "govuk_design_system_formbuilder", "~> 5.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,6 +180,8 @@ GEM
       rubocop
       smart_properties
     erubi (1.12.0)
+    et-orbi (1.2.7)
+      tzinfo
     factory_bot (6.4.5)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.3)
@@ -197,8 +199,18 @@ GEM
     flipflop (2.7.1)
       activesupport (>= 4.0)
       terminal-table (>= 1.8)
+    fugit (1.9.0)
+      et-orbi (~> 1, >= 1.2.7)
+      raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    good_job (3.24.0)
+      activejob (>= 6.0.0)
+      activerecord (>= 6.0.0)
+      concurrent-ruby (>= 1.0.2)
+      fugit (>= 1.1)
+      railties (>= 6.0.0)
+      thor (>= 0.14.1)
     govuk-components (5.1.0)
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (~> 6.0)
@@ -348,6 +360,7 @@ GEM
       nio4r (~> 2.0)
     pundit (2.3.1)
       activesupport (>= 3.0.0)
+    raabro (1.4.0)
     racc (1.7.3)
     rack (3.0.9)
     rack-oauth2 (2.2.0)
@@ -612,6 +625,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   flipflop
+  good_job (~> 3.24)
   govuk-components (~> 5.1)
   govuk_design_system_formbuilder (~> 5.1)
   httparty

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,6 +33,9 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  # Use GoodJob adapter for Active Job.
+  config.active_job.queue_adapter = :good_job
+
   config.action_mailer.delivery_method = :notify
   config.action_mailer.notify_settings = {
     api_key: ENV.fetch("GOVUK_NOTIFY_API_KEY"),

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,9 +57,8 @@ Rails.application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
-  # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "itt_mentor_services_production"
+  # Use GoodJob adapter for Active Job.
+  config.active_job.queue_adapter = :good_job
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -1,0 +1,21 @@
+# Configure GoodJob, an Active Job adapter backed by the Postgres database
+# More details at: https://github.com/bensheldon/good_job
+
+Rails.application.configure do
+  # In development, execute jobs within the main `rails server` process
+  config.good_job.execution_mode = :async if Rails.env.development?
+
+  # In production, execute jobs in a separate worker process (i.e. `good_job start`)
+  config.good_job.execution_mode = :external if Rails.env.production?
+
+  # Read scheduled jobs from config file
+  scheduled_jobs = YAML.load_file(
+    Rails.root.join("config/scheduled_jobs.yml"),
+    symbolize_names: true,
+  )
+
+  # Enable cron when running in production mode
+  # Disabled in development and test so scheduled jobs don't run automatically
+  config.good_job.enable_cron = Rails.env.production?
+  config.good_job.cron = scheduled_jobs || {}
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,11 @@
+class SupportUserConstraint
+  def self.matches?(request)
+    service = HostingEnvironment.current_service(request)
+    current_user = DfESignInUser.load_from_session(request.session, service:)&.user
+    current_user&.support_user?
+  end
+end
+
 Rails.application.routes.draw do
   scope via: :all do
     get "/404", to: "errors#not_found", as: :not_found
@@ -30,4 +38,8 @@ Rails.application.routes.draw do
   draw :claims
 
   get :healthcheck, controller: :heartbeat
+
+  # GoodJob admin interface – only accessible to support users
+  mount GoodJob::Engine => "/good_job", constraints: SupportUserConstraint
+  get "/good_job", to: redirect("/support")
 end

--- a/config/scheduled_jobs.yml
+++ b/config/scheduled_jobs.yml
@@ -1,0 +1,8 @@
+# Define scheduled jobs (cron jobs) in this file.
+#
+# EXAMPLE CONFIG
+#
+# name-of-job:
+#   cron: "* * * * * *" # also accepts natural language, e.g. "every second"
+#   class: NameOfAJob
+#   description: Description is shown in the GoodJob dashboard.

--- a/db/migrate/20240219162226_create_good_jobs.rb
+++ b/db/migrate/20240219162226_create_good_jobs.rb
@@ -1,0 +1,89 @@
+class CreateGoodJobs < ActiveRecord::Migration[7.1]
+  def change
+    # Uncomment for Postgres v12 or earlier to enable gen_random_uuid() support
+    # enable_extension 'pgcrypto'
+
+    create_table :good_jobs, id: :uuid do |t|
+      t.text :queue_name
+      t.integer :priority
+      t.jsonb :serialized_params
+      t.datetime :scheduled_at
+      t.datetime :performed_at
+      t.datetime :finished_at
+      t.text :error
+
+      t.timestamps
+
+      t.uuid :active_job_id
+      t.text :concurrency_key
+      t.text :cron_key
+      t.uuid :retried_good_job_id
+      t.datetime :cron_at
+
+      t.uuid :batch_id
+      t.uuid :batch_callback_id
+
+      t.boolean :is_discrete
+      t.integer :executions_count
+      t.text :job_class
+      t.integer :error_event, limit: 2
+      t.text :labels, array: true
+    end
+
+    create_table :good_job_batches, id: :uuid do |t|
+      t.timestamps
+      t.text :description
+      t.jsonb :serialized_properties
+      t.text :on_finish
+      t.text :on_success
+      t.text :on_discard
+      t.text :callback_queue_name
+      t.integer :callback_priority
+      t.datetime :enqueued_at
+      t.datetime :discarded_at
+      t.datetime :finished_at
+    end
+
+    create_table :good_job_executions, id: :uuid do |t|
+      t.timestamps
+
+      t.uuid :active_job_id, null: false
+      t.text :job_class
+      t.text :queue_name
+      t.jsonb :serialized_params
+      t.datetime :scheduled_at
+      t.datetime :finished_at
+      t.text :error
+      t.integer :error_event, limit: 2
+    end
+
+    create_table :good_job_processes, id: :uuid do |t|
+      t.timestamps
+      t.jsonb :state
+    end
+
+    create_table :good_job_settings, id: :uuid do |t|
+      t.timestamps
+      t.text :key
+      t.jsonb :value
+      t.index :key, unique: true
+    end
+
+    add_index :good_jobs, :scheduled_at, where: "(finished_at IS NULL)", name: :index_good_jobs_on_scheduled_at
+    add_index :good_jobs, %i[queue_name scheduled_at], where: "(finished_at IS NULL)", name: :index_good_jobs_on_queue_name_and_scheduled_at
+    add_index :good_jobs, %i[active_job_id created_at], name: :index_good_jobs_on_active_job_id_and_created_at
+    add_index :good_jobs, :concurrency_key, where: "(finished_at IS NULL)", name: :index_good_jobs_on_concurrency_key_when_unfinished
+    add_index :good_jobs, %i[cron_key created_at], where: "(cron_key IS NOT NULL)", name: :index_good_jobs_on_cron_key_and_created_at_cond
+    add_index :good_jobs, %i[cron_key cron_at], where: "(cron_key IS NOT NULL)", unique: true, name: :index_good_jobs_on_cron_key_and_cron_at_cond
+    add_index :good_jobs, [:finished_at], where: "retried_good_job_id IS NULL AND finished_at IS NOT NULL", name: :index_good_jobs_jobs_on_finished_at
+    add_index :good_jobs, %i[priority created_at], order: { priority: "DESC NULLS LAST", created_at: :asc },
+                                                   where: "finished_at IS NULL", name: :index_good_jobs_jobs_on_priority_created_at_when_unfinished
+    add_index :good_jobs, %i[priority created_at], order: { priority: "ASC NULLS LAST", created_at: :asc },
+                                                   where: "finished_at IS NULL", name: :index_good_job_jobs_for_candidate_lookup
+    add_index :good_jobs, [:batch_id], where: "batch_id IS NOT NULL"
+    add_index :good_jobs, [:batch_callback_id], where: "batch_callback_id IS NOT NULL"
+    add_index :good_jobs, :labels, using: :gin, where: "(labels IS NOT NULL)", name: :index_good_jobs_on_labels
+
+    add_index :good_job_executions, %i[active_job_id created_at], name: :index_good_job_executions_on_active_job_id_and_created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_16_121148) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_19_162226) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -36,6 +36,85 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_16_121148) do
     t.boolean "enabled", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "good_job_batches", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "description"
+    t.jsonb "serialized_properties"
+    t.text "on_finish"
+    t.text "on_success"
+    t.text "on_discard"
+    t.text "callback_queue_name"
+    t.integer "callback_priority"
+    t.datetime "enqueued_at"
+    t.datetime "discarded_at"
+    t.datetime "finished_at"
+  end
+
+  create_table "good_job_executions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "active_job_id", null: false
+    t.text "job_class"
+    t.text "queue_name"
+    t.jsonb "serialized_params"
+    t.datetime "scheduled_at"
+    t.datetime "finished_at"
+    t.text "error"
+    t.integer "error_event", limit: 2
+    t.index ["active_job_id", "created_at"], name: "index_good_job_executions_on_active_job_id_and_created_at"
+  end
+
+  create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.jsonb "state"
+  end
+
+  create_table "good_job_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "key"
+    t.jsonb "value"
+    t.index ["key"], name: "index_good_job_settings_on_key", unique: true
+  end
+
+  create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "queue_name"
+    t.integer "priority"
+    t.jsonb "serialized_params"
+    t.datetime "scheduled_at"
+    t.datetime "performed_at"
+    t.datetime "finished_at"
+    t.text "error"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "active_job_id"
+    t.text "concurrency_key"
+    t.text "cron_key"
+    t.uuid "retried_good_job_id"
+    t.datetime "cron_at"
+    t.uuid "batch_id"
+    t.uuid "batch_callback_id"
+    t.boolean "is_discrete"
+    t.integer "executions_count"
+    t.text "job_class"
+    t.integer "error_event", limit: 2
+    t.text "labels", array: true
+    t.index ["active_job_id", "created_at"], name: "index_good_jobs_on_active_job_id_and_created_at"
+    t.index ["batch_callback_id"], name: "index_good_jobs_on_batch_callback_id", where: "(batch_callback_id IS NOT NULL)"
+    t.index ["batch_id"], name: "index_good_jobs_on_batch_id", where: "(batch_id IS NOT NULL)"
+    t.index ["concurrency_key"], name: "index_good_jobs_on_concurrency_key_when_unfinished", where: "(finished_at IS NULL)"
+    t.index ["cron_key", "created_at"], name: "index_good_jobs_on_cron_key_and_created_at_cond", where: "(cron_key IS NOT NULL)"
+    t.index ["cron_key", "cron_at"], name: "index_good_jobs_on_cron_key_and_cron_at_cond", unique: true, where: "(cron_key IS NOT NULL)"
+    t.index ["finished_at"], name: "index_good_jobs_jobs_on_finished_at", where: "((retried_good_job_id IS NULL) AND (finished_at IS NOT NULL))"
+    t.index ["labels"], name: "index_good_jobs_on_labels", where: "(labels IS NOT NULL)", using: :gin
+    t.index ["priority", "created_at"], name: "index_good_job_jobs_for_candidate_lookup", where: "(finished_at IS NULL)"
+    t.index ["priority", "created_at"], name: "index_good_jobs_jobs_on_priority_created_at_when_unfinished", order: { priority: "DESC NULLS LAST" }, where: "(finished_at IS NULL)"
+    t.index ["queue_name", "scheduled_at"], name: "index_good_jobs_on_queue_name_and_scheduled_at", where: "(finished_at IS NULL)"
+    t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
   end
 
   create_table "mentor_memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/support/dfe_sign_in_user_helper.rb
+++ b/spec/support/dfe_sign_in_user_helper.rb
@@ -1,4 +1,10 @@
 module DfESignInUserHelper
+  def sign_in_as(user)
+    user_exists_in_dfe_sign_in(user:)
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
   def user_exists_in_dfe_sign_in(user:)
     OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
       fake_dfe_sign_in_auth_hash(

--- a/spec/system/good_job_dashboard_spec.rb
+++ b/spec/system/good_job_dashboard_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe "GoodJob admin dashboard", type: :system, service: :placements do
+  scenario "Access the dashboard as a support user" do
+    given_i_am_a_support_user
+    when_i_go_to_the_dashboard_path
+    then_i_can_see_the_dashboard
+  end
+
+  scenario "Cannot access the dashboard as a regular user" do
+    given_i_am_a_regular_user
+    when_i_go_to_the_dashboard_path
+    then_i_cannot_see_the_dashboard
+  end
+
+  scenario "Cannot access the dashboard as an unauthenticated user" do
+    when_i_go_to_the_dashboard_path
+    then_i_am_asked_to_sign_in
+  end
+
+  private
+
+  def given_i_am_a_support_user
+    sign_in_as create(:placements_support_user)
+  end
+
+  def given_i_am_a_regular_user
+    sign_in_as create(:placements_user)
+  end
+
+  def when_i_go_to_the_dashboard_path
+    visit "/good_job"
+  end
+
+  def then_i_can_see_the_dashboard
+    expect(page).to have_content "you're doing a Good Job"
+  end
+
+  def then_i_cannot_see_the_dashboard
+    expect(page).to have_content "You cannot perform this action"
+  end
+
+  def then_i_am_asked_to_sign_in
+    expect(page).to have_content "Sign in to Manage school placements"
+  end
+end


### PR DESCRIPTION
## Context

We need to be able to run asynchronous background tasks and scheduled jobs. To do this, we can use [GoodJob](https://github.com/bensheldon/good_job) which provides a backend adapter for [Active Job](https://guides.rubyonrails.org/active_job_basics.html).

GoodJob is similar to [Sidekiq](https://github.com/sidekiq/sidekiq) except it's backed by the existing Postgres database that the app already depends on. It keeps our stack simple by avoiding the need to set up Redis instances, as Sidekiq would require.

GoodJob also supports [cron-style scheduled jobs](https://github.com/bensheldon/good_job?tab=readme-ov-file#cron-style-repeatingrecurring-jobs) out of the box, akin to what you'd get from adding [sidekiq-scheduler](https://github.com/sidekiq-scheduler/sidekiq-scheduler) or [sidekiq-cron](https://github.com/sidekiq-cron/sidekiq-cron) on top of a Sidekiq setup.

## Changes proposed in this pull request

- Set up GoodJob and configure Active Job to use it
- Enable cron functionality so we can define scheduled jobs
- Create `config/scheduled_jobs.yml` with an example job definition
- Mount the GoodJob admin dashboard ([demo](https://goodjob-demo.herokuapp.com/)) at `/good_job` – this is only accessible to support users

### In development mode

GoodJob will execute jobs asynchronously in the main `rails server` process. There's no need to run an external worker process if the `rails server` is running.

Scheduled jobs will not run in development mode.

### In production mode

A GoodJob worker process needs to be run for jobs to execute. They will not be run within the main server process.

Scheduled jobs will run in production.

Start a worker process by running:

```
bundle exec good_job start
```

## Guidance to review

This is probably easiest reviewed commit-by-commit. I've tried to chunk up each commit logically, and add descriptive commit messages where I think they'd be helpful.

There are no Active Job jobs defined in our app yet, so there isn't anything to use if you wanted to test it locally. I did have a dummy job which I used while working on this PR, but I haven't committed it into this branch.

## Link to Trello card

https://trello.com/c/9uy2ArZJ/217-set-up-active-job