### PR TITLE
Refactor claim statuses

### DIFF
--- a/app/components/claim/status_tag_component.rb
+++ b/app/components/claim/status_tag_component.rb
@@ -8,9 +8,19 @@ class Claim::StatusTagComponent < ApplicationComponent
   end
 
   def call
-    css_class = claim.draft ? "govuk-tag--grey" : "govuk-tag--blue"
-    text = claim.draft ? t(".draft") : t(".submitted")
+    content_tag(:p, claim.status.humanize, class: "govuk-tag #{css_class}")
+  end
 
-    content_tag(:p, text, class: "govuk-tag #{css_class}")
+  private
+
+  def css_class
+    style_status_classes.fetch(claim.status)
+  end
+
+  def style_status_classes
+    {
+      draft: "govuk-tag--grey",
+      submitted: "govuk-tag--blue",
+    }.with_indifferent_access
   end
 end

--- a/app/controllers/claims/schools/claims_controller.rb
+++ b/app/controllers/claims/schools/claims_controller.rb
@@ -6,7 +6,7 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
   helper_method :claim_provider_form
 
   def index
-    @pagy, @claims = pagy(@school.claims.where(draft: false))
+    @pagy, @claims = pagy(@school.claims.not_internal)
   end
 
   def new; end
@@ -49,7 +49,7 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
   def submit
     Claims::Submit.call(
       claim: @claim,
-      claim_params: { draft: false, submitted_at: Time.current },
+      claim_params: { status: :submitted, submitted_at: Time.current },
     )
 
     redirect_to confirm_claims_school_claim_path(@school, @claim)

--- a/app/controllers/claims/support/claims_controller.rb
+++ b/app/controllers/claims/support/claims_controller.rb
@@ -3,7 +3,7 @@ class Claims::Support::ClaimsController < Claims::Support::ApplicationController
   before_action :authorize_claim
 
   def index
-    @pagy, @claims = pagy(Claim.all.order(created_at: :desc))
+    @pagy, @claims = pagy(Claim.not_internal.order(created_at: :desc))
   end
 
   def show; end

--- a/app/controllers/claims/support/schools/claims_controller.rb
+++ b/app/controllers/claims/support/schools/claims_controller.rb
@@ -6,7 +6,7 @@ class Claims::Support::Schools::ClaimsController < Claims::Support::ApplicationC
   helper_method :claim_provider_form
 
   def index
-    @pagy, @claims = pagy(@school.claims.order("created_at DESC"))
+    @pagy, @claims = pagy(@school.claims.not_internal.order("created_at DESC"))
   end
 
   def new; end
@@ -47,7 +47,7 @@ class Claims::Support::Schools::ClaimsController < Claims::Support::ApplicationC
   def submit
     Claims::Submit.call(
       claim: @claim,
-      claim_params: { draft: true },
+      claim_params: { status: :draft },
     )
 
     redirect_to claims_support_school_claims_path(@school), flash: { success: t(".success") }

--- a/app/forms/claim/provider_form.rb
+++ b/app/forms/claim/provider_form.rb
@@ -20,7 +20,7 @@ class Claim::ProviderForm < ApplicationForm
   def updated_claim
     @updated_claim ||= begin
       claim.provider_id = provider_id
-      claim.draft = true
+      claim.status = :internal
       claim.created_by = current_user
       claim
     end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -4,8 +4,8 @@
 #
 #  id              :uuid             not null, primary key
 #  created_by_type :string
-#  draft           :boolean          default(FALSE)
 #  reference       :string
+#  status          :enum
 #  submitted_at    :datetime
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
@@ -33,7 +33,14 @@ class Claim < ApplicationRecord
   has_many :mentor_trainings
   has_many :mentors, through: :mentor_trainings
 
+  validates :status, presence: true
   validates :reference, uniqueness: { case_sensitive: false }, allow_nil: true
