### PR TITLE
Fix claim back links

### DIFF
--- a/app/controllers/claims/schools/claims_controller.rb
+++ b/app/controllers/claims/schools/claims_controller.rb
@@ -32,6 +32,7 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
         claim_mentor_training_form: { hours_completed: last_mentor_training.hours_completed },
       },
     )
+    Claims::Claim::RemoveEmptyMentorTrainingHours.call(claim: @claim)
   end
 
   def edit; end

--- a/app/forms/claim/mentor_training_form.rb
+++ b/app/forms/claim/mentor_training_form.rb
@@ -14,7 +14,9 @@ class Claim::MentorTrainingForm < ApplicationForm
   end
 
   def back_path
-    if mentor_trainings.index(mentor_training).zero?
+    if claim.ready_to_be_checked?
+      check_claims_school_claim_path(claim.school, claim)
+    elsif mentor_trainings.index(mentor_training).zero?
       edit_claims_school_claim_mentor_path(claim.school, claim, mentor_training.mentor_id)
     else
       previous_mentor_training = mentor_trainings[mentor_trainings.index(mentor_training) - 1]

--- a/app/models/claims/claim.rb
+++ b/app/models/claims/claim.rb
@@ -63,4 +63,8 @@ class Claims::Claim < ApplicationRecord
   def amount
     Claims::Claim::CalculateAmount.call(claim: self)
   end
+
+  def ready_to_be_checked?
+    mentors.present? && mentor_trainings.without_hours.blank?
+  end
 end

--- a/app/services/claims/claim/remove_empty_mentor_training_hours.rb
+++ b/app/services/claims/claim/remove_empty_mentor_training_hours.rb
@@ -1,0 +1,15 @@
+class Claims::Claim::RemoveEmptyMentorTrainingHours
+  include ServicePattern
+
+  def initialize(claim:)
+    @claim = claim
+  end
+
+  def call
+    claim.mentor_trainings.without_hours.destroy_all
+  end
+
+  private
+
+  attr_reader :claim
+end

--- a/spec/factories/mentor_trainings.rb
+++ b/spec/factories/mentor_trainings.rb
@@ -27,7 +27,7 @@
 FactoryBot.define do
   factory :mentor_training, class: "Claims::MentorTraining" do
     association :claim
-    association :mentor
+    association :mentor, factory: :claims_mentor
     association :provider
   end
 end

--- a/spec/models/claims/claim_spec.rb
+++ b/spec/models/claims/claim_spec.rb
@@ -110,4 +110,26 @@ RSpec.describe Claims::Claim, type: :model do
       end
     end
   end
+
+  describe "#ready_to_be_checked?" do
+    it "returns true if the claim's mentors all have their hours recorded" do
+      claim = create(:claim)
+      create(:mentor_training, hours_completed: 20, claim:)
+
+      expect(claim.ready_to_be_checked?).to eq(true)
+    end
+
+    it "returns false if the claim does have mentors" do
+      claim = build(:claim)
+
+      expect(claim.ready_to_be_checked?).to eq(false)
+    end
+
+    it "returns false if the claim does have mentor training hours" do
+      claim = create(:claim)
+      create(:mentor_training, hours_completed: nil, claim:)
+
+      expect(claim.ready_to_be_checked?).to eq(false)
+    end
+  end
 end

--- a/spec/services/claims/claim/remove_empty_mentor_training_hours_spec.rb
+++ b/spec/services/claims/claim/remove_empty_mentor_training_hours_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe Claims::Claim::RemoveEmptyMentorTrainingHours do
+  subject(:service) { described_class.call(claim:) }
+
+  let!(:claim) { create(:claim, reference: nil, status: :internal, school:) }
+  let(:school) { create(:claims_school, urn: "1234") }
+
+  it_behaves_like "a service object" do
+    let(:params) { { claim: } }
+  end
+
+  describe "#call" do
+    it "removes the mentor trainings without hours from a claim" do
+      create(:mentor_training, hours_completed: nil, claim:)
+      create(:mentor_training, hours_completed: nil, claim:)
+      training_with_hours = create(:mentor_training, hours_completed: 20, claim:)
+      expect { service }.to change(Claims::MentorTraining, :count).by(-2)
+
+      expect(claim.mentor_trainings).to eq([training_with_hours])
+    end
+  end
+end


### PR DESCRIPTION
## Context

Previously, if a user didn't input mentor hours after adding a mentor
from the check page of the claim form and click the back link. A mentor
without hours would be added to the claim.

This commit will remove any mentors without hours when the user lands on
the check page of a claim. Fixing the issue

Also, this commit will redirect back to the check page when trying to
edit mentor training hours and clicking the back link
if the claim is ready to be checked. Previously the user would need to
cycle through all the mentor hours.

## Changes proposed in this pull request

Claim model methods
Claims controller check mentor
Back link redirect for mentor training hours form
Specs

## Guidance to review

Create a claim
On the check page change the mentors
Add a mentor and click continue
Hit the back link to not input any training hours
Hit the back link again
The Mentor you added without mentor training hours should not be on the check page again


## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/3e7892e1-9134-4948-b5d1-1255ea0a828a


Problem:

https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/fc5a59a5-45cc-4744-9a46-39495f26d8ee



