### PR TITLE
DRY Placement Route Helpers

### DIFF
--- a/app/helpers/placements/routes/organisations_helper.rb
+++ b/app/helpers/placements/routes/organisations_helper.rb
@@ -1,0 +1,89 @@
+module Placements::Routes::OrganisationsHelper
+  def organisation_users_path(organisation)
+    case organisation
+    when School
+      placements_school_users_path(organisation)
+    when Provider
+      placements_provider_users_path(organisation)
+    else
+      raise NotImplementedError
+    end
+  end
+
+  def placements_support_organisation_path(organisation)
+    case organisation
+    when School
+      placements_support_school_path(organisation)
+    when Provider
+      placements_support_provider_path(organisation)
+    else
+      raise NotImplementedError
+    end
+  end
+
+  def placements_organisation_user_path(organisation, user)
+    case organisation
+    when School
+      placements_school_user_path(organisation, user)
+    when Provider
+      placements_provider_user_path(organisation, user)
+    else
+      raise NotImplementedError
+    end
+  end
+
+  def placements_organisation_path(organisation)
+    case organisation
+    when School
+      placements_school_placements_path(organisation)
+    when Provider
+      placements_provider_path(organisation)
+    else
+      raise NotImplementedError
+    end
+  end
+
+  def placements_support_users_path(organisation)
+    case organisation
+    when School
+      placements_support_school_users_path(organisation)
+    when Provider
+      placements_support_provider_users_path(organisation)
+    else
+      raise NotImplementedError
+    end
+  end
+
+  def check_placements_organisation_users_path(organisation)
+    case organisation
+    when School
+      check_placements_school_users_path(organisation)
+    when Provider
+      check_placements_provider_users_path(organisation)
+    else
+      raise NotImplementedError
+    end
+  end
+
+  def placements_organisation_users_path(organisation)
+    case organisation
+    when School
+      placements_school_users_path(organisation)
+    when Provider
+      placements_provider_users_path(organisation)
+    else
+      raise NotImplementedError
+    end
+  end
+
+  def new_placements_organisation_user_path(organisation, params = {})
+    case organisation
+    when School
+      new_placements_school_user_path(organisation, params)
+    when Provider
+      new_placements_provider_user_path(organisation, params)
+    else
+      raise NotImplementedError
+    end
+  end
+end

--- a/app/helpers/placements/routes/organisations_helper.rb
+++ b/app/helpers/placements/routes/organisations_helper.rb
@@ -1,89 +1,42 @@
 module Placements::Routes::OrganisationsHelper
   def organisation_users_path(organisation)
-    case organisation
-    when School
-      placements_school_users_path(organisation)
-    when Provider
-      placements_provider_users_path(organisation)
-    else
-      raise NotImplementedError
-    end
+    polymorphic_path([:placements, Placements::ConvertInstanceToBaseInstance.call(organisation), :users])
   end
 
   def placements_support_organisation_path(organisation)
-    case organisation
-    when School
-      placements_support_school_path(organisation)
-    when Provider
-      placements_support_provider_path(organisation)
-    else
-      raise NotImplementedError
-    end
+    polymorphic_path([:placements, :support, Placements::ConvertInstanceToBaseInstance.call(organisation)])
   end
 
   def placements_organisation_user_path(organisation, user)
-    case organisation
-    when School
-      placements_school_user_path(organisation, user)
-    when Provider
-      placements_provider_user_path(organisation, user)
-    else
-      raise NotImplementedError
-    end
+    polymorphic_path([:placements,
+                      Placements::ConvertInstanceToBaseInstance.call(organisation),
+                      Placements::ConvertInstanceToBaseInstance.call(user)])
   end
 
   def placements_organisation_path(organisation)
     case organisation
     when School
-      placements_school_placements_path(organisation)
+      polymorphic_path([:placements, Placements::ConvertInstanceToBaseInstance.call(organisation), :placements])
     when Provider
-      placements_provider_path(organisation)
+      polymorphic_path([:placements, Placements::ConvertInstanceToBaseInstance.call(organisation)])
     else
       raise NotImplementedError
     end
   end
 
   def placements_support_users_path(organisation)