+
+  scope :not_internal, -> { where.not(status: :internal) }
+
+  enum :status,
+       { internal: "internal", draft: "draft", submitted: "submitted" },
+       validate: true
 
   delegate :name, to: :provider, prefix: true, allow_nil: true
 

--- a/db/migrate/20240313102047_add_statuses_to_claim.rb
+++ b/db/migrate/20240313102047_add_statuses_to_claim.rb
@@ -1,0 +1,7 @@
+class AddStatusesToClaim < ActiveRecord::Migration[7.1]
+  def change
+    create_enum :claim_status, %w[internal draft submitted]
+
+    add_column :claims, :status, :enum, enum_type: "claim_status"
+  end
+end

--- a/db/migrate/20240313104342_remove_draft_from_claim.rb
+++ b/db/migrate/20240313104342_remove_draft_from_claim.rb
@@ -1,0 +1,5 @@
+class RemoveDraftFromClaim < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :claims, :draft, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_11_101900) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_13_104342) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
+  create_enum "claim_status", ["internal", "draft", "submitted"]
   create_enum "mentor_training_type", ["refresher", "initial"]
   create_enum "placement_status", ["draft", "published"]
   create_enum "provider_type", ["scitt", "lead_school", "university"]
@@ -25,7 +26,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_11_101900) do
 
   create_table "claims", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "school_id", null: false
-    t.boolean "draft", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "provider_id"
@@ -33,6 +33,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_11_101900) do
     t.datetime "submitted_at"
     t.string "created_by_type"
     t.uuid "created_by_id"
+    t.enum "status", enum_type: "claim_status"
     t.index ["created_by_type", "created_by_id"], name: "index_claims_on_created_by"
     t.index ["provider_id"], name: "index_claims_on_provider_id"
     t.index ["reference"], name: "index_claims_on_reference", unique: true

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -4,8 +4,8 @@
 #
 #  id              :uuid             not null, primary key
 #  created_by_type :string
-#  draft           :boolean          default(FALSE)
 #  reference       :string
+#  status          :enum
 #  submitted_at    :datetime
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
@@ -31,10 +31,17 @@ FactoryBot.define do
     association :provider
     association :created_by, factory: :claims_user
 
-    reference { SecureRandom.random_number(99_999_999) }
+    status { "internal" }
 
     trait :draft do
-      draft { true }
+      status { "draft" }
+      reference { SecureRandom.random_number(99_999_999) }
+    end
+
+    trait :submitted do
+      status { "submitted" }
+      submitted_at { Time.current }
+      reference { SecureRandom.random_number(99_999_999) }
     end
   end
 end

--- a/spec/forms/claim/provider_form_spec.rb
+++ b/spec/forms/claim/provider_form_spec.rb
@@ -39,25 +39,25 @@ describe Claim::ProviderForm, type: :model do
 
   describe "save" do
     context "when claim doesn't exist" do
-      it "creates a draft claim with a provider" do
+      it "creates an internal claim with a provider" do
         form = described_class.new(provider_id: provider.id, school:, current_user:)
 
         expect {
           form.save!
         }.to change { form.claim.provider }.to provider
-        expect(form.claim.draft).to be(true)
+        expect(form.claim.internal?).to be(true)
         expect(form.claim.created_by).to eq(current_user)
       end
     end
 
     context "when claim does exist" do
-      it "creates a draft claim with a provider" do
+      it "creates an internal claim with a provider" do
         form = described_class.new(id: claim.id, provider_id: provider.id, school:, current_user:)
 
         expect {
           form.save!
         }.to change { claim.reload.provider }.to provider
-        expect(claim.draft).to be(true)
+        expect(claim.internal?).to be(true)
         expect(form.claim.created_by).to eq(current_user)
       end
     end

--- a/spec/services/claims/submit_spec.rb
+++ b/spec/services/claims/submit_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 describe Claims::Submit do
   subject(:submit_service) { described_class.call(claim:, claim_params:) }
 
