### PR TITLE
As a User, I want to see a list of my schools claims

### DIFF
--- a/app/controllers/claims/schools/claims_controller.rb
+++ b/app/controllers/claims/schools/claims_controller.rb
@@ -2,7 +2,7 @@ class Claims::Schools::ClaimsController < ApplicationController
   include Claims::BelongsToSchool
 
   def index
-    @pagy, @claims = pagy(@school.claims)
+    @pagy, @claims = pagy(@school.claims.where(draft: false))
   end
 
   def new

--- a/spec/system/claims/schools/claims/view_claims_spec.rb
+++ b/spec/system/claims/schools/claims/view_claims_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "View claims", type: :system, service: :claims do
     )
   end
 
-  let!(:draft_claim) { create(:claim, :draft, school: school_with_mentors) }
+  let!(:draft_claim) { create(:claim, :draft, school:) }
   let!(:submitted_claim) do
     create(
       :claim,
@@ -49,7 +49,23 @@ RSpec.describe "View claims", type: :system, service: :claims do
     i_see_a_list_of_the_schools_claims
   end
 
+  scenario "Anne visits the claims index page with draft claims" do
+    user_exists_in_dfe_sign_in(user: anne)
+    given_i_sign_in
+    vist_claims_index_page
+    i_do_not_see_any_draft_claims
+  end
+
   private
+
+  def i_do_not_see_any_draft_claims
+    expect(page).not_to have_content(draft_claim.id)
+    expect(page).to have_content("There are no claims for #{school.name}")
+  end
+
+  def vist_claims_index_page
+    click_on "Claims"
+  end
 
   def i_can_see_the_add_a_mentor_guidance
     within(".govuk-inset-text") do
@@ -86,12 +102,6 @@ RSpec.describe "View claims", type: :system, service: :claims do
     expect(page).to have_content("Status")
 
     within("tbody tr:nth-child(1)") do
-      expect(page).to have_content(draft_claim.id.first(8))
-      expect(page).to have_content(I18n.l(draft_claim.created_at.to_date, format: :short))
-      expect(page).to have_content("Draft")
-    end
-
-    within("tbody tr:nth-child(2)") do
       expect(page).to have_content(submitted_claim.id.first(8))
       expect(page).to have_content(submitted_claim.provider_name)
       expect(page).to have_content(submitted_claim.mentors.map(&:full_name).join(""))


### PR DESCRIPTION
## Context

The claims list should only show non-draft claims.

## Changes proposed in this pull request

Change query to only show non draft claims 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/VNzwg1AJ/167-as-a-user-i-want-to-see-a-list-of-my-schools-claims

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
