### PR TITLE
Add mentor training hours to claim form

### DIFF
--- a/app/controllers/claims/schools/claims/mentor_trainings_controller.rb
+++ b/app/controllers/claims/schools/claims/mentor_trainings_controller.rb
@@ -1,0 +1,49 @@
+class Claims::Schools::Claims::MentorTrainingsController < Claims::ApplicationController
+  include Claims::BelongsToSchool
+  before_action :authorize_claim
+  helper_method :mentor_training_form
+
+  def edit; end
+
+  def update
+    if mentor_training_form.save
+      redirect_to mentor_training_form.success_path
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def mentor_training_form
+    @mentor_training_form ||=
+      if params[:claim_mentor_training_form].present?
+        Claim::MentorTrainingForm.new(mentor_training_params)
+      else
+        Claim::MentorTrainingForm.new(default_params)
+      end
+  end
+
+  def mentor_training_params
+    params.require(:claim_mentor_training_form).permit(
+      :hours_completed,
+      :custom_hours_completed,
+    ).merge(default_params)
+  end
+
+  def default_params
+    { claim:, mentor_training: }
+  end
+
+  def mentor_training
+    @mentor_training ||= @claim.mentor_trainings.find(params.require(:id))
+  end
+
+  def claim
+    @claim ||= @school.claims.find(params.require(:claim_id))
+  end
+
+  def authorize_claim
+    authorize claim
+  end
+end

--- a/app/controllers/claims/schools/claims/mentors_controller.rb
+++ b/app/controllers/claims/schools/claims/mentors_controller.rb
@@ -8,7 +8,13 @@ class Claims::Schools::Claims::MentorsController < Claims::ApplicationController
 
   def create
     if claim_mentors_form.save
-      redirect_to check_claims_school_claim_path(@school, claim)
+      redirect_to(
+        edit_claims_school_claim_mentor_training_path(
+          @school,
+          claim,
+          claim.mentor_trainings.without_hours.first,
+        ),
+      )
     else
       render :new
     end
@@ -18,7 +24,7 @@ class Claims::Schools::Claims::MentorsController < Claims::ApplicationController
 
   def update
     if claim_mentors_form.save
-      redirect_to check_claims_school_claim_path(@school, claim)
+      redirect_to claim_mentors_form.update_success_path
     else
       render :edit
     end
@@ -44,6 +50,6 @@ class Claims::Schools::Claims::MentorsController < Claims::ApplicationController
   end
 
   def authorize_claim
-    authorize @claim || Claim
+    authorize claim
   end
 end

--- a/app/controllers/claims/schools/mentors_controller.rb
+++ b/app/controllers/claims/schools/mentors_controller.rb
@@ -5,7 +5,7 @@ class Claims::Schools::MentorsController < Claims::ApplicationController
   before_action :authorize_mentor
 
   def index
-    @pagy, @mentors = pagy(@school.mentors.order(:first_name, :last_name))
+    @pagy, @mentors = pagy(@school.mentors.order_by_full_name)
   end
 
   def show; end

--- a/app/forms/application_form.rb
+++ b/app/forms/application_form.rb
@@ -1,6 +1,7 @@
 class ApplicationForm
   include ActiveModel::Model
   include ActionView::Helpers::TranslationHelper
+  include Rails.application.routes.url_helpers
 
   def initialize(attributes = {})
     @virtual_path = "forms/#{self.class.name.underscore}"