-  let!(:claim) { create(:claim, :draft, reference: nil) }
-  let(:claim_params) { { draft: false, submitted_at: } }
+  let!(:claim) { create(:claim, reference: nil) }
+  let(:claim_params) { { status: "submitted", submitted_at: } }
   let(:submitted_at) { Time.new("2024-03-04 10:32:04 UTC") }
 
   describe "#call" do
@@ -12,7 +12,7 @@ describe Claims::Submit do
       allow(SecureRandom).to receive(:random_number).with(99_999_999).and_return(123)
 
       expect { submit_service }.to change(claim, :reference).from(nil).to("123")
-      expect(claim.draft).to eq(false)
+      expect(claim.status).to eq("submitted")
       expect(claim.submitted_at).to eq(submitted_at)
     end
 
@@ -32,19 +32,19 @@ describe Claims::Submit do
 
         expect { submit_service }.to change(claim, :reference).from(nil).to("456")
 
-        expect(claim.draft).to eq(false)
+        expect(claim.status).to eq("submitted")
         expect(claim.submitted_at).to eq(submitted_at)
       end
     end
 
-    context "when draft value is true" do
-      let(:claim_params) { { draft: true } }
+    context "when claim params contains draft status" do
+      let(:claim_params) { { status: "draft" } }
 
       it "submits the claim" do
         allow(SecureRandom).to receive(:random_number).with(99_999_999).and_return(123)
 
         expect { submit_service }.to change(claim, :reference).from(nil).to("123")
-        expect(claim.draft).to eq(true)
+        expect(claim.status).to eq("draft")
         expect(claim.submitted_at).to be_nil
       end
     end

--- a/spec/system/claims/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/schools/claims/create_claim_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     when_i_click("Continue")
     then_i_check_my_answers
     when_i_click("Submit claim")
-    then_i_get_a_claim_reference(Claim.where(draft: false).first)
+    then_i_get_a_claim_reference(Claim.submitted.first)
   end
 
   scenario "Anne does not fill the form correctly" do

--- a/spec/system/claims/schools/claims/view_claim_spec.rb
+++ b/spec/system/claims/schools/claims/view_claim_spec.rb
@@ -16,7 +16,16 @@ RSpec.describe "View a claim", type: :system, service: :claims do
   let!(:provider) { create(:provider, :best_practice_network) }
   let!(:claims_mentor) { create(:claims_mentor, first_name: "Barry", last_name: "Garlow") }
 
-  let!(:claim) { create(:claim, school:, reference: "12345678", submitted_at: Time.new(2024, 3, 5, 12, 31, 52, "+00:00"), provider:) }
+  let!(:claim) do
+    create(
+      :claim,
+      :submitted,
+      school:,
+      reference: "12345678",
+      submitted_at: Time.new(2024, 3, 5, 12, 31, 52, "+00:00"),
+      provider:,
+    )
+  end
   let!(:mentor_training) { create(:mentor_training, claim:, mentor: claims_mentor, hours_completed: 6) }
 
   scenario "Anne visits the claims index page with a submited" do

--- a/spec/system/claims/support/claims/download_claims_csv_spec.rb
+++ b/spec/system/claims/support/claims/download_claims_csv_spec.rb
@@ -38,6 +38,6 @@ RSpec.describe "Download claims CSV", type: :system, service: :claims do
     region = create(:region, name: "Inner London", claims_funding_available_per_hour: Money.from_amount(53.60, "GBP"))
     school = create(:claims_school, :claims, name: "School name 1", region_id: region.id, urn: "1234")
 
-    create(:claim, school_id: school.id, reference: "12345678")
+    create(:claim, :submitted, school_id: school.id, reference: "12345678")
   end
 end

--- a/spec/system/claims/support/claims/view_a_claim_spec.rb
+++ b/spec/system/claims/support/claims/view_a_claim_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "View claims", type: :system, service: :claims do
   let!(:claim) do
     create(
       :claim,
-      draft: false,
+      :submitted,
       provider:,
       mentors: [mentor],
     )

