### PR TITLE
Claim Submit and generate reference

### DIFF
--- a/app/controllers/claims/schools/claims_controller.rb
+++ b/app/controllers/claims/schools/claims_controller.rb
@@ -1,6 +1,6 @@
 class Claims::Schools::ClaimsController < Claims::ApplicationController
   include Claims::BelongsToSchool
-  before_action :set_claim, only: %i[show check]
+  before_action :set_claim, only: %i[show check confirm submit]
   before_action :authorize_claim
 
   helper_method :claim_provider_form
@@ -31,6 +31,14 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
     else
       render :edit
     end
+  end
+
+  def confirm; end
+
+  def submit
+    Claim::Submit.call(claim: @claim)
+
+    redirect_to confirm_claims_school_claim_path(@school, @claim)
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,4 +17,8 @@ module ApplicationHelper
     end
     link
   end
+
+  def safe_l(value, **options)
+    l(value, **options) if value
+  end
 end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -2,16 +2,19 @@
 #
 # Table name: claims
 #
-#  id          :uuid             not null, primary key
-#  draft       :boolean          default(FALSE)
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  provider_id :uuid
-#  school_id   :uuid             not null
+#  id           :uuid             not null, primary key
+#  draft        :boolean          default(FALSE)
+#  reference    :string
+#  submitted_at :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  provider_id  :uuid
+#  school_id    :uuid             not null
 #
 # Indexes
 #
 #  index_claims_on_provider_id  (provider_id)
+#  index_claims_on_reference    (reference) UNIQUE
 #  index_claims_on_school_id    (school_id)
 #
 # Foreign Keys
@@ -26,5 +29,11 @@ class Claim < ApplicationRecord
   has_many :mentor_trainings
   has_many :mentors, through: :mentor_trainings
 
+  validates :reference, uniqueness: true, allow_nil: true
+
   delegate :name, to: :provider, prefix: true, allow_nil: true
+
+  def submitted_on
+    submitted_at&.to_date
+  end
 end

--- a/app/policies/claim_policy.rb
+++ b/app/policies/claim_policy.rb
@@ -2,4 +2,12 @@ class ClaimPolicy < Claims::ApplicationPolicy
   def update?
     true
   end
+
+  def submit?
+    true
+  end
+
+  def confirm?
+    true
+  end
 end

--- a/app/services/claim/submit.rb
+++ b/app/services/claim/submit.rb
@@ -1,0 +1,29 @@
+class Claim::Submit
+  include ServicePattern
+
+  def initialize(claim:)
+    @claim = claim
+  end
+
+  def call
+    updated_claim.save!
+  end
+
+  private
+
+  attr_reader :claim
+
+  def updated_claim
+    @updated_claim ||= begin
+      claim.draft = false
+      claim.submitted_at = Time.current
+      claim.reference = generate_reference
+      claim
+    end
+  end
+
+  def generate_reference
+    reference = SecureRandom.random_number(99_999_999) while Claim.exists?(reference:)
+    reference
+  end
+end

--- a/app/views/claims/schools/claims/check.html.erb
+++ b/app/views/claims/schools/claims/check.html.erb
@@ -74,7 +74,7 @@
         <strong class="govuk-warning-text__text"><%= t(".warning") %></strong>
       </div>
 
-      <%= govuk_link_to t(".submit"), claims_school_claims_path(@school), class: "govuk-button" %>
+      <%= govuk_button_to t(".submit"), submit_claims_school_claim_path(@school, @claim) %>
 
       <p class="govuk-body">
         <%= govuk_link_to t("cancel"), claims_school_claims_path(@school), no_visited_state: true %>

--- a/app/views/claims/schools/claims/confirm.html.erb
+++ b/app/views/claims/schools/claims/confirm.html.erb
@@ -1,0 +1,21 @@
+<% content_for :page_title, t(".page_title") %>
+<% render "claims/schools/primary_navigation", school: @school, current: :claims %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <%= govuk_panel(title_text: t(".claim_submitted")) do %>
+        <div><%= t(".your_reference_number_id") %></div>
+        <div><strong><%= @claim.reference %></strong></div>
+      <% end %>
+
+      <h2 class="govuk-heading-m"><%= t(".what_happens_next") %></h2>
+      <p class="govuk-body"><%= t(".guidance") %></p>
+
+      <p class="govuk-body">
+        <%= govuk_link_to t(".view_claims"), claims_school_claims_path(@school), no_visited_state: true %>
+      </p>
+    <div>
+  <div>
+</div>

--- a/app/views/claims/schools/claims/index.html.erb
+++ b/app/views/claims/schools/claims/index.html.erb
@@ -26,7 +26,7 @@
       <% table.with_body do |body| %>
         <% @claims.each do |claim| %>
           <% body.with_row do |row| %>
