### PR TITLE
Add feedback page for Claims

### DIFF
--- a/app/controllers/claims/feedback_controller.rb
+++ b/app/controllers/claims/feedback_controller.rb
@@ -1,0 +1,26 @@
+class Claims::FeedbackController < Claims::ApplicationController
+  skip_before_action :authenticate_user!
+  before_action :skip_authorization
+  before_action :set_feedback_form, only: %i[new create]
+
+  def new; end
+
+  def create
+    if @feedback_form.valid?
+      # Send params to zendesk... if we use it
+      render :confirmation
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def feedback_params
+    params.require(:feedback).permit(:option, :improve_comment, :email, :full_name) if params[:feedback]
+  end
+
+  def set_feedback_form
+    @feedback_form = Claims::FeedbackForm.new(feedback_params)
+  end
+end

--- a/app/forms/claims/feedback_form.rb
+++ b/app/forms/claims/feedback_form.rb
@@ -1,0 +1,16 @@
+class Claims::FeedbackForm < ApplicationForm
+  attr_accessor :option, :improve_comment, :email, :full_name
+
+  validates :option, presence: { message: "Select how you feel about this service" }
+  validates :improve_comment, presence: { message: "Enter details about how we could improve this service" }
+
+  validate :validate_improve_comment_length
+
+  private
+
+  def validate_improve_comment_length
+    if improve_comment.present? && improve_comment.split.length > 200
+      errors.add(:improve_comment, "Details must be 200 words or fewer")
+    end
+  end
+end

--- a/app/helpers/feedback_helper.rb
+++ b/app/helpers/feedback_helper.rb
@@ -1,0 +1,11 @@
+module FeedbackHelper
+  def feedback_options
+    [
+      [:very_satified, t(".options.very_satisfied")],
+      [:satified, t(".options.satisfied")],
+      [:neutral, t(".options.neutral")],
+      [:dissatisfied, t(".options.dissatisfied")],
+      [:very_dissatified, t(".options.very_dissatisfied")],
+    ]
+  end
+end

--- a/app/helpers/routes_helper.rb
+++ b/app/helpers/routes_helper.rb
@@ -38,7 +38,7 @@ module RoutesHelper
 
   def feedback_path
     {
-      claims: claims_feedback_path,
+      claims: new_claims_feedback_path,
       placements: placements_feedback_path,
     }.fetch HostingEnvironment.current_service(request)
   end

--- a/app/views/claims/feedback/confirmation.html.erb
+++ b/app/views/claims/feedback/confirmation.html.erb
@@ -1,9 +1,14 @@
 <% content_for(:page_title) { t(".page_title") } %>
-
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l"><%= t(".page_title") %></h1>
+      <p class="govuk-body"><%= t(".feedback_response_time") %></p>
+
+      <p class="govuk-body">
+        <%= govuk_link_to t(".return_home"), root_path, no_visited_state: true %>
+      </p>
+
     </div>
   </div>
 </div>

--- a/app/views/claims/feedback/new.html.erb
+++ b/app/views/claims/feedback/new.html.erb
@@ -1,0 +1,46 @@
+<% content_for(:page_title) { t(".page_title") } %>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= t(".page_title") %></h1>
+
+      <%= form_with(model: @feedback_form, as: :feedback, url: claims_feedback_index_path, method: :post, scope: :feedback) do |f| %>
+        <%= f.govuk_error_summary %>
+
+        <%= f.govuk_collection_radio_buttons :option, feedback_options,
+            :first,
+            :second,
+            legend: { text: t(".service_rating") } %>
+
+        <div class="govuk-character-count" data-module="govuk-character-count" data-maxwords="200">
+          <div class="govuk-form-group">
+            <%= f.govuk_text_area :improve_comment,
+                                    class: "govuk-input--width-40 govuk-textarea govuk-js-character-count",
+                                    id: "improve_comment",
+                                    hint: { text: t(".improve_hint"), size: "s" },
+                                    label: { text: t(".improve"), size: "s" } %>
+          </div>
+          <div id="improve_comment-info" class="govuk-hint govuk-character-count__message">
+            <%= t(".improve") %>
+          </div>
+        </div>
+
+        <h2 class="govuk-heading-m"><%= t(".reply") %></h2>
+        <h1 class="govuk-body"><%= t(".reply_info") %></h1>
+
+        <div class="govuk-form-group">
+          <%= f.govuk_text_field :full_name,
+                                  class: "govuk-input--width-40",
+                                  label: { text: t(".your_name"), size: "s" } %>
+
+          <%= f.govuk_text_field :email,
+                                  class: "govuk-input--width-40",
+                                  hint: { text: t(".your_email_hint"), size: "s" },
+                                  label: { text: t(".your_email"), size: "s" } %>
+        </div>
+
+        <%= f.govuk_submit t(".submit") %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/locales/en/claims/feedback.yml
+++ b/config/locales/en/claims/feedback.yml
@@ -1,0 +1,26 @@
+en:
+  claims:
+    feedback:
+      new:
+        options:
+          very_satisfied: Very satisfied
+          satisfied: Satisfied
+          neutral: Neither satisfied nor dissatisfied
+          dissatisfied: Dissatisfied
+          very_dissatisfied: Very dissatisfied
+        page_title: Give feedback on Claim funding for mentor training
+        submit: Send feedback
+        service_rating: Overall, how do you feel about this service?
+        improve: How could we improve this service?
+        improve_hint: Do not include any personal or sensitive information
+        text_field_count_text: You can enter up to 200 words
+        your_name: Your name
+        your_email: Your email address
+        your_email_hint: We’ll only use this to reply to your message
+        reply: If you want a reply (optional)
+        reply_info: If you’d like us to get back to you, please leave your details below.
+      confirmation:
+        page_title: Thank you for submitting feedback
+        feedback_response_time: If you gave us your name and email, we will respond within 5 working days.
+        return_home: Return to the home page
+

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -6,9 +6,7 @@ scope module: :claims, as: :claims, constraints: { host: ENV["CLAIMS_HOST"] } do
   get :privacy, to: "pages#privacy"
   get :grant_conditions, to: "pages#grant_conditions"
 
