### PR TITLE
Jc/publish api to create sync subjects

### DIFF
--- a/app/jobs/publish_teacher_training/subject/sync_all_job.rb
+++ b/app/jobs/publish_teacher_training/subject/sync_all_job.rb
@@ -1,0 +1,11 @@
+module PublishTeacherTraining
+  module Subject
+    class SyncAllJob < ApplicationJob
+      queue_as :default
+
+      def perform
+        PublishTeacherTraining::Subject::Import.call
+      end
+    end
+  end
+end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -13,5 +13,9 @@ class Subject < ApplicationRecord
   has_many :placement_subject_joins
   has_many :placements, through: :placement_subject_joins
 
+  enum :subject_area,
+       { primary: "primary", secondary: "secondary" },
+       validate: true
+
   validates :subject_area, :name, presence: true
 end

--- a/app/services/publish_teacher_training/subject/api.rb
+++ b/app/services/publish_teacher_training/subject/api.rb
@@ -1,0 +1,18 @@
+module PublishTeacherTraining
+  module Subject
+    class Api
+      include ServicePattern
+
+      def call
+        response = HTTParty.get(link)
+        JSON.parse(response.to_s)
+      end
+
+      private
+
+      def link
+        "#{ENV["PUBLISH_BASE_URL"]}/api/public/v1/subject_areas?include=subjects"
+      end
+    end
+  end
+end

--- a/app/services/publish_teacher_training/subject/import.rb
+++ b/app/services/publish_teacher_training/subject/import.rb
@@ -1,0 +1,72 @@
+module PublishTeacherTraining
+  module Subject
+    class Import
+      include ServicePattern
+
+      PRIMARY_IDS = %w[PrimarySubject].freeze
+      SECONDARY_IDS = %w[SecondarySubject ModernLanguagesSubject].freeze
+
+      def call
+        fetch_subject
+      end
+
+      private
+
+      def fetch_subject
+        api_response = PublishTeacherTraining::Subject::Api.call
+        data = api_response.fetch("data")
+        # Find Primary Subjects IDs
+        primary_subject_ids = fetch_subject_ids(subject_area_ids: PRIMARY_IDS, data:)
+        secondary_subject_ids = fetch_subject_ids(subject_area_ids: SECONDARY_IDS, data:)
+
+        subjects_data = api_response.fetch("included")
+        # Sync Primary Subjects
+        sync_subjects(
+          subject_area: "primary",
+          subject_ids: primary_subject_ids,
+          subjects_data:,
+        )
+
+        # Sync Secondary Subjects
+        sync_subjects(
+          subject_area: "secondary",
+          subject_ids: secondary_subject_ids,
+          subjects_data:,
+        )
+      end
+
+      def sync_subjects(subject_area:, subject_ids:, subjects_data:)
+        subject_area_subjects_data = subjects_data.select do |subject|
+          subject_ids.include?(subject["id"])
+        end
+        subject_area_subjects_data.each do |subject_data|
+          subject_attributes = subject_data.fetch("attributes")
+          begin
+            ::Subject.find_or_create_by!(
+              subject_area:,
+              name: subject_attributes.fetch("name"),
+              code: subject_attributes.fetch("code"),
+            )
+          rescue ActiveRecord::RecordInvalid => e
+            Sentry.capture_exception(e)
+          end
+        end
+      end
+
+      def fetch_subject_ids(subject_area_ids:, data:)
+        subject_ids = []
+
+        subject_areas = data.select do |subject_area_data|
+          subject_area_ids.include?(subject_area_data.fetch("id"))
+        end
+        subject_areas.each do |subject_area|
+          subject_area.dig("relationships", "subjects", "data").each do |subject_data|
+            subject_ids << subject_data["id"]
+          end
+        end
+
+        subject_ids
+      end
+    end
+  end
+end

--- a/config/scheduled_jobs.yml
+++ b/config/scheduled_jobs.yml
@@ -7,6 +7,11 @@
 #   class: NameOfAJob
 #   description: Description is shown in the GoodJob dashboard.
 teaching_record_mentor_sync:
