### PR TITLE
Use symbols for enums

### DIFF
--- a/app/services/publish_teacher_training/subject/import.rb
+++ b/app/services/publish_teacher_training/subject/import.rb
@@ -22,14 +22,14 @@ module PublishTeacherTraining
         subjects_data = api_response.fetch("included")
         # Sync Primary Subjects
         sync_subjects(
-          subject_area: "primary",
+          subject_area: :primary,
           subject_ids: primary_subject_ids,
           subjects_data:,
         )
 
         # Sync Secondary Subjects
         sync_subjects(
-          subject_area: "secondary",
+          subject_area: :secondary,
           subject_ids: secondary_subject_ids,
           subjects_data:,
         )

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -31,15 +31,15 @@ FactoryBot.define do
     association :provider
     association :created_by, factory: :claims_user
 
-    status { "internal" }
+    status { :internal }
 
     trait :draft do
-      status { "draft" }
+      status { :draft }
       reference { SecureRandom.random_number(99_999_999) }
     end
 
     trait :submitted do
-      status { "submitted" }
+      status { :submitted }
       submitted_at { Time.current }
       reference { SecureRandom.random_number(99_999_999) }
     end

--- a/spec/factories/placements.rb
+++ b/spec/factories/placements.rb
@@ -23,10 +23,10 @@ FactoryBot.define do
     association :school, factory: :placements_school
     start_date { 1.month.from_now }
     end_date { 4.months.from_now }
-    status { "published" }
+    status { :published }
 
     trait :draft do
-      status { "draft" }
+      status { :draft }
     end
   end
 end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -38,15 +38,15 @@ FactoryBot.define do
     provider_type { Provider.provider_types.keys.sample }
 
     trait :scitt do
-      provider_type { "scitt" }
+      provider_type { :scitt }
     end
 
     trait :lead_school do
-      provider_type { "lead_school" }
+      provider_type { :lead_school }
     end
 
     trait :university do
-      provider_type { "university" }
+      provider_type { :university }
     end
 
     trait :placements do

--- a/spec/factories/subject.rb
+++ b/spec/factories/subject.rb
@@ -1,15 +1,15 @@
 FactoryBot.define do
   factory :subject do
-    subject_area { %w[primary secondary].sample }
+    subject_area { %i[primary secondary].sample }
     name { Faker::Educator.subject }
     code { Faker::Alphanumeric.alpha(number: 2) }
   end
 
   trait :primary do
-    subject_area { "primary" }
+    subject_area { :primary }
   end
 
   trait :secondary do
-    subject_area { "secondary" }
+    subject_area { :secondary }
   end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Provider, type: :model do
       ).case_insensitive
     end
 
-    it { is_expected.to allow_values("scitt", "lead_school", "university").for(:provider_type) }
+    it { is_expected.to allow_values(:scitt, :lead_school, :university).for(:provider_type) }
   end
 
   context "with scopes" do

--- a/spec/services/claims/submit_spec.rb
+++ b/spec/services/claims/submit_spec.rb
@@ -5,7 +5,7 @@ describe Claims::Submit do
 
   let!(:claim) { create(:claim, reference: nil, status: "internal") }
 
-  let(:claim_params) { { status: "submitted", submitted_at: } }
+  let(:claim_params) { { status: :submitted, submitted_at: } }
   let(:submitted_at) { Time.new("2024-03-04 10:32:04 UTC") }
   let(:user) { create(:claims_user) }
 
@@ -40,7 +40,7 @@ describe Claims::Submit do
     end
 
     context "when claim params contains draft status" do
-      let(:claim_params) { { status: "draft" } }
+      let(:claim_params) { { status: :draft } }
 
       it "submits the claim" do
         allow(SecureRandom).to receive(:random_number).with(99_999_999).and_return(123)

--- a/spec/services/publish_teacher_training/provider/importer_spec.rb
+++ b/spec/services/publish_teacher_training/provider/importer_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe PublishTeacherTraining::Provider::Importer do
 
     it "creates new provider records for responses" do
       expect { importer }.to change(Provider, :count).by(3)
-      expect(Provider.find_by(name: "Provider 1", code: "Prov1", provider_type: "scitt")).to be_present
-      expect(Provider.find_by(name: "Provider 2", code: "Prov2", provider_type: "university")).to be_present
-      expect(Provider.find_by(name: "Provider 3", code: "Prov3", provider_type: "lead_school")).to be_present
+      expect(Provider.find_by(name: "Provider 1", code: "Prov1", provider_type: :scitt)).to be_present
+      expect(Provider.find_by(name: "Provider 2", code: "Prov2", provider_type: :university)).to be_present
+      expect(Provider.find_by(name: "Provider 3", code: "Prov3", provider_type: :lead_school)).to be_present
     end
   end
 
