### PR TITLE
Leave date submitted blank for support claim

### DIFF
--- a/app/controllers/claims/schools/claims_controller.rb
+++ b/app/controllers/claims/schools/claims_controller.rb
@@ -47,7 +47,10 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
   def confirm; end
 
   def submit
-    Claims::Submit.call(claim: @claim, draft: false)
+    Claims::Submit.call(
+      claim: @claim,
+      claim_params: { draft: false, submitted_at: Time.current },
+    )
 
     redirect_to confirm_claims_school_claim_path(@school, @claim)
   end

--- a/app/controllers/claims/support/schools/claims_controller.rb
+++ b/app/controllers/claims/support/schools/claims_controller.rb
@@ -45,7 +45,10 @@ class Claims::Support::Schools::ClaimsController < Claims::Support::ApplicationC
   end
 
   def submit
-    Claims::Submit.call(claim: @claim, draft: true)
+    Claims::Submit.call(
+      claim: @claim,
+      claim_params: { draft: true },
+    )
 
     redirect_to claims_support_school_claims_path(@school), flash: { success: t(".success") }
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,7 +20,7 @@ module ApplicationHelper
 
   def safe_l(value, **options)
     if value
-      l(value, **options) if value
+      l(value, **options)
     else
       "-"
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,6 +19,10 @@ module ApplicationHelper
   end
 
   def safe_l(value, **options)
-    l(value, **options) if value
+    if value
+      l(value, **options) if value
+    else
+      "-"
+    end
   end
 end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -33,7 +33,7 @@ class Claim < ApplicationRecord
   has_many :mentor_trainings
   has_many :mentors, through: :mentor_trainings
 
-  validates :reference, uniqueness: true, allow_nil: true
+  validates :reference, uniqueness: { case_sensitive: false }, allow_nil: true
 
   delegate :name, to: :provider, prefix: true, allow_nil: true
 

--- a/app/services/claims/submit.rb
+++ b/app/services/claims/submit.rb
@@ -17,7 +17,7 @@ class Claims::Submit
   def updated_claim
     @updated_claim ||= begin
       claim.assign_attributes(claim_params)
-      claim.reference = generate_reference
+      claim.reference = generate_reference if claim.reference.nil?
       claim
     end
   end

--- a/app/services/claims/submit.rb
+++ b/app/services/claims/submit.rb
@@ -1,9 +1,9 @@
 class Claims::Submit
   include ServicePattern
 
-  def initialize(claim:, draft:)
+  def initialize(claim:, claim_params:)
     @claim = claim
-    @draft = draft
+    @claim_params = claim_params
   end
 
   def call
@@ -12,12 +12,11 @@ class Claims::Submit
 
   private
 
-  attr_reader :claim, :draft
+  attr_reader :claim, :claim_params
 
   def updated_claim
     @updated_claim ||= begin
-      claim.draft = draft
-      claim.submitted_at = Time.current
+      claim.assign_attributes(claim_params)
       claim.reference = generate_reference
       claim
     end

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -31,6 +31,8 @@ FactoryBot.define do
     association :provider
     association :created_by, factory: :claims_user
 
+    reference { SecureRandom.random_number(99_999_999) }
+
     trait :draft do
       draft { true }
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe ApplicationHelper do
     end
 
     context "when value is nil" do
-      it "returns nil" do
-        expect(safe_l(nil, format: :short)).to eq(nil)
+      it "returns '-'" do
+        expect(safe_l(nil, format: :short)).to eq("-")
       end
     end
   end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Claim, type: :model do
   context "with validations" do
     subject { build(:claim) }
 
-    it { is_expected.to validate_uniqueness_of(:reference).allow_nil }
+    it { is_expected.to validate_uniqueness_of(:reference).case_insensitive.allow_nil }
   end
 
   context "with delegations" do

--- a/spec/services/claims/submit_spec.rb
+++ b/spec/services/claims/submit_spec.rb
@@ -1,44 +1,42 @@
 require "rails_helper"
 
 describe Claims::Submit do
-  subject(:submit_service) { described_class.call(claim:, draft:) }
+  subject(:submit_service) { described_class.call(claim:, claim_params:) }
 
-  let(:draft) { false }
-  let!(:claim) { create(:claim, :draft) }
+  let!(:claim) { create(:claim, :draft, reference: nil) }
+  let(:claim_params) { { draft: false, submitted_at: } }
+  let(:submitted_at) { Time.new("2024-03-04 10:32:04 UTC") }
 
   describe "#call" do
     it "submits the claim" do
       allow(SecureRandom).to receive(:random_number).with(99_999_999).and_return(123)
-      allow(Time).to receive(:current).and_return("2024-03-04 10:32:04 UTC")
 
       expect { submit_service }.to change(claim, :reference).from(nil).to("123")
       expect(claim.draft).to eq(false)
-      expect(claim.submitted_at).to eq(Time.current)
+      expect(claim.submitted_at).to eq(submitted_at)
     end
 
     context "when claim reference is already taken" do
       it "submits the claim with a new reference" do
         create(:claim, reference: "123")
         allow(SecureRandom).to receive(:random_number).with(99_999_999).and_return(123, 456)
-        allow(Time).to receive(:current).and_return("2024-03-04 10:32:04 UTC")
 
         expect { submit_service }.to change(claim, :reference).from(nil).to("456")
 
         expect(claim.draft).to eq(false)
-        expect(claim.submitted_at).to eq(Time.current)
+        expect(claim.submitted_at).to eq(submitted_at)
       end
     end
 
     context "when draft value is true" do
-      let(:draft) { true }
+      let(:claim_params) { { draft: true } }
 
       it "submits the claim" do
         allow(SecureRandom).to receive(:random_number).with(99_999_999).and_return(123)
