### PR TITLE
Add Page Footer Content

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,6 @@
 $govuk-global-styles: true;
 $govuk-new-link-styles: true;
+$govuk-new-typography-scale: true;
 $govuk-assets-path: "";
 
 @import "govuk-frontend/dist/govuk/all";

--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -1,8 +1,8 @@
-@import "header";
+@import "autocomplete";
 @import "content_header";
+@import "header";
+@import "link";
 @import "organisation_list_item";
+@import "phase_banner";
 @import "primary_navigation";
 @import "secondary_navigation";
-@import "autocomplete";
-@import "phase_banner";
-@import "link";

--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -1,5 +1,6 @@
 @import "autocomplete";
 @import "content_header";
+@import "footer";
 @import "header";
 @import "link";
 @import "organisation_list_item";

--- a/app/assets/stylesheets/components/_content_header.scss
+++ b/app/assets/stylesheets/components/_content_header.scss
@@ -1,5 +1,6 @@
 .content-header {
   margin-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(2);
 
   @include govuk-media-query($from: tablet) {
     display: flex;

--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -1,0 +1,3 @@
+.govuk-footer__inline-list {
+  margin-bottom: 0;
+}

--- a/app/components/content_header_component.html.erb
+++ b/app/components/content_header_component.html.erb
@@ -1,9 +1,10 @@
 <div class="content-header">
   <div class="content-header-title">
-    <h4 class="govuk-heading-s govuk-heading-s govuk-!-margin-bottom-1">
+    <h4 class="govuk-heading-s govuk-heading-s govuk-!-margin-bottom-0">
      <%= title %>
     </h4>
   </div>
+
   <div class="content-header-actions">
     <% actions.each do |action| %>
       <%= action %>

--- a/app/components/footer_component.html.erb
+++ b/app/components/footer_component.html.erb
@@ -1,0 +1,56 @@
+<%= tag.footer(role: "contentinfo", **html_attributes) do %>
+  <%= tag.div(**container_html_attributes) do %>
+    <% if navigation.present? %>
+      <div class="<%= brand %>-footer__navigation">
+        <%= navigation %>
+      </div>
+
+      <%= tag.hr(class: "#{brand}-footer__section-break") %>
+    <% end %>
+
+    <%= tag.div(class: meta_classes, **meta_html_attributes) do %>
+      <% if meta.present? %>
+        <%= meta %>
+      <% else %>
+        <div class="<%= brand %>-footer__meta-item <%= brand %>-footer__meta-item--grow">
+          <% if meta_pre_content.present? %>
+            <div class="<%= brand %>-footer__meta-custom">
+              <%= meta_pre_content %>
+            </div>
+          <% end %>
+
+          <% if meta_items.any? %>
+            <h2 class="<%= brand %>-visually-hidden"><%= meta_items_title %></h2>
+
+            <ul class="<%= brand %>-footer__inline-list">
+
+              <% @meta_items.each do |item| %>
+                <li class="<%= brand %>-footer__inline-list-item">
+                  <%= govuk_footer_link_to(item[:text], item[:href]) %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+
+          <% if meta_content.present? %>
+            <div class="<%= brand %>-footer__meta-custom">
+              <%= meta_content %>
+            </div>
+          <% end %>
+
+          <% if meta_licence.nil? %>
+            <svg aria-hidden="true" focusable="false" class="<%= brand %>-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+              <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+            </svg>
+
+            <%= tag.span(default_licence, class: "#{brand}-footer__licence-description") %>
+          <% elsif meta_licence.present? %>
+            <%= tag.span(meta_licence, class: "#{brand}-footer__licence-description") %>
+          <% end %>
+        </div>
+
+        <%= tag.div(copyright, class: "#{brand}-footer__meta-item") %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/footer_component.rb
+++ b/app/components/footer_component.rb
@@ -1,0 +1,20 @@
+class FooterComponent < GovukComponent::FooterComponent
+  renders_one :meta_pre_content
+
+  private
+
+  def build_meta_links(links)
+    return [] if links.blank?
+
+    case links
+    when Array
+      links
+    when Hash
+      links.map do |text, href|
+        { text:, href: }
+      end
+    else
+      raise ArgumentError, "meta links must be a hash or array of hashes"
+    end
+  end
+end

--- a/app/helpers/footer_helper.rb
+++ b/app/helpers/footer_helper.rb
@@ -1,0 +1,11 @@
+module FooterHelper
+  def footer_meta_items
+    [
+      { text: t(".guidance"), href: "#" },
+      { text: t(".accessibility"), href: "#" },
+      { text: t(".cookies"), href: "#" },
+      { text: t(".privacy_policy"), href: "#" },
+      { text: t(".terms_and_conditions"), href: "#" },
+    ]
+  end
+end

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,0 +1,19 @@
+<%= render FooterComponent.new meta_items: footer_meta_items, meta_licence: false do |footer| %>
+  <% footer.with_meta_pre_content do %>
+    <h2 class="govuk-heading-m"><%= t(".get_help") %></h2>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h3 class="govuk-heading-3 govuk-!-margin-top-0 govuk-!-margin-bottom-1"><%= t(".email.heading") %></h3>
+
+        <p class="govuk-!-font-size-16 govuk-!-margin-bottom-1">
+          <%= govuk_footer_link_to t("#{current_service}.support_email"), "mailto:#{t("#{current_service}.support_email")}?subject=#{t("#{current_service}.service_name")}%20support" %>
+        </p>
+
+        <p class="govuk-!-font-size-16">
+          <%= t(".email.disclaimer") %>
+        </p>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -62,6 +62,6 @@
       <%= yield %>
     </main>
 
-    <%= govuk_footer %>
+    <%= render "layouts/footer" %>
   </body>
 </html>

--- a/config/locales/en/layouts/footer.yml
+++ b/config/locales/en/layouts/footer.yml
@@ -1,0 +1,14 @@
+en:
+  layouts:
+    footer:
+      get_help: Get help
+
+      email:
+        heading: Email
+        disclaimer: You'll get a response within 5 working days, or one working day for urgent requests.
+
+      guidance: Guidance
+      accessibility: Accessibility
+      cookies: Cookies
+      privacy_policy: Privacy policy
+      terms_and_conditions: Terms and conditions

--- a/spec/components/footer_component_spec.rb
+++ b/spec/components/footer_component_spec.rb
@@ -1,0 +1,101 @@
+require "rails_helper"
+
+RSpec.describe FooterComponent, type: :component do
+  it "renders the OGL licence by default" do
+    render_inline described_class.new
+
+    expect(page).to have_content("Open Government Licence v3.0")
+  end
+
+  context "when the OGL licence is disabled" do
+    it "does not render the OGL licence" do
+      render_inline described_class.new(meta_licence: false)
+
+      expect(page).not_to have_content("Open Government Licence v3.0")
+    end
+  end
+
+  context "when provided with meta_items" do
+    it "renders a list of links" do
+      meta_items = [
+        { text: "GOV.UK", href: "https://gov.uk" },
+        { text: "Guidance", href: "#guidance" },
+      ]
+
+      render_inline described_class.new(meta_items:)
+
+      expect(page).to have_link("GOV.UK", href: "https://gov.uk")
+      expect(page).to have_link("Guidance", href: "#guidance")
+    end
+  end
+
+  context "when provided with a meta_pre_content" do
+    it "renders the provided content before the licence and meta items" do
+      meta_items = [
+        { text: "GOV.UK", href: "https://gov.uk" },
+      ]
+
+      render_inline described_class.new(meta_items:) do |component|
+        component.with_meta_pre_content do
+          "This is the pre content"
+        end
+      end
+
+      earlier_content = "This is the pre content"
+      later_content = "GOV.UK"
+
+      expect(page.native.to_html).to match(/#{earlier_content}.*#{later_content}/m)
+
+      earlier_content = "This is the pre content"
+      later_content = "Open Government Licence v3.0"
+
+      expect(page.native.to_html).to match(/#{earlier_content}.*#{later_content}/m)
+    end
+  end
+
+  context "when provided with meta_html" do
+    it "renders the provided content after the meta items and before the licence" do
+      meta_items = [
+        { text: "GOV.UK", href: "https://gov.uk" },
+      ]
+
+      render_inline described_class.new(meta_items:) do |component|
+        component.with_meta_html do
+          "This is the meta content"
+        end
+      end
+
+      earlier_content = "GOV.UK"
+      later_content = "This is the meta content"
+
+      expect(page.native.to_html).to match(/#{earlier_content}.*#{later_content}/m)
+
+      earlier_content = "This is the meta content"
+      later_content = "Open Government Licence v3.0"
+
+      expect(page.native.to_html).to match(/#{earlier_content}.*#{later_content}/m)
+    end
+  end
+
+  describe "#build_meta_links" do
+    subject(:footer_component) { described_class.new }
+
+    it "returns the original array when recieving an array" do
+      meta_items = [{ text: "GOV.UK", href: "https://gov.uk" }]
+
+      expect(footer_component.send(:build_meta_links, meta_items)).to eq(meta_items)
+    end
+
+    it "converts a hash into array of hashes" do
+      meta_items = { "GOV.UK" => "https://gov.uk" }
+
+      expect(footer_component.send(:build_meta_links, meta_items)).to eq([{ text: "GOV.UK", href: "https://gov.uk" }])
+    end
+
+    it "raises an error when provided with a non-Hash, non-Array value" do
+      meta_items = "GOV.UK"
+
+      expect { footer_component.send(:build_meta_links, meta_items) }.to raise_error ArgumentError, "meta links must be a hash or array of hashes"
+    end
+  end
+end

--- a/spec/components/previews/application_component_preview.rb
+++ b/spec/components/previews/application_component_preview.rb
@@ -1,4 +1,5 @@
 require "factory_bot"
 
 class ApplicationComponentPreview < ViewComponent::Preview
+  include Rails.application.routes.url_helpers
 end

--- a/spec/components/previews/footer_component_preview.rb
+++ b/spec/components/previews/footer_component_preview.rb
@@ -1,0 +1,49 @@
+class FooterComponentPreview < ApplicationComponentPreview
+  def as_used_in_the_application
+    render FooterComponent.new(meta_items:, meta_licence: false) do |footer|
+      footer.with_meta_html do
+        "Meta content"
+      end
+    end
+  end
+
+  def default
+    render FooterComponent.new
+  end
+
+  def with_meta_content
+    render FooterComponent.new do |footer|
+      footer.with_meta_html do
+        "Meta content"
+      end
+    end
+  end
+
+  def with_meta_items
+    render FooterComponent.new(meta_items:)
+  end
+
+  def with_meta_pre_content
+    render FooterComponent.new do |footer|
+      footer.with_meta_pre_content do
+        "Meta pre content"
+      end
+    end
+  end
+
+  def without_meta_licence
+    render FooterComponent.new(meta_licence: false)
+  end
+
+  private
+
+  def meta_items
+    [
+      { text: "Guidance", href: "#guidance" },
+      { text: "Accessibility", href: "#accessibility" },
+      { text: "Cookies", href: "#cookies" },
+      { text: "Privacy Policy", href: "#privacy_policy" },
+      { text: "Terms and Conditions", href: "#terms_and_conditions" },
+    ]
+  end
+end


### PR DESCRIPTION
## Context

We want to show "help" information and useful links.

## Changes proposed in this pull request

- Add a custom `FooterComponent` that extends the `GovukComponent::FooterComponent` to add a `meta_pre_content` slot.
  - The component html template is copied over directly from the component library. This means we will not receive automatic updates to this component's layout moving forward.
  - I will reach out to Peter Yates to query whether we could add this additional slot in officially or not.
- Update the Footer content.

## Guidance to review

- View the review app.
- See the new footer content.
- The customised Footer component is copied from the `GovukComponent::FooterComponent`.
  - [build_meta_links](https://github.com/x-govuk/govuk-components/blob/main/app/components/govuk_component/footer_component.rb#L65) is overridden to avoid calling view helpers within the `#initialize` method.
  - The `footer_component.html.erb` is taken from https://github.com/x-govuk/govuk-components/blob/main/app/components/govuk_component/footer_component.html.erb with `meta_pre_content` added and `@meta_links` calling `govuk_footer_link_to` instead of rendering themselves as url helper components.

## Screenshots

![CleanShot 2024-02-26 at 13 48 45](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/1ef9a77b-5cab-491d-bd0d-7410251deb6f)

