### PR TITLE
Add auditing to claim and mentor training

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,9 @@ gem "discard"
 # Geocoding
 gem "geocoder"
 
+# Audit trail
+gem "audited"
+
 group :development do
   gem "annotate", require: false
   gem "prettier_print", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,9 @@ GEM
       rake (>= 10.4, < 14.0)
     ast (2.4.2)
     attr_required (1.0.1)
+    audited (5.4.3)
+      activerecord (>= 5.0, < 7.2)
+      request_store (~> 1.2)
     backport (1.2.0)
     base64 (0.2.0)
     benchmark (0.3.0)
@@ -617,6 +620,7 @@ DEPENDENCIES
   activerecord-nulldb-adapter
   amazing_print
   annotate
+  audited
   better_html
   bootsnap
   brakeman

--- a/app/models/claims/claim.rb
+++ b/app/models/claims/claim.rb
@@ -29,6 +29,9 @@
 #  fk_rails_...  (school_id => schools.id)
 #
 class Claims::Claim < ApplicationRecord
+  audited
+  has_associated_audits
+
   belongs_to :school
   belongs_to :provider
   belongs_to :created_by, polymorphic: true

--- a/app/models/claims/mentor_training.rb
+++ b/app/models/claims/mentor_training.rb
@@ -29,6 +29,8 @@ class Claims::MentorTraining < ApplicationRecord
   belongs_to :mentor, optional: true
   belongs_to :provider, optional: true
 
+  audited associated_with: :claim
+
   validates(
     :hours_completed,
     numericality: { greater_than: 0, less_than_or_equal_to: 20, only_integer: true },

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,5 +41,7 @@ module IttMentorServices
 
     config.autoload_paths += %W[#{config.root}/app/assets/components]
     config.exceptions_app = routes
+
+    config.active_record.yaml_column_permitted_classes = [Symbol, Date, Time, ActiveSupport::TimeWithZone, ActiveSupport::TimeZone]
   end
 end

--- a/db/migrate/20240325095831_install_audited.rb
+++ b/db/migrate/20240325095831_install_audited.rb
@@ -1,0 +1,30 @@
+class InstallAudited < ActiveRecord::Migration[7.1]
+  def self.up
+    create_table :audits, force: true do |t|
+      t.column :auditable_id, :uuid
+      t.column :auditable_type, :string
+      t.column :associated_id, :uuid
+      t.column :associated_type, :string
+      t.column :user_id, :uuid
+      t.column :user_type, :string
+      t.column :username, :string
+      t.column :action, :string
+      t.column :audited_changes, :text
+      t.column :version, :integer, default: 0
+      t.column :comment, :string
+      t.column :remote_address, :string
+      t.column :request_uuid, :string
+      t.datetime :created_at
+    end
+
+    add_index :audits, %i[auditable_type auditable_id version], name: "auditable_index"
+    add_index :audits, %i[associated_type associated_id], name: "associated_index"
+    add_index :audits, %i[user_id user_type], name: "user_index"
+    add_index :audits, :request_uuid
+    add_index :audits, :created_at
+  end
+
+  def self.down
+    drop_table :audits
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_22_145705) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_25_095831) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -23,6 +23,28 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_22_145705) do
   create_enum "provider_type", ["scitt", "lead_school", "university"]
   create_enum "service", ["claims", "placements"]
   create_enum "subject_area", ["primary", "secondary"]
+
+  create_table "audits", force: :cascade do |t|
+    t.uuid "auditable_id"
+    t.string "auditable_type"
+    t.uuid "associated_id"
+    t.string "associated_type"
+    t.uuid "user_id"
+    t.string "user_type"
+    t.string "username"
+    t.string "action"
+    t.text "audited_changes"
+    t.integer "version", default: 0
+    t.string "comment"
+    t.string "remote_address"
+    t.string "request_uuid"
+    t.datetime "created_at"
+    t.index ["associated_type", "associated_id"], name: "associated_index"
+    t.index ["auditable_type", "auditable_id", "version"], name: "auditable_index"
+    t.index ["created_at"], name: "index_audits_on_created_at"
+    t.index ["request_uuid"], name: "index_audits_on_request_uuid"
+    t.index ["user_id", "user_type"], name: "user_index"
+  end
 
   create_table "claims", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "school_id", null: false

--- a/spec/models/claims/claim_spec.rb
+++ b/spec/models/claims/claim_spec.rb
@@ -53,6 +53,11 @@ RSpec.describe Claims::Claim, type: :model do
     it { is_expected.to delegate_method(:full_name).to(:submitted_by).with_prefix.allow_nil }
   end
 
+  describe "auditing" do
+    it { is_expected.to be_audited }
+    it { is_expected.to have_associated_audits }
+  end
+
   describe "enums" do
     subject(:claim) { build(:claim) }
 

--- a/spec/models/claims/mentor_training_spec.rb
+++ b/spec/models/claims/mentor_training_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe Claims::MentorTraining, type: :model do
     it { is_expected.to belong_to(:provider).optional }
   end
 
+  describe "auditing" do
+    it { is_expected.to be_audited.associated_with(:claim) }
+  end
+
   context "with validations" do
     it {
       expect(mentor_training).to validate_numericality_of(:hours_completed)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@
 
 require "rspec/retry"
 require "pundit/rspec"
+require "audited-rspec"
 require "simplecov"
 require "simplecov-html"
 require "simplecov-lcov"


### PR DESCRIPTION
## Context

We also need to permit ActiveSupport time classes in application.rb to allow audits with datetime values. 

Using these audits will come in a separate PR

## Changes proposed in this pull request

Added gem
Migration
Audited claim and mentor training

## Guidance to review

Pull on local
Create some claims
View the audits in console with `claim.own_and_associated_audits` 

## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/3ceb59e5-dbd8-4a96-813a-e03a7ea652fb


