### PR TITLE
Claim should belong to a Claims::School

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -26,7 +26,7 @@
 #  fk_rails_...  (school_id => schools.id)
 #
 class Claim < ApplicationRecord
-  belongs_to :school
+  belongs_to :school, class_name: "Claims::School"
   belongs_to :provider
   belongs_to :created_by, polymorphic: true
 

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -29,7 +29,7 @@ require "rails_helper"
 
 RSpec.describe Claim, type: :model do
   context "with associations" do
-    it { is_expected.to belong_to(:school) }
+    it { is_expected.to belong_to(:school).class_name("Claims::School") }
     it { is_expected.to belong_to(:provider) }
     it { is_expected.to belong_to(:created_by) }
     it { is_expected.to have_many(:mentor_trainings) }


### PR DESCRIPTION
## Context

A claim should belong to a `Claims::School` not a `School` model as it's really for the claims domain.

## Changes proposed in this pull request

`belongs_to :school, class_name: "Claims::School"`

## Guidance to review

Review code

