### PR TITLE
As a user I would like to receive a confirmation email that my claim has been submitted

### DIFF
--- a/app/controllers/claims/schools/claims_controller.rb
+++ b/app/controllers/claims/schools/claims_controller.rb
@@ -50,6 +50,7 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
     Claims::Submit.call(
       claim: @claim,
       claim_params: { status: :submitted, submitted_at: Time.current },
+      user: current_user,
     )
 
     redirect_to confirm_claims_school_claim_path(@school, @claim)

--- a/app/controllers/claims/support/schools/claims_controller.rb
+++ b/app/controllers/claims/support/schools/claims_controller.rb
@@ -48,6 +48,7 @@ class Claims::Support::Schools::ClaimsController < Claims::Support::ApplicationC
     Claims::Submit.call(
       claim: @claim,
       claim_params: { status: :draft },
+      user: current_user,
     )
 
     redirect_to claims_support_school_claims_path(@school), flash: { success: t(".success") }

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -10,4 +10,15 @@ class UserMailer < ApplicationMailer
                  subject: t(".subject", organisation_name: organisation.name),
                  body: t(".body", user_name: user.full_name, organisation_name: organisation.name, service_name:)
   end
+
+  def claim_submitted_notification(user, claim)
+    link_to_claim = claims_school_claim_url(id: claim.id, school_id: claim.school.id)
+
+    notify_email to: user.email,
+                 subject: t(".subject"),
+                 body: t(".body",
+                         reference: claim.reference,
+                         amount: claim.amount.format(symbol: true, decimal_mark: ".", no_cents: false),
+                         link_to_claim:)
+  end
 end

--- a/app/services/claims/submit.rb
+++ b/app/services/claims/submit.rb
@@ -1,18 +1,32 @@
 class Claims::Submit
   include ServicePattern
 
-  def initialize(claim:, claim_params:)
+  def initialize(claim:, claim_params:, user:)
     @claim = claim
     @claim_params = claim_params
+    @user = user
   end
 
   def call
     updated_claim.save!
+
+    # We will be implementing a different email for support users in another ticket
+    if !user.support_user? && status_changed_to_submitted?
+      send_claim_submitted_notification_email
+    end
   end
 
   private
 
-  attr_reader :claim, :claim_params
+  attr_reader :claim, :claim_params, :user
+
+  def send_claim_submitted_notification_email
+    UserMailer.with(service: user.service).claim_submitted_notification(user, claim).deliver_later
+  end
+
+  def status_changed_to_submitted?
+    updated_claim.saved_change_to_status? && updated_claim.submitted?
+  end
 
   def updated_claim
     @updated_claim ||= begin

--- a/config/locales/en/user_mailer.yml
+++ b/config/locales/en/user_mailer.yml
@@ -15,3 +15,11 @@ en:
         Dear %{user_name},
 
         You have been removed from the %{service_name} service for %{organisation_name}.
+
+    claim_submitted_notification:
+      subject: Your ITT mentor training claim has been submitted
+      body: |
+        Reference: %{reference}
+        Amount: %{amount}
+
+        Link to claim: %{link_to_claim}

--- a/spec/services/claims/submit_spec.rb
+++ b/spec/services/claims/submit_spec.rb
@@ -1,11 +1,13 @@
 require "rails_helper"
 
 describe Claims::Submit do
-  subject(:submit_service) { described_class.call(claim:, claim_params:) }
+  subject(:submit_service) { described_class.call(claim:, claim_params:, user:) }
 
-  let!(:claim) { create(:claim, reference: nil) }
+  let!(:claim) { create(:claim, reference: nil, status: "internal") }
+
   let(:claim_params) { { status: "submitted", submitted_at: } }
   let(:submitted_at) { Time.new("2024-03-04 10:32:04 UTC") }
+  let(:user) { create(:claims_user) }
 
   describe "#call" do
     it "submits the claim" do
@@ -19,7 +21,7 @@ describe Claims::Submit do
     context "when claim has a reference already" do
       it "submits the claim with a new reference" do
         claim_with_reference = create(:claim, reference: "123")
-        service = described_class.call(claim: claim_with_reference, claim_params:)
+        service = described_class.call(claim: claim_with_reference, claim_params:, user:)
 
         expect { service }.not_to change(claim, :reference)
       end
@@ -46,6 +48,65 @@ describe Claims::Submit do
         expect { submit_service }.to change(claim, :reference).from(nil).to("123")
         expect(claim.status).to eq("draft")
         expect(claim.submitted_at).to be_nil
+      end
+    end
+
+    context "when claim params are not submitted" do
+      let(:claim_params) { { status: "draft" } }
+      let(:service) { described_class.call(claim:, claim_params:, user:) }
+
+      it "does not send an email" do
+        allow(SecureRandom).to receive(:random_number).with(99_999_999).and_return(123)
+
+        expect { service }.to change(claim, :reference).from(nil).to("123")
+        expect(claim.status).to eq("draft")
+        expect(claim.submitted_at).to be_nil
+
+        expect(service).not_to receive(:send_claim_submitted_notification_email)
+      end
+    end
+
+    context "when claim params are submitted" do
+      let(:claim_params) { { status: "submitted", submitted_at: } }
+
+      it "sends an email" do
+        allow(SecureRandom).to receive(:random_number).with(99_999_999).and_return(123)
+
+        expect { submit_service }.to change(claim, :reference).from(nil).to("123")
+        expect(claim.status).to eq("submitted")
+        expect(claim.submitted_at).to eq(submitted_at)
+
+        expect(submit_service.arguments.first).to eq("UserMailer")
+        expect(submit_service.arguments.second).to eq("claim_submitted_notification")
+      end
+    end
+
+    context "when claim params status is internal" do
+      let(:claim_params) { { status: "internal" } }
+      let(:service) { described_class.call(claim:, claim_params:, user:) }
+
+      it "does not send an email or call send_claim_submitted_notification_email " do
+        allow(SecureRandom).to receive(:random_number).with(99_999_999).and_return(123)
+
+        expect { service }.to change(claim, :reference).from(nil).to("123")
+        expect(claim.status).to eq("internal")
+        expect(claim.submitted_at).to be_nil
+        expect(service).not_to receive(:send_claim_submitted_notification_email)
+      end
+    end
+
+    context "when the current user is a support user" do
+      let(:claim_params) { { status: "submitted", submitted_at: } }
+      let(:support_user) { create(:claims_support_user, :colin) }
+      let(:service) { described_class.call(claim:, claim_params:, user: support_user) }
+
+      it "does not send an email or call send_claim_submitted_notification_email " do
+        allow(SecureRandom).to receive(:random_number).with(99_999_999).and_return(123)
+
+        expect { service }.to change(claim, :reference).from(nil).to("123")
+        expect(claim.status).to eq("submitted")
+        expect(claim.submitted_at).to eq(submitted_at)
+        expect(service).not_to receive(:send_claim_submitted_notification_email)
       end
     end
   end


### PR DESCRIPTION
## Context

We want to email the current user with a confirmation email containing relevant information about the claim being made.

## Changes proposed in this pull request

We send an email to the current user when a claim has been submitted

## Guidance to review

Submit a claim, and use mailcatcher to intercept the email. Or pull the branch locally and submit a claim and look in the console to see it being called/sent.

## Link to Trello card

https://trello.com/c/CWB019sD/247-as-a-user-i-would-like-to-receive-a-confirmation-email-that-my-claim-has-been-submitted

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