-    case organisation
-    when School
-      placements_support_school_users_path(organisation)
-    when Provider
-      placements_support_provider_users_path(organisation)
-    else
-      raise NotImplementedError
-    end
+    polymorphic_path([:placements, :support, Placements::ConvertInstanceToBaseInstance.call(organisation), :users])
   end
 
   def check_placements_organisation_users_path(organisation)
-    case organisation
-    when School
-      check_placements_school_users_path(organisation)
-    when Provider
-      check_placements_provider_users_path(organisation)
-    else
-      raise NotImplementedError
-    end
+    polymorphic_path([:check, :placements, Placements::ConvertInstanceToBaseInstance.call(organisation), :users])
   end
 
   def placements_organisation_users_path(organisation)
-    case organisation
-    when School
-      placements_school_users_path(organisation)
-    when Provider
-      placements_provider_users_path(organisation)
-    else
-      raise NotImplementedError
-    end
+    polymorphic_path([:placements, Placements::ConvertInstanceToBaseInstance.call(organisation), :users])
   end
 
   def new_placements_organisation_user_path(organisation, params = {})
-    case organisation
-    when School
-      new_placements_school_user_path(organisation, params)
-    when Provider
-      new_placements_provider_user_path(organisation, params)
-    else
-      raise NotImplementedError
-    end
+    new_polymorphic_path([:placements, Placements::ConvertInstanceToBaseInstance.call(organisation), :user], params)
   end
 end

--- a/app/helpers/routes_helper.rb
+++ b/app/helpers/routes_helper.rb
@@ -1,4 +1,6 @@
 module RoutesHelper
+  include Placements::Routes::OrganisationsHelper
+
   def root_path
     {
       claims: claims_root_path,
@@ -39,78 +41,6 @@ module RoutesHelper
       claims: claims_feedback_path,
       placements: placements_feedback_path,
     }.fetch current_service
-  end
-
-  def organisation_users_path(organisation)
-    case organisation
-    when School
-      placements_school_users_path(organisation)
-    when Provider
-      placements_provider_users_path(organisation)
-    end
-  end
-
-  def placements_support_organisation_path(organisation)
-    case organisation
-    when School
-      placements_support_school_path(organisation)
-    when Provider
-      placements_support_provider_path(organisation)
-    end
-  end
-
-  def placements_organisation_user_path(organisation, user)
-    case organisation
-    when School
-      placements_school_user_path(organisation, user)
-    when Provider
-      placements_provider_user_path(organisation, user)
-    end
-  end
-
-  def placements_organisation_path(organisation)
-    case organisation
-    when School
-      placements_school_placements_path(organisation)
-    when Provider
-      placements_provider_path(organisation)
-    end
-  end
-
-  def placements_support_users_path(organisation)
-    case organisation
-    when School
-      placements_support_school_users_path(organisation)
-    when Provider
-      placements_support_provider_users_path(organisation)
-    end
-  end
-
-  def check_placements_organisation_users_path(organisation)
-    case organisation
-    when School
-      check_placements_school_users_path
-    when Provider
-      check_placements_provider_users_path
-    end
-  end
-
-  def placements_organisation_users_path(organisation)
-    case organisation
-    when School
-      placements_school_users_path(organisation)
-    when Provider
-      placements_provider_users_path(organisation)
-    end
-  end
-
-  def new_placements_organisation_user_path(organisation, params = {})
-    case organisation
-    when School
-      new_placements_school_user_path(organisation, params)
-    when Provider
-      new_placements_provider_user_path(organisation, params)
-    end
   end
 
   def omniauth_sign_in_path(provider)

--- a/app/services/placements/convert_instance_to_base_instance.rb
+++ b/app/services/placements/convert_instance_to_base_instance.rb
@@ -1,0 +1,31 @@
+# Take an object and converts it to its base class
+# This is useful when you have a STI model and you want to convert it to its base class, the primary purpose for this
+# service is to assist with polymorphic_path when STI models are used as the generated paths do not map to valid routes.
+# Example:
+#   organisation = Placements::School.first
+#   # => #<Placements::School:0x000000012d092cb0 ...>
+#   Placements::ConvertInstanceToBaseInstance.call(organisation)
+#   # => #<School:0x000000012d092cb0 ...>
+class Placements::ConvertInstanceToBaseInstance
+  include ServicePattern
+
+  class ArgumentError < StandardError; end
+
+  def initialize(object)
+    raise ArgumentError, "Object must respond to base_class." unless object.class.respond_to?(:base_class)
+
+    @object = object
+  end
+
+  def call
+    convert_instance
+  end
+
+  private
+
+  attr_reader :object
+
+  def convert_instance
+    object.class.base_class? ? object : object.becomes(object.class.base_class)
+  end
+end

