### PR TITLE
Update CODEOWNERS for Placement-related models

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,10 @@ config/locales/*/claims.yml       @DFE-Digital/track-pay
 config/routes/claims.rb           @DFE-Digital/track-pay
 
 app/*/placements                  @DFE-Digital/school-placements
+app/models/placement*.rb          @DFE-Digital/school-placements
 spec/*/placements                 @DFE-Digital/school-placements
+spec/models/placement*.rb         @DFE-Digital/school-placements
+spec/factories/placements.rb      @DFE-Digital/school-placements
 config/locales/en/placements      @DFE-Digital/school-placements
 config/locales/en/placements.yml  @DFE-Digital/school-placements
 config/routes/placements.rb       @DFE-Digital/school-placements


### PR DESCRIPTION
I've updated CODEOWNERS to consider Placement-related models as being owned by the School Placements team. This covers the models:

- app/models/placement.rb
- app/models/placement_mentor_join.rb
- app/models/placement_subject_join.rb

As well as the associated spec files and factory:

- spec/models/placement_spec.rb
- spec/models/placement_mentor_join_spec.rb
- spec/models/placement_subject_join_spec.rb
- spec/factories/placements.rb

The intention is to reduce noise for the Track & Pay team as we build out Placement related features.
