### PR TITLE
Claim policies

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,6 +51,13 @@ class ApplicationController < ActionController::Base
   end
 
   def user_not_authorized
-    redirect_back fallback_location: root_path, alert: t("you_cannot_perform_this_action")
+    flash[:alert] = t("you_cannot_perform_this_action")
+    can_be_infinite_redirect = request.url == request.referer
+
+    if can_be_infinite_redirect
+      redirect_to root_path
+    else
+      redirect_back(fallback_location: root_path)
+    end
   end
 end

--- a/app/controllers/claims/schools/claims_controller.rb
+++ b/app/controllers/claims/schools/claims_controller.rb
@@ -1,6 +1,6 @@
 class Claims::Schools::ClaimsController < Claims::ApplicationController
   include Claims::BelongsToSchool
-  before_action :set_claim, only: %i[show check confirm submit]
+  before_action :set_claim, only: %i[show check confirm submit edit update]
   before_action :authorize_claim
 
   helper_method :claim_provider_form

--- a/app/controllers/claims/support/schools/claims_controller.rb
+++ b/app/controllers/claims/support/schools/claims_controller.rb
@@ -1,7 +1,7 @@
 class Claims::Support::Schools::ClaimsController < Claims::Support::ApplicationController
   include Claims::BelongsToSchool
 
-  before_action :set_claim, only: %i[check submit show]
+  before_action :set_claim, only: %i[check draft show edit update]
   before_action :authorize_claim
   helper_method :claim_provider_form
 
@@ -44,7 +44,7 @@ class Claims::Support::Schools::ClaimsController < Claims::Support::ApplicationC
     end
   end
 
-  def submit
+  def draft
     Claims::Submit.call(
       claim: @claim,
       claim_params: { status: :draft },
@@ -84,6 +84,6 @@ class Claims::Support::Schools::ClaimsController < Claims::Support::ApplicationC
   end
 
   def authorize_claim
-    authorize Claim
+    authorize @claim || Claim
   end
 end

--- a/app/policies/claim_policy.rb
+++ b/app/policies/claim_policy.rb
@@ -1,17 +1,29 @@
 class ClaimPolicy < Claims::ApplicationPolicy
+  def edit?
+    !record.submitted?
+  end
+
   def update?
-    true
+    edit?
   end
 
   def submit?
-    true
+    !user.support_user? && !record.submitted?
   end
 
   def confirm?
-    true
+    !user.support_user? && record.submitted?
+  end
+
+  def draft?
+    user.support_user? && record.internal?
+  end
+
+  def check?
+    record.draft? || record.internal?
   end
 
   def download_csv?
-    true
+    user.support_user?
   end
 end

--- a/app/views/claims/support/schools/claims/check.html.erb
+++ b/app/views/claims/support/schools/claims/check.html.erb
@@ -75,7 +75,7 @@
           <% end %>
         <% end %>
 
-      <%= govuk_button_to t(".submit"), submit_claims_support_school_claim_path(@school, @claim) %>
+      <%= govuk_button_to t(".submit"), draft_claims_support_school_claim_path(@school, @claim) %>
 
       <p class="govuk-body">
         <%= govuk_link_to t("cancel"), claims_support_school_claims_path(@school), no_visited_state: true %>

--- a/config/locales/en/claims/pages.yml
+++ b/config/locales/en/claims/pages.yml
@@ -4,7 +4,7 @@ en:
       start:
         page_title: Claim funding for mentor training
         claim_guidance: You can claim funding for mentors who supported trainee teachers from September 2023 to July 2024.
-        training_guidance: Training that took place for April 2024 for the school year starting September 2024 can only be claimed for from May 2025.
+        training_guidance: Training that took place from April 2024 for the school year starting September 2024 can only be claimed for from May 2025.
         before_you_start: Before you start
         you_will_be_asked: "You’ll be asked for:"
         itt_provider: initial teacher training (ITT) provider details

--- a/config/locales/en/claims/support/schools/claims.yml
+++ b/config/locales/en/claims/support/schools/claims.yml
@@ -3,7 +3,7 @@ en:
     support:
       schools:
         claims:
-          submit:
+          draft:
             success: Claim added
           edit:
             page_title: Accredited provider - Add claim

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -56,7 +56,7 @@ scope module: :claims, as: :claims, constraints: { host: ENV["CLAIMS_HOST"] } do
 
           member do
             get :check
-            post :submit
+            post :draft
           end
         end
 

--- a/spec/policies/claim_policy_spec.rb
+++ b/spec/policies/claim_policy_spec.rb
@@ -1,0 +1,163 @@
+require "rails_helper"
+
+describe ClaimPolicy do
+  subject(:claim_policy) { described_class }
+
+  let(:user) { build(:claims_user) }
+  let(:support_user) { build(:claims_support_user) }
+  let(:internal_claim) { build(:claim) }
+  let(:draft_claim) { build(:claim, :draft) }
+  let(:submitted_claim) { build(:claim, :submitted) }
+
+  permissions :edit? do
+    context "when user has an internal claim" do
+      it "grants access" do
+        expect(claim_policy).to permit(user, internal_claim)
+      end
+    end
+
+    context "when the user has a draft claim" do
+      it "grants access" do
+        expect(claim_policy).to permit(user, draft_claim)
+      end
+    end
+
+    context "when the user has a submitted claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, submitted_claim)
+      end
+    end
+  end
+
+  permissions :update? do
+    context "when user has an internal claim" do
+      it "grants access" do
+        expect(claim_policy).to permit(user, internal_claim)
+      end
+    end
+
+    context "when user has a draft claim" do
+      it "grants access" do
+        expect(claim_policy).to permit(user, draft_claim)
+      end
+    end
+
+    context "when user has a submitted claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, submitted_claim)
+      end
+    end
+  end
+
+  permissions :submit? do
+    context "when user has an internal claim" do
+      it "grants access" do
+        expect(claim_policy).to permit(user, internal_claim)
+      end
+    end
+
+    context "when user has a draft claim" do
+      it "grants access" do
+        expect(claim_policy).to permit(user, draft_claim)
+      end
+    end
+
+    context "when user has a subbitted claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, submitted_claim)
+      end
+    end
+
+    context "when user is a support user" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(support_user, submitted_claim)
+      end
+    end
+  end
+
+  permissions :confirm? do
+    context "when user has a submitted claim" do
+      it "grants access" do
+        expect(claim_policy).to permit(user, submitted_claim)
+      end
+    end
+
+    context "when user has an internal claim" do
+      it "grants access" do
+        expect(claim_policy).not_to permit(user, internal_claim)
+      end
+    end
+
+    context "when user has a draft claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, draft_claim)
+      end
+    end
+
+    context "when user is a support user" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(support_user, submitted_claim)
+      end
+    end
+  end
+
+  permissions :draft? do
+    context "when user has an internal claim" do
+      it "grants access" do
+        expect(claim_policy).to permit(support_user, internal_claim)
+      end
+    end
+
+    context "when user has a draft claim" do
+      it "grants access" do
+        expect(claim_policy).not_to permit(support_user, draft_claim)
+      end
+    end
+
+    context "when user has a submitted claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(support_user, submitted_claim)
+      end
+    end
+
+    context "when user is not a support user" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, submitted_claim)
+      end
+    end
+  end
+
+  permissions :check? do
+    context "when user has a draft claim" do
+      it "grants access" do
+        expect(claim_policy).to permit(user, draft_claim)
+      end
+    end
+
+    context "when user has an internal claim" do
+      it "grants access" do
+        expect(claim_policy).to permit(user, internal_claim)
+      end
+    end
+
+    context "when user has a submitted claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, submitted_claim)
+      end
+    end
+  end
+
+  permissions :download_csv? do
+    context "when user is a support user" do
+      it "grants access" do
+        expect(claim_policy).to permit(support_user)
+      end
+    end
+
+    context "when user is not support user" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user)
+      end
+    end
+  end
+end

