### PR TITLE
Jc/show page for placements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,29 +1,30 @@
-adr                               @DFE-Digital/school-placements  @DFE-Digital/track-pay
-app                               @DFE-Digital/school-placements  @DFE-Digital/track-pay
-bin                               @DFE-Digital/school-placements  @DFE-Digital/track-pay
-config                            @DFE-Digital/school-placements  @DFE-Digital/track-pay
-db                                @DFE-Digital/school-placements  @DFE-Digital/track-pay
-docs                              @DFE-Digital/school-placements  @DFE-Digital/track-pay
-lib                               @DFE-Digital/school-placements  @DFE-Digital/track-pay
-log                               @DFE-Digital/school-placements  @DFE-Digital/track-pay
-public                            @DFE-Digital/school-placements  @DFE-Digital/track-pay
-spec                              @DFE-Digital/school-placements  @DFE-Digital/track-pay
-storage                           @DFE-Digital/school-placements  @DFE-Digital/track-pay
-tmp                               @DFE-Digital/school-placements  @DFE-Digital/track-pay
-vendor                            @DFE-Digital/school-placements  @DFE-Digital/track-pay
+adr                                   @DFE-Digital/school-placements  @DFE-Digital/track-pay
+app                                   @DFE-Digital/school-placements  @DFE-Digital/track-pay
+bin                                   @DFE-Digital/school-placements  @DFE-Digital/track-pay
+config                                @DFE-Digital/school-placements  @DFE-Digital/track-pay
+db                                    @DFE-Digital/school-placements  @DFE-Digital/track-pay
+docs                                  @DFE-Digital/school-placements  @DFE-Digital/track-pay
+lib                                   @DFE-Digital/school-placements  @DFE-Digital/track-pay
+log                                   @DFE-Digital/school-placements  @DFE-Digital/track-pay
+public                                @DFE-Digital/school-placements  @DFE-Digital/track-pay
+spec                                  @DFE-Digital/school-placements  @DFE-Digital/track-pay
+storage                               @DFE-Digital/school-placements  @DFE-Digital/track-pay
+tmp                                   @DFE-Digital/school-placements  @DFE-Digital/track-pay
+vendor                                @DFE-Digital/school-placements  @DFE-Digital/track-pay
 
-app/*/claims                      @DFE-Digital/track-pay
-app/policies/claim_policy.rb      @DFE-Digital/track-pay
-spec/*/claims                     @DFE-Digital/track-pay
-config/locales/*/claims           @DFE-Digital/track-pay
-config/locales/*/claims.yml       @DFE-Digital/track-pay
-config/routes/claims.rb           @DFE-Digital/track-pay
+app/*/claims                          @DFE-Digital/track-pay
+app/policies/claim_policy.rb          @DFE-Digital/track-pay
+spec/*/claims                         @DFE-Digital/track-pay
+config/locales/*/claims               @DFE-Digital/track-pay
+config/locales/*/claims.yml           @DFE-Digital/track-pay
+config/routes/claims.rb               @DFE-Digital/track-pay
 
-app/*/placements                  @DFE-Digital/school-placements
-app/models/placement*.rb          @DFE-Digital/school-placements
-spec/*/placements                 @DFE-Digital/school-placements
-spec/models/placement*.rb         @DFE-Digital/school-placements
-spec/factories/placements.rb      @DFE-Digital/school-placements
-config/locales/en/placements      @DFE-Digital/school-placements
-config/locales/en/placements.yml  @DFE-Digital/school-placements
-config/routes/placements.rb       @DFE-Digital/school-placements
+app/*/placements                      @DFE-Digital/school-placements
+app/decorators/placement_decorator.rb @DFE-Digital/school-placements
+app/models/placement*.rb              @DFE-Digital/school-placements
+spec/*/placements                     @DFE-Digital/school-placements
+spec/models/placement*.rb             @DFE-Digital/school-placements
+spec/factories/placements.rb          @DFE-Digital/school-placements
+config/locales/en/placements          @DFE-Digital/school-placements
+config/locales/en/placements.yml      @DFE-Digital/school-placements
+config/routes/placements.rb           @DFE-Digital/school-placements

