### PR TITLE
[DO NOT MERGE] Add a route that will trigger a stack trace

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
   config.log_level = :info
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id]
+  config.log_tags = [:request_id, "from production.rb"]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -7,7 +7,7 @@ if Rails.env.development? || Rails.env.production?
     # }
     config.log_tags = [
       :request_id,
-      "Ollie is testing",
+      "from semantic_logger.rb",
     ]
   end
 

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -1,6 +1,14 @@
 if Rails.env.development? || Rails.env.production?
   Rails.application.configure do
-    config.log_tags = [:request_id] # Prepend all log lines with the following tags
+    # Prepend all log lines with the following tags
+    # config.log_tags = {
+    #   request_id: :request_id,
+    #   some_other_tag: "some other value",
+    # }
+    config.log_tags = [
+      :request_id,
+      "Ollie is testing",
+    ]
   end
 
   SemanticLogger.add_appender(io: $stdout, level: Rails.application.config.log_level, formatter: Rails.application.config.log_format)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,4 +42,7 @@ Rails.application.routes.draw do
   # GoodJob admin interface – only accessible to support users
   mount GoodJob::Engine => "/good_job", constraints: SupportUserConstraint
   get "/good_job", to: redirect("/support")
+
+  # Deliberately cause a stack trace so Colin can test how it gets logged
+  get "/explode" => ->(_env) { BOOM! }
 end


### PR DESCRIPTION
So that @saliceti can test how multi-line log entries are handled by Logit.

To trigger the error, run the app and visit the path `/explode`.

When the server us running locally with `bundle exec rails server`, it produces a stack trace in the STDOUT logs like this:

<img width="1291" alt="Console output showing a Rails stack trace" src="https://github.com/DFE-Digital/itt-mentor-services/assets/7735945/89c44441-ad29-4124-9040-a075c2509b70">