-            <% row.with_cell(text: govuk_link_to(claim.id.first(8), claims_school_claim_path(id: claim.id))) %>
+            <% row.with_cell(text: govuk_link_to(claim.reference, claims_school_claim_path(id: claim.id))) %>
             <% row.with_cell(text: claim.provider_name) %>
             <% row.with_cell do %>
               <ul class="govuk-list">
@@ -35,7 +35,7 @@
                 <% end %>
               </ul>
             <% end %>
-            <% row.with_cell(text: l(claim.created_at.to_date, format: :short)) %>
+            <% row.with_cell(text: safe_l(claim.submitted_on, format: :short)) %>
             <% row.with_cell(text: render(Claim::StatusTagComponent.new(claim:))) %>
           <% end %>
         <% end %>

--- a/config/locales/en/claims/schools/claims.yml
+++ b/config/locales/en/claims/schools/claims.yml
@@ -2,6 +2,13 @@ en:
   claims:
     schools:
       claims:
+        confirm:
+          page_title: Claim submitted
+          claim_submitted: Claim submitted
+          your_reference_number_id: Your reference number
+          what_happens_next: What happens next
+          view_claims: View claims
+          guidance: We will check your claim before processing payment. If we need to contact you for further information, we will use the email you used to access this service.
         check:
           page_title: Check your answers
           warning: You will not be able to change any of the claim details once you have submitted it.

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -13,6 +13,8 @@ scope module: :claims, as: :claims, constraints: { host: ENV["CLAIMS_HOST"] } do
 
         member do
           get :check
+          get :confirm
+          post :submit
         end
       end
 

--- a/db/migrate/20240229140214_add_columns_to_claims.rb
+++ b/db/migrate/20240229140214_add_columns_to_claims.rb
@@ -1,0 +1,7 @@
+class AddColumnsToClaims < ActiveRecord::Migration[7.1]
+  def change
+    add_column(:claims, :reference, :string)
+    add_index(:claims, :reference, unique: true)
+    add_column(:claims, :submitted_at, :datetime)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_22_135527) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_29_140214) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -29,7 +29,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_22_135527) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "provider_id"
+    t.string "reference"
+    t.datetime "submitted_at"
     t.index ["provider_id"], name: "index_claims_on_provider_id"
+    t.index ["reference"], name: "index_claims_on_reference", unique: true
     t.index ["school_id"], name: "index_claims_on_school_id"
   end
 

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -2,16 +2,19 @@
 #
 # Table name: claims
 #
-#  id          :uuid             not null, primary key
-#  draft       :boolean          default(FALSE)
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  provider_id :uuid
-#  school_id   :uuid             not null
+#  id           :uuid             not null, primary key
+#  draft        :boolean          default(FALSE)
+#  reference    :string
+#  submitted_at :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  provider_id  :uuid
+#  school_id    :uuid             not null
 #
 # Indexes
 #
 #  index_claims_on_provider_id  (provider_id)
+#  index_claims_on_reference    (reference) UNIQUE
 #  index_claims_on_school_id    (school_id)
 #
 # Foreign Keys

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -40,4 +40,18 @@ RSpec.describe ApplicationHelper do
       expect(current_service).to eq(:pineapple)
     end
   end
+
+  describe "#safe_l" do
+    it "returns the translation" do
+      value = Date.new(2024, 2, 4)
+
+      expect(safe_l(value, format: :short)).to eq("04/02/2024")
+    end
+
+    context "when value is nil" do
+      it "returns nil" do
+        expect(safe_l(nil, format: :short)).to eq(nil)
+      end
+    end
+  end
 end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -2,16 +2,19 @@
 #
 # Table name: claims
 #
-#  id          :uuid             not null, primary key
-#  draft       :boolean          default(FALSE)
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  provider_id :uuid
-#  school_id   :uuid             not null
+#  id           :uuid             not null, primary key
+#  draft        :boolean          default(FALSE)
+#  reference    :string
+#  submitted_at :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  provider_id  :uuid
+#  school_id    :uuid             not null
 #
 # Indexes
 #
 #  index_claims_on_provider_id  (provider_id)
+#  index_claims_on_reference    (reference) UNIQUE
 #  index_claims_on_school_id    (school_id)
 #
 # Foreign Keys
@@ -29,7 +32,29 @@ RSpec.describe Claim, type: :model do
     it { is_expected.to have_many(:mentors).through(:mentor_trainings) }
   end
 
+  context "with validations" do
+    subject { build(:claim) }
+
+    it { is_expected.to validate_uniqueness_of(:reference).allow_nil }
+  end
+
   context "with delegations" do
     it { is_expected.to delegate_method(:name).to(:provider).with_prefix }