--- a/app/forms/claim/mentor_training_form.rb
+++ b/app/forms/claim/mentor_training_form.rb
@@ -1,0 +1,72 @@
+class Claim::MentorTrainingForm < ApplicationForm
+  DEFAULT_HOURS_COMPLETED = %w[6 20].freeze
+  attr_accessor :claim, :mentor_training, :hours_completed, :custom_hours_completed
+
+  validates :hours_completed, presence: true, unless: :custom_hours?
+  validates :custom_hours_completed, presence: true, if: :custom_hours?
+
+  validate :validate_mentor_training_hours
+
+  delegate :mentor_full_name, to: :mentor_training
+
+  def persist
+    updated_mentor_training.save!
+  end
+
+  def back_path
+    if mentor_trainings.index(mentor_training).zero?
+      edit_claims_school_claim_mentor_path(claim.school, claim, mentor_training.mentor_id)
+    else
+      previous_mentor_training = mentor_trainings[mentor_trainings.index(mentor_training) - 1]
+      edit_claims_school_claim_mentor_training_path(
+        claim.school,
+        claim,
+        previous_mentor_training,
+        params: {
+          claim_mentor_training_form: { hours_completed: previous_mentor_training.hours_completed },
+        },
+      )
+    end
+  end
+
+  def success_path
+    if claim.mentor_trainings.without_hours.any?
+      edit_claims_school_claim_mentor_training_path(
+        claim.school,
+        claim,
+        claim.mentor_trainings.without_hours.first,
+      )
+    else
+      check_claims_school_claim_path(claim.school, claim)
+    end
+  end
+
+  def custom_hours?
+    @custom_hours ||= hours_completed == "on" || custom_hours_completed?
+  end
+
+  private
+
+  def custom_hours_completed?
+    if hours_completed.present?
+      !DEFAULT_HOURS_COMPLETED.include?(hours_completed)
+    end
+  end
+
+  def mentor_trainings
+    @mentor_trainings ||= claim.mentor_trainings.order_by_mentor_full_name
+  end
+
+  def updated_mentor_training
+    @updated_mentor_training ||= begin
+      mentor_training.hours_completed = custom_hours? ? custom_hours_completed : hours_completed
+      mentor_training
+    end
+  end
+
+  def validate_mentor_training_hours
+    if updated_mentor_training.invalid? && updated_mentor_training.errors[:hours_completed]
+      errors.add(:custom_hours_completed, updated_mentor_training.errors.first.message)
+    end
+  end
+end

--- a/app/forms/claim/mentors_form.rb
+++ b/app/forms/claim/mentors_form.rb
@@ -11,6 +11,18 @@ class Claim::MentorsForm < ApplicationForm
     claim
   end
 
+  def update_success_path
+    if claim.mentor_trainings.without_hours.any?
+      edit_claims_school_claim_mentor_training_path(
+        claim.school,
+        claim,
+        claim.mentor_trainings.without_hours.first,
+      )
+    else
+      check_claims_school_claim_path(claim.school, claim)
+    end
+  end
+
   private
 
   def updated_claim
@@ -22,7 +34,11 @@ class Claim::MentorsForm < ApplicationForm
 
   def mentor_trainings
     @mentor_trainings ||= Array.wrap(mentor_ids).map do |mentor_id|
-      claim.mentor_trainings.build(mentor_id:, provider_id: claim.provider_id)
+      claim.mentor_trainings.find_or_initialize_by(
+        mentor_id:,
+        provider_id: claim.provider_id,
+        claim_id: claim.id,
+      )
     end
   end
 

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -26,7 +26,5 @@ class Claim < ApplicationRecord
   has_many :mentor_trainings
   has_many :mentors, through: :mentor_trainings
 
-  accepts_nested_attributes_for :mentor_trainings
-
   delegate :name, to: :provider, prefix: true, allow_nil: true
 end

--- a/app/models/mentor.rb
+++ b/app/models/mentor.rb
@@ -20,6 +20,8 @@ class Mentor < ApplicationRecord
   validates :first_name, :last_name, presence: true
   validates :trn, presence: true, uniqueness: true, format: /\A\d{7}\z/
 
+  scope :order_by_full_name, -> { order(:first_name, :last_name) }
+
   def full_name
     "#{first_name} #{last_name}".strip
   end

