### PR TITLE
Allow support users to remove claims

### DIFF
--- a/app/controllers/claims/schools/claims_controller.rb
+++ b/app/controllers/claims/schools/claims_controller.rb
@@ -6,7 +6,7 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
   helper_method :claim_provider_form
 
   def index
-    @pagy, @claims = pagy(@school.claims.not_internal.order_created_at_desc)
+    @pagy, @claims = pagy(@school.claims.not_internal_archived_or_discarded.order_created_at_desc)
   end
 
   def new; end

--- a/app/controllers/claims/support/claims_controller.rb
+++ b/app/controllers/claims/support/claims_controller.rb
@@ -3,7 +3,7 @@ class Claims::Support::ClaimsController < Claims::Support::ApplicationController
   before_action :authorize_claim
 
   def index
-    @pagy, @claims = pagy(Claim.not_internal.order_created_at_desc)
+    @pagy, @claims = pagy(Claim.not_internal_archived_or_discarded.order_created_at_desc)
   end
 
   def show; end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -36,11 +36,11 @@ class Claim < ApplicationRecord
   validates :status, presence: true
   validates :reference, uniqueness: { case_sensitive: false }, allow_nil: true
 
-  scope :not_internal, -> { where.not(status: :internal) }
+  scope :not_internal_archived_or_discarded, -> { where.not(status: %i[internal archived discarded]) }
   scope :order_created_at_desc, -> { order(created_at: :desc) }
 
   enum :status,
-       { internal: "internal", draft: "draft", submitted: "submitted" },
+       { internal: "internal", draft: "draft", submitted: "submitted", archived: "archived", discarded: "discarded" },
        validate: true
 
   delegate :name, to: :provider, prefix: true, allow_nil: true

--- a/app/policies/claim_policy.rb
+++ b/app/policies/claim_policy.rb
@@ -11,6 +11,10 @@ class ClaimPolicy < Claims::ApplicationPolicy
     true
   end
 
+  def destroy?
+    true
+  end
+
   def download_csv?
     true
   end

--- a/app/views/claims/support/schools/claims/remove.html.erb
+++ b/app/views/claims/support/schools/claims/remove.html.erb
@@ -1,0 +1,21 @@
+<% content_for(:page_title) { t(".page_title") } %>
+<% render "claims/support/primary_navigation", current: :organisations %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: claims_support_school_claim_path(@school, @claim)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".caption", reference: @claim.reference, school_name: @school.name) %></span>
+      <h2 class="govuk-heading-l"><%= t(".warning") %></h2>
+
+      <%= govuk_button_to t(".remove_claim"), claims_support_school_claim_path(@school, @claim), warning: true, method: :delete %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to(t(".cancel"), claims_support_school_claim_path(@school, @claim), no_visited_state: true) %>
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/claims/support/schools/claims/show.html.erb
+++ b/app/views/claims/support/schools/claims/show.html.erb
@@ -71,4 +71,6 @@
         <% end %>
     </div>
   </div>
+
+  <%= govuk_link_to t(".remove_claim"), remove_claims_support_school_claim_path(@school, @claim), class: "app-link app-link--destructive" %>
 </div>

--- a/config/locales/en/claims/support/schools/claims.yml
+++ b/config/locales/en/claims/support/schools/claims.yml
@@ -28,8 +28,17 @@ en:
             grant_funding: Grant funding
             hours: hours
             page_caption: Claims - %{school_name}
+            remove_claim: Remove claim
           new:
             page_title: Accredited provider - Add claim
+          remove:
+            page_title: Accredited provider - Remove claim
+            caption: Claim - %{reference} - %{school_name}
+            warning: Are you sure you want to remove this claim?
+            cancel: Cancel
+            remove_claim: Remove claim
+          destroy:
+            success: Claim has been removed
           form:
             add_claim: Add claim - %{school}
             heading: Accredited provider

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -53,11 +53,12 @@ scope module: :claims, as: :claims, constraints: { host: ENV["CLAIMS_HOST"] } do
       end
 
       scope module: :schools do
-        resources :claims, except: %i[destroy] do
+        resources :claims do
           resources :mentors, only: %i[new create edit update], module: :claims
           resources :mentor_trainings, only: %i[edit update], module: :claims
 
           member do
+            get :remove
             get :check
             post :submit
           end

--- a/db/migrate/20240321065230_add_archived_status_to_claims.rb
+++ b/db/migrate/20240321065230_add_archived_status_to_claims.rb
@@ -1,0 +1,5 @@
+class AddArchivedStatusToClaims < ActiveRecord::Migration[7.1]
+  def change
+    add_enum_value :claim_status, "archived"
+  end
+end

--- a/db/migrate/20240321095050_add_discarded_status_to_claims.rb
+++ b/db/migrate/20240321095050_add_discarded_status_to_claims.rb
@@ -1,0 +1,5 @@
+class AddDiscardedStatusToClaims < ActiveRecord::Migration[7.1]
+  def change
+    add_enum_value :claim_status, "discarded"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_15_130549) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_21_095050) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
-  create_enum "claim_status", ["internal", "draft", "submitted"]
+  create_enum "claim_status", ["internal", "draft", "submitted", "archived", "discarded"]
   create_enum "mentor_training_type", ["refresher", "initial"]
   create_enum "placement_status", ["draft", "published"]
   create_enum "provider_type", ["scitt", "lead_school", "university"]
