### PR TITLE
Build Mentors and pass them through to School in spec

### DIFF
--- a/spec/system/claims/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/schools/claims/create_claim_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Create claim", type: :system, service: :claims do
+  let(:mentor1) { build(:claims_mentor, first_name: "Anne") }
+  let(:mentor2) { build(:claims_mentor, first_name: "Joe") }
   let!(:school) { create(:claims_school, mentors: [mentor1, mentor2], region: regions(:inner_london)) }
   let!(:anne) do
     create(
@@ -10,8 +12,6 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     )
   end
   let!(:provider) { create(:claims_provider, :best_practice_network) }
-  let(:mentor1) { create(:claims_mentor, first_name: "Anne") }
-  let(:mentor2) { create(:claims_mentor, first_name: "Joe") }
 
   before do
     user_exists_in_dfe_sign_in(user: anne)

--- a/spec/system/claims/support/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/create_claim_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Create claim", type: :system, service: :claims do
+  let(:mentor1) { build(:claims_mentor, first_name: "Anne") }
+  let(:mentor2) { build(:claims_mentor, first_name: "Joe") }
   let!(:school) { create(:claims_school, mentors: [mentor1, mentor2]) }
   let!(:colin) do
     create(
@@ -10,8 +12,6 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     )
   end
   let!(:provider) { create(:claims_provider, :best_practice_network) }
-  let(:mentor1) { create(:claims_mentor, first_name: "Anne") }
-  let(:mentor2) { create(:claims_mentor, first_name: "Joe") }
 
   before do
     user_exists_in_dfe_sign_in(user: colin)


### PR DESCRIPTION
## Context

These specs were creating more schools than necessary in the database.

## Changes proposed in this pull request

- Change `create(:claims_mentor)` call to `build(:claims_mentor)` call. This avoids preemptively creating the mentors with a school associated.
- Also, move up the mentor initialisation to put emphasis that they are being passed through to the `create(:claims_school)` call.

## Guidance to review

- Specs should pass.
- Only 1 school should be created in the changed files specs.
