### PR TITLE
Add claim amount to claim details page

### DIFF
--- a/app/views/claims/schools/claims/show.html.erb
+++ b/app/views/claims/schools/claims/show.html.erb
@@ -60,6 +60,14 @@
           <% end %>
         <% end %>
       <% end %>
+
+      <h2 class="govuk-heading-m"><%= t(".grant_funding") %></h2>
+        <%= govuk_summary_list do |summary_list| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: Claim.human_attribute_name(:claim_amount)) %>
+            <% row.with_value(text: humanized_money_with_symbol(@claim.amount)) %>
+          <% end %>
+        <% end %>
     </div>
   </div>
 </div>

--- a/config/locales/en/claims/schools/claims.yml
+++ b/config/locales/en/claims/schools/claims.yml
@@ -34,6 +34,7 @@ en:
           mentors: Mentors
           page_title: Claim - %{reference}
           hours_of_training: Hours of training
+          grant_funding: Grant funding
           hours: hours
         edit:
           page_title: Provider - Add claim

--- a/spec/system/claims/schools/claims/view_claim_spec.rb
+++ b/spec/system/claims/schools/claims/view_claim_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe "View a claim", type: :system, service: :claims do
     expect(page).to have_content("Hours of training")
     expect(page).to have_content("Status\nSubmitted")
     expect(page).to have_content("Barry Garlow#{mentor_training.hours_completed} hours")
+    expect(page).to have_content("Claim amount£321.60")
   end
 
   def given_i_sign_in


### PR DESCRIPTION
## Context

We need to add the claim amount to the claim details page

## Changes proposed in this pull request

Adds the claim amount

## Guidance to review

- Create a claim
- View the claim 

## Link to Trello card

https://trello.com/c/CN7obywm/223-add-claim-amount-to-claim-details-page

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<img width="1220" alt="Screenshot 2024-03-06 at 11 13 27" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/ebd83669-35e7-4a18-a934-428e03c0774c">

