### PR TITLE
Add claim form to support/school/claims

### DIFF
--- a/app/controllers/claims/schools/claims_controller.rb
+++ b/app/controllers/claims/schools/claims_controller.rb
@@ -21,7 +21,18 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
 
   def show; end
 
-  def check; end
+  def check
+    last_mentor_training = @claim.mentor_trainings.order_by_mentor_full_name.last
+
+    @back_path = edit_claims_school_claim_mentor_training_path(
+      @school,
+      @claim,
+      last_mentor_training,
+      params: {
+        claim_mentor_training_form: { hours_completed: last_mentor_training.hours_completed },
+      },
+    )
+  end
 
   def edit; end
 
@@ -36,7 +47,7 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
   def confirm; end
 
   def submit
-    Claims::Submit.call(claim: @claim)
+    Claims::Submit.call(claim: @claim, draft: false)
 
     redirect_to confirm_claims_school_claim_path(@school, @claim)
   end

--- a/app/controllers/claims/support/schools/claims/mentor_trainings_controller.rb
+++ b/app/controllers/claims/support/schools/claims/mentor_trainings_controller.rb
@@ -1,0 +1,59 @@
+class Claims::Support::Schools::Claims::MentorTrainingsController < Claims::ApplicationController
+  include Claims::BelongsToSchool
+  before_action :authorize_claim
+  helper_method :mentor_training_form
+
+  def edit; end
+
+  def update
+    if mentor_training_form.save
+      path = if claim.mentor_trainings.without_hours.any?
+               edit_claims_support_school_claim_mentor_training_path(
+                 claim.school,
+                 claim,
+                 claim.mentor_trainings.without_hours.first,
+               )
+             else
+               check_claims_support_school_claim_path(claim.school, claim)
+             end
+
+      redirect_to path
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def mentor_training_form
+    @mentor_training_form ||=
+      if params[:claim_mentor_training_form].present?
+        Claim::MentorTrainingForm.new(mentor_training_params)
+      else
+        Claim::MentorTrainingForm.new(default_params)
+      end
+  end
+
+  def mentor_training_params
+    params.require(:claim_mentor_training_form).permit(
+      :hours_completed,
+      :custom_hours_completed,
+    ).merge(default_params)
+  end
+
+  def default_params
+    { claim:, mentor_training: }
+  end
+
+  def mentor_training
+    @mentor_training ||= @claim.mentor_trainings.find(params.require(:id))
+  end
+
+  def claim
+    @claim ||= @school.claims.find(params.require(:claim_id))
+  end
+
+  def authorize_claim
+    authorize claim
+  end
+end

--- a/app/controllers/claims/support/schools/claims/mentors_controller.rb
+++ b/app/controllers/claims/support/schools/claims/mentors_controller.rb
@@ -1,0 +1,65 @@
+class Claims::Support::Schools::Claims::MentorsController < Claims::ApplicationController
+  include Claims::BelongsToSchool
+  before_action :authorize_claim
+
+  helper_method :claim_mentors_form
+
+  def new; end
+
+  def create
+    if claim_mentors_form.save
+      redirect_to(
+        edit_claims_support_school_claim_mentor_training_path(
+          @school,
+          claim,
+          claim.mentor_trainings.without_hours.first,
+        ),
+      )
+    else
+      render :new
+    end
+  end
+
+  def edit; end
+
+  def update
+    if claim_mentors_form.save
+      path = if claim.mentor_trainings.without_hours.any?
+               edit_claims_support_school_claim_mentor_training_path(
+                 claim.school,
+                 claim,
+                 claim.mentor_trainings.without_hours.first,
+               )
+             else
+               check_claims_support_school_claim_path(claim.school, claim)
+             end
+
+      redirect_to path
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def claim_params
+    params.require(:claim).permit(mentor_ids: [])
+  end
+
+  def claim
+    @claim ||= @school.claims.find(params.require(:claim_id))
+  end
+
+  def claim_mentors_form
+    @claim_mentors_form ||=
+      if params[:claim].present?
+        Claim::MentorsForm.new(claim:, mentor_ids: claim_params[:mentor_ids])
+      else
+        Claim::MentorsForm.new(claim:)
+      end
+  end
+
+  def authorize_claim
+    authorize claim
+  end
+end

