### PR TITLE
Match CI and local code coverage

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Run Tests
         run: |
           bundle exec rails test:prepare db:test:prepare
+          bundle exec rails zeitwerk:check
           bundle exec rspec --format progress
       - name: Upload code coverage report
         uses: actions/upload-artifact@v4

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
   # Eager loading loads your whole application. When running a single test locally,
   # this probably isn't necessary. It's a good idea to do in a continuous integration
   # system, or in some way before deploying your code.
-  config.eager_load = ENV["CI"].present?
+  config.eager_load = false
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true


### PR DESCRIPTION

## Context

It was noticed that the code coverage differed between local test and the CI test.

This was occurring due to `ENV["CI"].present?` being false when running rspec locally vs. running rspec on the CI. There is a great article on this exact issue https://reinteractive.com/articles/CI-simplecov-and-coverage-discrepancies and I have followed their advice.

## Guidance to review

If the CI passes without exploding, check the the code coverage report matches your local environment.

## Link to Trello card

[Work out why our code coverage figures are inconsistent](https://trello.com/c/n3bFhqTT)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
