### PR TITLE
Remove School Users

### DIFF
--- a/app/components/primary_navigation_component.html.erb
+++ b/app/components/primary_navigation_component.html.erb
@@ -1,13 +1,11 @@
-<div class="app-primary-navigation">
-  <div class="app-primary-navigation govuk-!-display-none-print">
-    <div class="govuk-width-container app-primary-navigation--justify-between">
-      <nav class="app-primary-navigation__nav" aria-label="main menu">
-        <ul class="app-primary-navigation__list">
-          <% navigation_items.each do |navigation_item| %>
-            <%= navigation_item %>
-          <% end %>
-        </ul>
-      </nav>
-    </div>
+<div class="app-primary-navigation govuk-!-display-none-print">
+  <div class="govuk-width-container app-primary-navigation--justify-between">
+    <nav class="app-primary-navigation__nav" aria-label="main menu">
+      <ul class="app-primary-navigation__list">
+        <% navigation_items.each do |navigation_item| %>
+          <%= navigation_item %>
+        <% end %>
+      </ul>
+    </nav>
   </div>
 </div>

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,8 @@ class ApplicationController < ActionController::Base
 
   helper_method :current_user, :support_controller?
 
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
   private
 
   def sign_in_user
@@ -46,5 +48,9 @@ class ApplicationController < ActionController::Base
 
   def support_controller?
     false
+  end
+
+  def user_not_authorized
+    redirect_back fallback_location: root_path, alert: t("you_cannot_perform_this_action")
   end
 end

--- a/app/controllers/claims/schools/users_controller.rb
+++ b/app/controllers/claims/schools/users_controller.rb
@@ -2,7 +2,7 @@ class Claims::Schools::UsersController < ApplicationController
   include Claims::BelongsToSchool
 
   before_action :set_user, only: %i[show remove destroy]
-  before_action :authorize_user
+  before_action :authorize_user, only: %i[remove destroy]
 
   def index
     @users = @school.users
@@ -49,6 +49,6 @@ class Claims::Schools::UsersController < ApplicationController
   end
 
   def authorize_user
-    authorize @user || Claims::User
+    authorize @user
   end
 end

--- a/app/controllers/claims/schools/users_controller.rb
+++ b/app/controllers/claims/schools/users_controller.rb
@@ -1,12 +1,11 @@
 class Claims::Schools::UsersController < ApplicationController
   include Claims::BelongsToSchool
 
+  before_action :set_user, only: %i[show remove destroy]
+  before_action :authorize_user
+
   def index
     @users = @school.users
-  end
-
-  def show
-    @user = @school.users.find(params.require(:id))
   end
 
   def new
@@ -20,7 +19,17 @@ class Claims::Schools::UsersController < ApplicationController
   def create
     user_form.save!
     User::Invite.call(user: user_form.user, organisation: @school)
-    redirect_to claims_school_users_path(@school), flash: { success: t(".user_added") }
+    redirect_to claims_school_users_path(@school), flash: { success: t(".success") }
+  end
+
+  def show; end
+
+  def remove; end
+
+  def destroy
+    User::Remove.call(user: @user, organisation: @school)
+
+    redirect_to claims_school_users_path(@school), flash: { success: t(".success") }
   end
 
   private
@@ -31,7 +40,15 @@ class Claims::Schools::UsersController < ApplicationController
           .merge({ service: current_service, organisation: @school })
   end
 
+  def set_user
+    @user = @school.users.find(params.require(:id))
+  end
+
   def user_form
     @user_form ||= UserInviteForm.new(user_params)
+  end
+
+  def authorize_user
+    authorize @user || Claims::User
   end
 end

--- a/app/controllers/claims/support/schools/users_controller.rb
+++ b/app/controllers/claims/support/schools/users_controller.rb
@@ -1,12 +1,10 @@
 class Claims::Support::Schools::UsersController < Claims::Support::ApplicationController
   include Claims::BelongsToSchool
 
+  before_action :set_user, only: %i[show remove destroy]
+
   def index
     @users = @school.users
