### PR TITLE
As a Support User, I want to download a CSV of claims / payment details

### DIFF
--- a/app/controllers/claims/schools/claims_controller.rb
+++ b/app/controllers/claims/schools/claims_controller.rb
@@ -36,7 +36,7 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
   def confirm; end
 
   def submit
-    Claim::Submit.call(claim: @claim)
+    Claims::Submit.call(claim: @claim)
 
     redirect_to confirm_claims_school_claim_path(@school, @claim)
   end

--- a/app/controllers/claims/support/claims_controller.rb
+++ b/app/controllers/claims/support/claims_controller.rb
@@ -8,6 +8,12 @@ class Claims::Support::ClaimsController < Claims::Support::ApplicationController
 
   def show; end
 
+  def download_csv
+    csv_data = Claims::GenerateClaimsCsv.call
+
+    send_data csv_data, filename: "claims.csv", type: "text/csv", disposition: "attachment"
+  end
+
   private
 
   def set_claim

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -36,4 +36,8 @@ class Claim < ApplicationRecord
   def submitted_on
     submitted_at&.to_date
   end
+
+  def amount
+    Claims::CalculateAmount.call(claim: self)
+  end
 end

--- a/app/policies/claim_policy.rb
+++ b/app/policies/claim_policy.rb
@@ -10,4 +10,8 @@ class ClaimPolicy < Claims::ApplicationPolicy
   def confirm?
     true
   end
+
+  def download_csv?
+    true
+  end
 end

--- a/app/services/claims/calculate_amount.rb
+++ b/app/services/claims/calculate_amount.rb
@@ -1,0 +1,20 @@
+class Claims::CalculateAmount
+  include ServicePattern
+
+  def initialize(claim:)
+    @claim = claim
+  end
+
+  attr_reader :claim
+
+  def call
+    region = claim.school.region
+    claims_funding_available_per_hour_pence = region.claims_funding_available_per_hour_pence
+
+    total_hours_completed = claim.mentor_trainings.sum(:hours_completed)
+
+    amount_in_pence = claims_funding_available_per_hour_pence * total_hours_completed
+
+    Money.new(amount_in_pence, "GBP")
+  end
+end

--- a/app/services/claims/generate_claims_csv.rb
+++ b/app/services/claims/generate_claims_csv.rb
@@ -1,0 +1,22 @@
+require "csv"
+
+class Claims::GenerateClaimsCsv
+  include ServicePattern
+
+  HEADERS = %w[school_name school_urn amount claim_reference_number].freeze
+
+  def call
+    CSV.generate(headers: true) do |csv|
+      csv << HEADERS
+
+      Claim.find_each do |claim|
+        csv << [
+          claim.school.name,
+          claim.school.urn,
+          claim.amount.format(symbol: false, decimal_mark: ".", no_cents: false),
+          claim.reference,
+        ]
+      end
+    end
+  end
+end

--- a/app/services/claims/submit.rb
+++ b/app/services/claims/submit.rb
@@ -1,4 +1,4 @@
-class Claim::Submit
+class Claims::Submit
   include ServicePattern
 
   def initialize(claim:)

--- a/app/views/claims/support/claims/index.html.erb
+++ b/app/views/claims/support/claims/index.html.erb
@@ -7,6 +7,8 @@
       <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 
       <% if @claims.any? %>
+        <%= govuk_button_to(t(".download_csv"), download_csv_claims_support_claims_path, method: :get) %>
+
         <%= govuk_table do |table| %>
           <% table.with_head do |head| %>
             <% head.with_row do |row| %>

--- a/config/locales/en/claims/support/claims.yml
+++ b/config/locales/en/claims/support/claims.yml
@@ -4,6 +4,7 @@ en:
       claims:
         index:
           heading: Claims
+          download_csv: Download claims
         show:
           heading: Claim
           status: Status

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -33,7 +33,10 @@ scope module: :claims, as: :claims, constraints: { host: ENV["CLAIMS_HOST"] } do
   namespace :support do
     root to: redirect("/support/schools")
 
-    resources :claims, only: %i[index show]
+    resources :claims, only: %i[index show] do
+      get :download_csv, on: :collection
+    end
+
     resources :support_users do
       get :check, on: :collection
       get :remove, on: :member

--- a/spec/services/claims/calculate_amount_spec.rb
+++ b/spec/services/claims/calculate_amount_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe Claims::CalculateAmount do
+  let!(:claim) { create(:claim, school_id: school.id, reference: "12345678") }
+
+  let!(:region) { create(:region, name: "Inner London", claims_funding_available_per_hour: Money.from_amount(53.60, "GBP")) }
+  let!(:school) { create(:claims_school, :claims, name: "School name 1", region_id: region.id, urn: "1234") }
+
+  describe "#call" do
+    it "calculates the claim amount" do
+      create(:mentor_training, claim:, hours_completed: 10)
+      create(:mentor_training, claim:, hours_completed: 10)
+
+      result = described_class.call(claim:)
+
+      expect(result).to eq(Money.new(107_200, "GBP"))
+    end
+  end
+end

