### PR TITLE
As a Support User, I want to add a Mentor to a School

### DIFF
--- a/app/controllers/claims/support/schools/mentors_controller.rb
+++ b/app/controllers/claims/support/schools/mentors_controller.rb
@@ -4,8 +4,24 @@ class Claims::Support::Schools::MentorsController < Claims::Support::Application
   before_action :set_mentor, only: %i[show remove destroy]
   before_action :authorize_mentor
 
+  helper_method :mentor_form
+
   def index
     @pagy, @mentors = pagy(@school.mentors.order(:first_name, :last_name))
+  end
+
+  def new; end
+
+  def create
+    mentor_form.save!
+
+    redirect_to claims_support_school_mentors_path(@school), flash: { success: t(".success") }
+  end
+
+  def check
+    render :new unless mentor_form.valid?
+  rescue TeachingRecord::RestClient::TeacherNotFoundError
+    render :no_results
   end
 
   def show; end
@@ -27,5 +43,24 @@ class Claims::Support::Schools::MentorsController < Claims::Support::Application
 
   def authorize_mentor
     authorize @mentor || Claims::Mentor
+  end
+
+  def default_params
+    { school: @school }
+  end
+
+  def mentor_params
+    params.require(:claims_mentor_form)
+          .permit(:first_name, :last_name, :trn)
+          .merge(default_params)
+  end
+
+  def mentor_form
+    @mentor_form ||=
+      if params[:claims_mentor_form].present?
+        Claims::MentorForm.new(mentor_params)
+      else
+        Claims::MentorForm.new(default_params)
+      end
   end
 end

--- a/app/forms/claims/mentor_form.rb
+++ b/app/forms/claims/mentor_form.rb
@@ -1,0 +1,42 @@
+class Claims::MentorForm < ApplicationForm
+  FORM_PARAMS = %i[trn].freeze
+
+  attr_accessor :school, :trn, :first_name, :last_name
+
+  validate :validate_mentor
+  validate :validate_membership
+
+  def persist
+    ActiveRecord::Base.transaction do
+      mentor.save! unless mentor.persisted?
+
+      mentor_membership.save!
+    end
+  end
+
+  def as_form_params
+    { "claims_mentor_form" => slice(FORM_PARAMS) }
+  end
+
+  def mentor
+    @mentor ||= MentorBuilder.call(trn:, first_name:, last_name:).becomes(Claims::Mentor)
+  end
+
+  def validate_mentor
+    if mentor.errors.any?
+      mentor.errors.each { |err| errors.add(:trn, err.message) }
+    end
+  end
+
+  private
+
+  def validate_membership
+    if mentor_membership.invalid?
+      errors.add(:trn, :taken)
+    end
+  end
+
+  def mentor_membership
+    @mentor_membership ||= mentor.mentor_memberships.new(school:)
+  end
+end

--- a/app/views/claims/support/schools/mentors/check.html.erb
+++ b/app/views/claims/support/schools/mentors/check.html.erb
@@ -1,0 +1,47 @@
+<% content_for :page_title, t(".page_title", school_name: @school.name) %>
+<% render "claims/support/primary_navigation", current: :organisations %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: new_claims_support_school_mentor_path(@school, params: mentor_form.as_form_params)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= form_with(model: mentor_form, url: claims_support_school_mentors_path, method: :post) do |f| %>
+        <%= f.hidden_field :first_name, value: mentor_form.mentor.first_name %>
+        <%= f.hidden_field :last_name, value: mentor_form.mentor.last_name %>
+        <%= f.hidden_field :trn, value: mentor_form.trn %>
+
+        <label class="govuk-label govuk-label--l">
+          <span class="govuk-caption-l"><%= t(".add_mentor_with_school_name", school_name: @school.name) %></span>
+          <%= t(".check_your_answers") %>
+        </label>
+
+        <%= govuk_summary_list do |summary_list| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: Mentor.human_attribute_name("first_name")) %>
+            <% row.with_value(text: mentor_form.mentor.first_name) %>
+          <% end %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: Mentor.human_attribute_name("last_name")) %>
+            <% row.with_value(text: mentor_form.mentor.last_name) %>
+          <% end %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".trn")) %>
+            <% row.with_value(text: mentor_form.trn) %>
+            <% row.with_action(text: t(".change"),
+                               href: new_claims_support_school_mentor_path(params: mentor_form.as_form_params),
+                               html_attributes: {
+                                 class: "govuk-link--no-visited-state",
+                               }) %>
+          <% end %>
+        <% end %>
+        <%= f.govuk_submit t(".add_mentor") %>
+        <p class="govuk-body">
+          <%= govuk_link_to(t(".cancel"), claims_support_school_mentors_path(@school), no_visited_state: true) %>
+        </p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/claims/support/schools/mentors/index.html.erb
+++ b/app/views/claims/support/schools/mentors/index.html.erb
@@ -11,6 +11,8 @@
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m"><%= t(".heading") %></h2>
 
