### PR TITLE
Add submit button to draft claim details for normal users

### DIFF
--- a/app/views/claims/schools/claims/show.html.erb
+++ b/app/views/claims/schools/claims/show.html.erb
@@ -11,6 +11,10 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l"><%= t(".page_title", reference: @claim.reference) %></h1>
 
+      <% if policy(@claim).submit? %>
+        <%= govuk_button_to t(".submit"), submit_claims_school_claim_path(@school, @claim) %>
+      <% end %>
+
       <%= govuk_summary_list do |summary_list| %>
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: Claims::Claim.human_attribute_name(:school)) %>

--- a/config/locales/en/claims/schools/claims.yml
+++ b/config/locales/en/claims/schools/claims.yml
@@ -44,5 +44,6 @@ en:
           hours_of_training: Hours of training
           grant_funding: Grant funding
           hours: hours
+          submit: Submit claim
         edit:
           page_title: Accredited provider - Add claim

--- a/spec/system/claims/schools/claims/view_claim_spec.rb
+++ b/spec/system/claims/schools/claims/view_claim_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe "View a claim", type: :system, service: :claims do
     given_i_sign_in
     when_i_visit_the_claim_show_page(submitted_claim)
     then_i_can_then_see_the_submitted_claim_details
+    then_i_cant_see_submit_button
   end
 
   scenario "Anne visits the show page of a draft claim" do
@@ -51,6 +52,8 @@ RSpec.describe "View a claim", type: :system, service: :claims do
     given_i_sign_in
     when_i_visit_the_claim_show_page(draft_claim)
     then_i_can_then_see_the_draft_claim_details
+    when_i_click_submit_button
+    then_i_get_a_claim_reference(draft_claim)
   end
 
   private
@@ -88,5 +91,19 @@ RSpec.describe "View a claim", type: :system, service: :claims do
   def given_i_sign_in
     visit sign_in_path
     click_on "Sign in using DfE Sign In"
+  end
+
+  def then_i_cant_see_submit_button
+    expect(page).not_to have_button("Submit claim")
+  end
+
+  def when_i_click_submit_button
+    click_on "Submit claim"
+  end
+
+  def then_i_get_a_claim_reference(claim)
+    within(".govuk-panel") do
+      expect(page).to have_content("Claim submitted\nYour reference number\n#{claim.reference}")
+    end
   end
 end


### PR DESCRIPTION
## Context

Normal users need to be able to submit a claim from the claims details. We can reuse the claim policy to enforce this.

## Changes proposed in this pull request

Added submit claim button

## Guidance to review

Submit a draft claim from claims details page

## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/1e6432e6-3c50-41b1-bf9c-214773e4ccc0


