### PR TITLE
Send email to all users of school for claim created by support

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -21,4 +21,15 @@ class UserMailer < ApplicationMailer
                          amount: claim.amount.format(symbol: true, decimal_mark: ".", no_cents: false),
                          link_to_claim:)
   end
+
+  def claim_created_support_notification(claim, email)
+    link_to_claim = claims_school_claim_url(id: claim.id, school_id: claim.school.id)
+
+    notify_email(to: email,
+                 subject: t(".subject"),
+                 body: t(".body",
+                         reference: claim.reference,
+                         amount: claim.amount.format(symbol: true, decimal_mark: ".", no_cents: false),
+                         link_to_claim:))
+  end
 end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -44,6 +44,7 @@ class Claim < ApplicationRecord
        validate: true
 
   delegate :name, to: :provider, prefix: true, allow_nil: true
+  delegate :users, to: :school, prefix: true
 
   def submitted_on
     submitted_at&.to_date

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -62,6 +62,8 @@ class School < ApplicationRecord
   belongs_to :trust, optional: true
 
   has_many :user_memberships, as: :organisation
+  has_many :users, through: :user_memberships
+
   has_many :mentor_memberships
   has_many :mentors, through: :mentor_memberships
 

--- a/config/locales/en/user_mailer.yml
+++ b/config/locales/en/user_mailer.yml
@@ -23,3 +23,11 @@ en:
         Amount: %{amount}
 
         Link to claim: %{link_to_claim}
+
+    claim_created_support_notification:
+      subject: A support user created your ITT mentor training claim
+      body: |
+        Reference: %{reference}
+        Amount: %{amount}
+
+        Link to claim: %{link_to_claim}

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Claim, type: :model do
 
   context "with delegations" do
     it { is_expected.to delegate_method(:name).to(:provider).with_prefix }
+    it { is_expected.to delegate_method(:users).to(:school).with_prefix }
   end
 
   describe "enums" do

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe School, type: :model do
     it { is_expected.to have_many(:user_memberships) }
     it { is_expected.to have_many(:mentor_memberships) }
     it { is_expected.to have_many(:mentors).through(:mentor_memberships) }
+    it { is_expected.to have_many(:users).through(:user_memberships) }
   end
 
   context "with scopes" do

--- a/spec/services/claims/submit_spec.rb
+++ b/spec/services/claims/submit_spec.rb
@@ -3,10 +3,11 @@ require "rails_helper"
 describe Claims::Submit do
   subject(:submit_service) { described_class.call(claim:, claim_params:, user:) }
 
-  let!(:claim) { create(:claim, reference: nil, status: "internal") }
+  let!(:claim) { create(:claim, reference: nil, status: :internal, school:) }
 
-  let(:claim_params) { { status: "submitted", submitted_at: } }
+  let(:claim_params) { { status: :submitted, submitted_at: } }
   let(:submitted_at) { Time.new("2024-03-04 10:32:04 UTC") }
+  let(:school) { create(:claims_school, urn: "1234") }
   let(:user) { create(:claims_user) }
 
   describe "#call" do
@@ -40,7 +41,7 @@ describe Claims::Submit do
     end
 
     context "when claim params contains draft status" do
-      let(:claim_params) { { status: "draft" } }
+      let(:claim_params) { { status: :draft } }
 
       it "submits the claim" do
         allow(SecureRandom).to receive(:random_number).with(99_999_999).and_return(123)
@@ -52,22 +53,21 @@ describe Claims::Submit do
     end
 
     context "when claim params are not submitted" do
-      let(:claim_params) { { status: "draft" } }
-      let(:service) { described_class.call(claim:, claim_params:, user:) }
+      let(:claim_params) { { status: :draft } }
 
       it "does not send an email" do
         allow(SecureRandom).to receive(:random_number).with(99_999_999).and_return(123)
 
-        expect { service }.to change(claim, :reference).from(nil).to("123")
+        expect { submit_service }.to change(claim, :reference).from(nil).to("123")
         expect(claim.status).to eq("draft")
         expect(claim.submitted_at).to be_nil
 
-        expect(service).not_to receive(:send_claim_submitted_notification_email)
+        expect(submit_service).to be_nil
       end
     end
 
     context "when claim params are submitted" do
-      let(:claim_params) { { status: "submitted", submitted_at: } }
+      let(:claim_params) { { status: :submitted, submitted_at: } }
 
       it "sends an email" do
         allow(SecureRandom).to receive(:random_number).with(99_999_999).and_return(123)
@@ -82,31 +82,39 @@ describe Claims::Submit do
     end
 
     context "when claim params status is internal" do
-      let(:claim_params) { { status: "internal" } }
-      let(:service) { described_class.call(claim:, claim_params:, user:) }
+      let(:claim_params) { { status: :internal } }
 
       it "does not send an email or call send_claim_submitted_notification_email " do
         allow(SecureRandom).to receive(:random_number).with(99_999_999).and_return(123)
 
-        expect { service }.to change(claim, :reference).from(nil).to("123")
+        expect { submit_service }.to change(claim, :reference).from(nil).to("123")
         expect(claim.status).to eq("internal")
         expect(claim.submitted_at).to be_nil
-        expect(service).not_to receive(:send_claim_submitted_notification_email)
+        expect(submit_service).to be_nil
       end
     end
 
     context "when the current user is a support user" do
-      let(:claim_params) { { status: "submitted", submitted_at: } }
+      before do
+        create(:claims_user, email: "babagoli@gmail.com", user_memberships: [create(:user_membership, organisation: school)])
+        create(:claims_user, email: "email@gmail.com", user_memberships: [create(:user_membership, organisation: school)])
+      end
+
+      let(:claim_params) { { status: :draft } }
       let(:support_user) { create(:claims_support_user, :colin) }
+
       let(:service) { described_class.call(claim:, claim_params:, user: support_user) }
 
-      it "does not send an email or call send_claim_submitted_notification_email " do
+      it "sends an email using the send_claim_created_support_notification_email to each user of a school" do
         allow(SecureRandom).to receive(:random_number).with(99_999_999).and_return(123)
 
+        mailer_stub = class_double("mailer")
+        expect(UserMailer).to receive(:with).with(any_args).twice.and_return(mailer_stub)
+        expect(mailer_stub).to receive(:claim_created_support_notification).twice.and_return(mailer_stub)
+        expect(mailer_stub).to receive(:deliver_later).twice
+
         expect { service }.to change(claim, :reference).from(nil).to("123")
-        expect(claim.status).to eq("submitted")
-        expect(claim.submitted_at).to eq(submitted_at)
-        expect(service).not_to receive(:send_claim_submitted_notification_email)
+        expect(claim.status).to eq("draft")
       end
     end
   end


### PR DESCRIPTION
## Context

When a support user adds a claim we need to notify all users of the claim school.

## Changes proposed in this pull request

Sends an email to the users of a school

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Xo9wQlhJ/260-send-email-to-all-users-of-school-for-claim-created-by-support

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