-  cron: "0 0 * * *"
+  cron: "5 0 * * *"
   class: "TeachingRecord::SyncAllMentorsJob"
   description: "Sync all mentor first and last name attributes"
+
+publish_subject_sync:
+  cron: "0 0 * * *"
+  class: "PublishTeacherTraining::Subject::SyncAllJob"
+  description: "Sync all subjects with data imported from Publish Teacher Training"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -91,13 +91,15 @@ mentors = Mentor.where(trn: %w[1234567 1212121 1313131])
 end
 
 # Create subjects
-# TODO: this method will be created with actual subject data after the Publish Api data is integrated
-Subject.upsert_all([{ subject_area: "primary", name: "Primary with English", code: "01" },
-                    { subject_area: "primary", name: "Primary with geography and history", code: "02" },
-                    { subject_area: "secondary", name: "Biology", code: "C1" },
-                    { subject_area: "secondary", name: "Classics", code: "Q8" }])
+PublishTeacherTraining::Subject::Import.call
 
 # Create placements
-placement = Placement.create!(school: Placements::School.first, start_date: 1.month.from_now, end_date: 2.months.from_now)
-PlacementSubjectJoin.create!(placement:, subject: Subject.first)
-PlacementMentorJoin.create!(placement:, mentor: Placements::Mentor.first)
+Placements::School.find_each do |school|
+  next if school.placements.any?
+
+  placement = Placement.create!(school:, start_date: 1.month.from_now, end_date: 2.months.from_now)
+
+  subject = school.phase == "Primary" ? Subject.primary.first : Subject.secondary.first
+  PlacementSubjectJoin.create!(placement:, subject:)
+  PlacementMentorJoin.create!(placement:, mentor: Placements::Mentor.first)
+end

--- a/lib/tasks/subject_data.rake
+++ b/lib/tasks/subject_data.rake
@@ -1,0 +1,6 @@
+namespace :subject_data do
+  desc "Import all Subjects from Publish Teacher Training"
+  task import: :environment do
+    PublishTeacherTraining::Subject::Import.call
+  end
+end

--- a/spec/factories/subject.rb
+++ b/spec/factories/subject.rb
@@ -2,5 +2,14 @@ FactoryBot.define do
   factory :subject do
     subject_area { %w[primary secondary].sample }
     name { Faker::Educator.subject }
+    code { Faker::String.random(length: 2) }
+  end
+
+  trait :primary do
+    subject_area { "primary" }
+  end
+
+  trait :secondary do
+    subject_area { "secondary" }
   end
 end

