### PR TITLE
Change claims service name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This application has two main services:
 
-- A service where schools or training providers can claim funding for internal teacher training.
+- A service where schools or training providers can claim funding for mentor training.
 - TODO: Add description for the other service
 
 ## Live Environments

--- a/config/locales/en/claims.yml
+++ b/config/locales/en/claims.yml
@@ -1,4 +1,4 @@
 en:
   claims:
-    service_name: Claim funding for mentors
+    service_name: Claim funding for mentor training
     support_email: becomingateacher@digital.education.gov.uk

--- a/config/locales/en/claims/pages.yml
+++ b/config/locales/en/claims/pages.yml
@@ -2,7 +2,7 @@ en:
   claims:
     pages:
       start:
-        page_title: Claim funding for mentors
+        page_title: Claim funding for mentor training
         claim_guidance: You can claim funding for mentors who supported trainee teachers from September 2023 to July 2024.
         training_guidance: Training that took place in April 2024 for the school year starting September 2024 can only be claimed for from May 2025.
         before_you_start: Before you start

--- a/config/locales/en/claims/support/support_users.yml
+++ b/config/locales/en/claims/support/support_users.yml
@@ -23,7 +23,7 @@ en:
           submit: Add user
           cancel: Cancel
           change: Change
-          warning: The user will be sent an email to tell them you’ve added them to Claim funding for mentors.
+          warning: The user will be sent an email to tell them you’ve added them to Claim funding for mentor training.
         create:
           success: User added
         show:
@@ -32,7 +32,7 @@ en:
         remove:
           page_title: Are you sure you want to remove this user? - %{user_name}
           title: Are you sure you want to remove this user?
-          warning: The user will be sent an email to tell them you removed them from Claim funding for mentors.
+          warning: The user will be sent an email to tell them you removed them from Claim funding for mentor training.
           submit: Remove user
           cancel: Cancel
         destroy:

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -3,7 +3,7 @@
 > [!NOTE]
 > This is a _draft_ document. It will change as we develop our understanding of the services that this application encapsulates.
 
-This application will power two user-facing services: 'Manage school placements' and 'Claim funding for mentors' (a.k.a. Track & Pay). Some data entities will be used by both services – for example, Mentors, Providers and Schools. Others will only be relevant to one service – for example, Funding Claims and School Placements.
+This application will power two user-facing services: 'Manage school placements' and 'Claim funding for mentor training' (a.k.a. Track & Pay). Some data entities will be used by both services – for example, Mentors, Providers and Schools. Others will only be relevant to one service – for example, Funding Claims and School Placements.
 
 ## Entity Relationship Diagram (ERD)
 

--- a/spec/mailers/support_user_mailer_spec.rb
+++ b/spec/mailers/support_user_mailer_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe SupportUserMailer, type: :mailer do
 
       it "is addressed to the user's email and contains a link to the claims sign in url" do
         expect(invite_email.to).to contain_exactly(user.email)
-        expect(invite_email.subject).to eq("Invitation to join Claim funding for mentors")
+        expect(invite_email.subject).to eq("Invitation to join Claim funding for mentor training")
         expect(invite_email.body).to have_content <<~EMAIL
           Dear John Doe,
 
-          You have been invited to join Claim funding for mentors.
+          You have been invited to join Claim funding for mentor training.
 
           Sign in here http://claims.localhost:3000/sign-in
         EMAIL
@@ -47,11 +47,11 @@ RSpec.describe SupportUserMailer, type: :mailer do
 
       it "is addressed to the user's email and contains a link to the claims sign in url" do
         expect(removal_email.to).to contain_exactly(user.email)
-        expect(removal_email.subject).to eq("You have been removed from Claim funding for mentors")
+        expect(removal_email.subject).to eq("You have been removed from Claim funding for mentor training")
         expect(removal_email.body).to have_content <<~EMAIL
           Dear John Doe,
 
-          You have been removed from Claim funding for mentors.
+          You have been removed from Claim funding for mentor training.
         EMAIL
       end
     end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe UserMailer, type: :mailer do
         expect(invite_email.body).to have_content <<~EMAIL
           Dear #{user.full_name},
 
-          You have been invited to join the Claim funding for mentors service for #{organisation.name}.
+          You have been invited to join the Claim funding for mentor training service for #{organisation.name}.
 
           Sign in here http://claims.localhost:3000/sign-in
         EMAIL
@@ -71,7 +71,7 @@ RSpec.describe UserMailer, type: :mailer do
         expect(removal_email.body).to have_content <<~EMAIL
           Dear #{user.full_name},
 
-          You have been removed from the Claim funding for mentors service for #{organisation.name}.
+          You have been removed from the Claim funding for mentor training service for #{organisation.name}.
         EMAIL
       end
     end

--- a/spec/smoke_tests/claims/home_page_spec.rb
+++ b/spec/smoke_tests/claims/home_page_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Home Page", type: :system, smoke_test: true, service: :claims do
 
   def i_can_see_the_claims_service_name_in_the_header
     within(".govuk-header") do
-      expect(page).to have_content("Claim funding for mentors")
+      expect(page).to have_content("Claim funding for mentor training")
     end
   end
 end

--- a/spec/system/claims/authenticate_user_spec.rb
+++ b/spec/system/claims/authenticate_user_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Authentication", type: :system, service: :claims do
   end
 
   def then_i_am_unable_to_access_the_page
