### PR TITLE
Add Claims::ClaimsQuery for complex filtering

### DIFF
--- a/app/controllers/claims/support/claims_controller.rb
+++ b/app/controllers/claims/support/claims_controller.rb
@@ -3,7 +3,7 @@ class Claims::Support::ClaimsController < Claims::Support::ApplicationController
   before_action :authorize_claim
 
   def index
-    @pagy, @claims = pagy(Claims::Claim.visible.order_created_at_desc)
+    @pagy, @claims = pagy(Claims::ClaimsQuery.call(params:))
   end
 
   def show; end

--- a/app/queries/application_query.rb
+++ b/app/queries/application_query.rb
@@ -1,0 +1,11 @@
+class ApplicationQuery
+  attr_reader :params
+
+  def initialize(params: {})
+    @params = params
+  end
+
+  def self.call(...)
+    new(...).call
+  end
+end

--- a/app/queries/claims/claims_query.rb
+++ b/app/queries/claims/claims_query.rb
@@ -1,0 +1,22 @@
+class Claims::ClaimsQuery < ApplicationQuery
+  def call
+    scope = Claims::Claim.visible
+    scope = school_condition(scope)
+    scope = provider_condition(scope)
+    scope.order_created_at_desc
+  end
+
+  private
+
+  def school_condition(scope)
+    return scope if params[:school_ids].blank?
+
+    scope.where(school_id: params[:school_ids])
+  end
+
+  def provider_condition(scope)
+    return scope if params[:provider_ids].blank?
+
+    scope.where(provider_id: params[:provider_ids])
+  end
+end

--- a/spec/queries/application_query_spec.rb
+++ b/spec/queries/application_query_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe ApplicationQuery do
+  describe ".call" do
+    context "when the instance #call method is not defined" do
+      it "raises a NoMethodError" do
+        expect { described_class.call }.to raise_error(NoMethodError)
+      end
+    end
+
+    context "when the instance #call method is defined" do
+      subject(:test_query) do
+        Class.new(ApplicationQuery) do
+          def call
+            [1, 2, 3]
+          end
+        end
+      end
+
+      it "forwards the call to the instance method #call" do
+        expect(test_query.call).to eq([1, 2, 3])
+      end
+    end
+
+    context "when provided with a 'params' hash" do
+      subject(:test_query) do
+        Class.new(ApplicationQuery) do
+          def call
+            params[:number]
+          end
+        end
+      end
+
+      let(:params) { { number: 42 } }
+
+      it "passes the params to the instance initializer and can be used within #call" do
+        expect(test_query.call(params:)).to eq(42)
+      end
+    end
+  end
+end

--- a/spec/queries/claims/claims_query_spec.rb
+++ b/spec/queries/claims/claims_query_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+describe Claims::ClaimsQuery do
+  subject(:claims_query) { described_class.call(params:) }
+
+  let(:params) { {} }
+
+  describe "#call" do
+    it "returns all visible claims, ordered by created at date descending" do
+      _internal_claim = create(:claim)
+      draft_claim = create(:claim, :draft, created_at: Date.parse("29 March 2024"))
+      submitted_claim = create(:claim, :submitted, created_at: Date.parse("28 March 2024"))
+
+      expect(claims_query).to eq([draft_claim, submitted_claim])
+    end
+
+    context "when given school ids" do
+      let(:school) { create(:claims_school) }
+      let(:params) { { school_ids: [school.id] } }
+
+      it "filters the results by provided school ids" do
+        claim_belonging_to_filtered_school = create(:claim, :submitted, school:)
+        _claim_not_belonging_to_filtered_school = create(:claim, :submitted)
+
+        expect(claims_query).to match_array([claim_belonging_to_filtered_school])
+      end
+    end
+
+    context "when given provider ids" do
+      let(:provider) { create(:claims_provider) }
+      let(:params) { { provider_ids: [provider.id] } }
+
+      it "filters the results by provided provider ids" do
+        claim_belonging_to_filtered_provider = create(:claim, :submitted, provider:)
+        _claim_not_belonging_to_filtered_provider = create(:claim, :submitted)
+
+        expect(claims_query).to match_array([claim_belonging_to_filtered_provider])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We want to provide a maintainable approach to complex queries, such as Search and Filter capabilities.

## Changes proposed in this pull request

- Add an `ApplicationQuery` class as a base class for creating query objects.

## Guidance to review

- Review the example `Claims::ClaimsQuery` class and it's drop-in replacement usage.
- Review the `ApplicationQuery`.
- Think of how you would use the existing `ApplicationQuery` and patterns in `Claims::ClaimsQuery` to add your own query objects.
