### PR TITLE
Don't setup fixtures when running smoke tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,7 +47,7 @@ RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [Rails.root.join("spec/fixtures")]
 
-  config.global_fixtures = :all
+  config.global_fixtures = :all unless ENV["SMOKE_TEST"] == "true"
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
## Context

The smoke tests should not need access to a database. Fixtures tap into pre-filling data in a database. Without a database, this fails, even with the nulldb adapter.

## Changes proposed in this pull request

- Avoid setting up fixtures when the ENV `SMOKE_TEST` is `"true"`.

## Guidance to review

Smoke tests should pass.
