### PR TITLE
Fix a typo in the Azure doc

### DIFF
--- a/docs/connect-to-azure.md
+++ b/docs/connect-to-azure.md
@@ -29,7 +29,7 @@ You need to grant yourself permission to access Azure resources in the test envi
    >
    > ![](images/connect-to-azure/azure-groups.png)
 
-4. Click "Active" on `s189-teacher-services-cloud-test`.
+4. Click "Activate" on `s189-teacher-services-cloud-test`.
 
    > Enter a reason for needing access. For example, "Running a Rake task".
    >


### PR DESCRIPTION
Fix a typo in `docs/connect-to-azure.md`:

```diff
- 4. Click "Active" on `s189-teacher-services-cloud-test`.
+ 4. Click "Activate" on `s189-teacher-services-cloud-test`.
```

[Before](https://github.com/DFE-Digital/itt-mentor-services/blob/7dd1470fa03bb22489cee17904211df76b0f6e3b/docs/connect-to-azure.md) | [After](https://github.com/DFE-Digital/itt-mentor-services/blob/af3c7825568295b21e367212d516261471db2982/docs/connect-to-azure.md)