### PR TITLE
Refactors the placement route helpers in routes_helper.rb

### DIFF
--- a/app/helpers/placements/routes/organisations_helper.rb
+++ b/app/helpers/placements/routes/organisations_helper.rb
@@ -1,0 +1,89 @@
+module Placements::Routes::OrganisationsHelper
+  def organisation_users_path(organisation)
+    case organisation
+    when School
+      placements_school_users_path(organisation)
+    when Provider
+      placements_provider_users_path(organisation)
+    else
+      raise NotImplementedError
+    end
+  end
+
+  def placements_support_organisation_path(organisation)
+    case organisation
+    when School
+      placements_support_school_path(organisation)
+    when Provider
+      placements_support_provider_path(organisation)
+    else
+      raise NotImplementedError
+    end
+  end
+
+  def placements_organisation_user_path(organisation, user)
+    case organisation
+    when School
+      placements_school_user_path(organisation, user)
+    when Provider
+      placements_provider_user_path(organisation, user)
+    else
+      raise NotImplementedError
+    end
+  end
+
+  def placements_organisation_path(organisation)
+    case organisation
+    when School
+      placements_school_placements_path(organisation)
+    when Provider
+      placements_provider_path(organisation)
+    else
+      raise NotImplementedError
+    end
+  end
+
+  def placements_support_users_path(organisation)
+    case organisation
+    when School
+      placements_support_school_users_path(organisation)
+    when Provider
+      placements_support_provider_users_path(organisation)
+    else
+      raise NotImplementedError
+    end
+  end
+
+  def check_placements_organisation_users_path(organisation)
+    case organisation
+    when School
+      check_placements_school_users_path(organisation)
+    when Provider
+      check_placements_provider_users_path(organisation)
+    else
+      raise NotImplementedError
+    end
+  end
+
+  def placements_organisation_users_path(organisation)
+    case organisation
+    when School
+      placements_school_users_path(organisation)
+    when Provider
+      placements_provider_users_path(organisation)
+    else
+      raise NotImplementedError
+    end
+  end
+
+  def new_placements_organisation_user_path(organisation, params = {})
+    case organisation
+    when School
+      new_placements_school_user_path(organisation, params)
+    when Provider
+      new_placements_provider_user_path(organisation, params)
+    else
+      raise NotImplementedError
+    end
+  end
+end

--- a/app/helpers/routes_helper.rb
+++ b/app/helpers/routes_helper.rb
@@ -1,4 +1,6 @@
 module RoutesHelper
+  include Placements::Routes::OrganisationsHelper
+
   def root_path
     {
       claims: claims_root_path,
@@ -39,78 +41,6 @@ module RoutesHelper
       claims: claims_feedback_path,
       placements: placements_feedback_path,
     }.fetch current_service
-  end
-
-  def organisation_users_path(organisation)
-    case organisation
-    when School
-      placements_school_users_path(organisation)
-    when Provider
-      placements_provider_users_path(organisation)
-    end
-  end
-
-  def placements_support_organisation_path(organisation)
-    case organisation
-    when School
-      placements_support_school_path(organisation)
-    when Provider
-      placements_support_provider_path(organisation)
-    end
-  end
-
-  def placements_organisation_user_path(organisation, user)
-    case organisation
-    when School
-      placements_school_user_path(organisation, user)
-    when Provider
-      placements_provider_user_path(organisation, user)
-    end
-  end
-
-  def placements_organisation_path(organisation)
-    case organisation
-    when School
-      placements_school_placements_path(organisation)
-    when Provider
-      placements_provider_path(organisation)
-    end
-  end
-
-  def placements_support_users_path(organisation)
-    case organisation
-    when School
-      placements_support_school_users_path(organisation)
-    when Provider
-      placements_support_provider_users_path(organisation)
-    end
-  end
-
-  def check_placements_organisation_users_path(organisation)
-    case organisation
-    when School
-      check_placements_school_users_path
-    when Provider
-      check_placements_provider_users_path
-    end
-  end
-
-  def placements_organisation_users_path(organisation)
-    case organisation
-    when School
-      placements_school_users_path(organisation)
-    when Provider
-      placements_provider_users_path(organisation)
-    end
-  end
-
-  def new_placements_organisation_user_path(organisation, params = {})
-    case organisation
-    when School
-      new_placements_school_user_path(organisation, params)
-    when Provider
-      new_placements_provider_user_path(organisation, params)
-    end
   end
 
   def omniauth_sign_in_path(provider)