--- a/app/models/mentor_training.rb
+++ b/app/models/mentor_training.rb
@@ -28,4 +28,15 @@ class MentorTraining < ApplicationRecord
   belongs_to :claim
   belongs_to :mentor, optional: true
   belongs_to :provider, optional: true
+
+  validates(
+    :hours_completed,
+    numericality: { greater_than: 0, less_than_or_equal_to: 20, only_integer: true },
+    allow_nil: true,
+  )
+
+  scope :without_hours, -> { where(hours_completed: nil).order_by_mentor_full_name }
+  scope :order_by_mentor_full_name, -> { joins(:mentor).merge(Mentor.order_by_full_name) }
+
+  delegate :full_name, to: :mentor, prefix: true, allow_nil: true
 end

--- a/app/views/claims/schools/claims/check.html.erb
+++ b/app/views/claims/schools/claims/check.html.erb
@@ -44,6 +44,29 @@
         <% end %>
       <% end %>
 
+      <h2 class="govuk-heading-m"><%= t(".hours_of_training") %></h2>
+
+      <%= govuk_summary_list do |summary_list| %>
+        <% @claim.mentor_trainings.order_by_mentor_full_name.each do |mentor_training| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: mentor_training.mentor.full_name) %>
+            <% row.with_value(text: t(".hours", hours: mentor_training.hours_completed)) %>
+            <% row.with_action(text: t("change"),
+                               href: edit_claims_school_claim_mentor_training_path(
+                                 @school,
+                                 @claim,
+                                 mentor_training,
+                                 params: {
+                                   claim_mentor_training_form: { hours_completed: mentor_training.hours_completed },
+                                 },
+                               ),
+                               html_attributes: {
+                                 class: "govuk-link--no-visited-state",
+                               }) %>
+            <% end %>
+          <% end %>
+      <% end %>
+
       <p class="govuk-body"><%= t(".disclaimer") %></p>
 
       <div class="govuk-warning-text">