+      <%= govuk_button_to(t(".add_mentor"), new_claims_support_school_mentor_path, method: :get) %>
+
       <% if @mentors.any? %>
         <%= govuk_table do |table| %>
           <% table.with_head do |head| %>

--- a/app/views/claims/support/schools/mentors/new.html.erb
+++ b/app/views/claims/support/schools/mentors/new.html.erb
@@ -1,0 +1,34 @@
+<% content_for :page_title, mentor_form.errors.any? ? t(".page_title_with_error", school_name: @school.name) : t(".page_title", school_name: @school.name) %>
+<% render "claims/support/primary_navigation", current: :organisations %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: claims_support_school_mentors_path(@school)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= form_with(model: mentor_form, url: check_claims_support_school_mentors_path, method: "get") do |f| %>
+    <%= f.govuk_error_summary %>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-form-group">
+          <%= f.govuk_text_field :trn, width: "two-thirds", label: -> do %>
+            <span class="govuk-caption-l"><%= t(".add_mentor_with_school_name", school_name: @school.name) %></span>
+            <h2 class="govuk-heading-l"><%= t(".enter_a_trn") %></h2>
+          <% end %>
+        </div>
+
+        <%= govuk_details(summary_text: t(".help_with_the_trn")) do %>
+          <p>
+            <%= t(".guidance_html", guidance_link: govuk_link_to(t(".guidance_link_text"), "https://www.gov.uk/guidance/teacher-reference-number-trn", new_tab: true, no_visited_state: true)) %>
+          </p>
+        <% end %>
+
+        <%= f.govuk_submit t(".continue") %>
+        <p class="govuk-body">
+          <%= govuk_link_to(t(".cancel"), claims_support_school_mentors_path(@school), no_visited_state: true) %>
+        </p>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/claims/support/schools/mentors/no_results.html.erb
+++ b/app/views/claims/support/schools/mentors/no_results.html.erb
@@ -1,0 +1,19 @@
+<% content_for :page_title, t(".page_title", trn: @mentor_form.trn, school_name: @school.name) %>
+<% render "claims/support/primary_navigation", current: :organisations %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: new_claims_support_school_mentor_path(@school, params: @mentor_form.as_form_params)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <h1 class="govuk-heading-l">
+    <span class="govuk-caption-l"><%= t(".add_mentor_with_school_name", school_name: @school.name) %></span>
+    <%= t(".no_results_found", trn: @mentor_form.trn) %>
+  </h1>
+  <p class="govuk-body">
+    <%= t(".help_text") %>
+  </p>
+  <p class="govuk-body">
+    <%= govuk_link_to(t(".change_your_search"), new_claims_support_school_mentor_path(@school, params: @mentor_form.as_form_params)) %>
+  </p>
+</div>

--- a/app/views/claims/support/schools/mentors/remove.html.erb
+++ b/app/views/claims/support/schools/mentors/remove.html.erb
@@ -1,6 +1,7 @@
-<% content_for :page_title, "#{t(".header_info")} - #{@mentor.full_name} - #{@school.name}" %>
+<%= content_for :page_title, sanitize(t(".page_title", user_name: @mentor.full_name, school_name: @school.name)) %>
 
 <% render "claims/support/primary_navigation", current: :organisations %>
+
 <% content_for(:before_content) do %>
   <%= govuk_back_link(href: claims_support_school_mentor_path(id: @mentor.id)) %>
 <% end %>
@@ -9,7 +10,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l"><%= @mentor.full_name %> - <%= @school.name %></span>
-      <h1 class="govuk-heading-l"><%= t(".confirm_removal") %></h1>
+      <h1 class="govuk-heading-l"><%= t(".are_you_sure") %></h1>
     </div>
   </div>
 

