### PR TITLE
Move page routes into a scope block

### DIFF
--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -1,10 +1,13 @@
 scope module: :claims, as: :claims, constraints: { host: ENV["CLAIMS_HOST"] } do
   root to: "pages#start"
-  get :accessibility, to: "pages#accessibility"
-  get :cookies, to: "pages#cookies"
-  get :terms, to: "pages#terms"
-  get :privacy, to: "pages#privacy"
-  get :grant_conditions, to: "pages#grant_conditions"
+
+  scope module: :pages do
+    get :accessibility
+    get :cookies
+    get :terms
+    get :privacy
+    get :grant_conditions
+  end
 
   resources :feedback, only: %i[new create]
 


### PR DESCRIPTION
## Context

We can reduce the verbosity of our route definitions here.

## Changes proposed in this pull request

- Move `pages` routes into a `scope` block.

## Guidance to review

- Specs all pass.