--- a/app/views/claims/schools/claims/mentor_trainings/edit.html.erb
+++ b/app/views/claims/schools/claims/mentor_trainings/edit.html.erb
@@ -1,0 +1,61 @@
+<% content_for(
+  :page_title,
+  t(".page_title", mentor: mentor_training_form.mentor_training.mentor_full_name),
+) %>
+
+<% render "claims/schools/primary_navigation", school: @school, current: :claims %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: mentor_training_form.back_path) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= form_with(
+    model: mentor_training_form,
+    url: claims_school_claim_mentor_training_path(
+      @school,
+      mentor_training_form.claim,
+      mentor_training_form.mentor_training,
+    ),
+    method: :patch,
+  ) do |f| %>
+    <%= f.govuk_error_summary %>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <span class="govuk-caption-l"><%= t(".add_claim", school: @school.name) %></span>
+        <%= f.govuk_radio_buttons_fieldset(
+          :hours_completed,
+          legend: {
+            size: "l",
+            text: t(".hours_of_training", mentor: mentor_training_form.mentor_full_name),
+          },
+        ) do %>
+          <%= f.govuk_radio_button :hours_completed, "20", label: { text: t(".20_hours") } %>
+          <%= f.govuk_radio_button :hours_completed, "6", label: { text: t(".6_hours") } %>
+
+          <%= f.govuk_radio_divider %>
+
+          <%= f.govuk_radio_button(
+            :hours_completed,
+            "on",
+            checked: mentor_training_form.custom_hours?,
+            label: { text: t(".other_amount") },
+          ) do %>
+            <h5 class="govuk-heading-s govuk-!-margin-bottom-1"><%= t(".number_of_hours") %></h5>
+            <%= f.govuk_number_field(
+              :custom_hours_completed,
+              value: mentor_training_form.custom_hours? ? mentor_training_form.mentor_training.hours_completed : nil,
+              class: "govuk-input--width-2",
+              label: { text: t(".enter_whole_numbers") },
+            ) %>
+          <% end %>
+        <% end %>
+
+        <%= f.govuk_submit t("continue") %>
+        <p class="govuk-body">
+          <%= govuk_link_to(t("cancel"), claims_school_claims_path(@school), no_visited_state: true) %>
+        </p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/claims/schools/claims/mentors/_form.html.erb
+++ b/app/views/claims/schools/claims/mentors/_form.html.erb
@@ -7,7 +7,7 @@
 
         <%= f.govuk_collection_check_boxes(
           :mentor_ids,
-          school.mentors,
+          school.mentors.order_by_full_name,
           :id,
           :full_name,
           :trn,

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -4,6 +4,12 @@ en:
       messages:
         record_invalid: "Validation failed: %{errors}"
       models:
+        claim/mentor_training_form:
+          attributes:
+            custom_hours_completed:
+              blank: Enter the number of hours
+            hours_completed:
+              blank: Select the number of hours
         placements/mentor_form:
           attributes:
             trn:

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -36,6 +36,10 @@ en:
               blank: Enter a provider name
             mentor_id: 
               blank: Enter a mentor's name
+            hours_completed:
+              greater_than: Enter the number of hours between 1 and 20
+              less_than_or_equal_to: Enter the number of hours between 1 and 20
+              not_an_integer: Enter the number of hours between 1 and 20
         user:
           attributes:
             first_name:

--- a/config/locales/en/claims/schools/claims.yml
+++ b/config/locales/en/claims/schools/claims.yml
@@ -9,6 +9,8 @@ en:
           page_title: Check your answers
           add_claim: Add claim
           disclaimer: By submitting this claim, you confirm that the details provided are correct to the best of your knowledge.
+          hours: "%{hours} hours"
+          hours_of_training: Hours of training
         form:
           add_claim: Add claim
           heading: Provider

--- a/config/locales/en/claims/schools/claims/mentor_trainings.yml
+++ b/config/locales/en/claims/schools/claims/mentor_trainings.yml
@@ -1,0 +1,14 @@
+en:
+  claims:
+    schools:
+      claims:
+        mentor_trainings:
+          edit:
+            page_title: Hours of training for %{mentor}
+            add_claim: Add claim - %{school} 
+            hours_of_training: Hours of training for %{mentor}
+            20_hours: 20 hours
+            6_hours: 6 hours
+            other_amount: Other amount
+            enter_whole_numbers: Enter whole numbers up to a maximum of 20 hours
+            number_of_hours: Number of hours

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -9,6 +9,7 @@ scope module: :claims, as: :claims, constraints: { host: ENV["CLAIMS_HOST"] } do
     scope module: :schools do
       resources :claims, only: %i[index new create show edit update] do
         resources :mentors, only: %i[new create edit update], module: :claims
+        resources :mentor_trainings, only: %i[edit update], module: :claims
 
         member do
           get :check

--- a/spec/forms/claim/mentor_training_form_spec.rb
+++ b/spec/forms/claim/mentor_training_form_spec.rb
@@ -1,0 +1,179 @@
+require "rails_helper"
+
+describe Claim::MentorTrainingForm, type: :model do
+  let!(:claim) { create(:claim) }
+  let!(:mentor_training) { create(:mentor_training, claim:, mentor:, hours_completed: 6) }
+  let(:mentor) { create(:mentor, first_name: "Anne") }
+  let(:hours_completed) { 20 }
+
+  describe "validations" do
+    context "when hours_completed is blank" do
+      it "returns invalid" do
+        form = described_class.new(claim:, mentor_training:)
+        expect(form.valid?).to eq(false)
+        expect(form.errors.messages[:hours_completed]).to include("Select the number of hours")
+      end
+    end
+
+    context "when custom_hours_completed is blank and user clicked on custom hours radio button" do
+      it "returns invalid" do
+        form = described_class.new(claim:, mentor_training:, hours_completed: "on")
+        expect(form.valid?).to eq(false)
+        expect(form.errors.messages[:custom_hours_completed]).to include("Enter the number of hours")
+      end
+    end
+  end
+
+  describe "save" do
+    it "adds hours completed to the mentor_training " do
+      mentor_training_with_custom_hours = create(
+        :mentor_training,
+        claim:,
+        mentor: create(:mentor),
+      )
+
+      form = described_class.new(
+        claim:,
+        mentor_training: mentor_training_with_custom_hours,
+        hours_completed: "20",
+      )
+
+      expect {
+        form.save!
+      }.to change { mentor_training_with_custom_hours.hours_completed }.to eq(20)
+    end
+
+    context "when custom_hours_completed is available" do
+      it "adds hours custom_hours_completed to the mentor_training " do
+        mentor_training_with_completed_hours = create(
+          :mentor_training,
+          hours_completed: 20,
+          claim:,
+          mentor: create(:mentor),
+        )
+
+        form = described_class.new(
+          claim:,
+          mentor_training: mentor_training_with_completed_hours,
+          hours_completed: "on",
+          custom_hours_completed: "12",
+        )
+
+        expect {
+          form.save!
+        }.to change { mentor_training_with_completed_hours.hours_completed }.to eq(12)
+      end
+    end
+
+    describe "#back_path" do
+      context "when we are on the first mentor training hours page" do
+        it "returns the path to the mentors check list" do
+          form = described_class.new(claim:, mentor_training:)
+
+          expect(form.back_path).to eq(
+            "/schools/#{claim.school_id}/claims/#{claim.id}/mentors/#{mentor_training.mentor_id}/edit",
+          )
+        end
+      end
+
+      context "when we are on the second mentor training hours page" do
+        it "returns the path to the first mentor training" do
+          second_mentor_training = create(
+            :mentor_training,
+            claim:,
+            mentor: create(:mentor, first_name: "John"),
+          )
+          form = described_class.new(claim:, mentor_training: second_mentor_training)
+
+          expect(form.back_path).to eq(
+            "/schools/#{claim.school_id}/claims/#{claim.id}/mentor_trainings/#{mentor_training.id}/edit?claim_mentor_training_form%5Bhours_completed%5D=#{mentor_training.hours_completed}",
+          )
+        end
+      end
+    end
+
+    describe "#success_path" do
+      context "when there are no more mentor trainings without hours completed" do
+        it "returns the path to the check page" do
+          form = described_class.new(claim:, mentor_training:)
+
+          expect(form.success_path).to eq(
+            "/schools/#{claim.school_id}/claims/#{claim.id}/check",
+          )
+        end
+      end
+
+      context "when there are mentor trainings without hours completed" do
+        it "returns the path to the next mentor training hours" do
+          mentor_training_without_hours = create(
+            :mentor_training,
+            claim:,
+            mentor: create(:mentor),
+          )
+          form = described_class.new(claim:, mentor_training:)
+
+          expect(form.success_path).to eq(
+            "/schools/#{claim.school_id}/claims/#{claim.id}/mentor_trainings/#{mentor_training_without_hours.id}/edit",
+          )
+        end
+      end
+    end
+
+    describe "#custom_hours?" do
+      context "when user choosed the radio button to input custom hours" do
+        it "returns true" do
+          form = described_class.new(claim:, mentor_training:, hours_completed: "on")
+          expect(form.custom_hours?).to eq(true)
+        end
+      end
+
+      context "when the mentor training has custom_hours_completed" do
+        it "returns true" do
+          mentor_training_with_custom_hours = create(
+            :mentor_training,
+            hours_completed: 12,
+            claim:,
+            mentor: create(:mentor),
+          )
+
+          form = described_class.new(
+            claim:,
+            mentor_training: mentor_training_with_custom_hours,
+            hours_completed: "12",
+          )
+          expect(form.custom_hours?).to eq(true)
+        end
+      end
+
+      context "when the mentor training has pre-determened hours_completed" do
+        it "returns false" do
+          form = described_class.new(claim:, mentor_training:, hours_completed: "20")
+          expect(form.custom_hours?).to eq(false)
+        end
+      end
+    end
+  end
+
+  describe "#custom_hours?" do
+    context "when user inputs pre selected hours" do
+      it "returns false" do
+        form = described_class.new(claim:, mentor_training:, hours_completed: "20")
+        expect(form.custom_hours?).to eq(false)
+      end
+    end
+
+    context "when user inputs custom hours" do
+      it "returns true" do
+        form = described_class.new(claim:, mentor_training:, hours_completed: "on")
+        expect(form.custom_hours?).to eq(true)
+      end
+    end
+
+    context "when user edits custom hours" do
+      it "returns true" do
+        form = described_class.new(claim:, mentor_training:, hours_completed: "12")
+        expect(form.custom_hours?).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/forms/claim/mentors_form_spec.rb
+++ b/spec/forms/claim/mentors_form_spec.rb
@@ -35,4 +35,34 @@ describe Claim::MentorsForm, type: :model do
       ])
     end
   end