-  end
-
-  def show
-    @user = @school.users.find(params.require(:id))
   end
 
   def new
@@ -25,12 +23,26 @@ class Claims::Support::Schools::UsersController < Claims::Support::ApplicationCo
     redirect_to claims_support_school_users_path(@school), flash: { success: t(".success") }
   end
 
+  def show; end
+
+  def remove; end
+
+  def destroy
+    User::Remove.call(user: @user, organisation: @school)
+
+    redirect_to claims_support_school_users_path(@school), flash: { success: t(".success") }
+  end
+
   private
 
   def user_params
     params.require(:user_invite_form)
           .permit(:first_name, :last_name, :email)
           .merge({ service: current_service, organisation: @school })
+  end
+
+  def set_user
+    @user = @school.users.find(params.require(:id))
   end
 
   def user_form

--- a/app/controllers/claims/support/support_users_controller.rb
+++ b/app/controllers/claims/support/support_users_controller.rb
@@ -1,5 +1,6 @@
 class Claims::Support::SupportUsersController < Claims::Support::ApplicationController
   before_action :set_support_user, only: %i[show remove destroy]
+  before_action :authorize_support_user, only: %i[remove destroy]
 
   def index
     @support_users = Claims::SupportUser.order(created_at: :desc)
@@ -24,9 +25,8 @@ class Claims::Support::SupportUsersController < Claims::Support::ApplicationCont
   def remove; end
 
   def destroy
-    authorize @support_user
-
     SupportUser::Remove.call(support_user: @support_user)
+
     redirect_to claims_support_support_users_path, flash: { success: t(".success") }
   end
 
@@ -44,5 +44,9 @@ class Claims::Support::SupportUsersController < Claims::Support::ApplicationCont
 
   def support_user_form
     @support_user_form ||= SupportUserInviteForm.new(support_user_params)
+  end
+
+  def authorize_support_user
+    authorize @support_user
   end
 end

--- a/app/controllers/placements/support/organisations/users_controller.rb
+++ b/app/controllers/placements/support/organisations/users_controller.rb
@@ -1,6 +1,7 @@
 class Placements::Support::Organisations::UsersController < Placements::Support::ApplicationController
   before_action :set_organisation
   before_action :set_user, only: %i[show remove destroy]
+  before_action :authorize_user, only: %i[remove destroy]
 
   def index
     users
@@ -49,5 +50,9 @@ class Placements::Support::Organisations::UsersController < Placements::Support:
 
   def user_form
     @user_form ||= UserInviteForm.new(user_params)
+  end
+
+  def authorize_user
+    authorize @user
   end
 end

--- a/app/controllers/placements/support/support_users_controller.rb
+++ b/app/controllers/placements/support/support_users_controller.rb
@@ -1,5 +1,6 @@
 class Placements::Support::SupportUsersController < Placements::Support::ApplicationController
   before_action :set_support_user, only: %i[show remove destroy]
+  before_action :authorize_support_user, only: %i[remove destroy]
 
   def index
     @support_users = Placements::SupportUser.order(created_at: :desc)
@@ -44,5 +45,9 @@ class Placements::Support::SupportUsersController < Placements::Support::Applica
 
   def support_user_form
     @support_user_form ||= SupportUserInviteForm.new(support_user_params)
+  end
+
+  def authorize_support_user
+    authorize @support_user
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -7,19 +7,23 @@ class ApplicationPolicy
   end
 
   def index?
-    false
+    true
   end
 
   def show?
-    false
+    true
   end
 
   def create?
-    false
+    true
   end
 
   def new?
     create?
+  end
+
+  def check?
+    new?
   end
 
   def update?
@@ -32,6 +36,10 @@ class ApplicationPolicy
 
   def destroy?
     false
+  end
+
+  def remove?
+    destroy?
   end
 
   class Scope

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -6,42 +6,6 @@ class ApplicationPolicy
     @record = record
   end
 
