### PR TITLE
Allow support users to remove claims

### DIFF
--- a/app/controllers/claims/schools/claims_controller.rb
+++ b/app/controllers/claims/schools/claims_controller.rb
@@ -6,7 +6,7 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
   helper_method :claim_provider_form
 
   def index
-    @pagy, @claims = pagy(@school.claims.not_internal.order_created_at_desc)
+    @pagy, @claims = pagy(@school.claims.visible.order_created_at_desc)
   end
 
   def new; end

--- a/app/controllers/claims/support/claims_controller.rb
+++ b/app/controllers/claims/support/claims_controller.rb
@@ -3,7 +3,7 @@ class Claims::Support::ClaimsController < Claims::Support::ApplicationController
   before_action :authorize_claim
 
   def index
-    @pagy, @claims = pagy(Claims::Claim.not_internal.order_created_at_desc)
+    @pagy, @claims = pagy(Claims::Claim.visible.order_created_at_desc)
   end
 
   def show; end

--- a/app/controllers/claims/support/schools/claims_controller.rb
+++ b/app/controllers/claims/support/schools/claims_controller.rb
@@ -1,17 +1,25 @@
 class Claims::Support::Schools::ClaimsController < Claims::Support::ApplicationController
   include Claims::BelongsToSchool
 
-  before_action :set_claim, only: %i[check draft show edit update]
+  before_action :set_claim, only: %i[check draft show edit update remove destroy]
   before_action :authorize_claim
   helper_method :claim_provider_form
 
   def index
-    @pagy, @claims = pagy(@school.claims.not_internal.order_created_at_desc)
+    @pagy, @claims = pagy(@school.claims.visible.order_created_at_desc)
   end
 
   def new; end
 
   def show; end
+
+  def remove; end
+
+  def destroy
+    @claim.destroy!
+
+    redirect_to claims_support_school_claims_path(@school, @claim), flash: { success: t(".success") }
+  end
 
   def create
     if claim_provider_form.save

--- a/app/models/claims/claim.rb
+++ b/app/models/claims/claim.rb
@@ -34,13 +34,15 @@ class Claims::Claim < ApplicationRecord
   belongs_to :created_by, polymorphic: true
   belongs_to :submitted_by, polymorphic: true, optional: true
 
-  has_many :mentor_trainings
+  has_many :mentor_trainings, dependent: :destroy
   has_many :mentors, through: :mentor_trainings
 
   validates :status, presence: true
   validates :reference, uniqueness: { case_sensitive: false }, allow_nil: true
 
-  scope :not_internal, -> { where.not(status: :internal) }
+  VISIBLE_STATUSES = %i[draft submitted].freeze
+
+  scope :visible, -> { where(status: VISIBLE_STATUSES) }
   scope :order_created_at_desc, -> { order(created_at: :desc) }
 
   enum :status,

--- a/app/policies/claims/claim_policy.rb
+++ b/app/policies/claims/claim_policy.rb
@@ -11,6 +11,10 @@ class Claims::ClaimPolicy < Claims::ApplicationPolicy
     !user.support_user? && !record.submitted?
   end
 
+  def destroy?
+    user.support_user? && record.draft?
+  end
+
   def confirm?
     !user.support_user? && record.submitted?
   end

--- a/app/views/claims/support/schools/claims/remove.html.erb
+++ b/app/views/claims/support/schools/claims/remove.html.erb
@@ -1,0 +1,21 @@
+<% content_for(:page_title) { t(".page_title") } %>
+<% render "claims/support/primary_navigation", current: :organisations %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: claims_support_school_claim_path(@school, @claim)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".caption", reference: @claim.reference, school_name: @school.name) %></span>
+      <h2 class="govuk-heading-l"><%= t(".warning") %></h2>
+
+      <%= govuk_button_to t(".remove_claim"), claims_support_school_claim_path(@school, @claim), warning: true, method: :delete %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to(t(".cancel"), claims_support_school_claim_path(@school, @claim), no_visited_state: true) %>
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/claims/support/schools/claims/show.html.erb
+++ b/app/views/claims/support/schools/claims/show.html.erb
@@ -76,4 +76,8 @@
         <% end %>
     </div>
   </div>
+
+  <% if policy(@claim).remove? %>
+    <%= govuk_link_to t(".remove_claim"), remove_claims_support_school_claim_path(@school, @claim), class: "app-link app-link--destructive" %>
+  <% end %>
 </div>

--- a/config/locales/en/claims/support/schools/claims.yml
+++ b/config/locales/en/claims/support/schools/claims.yml
@@ -28,9 +28,17 @@ en:
             grant_funding: Grant funding
             hours: hours
             page_caption: Claims - %{school_name}
+            remove_claim: Remove claim
           new:
             page_title: Accredited provider - Add claim