--- a/spec/jobs/publish_teacher_training/subject/sync_all_job_spec.rb
+++ b/spec/jobs/publish_teacher_training/subject/sync_all_job_spec.rb
@@ -1,0 +1,225 @@
+require "rails_helper"
+
+RSpec.describe PublishTeacherTraining::Subject::SyncAllJob, type: :job do
+  describe "#perform" do
+    context "when the response contains only valid subject data" do
+      before do
+        success_stub_request
+      end
+
+      it "creates a subject record per Subject returned by the Publish API" do
+        expect { described_class.perform_now }.to change(Subject.primary, :count)
+        .by(2).and change(
+          Subject.secondary, :count
+        ).by(3)
+
+        expect(Subject.primary.pluck(:name)).to match_array([
+          "Primary", "Primary with English"
+        ])
+
+        expect(Subject.secondary.pluck(:name)).to match_array([
+          "Art and design", "Science", "French"
+        ])
+      end
+
+      context "when a subject already exists" do
+        it "only creates a subject for each not pre-existing subject" do
+          create(:subject, :primary, name: "Primary", code: "00")
+
+          expect {
+            described_class.perform_now
+          }.to change(Subject, :count).by(4)
+        end
+      end
+    end
+
+    context "when the response contains an invalid subject data" do
+      before do
+        failure_stub_request
+      end
+
+      it "only creates a the valid subject" do
+        allow(Sentry).to receive(:capture_exception)
+
+        expect { described_class.perform_now }.to change(Subject.primary, :count).by(1)
+
+        expect(Subject.primary.pluck(:name)).to contain_exactly("Primary with English")
+        expect(Sentry).to have_received(:capture_exception)
+      end
+    end
+  end
+
+  def success_stub_request
+    stub_request(
+      :get,
+      "https://www.publish-teacher-training-courses.service.gov.uk/api/public/v1/subject_areas?include=subjects",
+    ).to_return(
+      status: 200,
+      body: response_body.to_json,
+    )
+  end
+
+  def failure_stub_request
+    stub_request(
+      :get,
+      "https://www.publish-teacher-training-courses.service.gov.uk/api/public/v1/subject_areas?include=subjects",
+    ).to_return(
+      status: 200,
+      body: invalid_response_body.to_json,
+    )
+  end
+
+  def invalid_response_body
+    {
+      "data" => [
+        {
+          "id" => "PrimarySubject",
+          "relationships" => {
+            "subjects" => {
+              "data" => [
+                {
+                  "type" => "subjects",
+                  "id" => "1",
+                },
+                {
+                  "type" => "subjects",
+                  "id" => "2",
+                },
+              ],
+            },
+          },
+        },
+      ],
+      "included" => [
+        {
+          "id" => "1",
+          "attributes" => {
+            "name" => "",
+            "code" => "00",
+          },
+        },
+        {
+          "id" => "2",
+          "attributes" => {
+            "name" => "Primary with English",
+            "code" => "01",
+          },
+        },
+      ],
+    }
+  end
+
+  def response_body
+    {
+      "data" => [
+        {
+          "id" => "PrimarySubject",
+          "relationships" => {
+            "subjects" => {
+              "data" => [
+                {
+                  "type" => "subjects",
+                  "id" => "1",
+                },
+                {
+                  "type" => "subjects",
+                  "id" => "2",
+                },
+              ],
+            },
+          },
+        },
+        {
+          "id" => "SecondarySubject",
+          "relationships" => {
+            "subjects" => {
+              "data" => [
+                {
+                  "type" => "subjects",
+                  "id" => "3",
+                },
+                {
+                  "type" => "subjects",
+                  "id" => "4",
+                },
+              ],
+            },
+          },
+        },
+        {
+          "id" => "ModernLanguagesSubject",
+          "relationships" => {
+            "subjects" => {
+              "data" => [
+                {
+                  "type" => "subjects",
+                  "id" => "5",
+                },
+              ],
+            },
+          },
+        },
+        {
+          # FurtherEducationSubject is not a valid subject area
+          "id" => "FurtherEducationSubject",
+          "relationships" => {
+            "subjects" => {
+              "data" => [
+                {
+                  "type" => "subjects",
+                  "id" => "6",
+                },
+              ],
+            },
+          },
+        },
+      ],
+      "included" => [
+        {
+          "id" => "1",
+          "attributes" => {
+            "name" => "Primary",
+            "code" => "00",
+          },
+        },
+        {
+          "id" => "2",
+          "attributes" => {
+            "name" => "Primary with English",
+            "code" => "01",
+          },
+        },
+        {
+          "id" => "3",
+          "attributes" => {
+            "name" => "Art and design",
+            "code" => "W1",
+          },
+        },
+        {
+          "id" => "4",
+          "type" => "subjects",
+          "attributes" => {
+            "name" => "Science",
+            "code" => "F0",
+          },
+        },
+        {
+          "id" => "5",
+          "attributes" => {
+            "name" => "French",
+            "code" => "15",
+          },
+        },
+        {
+          # Further education is not a valid subject
+          "id" => "6",
+          "attributes" => {
+            "name" => "Further education",
+            "code" => "41",
+          },
+        },
+      ],
+    }
+  end
+end