-  def index?
-    true
-  end
-
-  def show?
-    true
-  end
-
-  def create?
-    true
-  end
-
-  def new?
-    create?
-  end
-
-  def check?
-    new?
-  end
-
-  def update?
-    false
-  end
-
-  def edit?
-    update?
-  end
-
-  def destroy?
-    false
-  end
-
-  def remove?
-    destroy?
-  end
-
   class Scope
     def initialize(user, scope)
       @user = user

--- a/app/policies/claims/support_user_policy.rb
+++ b/app/policies/claims/support_user_policy.rb
@@ -2,4 +2,8 @@ class Claims::SupportUserPolicy < ApplicationPolicy
   def destroy?
     user != record
   end
+
+  def remove?
+    destroy?
+  end
 end

--- a/app/policies/claims/user_policy.rb
+++ b/app/policies/claims/user_policy.rb
@@ -2,4 +2,8 @@ class Claims::UserPolicy < ApplicationPolicy
   def destroy?
     user != record
   end
+
+  def remove?
+    destroy?
+  end
 end

--- a/app/policies/claims/user_policy.rb
+++ b/app/policies/claims/user_policy.rb
@@ -1,0 +1,5 @@
+class Claims::UserPolicy < ApplicationPolicy
+  def destroy?
+    user != record
+  end
+end

--- a/app/policies/placements/support_user_policy.rb
+++ b/app/policies/placements/support_user_policy.rb
@@ -2,4 +2,8 @@ class Placements::SupportUserPolicy < ApplicationPolicy
   def destroy?
     user != record
   end
+
+  def remove?
+    destroy?
+  end
 end

--- a/app/policies/placements/user_policy.rb
+++ b/app/policies/placements/user_policy.rb
@@ -2,4 +2,8 @@ class Placements::UserPolicy < ApplicationPolicy
   def destroy?
     user != record
   end
+
+  def remove?
+    destroy?
+  end
 end

--- a/app/views/claims/schools/users/remove.html.erb
+++ b/app/views/claims/schools/users/remove.html.erb
@@ -16,7 +16,7 @@
       <%= govuk_button_to t(".remove_user"), claims_school_user_path(@school, @user), warning: true, method: :delete %>
 
       <p class="govuk-body">
-        <%= govuk_link_to(t(".cancel"), claims_school_user_path(@school, @user)) %>
+        <%= govuk_link_to(t(".cancel"), claims_school_user_path(@school, @user), no_visited_state: true) %>
       </p>
     </div>
   </div>

--- a/app/views/claims/schools/users/remove.html.erb
+++ b/app/views/claims/schools/users/remove.html.erb
@@ -1,0 +1,23 @@
+<% content_for(:page_title) { sanitize(t(".page_title", user_name: @user.full_name)) } %>
+<% render "claims/support/primary_navigation", current: :organisations %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: claims_school_user_path(@school, @user)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".caption", user_name: @user.full_name) %></span>
+      <h2 class="govuk-heading-l"><%= t(".heading") %></h2>
+
+      <%= govuk_warning_text(text: t(".warning", school_name: @school.name)) %>
+
+      <%= govuk_button_to t(".remove_user"), claims_school_user_path(@school, @user), warning: true, method: :delete %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to(t(".cancel"), claims_school_user_path(@school, @user)) %>
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/claims/schools/users/show.html.erb
+++ b/app/views/claims/schools/users/show.html.erb
@@ -12,19 +12,24 @@
 
       <%= govuk_summary_list do |summary_list| %>
         <% summary_list.with_row do |row| %>
-          <% row.with_key(text: User.human_attribute_name("first_name")) %>
+          <% row.with_key(text: User.human_attribute_name(:first_name)) %>
           <% row.with_value(text: @user.first_name) %>
         <% end %>
+
         <% summary_list.with_row do |row| %>
-          <% row.with_key(text: User.human_attribute_name("last_name")) %>
+          <% row.with_key(text: User.human_attribute_name(:last_name)) %>
           <% row.with_value(text: @user.last_name) %>
         <% end %>
+
         <% summary_list.with_row do |row| %>