@@ -271,10 +271,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_15_130549) do
     t.string "district_admin_code"
     t.uuid "region_id"
     t.uuid "trust_id"
-    t.float "longitude"
-    t.float "latitude"
     t.string "local_authority_name"
     t.string "local_authority_code"
+    t.float "longitude"
+    t.float "latitude"
     t.index ["claims_service"], name: "index_schools_on_claims_service"
     t.index ["latitude"], name: "index_schools_on_latitude"
     t.index ["longitude"], name: "index_schools_on_longitude"

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: subjects
+#
+#  id           :uuid             not null, primary key
+#  code         :string
+#  name         :string           not null
+#  subject_area :enum
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 FactoryBot.define do
   factory :subject do
     subject_area { %i[primary secondary].sample }

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -53,19 +53,19 @@ RSpec.describe Claim, type: :model do
 
     it "defines the expected values" do
       expect(claim).to define_enum_for(:status)
-        .with_values(internal: "internal", draft: "draft", submitted: "submitted")
+        .with_values(internal: "internal", draft: "draft", submitted: "submitted", archived: "archived", discarded: "discarded")
         .backed_by_column_of_type(:enum)
     end
   end
 
   describe "scopes" do
-    describe "#not_internal" do
+    describe "#not_internal_archived_or_discarded" do
       it "returns the claims that dont have status internal" do
         create(:claim)
         claim1 = create(:claim, :draft)
         claim2 = create(:claim, :submitted)
 
-        expect(described_class.not_internal).to eq(
+        expect(described_class.not_internal_archived_or_discarded).to eq(
           [claim1, claim2],
         )
       end

--- a/spec/system/claims/support/schools/claims/removing_a_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/removing_a_claim_spec.rb
@@ -1,0 +1,108 @@
+require "rails_helper"
+
+RSpec.describe "Create claim", type: :system, service: :claims do
+  let!(:school) { create(:claims_school, mentors: [mentor1, mentor2], name: "A School") }
+  let!(:colin) do
+    create(
+      :claims_support_user,
+      :colin,
+      user_memberships: [create(:user_membership, organisation: school)],
+    )
+  end
+  let!(:provider) { create(:provider, :best_practice_network) }
+
+  let(:claims_mentor) { create(:claims_mentor, first_name: "Barry", last_name: "Garlow") }
+
+  let!(:submitted_claim) do
+    create(
+      :claim,
+      :submitted,
+      school:,
+      reference: "12345678",
+      submitted_at: Time.new(2024, 3, 5, 12, 31, 52, "+00:00"),
+      provider:,
+    )
+  end
+
+  let!(:draft_claim) do
+    create(
+      :claim,
+      :draft,
+      school:,
+      reference: "111111111",
+      provider:,
+    )
+  end
+
+  let(:mentor1) { create(:mentor, first_name: "Anne") }
+  let(:mentor2) { create(:mentor, first_name: "Joe") }
+
+  let(:mentor_training) { create(:mentor_training, claim: submitted_claim, mentor: claims_mentor, hours_completed: 6) }
+  let(:mentor_training2) { create(:mentor_training, claim: draft_claim, mentor: claims_mentor, hours_completed: 6) }
+
+  before do
+    user_exists_in_dfe_sign_in(user: colin)
+    given_i_sign_in
+  end
+
+  scenario "When removing a submitted claim" do
+    when_i_select_a_school
+    when_i_click_on_claims
+    when_i_visit_the_submitted_claim_show_page
+    when_i_click_remove_claim
+    when_i_confirm_removal
+    then_the_claim_is_now_discarded
+  end
+
+  scenario "When removing a draft claim" do
+    when_i_select_a_school
+    when_i_click_on_claims
+    when_i_visit_the_draft_claim_show_page
+    when_i_click_remove_claim
+    when_i_confirm_removal
+    then_the_claim_has_been_deleted
+  end
+
+  private
+
+  def given_i_sign_in
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def when_i_select_a_school
+    click_on "A School"
+  end
+
+  def when_i_click_on_claims
+    within(".app-secondary-navigation__list") do
+      click_on("Claims")
+    end
+  end
+
+  def when_i_visit_the_submitted_claim_show_page
+    click_on submitted_claim.reference
+  end
+
+  def when_i_visit_the_draft_claim_show_page
+    click_on draft_claim.reference
+  end
+
+  def when_i_click_remove_claim
+    click_on "Remove claim"
+  end
+
+  def when_i_confirm_removal
+    expect(page).to have_content("Are you sure you want to remove this claim?")
+    click_on "Remove claim"
+  end
+
+  def then_the_claim_is_now_discarded
+    expect(page).not_to have_content("12345678")
+    expect(Claim.find(submitted_claim.id).status).to eq("discarded")
+  end
+
+  def then_the_claim_has_been_deleted
+    expect(page).not_to have_content("111111111")
+  end
+end


### PR DESCRIPTION
## Context

We need to allow the support user to remove claims. Currently the only states the claim can be in are draft and submitted, at least user facing.

## Changes proposed in this pull request

Implement archived and discarded status enums

## Guidance to review

- Creare a draft and submitted claim
- View the claim
- Follow the deleted flow

## Link to Trello card

https://trello.com/c/JUhoXxIJ/259-allow-support-users-to-remove-claims

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
