### PR TITLE
Create Trust model & populate via GIAS sync

### DIFF
--- a/app/models/claims/school.rb
+++ b/app/models/claims/school.rb
@@ -40,17 +40,20 @@
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  region_id                    :uuid
+#  trust_id                     :uuid
 #
 # Indexes
 #
 #  index_schools_on_claims_service      (claims_service)
 #  index_schools_on_placements_service  (placements_service)
 #  index_schools_on_region_id           (region_id)
+#  index_schools_on_trust_id            (trust_id)
 #  index_schools_on_urn                 (urn) UNIQUE
 #
 # Foreign Keys
 #
 #  fk_rails_...  (region_id => regions.id)
+#  fk_rails_...  (trust_id => trusts.id)
 #
 class Claims::School < School
   default_scope { claims_service }

--- a/app/models/placements/school.rb
+++ b/app/models/placements/school.rb
@@ -40,17 +40,20 @@
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  region_id                    :uuid
+#  trust_id                     :uuid
 #
 # Indexes
 #
 #  index_schools_on_claims_service      (claims_service)
 #  index_schools_on_placements_service  (placements_service)
 #  index_schools_on_region_id           (region_id)
+#  index_schools_on_trust_id            (trust_id)
 #  index_schools_on_urn                 (urn) UNIQUE
 #
 # Foreign Keys
 #
 #  fk_rails_...  (region_id => regions.id)
+#  fk_rails_...  (trust_id => trusts.id)
 #
 class Placements::School < School
   default_scope { placements_service }

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -40,22 +40,26 @@
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  region_id                    :uuid
+#  trust_id                     :uuid
 #
 # Indexes
 #
 #  index_schools_on_claims_service      (claims_service)
 #  index_schools_on_placements_service  (placements_service)
 #  index_schools_on_region_id           (region_id)
+#  index_schools_on_trust_id            (trust_id)
 #  index_schools_on_urn                 (urn) UNIQUE
 #
 # Foreign Keys
 #
 #  fk_rails_...  (region_id => regions.id)
+#  fk_rails_...  (trust_id => trusts.id)
 #
 class School < ApplicationRecord
   include PgSearch::Model
 
   belongs_to :region
+  belongs_to :trust, optional: true
 
   has_many :user_memberships, as: :organisation
   has_many :mentor_memberships

--- a/app/models/trust.rb
+++ b/app/models/trust.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: trusts
+#
+#  id         :uuid             not null, primary key
+#  name       :string           not null
+#  uid        :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_trusts_on_uid  (uid) UNIQUE
+#
+class Trust < ApplicationRecord
+  validates :uid, :name, presence: true
+  validates :uid, uniqueness: { case_sensitive: false }
+
+  has_many :schools
+end

--- a/app/services/gias/csv_importer.rb
+++ b/app/services/gias/csv_importer.rb
@@ -111,7 +111,7 @@ module Gias
       Rails.logger.debug "Associating schools to trusts... "
 
       trust_data.each do |uid, urns|
-        trust = Trust.find_by(uid:)
+        trust = Trust.find_by!(uid:)
         School.where(urn: urns).update_all(trust_id: trust.id)
       end
     end

--- a/app/services/gias/csv_importer.rb
+++ b/app/services/gias/csv_importer.rb
@@ -111,7 +111,7 @@ module Gias
       Rails.logger.debug "Associating schools to trusts... "
 
       trust_data.each do |uid, urns|
-        trust = Trust.find(uid:)
+        trust = Trust.find_by(uid:)
         School.where(urn: urns).update_all(trust_id: trust.id)
       end
     end

--- a/app/services/gias/csv_importer.rb
+++ b/app/services/gias/csv_importer.rb
@@ -111,9 +111,7 @@ module Gias
       Rails.logger.debug "Associating schools to trusts... "
 
       trust_data.each do |uid, urns|
-        trust = Trust.find_by(uid:)
-        next unless trust
-
+        trust = Trust.find(uid:)
         School.where(urn: urns).update_all(trust_id: trust.id)
       end
     end

--- a/app/services/gias/csv_importer.rb
+++ b/app/services/gias/csv_importer.rb
@@ -76,7 +76,7 @@ module Gias
 
       Rails.logger.silence do
         School.upsert_all(school_records, unique_by: :urn)