--- a/spec/services/publish_teacher_training/subject/api_spec.rb
+++ b/spec/services/publish_teacher_training/subject/api_spec.rb
@@ -1,0 +1,115 @@
+require "rails_helper"
+
+RSpec.describe PublishTeacherTraining::Subject::Api do
+  before do
+    success_stub_request
+  end
+
+  describe ".call" do
+    it "returns the API data from the Publish Subject Area endpoint" do
+      expect(described_class.call).to eq(response_body)
+    end
+  end
+
+  def success_stub_request
+    stub_request(
+      :get,
+      "https://www.publish-teacher-training-courses.service.gov.uk/api/public/v1/subject_areas?include=subjects",
+    ).to_return(
+      status: 200,
+      body: response_body.to_json,
+    )
+  end
+
+  def response_body
+    {
+      "data" => [
+        {
+          "id" => "PrimarySubject",
+          "relationships" => {
+            "subjects" => {
+              "data" => [
+                {
+                  "type" => "subjects",
+                  "id" => "1",
+                },
+                {
+                  "type" => "subjects",
+                  "id" => "2",
+                },
+              ],
+            },
+          },
+        },
+        {
+          "id" => "SecondarySubject",
+          "relationships" => {
+            "subjects" => {
+              "data" => [
+                {
+                  "type" => "subjects",
+                  "id" => "3",
+                },
+                {
+                  "type" => "subjects",
+                  "id" => "4",
+                },
+              ],
+            },
+          },
+        },
+        {
+          "id" => "ModernLanguagesSubject",
+          "relationships" => {
+            "subjects" => {
+              "data" => [
+                {
+                  "type" => "subjects",
+                  "id" => "5",
+                },
+              ],
+            },
+          },
+        },
+      ],
+      "included" => [
+        {
+          "id" => "1",
+          "attributes" => {
+            "name" => "Primary",
+            "code" => "00",
+          },
+        },
+        {
+          "id" => "2",
+          "attributes" => {
+            "name" => "Primary with English",
+            "code" => "01",
+          },
+        },
+        {
+          "id" => "3",
+          "attributes" => {
+            "name" => "Art and design",
+            "code" => "W1",
+          },
+        },
+        {
+          "id" => "4",
+          "type" => "subjects",
+          "attributes" => {
+            "name" => "Science",
+            "code" => "F0",
+          },
+        },
+        {
+          "id" => "5",
+          "attributes" => {
+            "name" => "French",
+            "code" => "15",
+          },
+        },
+      ],
+    }
+  end
+end