--- a/app/controllers/placements/schools/placements_controller.rb
+++ b/app/controllers/placements/schools/placements_controller.rb
@@ -1,12 +1,19 @@
 class Placements::Schools::PlacementsController < ApplicationController
   before_action :set_school
+  before_action :set_placement, only: [:show]
 
   def index
     @pagy, placements = pagy(@school.placements.includes(:subjects, :mentors).order("subjects.name"))
     @placements = placements.decorate
   end
 
+  def show; end
+
   private
+
+  def set_placement
+    @placement = @school.placements.find(params.require(:id)).decorate
+  end
 
   def set_school
     @school = current_user.schools.find(params.require(:school_id))

--- a/app/decorators/placement_decorator.rb
+++ b/app/decorators/placement_decorator.rb
@@ -5,7 +5,7 @@ class PlacementDecorator < Draper::Decorator
     if mentors.any?
       mentors.map(&:full_name).sort.to_sentence
     else
-      I18n.t("placements.schools.placements.not_entered")
+      I18n.t("placements.schools.placements.not_known_yet")
     end
   end
 
@@ -18,11 +18,19 @@ class PlacementDecorator < Draper::Decorator
   end
 
   def window
-    I18n.t(
-      "placements.schools.placements.window_date",
-      start_month: I18n.l(start_date, format: :month),
-      end_month: I18n.l(end_date, format: :month),
-    )
+    if start_date.month == 9 && end_date.month == 12
+      I18n.t("placements.schools.placements.terms.autumn")
+    elsif start_date.month == 1 && end_date.month == 3
+      I18n.t("placements.schools.placements.terms.spring")
+    elsif start_date.month == 4 && end_date.month == 7
+      I18n.t("placements.schools.placements.terms.summer")
+    else
+      I18n.t(
+        "placements.schools.placements.window_date",
+        start_month: I18n.l(start_date, format: :month),
+        end_month: I18n.l(end_date, format: :month),
+      )
+    end
   end
 
   def formatted_start_date

--- a/app/decorators/placement_decorator.rb
+++ b/app/decorators/placement_decorator.rb
@@ -13,6 +13,18 @@ class PlacementDecorator < Draper::Decorator
     subjects.pluck(:name).sort.to_sentence
   end
 
+  def school_level
+    subjects.pick(:subject_area).titleize
+  end
+
+  def window
+    I18n.t(
+      "placements.schools.placements.window_date",
+      start_month: I18n.l(start_date, format: :month),
+      end_month: I18n.l(end_date, format: :month),
+    )
+  end
+
   def formatted_start_date
     I18n.l(start_date, format: :long)
   end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -80,7 +80,14 @@ class School < ApplicationRecord
                   against: %i[name postcode],
                   using: { trigram: { word_similarity: true } }
 
+  PRIMARY_PHASE = "Primary".freeze
+  SECONDARY_PHASE = "Secondary".freeze
+
   def organisation_type
     "school"
+  end
+
+  def primary_or_secondary_only?
+    [PRIMARY_PHASE, SECONDARY_PHASE].include?(phase)
   end
 end

--- a/app/views/placements/schools/placements/index.html.erb
+++ b/app/views/placements/schools/placements/index.html.erb
@@ -10,7 +10,7 @@
             <% head.with_row do |row| %>
               <% row.with_cell(header: true, text: t(".subject")) %>
               <% row.with_cell(header: true, text: t(".mentor")) %>
-              <% row.with_cell(header: true, text: Placement.human_attribute_name(:start_date)) %>
+              <% row.with_cell(header: true, text: t(".placement_window")) %>
               <% row.with_cell(header: true, text: Placement.human_attribute_name(:status)) %>
             <% end %>
           <% end %>
@@ -22,7 +22,7 @@
                   placements_school_placement_path(school_id: @school.id, id: placement.id),
                 )) %>
                 <% row.with_cell(text: placement.mentor_names) %>
