### PR TITLE
Fix placements routing typo

### DIFF
--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -21,7 +21,7 @@ scope module: :placements,
       collection { get :select_type }
     end
 
-    resources :schools, expect: %i[edit update show] do
+    resources :schools, except: %i[edit update] do
       collection do
         get :check
         get :check_school_option
@@ -41,7 +41,7 @@ scope module: :placements,
       end
     end
 
-    resources :providers, expect: %i[edit update show] do
+    resources :providers, except: %i[edit update] do
       collection do
         get :check
         get :check_provider_option


### PR DESCRIPTION
## Context

Whilst running `rails routes`, I saw some routes that jumped out with an `expect` constraint.

## Changes proposed in this pull request

- Fix typo from `expect` to `except`.

## Guidance to review

- Tests pass.
- Correct routes are added.