--- a/spec/services/publish_teacher_training/subject/import_spec.rb
+++ b/spec/services/publish_teacher_training/subject/import_spec.rb
@@ -1,0 +1,229 @@
+require "rails_helper"
+
+RSpec.describe PublishTeacherTraining::Subject::Import do
+  include ActiveJob::TestHelper
+
+  before do
+    success_stub_request
+  end
+
+  describe ".call" do
+    context "when the response contains only valid subject data" do
+      it "runs a PublishTeacherTraining::Subject::SyncJob per API response,
+        creating a subject for each valid subject in the API" do
+        expect {
+          described_class.call
+        }.to change(Subject.primary, :count).by(2).and change(
+          Subject.secondary, :count
+        ).by(3)
+
+        expect(Subject.primary.pluck(:name)).to match_array([
+          "Primary", "Primary with English"
+        ])
+
+        expect(Subject.secondary.pluck(:name)).to match_array([
+          "Art and design", "Science", "French"
+        ])
+      end
+
+      context "when a subject already exists" do
+        it "only creates a subject for each not pre-existing subject" do
+          create(:subject, :primary, name: "Primary", code: "00")
+
+          expect {
+            described_class.call
+          }.to change(Subject, :count).by(4)
+        end
+      end
+    end
+
+    context "when the response contains an invalid subject data" do
+      before do
+        failure_stub_request
+      end
+
+      it "only creates a the valid subject" do
+        allow(Sentry).to receive(:capture_exception)
+
+        expect { described_class.call }.to change(Subject.primary, :count).by(1)
+
+        expect(Subject.primary.pluck(:name)).to contain_exactly("Primary with English")
+        expect(Sentry).to have_received(:capture_exception)
+      end
+    end
+  end
+
+  def success_stub_request
+    stub_request(
+      :get,
+      "https://www.publish-teacher-training-courses.service.gov.uk/api/public/v1/subject_areas?include=subjects",
+    ).to_return(
+      status: 200,
+      body: response_body.to_json,
+    )
+  end
+
+  def failure_stub_request
+    stub_request(
+      :get,
+      "https://www.publish-teacher-training-courses.service.gov.uk/api/public/v1/subject_areas?include=subjects",
+    ).to_return(
+      status: 200,
+      body: invalid_response_body.to_json,
+    )
+  end
+
+  def invalid_response_body
+    {
+      "data" => [
+        {
+          "id" => "PrimarySubject",
+          "relationships" => {
+            "subjects" => {
+              "data" => [
+                {
+                  "type" => "subjects",
+                  "id" => "1",
+                },
+                {
+                  "type" => "subjects",
+                  "id" => "2",
+                },
+              ],
+            },
+          },
+        },
+      ],
+      "included" => [
+        {
+          "id" => "1",
+          "attributes" => {
+            "name" => "",
+            "code" => "00",
+          },
+        },
+        {
+          "id" => "2",
+          "attributes" => {
+            "name" => "Primary with English",
+            "code" => "01",
+          },
+        },
+      ],
+    }
+  end
+
+  def response_body
+    {
+      "data" => [
+        {
+          "id" => "PrimarySubject",
+          "relationships" => {
+            "subjects" => {
+              "data" => [
+                {
+                  "type" => "subjects",
+                  "id" => "1",
+                },
+                {
+                  "type" => "subjects",
+                  "id" => "2",
+                },
+              ],
+            },
+          },
+        },
+        {
+          "id" => "SecondarySubject",
+          "relationships" => {
+            "subjects" => {
+              "data" => [
+                {
+                  "type" => "subjects",
+                  "id" => "3",
+                },
+                {
+                  "type" => "subjects",
+                  "id" => "4",
+                },
+              ],
+            },
+          },
+        },
+        {
+          "id" => "ModernLanguagesSubject",
+          "relationships" => {
+            "subjects" => {
+              "data" => [
+                {
+                  "type" => "subjects",
+                  "id" => "5",
+                },
+              ],
+            },
+          },
+        },
+        {
+          # FurtherEducationSubject is not a valid subject area
+          "id" => "FurtherEducationSubject",
+          "relationships" => {
+            "subjects" => {
+              "data" => [
+                {
+                  "type" => "subjects",
+                  "id" => "6",
+                },
+              ],
+            },
+          },
+        },
+      ],
+      "included" => [
+        {
+          "id" => "1",
+          "attributes" => {
+            "name" => "Primary",
+            "code" => "00",
+          },
+        },
+        {
+          "id" => "2",
+          "attributes" => {
+            "name" => "Primary with English",
+            "code" => "01",
+          },
+        },
+        {
+          "id" => "3",
+          "attributes" => {
+            "name" => "Art and design",
+            "code" => "W1",
+          },
+        },
+        {
+          "id" => "4",
+          "type" => "subjects",
+          "attributes" => {
+            "name" => "Science",
+            "code" => "F0",
+          },
+        },
+        {
+          "id" => "5",
+          "attributes" => {
+            "name" => "French",
+            "code" => "15",
+          },
+        },
+        {
+          # Further education is not a valid subject
+          "id" => "6",
+          "attributes" => {
+            "name" => "Further education",
+            "code" => "41",
+          },
+        },
+      ],
+    }
+  end
+end