-                <% row.with_cell(text: placement.formatted_start_date) %>
+                <% row.with_cell(text: placement.window) %>
                 <% row.with_cell do |cell| %>
                   <%= render Placement::StatusTagComponent.new(placement.status) %>
                 <% end %>

--- a/app/views/placements/schools/placements/index.html.erb
+++ b/app/views/placements/schools/placements/index.html.erb
@@ -17,7 +17,10 @@
           <% table.with_body do |body| %>
             <% @placements.each do |placement| %>
               <% body.with_row do |row| %>
-                <% row.with_cell(text: placement.subject_names) %>
+                <% row.with_cell(text: govuk_link_to(
+                  placement.subject_names,
+                  placements_school_placement_path(school_id: @school.id, id: placement.id),
+                )) %>
                 <% row.with_cell(text: placement.mentor_names) %>
                 <% row.with_cell(text: placement.formatted_start_date) %>
                 <% row.with_cell do |cell| %>

--- a/app/views/placements/schools/placements/index.html.erb
+++ b/app/views/placements/schools/placements/index.html.erb
@@ -10,7 +10,7 @@
             <% head.with_row do |row| %>
               <% row.with_cell(header: true, text: t(".subject")) %>
               <% row.with_cell(header: true, text: t(".mentor")) %>
-              <% row.with_cell(header: true, text: t(".placement_window")) %>
+              <% row.with_cell(header: true, text: t(".window")) %>
               <% row.with_cell(header: true, text: Placement.human_attribute_name(:status)) %>
             <% end %>
           <% end %>
@@ -19,7 +19,7 @@
               <% body.with_row do |row| %>
                 <% row.with_cell(text: govuk_link_to(
                   placement.subject_names,
-                  placements_school_placement_path(school_id: @school.id, id: placement.id),
+                  placements_school_placement_path(@school, placement),
                 )) %>
                 <% row.with_cell(text: placement.mentor_names) %>
                 <% row.with_cell(text: placement.window) %>

--- a/app/views/placements/schools/placements/show.html.erb
+++ b/app/views/placements/schools/placements/show.html.erb
@@ -15,9 +15,11 @@
       </h2>
 
       <%= govuk_summary_list do |summary_list| %>
-        <% summary_list.with_row do |row| %>
-          <% row.with_key(text: t(".attributes.placements.school_level")) %>
-          <% row.with_value(text: @placement.school_level) %>
+        <% if !Subject.subject_areas.values.include?(@school.phase&.downcase) %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".attributes.placements.school_level")) %>
+            <% row.with_value(text: @placement.school_level) %>
+          <% end %>
         <% end %>
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: t(".attributes.placements.subject")) %>

--- a/app/views/placements/schools/placements/show.html.erb
+++ b/app/views/placements/schools/placements/show.html.erb
@@ -3,7 +3,7 @@
 <%= render "placements/schools/primary_navigation", school: @school, current_navigation: :placements %>
 
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: placements_school_placements_path(school_id: @school.id)) %>
+  <%= govuk_back_link(href: placements_school_placements_path(@school.id)) %>
 <% end %>
 
 <div class="govuk-width-container">
@@ -14,7 +14,7 @@
       </h2>
 
       <%= govuk_summary_list do |summary_list| %>
-        <% if !Subject.subject_areas.values.include?(@school.phase&.downcase) %>
+        <% if !@school.primary_or_secondary_only? %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".attributes.placements.school_level")) %>
             <% row.with_value(text: @placement.school_level) %>
@@ -45,7 +45,7 @@
           <% end %>
         <% end %>
         <% summary_list.with_row do |row| %>
-          <% row.with_key(text: t(".attributes.placements.placement_window")) %>
+          <% row.with_key(text: t(".attributes.placements.window")) %>
           <% row.with_value(text: @placement.window) %>
         <% end %>
         <% summary_list.with_row do |row| %>

