### PR TITLE
As a User, I should be able to view the details of a Claim

### DIFF
--- a/app/views/claims/schools/claims/show.html.erb
+++ b/app/views/claims/schools/claims/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, t(".page_title", reference: @claim.reference) %>
+
 <% render "claims/schools/primary_navigation", school: @school, current: :claims %>
 
 <%= content_for(:before_content) do %>
@@ -5,29 +7,59 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
-  <h2 class="govuk-heading-m"><%= t(".providers_heading") %></h2>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= t(".page_title", reference: @claim.reference) %></h1>
 
-  <%= govuk_task_list(id_prefix: "providers", classes: "providers-task-list") do |task_list| %>
-    <%= task_list.with_item(
-      title: t(".itt_provider"),
-      href: edit_claims_school_claim_path(@school, @claim, "providers"),
-      status: govuk_tag(
-        text: @claim.item_status_tag("provider").fetch(:text),
-        colour: @claim.item_status_tag("provider").fetch(:colour),
-      ),
-    ) %>
-  <% end %>
+      <%= govuk_summary_list do |summary_list| %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: Claim.human_attribute_name(:school)) %>
+          <% row.with_value(text: @school.name) %>
+        <% end %>
 
-  <h2 class="govuk-heading-m"><%= t(".mentors_heading") %></h2>
-  <%= govuk_task_list(id_prefix: "mentors", classes: "mentors-task-list") do |task_list| %>
-    <%= task_list.with_item(
-      title: t(".general_mentors"),
-      href: edit_claims_school_claim_path(@school, @claim, "mentors"),
-      status: govuk_tag(
-        text: @claim.item_status_tag("mentors").fetch(:text),
-        colour: @claim.item_status_tag("mentors").fetch(:colour),
-      ),
-    ) %>
-  <% end %>
+        <% if @claim.provider %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: Claim.human_attribute_name(:provider)) %>
+            <% row.with_value(text: @claim.provider.name) %>
+          <% end %>
+        <% else %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: Claim.human_attribute_name(:provider)) %>
+            <% row.with_value(text: t("none")) %>
+          <% end %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".mentors")) %>
+          <% row.with_value do %>
+            <ul class="govuk-list">
+              <% @claim.mentors.each do |mentor| %>
+                <li><%= mentor.full_name %></li>
+              <% end %>
+            </ul>
+          <% end %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: Claim.human_attribute_name(:date_submitted)) %>
+          <% row.with_value(text: safe_l(@claim.submitted_on, format: :long)) %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: Claim.human_attribute_name(:status)) %>
+          <% row.with_value(text: render(Claim::StatusTagComponent.new(claim: @claim))) %>
+        <% end %>
+      <% end %>
+
+      <h2 class="govuk-heading-m"><%= t(".hours_of_training") %></h2>
+        <%= govuk_summary_list do |summary_list| %>
+         <%= @claim.mentor_trainings.order_by_mentor_full_name.each do |mentor_training| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: mentor_training.mentor.full_name) %>
+            <% row.with_value(text: "#{mentor_training.hours_completed} #{t(".hours")}") %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/config/locales/en/claims/schools/claims.yml
+++ b/config/locales/en/claims/schools/claims.yml
@@ -13,7 +13,6 @@ en:
           page_title: Check your answers
           warning: You will not be able to change any of the claim details once you have submitted it.
           submit: Submit claim
-          page_title: Check your answers
           add_claim: Add claim
           disclaimer: By submitting this claim, you confirm that the details provided are correct to the best of your knowledge.
           hours: "%{hours} hours"
@@ -32,10 +31,9 @@ en:
         update:
           claim_updated: Claim updated
         show:
-          heading: Claim general mentor training funding
-          providers_heading: 1. ITT provider
-          mentors_heading: 2. General mentors
-          itt_provider: ITT provider
-          general_mentors: General mentors
+          mentors: Mentors
+          page_title: Claim - %{reference}
+          hours_of_training: Hours of training
+          hours: hours
         edit:
           page_title: Provider - Add claim

--- a/spec/system/claims/schools/claims/view_claim_spec.rb
+++ b/spec/system/claims/schools/claims/view_claim_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe "View a claim", type: :system, service: :claims do
+  let(:school) { create(:claims_school, name: "A School") }
+
+  let(:anne) do
+    create(
+      :claims_user,
+      :anne,
+      user_memberships: [create(:user_membership, organisation: school)],
+    )
+  end
+
+  let!(:provider) { create(:provider, :best_practice_network) }
+  let!(:claims_mentor) { create(:claims_mentor, first_name: "Barry", last_name: "Garlow") }
+
+  let!(:claim) { create(:claim, school:, reference: "12345678", submitted_at: Time.new(2024, 3, 5, 12, 31, 52, "+00:00"), provider:) }
+  let!(:mentor_training) { create(:mentor_training, claim:, mentor: claims_mentor, hours_completed: 6) }
+
+  scenario "Anne visits the claims index page with a submited" do
+    user_exists_in_dfe_sign_in(user: anne)
+    given_i_sign_in
+    when_i_visit_the_claim_show_page
+    then_i_can_then_see_the_claim_details
+  end
+
+  private
+
+  def when_i_visit_the_claim_show_page
+    click_on claim.reference
+  end
+
+  def then_i_can_then_see_the_claim_details
+    expect(page).to have_content("Claim - 12345678")
+    expect(page).to have_content("SchoolA School")
+    expect(page).to have_content("ProviderBest Practice Network")
+    expect(page).to have_content("Mentors\nBarry Garlow")
+    expect(page).to have_content("Date submitted 5 March 2024")
+    expect(page).to have_content("Hours of training")
+    expect(page).to have_content("Status\nSubmitted")
+    expect(page).to have_content("Barry Garlow#{mentor_training.hours_completed} hours")
+  end
+
+  def given_i_sign_in
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+end


### PR DESCRIPTION
## Context

Update the claims details page to match the prototype 

prototype: https://itt-mentoring-beta-94341ca35a2c.herokuapp.com/organisations/049fc44e-6876-4884-8a77-d363173ce8d2/claims/34ce9b59-bba4-4714-8f51-d2a93d533e03

## Changes proposed in this pull request

Update the 

## Guidance to review

- Sign in as a normal user
- Create a claim
- Submit the claim
- View the claims index page
- Select the claim

## Link to Trello card

https://trello.com/c/FDAv0ZRT/197-as-a-user-i-should-be-able-to-view-the-details-of-a-claim

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<img width="726" alt="Screenshot 2024-03-05 at 14 25 26" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/4a619dd3-3516-46ca-ba36-397f9f2d14fc">