-        Trust.upsert_all(trust_records, unique_by: :uid)
+        Trust.upsert_all(trust_records.uniq, unique_by: :uid)
 
         associate_schools_to_regions
         associate_schools_to_trusts(trust_associations)

--- a/db/migrate/20240311101329_create_trusts.rb
+++ b/db/migrate/20240311101329_create_trusts.rb
@@ -1,0 +1,11 @@
+class CreateTrusts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :trusts, id: :uuid do |t|
+      t.string :uid, null: false
+      t.index :uid, unique: true
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240311101900_add_trust_to_school.rb
+++ b/db/migrate/20240311101900_add_trust_to_school.rb
@@ -1,0 +1,5 @@
+class AddTrustToSchool < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :schools, :trust, null: true, foreign_key: true, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_07_100355) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_11_101329) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -281,6 +281,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_07_100355) do
     t.string "code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "trusts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "uid", null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["uid"], name: "index_trusts_on_uid", unique: true
   end
 
   create_table "user_memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_11_101329) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_11_101900) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -269,9 +269,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_11_101329) do
     t.string "district_admin_name"
     t.string "district_admin_code"
     t.uuid "region_id"
+    t.uuid "trust_id"
     t.index ["claims_service"], name: "index_schools_on_claims_service"
     t.index ["placements_service"], name: "index_schools_on_placements_service"
     t.index ["region_id"], name: "index_schools_on_region_id"
+    t.index ["trust_id"], name: "index_schools_on_trust_id"
     t.index ["urn"], name: "index_schools_on_urn", unique: true
   end
 
@@ -329,5 +331,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_11_101329) do
   add_foreign_key "placement_subject_joins", "subjects"
   add_foreign_key "placements", "schools"
   add_foreign_key "schools", "regions"
+  add_foreign_key "schools", "trusts"
   add_foreign_key "user_memberships", "users"
 end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -40,17 +40,20 @@
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  region_id                    :uuid
+#  trust_id                     :uuid
 #
 # Indexes
 #
 #  index_schools_on_claims_service      (claims_service)
 #  index_schools_on_placements_service  (placements_service)
 #  index_schools_on_region_id           (region_id)
+#  index_schools_on_trust_id            (trust_id)
 #  index_schools_on_urn                 (urn) UNIQUE
 #
 # Foreign Keys
 #
 #  fk_rails_...  (region_id => regions.id)
+#  fk_rails_...  (trust_id => trusts.id)
 #
 FactoryBot.define do
   factory :school do

--- a/spec/factories/trusts.rb
+++ b/spec/factories/trusts.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: trusts
+#
+#  id         :uuid             not null, primary key
+#  name       :string           not null
+#  uid        :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_trusts_on_uid  (uid) UNIQUE
+#
+FactoryBot.define do
+  factory :trust do
+    uid { _1 }
+    name { "Department for Education Trust" }
+  end
+end

--- a/spec/fixtures/gias/import_with_invalid_schools.csv
+++ b/spec/fixtures/gias/import_with_invalid_schools.csv
@@ -1,8 +1,9 @@
-URN,EstablishmentName,Town,Postcode,EstablishmentStatus (code),TypeOfEstablishment (code),DistrictAdministrative (code)
-130,InnerLondonSchool,InnerLondonTown,Postcode,1,7,E09000007
-131,OuterLondonSchool,OuterLondonTown,Postcode,1,7,E09000004
-123,FringeSchool,FringeTown,Postcode,1,7,E06000039
-132,RestOfEnglandSchool,RestOfEnglandTown,Postcode,1,7,E09000099
-124,School,Town,Postcode,2,7,E06000031
-124,School,Town,Postcode,1,8,E06000031
-124,,Town,Postcode,1,7,E06000031
+URN,EstablishmentName,Town,Postcode,EstablishmentStatus (code),TypeOfEstablishment (code),DistrictAdministrative (code),TrustSchoolFlag (code),Trusts (code),Trusts (name)
+130,InnerLondonSchool,InnerLondonTown,Postcode,1,7,E09000007,,
+131,OuterLondonSchool,OuterLondonTown,Postcode,1,7,E09000004,,
+123,FringeSchool,FringeTown,Postcode,1,7,E06000039,,
+132,RestOfEnglandSchool,RestOfEnglandTown,Postcode,1,7,E09000099,,
+124,School,Town,Postcode,2,7,E06000031,,
+124,School,Town,Postcode,1,8,E06000031,,
+124,,Town,Postcode,1,7,E06000031,,
+140,TrustSchool,TrustTown,Postcode,1,7,E09000007,1,12345,Department for Education Trust