-          <% row.with_key(text: User.human_attribute_name("email")) %>
+          <% row.with_key(text: User.human_attribute_name(:email)) %>
           <% row.with_value(text: @user.email) %>
         <% end %>
       <% end %>
 
+      <% if policy(@user).destroy? %>
+        <%= govuk_link_to t(".remove_user"), remove_claims_school_user_path(@school, @user), class: "app-link app-link--destructive" %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/claims/support/schools/users/new.html.erb
+++ b/app/views/claims/support/schools/users/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, @user_form.errors.any? ? sanitize(t(".page_title_with_error", school_name: @school.name)) : sanitize(t(".page_title", school_name: @school.name)) %>
-<%= render "claims/support/primary_navigation", current: :organisations %>
+<% render "claims/support/primary_navigation", current: :organisations %>
 
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: claims_support_school_users_path(@school)) %>

--- a/app/views/claims/support/schools/users/remove.html.erb
+++ b/app/views/claims/support/schools/users/remove.html.erb
@@ -16,7 +16,7 @@
       <%= govuk_button_to t(".remove_user"), claims_support_school_user_path(@school, @user), warning: true, method: :delete %>
 
       <p class="govuk-body">
-        <%= govuk_link_to(t(".cancel"), claims_support_school_user_path(@school, @user)) %>
+        <%= govuk_link_to(t(".cancel"), claims_support_school_user_path(@school, @user), no_visited_state: true) %>
       </p>
     </div>
   </div>

--- a/app/views/claims/support/schools/users/remove.html.erb
+++ b/app/views/claims/support/schools/users/remove.html.erb
@@ -1,0 +1,23 @@
+<% content_for(:page_title) { sanitize(t(".page_title", user_name: @user.full_name, school_name: @school.name)) } %>
+<% render "claims/support/primary_navigation", current: :organisations %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: claims_support_school_user_path(@school, @user)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".caption", user_name: @user.full_name, school_name: @school.name) %></span>
+      <h2 class="govuk-heading-l"><%= t(".heading") %></h2>
+
+      <%= govuk_warning_text(text: t(".warning", school_name: @school.name)) %>
+
+      <%= govuk_button_to t(".remove_user"), claims_support_school_user_path(@school, @user), warning: true, method: :delete %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to(t(".cancel"), claims_support_school_user_path(@school, @user)) %>
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/claims/support/schools/users/show.html.erb
+++ b/app/views/claims/support/schools/users/show.html.erb
@@ -9,20 +9,22 @@
       <span class="govuk-caption-l"><%= @school.name %></span>
       <h2 class="govuk-heading-l"><%= @user.full_name %></h2>
 
-      <dl class="govuk-summary-list">
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key"><%= t(".attributes.users.first_name") %></dt>
-          <dd class="govuk-summary-list__value"><%= @user.first_name %></dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key"><%= t(".attributes.users.last_name") %></dt>
-          <dd class="govuk-summary-list__value"><%= @user.last_name %></dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key"><%= t(".attributes.users.email") %></dt>
-          <dd class="govuk-summary-list__value"><%= @user.email %></dd>
-        </div>
-      </dl>
+      <%= govuk_summary_list do |summary_list| %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: User.human_attribute_name(:first_name)) %>
+          <% row.with_value(text: @user.first_name) %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: User.human_attribute_name(:last_name)) %>
+          <% row.with_value(text: @user.last_name) %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: User.human_attribute_name(:email)) %>
+          <% row.with_value(text: @user.email) %>
+        <% end %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/claims/support/schools/users/show.html.erb
+++ b/app/views/claims/support/schools/users/show.html.erb
@@ -25,6 +25,8 @@
           <% row.with_value(text: @user.email) %>
         <% end %>
       <% end %>
+
+      <%= govuk_link_to t(".remove_user"), remove_claims_support_school_user_path(@school, @user), class: "app-link app-link--destructive" %>
     </div>
   </div>
 </div>

--- a/config/locales/en/claims/schools/users.yml
+++ b/config/locales/en/claims/schools/users.yml
@@ -22,4 +22,15 @@ en:
           warning: "The user will be sent an email to tell them you’ve added them to %{school_name}."
           change: Change
         create:
-            user_added: User added
+          success: User added
+        show:
+          remove_user: Remove user
+        remove:
+          page_title: Are you sure you want to remove this user? - %{user_name}
+          caption: "%{user_name}"
+          heading: Are you sure you want to remove this user?
+          warning: The user will be sent an email to tell them you removed them from %{school_name}.
+          remove_user: Remove user
+          cancel: Cancel
+        destroy:
+          success: User removed

--- a/config/locales/en/claims/support/schools/users.yml
+++ b/config/locales/en/claims/support/schools/users.yml
@@ -23,6 +23,7 @@ en:
             page_title: "Personal details - Add user - %{school_name}"
             page_title_with_error: "Error: Personal details - Add user - %{school_name}"
           show:
+            remove_user: Remove user
             attributes:
               users:
                 first_name: First name
@@ -41,3 +42,12 @@ en:
             change: Change
           create:
             success: User added
+          remove:
+            page_title: Are you sure you want to remove this user? - %{user_name} - %{school_name}
+            caption: "%{user_name} - %{school_name}"
+            heading: Are you sure you want to remove this user?
+            warning: The user will be sent an email to tell them you removed them from %{school_name}.
+            remove_user: Remove user
+            cancel: Cancel
+          destroy:
+            success: User removed

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -43,8 +43,9 @@ scope module: :claims, as: :claims, constraints: { host: ENV["CLAIMS_HOST"] } do
           get :remove, on: :member
         end
 
-        resources :users, only: %i[index new create show] do
+        resources :users, only: %i[index new create show destroy] do
           get :check, on: :collection
+          get :remove, on: :member
         end
       end
     end

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -13,10 +13,13 @@ scope module: :claims, as: :claims, constraints: { host: ENV["CLAIMS_HOST"] } do
           patch "/update/:step", to: "claims#update", as: "update"
         end
       end
-      resources :users, only: %i[index new create show] do
-        get :check, on: :collection
-      end
+
       resources :mentors, only: %i[index]
+
+      resources :users, only: %i[index new create show destroy] do
+        get :check, on: :collection
+        get :remove, on: :member
+      end
     end
   end
 

--- a/spec/system/claims/schools/users/remove_a_user_spec.rb
+++ b/spec/system/claims/schools/users/remove_a_user_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+RSpec.describe "Remove a user", type: :system, service: :claims do
+  let!(:school) { create(:claims_school) }
+  let!(:user) do
+    create(:claims_user) { |user| school.users << user }
+  end
+  let!(:current_user) do
+    create(:claims_user) { |user| school.users << user }
+  end
+
+  scenario "I sign in as a user and remove a user from a school" do
+    given_i_am_signed_in_as(current_user)
+    and_i_navigate_to_user_details_page(user)
+    when_i_click_on_remove_user
+    then_i_am_taken_to_a_removal_confirmation_page(school, user)
+    when_i_click_on_remove_user
+    then_the_user_has_been_removed_from_the_school(user)
+  end
+
+  scenario "I sign in as a user and I do not see the link to remove myself from a school" do
+    given_i_am_signed_in_as(current_user)
+    and_i_navigate_to_user_details_page(current_user)
+    then_i_do_not_see_the_remove_user_button
+  end
+
+  scenario "I sign in as a user and I cannot remove myself from a school" do
+    given_i_am_signed_in_as(current_user)
+    and_i_navigate_to_user_removal_page(school, current_user)
+    then_i_am_forbidden_to_perform_this_action
+  end
+
+  private
+
+  def given_i_am_signed_in_as(user)
+    sign_in_as user
+  end
+
+  def and_i_navigate_to_user_details_page(user)
+    within(".app-primary-navigation") do
+      click_on "Users"
+    end
+
+    click_on user.full_name
+  end
+
+  def and_i_navigate_to_user_removal_page(school, user)
+    visit remove_claims_school_user_path(school, user)
+  end
+
+  def when_i_click_on_remove_user
+    click_on "Remove user"
+  end
+
+  def then_i_am_taken_to_a_removal_confirmation_page(school, user)
+    expect(page).to have_content user.full_name
+    expect(page).to have_content "The user will be sent an email to tell them you removed them from #{school.name}."
+  end
+
+  def then_the_user_has_been_removed_from_the_school(user)
+    expect(page).to have_content "User removed"
+
+    expect(page).not_to have_content user.full_name
+    expect(page).not_to have_content user.email
+  end
+
+  def then_i_do_not_see_the_remove_user_button
+    expect(page).not_to have_content "Remove user"
+  end
+
+  def then_i_am_forbidden_to_perform_this_action
+    expect(page).to have_content "You cannot perform this action"
+  end
+end