--- a/spec/services/claims/generate_claims_csv_spec.rb
+++ b/spec/services/claims/generate_claims_csv_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe Claims::GenerateClaimsCsv do
+  subject(:generate_claims_csv) { described_class.call }
+
+  before do
+    region1 = create(:region, name: "Inner London", claims_funding_available_per_hour: Money.from_amount(53.60, "GBP"))
+    region2 = create(:region, name: "Outer London", claims_funding_available_per_hour: Money.from_amount(48.25, "GBP"))
+    region3 = create(:region, name: "Fringe", claims_funding_available_per_hour: Money.from_amount(45.10, "GBP"))
+
+    school1 = create(:claims_school, :claims, name: "School name 1", region: region1, urn: "1234")
+    school2 = create(:claims_school, :claims, name: "School name 2", region: region2, urn: "5678")
+    school3 = create(:claims_school, :claims, name: "School name 3", region: region3, urn: "5679")
+
+    claim1 = create(:claim, school: school1, reference: "12345678")
+    claim2 = create(:claim, school: school2, reference: "12345679")
+    claim3 = create(:claim, school: school3, reference: "12345677")
+    claim4 = create(:claim, school: school3, reference: "12345671")
+
+    create(:mentor_training, claim: claim1, hours_completed: 10)
+    create(:mentor_training, claim: claim2, hours_completed: 10)
+
+    create(:mentor_training, claim: claim3, hours_completed: 8)
+    create(:mentor_training, claim: claim3, hours_completed: 5)
+    create(:mentor_training, claim: claim3, hours_completed: 2)
+
+    create(:mentor_training, claim: claim4, hours_completed: 1)
+    create(:mentor_training, claim: claim4, hours_completed: 1)
+  end
+
+  it "inserts the correct headers" do
+    expect(generate_claims_csv.lines.first.chomp).to eq("school_name,school_urn,amount,claim_reference_number")
+  end
+
+  it "contains all clims" do
+    expect(generate_claims_csv.lines.sort).to eq([
+      "school_name,school_urn,amount,claim_reference_number\n",
+      "School name 1,1234,536.00,12345678\n",
+      "School name 2,5678,482.50,12345679\n",
+      "School name 3,5679,676.50,12345677\n",
+      "School name 3,5679,90.20,12345671\n",
+    ].sort)
+  end
+end

--- a/spec/services/claims/submit_spec.rb
+++ b/spec/services/claims/submit_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Claim::Submit do
+describe Claims::Submit do
   subject(:submit_service) { described_class.call(claim:) }
 
   let!(:claim) { create(:claim, :draft) }

--- a/spec/system/claims/support/claims/download_claims_csv_spec.rb
+++ b/spec/system/claims/support/claims/download_claims_csv_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe "Download claims CSV", type: :system, service: :claims do
+  let(:support_user) { create(:claims_support_user) }
+
+  before do
+    create_claim
+    user_exists_in_dfe_sign_in(user: support_user)
+    given_i_sign_in
+  end
+
+  scenario "Support user visits the claims index page and downloads CSV" do
+    given_i_am_on_the_claims_index_page
+    when_i_click_download_claims
+    then_i_receive_a_csv_file
+  end
+
+  private
+
+  def given_i_sign_in
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def given_i_am_on_the_claims_index_page
+    click_on("Claims")
+  end
+
+  def when_i_click_download_claims
+    click_on("Download claims")
+  end
+
+  def then_i_receive_a_csv_file
+    expect(response_headers["Content-Type"]).to eq "text/csv"
+  end
+
+  def create_claim
+    region = create(:region, name: "Inner London", claims_funding_available_per_hour: Money.from_amount(53.60, "GBP"))
+    school = create(:claims_school, :claims, name: "School name 1", region_id: region.id, urn: "1234")
+
+    create(:claim, school_id: school.id, reference: "12345678")
+  end
+end


### PR DESCRIPTION
## Context

Allow a support use to download all claims

## Changes proposed in this pull request

Adds a button on the Claims page to allow all claims to be downloaded

## Guidance to review

- Sign in as support user
- Go to claims
- Click Download claims

## Link to Trello card

https://trello.com/c/znGU9fJy/191-as-a-support-user-i-want-to-download-a-csv-of-claims-payment-details

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots
![Screenshot 2024-03-04 at 20 22 45](https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/af890337-86d7-4944-a0f3-9789355f197c)

<!-- Sceenshots to aid with reviewing if needed-->