--- a/app/controllers/claims/support/schools/claims_controller.rb
+++ b/app/controllers/claims/support/schools/claims_controller.rb
@@ -1,13 +1,81 @@
 class Claims::Support::Schools::ClaimsController < Claims::Support::ApplicationController
   include Claims::BelongsToSchool
 
+  before_action :set_claim, only: %i[check submit]
   before_action :authorize_claim
+  helper_method :claim_provider_form
 
   def index
     @claims = @school.claims.order("created_at DESC")
   end
 
+  def new; end
+
+  def create
+    if claim_provider_form.save
+      redirect_to new_claims_support_school_claim_mentor_path(@school, claim_provider_form.claim)
+    else
+      render :new
+    end
+  end
+
+  def check
+    last_mentor_training = @claim.mentor_trainings.order_by_mentor_full_name.last
+
+    @back_path = edit_claims_support_school_claim_mentor_training_path(
+      @school,
+      @claim,
+      last_mentor_training,
+      params: {
+        claim_mentor_training_form: { hours_completed: last_mentor_training.hours_completed },
+      },
+    )
+  end
+
+  def edit; end
+
+  def update
+    if claim_provider_form.save
+      redirect_to check_claims_support_school_claim_path(@school, claim_provider_form.claim)
+    else
+      render :edit
+    end
+  end
+
+  def submit
+    Claims::Submit.call(claim: @claim, draft: true)
+
+    redirect_to claims_support_school_claims_path(@school), flash: { success: t(".success") }
+  end
+
   private
+
+  def claim_params
+    params.require(:claim)
+      .permit(:id, :provider_id)
+      .merge(default_params)
+  end
+
+  def default_params
+    { school: @school }
+  end
+
+  def claim_id
+    params[:claim_id] || params[:id]
+  end
+
+  def set_claim
+    @claim = @school.claims.find(claim_id).decorate
+  end
+
+  def claim_provider_form
+    @claim_provider_form ||=
+      if params[:claim].present?
+        Claim::ProviderForm.new(claim_params)
+      else
+        Claim::ProviderForm.new(default_params.merge(id: claim_id))
+      end
+  end
 
   def authorize_claim
     authorize Claim

--- a/app/services/claims/submit.rb
+++ b/app/services/claims/submit.rb
@@ -1,8 +1,9 @@
 class Claims::Submit
   include ServicePattern
 
-  def initialize(claim:)
+  def initialize(claim:, draft:)
     @claim = claim
+    @draft = draft
   end
 
   def call
@@ -11,11 +12,11 @@ class Claims::Submit
 
   private
 
-  attr_reader :claim
+  attr_reader :claim, :draft
 
   def updated_claim
     @updated_claim ||= begin
-      claim.draft = false
+      claim.draft = draft
       claim.submitted_at = Time.current
       claim.reference = generate_reference
       claim

--- a/app/views/claims/support/schools/claims/_form.html.erb
+++ b/app/views/claims/support/schools/claims/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_with(model: claim_provider_form, url: form_url, method:) do |f| %>
+  <%= f.govuk_error_summary %>
+  <%= f.hidden_field :id, value: claim_provider_form.claim.id %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".add_claim", school: @school.name) %></span>
+
+      <%= f.govuk_collection_radio_buttons(
+        :provider_id,
+        Provider.private_beta_providers,
+        :id,
+        :name,
+        legend: { text: t(".heading"), size: "l" },
+      ) %>
+
+      <%= f.govuk_submit t("continue") %>
+      <p class="govuk-body">
+        <%= govuk_link_to(t("cancel"), claims_support_school_claims_path(school), no_visited_state: true) %>
+      </p>
+  </div>
+<% end %>

--- a/app/views/claims/support/schools/claims/check.html.erb
+++ b/app/views/claims/support/schools/claims/check.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, t(".page_title") %>
-<% render "claims/schools/primary_navigation", school: @school, current: :claims %>
+<% render "claims/support/primary_navigation", current: :organisations %>
 
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: @back_path) %>
@@ -9,7 +9,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <label class="govuk-label govuk-label--l">
-        <span class="govuk-caption-l"><%= t(".add_claim") %></span>
+        <span class="govuk-caption-l"><%= t(".add_claim", school: @school.name) %></span>
         <%= t(".page_title") %>
       </label>
 