+
+  describe "#update_success_path" do
+    context "when there are mentors without mentor training hours" do
+      it "returns the path to the mentor training hours form" do
+        mentor_training = create(
+          :mentor_training,
+          claim:,
+          mentor: mentor1,
+        )
+        form = described_class.new(claim:)
+
+        expect(form.update_success_path).to eq(
+          "/schools/#{claim.school_id}/claims/#{claim.id}/mentor_trainings/#{mentor_training.id}/edit",
+        )
+      end
+    end
+
+    context "when all mentors have mentor training hours" do
+      it "returns the path to the claim check page" do
+        if claim.mentor_trainings
+          claim.mentor_trainings.update_all(hours_completed: 20)
+        end
+        form = described_class.new(claim:)
+
+        expect(form.update_success_path).to eq(
+          "/schools/#{claim.school_id}/claims/#{claim.id}/check",
+        )
+      end
+    end
+  end
 end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe Claim, type: :model do
     it { is_expected.to belong_to(:provider) }
     it { is_expected.to have_many(:mentor_trainings) }
     it { is_expected.to have_many(:mentors).through(:mentor_trainings) }
-    it { is_expected.to accept_nested_attributes_for(:mentor_trainings) }
   end
 
   context "with delegations" do

--- a/spec/models/mentor_spec.rb
+++ b/spec/models/mentor_spec.rb
@@ -43,6 +43,20 @@ RSpec.describe Mentor, type: :model do
     end
   end
 