-    expect(page).to have_content("Sign in to Claim funding for mentors")
+    expect(page).to have_content("Sign in to Claim funding for mentor training")
   end
 
   def then_i_am_able_to_access_the_page

--- a/spec/system/claims/sign_in_page_spec.rb
+++ b/spec/system/claims/sign_in_page_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Sign in Page", type: :system, service: :claims do
 
   def i_can_see_the_claims_service_name_in_the_header
     within(".govuk-header") do
-      expect(page).to have_content("Claim funding for mentors")
+      expect(page).to have_content("Claim funding for mentor training")
     end
   end
 

--- a/spec/system/claims/sign_out_as_claims_user_spec.rb
+++ b/spec/system/claims/sign_out_as_claims_user_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Sign out as a Claims User", type: :system, service: :claims do
   end
 
   def i_expect_to_be_on_sign_in_page
-    expect(page).to have_content("Sign in to Claim funding for mentors")
+    expect(page).to have_content("Sign in to Claim funding for mentor training")
     expect(page).to have_content("Sign in using DfE Sign In")
   end
 end

--- a/spec/system/claims/start_page_spec.rb
+++ b/spec/system/claims/start_page_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Sign in Page", type: :system, service: :claims do
 
   def then_i_can_see_the_start_page
     within(".govuk-header") do
-      expect(page).to have_content("Claim funding for mentors")
+      expect(page).to have_content("Claim funding for mentor training")
     end
 
     expect(page).to have_content(

--- a/spec/system/claims/support/support_users/add_a_support_user_spec.rb
+++ b/spec/system/claims/support/support_users/add_a_support_user_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Add a support user", type: :system do
     and_i_click_on_add_a_support_user
     and_i_fill_in_the_support_user_form(email_address: "john.doe@example.com")
     then_i_see_an_error("Enter a Department for Education email address in the correct format, like name@education.gov.uk")
-    and_the_page_title_is("Error: Personal details - Add user - Claim funding for mentors")
+    and_the_page_title_is("Error: Personal details - Add user - Claim funding for mentor training")
   end
 
   scenario "Attempt to add a support user with an email that already exists in the system" do
@@ -36,7 +36,7 @@ RSpec.describe "Add a support user", type: :system do
     and_i_click_on_add_a_support_user
     and_i_fill_in_the_support_user_form(email_address: "john.doe@education.gov.uk")
     then_i_see_an_error("Email address already in use")
-    and_the_page_title_is("Error: Personal details - Add user - Claim funding for mentors")
+    and_the_page_title_is("Error: Personal details - Add user - Claim funding for mentor training")
   end
 
   scenario "Make changes while adding a support user" do
@@ -97,7 +97,7 @@ RSpec.describe "Add a support user", type: :system do
 
   def and_an_email_is_sent_to_the_support_user(email_address:)
     email = ActionMailer::Base.deliveries.find do |delivery|
-      delivery.to.include?(email_address) && delivery.subject == "Invitation to join Claim funding for mentors"
+      delivery.to.include?(email_address) && delivery.subject == "Invitation to join Claim funding for mentor training"
     end
 
     expect(email).not_to be_nil

--- a/spec/system/claims/support/support_users/re_add_a_discarded_support_user_spec.rb
+++ b/spec/system/claims/support/support_users/re_add_a_discarded_support_user_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe "Re-add a discarded support user", type: :system do
   def and_an_email_is_sent_to_the_support_user(email_address:)
     email = ActionMailer::Base.deliveries.find do |delivery|
       delivery.to.include?(email_address) &&
-        delivery.subject == "Invitation to join Claim funding for mentors"
+        delivery.subject == "Invitation to join Claim funding for mentor training"
     end
 
     expect(email).not_to be_nil

--- a/spec/system/claims/support/support_users/remove_a_support_user_spec.rb
+++ b/spec/system/claims/support/support_users/remove_a_support_user_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Remove a support user", type: :system do
 
   def then_an_email_is_sent(email)
     email = ActionMailer::Base.deliveries.find do |delivery|
-      delivery.to.include?(email) && delivery.subject == "You have been removed from Claim funding for mentors"
+      delivery.to.include?(email) && delivery.subject == "You have been removed from Claim funding for mentor training"
     end
 
     expect(email).not_to be_nil

--- a/spec/system/error_pages_spec.rb
+++ b/spec/system/error_pages_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe "Error pages", type: :system do
   describe "Claims errors", service: :claims do
     it "shows the 404 error page" do
       when_i_visit("/404")
-      then_i_see_404_content_for("Claim funding for mentors")
+      then_i_see_404_content_for("Claim funding for mentor training")
     end
 
     it "shows the 422 error page" do
       when_i_visit("/422")
-      then_i_see_422_content_for("Claim funding for mentors")
+      then_i_see_422_content_for("Claim funding for mentor training")
     end
 
     it "shows the 500 error page" do


### PR DESCRIPTION
## Context

Our service is now called `Claim funding for mentor training` this changes the translations to reflect this

## Changes proposed in this pull request

Translations
Specs
Emails

## Guidance to review

Review the changes


![Screenshot from 2024-03-12 16-04-51](https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/83d5a587-06b7-491a-927c-20d9a53b0252)