--- a/app/views/placements/schools/placements/show.html.erb
+++ b/app/views/placements/schools/placements/show.html.erb
@@ -1,0 +1,37 @@
+<%= content_for :page_title, sanitize(@placement.subject_names) %>
+
+<%= render "placements/schools/primary_navigation", school: @school, current_navigation: :placements %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: placements_school_placements_path(school_id: @school.id)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-l">
+        <%= @placement.subject_names %>
+        <%= render Placement::StatusTagComponent.new(@placement.status) %>
+      </h2>
+
+      <%= govuk_summary_list do |summary_list| %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".attributes.placements.school_level")) %>
+          <% row.with_value(text: @placement.school_level) %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".attributes.placements.subject")) %>
+          <% row.with_value(text: @placement.subject_names) %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".attributes.placements.mentor")) %>
+          <% row.with_value(text: @placement.mentor_names) %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".attributes.placements.window")) %>
+          <% row.with_value(text: @placement.window) %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/placements/schools/placements/show.html.erb
+++ b/app/views/placements/schools/placements/show.html.erb
@@ -21,14 +21,30 @@
         <% end %>
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: t(".attributes.placements.subject")) %>
-          <% row.with_value(text: @placement.subject_names) %>
+          <% row.with_value do %>
+            <ul class="govuk-list">
+              <% @placement.subjects.each do |subject| %>
+                <li><%= subject.name %></li>
+              <% end %>
+            </ul>
+          <% end %>
         <% end %>
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: t(".attributes.placements.mentor")) %>
-          <% row.with_value(text: @placement.mentor_names) %>
+          <% row.with_value do %>
+            <% if @placement.mentors.any? %>
+              <ul class="govuk-list">
+                <% @placement.mentors.each do |mentor| %>
+                  <li><%= mentor.full_name %></li>
+                <% end %>
+              </ul>
+            <% else %>
+              <%= t(".not_known_yet") %>
+            <% end %>
+          <% end %>
         <% end %>
         <% summary_list.with_row do |row| %>
-          <% row.with_key(text: t(".attributes.placements.window")) %>
+          <% row.with_key(text: t(".attributes.placements.placement_window")) %>
           <% row.with_value(text: @placement.window) %>
         <% end %>
       <% end %>

--- a/app/views/placements/schools/placements/show.html.erb
+++ b/app/views/placements/schools/placements/show.html.erb
@@ -11,7 +11,6 @@
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-l">
         <%= @placement.subject_names %>
-        <%= render Placement::StatusTagComponent.new(@placement.status) %>
       </h2>
 
       <%= govuk_summary_list do |summary_list| %>
@@ -41,13 +40,19 @@
                 <% end %>
               </ul>
             <% else %>
-              <%= t(".not_known_yet") %>
+              <%= t("placements.schools.placements.not_known_yet") %>
             <% end %>
           <% end %>
         <% end %>
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: t(".attributes.placements.placement_window")) %>
           <% row.with_value(text: @placement.window) %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".attributes.placements.status")) %>
+          <% row.with_value do %>
+            <%= render Placement::StatusTagComponent.new(@placement.status) %>
+          <% end %>
         <% end %>
       <% end %>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,7 @@ en:
   change: Change
   date:
     formats:
+      month: "%B"
       long: "%e %B %Y"
       short: "%d/%m/%Y"
   time:

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -9,13 +9,14 @@ en:
           placements: Placements
           subject: Subject
           mentor: Mentor
-          start_date: Start date
+          placement_window: Placement window
           status: Status
           not_entered: Not entered
         show:
+          not_known_yet: Not known yet
           attributes:
             placements:
               school_level: School level
               subject: Subject
               mentor: Mentor
-              window: Window
+              placement_window: Placement window

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -13,7 +13,7 @@ en:
           placements: Placements
           subject: Subject
           mentor: Mentor
-          placement_window: Placement window
+          window: Window
           status: Status
           not_entered: Not entered
         show:
@@ -22,5 +22,5 @@ en:
               school_level: School level
               subject: Subject
               mentor: Mentor