+          remove:
+            page_title: Are you sure you want to remove this claim?
+            caption: Claim - %{reference} - %{school_name}
+            warning: Are you sure you want to remove this claim?
+            cancel: Cancel
+            remove_claim: Remove claim
+          destroy:
+            success: Claim has been removed
           form:
             add_claim: Add claim - %{school}
             heading: Accredited provider
-

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -55,11 +55,12 @@ scope module: :claims, as: :claims, constraints: { host: ENV["CLAIMS_HOST"] } do
       end
 
       scope module: :schools do
-        resources :claims, except: %i[destroy] do
+        resources :claims do
           resources :mentors, only: %i[new create edit update], module: :claims
           resources :mentor_trainings, only: %i[edit update], module: :claims
 
           member do
+            get :remove
             get :check
             post :draft
           end

--- a/spec/models/claims/claim_spec.rb
+++ b/spec/models/claims/claim_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Claims::Claim, type: :model do
     it { is_expected.to belong_to(:provider) }
     it { is_expected.to belong_to(:created_by) }
     it { is_expected.to belong_to(:submitted_by).optional }
-    it { is_expected.to have_many(:mentor_trainings) }
+    it { is_expected.to have_many(:mentor_trainings).dependent(:destroy) }
     it { is_expected.to have_many(:mentors).through(:mentor_trainings) }
   end
 
@@ -64,13 +64,14 @@ RSpec.describe Claims::Claim, type: :model do
   end
 
   describe "scopes" do
-    describe "#not_internal" do
+    describe "#visible" do
       it "returns the claims that dont have status internal" do
         create(:claim)
         claim1 = create(:claim, :draft)
         claim2 = create(:claim, :submitted)
+        create(:claim, :internal)
 
-        expect(described_class.not_internal).to eq(
+        expect(described_class.visible).to eq(
           [claim1, claim2],
         )
       end

--- a/spec/system/claims/support/schools/claims/removing_a_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/removing_a_claim_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.describe "Create claim", type: :system, service: :claims do
+  let!(:school) { create(:claims_school, mentors: [mentor1, mentor2], name: "A School") }
+  let!(:colin) do
+    create(
+      :claims_support_user,
+      :colin,
+      user_memberships: [create(:user_membership, organisation: school)],
+    )
+  end
+  let!(:provider) { create(:provider, :best_practice_network) }
+
+  let(:claims_mentor) { create(:claims_mentor, first_name: "Barry", last_name: "Garlow") }
+
+  let!(:submitted_claim) do
+    create(
+      :claim,
+      :submitted,
+      school:,
+      reference: "12345678",
+      submitted_at: Time.new(2024, 3, 5, 12, 31, 52, "+00:00"),
+      provider:,
+    )
+  end
+
+  let!(:draft_claim) do
+    create(
+      :claim,
+      :draft,
+      school:,
+      reference: "111111111",
+      provider:,
+    )
+  end
+
+  let(:mentor1) { create(:mentor, first_name: "Anne") }
+  let(:mentor2) { create(:mentor, first_name: "Joe") }
+
+  let(:mentor_training) { create(:mentor_training, claim: submitted_claim, mentor: claims_mentor, hours_completed: 6) }
+  let(:mentor_training2) { create(:mentor_training, claim: draft_claim, mentor: claims_mentor, hours_completed: 6) }
+
+  before do
+    user_exists_in_dfe_sign_in(user: colin)
+    given_i_sign_in
+  end
+
+  scenario "When removing a draft claim" do
+    when_i_select_a_school
+    when_i_click_on_claims
+    when_i_visit_the_draft_claim_show_page
+    when_i_click_remove_claim
+    when_i_confirm_removal
+    then_the_claim_has_been_deleted
+  end
+
+  private
+
+  def given_i_sign_in
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def when_i_select_a_school
+    click_on "A School"
+  end
+
+  def when_i_click_on_claims
+    within(".app-secondary-navigation__list") do
+      click_on("Claims")
+    end
+  end
+
+  def when_i_visit_the_submitted_claim_show_page
+    click_on submitted_claim.reference
+  end
+
+  def when_i_visit_the_draft_claim_show_page
+    click_on draft_claim.reference
+  end
+
+  def when_i_click_remove_claim
+    click_on "Remove claim"
+  end
+
+  def when_i_confirm_removal
+    expect(page).to have_content("Are you sure you want to remove this claim?")
+    click_on "Remove claim"
+  end
+
+  def then_the_claim_has_been_deleted
+    expect(page).not_to have_content("111111111")
+    expect(page).to have_content("Claim has been removed")
+  end
+end


### PR DESCRIPTION
## Context

We need to allow the support user to remove claims. Currently the only states the claim can be in are draft and submitted, at least user facing.

## Changes proposed in this pull request

Implement the discarded gem for a Claim

## Guidance to review

- Creare a draft and submitted claim
- View the claim
- Follow the deleted flow
- Claim will not appear 
- Claim will be discarded

## Link to Trello card

https://trello.com/c/JUhoXxIJ/259-allow-support-users-to-remove-claims

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
