### PR TITLE
Make error 

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -87,7 +87,9 @@ RSpec.configure do |config|
     service = self.class.metadata[:service] || :claims
 
     Capybara.app_host = "http://#{service_host(service)}"
+    Capybara.asset_host = "http://#{service_host(service)}:#{ENV["PORT"]}"
     example.run
+    Capybara.asset_host = nil
     Capybara.app_host = nil
   end
 


### PR DESCRIPTION
## Context

When running tests, capybara creates HTML snapshots. To correctly load the styling assets, we can provide an asset host.

https://github.com/mattheworiordan/capybara-screenshot?tab=readme-ov-file#better-looking-html-screenshots

## Changes proposed in this pull request

- Add `Capybara.asset_host`

## Guidance to review

- Create a breaking system spec, run it.

  ```ruby
  # spec/system/failing_spec.rb
  require "rails_helper"

  RSpec.describe "Failing system spec", type: :system, service: :claims do
    scenario "Access the dashboard as a support user" do
      visit "/"
      expect(page).to have_content "This content should not exist"
    end
  end
  ```

- Open the `.html` screenshot while you have your localhost running.
  - You must have a local server running.
  - You must have the `ENV["PORT"]` value set to match your local server.

## Screenshots

|        | Screenshot |
| ------ | ---------- |
| Before | ![CleanShot 2024-02-22 at 11 38 18](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/5544f021-b80f-4fbb-b463-490c8824ba7f) |
| After  | ![CleanShot 2024-02-22 at 11 39 21](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/23fb2dd7-b670-40ef-bfcd-a47344266ce0) |