--- a/spec/helpers/placements/routes/organisations_helper_spec.rb
+++ b/spec/helpers/placements/routes/organisations_helper_spec.rb
@@ -1,0 +1,192 @@
+require "rails_helper"
+
+RSpec.describe Placements::Routes::OrganisationsHelper do
+  describe "#organisation_users_path" do
+    context "when organisation is a school" do
+      it "returns the school users path" do
+        organisation = create(:school)
+        expect(organisation_users_path(organisation)).to eq(placements_school_users_path(organisation))
+      end
+    end
+
+    context "when organisation is a provider" do
+      it "returns the provider users path" do
+        organisation = create(:provider)
+        expect(organisation_users_path(organisation)).to eq(placements_provider_users_path(organisation))
+      end
+    end
+
+    context "when organisation is not a school or provider" do
+      it "raises NotImplementedError" do
+        organisation = create(:claim)
+        expect { organisation_users_path(organisation) }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+
+  describe "#placements_support_organisation_path" do
+    context "when organisation is a school" do
+      it "returns the support school path" do
+        organisation = create(:school)
+        expect(placements_support_organisation_path(organisation)).to eq(placements_support_school_path(organisation))
+      end
+    end
+
+    context "when organisation is a provider" do
+      it "returns the support provider path" do
+        organisation = create(:provider)
+        expect(placements_support_organisation_path(organisation)).to eq(placements_support_provider_path(organisation))
+      end
+    end
+
+    context "when organisation is not a school or provider" do
+      it "raises NotImplementedError" do
+        organisation = create(:claim)
+        expect { placements_support_organisation_path(organisation) }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+
+  describe "#placements_organisation_user_path" do
+    context "when organisation is a school" do
+      it "returns the school user path" do
+        organisation = create(:school)
+        user = create(:user, type: "Placements::User")
+        expect(placements_organisation_user_path(organisation, user)).to eq(placements_school_user_path(organisation, user))
+      end
+    end
+
+    context "when organisation is a provider" do
+      it "returns the provider user path" do
+        organisation = create(:provider)
+        user = create(:user, type: "Placements::User")
+        expect(placements_organisation_user_path(organisation, user)).to eq(placements_provider_user_path(organisation, user))
+      end
+    end
+
+    context "when organisation is not a school or provider" do
+      it "raises NotImplementedError" do
+        organisation = create(:claim)
+        user = create(:user, type: "Placements::User")
+        expect { placements_organisation_user_path(organisation, user) }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+
+  describe "#placements_organisation_path" do
+    context "when organisation is a school" do
+      it "returns the school placements path" do
+        organisation = create(:school)
+        expect(placements_organisation_path(organisation)).to eq(placements_school_placements_path(organisation))
+      end
+    end
+
+    context "when organisation is a provider" do
+      it "returns the provider path" do
+        organisation = create(:provider)
+        expect(placements_organisation_path(organisation)).to eq(placements_provider_path(organisation))
+      end
+    end
+
+    context "when organisation is not a school or provider" do
+      it "raises NotImplementedError" do
+        organisation = create(:claim)
+        expect { placements_organisation_path(organisation) }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+
+  describe "#placements_support_users_path" do
+    context "when organisation is a school" do
+      it "returns the support school users path" do
+        organisation = create(:school)
+        expect(placements_support_users_path(organisation)).to eq(placements_support_school_users_path(organisation))
+      end
+    end
+
+    context "when organisation is a provider" do
+      it "returns the support provider users path" do
+        organisation = create(:provider)
+        expect(placements_support_users_path(organisation)).to eq(placements_support_provider_users_path(organisation))
+      end
+    end
+
+    context "when organisation is not a school or provider" do
+      it "raises NotImplementedError" do
+        organisation = create(:claim)
+        expect { placements_support_users_path(organisation) }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+
+  describe "#check_placements_organisation_users_path" do
+    context "when organisation is a school" do
+      it "returns the check school users path" do
+        organisation = create(:school)
+        expect(check_placements_organisation_users_path(organisation)).to eq(check_placements_school_users_path(organisation))
+      end
+    end
+
+    context "when organisation is a provider" do
+      it "returns the check provider users path" do
+        organisation = create(:provider)
+        expect(check_placements_organisation_users_path(organisation)).to eq(check_placements_provider_users_path(organisation))
+      end
+    end
+
+    context "when organisation is not a school or provider" do
+      it "raises NotImplementedError" do
+        organisation = create(:claim)
+        expect { check_placements_organisation_users_path(organisation) }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+
+  describe "#placements_organisation_users_path" do
+    context "when organisation is a school" do
+      it "returns the school users path" do
+        organisation = create(:school)
+        expect(placements_organisation_users_path(organisation)).to eq(placements_school_users_path(organisation))
+      end
+    end
+
+    context "when organisation is a provider" do
+      it "returns the provider users path" do
+        organisation = create(:provider)
+        expect(placements_organisation_users_path(organisation)).to eq(placements_provider_users_path(organisation))
+      end
+    end
+
+    context "when organisation is not a school or provider" do
+      it "raises NotImplementedError" do
+        organisation = create(:claim)
+        expect { placements_organisation_users_path(organisation) }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+
+  describe "#new_placements_organisation_user_path" do
+    let(:params) { { foo: "bar" } }
+
+    context "when organisation is a school" do
+      it "returns the new school user path" do
+        organisation = create(:school)
+        expect(new_placements_organisation_user_path(organisation, params)).to eq(new_placements_school_user_path(organisation, params))
+      end
+    end
+
+    context "when organisation is a provider" do
+      it "returns the new provider user path" do
+        organisation = create(:provider)
+        expect(new_placements_organisation_user_path(organisation, params)).to eq(new_placements_provider_user_path(organisation, params))
+      end
+    end
+
+    context "when organisation is not a school or provider" do
+      it "raises NotImplementedError" do
+        organisation = create(:claim)
+        expect { new_placements_organisation_user_path(organisation, params) }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+end