--- a/spec/helpers/placements/routes/organisations_helper_spec.rb
+++ b/spec/helpers/placements/routes/organisations_helper_spec.rb
@@ -1,0 +1,192 @@
+require "rails_helper"
+
+RSpec.describe Placements::Routes::OrganisationsHelper do
+  describe "#organisation_users_path" do
+    context "when organisation is a school" do
+      it "returns the school users path" do
+        organisation = create(:school)
+        expect(organisation_users_path(organisation)).to eq(placements_school_users_path(organisation))
+      end
+    end
+
+    context "when organisation is a provider" do
+      it "returns the provider users path" do
+        organisation = create(:provider)
+        expect(organisation_users_path(organisation)).to eq(placements_provider_users_path(organisation))
+      end
+    end
+
+    context "when organisation is not a school or provider" do
+      it "raises NotImplementedError" do
+        organisation = create(:claim)
+        expect { organisation_users_path(organisation) }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+
+  describe "#placements_support_organisation_path" do
+    context "when organisation is a school" do
+      it "returns the support school path" do
+        organisation = create(:school)
+        expect(placements_support_organisation_path(organisation)).to eq(placements_support_school_path(organisation))
+      end
+    end
+
+    context "when organisation is a provider" do
+      it "returns the support provider path" do
+        organisation = create(:provider)
+        expect(placements_support_organisation_path(organisation)).to eq(placements_support_provider_path(organisation))
+      end
+    end
+
+    context "when organisation is not a school or provider" do
+      it "raises NotImplementedError" do
+        organisation = create(:claim)
+        expect { placements_support_organisation_path(organisation) }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+
+  describe "#placements_organisation_user_path" do
+    context "when organisation is a school" do
+      it "returns the school user path" do
+        organisation = create(:school)
+        user = create(:user, type: "Placements::User")
+        expect(placements_organisation_user_path(organisation, user)).to eq(placements_school_user_path(organisation, user))
+      end
+    end
+
+    context "when organisation is a provider" do
+      it "returns the provider user path" do
+        organisation = create(:provider)
+        user = create(:user, type: "Placements::User")
+        expect(placements_organisation_user_path(organisation, user)).to eq(placements_provider_user_path(organisation, user))
+      end
+    end
+
+    context "when organisation is not a school or provider" do
+      it "raises NotImplementedError" do
+        organisation = create(:claim)
+        user = create(:user, type: "Placements::User")
+        expect { placements_organisation_user_path(organisation, user) }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+
+  describe "#placements_organisation_path" do
+    context "when organisation is a school" do
+      it "returns the school placements path" do
+        organisation = create(:school)
+        expect(placements_organisation_path(organisation)).to eq(placements_school_placements_path(organisation))
+      end
+    end
+
+    context "when organisation is a provider" do
+      it "returns the provider path" do
+        organisation = create(:provider)
+        expect(placements_organisation_path(organisation)).to eq(placements_provider_path(organisation))
+      end
+    end
+
+    context "when organisation is not a school or provider" do
+      it "raises NotImplementedError" do
+        organisation = create(:claim)
+        expect { placements_organisation_path(organisation) }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+
+  describe "#placements_support_users_path" do
+    context "when organisation is a school" do
+      it "returns the support school users path" do
+        organisation = create(:school)
+        expect(placements_support_users_path(organisation)).to eq(placements_support_school_users_path(organisation))
+      end
+    end
+
+    context "when organisation is a provider" do
+      it "returns the support provider users path" do
+        organisation = create(:provider)
+        expect(placements_support_users_path(organisation)).to eq(placements_support_provider_users_path(organisation))
+      end
+    end
+
+    context "when organisation is not a school or provider" do
+      it "raises NotImplementedError" do
+        organisation = create(:claim)
+        expect { placements_support_users_path(organisation) }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+
+  describe "#check_placements_organisation_users_path" do
+    context "when organisation is a school" do
+      it "returns the check school users path" do
+        organisation = create(:school)
+        expect(check_placements_organisation_users_path(organisation)).to eq(check_placements_school_users_path(organisation))
+      end
+    end
+
+    context "when organisation is a provider" do
+      it "returns the check provider users path" do
+        organisation = create(:provider)
+        expect(check_placements_organisation_users_path(organisation)).to eq(check_placements_provider_users_path(organisation))
+      end
+    end
+
+    context "when organisation is not a school or provider" do
+      it "raises NotImplementedError" do
+        organisation = create(:claim)
+        expect { check_placements_organisation_users_path(organisation) }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+
+  describe "#placements_organisation_users_path" do
+    context "when organisation is a school" do
+      it "returns the school users path" do
+        organisation = create(:school)
+        expect(placements_organisation_users_path(organisation)).to eq(placements_school_users_path(organisation))
+      end
+    end
+
+    context "when organisation is a provider" do
+      it "returns the provider users path" do
+        organisation = create(:provider)
+        expect(placements_organisation_users_path(organisation)).to eq(placements_provider_users_path(organisation))
+      end
+    end
+
+    context "when organisation is not a school or provider" do
+      it "raises NotImplementedError" do
+        organisation = create(:claim)
+        expect { placements_organisation_users_path(organisation) }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+
+  describe "#new_placements_organisation_user_path" do
+    let(:params) { { foo: "bar" } }
+
+    context "when organisation is a school" do
+      it "returns the new school user path" do
+        organisation = create(:school)
+        expect(new_placements_organisation_user_path(organisation, params)).to eq(new_placements_school_user_path(organisation, params))
+      end
+    end
+
+    context "when organisation is a provider" do
+      it "returns the new provider user path" do
+        organisation = create(:provider)
+        expect(new_placements_organisation_user_path(organisation, params)).to eq(new_placements_provider_user_path(organisation, params))
+      end
+    end
+
+    context "when organisation is not a school or provider" do
+      it "raises NotImplementedError" do
+        organisation = create(:claim)
+        expect { new_placements_organisation_user_path(organisation, params) }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Whilst looking through the application logic I noticed that we had a lot of specific route helpers that would ideally be refactored to avoid creating _n_ helpers whenever new routes are required, however to refactor the logic we should first make sure the logic is separated and tested.

## Changes proposed in this pull request

Moved the relevant route helpers into their own file and added tests. One invalid route was found whilst adding tests and addressed.

## Guidance to review

The application should continue to work as expected, I identified that one helper `check_placements_organisation_users_path(organisation)` was returning an error upon testing and have updated the logic in what I believe to be the correct way, this should be checked.

## Link to Trello card

N/A I do not have access to Trello yet.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