-              placement_window: Placement window
+              window: Window
               status: Status

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -2,7 +2,11 @@ en:
   placements:
     schools:
       placements:
-        not_entered: Not entered
+        terms:
+          autumn: Autumn
+          spring: Spring
+          summer: Summer
+        not_known_yet: Not known yet
         window_date: "%{start_month} to %{end_month}"
         index:
           page_title: Placements
@@ -13,10 +17,10 @@ en:
           status: Status
           not_entered: Not entered
         show:
-          not_known_yet: Not known yet
           attributes:
             placements:
               school_level: School level
               subject: Subject
               mentor: Mentor
               placement_window: Placement window
+              status: Status

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -3,6 +3,7 @@ en:
     schools:
       placements:
         not_entered: Not entered
+        window_date: "%{start_month} to %{end_month}"
         index:
           page_title: Placements
           placements: Placements
@@ -11,3 +12,10 @@ en:
           start_date: Start date
           status: Status
           not_entered: Not entered
+        show:
+          attributes:
+            placements:
+              school_level: School level
+              subject: Subject
+              mentor: Mentor
+              window: Window

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -70,7 +70,7 @@ scope module: :placements,
         collection { get :check }
       end
 
-      resources :placements, only: [:index, :show]
+      resources :placements, only: %i[index show]
     end
   end
 

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -70,7 +70,7 @@ scope module: :placements,
         collection { get :check }
       end
 
-      resources :placements, only: [:index]
+      resources :placements, only: [:index, :show]
     end
   end
 

--- a/spec/factories/placements.rb
+++ b/spec/factories/placements.rb
@@ -24,5 +24,9 @@ FactoryBot.define do
     start_date { 1.month.from_now }
     end_date { 4.months.from_now }
     status { "published" }
+
+    trait :draft do
+      status { "draft" }
+    end
   end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -89,4 +89,26 @@ RSpec.describe School, type: :model do
     it { is_expected.to validate_presence_of(:urn) }
     it { is_expected.to validate_uniqueness_of(:urn).case_insensitive }
   end
+
+  describe "#primary_or_secondary_only?" do
+    subject { school.primary_or_secondary_only? }
+
+    context "when given a school with phase Primary" do
+      let(:school) { create(:school, phase: "Primary") }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "when given a school with phase Secondary" do
+      let(:school) { create(:school, phase: "Secondary") }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "when given a school with phase not Primary or Secondary" do
+      let(:school) { create(:school, phase: "All-through") }
+
+      it { is_expected.to eq(false) }
+    end
+  end
 end

--- a/spec/system/placements/schools/mentors/view_a_mentor_spec.rb
+++ b/spec/system/placements/schools/mentors/view_a_mentor_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Placements / Schools / Mentors / View a mentor", type: :system, 
     given_i_sign_in_as_anne
   end
 