--- a/spec/models/claims/school_spec.rb
+++ b/spec/models/claims/school_spec.rb
@@ -40,17 +40,20 @@
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  region_id                    :uuid
+#  trust_id                     :uuid
 #
 # Indexes
 #
 #  index_schools_on_claims_service      (claims_service)
 #  index_schools_on_placements_service  (placements_service)
 #  index_schools_on_region_id           (region_id)
+#  index_schools_on_trust_id            (trust_id)
 #  index_schools_on_urn                 (urn) UNIQUE
 #
 # Foreign Keys
 #
 #  fk_rails_...  (region_id => regions.id)
+#  fk_rails_...  (trust_id => trusts.id)
 #
 require "rails_helper"
 

--- a/spec/models/placements/school_spec.rb
+++ b/spec/models/placements/school_spec.rb
@@ -40,17 +40,20 @@
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  region_id                    :uuid
+#  trust_id                     :uuid
 #
 # Indexes
 #
 #  index_schools_on_claims_service      (claims_service)
 #  index_schools_on_placements_service  (placements_service)
 #  index_schools_on_region_id           (region_id)
+#  index_schools_on_trust_id            (trust_id)
 #  index_schools_on_urn                 (urn) UNIQUE
 #
 # Foreign Keys
 #
 #  fk_rails_...  (region_id => regions.id)
+#  fk_rails_...  (trust_id => trusts.id)
 #
 require "rails_helper"
 

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -40,26 +40,31 @@
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  region_id                    :uuid
+#  trust_id                     :uuid
 #
 # Indexes
 #
 #  index_schools_on_claims_service      (claims_service)
 #  index_schools_on_placements_service  (placements_service)
 #  index_schools_on_region_id           (region_id)
+#  index_schools_on_trust_id            (trust_id)
 #  index_schools_on_urn                 (urn) UNIQUE
 #
 # Foreign Keys
 #
 #  fk_rails_...  (region_id => regions.id)
+#  fk_rails_...  (trust_id => trusts.id)
 #
 require "rails_helper"
 
 RSpec.describe School, type: :model do
   context "with associations" do
+    it { is_expected.to belong_to(:region) }
+    it { is_expected.to belong_to(:trust).optional }
+
     it { is_expected.to have_many(:user_memberships) }
     it { is_expected.to have_many(:mentor_memberships) }
     it { is_expected.to have_many(:mentors).through(:mentor_memberships) }
-    it { is_expected.to belong_to(:region) }
   end
 
   context "with scopes" do

--- a/spec/models/trust_spec.rb
+++ b/spec/models/trust_spec.rb
@@ -1,0 +1,29 @@
+# == Schema Information
+#
+# Table name: trusts
+#
+#  id         :uuid             not null, primary key
+#  name       :string           not null
+#  uid        :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_trusts_on_uid  (uid) UNIQUE
+#
+require "rails_helper"
+
+RSpec.describe Trust, type: :model do
+  describe "associations" do
+    it { is_expected.to have_many(:schools) }
+  end
+
+  describe "validations" do
+    subject { build(:trust) }
+
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:uid) }
+    it { is_expected.to validate_uniqueness_of(:uid).case_insensitive }
+  end
+end


### PR DESCRIPTION
## Context

It has become apparent in our user research that adding the ability to automatically add schools when in a trust would improve UX. Additionally this will give us more data-points for collecting information on the uptake and usage of this service.

## Changes proposed in this pull request

- [x] Adds the Trust model and associated files
- [x] Adds an optional `trust_id` foreign key to the `schools` table
- [x] Updates the GIAS importer to also sync Trusts and create the relevant associations to schools

## Guidance to review

Run the migrations to ensure they have been added properly, then run the `Gias::SyncAllSchoolsJob.perform_now` two times via your local console to ensure that the sync completes successfully. Finally, run a query to see that `Trust` data has been created and associated to schools.

## Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/guVHJIOC)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