--- a/spec/helpers/placements/routes/organisations_helper_spec.rb
+++ b/spec/helpers/placements/routes/organisations_helper_spec.rb
@@ -15,13 +15,6 @@ RSpec.describe Placements::Routes::OrganisationsHelper do
         expect(organisation_users_path(organisation)).to eq(placements_provider_users_path(organisation))
       end
     end
-
-    context "when organisation is not a school or provider" do
-      it "raises NotImplementedError" do
-        organisation = create(:claim)
-        expect { organisation_users_path(organisation) }.to raise_error(NotImplementedError)
-      end
-    end
   end
 
   describe "#placements_support_organisation_path" do
@@ -36,13 +29,6 @@ RSpec.describe Placements::Routes::OrganisationsHelper do
       it "returns the support provider path" do
         organisation = create(:provider)
         expect(placements_support_organisation_path(organisation)).to eq(placements_support_provider_path(organisation))
-      end
-    end
-
-    context "when organisation is not a school or provider" do
-      it "raises NotImplementedError" do
-        organisation = create(:claim)
-        expect { placements_support_organisation_path(organisation) }.to raise_error(NotImplementedError)
       end
     end
   end
@@ -61,14 +47,6 @@ RSpec.describe Placements::Routes::OrganisationsHelper do
         organisation = create(:provider)
         user = create(:user, type: "Placements::User")
         expect(placements_organisation_user_path(organisation, user)).to eq(placements_provider_user_path(organisation, user))
-      end
-    end
-
-    context "when organisation is not a school or provider" do
-      it "raises NotImplementedError" do
-        organisation = create(:claim)
-        user = create(:user, type: "Placements::User")
-        expect { placements_organisation_user_path(organisation, user) }.to raise_error(NotImplementedError)
       end
     end
   end
@@ -90,7 +68,7 @@ RSpec.describe Placements::Routes::OrganisationsHelper do
 
     context "when organisation is not a school or provider" do
       it "raises NotImplementedError" do
-        organisation = create(:claim)
+        organisation = create(:placements_user)
         expect { placements_organisation_path(organisation) }.to raise_error(NotImplementedError)
       end
     end
