### PR TITLE
Jc/create job to sync mentor details with trs

### DIFF
--- a/app/jobs/teaching_record/sync_all_mentors_job.rb
+++ b/app/jobs/teaching_record/sync_all_mentors_job.rb
@@ -1,0 +1,18 @@
+module TeachingRecord
+  class SyncAllMentorsJob < ApplicationJob
+    queue_as :default
+
+    def perform
+      # ISSUE 1: Teaching Record Service only has an API to handle requests per TRN.
+      # ISSUE 2: Teaching Record Service request limit is 300 requests per minute.
+
+      # Find mentors in batches of 300.
+      Mentor.find_in_batches(batch_size: 300).with_index do |mentors, batch_index|
+        mentors.each do |mentor|
+          # Each batch of 300 mentors is processed 1 minute apart.
+          TeachingRecord::SyncMentorJob.set(wait: batch_index.minutes).perform_later(mentor)
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/teaching_record/sync_mentor_job.rb
+++ b/app/jobs/teaching_record/sync_mentor_job.rb
@@ -1,0 +1,15 @@
+module TeachingRecord
+  class SyncMentorJob < ApplicationJob
+    queue_as :default
+
+    def perform(mentor)
+      response = TeachingRecord::GetTeacher.call(trn: mentor.trn)
+      mentor.update!(
+        first_name: response["firstName"],
+        last_name: response["lastName"],
+      )
+    rescue TeachingRecord::RestClient::TeacherNotFoundError => e
+      Sentry.capture_exception(e)
+    end
+  end
+end

--- a/config/scheduled_jobs.yml
+++ b/config/scheduled_jobs.yml
@@ -6,3 +6,7 @@
 #   cron: "* * * * * *" # also accepts natural language, e.g. "every second"
 #   class: NameOfAJob
 #   description: Description is shown in the GoodJob dashboard.
+teaching_record_mentor_sync:
+  cron: "0 0 * * *"
+  class: "TeachingRecord::SyncAllMentorsJob"
+  description: "Sync all mentor first and last name attributes"

--- a/spec/jobs/teaching_record/sync_all_mentors_job_spec.rb
+++ b/spec/jobs/teaching_record/sync_all_mentors_job_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe TeachingRecord::SyncAllMentorsJob, type: :job do
   end
 
   describe "#perform" do
-    it "enqueues a TRSUpdateMentorDetailsJob per Mentor in our database" do
+    it "enqueues a TeachingRecord::SyncMentorJob per Mentor in our database" do
       expect { described_class.perform_now }.to have_enqueued_job(
         TeachingRecord::SyncMentorJob,
       ).exactly(:twice)

--- a/spec/jobs/teaching_record/sync_all_mentors_job_spec.rb
+++ b/spec/jobs/teaching_record/sync_all_mentors_job_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe TeachingRecord::SyncAllMentorsJob, type: :job do
+  let(:mentor_1) { create(:mentor, first_name: "Joe", last_name: "Bloggs") }
+  let(:mentor_2) { create(:mentor, first_name: "Agatha", last_name: "Christie") }
+
+  before do
+    mentor_1
+    mentor_2
+  end
+
+  describe "#perform" do
+    it "enqueues a TRSUpdateMentorDetailsJob per Mentor in our database" do
+      expect { described_class.perform_now }.to have_enqueued_job(
+        TeachingRecord::SyncMentorJob,
+      ).exactly(:twice)
+    end
+  end
+end

