### PR TITLE
Remove information from Organisation Details page

### DIFF
--- a/app/views/claims/schools/show.html.erb
+++ b/app/views/claims/schools/show.html.erb
@@ -9,12 +9,6 @@
       <%= render "shared/organisations/organisation_details", organisation: @school %>
       <h2 class="govuk-heading-m govuk-!-margin-top-9"><%= t(".grant_funding") %></h2>
       <%= render "shared/organisations/grant_funding", organisation: @school %>
-      <h2 class="govuk-heading-m govuk-!-margin-top-9"><%= t(".additional_details") %></h2>
-      <%= render "shared/schools/additional_details", school: @school %>
-      <h2 class="govuk-heading-m govuk-!-margin-top-9"><%= t(".send") %></h2>
-      <%= render "shared/schools/send_details", school: @school %>
-      <h2 class="govuk-heading-m govuk-!-margin-top-9"><%= t(".ofsted") %></h2>
-      <%= render "shared/schools/ofsted_details", school: @school %>
       <h2 class="govuk-heading-m govuk-!-margin-top-9"><%= t(".contact_details") %></h2>
       <%= render "shared/organisations/contact_details", organisation: @school %>
     </div>

--- a/app/views/claims/support/schools/show.html.erb
+++ b/app/views/claims/support/schools/show.html.erb
@@ -11,12 +11,6 @@
       <%= render "shared/organisations/organisation_details", organisation: @school %>
       <h2 class="govuk-heading-m govuk-!-margin-top-9"><%= t(".grant_funding") %></h2>
       <%= render "shared/organisations/grant_funding", organisation: @school %>
-      <h2 class="govuk-heading-m govuk-!-margin-top-9"><%= t(".additional_details") %></h2>
-      <%= render "shared/schools/additional_details", school: @school %>
-      <h2 class="govuk-heading-m govuk-!-margin-top-9"><%= t(".send") %></h2>
-      <%= render "shared/schools/send_details", school: @school %>
-      <h2 class="govuk-heading-m govuk-!-margin-top-9"><%= t(".ofsted") %></h2>
-      <%= render "shared/schools/ofsted_details", school: @school %>
       <h2 class="govuk-heading-m govuk-!-margin-top-9"><%= t(".contact_details") %></h2>
       <%= render "shared/organisations/contact_details", organisation: @school %>
     </div>

--- a/config/locales/en/claims/schools.yml
+++ b/config/locales/en/claims/schools.yml
@@ -8,7 +8,6 @@ en:
         unknown: Unknown
         not_entered: Not entered
         not_applicable: Not applicable
-        additional_details: Additional details
         group: Group
         type: Type
         phase: Phase

--- a/config/locales/en/claims/support/schools.yml
+++ b/config/locales/en/claims/support/schools.yml
@@ -13,9 +13,6 @@ en:
         create:
           organisation_added: Organisation added
         show:
-          additional_details: Additional details
-          send: Special educational needs and disabilities (SEND)
-          ofsted: Ofsted
           contact_details: Contact details
           grant_funding: Grant funding
         index:

--- a/spec/system/claims/schools/view_school_spec.rb
+++ b/spec/system/claims/schools/view_school_spec.rb
@@ -64,43 +64,13 @@ RSpec.describe "School Page", type: :system do
       expect(page).to have_content "Organisation details"
     end
 
-    expect(page).to have_content "Additional details"
-    expect(page).to have_content "Special educational needs and disabilities (SEND)"
-    expect(page).to have_content "Ofsted"
+    expect(page).to have_content "Grant funding"
     expect(page).to have_content "Contact details"
 
     within("#organisation-details") do
       expect(page).to have_content "Organisation name"
       expect(page).to have_content "UK provider reference number (UKPRN)"
       expect(page).to have_content "Unique reference number (URN)"
-    end
-
-    within("#additional-details") do
-      expect(page).to have_content "Group"
-      expect(page).to have_content "Type"
-      expect(page).to have_content "Phase"
-      expect(page).to have_content "Gender"
-      expect(page).to have_content "Minimum age"
-      expect(page).to have_content "Maximum age"
-      expect(page).to have_content "Religious character"
-      expect(page).to have_content "Admissions policy"
-      expect(page).to have_content "Urban or rural"
-      expect(page).to have_content "School capacity"
-      expect(page).to have_content "Total pupils"
-      expect(page).to have_content "Total girls"
-      expect(page).to have_content "Total boys"
-      expect(page).to have_content "Percentage free school meals"
-    end
-
-    within("#send-details") do
-      expect(page).to have_content "Special classes"
-      expect(page).to have_content "SEND provision"
-      expect(page).to have_content "Training with disabilities"
-    end
-
-    within("#ofsted-details") do
-      expect(page).to have_content "Rating"
-      expect(page).to have_content "Last inspection date"
     end
 
     within("#contact-details") do

--- a/spec/system/claims/support/schools/view_a_school_spec.rb
+++ b/spec/system/claims/support/schools/view_a_school_spec.rb
@@ -31,9 +31,7 @@ RSpec.describe "View a school", type: :system do
   end
 
   def i_see_the_schools_details_sections
-    expect(page).to have_selector("h2", text: "Additional details")
-    expect(page).to have_selector("h2", text: "Special educational needs and disabilities (SEND)")
-    expect(page).to have_selector("h2", text: "Ofsted")
+    expect(page).to have_selector("h2", text: "Grant funding")
     expect(page).to have_selector("h2", text: "Contact details")
   end
 end


### PR DESCRIPTION
## Context

Currently on the Organisation details for a normal user and support we show a bit too much information.
We need to remove the Additional details, SEND and Ofsted information. There’s no need to show these in our service

## Changes proposed in this pull request

Remove those sections mentioned above

## Guidance to review

View the Organisation details page as a normal user and support

## Link to Trello card

https://trello.com/c/FFdDOuJV/246-remove-information-from-organisation-details-page

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots
<img width="591" alt="Screenshot 2024-03-14 at 12 35 18" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/de96c4ff-f61f-4a2b-98a8-e23ea11ceaaa">

<!-- Sceenshots to aid with reviewing if needed-->
