### PR TITLE
Lb/school user views list of placements for school

### DIFF
--- a/app/components/placement/status_tag_component.rb
+++ b/app/components/placement/status_tag_component.rb
@@ -1,0 +1,20 @@
+class Placement::StatusTagComponent < ApplicationComponent
+  attr_reader :placement_status
+
+  # NOTE: valid colours for the TagComponent are %w(grey green turquoise blue light-blue red purple pink orange yellow)
+  STATUS_COLOUR_MAP = {
+    published: "blue",
+    draft: "grey",
+  }.freeze
+
+  def initialize(placement_status, classes: [], html_attributes: {})
+    super(classes:, html_attributes:)
+
+    @placement_status = placement_status
+  end
+
+  def call
+    render GovukComponent::TagComponent.new(text: placement_status.capitalize,
+                                            colour: STATUS_COLOUR_MAP.fetch(placement_status.to_sym, "grey"))
+  end
+end

--- a/app/controllers/placements/schools/placements_controller.rb
+++ b/app/controllers/placements/schools/placements_controller.rb
@@ -1,0 +1,14 @@
+class Placements::Schools::PlacementsController < ApplicationController
+  before_action :set_school
+
+  def index
+    @pagy, placements = pagy(@school.placements.includes(:subjects, :mentors).order("subjects.name"))
+    @placements = placements.decorate
+  end
+
+  private
+
+  def set_school
+    @school = current_user.schools.find(params.require(:school_id))
+  end
+end

--- a/app/decorators/placement_decorator.rb
+++ b/app/decorators/placement_decorator.rb
@@ -1,0 +1,19 @@
+class PlacementDecorator < Draper::Decorator
+  delegate_all
+
+  def mentor_names
+    if mentors.any?
+      mentors.map(&:full_name).sort.to_sentence
+    else
+      I18n.t("placements.schools.placements.not_entered")
+    end
+  end
+
+  def subject_names
+    subjects.map(&:name).sort.to_sentence
+  end
+
+  def formatted_start_date
+    I18n.l(start_date, format: :long)
+  end
+end

--- a/app/decorators/placement_decorator.rb
+++ b/app/decorators/placement_decorator.rb
@@ -10,7 +10,7 @@ class PlacementDecorator < Draper::Decorator
   end
 
   def subject_names
-    subjects.map(&:name).sort.to_sentence
+    subjects.pluck(:name).sort.to_sentence
   end
 
   def formatted_start_date

--- a/app/helpers/routes_helper.rb
+++ b/app/helpers/routes_helper.rb
@@ -71,7 +71,7 @@ module RoutesHelper
   def placements_organisation_path(organisation)
     case organisation
     when School
-      placements_school_mentors_path(organisation)
+      placements_school_placements_path(organisation)
     when Provider
       placements_provider_path(organisation)
     end

--- a/app/views/placements/schools/_primary_navigation.html.erb
+++ b/app/views/placements/schools/_primary_navigation.html.erb
@@ -10,7 +10,7 @@
 
 <%= content_for(:primary_navigation_content) do %>
   <%= render PrimaryNavigationComponent.new do |component| %>
-    <% component.with_navigation_item t(".placements"), "#", current: current_navigation == :placements %>
+    <% component.with_navigation_item t(".placements"), placements_school_placements_path(school), current: current_navigation == :placements %>
     <% component.with_navigation_item t(".mentors"), placements_school_mentors_path(school), current: current_navigation == :mentors %>
     <% component.with_navigation_item t(".users"), placements_school_users_path(school), current: current_navigation == :users %>
     <% component.with_navigation_item t(".organisation_details"),