--- a/spec/system/claims/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/schools/claims/create_claim_spec.rb
@@ -63,6 +63,20 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     then_i_see_the_error("Enter the number of hours between 1 and 20")
   end
 
+  scenario "Anne creates a claim and tries to edit it" do
+    when_i_click("Add claim")
+    when_i_choose_a_provider
+    when_i_click("Continue")
+    when_i_select_a_mentor(mentor1)
+    when_i_click("Continue")
+    when_i_add_training_hours("20 hours")
+    when_i_click("Continue")
+    when_i_click("Submit claim")
+    then_i_get_a_claim_reference(Claim.submitted.last)
+    given_i_visit_claim_check_page_after_submitting(Claim.submitted.last)
+    then_i_am_redirected_to_root_path_with_alert
+  end
+
   private
 
   def given_i_sign_in
@@ -81,6 +95,10 @@ RSpec.describe "Create claim", type: :system, service: :claims do
   def when_i_select_all_mentors
     page.check(mentor1.full_name)
     page.check(mentor2.full_name)
+  end
+
+  def when_i_select_a_mentor(mentor)
+    page.check(mentor.full_name)
   end
 
   def then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor)
@@ -152,5 +170,19 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     within(".govuk-form-group--error") do
       expect(page).to have_content message
     end
+  end
+
+  def given_i_visit_claim_check_page_after_submitting(claim)
+    Capybara.current_session.driver.header(
+      "Referer",
+      check_claims_school_claim_url(school, claim),
+    )
+
+    visit check_claims_school_claim_path(school, claim)
+  end
+
+  def then_i_am_redirected_to_root_path_with_alert
+    expect(page.current_url).to eq(claims_school_claims_url(school))
+    expect(page).to have_content "You cannot perform this action"
   end
 end

--- a/spec/system/claims/start_page_spec.rb
+++ b/spec/system/claims/start_page_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Sign in Page", type: :system, service: :claims do
        "September 2023 to July 2024.",
     )
     expect(page).to have_content(
-      "Training that took place for April 2024 for the school year starting "\
+      "Training that took place from April 2024 for the school year starting "\
       "September 2024 can only be claimed for from May 2025.",
     )
     expect(page).to have_content(

--- a/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
 
   let(:mentor1) { create(:mentor, first_name: "Anne") }
   let(:mentor2) { create(:mentor, first_name: "Joe") }
-  let!(:claim) { create(:claim, :draft, school:, provider: provider1) }
+  let!(:claim) { create(:claim, :internal, school:, provider: provider1) }
 
   before do
     user_exists_in_dfe_sign_in(user: colin)


### PR DESCRIPTION
## Context

Claim policies

The claim form didn't have any policies, meaning a claim could have been
updated or submitted twice by a user if they would know the url.

This PR fixes these edge cases.

It also will redirect the user to root path if he doesn't have access to a resource. This is because redirecting back to request.referrer can cause a redirection loop if the `request.referrer` is not a path the user has access to as well.

## Changes proposed in this pull request

Claim policies
`Claims::Support::Schools::ClaimsController` submit action
Redirect to root_path if no access, only for claims domain

## Guidance to review

Try to submit the claim twice by clicking on the back button on the confirm page
Try to edit a submitted claim. 


## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/065235b6-5b99-4f70-949b-d20542ceaeaa


