### PR TITLE
Change claims contact email

### DIFF
--- a/app/views/claims/pages/start.html.erb
+++ b/app/views/claims/pages/start.html.erb
@@ -25,7 +25,7 @@
       <p class="govuk-body">
         <%= t(
           ".setup_organisation_guidance_html",
-          link_to: govuk_mail_to("becomingateacher@digital.education.gov.uk"),
+          link_to: govuk_mail_to(t("claims.support_email")),
         ) %>
       </p>
     </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -12,7 +12,7 @@
       <% end %>
 
       <p class="govuk-body">
-        <%= sanitize t(".disclaimer", service_name:, support_email: mail_to("becomingateacher@digital.education.gov.uk")) %>
+        <%= sanitize t(".disclaimer", service_name:, support_email: mail_to(t("#{current_service}.support_email"))) %>
       </p>
     </div>
   </div>

--- a/config/locales/en/claims.yml
+++ b/config/locales/en/claims.yml
@@ -1,4 +1,4 @@
 en:
   claims:
     service_name: Claim funding for mentor training
-    support_email: becomingateacher@digital.education.gov.uk
+    support_email: ittmentor.funding@education.gov.uk

--- a/spec/system/claims/start_page_spec.rb
+++ b/spec/system/claims/start_page_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Start Page", type: :system, service: :claims do
       "Get an account to claim funding for mentor training\n"\
       "Ask a colleague within your organisation to add you if you do not have an account.\n"\
       "If your organisation has not been set up to claim funding for mentor training, "\
-      "send an email to becomingateacher@digital.education.gov.uk.",
+      "send an email to ittmentor.funding@education.gov.uk.",
     )
     expect(page).to have_content("Related content")
     expect(page).to have_link(

--- a/spec/system/error_pages_spec.rb
+++ b/spec/system/error_pages_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Error pages", type: :system do
     expect(page).to have_content "Page not found"
     expect(page).to have_content "If you entered a web address, check it is correct."
     expect(page).to have_content "If you pasted the web address, check you copied the entire address."
-    expect(page).to have_content "If the web address is correct or you selected a link or button and you need to speak to someone about this problem, contact the #{service_name} team: becomingateacher@digital.education.gov.uk"
+    expect(page).to have_content "If the web address is correct or you selected a link or button and you need to speak to someone about this problem, contact the #{service_name} team: #{support_email}"
     expect(page.driver.status_code).to eq 404
   end
 
@@ -64,7 +64,7 @@ RSpec.describe "Error pages", type: :system do
     expect(page).to have_title "Sorry, there’s a problem with the service"
     expect(page).to have_content "Sorry, there’s a problem with the service"
     expect(page).to have_content "Try again later."
-    expect(page).to have_content "If you continue to see this error contact the #{service_name} team: becomingateacher@digital.education.gov.uk"
+    expect(page).to have_content "If you continue to see this error contact the #{service_name} team: #{support_email}"
     expect(page.driver.status_code).to eq 422
   end
 
@@ -80,7 +80,15 @@ RSpec.describe "Error pages", type: :system do
     expect(page).to have_title "Sorry, there’s a problem with the service"
     expect(page).to have_content "Sorry, there’s a problem with the service"
     expect(page).to have_content "Try again later."
-    expect(page).to have_content "If you have any questions, please email us at becomingateacher@digital.education.gov.uk"
+    expect(page).to have_content "If you have any questions, please email us at "
     expect(page.driver.status_code).to eq 429
+  end
+
+  def support_email
+    if self.class.metadata[:service] == :claims
+      "ittmentor.funding@education.gov.uk"
+    else
+      "becomingateacher@digital.education.gov.uk"
+    end
   end
 end


### PR DESCRIPTION
## Context

Change claims contact email from `becomingateacher@digital.education.gov.uk` to `ittmentor.funding@education.gov.uk`

## Changes

translations

## Screenshots

![Screenshot from 2024-03-21 15-11-39](https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/9d04b8f6-e6ef-47ab-99af-d23a5e5cb368)
![Screenshot from 2024-03-21 15-11-33](https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/63e704bc-3c38-4233-b9cb-f0f2325adf01)

