### PR TITLE
Add Claims Start Page

### DIFF
--- a/app/assets/stylesheets/app-related-aside.scss
+++ b/app/assets/stylesheets/app-related-aside.scss
@@ -1,0 +1,10 @@
+.app-related {
+  border-top: 2px solid govuk-colour("blue");
+  padding-top: govuk_spacing(3);
+}
+
+.app-related__list-item {
+  @include govuk-font(16);
+  font-weight: bold;
+  margin-top: govuk-spacing(3);
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,3 +8,4 @@ $govuk-assets-path: "";
 @import "accessible-autocomplete/dist/accessible-autocomplete.min";
 @import "search-form";
 @import "filter-form";
+@import "app-related-aside";

--- a/app/controllers/claims/support/application_controller.rb
+++ b/app/controllers/claims/support/application_controller.rb
@@ -6,7 +6,7 @@ class Claims::Support::ApplicationController < Claims::ApplicationController
   def authorize_user!
     return if current_user.support_user?
 
-    redirect_to claims_root_path, alert: t("you_cannot_perform_this_action")
+    redirect_to sign_in_path, alert: t("you_cannot_perform_this_action")
   end
 
   def support_controller?

--- a/app/helpers/routes_helper.rb
+++ b/app/helpers/routes_helper.rb
@@ -3,7 +3,7 @@ module RoutesHelper
 
   def root_path
     {
-      claims: claims_root_path,
+      claims: sign_in_path,
       placements: placements_root_path,
     }.fetch current_service
   end

--- a/app/views/claims/pages/start.html.erb
+++ b/app/views/claims/pages/start.html.erb
@@ -1,0 +1,48 @@
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl"><%= t(".page_title") %></h1>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body"><%= t(".claim_guidance") %></p>
+      <p class="govuk-body"><%= t(".training_guidance") %></p>
+
+      <h2 class="govuk-heading-m"><%= t(".before_you_start") %></h2>
+      <p class="govuk-body"><%= t(".you_will_be_asked") %></p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li><%= t(".itt_provider") %></li>
+        <li><%= t(".trn") %></li>
+        <li><%= t(".hours_of_training") %></li>
+      </ul>
+
+      <%= govuk_start_button(text: t(".start_now"), href: sign_in_path) %>
+
+      <h2 class="govuk-heading-m"><%= t(".get_an_account") %></h2>
+      <p class="govuk-body"><%= t(".account_guidance") %></p>
+      <p class="govuk-body">
+        <%= t(
+          ".setup_organisation_guidance_html",
+          link_to: govuk_mail_to("becomingateacher@digital.education.gov.uk"),
+        ) %>
+      </p>
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+      <aside class="app-related" role="complementary">
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-2"><%= t(".related_content") %></h2>
+
+        <ul class="govuk-list">
+          <li class="app-related__list-item">
+            <%= govuk_link_to t(".provider_guidance_link"), "https://www.gov.uk/government/collections/initial-teacher-training" %>
+          </li>
+          <li class="app-related__list-item">
+            <%= govuk_link_to t(".trn_guidance_link"), "https://www.gov.uk/guidance/teacher-reference-number-trn" %>
+          </li>
+        </ul>
+      </aside>
+    </div>
+  </div>
+</div>

--- a/config/locales/en/claims/pages.yml
+++ b/config/locales/en/claims/pages.yml
@@ -1,5 +1,21 @@
 en:
   claims:
     pages:
+      start:
+        page_title: Claim funding for mentors
+        claim_guidance: You can claim funding for mentors who supported trainee teachers from September 2023 to July 2024.
+        training_guidance: Training that took place in April 2024 for the school year starting September 2024 can only be claimed for from May 2025.
+        before_you_start: Before you start
+        you_will_be_asked: "You’ll be asked for:"
+        itt_provider: initial teacher training (ITT) provider details
+        trn: your mentors’ teacher reference numbers (TRN)
+        hours_of_training: hours of training each mentor completed
+        start_now: Start now
+        get_an_account: Get an account to claim funding for mentor training
+        account_guidance: Ask a colleague within your organisation to add you if you do not have an account.
+        setup_organisation_guidance_html: If your organisation has not been set up to claim funding for mentor training, send an email to %{link_to}.
+        provider_guidance_link: Guidance for providers on initial teacher training (ITT)
+        trn_guidance_link: Find out what a teacher reference number (TRN) is and how to find or request a TRN
+        related_content: Related content
       feedback:
         page_title: Feedback

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -1,5 +1,5 @@
 scope module: :claims, as: :claims, constraints: { host: ENV["CLAIMS_HOST"] } do
-  root to: redirect("/sign-in")
+  root to: "pages#start"
 
   scope module: :pages do
     get :feedback

--- a/spec/support/dfe_sign_in_user_helper.rb
+++ b/spec/support/dfe_sign_in_user_helper.rb
@@ -4,6 +4,7 @@ module DfESignInUserHelper
     visit sign_in_path
     click_on "Sign in using DfE Sign In"
   end
+  alias_method :given_i_sign_in_as, :sign_in_as
 
   def user_exists_in_dfe_sign_in(user:)
     OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(

--- a/spec/system/claims/sign_in_page_spec.rb
+++ b/spec/system/claims/sign_in_page_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
-RSpec.describe "Home Page", type: :system, service: :claims do
-  scenario "User visits the claims homepage with dfe sign in" do
+RSpec.describe "Sign in Page", type: :system, service: :claims do
+  scenario "User visits the claims sign in page with dfe sign in" do
     given_i_am_on_the_start_page
     i_can_see_the_claims_service_name_in_the_header
     i_can_see_the_dfe_sign_in_button
   end
 
-  scenario "User visits the claims homepage with person sign in", persona_sign_in: true do
+  scenario "User visits the claims sign in page with person sign in", persona_sign_in: true do
     given_i_am_on_the_start_page
     i_can_see_the_claims_service_name_in_the_header
     i_can_see_the_persona_sign_in_button
@@ -16,7 +16,7 @@ RSpec.describe "Home Page", type: :system, service: :claims do
   private
 
   def given_i_am_on_the_start_page
-    visit "/"
+    visit sign_in_path
   end
 
   def i_can_see_the_claims_service_name_in_the_header

--- a/spec/system/claims/start_page_spec.rb
+++ b/spec/system/claims/start_page_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe "Sign in Page", type: :system, service: :claims do
+  scenario "User visits the start page" do
+    given_i_am_on_the_start_page
+    then_i_can_see_the_start_page
+    when_i_click_start_now
+    then_i_land_on_the_sign_in_page
+  end
+
+  private
+
+  def given_i_am_on_the_start_page
+    visit claims_root_path
+  end
+
+  def then_i_can_see_the_start_page
+    within(".govuk-header") do
+      expect(page).to have_content("Claim funding for mentors")
+    end
+
+    expect(page).to have_content(
+      "You can claim funding for mentors who supported trainee teachers from "\
+       "September 2023 to July 2024.",
+    )
+    expect(page).to have_content(
+      "Training that took place in April 2024 for the school year starting "\
+      "September 2024 can only be claimed for from May 2025.",
+    )
+    expect(page).to have_content(
+      "Before you start\n"\
+      "You’ll be asked for:\n"\
+      "initial teacher training (ITT) provider details "\
+      "your mentors’ teacher reference numbers (TRN) "\
+      "hours of training each mentor completed",
+    )
+    expect(page).to have_content(
+      "Get an account to claim funding for mentor training\n"\
+      "Ask a colleague within your organisation to add you if you do not have an account.\n"\
+      "If your organisation has not been set up to claim funding for mentor training, "\
+      "send an email to becomingateacher@digital.education.gov.uk.",
+    )
+    expect(page).to have_content("Related content")
+    expect(page).to have_link(
+      "Guidance for providers on initial teacher training (ITT)",
+      href: "https://www.gov.uk/government/collections/initial-teacher-training",
+    )
+    expect(page).to have_link(
+      "Find out what a teacher reference number (TRN) is and how to find or request a TRN",
+      href: "https://www.gov.uk/guidance/teacher-reference-number-trn",
+    )
+  end
+
+  def when_i_click_start_now
+    click_on("Start now")
+  end
+
+  def then_i_land_on_the_sign_in_page
+    expect(page.current_url).to eq("http://claims.localhost/sign-in")
+  end
+end

--- a/spec/system/claims/support/schools/view_a_school_spec.rb
+++ b/spec/system/claims/support/schools/view_a_school_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe "View a school", type: :system do
   let!(:school) { create(:school, :claims) }
 
   scenario "View a school's details as a support user" do
-    user_exists_in_dfe_sign_in(user: support_user)
-    when_i_sign_in
+    given_i_sign_in_as(support_user)
     and_i_visit_the_school_page(school)
     i_see_the_school_details(school)
     and_i_see_the_secondary_navigation_links(school)
@@ -14,11 +13,6 @@ RSpec.describe "View a school", type: :system do
   end
 
   private
-
-  def when_i_sign_in
-    visit claims_root_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def and_i_visit_the_school_page(school)
     click_on school.name

--- a/spec/system/claims/support/support_users/add_a_support_user_spec.rb
+++ b/spec/system/claims/support/support_users/add_a_support_user_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Add a support user", type: :system do
   let!(:support_user) { create(:claims_support_user, :colin) }
 
   scenario "Add a support user" do
-    when_i_sign_in_as_a_support_user
+    given_i_sign_in_as(support_user)
     and_i_visit_the_support_users_page
     and_i_click_on_add_a_support_user
     and_i_fill_in_the_support_user_form(email_address: "john.doe@education.gov.uk")
@@ -21,7 +21,7 @@ RSpec.describe "Add a support user", type: :system do
   end
 
   scenario "Attempt to add a support user without an @education.gov.uk email address" do
-    when_i_sign_in_as_a_support_user
+    given_i_sign_in_as(support_user)
     and_i_visit_the_support_users_page
     and_i_click_on_add_a_support_user
     and_i_fill_in_the_support_user_form(email_address: "john.doe@example.com")
@@ -31,7 +31,7 @@ RSpec.describe "Add a support user", type: :system do
 
   scenario "Attempt to add a support user with an email that already exists in the system" do
     given_there_is_a_support_user_with(email_address: "john.doe@education.gov.uk")
-    when_i_sign_in_as_a_support_user
+    given_i_sign_in_as(support_user)
     and_i_visit_the_support_users_page
     and_i_click_on_add_a_support_user
     and_i_fill_in_the_support_user_form(email_address: "john.doe@education.gov.uk")
@@ -40,7 +40,7 @@ RSpec.describe "Add a support user", type: :system do
   end
 
   scenario "Make changes while adding a support user" do
-    when_i_sign_in_as_a_support_user
+    given_i_sign_in_as(support_user)
     and_i_visit_the_support_users_page
     and_i_click_on_add_a_support_user
     and_i_fill_in_the_support_user_form(email_address: "john.doe@education.gov.uk")
@@ -56,12 +56,6 @@ RSpec.describe "Add a support user", type: :system do
 
   def given_there_is_a_support_user_with(email_address:)
     create(:claims_support_user, email: email_address)
-  end
-
-  def when_i_sign_in_as_a_support_user
-    user_exists_in_dfe_sign_in(user: support_user)
-    visit claims_root_path
-    click_on "Sign in using DfE Sign In"
   end
 
   def and_i_visit_the_support_users_page

--- a/spec/system/claims/support/support_users/remove_a_support_user_spec.rb
+++ b/spec/system/claims/support/support_users/remove_a_support_user_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Remove a support user", type: :system do
   let!(:support_user_to_be_removed) { create(:claims_support_user) }
 
   scenario "Remove a support user" do
-    when_i_sign_in_as_a_support_user(support_user)
+    given_i_sign_in_as(support_user)
     and_i_visit_the_support_users_page
     and_i_click_on_a_support_user(support_user_to_be_removed)
     and_i_click_on_remove
@@ -22,19 +22,13 @@ RSpec.describe "Remove a support user", type: :system do
   end
 
   scenario "A support user can not remove themselves as a support user" do
-    when_i_sign_in_as_a_support_user(support_user)
+    given_i_sign_in_as(support_user)
     and_i_visit_the_support_users_page
     and_i_click_on_a_support_user(support_user)
     then_i_can_not_see_a_remove_link
   end
 
   private
-
-  def when_i_sign_in_as_a_support_user(support_user)
-    user_exists_in_dfe_sign_in(user: support_user)
-    visit claims_root_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def and_i_visit_the_support_users_page
     within(".app-primary-navigation nav") do

--- a/spec/system/claims/support/support_users/view_a_support_user_spec.rb
+++ b/spec/system/claims/support/support_users/view_a_support_user_spec.rb
@@ -4,19 +4,13 @@ RSpec.describe "View a support user", type: :system do
   let!(:support_user) { create(:claims_support_user, :colin) }
 
   scenario "View a support user" do
-    user_exists_in_dfe_sign_in(user: support_user)
-    when_i_sign_in_as_a_support_user
+    given_i_sign_in_as(support_user)
     and_i_visit_the_support_users_page
     and_i_click_on_a_support_user(support_user)
     i_see_the_details_of_the_support_user(support_user)
   end
 
   private
-
-  def when_i_sign_in_as_a_support_user
-    visit claims_root_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def and_i_visit_the_support_users_page
     within(".app-primary-navigation nav") do

--- a/spec/system/claims/support/support_users/view_support_users_spec.rb
+++ b/spec/system/claims/support/support_users/view_support_users_spec.rb
@@ -5,18 +5,12 @@ RSpec.describe "View support users", type: :system do
   let!(:support_user_2) { create(:claims_support_user, created_at: "2024-01-01") }
 
   scenario "View list of all support users" do
-    user_exists_in_dfe_sign_in(user: support_user)
-    when_i_sign_in_as_a_support_user
+    given_i_sign_in_as(support_user)
     and_i_visit_the_support_users_page
     i_see_the_list_of_all_support_users_ordered_by_latest_created_at_first
   end
 
   private
-
-  def when_i_sign_in_as_a_support_user
-    visit claims_root_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def and_i_visit_the_support_users_page
     within(".app-primary-navigation nav") do


### PR DESCRIPTION
## Context

The start page will be the new root_path of the claims domain, some changes have been made to accomodate this like specs or redirects

## Changes proposed in this pull request

New root_path
New start page

## Guidance to review

Go to claims root_path
Inspect the start page
Click Start now
Sign in as before


## Screenshots

Prototype: https://itt-mentoring-beta-94341ca35a2c.herokuapp.com/


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/acfc1b27-09f1-4819-b54e-dfcf0bd2145d