@@ -18,7 +18,7 @@
           <% row.with_key(text: Claim.human_attribute_name(:provider)) %>
           <% row.with_value(text: @claim.provider_name) %>
           <% row.with_action(text: t("change"),
-                             href: edit_claims_school_claim_path(
+                             href: edit_claims_support_school_claim_path(
                                @school,
                                @claim,
                              ),
@@ -37,7 +37,7 @@
             </ul>
           <% end %>
           <% row.with_action(text: t("change"),
-                             href: edit_claims_school_claim_mentor_path(@school, @claim),
+                             href: edit_claims_support_school_claim_mentor_path(@school, @claim),
                              html_attributes: {
                                class: "govuk-link--no-visited-state",
                              }) %>
@@ -52,7 +52,7 @@
             <% row.with_key(text: mentor_training.mentor.full_name) %>
             <% row.with_value(text: t(".hours", hours: mentor_training.hours_completed)) %>
             <% row.with_action(text: t("change"),
-                               href: edit_claims_school_claim_mentor_training_path(
+                               href: edit_claims_support_school_claim_mentor_training_path(
                                  @school,
                                  @claim,
                                  mentor_training,
@@ -74,10 +74,10 @@
         <strong class="govuk-warning-text__text"><%= t(".warning") %></strong>
       </div>
 
-      <%= govuk_button_to t(".submit"), submit_claims_school_claim_path(@school, @claim) %>
+      <%= govuk_button_to t(".submit"), submit_claims_support_school_claim_path(@school, @claim) %>
 
       <p class="govuk-body">
-        <%= govuk_link_to t("cancel"), claims_school_claims_path(@school), no_visited_state: true %>
+        <%= govuk_link_to t("cancel"), claims_support_school_claims_path(@school), no_visited_state: true %>
       </p>
     <div>
   <div>

--- a/app/views/claims/support/schools/claims/edit.html.erb
+++ b/app/views/claims/support/schools/claims/edit.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title, t(".page_title") %>
+<% render "claims/support/primary_navigation", current: :organisations %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: check_claims_support_school_claim_path(@school, claim_provider_form.claim)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= render(
+    partial: "form",
+    locals: {
+      claim_provider_form:,
+      form_url: claims_support_school_claim_path(@school, claim_provider_form.claim),
+      method: :patch,
+      school: @school,
+    },
+  ) %>
+</div>

--- a/app/views/claims/support/schools/claims/index.html.erb
+++ b/app/views/claims/support/schools/claims/index.html.erb
@@ -5,6 +5,13 @@
 
   <%= render "claims/support/schools/secondary_navigation", school: @school %>
 
+  <% if @school.mentors.any? %>
+    <p class="govuk-inset-text"><%= t(".guidance") %></p>
+    <%= govuk_link_to t(".add_claim"), new_claims_support_school_claim_path, class: "govuk-button" %>
+  <% else %>
+    <p class="govuk-inset-text"><%= t(".add_mentor_guidance_html", link_to: govuk_link_to(t(".add_a_mentor"), claims_support_school_mentors_path(@school))) %></p>
+  <% end %>
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m"><%= t(".heading") %></h2>

--- a/app/views/claims/support/schools/claims/mentor_trainings/edit.html.erb
+++ b/app/views/claims/support/schools/claims/mentor_trainings/edit.html.erb
@@ -1,0 +1,61 @@
+<% content_for(
+  :page_title,
+  t(".page_title", mentor: mentor_training_form.mentor_training.mentor_full_name),
+) %>
+
+<% render "claims/support/primary_navigation", current: :organisations %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: edit_claims_support_school_claim_mentor_path(@school, mentor_training_form.claim)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= form_with(
+    model: mentor_training_form,
+    url: claims_support_school_claim_mentor_training_path(
+      @school,
+      mentor_training_form.claim,
+      mentor_training_form.mentor_training,
+    ),
+    method: :patch,
+  ) do |f| %>
+    <%= f.govuk_error_summary %>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <span class="govuk-caption-l"><%= t(".add_claim", school: @school.name) %></span>
+        <%= f.govuk_radio_buttons_fieldset(
+          :hours_completed,
+          legend: {
+            size: "l",
+            text: t(".hours_of_training", mentor: mentor_training_form.mentor_full_name),
+          },
+        ) do %>
+          <%= f.govuk_radio_button :hours_completed, "20", label: { text: t(".20_hours") } %>
+          <%= f.govuk_radio_button :hours_completed, "6", label: { text: t(".6_hours") } %>
+
+          <%= f.govuk_radio_divider %>
+
+          <%= f.govuk_radio_button(
+            :hours_completed,
+            "on",
+            checked: mentor_training_form.custom_hours?,
+            label: { text: t(".other_amount") },
+          ) do %>
+            <h5 class="govuk-heading-s govuk-!-margin-bottom-1"><%= t(".number_of_hours") %></h5>
+            <%= f.govuk_number_field(
+              :custom_hours_completed,
+              value: mentor_training_form.custom_hours? ? mentor_training_form.mentor_training.hours_completed : nil,
+              class: "govuk-input--width-2",
+              label: { text: t(".enter_whole_numbers") },
+            ) %>
+          <% end %>
+        <% end %>
+
+        <%= f.govuk_submit t("continue") %>
+        <p class="govuk-body">
+          <%= govuk_link_to(t("cancel"), claims_support_school_claims_path(@school), no_visited_state: true) %>
+        </p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/claims/support/schools/claims/mentors/_form.html.erb
+++ b/app/views/claims/support/schools/claims/mentors/_form.html.erb
@@ -1,0 +1,24 @@
+  <%= form_with model: claim_mentors_form, url: form_url, method: do |f| %>
+    <%= f.govuk_error_summary %>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <span class="govuk-caption-l"><%= t(".add_claim", school: @school.name) %></span>
+
+        <%= f.govuk_collection_check_boxes(
+          :mentor_ids,
+          school.mentors.order_by_full_name,
+          :id,
+          :full_name,
+          :trn,
+          include_hidden: false,
+          legend: { text: t(".heading"), size: "l" },
+          hint: { text: t(".select_all_that_apply") },
+        ) %>
+
+        <%= f.govuk_submit t("continue") %>
+        <p class="govuk-body">
+          <%= govuk_link_to(t("cancel"), claims_support_school_claims_path(school), no_visited_state: true) %>
+        </p>
+    </div>
+  <% end %>

--- a/app/views/claims/support/schools/claims/mentors/edit.html.erb
+++ b/app/views/claims/support/schools/claims/mentors/edit.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title, t(".page_title") %>
+<% render "claims/support/primary_navigation", current: :organisations %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: edit_claims_support_school_claim_path(@school, claim_mentors_form.claim)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= render(
+    partial: "form",
+    locals: {
+      claim_mentors_form:,
+      form_url: claims_support_school_claim_mentor_path(@school, claim_mentors_form.claim),
+      method: :patch,
+      school: @school,
+    },
+  ) %>
+</div>

--- a/app/views/claims/support/schools/claims/mentors/new.html.erb
+++ b/app/views/claims/support/schools/claims/mentors/new.html.erb
@@ -1,0 +1,21 @@
+<% content_for :page_title, t(".page_title") %>
+<% render "claims/support/primary_navigation", current: :organisations %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: new_claims_support_school_claim_path(
+    @school,
+    params: { id: claim_mentors_form.claim.id },
+  )) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= render(
+    partial: "form",
+    locals: {
+      claim_mentors_form:,
+      form_url: claims_support_school_claim_mentors_path(@school, claim_mentors_form.claim),
+      method: :post,
+      school: @school,
+    },
+  ) %>
+</div>

--- a/app/views/claims/support/schools/claims/new.html.erb
+++ b/app/views/claims/support/schools/claims/new.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title, t(".page_title") %>
+<% render "claims/support/primary_navigation", current: :organisations %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: claims_support_school_claims_path(@school)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= render(
+    partial: "form",
+    locals: {
+      claim_provider_form:,
+      form_url: claims_support_school_claims_path(@school),
+      method: :post,
+      school: @school,
+    },
+  ) %>
+</div>

--- a/config/locales/en/claims/support/schools/claims.yml
+++ b/config/locales/en/claims/support/schools/claims.yml
@@ -3,6 +3,29 @@ en:
     support:
       schools:
         claims:
+          submit:
+            success: Claim added
+          edit:
+            page_title: Provider - Add claim
+          check:
+            page_title: Check your answers
+            warning: You will not be able to change any of the claim details once you have submitted it.
+            submit: Add claim
+            page_title: Check your answers
+            add_claim: Add claim - %{school}
+            disclaimer: By submitting this claim, you confirm that the details provided are correct to the best of your knowledge.
+            hours: "%{hours} hours"
+            hours_of_training: Hours of training
           index:
             heading: Claims
             claim_id: ID
+            add_claim: Add claim
+            guidance: You can only claim for the academic year September 2023 to July 2024.
+            add_mentor_guidance_html: You need to %{link_to} before creating a claim.</p>
+            add_a_mentor: add a mentor
+          new:
+            page_title: Provider - Add claim
+          form:
+            add_claim: Add claim - %{school}
+            heading: Provider
+

--- a/config/locales/en/claims/support/schools/claims/mentor_trainings.yml
+++ b/config/locales/en/claims/support/schools/claims/mentor_trainings.yml
@@ -1,0 +1,15 @@
+en:
+  claims:
+    support:
+      schools:
+        claims:
+          mentor_trainings:
+            edit:
+              page_title: Hours of training for %{mentor}
+              add_claim: Add claim - %{school} 
+              hours_of_training: Hours of training for %{mentor}
+              20_hours: 20 hours
+              6_hours: 6 hours
+              other_amount: Other amount
+              enter_whole_numbers: Enter whole numbers up to a maximum of 20 hours
+              number_of_hours: Number of hours

--- a/config/locales/en/claims/support/schools/claims/mentors.yml
+++ b/config/locales/en/claims/support/schools/claims/mentors.yml
@@ -1,0 +1,14 @@
+en:
+  claims:
+    support:
+      schools:
+        claims:
+          mentors:
+            form:
+              heading: Mentor
+              select_all_that_apply: Select all that apply
+              add_claim: Add claim - %{school}
+            new:
+              page_title: Mentor - Add claim
+            edit:
+              page_title: Mentor - Add claim

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -7,7 +7,7 @@ scope module: :claims, as: :claims, constraints: { host: ENV["CLAIMS_HOST"] } do
 
   resources :schools, only: %i[index show] do
     scope module: :schools do
-      resources :claims, only: %i[index new create show edit update] do
+      resources :claims, except: %i[destroy] do
         resources :mentors, only: %i[new create edit update], module: :claims
         resources :mentor_trainings, only: %i[edit update], module: :claims
 
@@ -50,7 +50,15 @@ scope module: :claims, as: :claims, constraints: { host: ENV["CLAIMS_HOST"] } do
       end
 
       scope module: :schools do
-        resources :claims
+        resources :claims, except: %i[destroy] do
+          resources :mentors, only: %i[new create edit update], module: :claims
+          resources :mentor_trainings, only: %i[edit update], module: :claims
+
+          member do
+            get :check
+            post :submit
+          end
+        end
 
         resources :mentors, only: %i[index new create show destroy] do
           member { get :remove }

--- a/spec/services/claims/submit_spec.rb
+++ b/spec/services/claims/submit_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
 describe Claims::Submit do
-  subject(:submit_service) { described_class.call(claim:) }
+  subject(:submit_service) { described_class.call(claim:, draft:) }
 
+  let(:draft) { false }
   let!(:claim) { create(:claim, :draft) }
 
   describe "#call" do
@@ -24,6 +25,19 @@ describe Claims::Submit do
         expect { submit_service }.to change(claim, :reference).from(nil).to("456")
 
         expect(claim.draft).to eq(false)
+        expect(claim.submitted_at).to eq(Time.current)
+      end
+    end
+
+    context "when draft value is true" do
+      let(:draft) { true }
+
+      it "submits the claim" do
+        allow(SecureRandom).to receive(:random_number).with(99_999_999).and_return(123)
+        allow(Time).to receive(:current).and_return("2024-03-04 10:32:04 UTC")
+
+        expect { submit_service }.to change(claim, :reference).from(nil).to("123")
+        expect(claim.draft).to eq(true)
         expect(claim.submitted_at).to eq(Time.current)
       end
     end

--- a/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
@@ -1,0 +1,222 @@
+require "rails_helper"
+
+RSpec.describe "Change claim on check page", type: :system, service: :claims do
+  let!(:school) { create(:claims_school, mentors: [mentor1, mentor2]) }
+  let!(:colin) do
+    create(
+      :claims_support_user,
+      :colin,
+      user_memberships: [create(:user_membership, organisation: school)],
+    )
+  end
+  let!(:provider1) { create(:provider, :best_practice_network) }
+  let!(:provider2) { create(:provider, :niot) }
+
+  let(:mentor1) { create(:mentor, first_name: "Anne") }
+  let(:mentor2) { create(:mentor, first_name: "Joe") }
+  let!(:claim) { create(:claim, :draft, school:, provider: provider1) }
+
+  before do
+    user_exists_in_dfe_sign_in(user: colin)
+    given_i_sign_in
+    create(:mentor_training, mentor: mentor1, provider: provider1, claim:, hours_completed: 20)
+    create(:mentor_training, mentor: mentor2, provider: provider1, claim:, hours_completed: 12)
+  end
+
+  scenario "Colin changes the provider on claim on check page" do
+    given_i_visit_claim_support_check_page
+    when_i_click_change_provider
+    then_i_expect_the_provider_to_be_checked(provider1)
+    when_i_change_the_provider
+    then_i_expect_the_provider_to_be_checked(provider2)
+    when_i_click("Continue")
+    then_i_check_my_answers(provider2, [mentor1, mentor2], [20, 12])
+    when_i_click("Add claim")
+    then_i_am_redirectd_to_index_page(claim)
+  end
+
+  scenario "Colin does not have a provider selected when editing a claim from check page" do
+    given_i_visit_claim_support_check_page
+    when_i_click_change_provider
+    then_i_expect_the_provider_to_be_checked(provider1)
+    when_i_remove_the_provider_from_the_claim
+    then_i_reload_the_page
+    when_i_click("Continue")
+    then_i_see_the_error("Select a provider")
+  end
+
+  scenario "Colin changes the mentors on claim on check page" do
+    given_i_visit_claim_support_check_page
+    when_i_click_change_mentors
+    then_i_expect_the_mentors_to_be_checked([mentor1, mentor2])
+    when_i_uncheck_the_mentors([mentor1, mentor2])
+    when_i_click("Continue")
+    then_i_see_the_error("Select a mentor")
+    when_i_check_the_mentor(mentor2)
+    when_i_click("Continue")
+    when_i_click("Continue")
+    then_i_see_the_error("Select the number of hours")
+    when_i_add_training_hours("20 hours")
+    when_i_click("Continue")
+    then_i_check_my_answers(provider1, [mentor2], [20])
+    when_i_click("Add claim")
+    then_i_am_redirectd_to_index_page(claim)
+  end
+
+  scenario "Colin clicks change mentors the check page and is redirected back to check page" do
+    given_i_visit_claim_support_check_page
+    when_i_click_change_mentors
+    then_i_expect_the_mentors_to_be_checked([mentor1, mentor2])
+    when_i_click("Continue")
+    then_i_check_my_answers(provider1, [mentor1, mentor2], [20])
+  end
+
+  scenario "Colin changes the training hours for a mentor on check page" do
+    given_i_visit_claim_support_check_page
+    when_i_click_change_training_hours_for_mentor
+    then_i_expect_the_training_hours_to_be_selected("20")
+    when_i_choose_other_amount
+    when_i_click("Continue")
+    then_i_see_the_error("Enter the number of hours")
+    when_i_choose_other_amount_and_input_hours(6, with_error: true)
+    when_i_click("Continue")
+    then_i_check_my_answers(provider1, [mentor1, mentor2], [6, 12])
+  end
+
+  private
+
+  def given_i_sign_in
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def given_i_visit_claim_support_check_page
+    visit check_claims_support_school_claim_path(school, claim)
+  end
+
+  def when_i_click_change_provider
+    within("dl.govuk-summary-list:nth(1)") do
+      within(".govuk-summary-list__row:nth(1)") do
+        click_on("Change")
+      end
+    end
+  end
+
+  def when_i_click_change_mentors
+    within("dl.govuk-summary-list:nth(1)") do
+      within(".govuk-summary-list__row:nth(2)") do
+        click_on("Change")
+      end
+    end
+  end
+
+  def when_i_click_change_training_hours_for_mentor
+    within("dl.govuk-summary-list:nth(2)") do
+      within(".govuk-summary-list__row:nth(1)") do
+        click_on("Change")
+      end
+    end
+  end
+
+  def when_i_choose_other_amount
+    page.choose("Other amount")
+  end
+
+  def when_i_choose_other_amount_and_input_hours(hours, with_error: false)
+    page.choose("Other amount")
+
+    if with_error
+      fill_in("claim-mentor-training-form-custom-hours-completed-field-error", with: hours)
+    else
+      fill_in("claim-mentor-training-form-custom-hours-completed-field", with: hours)
+    end
+  end
+
+  def then_i_expect_the_provider_to_be_checked(provider)
+    has_checked_field?("#claim-provider-form-provider-id-#{provider.id}-field")
+  end
+
+  def then_i_expect_the_mentors_to_be_checked(mentors)
+    mentors.each do |mentor|
+      has_checked_field?("#claim-mentor-ids-#{mentor.id}-field")
+    end
+  end
+
+  def when_i_click(button)
+    click_on(button)
+  end
+
+  def when_i_change_the_provider
+    page.choose(provider2.name)
+  end
+
+  def when_i_uncheck_the_mentors(mentors)
+    mentors.each do |mentor|
+      uncheck(mentor.full_name)
+    end
+  end
+
+  def when_i_check_the_mentor(mentor)
+    check(mentor.full_name)
+  end
+
+  def when_i_add_training_hours(hours)
+    choose(hours)
+  end
+
+  def then_i_expect_the_training_hours_to_be_selected(hours)
+    find("#claim-mentor-training-form-hours-completed-#{hours}-field").checked?
+  end
+
+  def then_i_check_my_answers(provider, mentors, mentor_hours)
+    expect(page).to have_content("Check your answers")
+
+    within("dl.govuk-summary-list:nth(1)") do
+      within(".govuk-summary-list__row:nth(1)") do
+        expect(page).to have_content("Provider")
+        expect(page).to have_content(provider.name)
+      end
+
+      within(".govuk-summary-list__row:nth(2)") do
+        expect(page).to have_content("Mentors")
+        mentors.each do |mentor|
+          expect(page).to have_content(mentor.full_name)
+        end
+      end
+    end
+
+    within("dl.govuk-summary-list:nth(2)") do
+      claim.mentor_trainings.each_with_index do |mentor_training, index|
+        expect(page).to have_content(mentor_training.mentor.full_name)
+        expect(page).to have_content(mentor_hours[index])
+      end
+    end
+  end
+
+  def then_i_see_the_error(message)
+    within(".govuk-error-summary") do
+      expect(page).to have_content message
+    end
+
+    within(".govuk-form-group--error") do
+      expect(page).to have_content message
+    end
+  end
+
+  def then_i_am_redirectd_to_index_page(claim)
+    within(".govuk-notification-banner--success") do
+      expect(page).to have_content "Claim added"
+    end
+
+    expect(page).to have_content(claim.id)
+  end
+
+  def when_i_remove_the_provider_from_the_claim
+    claim.provider_id = nil
+    claim.save!(validate: false)
+  end
+
+  def then_i_reload_the_page
+    refresh
+  end
+end

--- a/spec/system/claims/support/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/create_claim_spec.rb
@@ -1,0 +1,158 @@
+require "rails_helper"
+
+RSpec.describe "Create claim", type: :system, service: :claims do
+  let!(:school) { create(:claims_school, mentors: [mentor1, mentor2]) }
+  let!(:colin) do
+    create(
+      :claims_support_user,
+      :colin,
+      user_memberships: [create(:user_membership, organisation: school)],
+    )
+  end
+  let!(:provider) { create(:provider, :best_practice_network) }
+  let(:mentor1) { create(:mentor, first_name: "Anne") }
+  let(:mentor2) { create(:mentor, first_name: "Joe") }
+
+  before do
+    user_exists_in_dfe_sign_in(user: colin)
+    given_i_sign_in
+  end
+
+  scenario "Colin creates a claim" do
+    when_i_click(school.name)
+    when_i_click_on_claims
+    when_i_click("Add claim")
+    when_i_choose_a_provider
+    when_i_click("Continue")
+    when_i_select_all_mentors
+    when_i_click("Continue")
+    then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor1)
+    when_i_add_training_hours("20 hours")
+    when_i_click("Continue")
+    then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor2)
+    when_i_choose_other_amount_and_input_hours(12)
+    when_i_click("Continue")
+    then_i_check_my_answers
+    when_i_click("Add claim")
+    then_i_am_redirectd_to_index_page(Claim.where(draft: true).first)
+  end
+
+  scenario "Colin does not fill the form correctly" do
+    when_i_click(school.name)
+    when_i_click_on_claims
+    when_i_click("Add claim")
+    when_i_click("Continue")
+    then_i_see_the_error("Select a provider")
+    when_i_choose_a_provider
+    when_i_click("Continue")
+    when_i_click("Continue")
+    then_i_see_the_error("Select a mentor")
+    when_i_select_all_mentors
+    when_i_click("Continue")
+    when_i_click("Continue")
+    then_i_see_the_error("Select the number of hours")
+    when_i_choose_other_amount
+    when_i_click("Continue")
+    then_i_see_the_error("Enter the number of hours")
+    when_i_choose_other_amount_and_input_hours(-1)
+    when_i_click("Continue")
+    then_i_see_the_error("Enter the number of hours between 1 and 20")
+    when_i_choose_other_amount_and_input_hours(21)
+    when_i_click("Continue")
+    then_i_see_the_error("Enter the number of hours between 1 and 20")
+    when_i_choose_other_amount_and_input_hours(0.5)
+    when_i_click("Continue")
+    then_i_see_the_error("Enter the number of hours between 1 and 20")
+  end
+
+  private
+
+  def given_i_sign_in
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def when_i_click(button)
+    click_on(button)
+  end
+
+  def when_i_click_on_claims
+    within(".app-secondary-navigation__list") do
+      click_on("Claims")
+    end
+  end
+
+  def when_i_choose_a_provider
+    page.choose(provider.name)
+  end
+
+  def when_i_select_all_mentors
+    page.check(mentor1.full_name)
+    page.check(mentor2.full_name)
+  end
+
+  def then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor)
+    expect(page).to have_content("Hours of training for #{mentor.full_name}")
+  end
+
+  def when_i_add_training_hours(radio_button)
+    page.choose(radio_button)
+  end
+
+  def when_i_choose_other_amount
+    page.choose("Other amount")
+  end
+
+  def when_i_choose_other_amount_and_input_hours(hours)
+    page.choose("Other amount")
+    fill_in("Enter whole numbers up to a maximum of 20 hours", with: hours)
+  end
+
+  def then_i_check_my_answers
+    expect(page).to have_content("Check your answers")
+    expect(page).to have_content("Hours of training")
+
+    within("dl.govuk-summary-list:nth(1)") do
+      within(".govuk-summary-list__row:nth(1)") do
+        expect(page).to have_content("Provider")
+        expect(page).to have_content(provider.name)
+      end
+
+      within(".govuk-summary-list__row:nth(2)") do
+        expect(page).to have_content("Mentors")
+        expect(page).to have_content(mentor1.full_name)
+        expect(page).to have_content(mentor2.full_name)
+      end
+    end
+
+    within("dl.govuk-summary-list:nth(2)") do
+      within(".govuk-summary-list__row:nth(1)") do
+        expect(page).to have_content(mentor1.full_name)
+        expect(page).to have_content("20 hours")
+      end
+
+      within(".govuk-summary-list__row:nth(2)") do
+        expect(page).to have_content(mentor2.full_name)
+        expect(page).to have_content("12 hours")
+      end
+    end
+  end
+
+  def then_i_am_redirectd_to_index_page(claim)
+    within(".govuk-notification-banner--success") do
+      expect(page).to have_content "Claim added"
+    end
+
+    expect(page).to have_content(claim.id)
+  end
+
+  def then_i_see_the_error(message)
+    within(".govuk-error-summary") do
+      expect(page).to have_content message
+    end
+
+    within(".govuk-form-group--error") do
+      expect(page).to have_content message
+    end
+  end
+end


### PR DESCRIPTION
## Context

This is using the claim form already in place with a few tweaks like the support user cannot submit a claim, it just adds a claim in a draft status

## Changes

- Support school claims form controllers
- Fix school claims check back link
- Changed Claim::Submit service to work with both support and not support claim forms

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Pull or go onto the review app
Login as support user
Go into a school
Create a claim
Edit claim on the check page
Add the claim


## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/6789d888-8703-4413-bfe5-6e1650f96222