@@ -110,13 +88,6 @@ RSpec.describe Placements::Routes::OrganisationsHelper do
         expect(placements_support_users_path(organisation)).to eq(placements_support_provider_users_path(organisation))
       end
     end
-
-    context "when organisation is not a school or provider" do
-      it "raises NotImplementedError" do
-        organisation = create(:claim)
-        expect { placements_support_users_path(organisation) }.to raise_error(NotImplementedError)
-      end
-    end
   end
 
   describe "#check_placements_organisation_users_path" do
@@ -131,13 +102,6 @@ RSpec.describe Placements::Routes::OrganisationsHelper do
       it "returns the check provider users path" do
         organisation = create(:provider)
         expect(check_placements_organisation_users_path(organisation)).to eq(check_placements_provider_users_path(organisation))
-      end
-    end
-
-    context "when organisation is not a school or provider" do
-      it "raises NotImplementedError" do
-        organisation = create(:claim)
-        expect { check_placements_organisation_users_path(organisation) }.to raise_error(NotImplementedError)
       end
     end
   end
@@ -156,13 +120,6 @@ RSpec.describe Placements::Routes::OrganisationsHelper do
         expect(placements_organisation_users_path(organisation)).to eq(placements_provider_users_path(organisation))
       end
     end
-
-    context "when organisation is not a school or provider" do
-      it "raises NotImplementedError" do
-        organisation = create(:claim)
-        expect { placements_organisation_users_path(organisation) }.to raise_error(NotImplementedError)
-      end
-    end
   end
 
   describe "#new_placements_organisation_user_path" do
@@ -179,13 +136,6 @@ RSpec.describe Placements::Routes::OrganisationsHelper do
       it "returns the new provider user path" do
         organisation = create(:provider)
         expect(new_placements_organisation_user_path(organisation, params)).to eq(new_placements_provider_user_path(organisation, params))
-      end
-    end
-
-    context "when organisation is not a school or provider" do
-      it "raises NotImplementedError" do
-        organisation = create(:claim)
-        expect { new_placements_organisation_user_path(organisation, params) }.to raise_error(NotImplementedError)
       end
     end
   end

--- a/spec/services/placements/convert_instance_to_base_instance_spec.rb
+++ b/spec/services/placements/convert_instance_to_base_instance_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe Placements::ConvertInstanceToBaseInstance do
+  describe "#call" do
+    let(:placements_school) { create(:placements_school) }
+    let(:school) { create(:school) }
+
+    context "when the object has a base class" do
+      it "returns the base class for a school", :aggregate_failures do
+        expect(placements_school).to be_a(Placements::School)
+        expect(described_class.call(placements_school)).to be_a(School)
+      end
+    end
+
+    context "when the object has no base class" do
+      it "returns the base class for a user", :aggregate_failures do
+        expect(school).to be_a(School)
+        expect(described_class.call(school)).to be_a(School)
+      end
+    end
+
+    context "when the object does not respond to base_class" do
+      it "raises an ArgumentError" do
+        expect { described_class.call("not an object") }
+          .to raise_error(Placements::ConvertInstanceToBaseInstance::ArgumentError, "Object must respond to base_class.")
+      end
+    end
+  end
+end

--- a/spec/services/placements/convert_instance_to_base_instance_spec.rb
+++ b/spec/services/placements/convert_instance_to_base_instance_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Placements::ConvertInstanceToBaseInstance do
 
     context "when the object does not respond to base_class" do
       it "raises an ArgumentError" do
-        expect { described_class.call("not an object") }
+        expect { described_class.call("not a valid object") }
           .to raise_error(Placements::ConvertInstanceToBaseInstance::ArgumentError, "Object must respond to base_class.")
       end
     end


### PR DESCRIPTION
⚠️ Blocked on merging #330 

## Context

There was a lot of repetition when looking at the case statements for the placement route helpers, using `polymorphic_path` offered a way to achieve the same results with less code.

## Changes proposed in this pull request

Replace all case statements (where possible) with `polymorphic_path`
Adds a new service that returns and instance of a passed object as its base class. This was required due to Rails being too clever and not matching our routes when given a class that uses STI.

## Guidance to review

There should be no noticeable changes to how the application functions.

## Link to Trello card

N/A I don't have access

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