--- a/spec/jobs/teaching_record/sync_mentor_job_spec.rb
+++ b/spec/jobs/teaching_record/sync_mentor_job_spec.rb
@@ -1,0 +1,118 @@
+require "rails_helper"
+
+RSpec.describe TeachingRecord::SyncMentorJob, type: :job do
+  describe "#perform" do
+    context "when the mentor has a valid trn" do
+      let!(:mentor) { create(:mentor, first_name: "Joe", last_name: "Bloggs", trn: "1234567") }
+
+      before do
+        success_stub_request
+      end
+
+      it "updates the mentors first_name and last_name attributes" do
+        expect { described_class.perform_now(mentor) }.to change {
+          mentor.reload.first_name
+        }.from("Joe").to("Judith").and change {
+          mentor.reload.last_name
+        }.from("Bloggs").to("Chicken")
+      end
+    end
+
+    context "when the mentor has an invalid trn" do
+      let!(:mentor) { create(:mentor, first_name: "Joe", last_name: "Bloggs", trn: "2222222") }
+
+      before do
+        failure_stub_request
+      end
+
+      it "does not update the mentors first name" do
+        expect { described_class.perform_now(mentor) }.not_to change {
+          mentor.reload.first_name
+        }.from("Joe")
+      end
+
+      it "does not update the mentors last name" do
+        expect { described_class.perform_now(mentor) }.not_to change {
+          mentor.reload.last_name
+        }.from("Bloggs")
+      end
+
+      it "sends an error to sentry" do
+        allow(Sentry).to receive(:capture_exception)
+        described_class.perform_now(mentor)
+        expect(Sentry).to have_received(:capture_exception)
+      end
+    end
+
+    context "when the request returns an unhandled error" do
+      let!(:mentor) { create(:mentor, first_name: "Joe", last_name: "Bloggs", trn: "3333333") }
+
+      before do
+        unhandled_stub_request
+      end
+
+      it "raises an error" do
+        expect { described_class.perform_now(mentor) }.to raise_error(
+          TeachingRecord::RestClient::HttpError,
+        )
+      end
+    end
+  end
+
+  def success_stub_request
+    stub_request(:get, "https://preprod.teacher-qualifications-api.education.gov.uk/v3/teachers/1234567")
+      .with(
+        headers: {
+          "Accept" => "application/json",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Authorization" => "Bearer secret",
+          "Content-Type" => "application/json;odata.metadata=minimal",
+          "User-Agent" => "Ruby",
+          "X-Api-Version" => "20240101",
+        },
+      )
+      .to_return(
+        status: 200,
+        body: "{\"trn\":\"1234567\",\"firstName\":\"Judith\",\"middleName\":\"\",\"lastName\":\"Chicken\",\"dateOfBirth\":\"1991-01-22\",\"nationalInsuranceNumber\":\"B15J60R13\",\"email\":\"anonymous@anonymousdomain.org.net.co.uk\",\"qts\":null,\"eyts\":null}",
+        headers: {},
+      )
+  end
+
+  def failure_stub_request
+    stub_request(:get, "https://preprod.teacher-qualifications-api.education.gov.uk/v3/teachers/2222222")
+      .with(
+        headers: {
+          "Accept" => "application/json",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Authorization" => "Bearer secret",
+          "Content-Type" => "application/json;odata.metadata=minimal",
+          "User-Agent" => "Ruby",
+          "X-Api-Version" => "20240101",
+        },
+      )
+      .to_return(
+        status: 404,
+        body: "{\"type\":\"https://tools.ietf.org/html/rfc9110#section-15.5.5\",\"title\":\"Not Found\",\"status\":404,\"traceId\":\"00-dff9d2243466591e882b480c8bdbfc27-f60a1ced105d1602-00\"}",
+        headers: {},
+      )
+  end
+
+  def unhandled_stub_request
+    stub_request(:get, "https://preprod.teacher-qualifications-api.education.gov.uk/v3/teachers/3333333")
+      .with(
+        headers: {
+          "Accept" => "application/json",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Authorization" => "Bearer secret",
+          "Content-Type" => "application/json;odata.metadata=minimal",
+          "User-Agent" => "Ruby",
+          "X-Api-Version" => "20240101",
+        },
+      )
+      .to_return(
+        status: 500,
+        body: "{\"type\":\"https://tools.ietf.org/html/rfc9110#section-15.5.5\",\"title\":\"Not Found\",\"status\":404,\"traceId\":\"00-dff9d2243466591e882b480c8bdbfc27-f60a1ced105d1602-00\"}",
+        headers: {},
+      )
+  end
+end


### PR DESCRIPTION
## Context

Teaching Record System (TRS) is our source of truth for mentor details.
This PR adds jobs which will run over night to sync/update all mentor details with the TRS

## Changes proposed in this pull request

- Add jobs to update/sync mentor details with TRS

## Guidance to review

- In `rails console` update a `Mentor`'s TRN to `1234567` (assuming you don't have a mentor with attributes `first_name: "Judith", last_name: "Chicken" trn: "1234567"`)
- Sign in as Support User Colin
- In one tab visit `http://placements.localhost:3000/support/schools/:school_id/mentors/:id` for the changed mentor (_observe the first and last name displayed_)
- In another tab open `http://placements.localhost:3000/good_job/cron_entries?locale=en`
- Click the "Enqueue entry now button" (>>|)
- (Once queued) Click the "Jobs" tab
- Wait for the jobs to complete successfully
- Refresh the tab for the mentor show page (`http://placements.localhost:3000/support/schools/:school_id/mentors/:id`)
- The mentors first and last name should have changed.


## Link to Trello card

https://trello.com/c/PgX2Vtsu/212-synchronise-all-mentor-first-and-last-names-with-trs

## Screenshots

https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/11577782-fac2-40f6-a2e3-761844cbfd18