@@ -27,7 +27,7 @@ RSpec.describe PublishTeacherTraining::Provider::Importer do
     it "creates new provider records for responses which don't already exist or are valid,
       and updates any pre-existing providers" do
       expect { importer }.to change(Provider, :count).by(1)
-      expect(Provider.find_by(name: "Provider 1", code: "Prov1", provider_type: "scitt")).to be_present
+      expect(Provider.find_by(name: "Provider 1", code: "Prov1", provider_type: :scitt)).to be_present
       expect(Provider.where(name: existing_provider.name, code: existing_provider.code).count).to eq(1)
       expect(Provider.find_by(code: changeable_provider.code).name).to eq("Changed Provider")
     end
@@ -42,7 +42,7 @@ RSpec.describe PublishTeacherTraining::Provider::Importer do
       expect(Rails.logger).to receive(:info).with("Invalid Providers - [\"Provider with code Inv is invalid\"]")
       expect(Rails.logger).to receive(:info).with("Done!")
       expect { importer }.to change(Provider, :count).by(1)
-      expect(Provider.find_by(name: "Provider 1", code: "Prov1", provider_type: "scitt")).to be_present
+      expect(Provider.find_by(name: "Provider 1", code: "Prov1", provider_type: :scitt)).to be_present
       expect(Provider.find_by(name: "Invalid Provider", code: "Inv")).not_to be_present
     end
   end
@@ -55,8 +55,8 @@ RSpec.describe PublishTeacherTraining::Provider::Importer do
 
     it "iterates over the links in the API response to create records for providers across all pages" do
       expect { importer }.to change(Provider, :count).by(2)
-      expect(Provider.find_by(name: "Page 1 Provider", code: "Pg1", provider_type: "scitt")).to be_present
-      expect(Provider.find_by(name: "Page 2 Provider", code: "Pg2", provider_type: "scitt")).to be_present
+      expect(Provider.find_by(name: "Page 1 Provider", code: "Pg1", provider_type: :scitt)).to be_present
+      expect(Provider.find_by(name: "Page 2 Provider", code: "Pg2", provider_type: :scitt)).to be_present
     end
   end
 

--- a/spec/system/claims/schools/claims/view_claims_spec.rb
+++ b/spec/system/claims/schools/claims/view_claims_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "View claims", type: :system, service: :claims do
   end
 
   before do
-    create(:claim, status: "internal", school:)
+    create(:claim, status: :internal, school:)
   end
 
   scenario "Anne visits the claims index page with no mentors" do

--- a/spec/system/placements/schools/placements/remove_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/remove_a_placement_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe "Placements / Schools / Placements / Remove a placement",
   let!(:placement_1) { create(:placement, school:, subjects: [subject_1]) }
   let(:placement_2) { create(:placement, school:, subjects: [subject_2]) }
   let(:school) { build(:placements_school, name: "School 1", phase: "Primary") }
-  let(:subject_1) { build(:subject, name: "Subject 1", subject_area: "primary") }
-  let(:subject_2) { build(:subject, name: "Subject 2", subject_area: "primary") }
+  let(:subject_1) { build(:subject, name: "Subject 1", subject_area: :primary) }
+  let(:subject_2) { build(:subject, name: "Subject 2", subject_area: :primary) }
 
   before do
     given_i_sign_in_as_anne

--- a/spec/system/placements/schools/placements/view_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/view_a_placement_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
                type: :system, service: :placements do
   let!(:school) { create(:placements_school, name: "School 1", phase: "Primary") }
   let!(:placement) { create(:placement, school:) }
-  let!(:subject_1) { create(:subject, name: "Subject 1", subject_area: "primary") }
+  let!(:subject_1) { create(:subject, name: "Subject 1", subject_area: :primary) }
 
   before do
     given_i_sign_in_as_anne

--- a/spec/system/placements/schools/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/schools/placements/view_placements_list_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Placement school user views a list of placements", type: :system
   end
 
   def given_a_published_placement_exists
-    create(:placement, status: "published", school:)
+    create(:placement, status: :published, school:)
   end
 
   def then_i_see_published_status_tag
@@ -112,7 +112,7 @@ RSpec.describe "Placement school user views a list of placements", type: :system
     biology = create(:subject, name: "Biology")
     maths = create(:subject, name: "Maths")
     subjects = [maths, biology]
-    create(:placement, status: "draft", school:, mentors:, subjects:)
+    create(:placement, status: :draft, school:, mentors:, subjects:)
   end
 
   def given_placement_exists_for_another_school


### PR DESCRIPTION
## Context

We’ve been using symbols and strings interchangeably for our enumerables within the application, this task will convert all string usages to symbols.

## Changes proposed in this pull request

Updates all string uses for the `Claim#status`, `Placement#status`, `Subject#subject_area` and `Provider#provider_type` enumerables.

## Guidance to review

There should be no noticeble changes in the application, all tests should continue to pass as normal.

## Link to Trello card

[Prefer symbols for enumerables](https://trello.com/c/k7B8irib)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
