### PR TITLE
Add Import register placement schools into support schools rake task

### DIFF
--- a/app/services/claims/import_schools.rb
+++ b/app/services/claims/import_schools.rb
@@ -1,0 +1,21 @@
+require "csv"
+
+class Claims::ImportSchools
+  include ServicePattern
+
+  def initialize(csv_file_path:)
+    @csv_file_path = csv_file_path
+  end
+
+  def call
+    urns = CSV.read(csv_file_path, headers: true).map { |row| row["urn"] }
+
+    updated_count = School.where(urn: urns).update_all(claims_service: true)
+
+    Rails.logger.info "#{updated_count} schools updated."
+  end
+
+  private
+
+  attr_reader :csv_file_path
+end

--- a/lib/tasks/import_schools.rake
+++ b/lib/tasks/import_schools.rake
@@ -1,0 +1,8 @@
+namespace :import_schools do
+  desc "Import of schools into the claims domain"
+  task :import, [:csv_file_path] => :environment do |_task, args|
+    csv_file_path = args[:csv_file_path]
+
+    Claims::ImportSchools.call(csv_file_path:)
+  end
+end

--- a/spec/fixtures/import_schools.csv
+++ b/spec/fixtures/import_schools.csv
@@ -1,0 +1,4 @@
+provider_name,school_id,school_name,urn,postcode,local_authority,government_office_region
+Best Practice Network,2180,"Newton Farm Nursery, Infant and Junior School",102181,HA2 9JU,Harrow,London
+Best Practice Network,23441,Adderley CofE Primary School,123457,TF9 3TF,Shropshire,West Midlands
+Best Practice Network,40435,Yeo Moor Primary School,141361,BS21 6JL,North Somerset,South West

--- a/spec/services/claims/import_schools_spec.rb
+++ b/spec/services/claims/import_schools_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+describe Claims::ImportSchools do
+  before do
+    region = create(:region, name: "Inner London", claims_funding_available_per_hour: Money.from_amount(53.60, "GBP"))
+    create(:school, name: "Newton Farm Nursery, Infant and Junior School", region:, urn: "102181", claims_service: false)
+    create(:school, name: "Adderley CofE Primary School", region:, urn: "123457", claims_service: false)
+    create(:school, name: "Yeo Moor Primary School", region:, urn: "141361", claims_service: false)
+  end
+
+  describe "#call" do
+    it "increases the number of claims schools by 3" do
+      csv_file_path = Rails.root.join("spec/fixtures/import_schools.csv")
+
+      expect { described_class.call(csv_file_path:) }.to change(Claims::School, :count).by(3)
+    end
+  end
+end

--- a/spec/tasks/import_schools_spec.rb
+++ b/spec/tasks/import_schools_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+require "rake"
+
+describe "import_schools" do
+  describe "import" do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+    subject(:import_schools) { Rake::Task["import_schools:import"].invoke }
+
+    it "calls Claims::ImportSchools service" do
+      expect(Claims::ImportSchools).to receive(:call)
+      import_schools
+    end
+  end
+end


### PR DESCRIPTION
## Context

For private beta we want to onboard over 300 schools into our service, this is different from the schools in GIAS(School model). We are talking about the Claims::School model

## Changes proposed in this pull request

Add a rake task that allows us to upload these schools

## Guidance to review

Run `'import_register_placement_schools:import[CSV_LOCATION]'`

## Link to Trello card

https://trello.com/c/eTZ8OzLD/237-private-beta-import-register-placement-schools-into-support-schools

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