-  scenario "Support User views a school mentor's details" do
+  scenario "User views a school mentor's details" do
     given_a_mentor_exists_in(school:)
     when_i_visit_the_show_page_for(school, mentor)
     then_i_see_the_mentor_details(

--- a/spec/system/placements/schools/placements/view_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/view_a_placement_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
     end
   end
 
-  context "without a mentors" do
+  context "without a mentor" do
     before do
       given_a_placement_has_one_subject(subject_1)
     end

--- a/spec/system/placements/schools/placements/view_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/view_a_placement_spec.rb
@@ -66,16 +66,35 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
     end
   end
 
+  # TODO: This may change when design history is published
+
   context "with placement window" do
     before do
       given_a_placement_has_one_subject(subject_1)
     end
 
-    # TODO: This may change when design history is published
-    scenario "User views a placement with a placement window" do
+    scenario "User views a placement with a placement window in Autumn (September to December)" do
       given_a_placement_with_a_placement_window("01/09/2024", "31/12/2024")
       when_i_visit_the_placement_show_page
-      then_i_the_placement_window_in_the_placement_details("September to December")
+      then_i_the_placement_window_in_the_placement_details("Autumn")
+    end
+
+    scenario "User views a placement with a placement window in Spring (January to March)" do
+      given_a_placement_with_a_placement_window("01/01/2024", "31/03/2024")
+      when_i_visit_the_placement_show_page
+      then_i_the_placement_window_in_the_placement_details("Spring")
+    end
+
+    scenario "User views a placement with a placement window in Spring (April to July)" do
+      given_a_placement_with_a_placement_window("01/04/2024", "31/07/2024")
+      when_i_visit_the_placement_show_page
+      then_i_the_placement_window_in_the_placement_details("Summer")
+    end
+
+    scenario "User views a placement with a placement window not in a defined term" do
+      given_a_placement_with_a_placement_window("01/09/2024", "30/11/2024")
+      when_i_visit_the_placement_show_page
+      then_i_the_placement_window_in_the_placement_details("September to November")
     end
   end
 
@@ -106,6 +125,24 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
       given_a_placement_in_a_school_with_phase("Secondary")
       when_i_visit_the_placement_show_page
       then_i_do_not_see_the_school_level_in_the_placement_details(school_level: "Secondary")
+    end
+  end
+
+  context "with a status" do
+    before do
+      given_a_placement_has_one_subject(subject_1)
+    end
+
+    scenario "User views a placement in draft state" do
+      given_a_placement_with_status("draft")
+      when_i_visit_the_placement_show_page
+      then_see_the_status_in_the_placement_details(status: "Draft")
+    end
+
+    scenario "User views a placement in published state" do
+      given_a_placement_with_status("published")
+      when_i_visit_the_placement_show_page
+      then_see_the_status_in_the_placement_details(status: "Published")
     end
   end
 
@@ -224,6 +261,16 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
   def then_i_see_the_school_level_in_the_placement_details(school_level:)
     within(".govuk-summary-list") do
       expect(page).to have_content(school_level)
+    end
+  end
+
+  def given_a_placement_with_status(status)
+    placement.update!(status:)
+  end
+
+  def then_see_the_status_in_the_placement_details(status:)
+    within(".govuk-summary-list") do
+      expect(page.find(".govuk-tag")).to have_content(status)
     end
   end
 end

--- a/spec/system/placements/schools/placements/view_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/view_a_placement_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe "Placements / Schools / Placements / View a placement", type: :system, service: :placements do
+  let!(:school) { create(:placements_school, name: "School 1") }
+
+  before do
+    given_i_sign_in_as_anne
+    visit placements_school_placement_path(school, placement)
+  end
+
+  context "when a placement has been fully completed and published" do
+    let!(:placement, school:)
+
+    context "when the placement has one subject assigned" do
+      it "displays only the subject assigned to the placement" do
+        given_
+      end
+    end
+  end
+
+  private
+
+  def and_there_is_an_existing_user_for(user_name)
+    user = create(:placements_user, user_name.downcase.to_sym)
+    user_exists_in_dfe_sign_in(user:)
+    and_user_has_one_school(user:)
+  end
+
+  def and_i_visit_the_sign_in_path
+    visit sign_in_path
+  end
+
+  def and_i_click_sign_in
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def given_i_sign_in_as_anne
+    and_there_is_an_existing_user_for("Anne")
+    and_i_visit_the_sign_in_path
+    and_i_click_sign_in
+  end
+end

--- a/spec/system/placements/schools/placements/view_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/view_a_placement_spec.rb
@@ -2,19 +2,78 @@ require "rails_helper"
 
 RSpec.describe "Placements / Schools / Placements / View a placement", type: :system, service: :placements do
   let!(:school) { create(:placements_school, name: "School 1") }
+  let!(:placement) { create(:placement, school:) }
+  let!(:subject_1) { create(:subject, name: "Subject 1") }
 
   before do
     given_i_sign_in_as_anne
-    visit placements_school_placement_path(school, placement)
   end
 
-  context "when a placement has been fully completed and published" do
-    let!(:placement, school:)
+  context "with subjects" do
+    let!(:subject_2) { create(:subject, name: "Subject 2") }
+    let!(:subject_3) { create(:subject, name: "Subject 3") }
 
-    context "when the placement has one subject assigned" do
-      it "displays only the subject assigned to the placement" do
-        given_
-      end
+    scenario "User views a placement with one subject" do
+      given_a_placement_has_one_subject(subject_1)
+      when_i_visit_the_placement_show_page
+      then_i_see_the_subject_name_in_the_placement_details("Subject 1")
+    end
+
+    scenario "User views a placement with multiple subjects" do
+      given_a_placement_with_multiple_subjects([subject_1, subject_2, subject_3])
+      when_i_visit_the_placement_show_page
+      then_i_see_all_of_the_subjects_names_in_the_placement_details(
+        ["Subject 1", "Subject 2", "Subject 3"],
+      )
+    end
+  end
+
+  context "with mentors" do
+    let!(:mentor_1) { create(:placements_mentor, first_name: "Joe", last_name: "Bloggs") }
+    let!(:mentor_2) { create(:placements_mentor, first_name: "John", last_name: "Doe") }
+    let!(:mentor_3) { create(:placements_mentor, first_name: "Agatha", last_name: "Christie") }
+
+    before do
+      given_a_placement_has_one_subject(subject_1)
+      given_the_school_has_mentors(school:, mentors: [mentor_1, mentor_2, mentor_3])
+    end
+
+    scenario "User views a placement with one mentor" do
+      given_a_placement_with_one_mentor(mentor_1)
+      when_i_visit_the_placement_show_page
+      then_i_see_the_mentor_name_in_the_placement_details("Joe Bloggs")
+    end
+
+    scenario "User views a placement with multiple mentors" do
+      given_a_placement_with_multiple_mentors([mentor_1, mentor_2, mentor_3])
+      when_i_visit_the_placement_show_page
+      then_i_see_all_of_the_mentors_names_in_the_placement_details(
+        ["Joe Bloggs", "John Doe", "Agatha Christie"],
+      )
+    end
+  end
+
+  context "without a mentors" do
+    before do
+      given_a_placement_has_one_subject(subject_1)
+    end
+
+    scenario "User views a placement with no mentors" do
+      given_a_placement_with_no_mentor
+      when_i_visit_the_placement_show_page
+      then_i_the_mentor_is_not_known_yet_in_the_placement_details
+    end
+  end
+
+  context "with placement window" do
+    before do
+      given_a_placement_has_one_subject(subject_1)
+    end
+
+    scenario "User views a placement with a placement window" do
+      given_a_placement_with_a_placement_window("01/09/2024", "31/12/2024")
+      when_i_visit_the_placement_show_page
+      then_i_the_placement_window_in_the_placement_details("September to December")
     end
   end
 
@@ -23,7 +82,7 @@ RSpec.describe "Placements / Schools / Placements / View a placement", type: :sy
   def and_there_is_an_existing_user_for(user_name)
     user = create(:placements_user, user_name.downcase.to_sym)
     user_exists_in_dfe_sign_in(user:)
-    and_user_has_one_school(user:)
+    create(:user_membership, user:, organisation: school)
   end
 
   def and_i_visit_the_sign_in_path
@@ -34,9 +93,89 @@ RSpec.describe "Placements / Schools / Placements / View a placement", type: :sy
     click_on "Sign in using DfE Sign In"
   end
 
+  def when_i_visit_the_placement_show_page
+    visit placements_school_placement_path(school, placement)
+  end
+
   def given_i_sign_in_as_anne
     and_there_is_an_existing_user_for("Anne")
     and_i_visit_the_sign_in_path
     and_i_click_sign_in
+  end
+
+  def given_a_placement_has_one_subject(placements_subject)
+    PlacementSubjectJoin.create!(placement:, subject: placements_subject)
+  end
+
+  def then_i_see_the_subject_name_in_the_placement_details(subject_name)
+    expect(page.find(".govuk-heading-l")).to have_content(subject_name)
+
+    within(".govuk-summary-list") do
+      expect(page).to have_content(subject_name)
+    end
+  end
+
+  def given_a_placement_with_multiple_subjects(placements_subjects)
+    placements_subjects.each do |placements_subject|
+      PlacementSubjectJoin.create!(placement:, subject: placements_subject)
+    end
+  end
+
+  def then_i_see_all_of_the_subjects_names_in_the_placement_details(subject_names)
+    subject_title = subject_names.sort.to_sentence
+    expect(page.find(".govuk-heading-l")).to have_content(subject_title)
+
+    subject_names.each do |subject_name|
+      expect(page).to have_content(subject_name)
+    end
+  end
+
+  def given_a_placement_with_no_mentor; end
+
+  def given_a_placement_with_one_mentor(mentor)
+    PlacementMentorJoin.create!(placement:, mentor:)
+  end
+
+  def then_i_see_the_mentor_name_in_the_placement_details(mentor_name)
+    within(".govuk-summary-list") do
+      expect(page).to have_content(mentor_name)
+    end
+  end
+
+  def given_the_school_has_mentors(school:, mentors:)
+    mentors.each do |mentor|
+      create(:placements_mentor_membership, school:, mentor:)
+    end
+  end
+
+  def given_a_placement_with_multiple_mentors(mentors)
+    mentors.each do |mentor|
+      PlacementMentorJoin.create!(placement:, mentor:)
+    end
+  end
+
+  def then_i_see_all_of_the_mentors_names_in_the_placement_details(mentor_names)
+    mentor_names.each do |mentor_name|
+      then_i_see_the_mentor_name_in_the_placement_details(mentor_name)
+    end
+  end
+
+  def then_i_the_mentor_is_not_known_yet_in_the_placement_details
+    within(".govuk-summary-list") do
+      expect(page).to have_content("Not known yet")
+    end
+  end
+
+  def given_a_placement_with_a_placement_window(start_date, end_date)
+    placement.update!(
+      start_date: Date.parse(start_date),
+      end_date: Date.parse(end_date),
+    )
+  end
+
+  def then_i_the_placement_window_in_the_placement_details(placement_window_text)
+    within(".govuk-summary-list") do
+      expect(page).to have_content(placement_window_text)
+    end
   end
 end

--- a/spec/system/placements/schools/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/schools/placements/view_placements_list_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Placement school user views a list of placements", type: :system
     scenario "where placement has no mentors attached" do
       given_a_published_placement_exists
       given_i_sign_in_as_anne
-      then_i_see_mentor_names("Not entered")
+      then_i_see_mentor_names("Not known yet")
     end
   end
 


### PR DESCRIPTION
## Context

- Add a show page for School Users to view the details of a placement.

## Changes proposed in this pull request

- Views/Controllers/Routes/etc to create a show page for School Users to view placements.

## Guidance to review

- Review should currently be based on [prototype](https://school-placements-beta-dev-73591d8bbe5f.herokuapp.com/organisations/049fc44e-6876-4884-8a77-d363173ce8d2/placements) placements. (27/02/2024)
- Screenshot of prototype at time:
<img width="1452" alt="Screenshot 2024-02-27 at 15 21 38" src="https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/46a41a18-4c1f-4a44-b9c8-ef565219aa07">

- _Note: Things such as placement window are still in flux, so currently unsure as to it's final look._

_How to review functionally_

- Sign in as Anne
- (Assuming you have placements in her school, if not run the seed data) 
- Click the "Placements" nav option
- This will display the index page of placements for that school
- Click on the link to view the first placement
- This will direct you to the show page of this placement.

## Link to Trello card

https://trello.com/c/pfsKkGbJ/141-as-a-school-user-i-can-view-the-details-of-a-placement

## Screenshots
<img width="1446" alt="Screenshot 2024-02-27 at 17 10 10" src="https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/34963d35-446f-4be5-b3a7-144786e2cd17">





