### PR TITLE
Fix factory subject code

### DIFF
--- a/spec/factories/subject.rb
+++ b/spec/factories/subject.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :subject do
     subject_area { %w[primary secondary].sample }
     name { Faker::Educator.subject }
-    code { Faker::String.random(length: 2) }
+    code { Faker::Alphanumeric.alpha(number: 2) }
   end
 
   trait :primary do


### PR DESCRIPTION
## Context

Change Subject Factory code from `Faker::String.random(length: 2)` to `Faker::Alphanumeric.alpha(number: 2)`.
Faker::String.random(length: 2) => " 蛏" / "횝\u{5BD40}" / "铍Y"
Faker::Alphanumeric.alpha(number: 2) => "ax" / "dw" / "hd"

## Changes proposed in this pull request

- Change Subject Factory code from `Faker::String.random(length: 2)` to `Faker::Alphanumeric.alpha(number: 2)`.
