### PR TITLE
Change schedule for GIAS sync job

### DIFF
--- a/config/scheduled_jobs.yml
+++ b/config/scheduled_jobs.yml
@@ -7,7 +7,7 @@
 #   class: NameOfAJob
 #   description: Description is shown in the GoodJob dashboard.
 gias_school_sync:
-  cron: "10 0 * * *"
+  cron: "30 23 * * *"
   class: "Gias::SyncAllSchoolsJob"
   description: "Import/Update Schools using GIAS data"
 


### PR DESCRIPTION
## Context

- Due to an issue when collecting the GIAS CSV at midnight (https://manage-school-placements-qa.test.teacherservices.cloud/good_job/jobs/d3c3adf2-f4b7-4c9b-a0cb-5bf50e17195e?locale=en#discrete_execution_31b2f310-cc1a-45f2-aa35-675ec692837c), change the schedule to run at the end of the day.

## Changes proposed in this pull request

- Change the `gias_school_sync` scheduled job to run at 23:30.