--- a/spec/system/claims/support/schools/users/remove_a_user_spec.rb
+++ b/spec/system/claims/support/schools/users/remove_a_user_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe "Remove a user", type: :system, service: :claims do
+  let!(:school) { create(:claims_school) }
+  let!(:user) do
+    create(:claims_user) { |user| school.users << user }
+  end
+
+  scenario "I sign in as a support user and invite a user to a school" do
+    given_i_am_signed_in_as_support_user
+    and_i_navigate_to_a_school_user_details_page(school, user)
+    when_i_click_on_remove_user
+    then_i_am_taken_to_a_removal_confirmation_page(school, user)
+    when_i_click_on_remove_user
+    then_the_user_has_been_removed_from_the_school(school, user)
+  end
+
+  private
+
+  def given_i_am_signed_in_as_support_user
+    sign_in_as create(:claims_support_user)
+  end
+
+  def and_i_navigate_to_a_school_user_details_page(school, user)
+    click_on school.name
+
+    within(".app-secondary-navigation") do
+      click_on "Users"
+    end
+
+    click_on user.full_name
+  end
+
+  def when_i_click_on_remove_user
+    click_on "Remove user"
+  end
+
+  def then_i_am_taken_to_a_removal_confirmation_page(school, user)
+    expect(page).to have_content "#{user.full_name} - #{school.name}"
+    expect(page).to have_content "The user will be sent an email to tell them you removed them from #{school.name}."
+  end
+
+  def then_the_user_has_been_removed_from_the_school(_school, user)
+    expect(page).to have_content "User removed"
+
+    expect(page).not_to have_content user.full_name
+    expect(page).not_to have_content user.email
+  end
+end

--- a/spec/system/claims/support/schools/users/view_a_users_details_spec.rb
+++ b/spec/system/claims/support/schools/users/view_a_users_details_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe "View a users details", type: :system do
 
   def verify_user_details
     expect(page).to have_content("Test School")
-    expect(page).to have_content("First name Barry")
-    expect(page).to have_content("Last name Garlow")
-    expect(page).to have_content("Email barry.garlow@gmail.com")
+    expect(page).to have_content("Barry")
+    expect(page).to have_content("Garlow")
+    expect(page).to have_content("barry.garlow@gmail.com")
   end
 end


### PR DESCRIPTION
## Context

We need to be able to remove users from schools.

## Changes proposed in this pull request

- Add remove flows for both Users and Support Users.
- Updated `ApplicationPolicy` to create sensible defaults.
  - The `update?` method is not used within the `UsersController` scope and `undercover` is blocking changes, therefore, we will keep the default `update?` as `false` for now.

## Guidance to review

- Try adding a User and removing them.
- You shouldn't be able to remove yourself from a school when signed in as a non-support User.

## Screenshots

| Change | Screenshot |
| ------ | ---------- |
| Added "Remove user" link | ![CleanShot 2024-02-22 at 10 55 54](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/9cf0a26e-405b-407c-9785-f56452098c57) |
| Added `/schools/:school_id/users/:user_id/remove` path | ![CleanShot 2024-02-22 at 10 56 16](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/e107a871-2ec0-4a49-a4b4-2c674b85db8b) |
| Removal alert | ![CleanShot 2024-02-22 at 10 56 59](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/c2fb52b2-1cc9-4279-8040-4aa0a7ac2aec) |