-        allow(Time).to receive(:current).and_return("2024-03-04 10:32:04 UTC")
 
         expect { submit_service }.to change(claim, :reference).from(nil).to("123")
         expect(claim.draft).to eq(true)
-        expect(claim.submitted_at).to eq(Time.current)
+        expect(claim.submitted_at).to be_nil
       end
     end
   end

--- a/spec/services/claims/submit_spec.rb
+++ b/spec/services/claims/submit_spec.rb
@@ -16,6 +16,15 @@ describe Claims::Submit do
       expect(claim.submitted_at).to eq(submitted_at)
     end
 
+    context "when claim has a reference already" do
+      it "submits the claim with a new reference" do
+        claim_with_reference = create(:claim, reference: "123")
+        service = described_class.call(claim: claim_with_reference, claim_params:)
+
+        expect { service }.not_to change(claim, :reference)
+      end
+    end
+
     context "when claim reference is already taken" do
       it "submits the claim with a new reference" do
         create(:claim, reference: "123")

--- a/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
 
   def then_i_get_a_claim_reference(claim)
     within(".govuk-panel") do
-      expect(page).to have_content("Claim submitted\nYour reference number\n#{claim.reference}")
+      expect(page).to have_content("Claim submitted\nYour reference number\n#{claim.reload.reference}")
     end
   end
 

--- a/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
 
   let(:mentor1) { create(:mentor, first_name: "Anne") }
   let(:mentor2) { create(:mentor, first_name: "Joe") }
-  let!(:claim) { create(:claim, :draft, school:, provider: provider1) }
+  let!(:claim) { create(:claim, :draft, school:, provider: provider1, reference: nil) }
 
   before do
     user_exists_in_dfe_sign_in(user: anne)
@@ -208,7 +208,7 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
 
   def then_i_get_a_claim_reference(claim)
     within(".govuk-panel") do
-      expect(page).to have_content("Claim submitted\nYour reference number\n#{claim.reload.reference}")
+      expect(page).to have_content("Claim submitted\nYour reference number\n#{claim.reference}")
     end
   end
 

--- a/spec/system/claims/schools/claims/view_claims_spec.rb
+++ b/spec/system/claims/schools/claims/view_claims_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe "View claims", type: :system, service: :claims do
     expect(page).to have_content("Status")
 
     within("tbody tr:nth-child(1)") do
-      expect(page).to have_content(submitted_claim.id.first(8))
+      expect(page).to have_content(submitted_claim.reference)
       expect(page).to have_content(submitted_claim.provider_name)
       expect(page).to have_content(submitted_claim.mentors.map(&:full_name).join(""))
       expect(page).to have_content("05/03/2024")

--- a/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
       expect(page).to have_content "Claim added"
     end
 
-    expect(page).to have_content(claim.reference)
+    expect(page).to have_content(claim.reload.reference)
   end
 
   def when_i_remove_the_provider_from_the_claim

--- a/spec/system/claims/support/schools/claims/view_a_schools_claims_spec.rb
+++ b/spec/system/claims/support/schools/claims/view_a_schools_claims_spec.rb
@@ -6,7 +6,14 @@ RSpec.describe "View a schools claims", type: :system, service: :claims do
 
   let!(:colin) { create(:claims_support_user, :colin) }
 
-  let!(:submitted_claim) { create(:claim, school_id: school.id, draft: false) }
+  let!(:submitted_claim) do
+    create(
+      :claim,
+      school_id: school.id,
+      draft: false,
+      submitted_at: Time.new(2024, 3, 5, 12, 31, 52, "+00:00"),
+    )
+  end
   let!(:draft_claim) { create(:claim, school_id: school.id, draft: true) }
   let!(:claim_from_another_school) { create(:claim, school_id: another_school.id, draft: true) }
 
@@ -30,8 +37,28 @@ RSpec.describe "View a schools claims", type: :system, service: :claims do
   end
 
   def i_see_a_list_of_the_schools_claims
-    expect(page).to have_content("Claim reference#{draft_claim.reference}")
-    expect(page).to have_content("Claim reference#{submitted_claim.reference}")
+    expect(page).to have_content("Claim reference")
+    expect(page).to have_content("Accredited provider")
+    expect(page).to have_content("Mentors")
+    expect(page).to have_content("Date submitted")
+    expect(page).to have_content("Status")
+    expect(page).to have_content("Date submitted")
+
+    within("tbody tr:nth-child(1)") do
+      expect(page).to have_content(draft_claim.reference)
+      expect(page).to have_content(draft_claim.provider_name)
+      expect(page).to have_content(draft_claim.mentors.map(&:full_name).join(""))
+      expect(page).to have_content("-")
+      expect(page).to have_content("Draft")
+    end
+
+    within("tbody tr:nth-child(2)") do
+      expect(page).to have_content(submitted_claim.reference)
+      expect(page).to have_content(submitted_claim.provider_name)
+      expect(page).to have_content(submitted_claim.mentors.map(&:full_name).join(""))
+      expect(page).to have_content("05/03/2024")
+      expect(page).to have_content("Submitted")
+    end
   end
 
   def i_dont_see_claims_from_other_schools


### PR DESCRIPTION
## Context

`Claim::Submit` service now accepts params hash. This way we can leave the `submitted_at` nil when a support user creates a claim. The support user cannot submit a claim.

This PR also fixes an edge case when there is a claim with a reference already in place and we submit that claim, instead of creating another reference we use the existing one.

## Changes proposed in this pull request

Claim::Submit service
ApplicationHelper
Views
Specs

## Guidance to review

Create a claim as a support user
The date submitted should be blank


## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/d8a01577-a25d-477e-b528-d2208b3ee39a