--- a/spec/tasks/subject_data_spec.rb
+++ b/spec/tasks/subject_data_spec.rb
@@ -1,0 +1,145 @@
+require "rails_helper"
+require "rake"
+
+describe "subject_data" do
+  Rails.application.load_tasks if Rake::Task.tasks.empty?
+
+  describe "import" do
+    subject(:import) { Rake::Task["subject_data:import"].invoke }
+
+    before do
+      success_stub_request
+    end
+
+    it "runs the PublishTeacherTraining::Subject::Import service, creating a subject
+      per valid subject in the Publish API" do
+      expect { import }.to change(Subject.primary, :count).by(2).and change(
+        Subject.secondary, :count
+      ).by(3)
+    end
+  end
+
+  def success_stub_request
+    stub_request(
+      :get,
+      "https://www.publish-teacher-training-courses.service.gov.uk/api/public/v1/subject_areas?include=subjects",
+    ).to_return(
+      status: 200,
+      body: response_body.to_json,
+    )
+  end
+
+  def response_body
+    {
+      "data" => [
+        {
+          "id" => "PrimarySubject",
+          "relationships" => {
+            "subjects" => {
+              "data" => [
+                {
+                  "type" => "subjects",
+                  "id" => "1",
+                },
+                {
+                  "type" => "subjects",
+                  "id" => "2",
+                },
+              ],
+            },
+          },
+        },
+        {
+          "id" => "SecondarySubject",
+          "relationships" => {
+            "subjects" => {
+              "data" => [
+                {
+                  "type" => "subjects",
+                  "id" => "3",
+                },
+                {
+                  "type" => "subjects",
+                  "id" => "4",
+                },
+              ],
+            },
+          },
+        },
+        {
+          "id" => "ModernLanguagesSubject",
+          "relationships" => {
+            "subjects" => {
+              "data" => [
+                {
+                  "type" => "subjects",
+                  "id" => "5",
+                },
+              ],
+            },
+          },
+        },
+        {
+          # FurtherEducationSubject is not a valid subject area
+          "id" => "FurtherEducationSubject",
+          "relationships" => {
+            "subjects" => {
+              "data" => [
+                {
+                  "type" => "subjects",
+                  "id" => "6",
+                },
+              ],
+            },
+          },
+        },
+      ],
+      "included" => [
+        {
+          "id" => "1",
+          "attributes" => {
+            "name" => "Primary",
+            "code" => "00",
+          },
+        },
+        {
+          "id" => "2",
+          "attributes" => {
+            "name" => "Primary with English",
+            "code" => "01",
+          },
+        },
+        {
+          "id" => "3",
+          "attributes" => {
+            "name" => "Art and design",
+            "code" => "W1",
+          },
+        },
+        {
+          "id" => "4",
+          "type" => "subjects",
+          "attributes" => {
+            "name" => "Science",
+            "code" => "F0",
+          },
+        },
+        {
+          "id" => "5",
+          "attributes" => {
+            "name" => "French",
+            "code" => "15",
+          },
+        },
+        {
+          # Further education is not a valid subject
+          "id" => "6",
+          "attributes" => {
+            "name" => "Further education",
+            "code" => "41",
+          },
+        },
+      ],
+    }
+  end
+end


### PR DESCRIPTION
## Context

- Add jobs and rake tasks to add/sync subjects with the list provided by the Publish Teacher Training API

## Changes proposed in this pull request

- Add jobs to sync subjects with the list provided by the Publish Teacher Training API
- Add rake task to sync subjects with the list provided by the Publish Teacher Training API
- Improved Seed data to add subjects to depict actual data from Publish Teacher Training API

## Guidance to review

(Start each check with no subjects in your database)
(Once each check is run you should have (45 Subject (Primary: 7, Secondary: 38)))

- To check the rake task run `bundle exec rake subject_data:import`
- To check the job:
  - Sign in as Colin
  - visit http://placements.localhost:3000/good_job/cron_entries?locale=en
  - Run the `publish_subject_sync` job (>>|)
- To check the seeds run `bundle exec rake db:setup`
  - As well as the 45 Subjects, you should also have 3 Placements
 
## Link to Trello card

https://trello.com/c/Tmr1x5Uo/143-use-publish-api-to-create-sync-subjects-for-placements