--- a/app/views/claims/support/schools/mentors/show.html.erb
+++ b/app/views/claims/support/schools/mentors/show.html.erb
@@ -1,6 +1,7 @@
-<% content_for :page_title, "#{@mentor.full_name} - #{t(".heading")} - #{@school.name}" %>
+<%= content_for :page_title, sanitize(t(".page_title", mentor_name: @mentor.full_name, school_name: @school.name)) %>
 
 <% render "claims/support/primary_navigation", current: :organisations %>
+
 <% content_for(:before_content) do %>
   <%= govuk_back_link(href: claims_support_school_mentors_path(@school)) %>
 <% end %>
@@ -8,7 +9,7 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-l"><%= t(".heading") %> <%= @school.name %></span>
+      <span class="govuk-caption-l"><%= t(".caption", school_name: @school.name) %></span>
       <h2 class="govuk-heading-l"><%= @mentor.full_name %></h2>
 
       <%= govuk_summary_list do |summary_list| %>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -8,6 +8,10 @@ en:
           attributes:
             trn:
               taken: The mentor has already been added
+        claims/mentor_form:
+          attributes:
+            trn:
+              taken: The mentor has already been added
         user_invite_form:
           attributes:
             email:

--- a/config/locales/en/claims/support/schools/mentors.yml
+++ b/config/locales/en/claims/support/schools/mentors.yml
@@ -6,17 +6,46 @@ en:
           index:
             heading: Mentors
             trn: Teacher reference number (TRN)
+            add_mentor: Add mentor
+            page_title: Mentors
           show:
-            heading: Mentors
+            page_title: "%{mentor_name} - Mentors - %{school_name}"
+            caption: "Mentors - %{school_name}"
             remove_mentor: Remove mentor
             attributes:
               mentors:
                 trn: Teacher reference number (TRN)
+          new:
+            page_title: Enter a teacher reference number (TRN) - Add mentor - %{school_name}
+            page_title_with_error: "Error: Enter a teacher reference number (TRN) - Add mentor - %{school_name}"
+            add_mentor_with_school_name: Add mentor - %{school_name}
+            cancel: Cancel
+            continue: Continue
+            enter_a_trn: Enter a teacher reference number (TRN)
+            help_with_the_trn: Help with the teacher reference number (TRN)
+            guidance_html: If you don’t have a TRN, read the %{guidance_link} to find a lost TRN, or apply for one.
+            guidance_link_text: Teacher reference number (TRN) guidance
+          check:
+            page_title: Check your answers - Add mentor - %{school_name}
+            add_mentor: Add mentor
+            add_mentor_with_school_name: Add mentor - %{school_name}
+            cancel: Cancel
+            change: Change
+            check_your_answers: Check your answers
+            trn: Teacher reference number (TRN)
+          no_results:
+            page_title: No results found for ‘%{trn}’ - Add mentor - %{school_name}
+            add_mentor_with_school_name: Add mentor - %{school_name}
+            change_your_search: Change your search
+            help_text: Check that you typed in the teacher reference number (TRN) correctly.
+            no_results_found: No results found for ‘%{trn}’
+          create:
+            success: Mentor added
           remove:
-            confirm_removal: Are you sure you want to remove this mentor?
+            page_title: Are you sure you want to remove this mentor? - %{user_name} - %{school_name}
+            are_you_sure: Are you sure you want to remove this mentor?
             cancel: Cancel
             remove_mentor: Remove mentor
-            header_info: Are you sure you want to remove this mentor?
           destroy:
             success: Mentor removed
 

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -44,8 +44,9 @@ scope module: :claims, as: :claims, constraints: { host: ENV["CLAIMS_HOST"] } do
       scope module: :schools do
         resources :claims
 
-        resources :mentors, only: %i[index show destroy] do
-          get :remove, on: :member
+        resources :mentors, only: %i[index new create show destroy] do
+          member { get :remove }
+          collection { get :check }
         end
 
         resources :users, only: %i[index new create show destroy] do