-  scope module: :pages do
-    get :feedback
-  end
+  resources :feedback, only: %i[new create]
 
   resources :schools, only: %i[index show] do
     scope module: :schools do

--- a/spec/helpers/routes_helper_spec.rb
+++ b/spec/helpers/routes_helper_spec.rb
@@ -84,7 +84,7 @@ describe RoutesHelper do
       context "when the current service is claims" do
         it "returns the correct path" do
           allow(HostingEnvironment).to receive(:current_service).and_return(:claims)
-          expect(helper.feedback_path).to eq(claims_feedback_path)
+          expect(helper.feedback_path).to eq(new_claims_feedback_path)
         end
       end
 

--- a/spec/system/claims/feedback_page_spec.rb
+++ b/spec/system/claims/feedback_page_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe "Feedback Page", type: :system, service: :claims do
+  scenario "User visits the feedback page and succesfully submits" do
+    given_i_am_on_the_feedback_page
+    when_i_fill_in_the_required_form_fields
+    then_i_successfully_submit
+  end
+
+  scenario "User visits the feedback page and unsuccesfully submits" do
+    given_i_am_on_the_feedback_page
+    then_i_see_the_form_errors
+  end
+
+  scenario "User visits the feedback page and types more than 200 words" do
+    given_i_am_on_the_feedback_page
+    when_i_type_more_than_200_words
+    then_i_see_the_word_count_error
+  end
+
+  private
+
+  def given_i_am_on_the_feedback_page
+    visit new_claims_feedback_path
+  end
+
+  def when_i_fill_in_the_required_form_fields
+    page.choose("Very satisfied")
+    fill_in "improve_comment", with: "I LOVE IT"
+  end
+
+  def when_i_type_more_than_200_words
+    comment = Faker::Lorem.words(number: 205).join(" ")
+
+    page.choose("Very satisfied")
+    fill_in "improve_comment", with: comment
+  end
+
+  def then_i_successfully_submit
+    click_on "Send feedback"
+    expect(page).to have_content("Thank you for submitting feedback")
+    expect(page).to have_content("If you gave us your name and email, we will respond within 5 working days.")
+    expect(page).to have_content("Return to the home page")
+  end
+
+  def then_i_see_the_word_count_error
+    click_on "Send feedback"
+    expect(page).to have_content("Details must be 200 words or fewer")
+  end
+
+  def then_i_see_the_form_errors
+    click_on "Send feedback"
+    expect(page).not_to have_content("Thank you for submitting feedback")
+    expect(page).to have_content("Select how you feel about this service")
+  end
+end


### PR DESCRIPTION
## Context

This PR adds JUST the feedback claims form

## Changes proposed in this pull request

Added the feedback claims form 

## Guidance to review

- Click on the feedback link at the top of the page`This is a new service – your [feedback](http://claims.localhost:3000/feedback) will help us to improve it`.`
- Fill in the form
- Should end up back on the sign in page if not signed in

## Link to Trello card

https://trello.com/c/1gUazno7/298-add-feedback-page

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