+  context "with scopes" do
+    describe "#order_by_full_name" do
+      it "returns the mentors ordered by full name" do
+        mentor1 = create(:mentor, first_name: "Anne", last_name: "Smith")
+        mentor2 = create(:mentor, first_name: "Anne", last_name: "Doe")
+        mentor3 = create(:mentor, first_name: "John", last_name: "Doe")
+
+        expect(described_class.order_by_full_name).to eq(
+          [mentor2, mentor1, mentor3],
+        )
+      end
+    end
+  end
+
   describe "#full_name" do
     it "returns the mentors full name" do
       mentor = build(:mentor, first_name: "Jane", last_name: "Doe")

--- a/spec/system/claims/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/schools/claims/create_claim_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     )
   end
   let!(:provider) { create(:provider, :best_practice_network) }
-  let!(:mentor1) { create(:mentor) }
-  let!(:mentor2) { create(:mentor) }
+  let(:mentor1) { create(:mentor, first_name: "Anne") }
+  let(:mentor2) { create(:mentor, first_name: "Joe") }
 
   before do
     user_exists_in_dfe_sign_in(user: anne)
@@ -23,6 +23,12 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     when_i_choose_a_provider
     when_i_click("Continue")
     when_i_select_all_mentors
+    when_i_click("Continue")
+    then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor1)
+    when_i_add_training_hours("20 hours")
+    when_i_click("Continue")
+    then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor2)
+    when_i_choose_other_amount_and_input_hours(12)
     when_i_click("Continue")
     then_i_check_my_answers
     when_i_click("Submit claim")