--- a/spec/system/claims/support/claims/view_claims_spec.rb
+++ b/spec/system/claims/support/claims/view_claims_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.describe "View claims", type: :system, service: :claims do
   let!(:support_user) { create(:claims_support_user) }
-  let!(:claim_2) { create(:claim, draft: false) }
-  let!(:claim_1) { create(:claim, draft: true) }
+  let!(:claim_2) { create(:claim, :submitted) }
+  let!(:claim_1) { create(:claim, :draft) }
 
   before do
     user_exists_in_dfe_sign_in(user: support_user)

--- a/spec/system/claims/support/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/create_claim_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     when_i_click("Continue")
     then_i_check_my_answers
     when_i_click("Add claim")
-    then_i_am_redirectd_to_index_page(Claim.where(draft: true).first)
+    then_i_am_redirectd_to_index_page(Claim.draft.first)
   end
 
   scenario "Colin does not fill the form correctly" do

--- a/spec/system/claims/support/schools/claims/view_a_schools_claims_spec.rb
+++ b/spec/system/claims/support/schools/claims/view_a_schools_claims_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe "View a schools claims", type: :system, service: :claims do
   let!(:submitted_claim) do
     create(
       :claim,
+      :submitted,
       school_id: school.id,
-      draft: false,
       submitted_at: Time.new(2024, 3, 5, 12, 31, 52, "+00:00"),
     )
   end
-  let!(:draft_claim) { create(:claim, school_id: school.id, draft: true) }
-  let!(:claim_from_another_school) { create(:claim, school_id: another_school.id, draft: true) }
+  let!(:draft_claim) { create(:claim, :draft, school_id: school.id) }
+  let!(:claim_from_another_school) { create(:claim, :draft, school_id: another_school.id) }
 
   scenario "View a school's claims as a support user" do
     user_exists_in_dfe_sign_in(user: colin)

--- a/spec/system/claims/support/schools/claims/view_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/view_claim_spec.rb
@@ -10,7 +10,16 @@ RSpec.describe "View a claim", type: :system, service: :claims do
   let!(:provider) { create(:provider, :best_practice_network) }
   let!(:claims_mentor) { create(:claims_mentor, first_name: "Barry", last_name: "Garlow") }
 
-  let!(:claim) { create(:claim, school:, reference: "12345678", submitted_at: Time.new(2024, 3, 5, 12, 31, 52, "+00:00"), provider:) }
+  let!(:claim) do
+    create(
+      :claim,
+      :submitted,
+      school:,
+      reference: "12345678",
+      submitted_at: Time.new(2024, 3, 5, 12, 31, 52, "+00:00"),
+      provider:,
+    )
+  end
   let!(:mentor_training) { create(:mentor_training, claim:, mentor: claims_mentor, hours_completed: 6) }
 
   scenario "A support user visits the claims index page with a submited claim" do


### PR DESCRIPTION
## Context

Previously, the claim status is determined by a boolean draft column on the claims table. As requirements have changed this is not supporting the functionality we need.

We need an `internal` status because we create a claim in DB when the user adds a mentor to a claim. Those claims should not be shown to the user.

The user should see claims that are `draft` or `submitted`, the other two statuses added in this commit.

We could have used the claim values to calculate the status of the claim but the logic would not scale very well so an enum seemed like the correct choice here.

These statuses should also help us with implementing policies.

## Changes

Migrations to add status enum and remove draft boolean (There is no live data so we don't need to migrate data)
Set the correct status in the claim form
Change specs

## Guidance to review

- If you have claims on your local machine, you will need to delete all those claims by running: 
`MentorTraining.destroy_all`
`Claim.destroy_all`
- Create new claims as support and normal user
- Only draft and submitted claims should be shown on claim index pages.

## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/a54ff6f0-96c1-46fc-867e-9d4e11827c14