--- a/app/views/placements/schools/placements/index.html.erb
+++ b/app/views/placements/schools/placements/index.html.erb
@@ -1,0 +1,42 @@
+<% content_for :page_title, t(".page_title") %>
+<%= render "placements/schools/primary_navigation", school: @school, current_navigation: :placements %>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= t(".placements") %></h1>
+      <% if @placements.any? %>
+        <%= govuk_table do |table| %>
+          <% table.with_head do |head| %>
+            <% head.with_row do |row| %>
+              <% row.with_cell(header: true, text: t(".subject")) %>
+              <% row.with_cell(header: true, text: t(".mentor")) %>
+              <% row.with_cell(header: true, text: Placement.human_attribute_name(:start_date)) %>
+              <% row.with_cell(header: true, text: Placement.human_attribute_name(:status)) %>
+            <% end %>
+          <% end %>
+          <% table.with_body do |body| %>
+            <% @placements.each do |placement| %>
+              <% body.with_row do |row| %>
+                <% row.with_cell(text: placement.subject_names) %>
+                <% row.with_cell(text: placement.mentor_names) %>
+                <% row.with_cell(text: placement.formatted_start_date) %>
+                <% row.with_cell do |cell| %>
+                  <%= render Placement::StatusTagComponent.new(placement.status) %>
+                <% end %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+
+        <%= govuk_pagination(pagy: @pagy) %>
+        <p>
+          <%= t("pagination_info", from: @pagy.from, to: @pagy.to, count: @pagy.count) %>
+        </p>
+      <% else %>
+        <p>
+          <%= t("no_records_for", records: "placements", for: @school.name) %>
+        </p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -1,0 +1,13 @@
+en:
+  placements:
+    schools:
+      placements:
+        not_entered: Not entered
+        index:
+          page_title: Placements
+          placements: Placements
+          subject: Subject
+          mentor: Mentor
+          start_date: Start date
+          status: Status
+          not_entered: Not entered

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -69,6 +69,8 @@ scope module: :placements,
         member { get :remove }
         collection { get :check }
       end
+
+      resources :placements, only: [:index]
     end
   end
 

--- a/spec/components/previews/placement_status_tag_component_preview.rb
+++ b/spec/components/previews/placement_status_tag_component_preview.rb
@@ -1,0 +1,9 @@
+class PlacementStatusTagComponentPreview < ApplicationComponentPreview
+  def draft_status
+    render Placement::StatusTagComponent.new("draft")
+  end
+
+  def published_status
+    render Placement::StatusTagComponent.new("published")
+  end
+end

--- a/spec/factories/subject.rb
+++ b/spec/factories/subject.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :subject do
+    subject_area { %w[primary secondary].sample }
+    name { Faker::Educator.subject }
+  end
+end

--- a/spec/system/placements/organisations/view_organisations_spec.rb
+++ b/spec/system/placements/organisations/view_organisations_spec.rb
@@ -89,18 +89,17 @@ RSpec.describe "View organisations", type: :system, service: :placements do
   end
 
   def then_i_see_the_school_page(school)
-    expect(page).to have_current_path placements_school_mentors_path(school), ignore_query: true
+    expect(page).to have_current_path placements_school_placements_path(school), ignore_query: true
     within(".app-primary-navigation__nav") do
-      expect(page).to have_link "Placements", current: "false"
-      expect(page).to have_link "Mentors", current: "page"
+      expect(page).to have_link "Placements", current: "page"
+      expect(page).to have_link "Mentors", current: "false"
       expect(page).to have_link "Users", current: "false"
       expect(page).to have_link "Organisation details", current: "false"
     end
 
     within(".govuk-main-wrapper") do
       expect(page).to have_content school.name
-      expect(page).to have_content "Mentors"
-      expect(page).to have_content "Add mentor"
+      expect(page).to have_content "Placements"
     end
   end
 