+  end
+
+  describe "#submitted_on" do
+    it "returns the submitted_at in date format" do
+      claim = build(:claim, submitted_at: Time.zone.local(2024, 2, 4, 10, 10))
+
+      expect(claim.submitted_on).to eq(Date.new(2024, 2, 4))
+    end
+
+    context "when submitted_at is nil" do
+      it "returns nil" do
+        claim = build(:claim)
+
+        expect(claim.submitted_on).to eq(nil)
+      end
+    end
   end
 end

--- a/spec/services/claim/submit_spec.rb
+++ b/spec/services/claim/submit_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe Claim::Submit do
+  subject(:submit_service) { described_class.call(claim:) }
+
+  let!(:claim) { create(:claim, :draft) }
+
+  describe "#call" do
+    it "submits the claim" do
+      allow(SecureRandom).to receive(:random_number).with(99_999_999).and_return(123)
+      allow(Time).to receive(:current).and_return("2024-03-04 10:32:04 UTC")
+
+      expect { submit_service }.to change(claim, :reference).from(nil).to("123")
+      expect(claim.draft).to eq(false)
+      expect(claim.submitted_at).to eq(Time.current)
+    end
+
+    context "when claim reference is already taken" do
+      it "submits the claim with a new reference" do
+        create(:claim, reference: "123")
+        allow(SecureRandom).to receive(:random_number).with(99_999_999).and_return(123, 456)
+        allow(Time).to receive(:current).and_return("2024-03-04 10:32:04 UTC")
+
+        expect { submit_service }.to change(claim, :reference).from(nil).to("456")
+
+        expect(claim.draft).to eq(false)
+        expect(claim.submitted_at).to eq(Time.current)
+      end
+    end
+  end
+end

--- a/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
 
   let(:mentor1) { create(:mentor, first_name: "Anne") }
   let(:mentor2) { create(:mentor, first_name: "Joe") }
-  let!(:claim) { create(:claim, school:, provider: provider1) }
+  let!(:claim) { create(:claim, :draft, school:, provider: provider1) }
 
   before do
     user_exists_in_dfe_sign_in(user: anne)
@@ -32,7 +32,7 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
     when_i_click("Continue")
     then_i_check_my_answers(provider2, [mentor1, mentor2], [20, 12])
     when_i_click("Submit claim")
-    # then_i_get_a_claim_reference
+    then_i_get_a_claim_reference(claim)
   end
 
   scenario "Anne does not have a provider selected when editing a claim from check page" do
@@ -60,7 +60,7 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
     when_i_click("Continue")
     then_i_check_my_answers(provider1, [mentor2], [20])
     when_i_click("Submit claim")
-    # then_i_get_a_claim_reference
+    then_i_get_a_claim_reference(claim)
   end
 
   scenario "Anne changes the training hours for a mentor on check page" do
@@ -192,6 +192,12 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
 
     within(".govuk-form-group--error") do
       expect(page).to have_content message
+    end
+  end
+
+  def then_i_get_a_claim_reference(claim)
+    within(".govuk-panel") do
+      expect(page).to have_content("Claim submitted\nYour reference number\n#{claim.reference}")
     end
   end
 

--- a/spec/system/claims/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/schools/claims/create_claim_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     when_i_click("Continue")
     then_i_check_my_answers
     when_i_click("Submit claim")
-    # then_i_get_a_claim_reference
+    then_i_get_a_claim_reference(Claim.where(draft: false).first)
   end
 
   scenario "Anne does not fill the form correctly" do
@@ -125,6 +125,12 @@ RSpec.describe "Create claim", type: :system, service: :claims do
         expect(page).to have_content(mentor2.full_name)
         expect(page).to have_content("12 hours")
       end
+    end
+  end
+
+  def then_i_get_a_claim_reference(claim)
+    within(".govuk-panel") do
+      expect(page).to have_content("Claim submitted\nYour reference number\n#{claim.reference}")
     end
   end
 

--- a/spec/system/claims/schools/claims/view_claims_spec.rb
+++ b/spec/system/claims/schools/claims/view_claims_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe "View claims", type: :system, service: :claims do
       school: school_with_mentors,
       provider: create(:provider),
       mentors: [create(:claims_mentor)],
+      submitted_at: Time.current,
     )
   end
   let(:mary) do


### PR DESCRIPTION
## Context

This is the last step in the create claim flow, the submit a claim functionality. For now we decided to use a Random number of 8 digits for the reference. This PR also adds a submitted_at datetime column to claim model

## Changes proposed in this pull request

Migration
New Claims::Submit service
New Submit Page
Random 8 digits reference

## Guidance to review

Pull or go on review app
Go through the `Add claim` flow and submit a claim
You should get a reference back
And the claim you just created should be on the index page of the school/claims


## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/4451e9eb-906c-496e-af53-38abf645964e