--- a/spec/system/claims/support/schools/mentors/support_user_adds_a_mentor_spec.rb
+++ b/spec/system/claims/support/schools/mentors/support_user_adds_a_mentor_spec.rb
@@ -1,0 +1,222 @@
+require "rails_helper"
+
+RSpec.describe "Claims support user adds mentors to schools", type: :system, service: :claims do
+  let!(:school) { create(:claims_school, name: "School") }
+  let(:another_school) { create(:claims_school, name: "Another School") }
+  let(:claims_mentor) { create(:claims_mentor) }
+  let(:another_claims_mentor) { create(:claims_mentor) }
+  let(:new_mentor) { build(:claims_mentor) }
+
+  before { given_i_sign_in_as_colin }
+
+  scenario "I can navigate back to the index page" do
+    given_i_navigate_to_schools_mentors_list(school)
+    and_i_click_on("Add mentor")
+    when_i_click_on("Back")
+    then_i_see_the_index_page(school)
+    when_i_click_on("Add mentor")
+    and_i_click_on("Cancel")
+    then_i_see_the_index_page(school)
+  end
+
+  scenario "I can view help with the trn" do
+    given_i_navigate_to_schools_mentors_list(school)
+    and_i_click_on "Add mentor"
+    when_i_click_on_help_text
+    then_i_see_link_to_trn_guidance
+  end
+
+  scenario "I do not enter a trn" do
+    given_i_navigate_to_schools_mentors_list(school)
+    and_i_click_on("Add mentor")
+    when_i_click_on("Continue")
+    then_i_see_the_error("Enter a teacher reference number (TRN)")
+  end
+
+  scenario "I enter an invalid trn" do
+    given_i_navigate_to_schools_mentors_list(school)
+    and_i_click_on("Add mentor")
+    when_i_enter_trn("12a")
+    and_i_click_on("Continue")
+    then_i_see_the_error("Enter a valid teacher reference number (TRN)")
+  end
+
+  scenario "I enter a trn of mentor who already exists for this school" do
+    given_a_another_claims_mentor_exists(school, another_claims_mentor)
+    given_i_navigate_to_schools_mentors_list(school)
+    and_i_click_on("Add mentor")
+    when_i_enter_trn(another_claims_mentor.trn)
+    and_i_click_on("Continue")
+    then_i_see_the_error("The mentor has already been added")
+  end
+
+  scenario "I enter the trn of an existing claims mentor" do
+    given_a_claims_mentor_exists
+    given_i_navigate_to_schools_mentors_list(school)
+    and_i_click_on("Add mentor")
+    when_i_enter_trn(claims_mentor.trn)
+    and_i_click_on("Continue")
+    then_i_see_check_page_for(claims_mentor)
+    when_i_click_on("Back")
+    then_i_see_form_with_trn(claims_mentor.trn)
+    when_i_click_on("Continue")
+    then_i_see_check_page_for(claims_mentor)
+    when_i_click_on("Change")
+    then_i_see_form_with_trn(claims_mentor.trn)
+    when_i_click_on("Continue")
+    then_i_see_check_page_for(claims_mentor)
+    when_i_click_on("Add mentor")
+    then_mentor_is_added(claims_mentor.full_name)
+  end
+
+  scenario "I enter the trn of an existing claims mentor from another school" do
+    given_a_another_claims_mentor_exists(another_school, another_claims_mentor)
+    given_i_navigate_to_schools_mentors_list(school)
+    and_i_click_on("Add mentor")
+    when_i_enter_trn(another_claims_mentor.trn)
+    and_i_click_on("Continue")
+    then_i_see_check_page_for(another_claims_mentor)
+    when_i_click_on("Back")
+    then_i_see_form_with_trn(another_claims_mentor.trn)
+    when_i_click_on("Continue")
+    then_i_see_check_page_for(another_claims_mentor)
+    when_i_click_on("Add mentor")
+    then_mentor_is_added(another_claims_mentor.full_name)
+  end
+
+  describe "when trn is valid-looking, but does not exists in Teaching Record Service" do
+    before do
+      allow(TeachingRecord::GetTeacher).to receive(:call)
+                                             .with(trn: new_mentor.trn)
+                                             .and_raise TeachingRecord::RestClient::TeacherNotFoundError
+    end
+
+    scenario "I enter a a valid-looking trn that does not exist in the Teaching Record service" do
+      given_i_navigate_to_schools_mentors_list(school)
+      and_i_click_on("Add mentor")
+      when_i_enter_trn(new_mentor.trn)
+      and_i_click_on("Continue")
+      then_i_see_no_results_page(school.name, new_mentor.trn)
+      when_i_click_on "Change your search"
+      then_i_see_form_with_trn(new_mentor.trn)
+    end
+  end
+
+  describe "when trn is valid-looking and mentor is found on Teaching Record Service" do
+    before do
+      allow(TeachingRecord::GetTeacher).to receive(:call)
+                                             .with(trn: new_mentor.trn)
+                                             .and_return teaching_record_valid_response(new_mentor)
+    end
+
+    scenario "I enter a valid-looking trn that does exist on the Teaching Record Service" do
+      given_i_navigate_to_schools_mentors_list(school)
+      and_i_click_on("Add mentor")
+      when_i_enter_trn(new_mentor.trn)
+      and_i_click_on("Continue")
+      then_i_see_check_page_for(new_mentor)
+      when_i_click_on("Add mentor")
+      then_mentor_is_added(new_mentor.full_name)
+    end
+  end
+
+  def given_i_sign_in_as_colin
+    user = create(:claims_support_user, :colin)
+    user_exists_in_dfe_sign_in(user:)
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def given_a_claims_mentor_exists
+    create(:claims_mentor_membership, school: another_school, mentor: claims_mentor)
+  end
+
+  def given_a_another_claims_mentor_exists(school, mentor)
+    create(:claims_mentor_membership, school:, mentor:)
+  end
+
+  def given_i_navigate_to_schools_mentors_list(school)
+    click_on school.name
+    within(".app-secondary-navigation") do
+      click_on "Mentors"
+    end
+  end
+
+  def when_i_click_on(text)
+    click_on text
+  end
+
+  def when_i_click_on_help_text
+    find("span", text: "Help with the teacher reference number (TRN)").click
+  end
+
+  def then_i_see_check_page_for(mentor)
+    expect_organisations_to_be_selected_in_primary_navigation
+    expect(page).to have_content "Add mentor"
+    expect(page).to have_content "Check your answers"
+    name_row = page.all(".govuk-summary-list__row")[0]
+    within(name_row) do
+      expect(page).to have_content "First name"
+      expect(page).to have_content mentor.first_name
+    end
+  end
+
+  def expect_organisations_to_be_selected_in_primary_navigation
+    within(".app-primary-navigation__nav") do
+      expect(page).to have_link "Organisations", current: "page"
+      expect(page).to have_link "Users", current: "false"
+    end
+  end
+
+  def then_mentor_is_added(mentor_name)
+    within(".govuk-notification-banner--success") do
+      expect(page).to have_content "Mentor added"
+    end
+    expect(page).to have_content mentor_name
+  end
+
+  def when_i_enter_trn(trn)
+    fill_in "claims-mentor-form-trn-field", with: trn
+  end
+
+  def then_i_see_the_index_page(school)
+    expect(page).to have_current_path claims_support_school_mentors_path(school), ignore_query: true
+  end
+
+  def then_i_see_the_error(message)
+    expect(page).to have_title "Error: Enter a teacher reference number (TRN)"
+    within(".govuk-error-summary") do
+      expect(page).to have_content message
+    end
+
+    within(".govuk-form-group--error") do
+      expect(page).to have_content message
+    end
+  end
+
+  def then_i_see_form_with_trn(trn)
+    expect(page.find("#claims-mentor-form-trn-field").value).to eq(trn)
+  end
+
+  def then_i_see_no_results_page(_school_name, trn)
+    expect(page).to have_title "No results found for ‘#{trn}’"
+    expect(page).to have_content "Add mentor - #{school.name}"
+    expect(page).to have_content "No results found for ‘#{trn}’"
+  end
+
+  def teaching_record_valid_response(mentor)
+    {
+      "trn" => mentor.trn.to_s,
+      "firstName" => mentor.first_name.to_s,
+      "middleName" => "",
+      "lastName" => mentor.last_name.to_s,
+    }
+  end
+
+  def then_i_see_link_to_trn_guidance
+    expect(page).to have_content "If you don’t have a TRN, read the Teacher reference number (TRN) guidance (opens in new tab) to find a lost TRN, or apply for one."
+    expect(page).to have_link("Teacher reference number (TRN) guidance (opens in new tab)", href: "https://www.gov.uk/guidance/teacher-reference-number-trn")
+  end
+
+  alias_method :and_i_click_on, :when_i_click_on
+end


### PR DESCRIPTION
## Context

To allow support users to add a mentor to an organisation

## Changes proposed in this pull request

Add the add mentor flow for a support user

## Guidance to review

- Sign in as support user
- Go to mentors
- Follow the flow to add a user to a school
- Sign in as a user to that school and check the mentor is there

## Link to Trello card

https://trello.com/c/1kWR8Luj/189-claims-as-a-support-user-i-want-to-add-a-mentor-to-a-school

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