--- a/spec/system/placements/schools/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/schools/placements/view_placements_list_spec.rb
@@ -1,0 +1,119 @@
+require "rails_helper"
+
+RSpec.describe "Placement school user views a list of placements", type: :system, service: :placements do
+  let!(:school) { create(:placements_school) }
+
+  scenario "View school placements page where school has no placements" do
+    given_i_sign_in_as_anne
+    then_i_see_the_placements_page
+    then_i_see_the_empty_state
+  end
+
+  context "with placements" do
+    scenario "where placement has multiple mentors and multiple subjects" do
+      given_a_draft_placement_exists_with_multiple_mentors_and_subjects
+      given_i_sign_in_as_anne
+      then_i_see_mentor_names("Bart Simpson and Lisa Simpson")
+      and_i_see_subject_names("Biology and Maths")
+      and_i_see_draft_status_tag
+    end
+
+    scenario "placement has status of published" do
+      given_a_published_placement_exists
+      given_i_sign_in_as_anne
+      then_i_see_published_status_tag
+    end
+  end
+
+  private
+
+  def given_i_sign_in_as_anne
+    user = create(:placements_user, :anne)
+    create(:user_membership, user:, organisation: school)
+    user_exists_in_dfe_sign_in(user:)
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def given_a_published_placement_exists
+    create(:placement, status: "published", school:)
+  end
+
+  def then_i_see_published_status_tag
+    within("tbody tr:nth-child(1) td:nth-child(4)") do
+      within(".govuk-tag--blue") do
+        expect(page).to have_content "Published"
+      end
+    end
+  end
+
+  def then_i_see_the_placements_page
+    expect_placements_is_selected_in_the_primary_navigation
+    expect(page).to have_title "Placements"
+    expect(page).to have_current_path placements_school_placements_path(school)
+    within(".govuk-heading-l") do
+      expect(page).to have_content "Placements"
+    end
+  end
+
+  def expect_placements_is_selected_in_the_primary_navigation
+    within(".app-primary-navigation__nav") do
+      expect(page).to have_link "Placements", current: "page"
+      expect(page).to have_link "Mentors", current: "false"
+      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Organisation details", current: "false"
+    end
+  end
+
+  def then_i_see_the_empty_state
+    expect(page).to have_content "There are no placements for #{school.name}"
+  end
+
+  def then_i_see_subject_names(names)
+    within("tbody tr:nth-child(1) td:nth-child(1)") do
+      expect(page).to have_content names
+    end
+  end
+
+  alias_method :and_i_see_subject_names, :then_i_see_subject_names
+
+  def then_i_see_mentor_names(names)
+    within("tbody tr:nth-child(1) td:nth-child(2)") do
+      expect(page).to have_content names
+    end
+  end
+
+  def and_i_see_draft_status_tag
+    within("tbody tr:nth-child(1) td:nth-child(4)") do
+      within(".govuk-tag--grey") do
+        expect(page).to have_content "Draft"
+      end
+    end
+  end
+
+  def given_a_draft_placement_exists_with_multiple_mentors_and_subjects
+    mentor_lisa = create(:placements_mentor, first_name: "Lisa", last_name: "Simpson")
+    mentor_bart = create(:placements_mentor, first_name: "Bart", last_name: "Simpson")
+    mentors = [mentor_lisa, mentor_bart]
+
+    biology = create(:subject, name: "Biology")
+    maths = create(:subject, name: "Maths")
+    subjects = [maths, biology]
+    create(:placement, status: "draft", school:, mentors:, subjects:)
+  end
+
+  def and_i_see_published_status_tag
+    within(".gov-tag--blue") do
+      expect(page).to have_content "Published"
+    end
+  end
+
+  def expect_to_see_table_headings
+    within(".govuk-table__head") do
+      expect(page).to have_content "Subject"
+      expect(page).to have_content "Mentor"
+      expect(page).to have_content "Start date"
+      expect(page).to have_content "Status"
+    end
+  end
+end

--- a/spec/system/placements/schools/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/schools/placements/view_placements_list_spec.rb
@@ -2,10 +2,17 @@ require "rails_helper"
 
 RSpec.describe "Placement school user views a list of placements", type: :system, service: :placements do
   let!(:school) { create(:placements_school) }
+  let!(:another_school) { create(:placements_school) }
 
   scenario "View school placements page where school has no placements" do
     given_i_sign_in_as_anne
     then_i_see_the_placements_page
+    then_i_see_the_empty_state
+  end
+
+  scenario "where placements for another school exists" do
+    given_placement_exists_for_another_school
+    given_i_sign_in_as_anne
     then_i_see_the_empty_state
   end
 
@@ -106,6 +113,10 @@ RSpec.describe "Placement school user views a list of placements", type: :system
     maths = create(:subject, name: "Maths")
     subjects = [maths, biology]
     create(:placement, status: "draft", school:, mentors:, subjects:)
+  end
+
+  def given_placement_exists_for_another_school
+    create(:placement, school: another_school)
   end
 
   def and_i_see_published_status_tag

--- a/spec/system/placements/schools/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/schools/placements/view_placements_list_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe "Placement school user views a list of placements", type: :system
       given_i_sign_in_as_anne
       then_i_see_published_status_tag
     end
+
+    scenario "where placement has no mentors attached" do
+      given_a_published_placement_exists
+      given_i_sign_in_as_anne
+      then_i_see_mentor_names("Not entered")
+    end
   end
 
   private


### PR DESCRIPTION
## Context

School users should see a list of placements.

## Changes proposed in this pull request

- Default schools users to the placements index page after sign in
- Index view of placements for school users

## Guidance to review

Create some placements. Some with one mentor, some with more than one, some with multiple subjects, etc
Navigate to the placements page
You should see them listed there


## Link to Trello card
https://trello.com/c/vv3azfsy


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<img width="899" alt="image" src="https://github.com/DFE-Digital/itt-mentor-services/assets/44073106/644289b3-15d1-4ae5-941c-1179bd46f88d">