@@ -37,6 +43,22 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     when_i_click("Continue")
     when_i_click("Continue")
     then_i_see_the_error("Select a mentor")
+    when_i_select_all_mentors
+    when_i_click("Continue")
+    when_i_click("Continue")
+    then_i_see_the_error("Select the number of hours")
+    when_i_choose_other_amount
+    when_i_click("Continue")
+    then_i_see_the_error("Enter the number of hours")
+    when_i_choose_other_amount_and_input_hours(-1)
+    when_i_click("Continue")
+    then_i_see_the_error("Enter the number of hours between 1 and 20")
+    when_i_choose_other_amount_and_input_hours(21)
+    when_i_click("Continue")
+    then_i_see_the_error("Enter the number of hours between 1 and 20")
+    when_i_choose_other_amount_and_input_hours(0.5)
+    when_i_click("Continue")
+    then_i_see_the_error("Enter the number of hours between 1 and 20")
   end
 
   private
@@ -59,18 +81,50 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     page.check(mentor2.full_name)
   end
 
+  def then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor)
+    expect(page).to have_content("Hours of training for #{mentor.full_name}")
+  end
+
+  def when_i_add_training_hours(radio_button)
+    page.choose(radio_button)
+  end
+
+  def when_i_choose_other_amount
+    page.choose("Other amount")
+  end
+
+  def when_i_choose_other_amount_and_input_hours(hours)
+    page.choose("Other amount")
+    fill_in("Enter whole numbers up to a maximum of 20 hours", with: hours)
+  end
+
   def then_i_check_my_answers
     expect(page).to have_content("Check your answers")
+    expect(page).to have_content("Hours of training")
 
-    within(".govuk-summary-list__row:nth(1)") do
-      expect(page).to have_content("Provider")
-      expect(page).to have_content(provider.name)
+    within("dl.govuk-summary-list:nth(1)") do
+      within(".govuk-summary-list__row:nth(1)") do
+        expect(page).to have_content("Provider")
+        expect(page).to have_content(provider.name)
+      end
+
+      within(".govuk-summary-list__row:nth(2)") do
+        expect(page).to have_content("Mentors")
+        expect(page).to have_content(mentor1.full_name)
+        expect(page).to have_content(mentor2.full_name)
+      end
     end
 
-    within(".govuk-summary-list__row:nth(2)") do
-      expect(page).to have_content("Mentors")
-      expect(page).to have_content(mentor1.full_name)
-      expect(page).to have_content(mentor2.full_name)
+    within("dl.govuk-summary-list:nth(2)") do
+      within(".govuk-summary-list__row:nth(1)") do
+        expect(page).to have_content(mentor1.full_name)
+        expect(page).to have_content("20 hours")
+      end
+
+      within(".govuk-summary-list__row:nth(2)") do
+        expect(page).to have_content(mentor2.full_name)
+        expect(page).to have_content("12 hours")
+      end
     end
   end
 


### PR DESCRIPTION
## Context

The mentor training hours form will come after the user selects the mentors for the claim. It will cycle through the mentors who don't have mentor training hours.

A column has been added to the mentor_training table, `custom_hours_completed`. This is for capturing the custom hours the user can input.

After inputting all the hours for the mentors the form will redirect to the check claim page.

The form also handles the paths of the backlinks and the success redirects.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

`Claims::Schools::Claims::MentorTrainingsController`
`Claim::MentorTrainingForm`
Changes to `Claim::MentorsForm`
Changes to claims#check page

## Guidance to review

Pull or go on review app
Create a claim with a few mentors
Add mentor hours
Change the mentor hours on check page
Change the mentors on check page
Leave inputs blank to get errors
Play around with the back links
Thank you 🥇 

## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/5a02f6ec-ec7a-42e2-bbe6-f03a5f38f417


