### PR TITLE
Show only submitted claims on support claims

### DIFF
--- a/app/queries/claims/claims_query.rb
+++ b/app/queries/claims/claims_query.rb
@@ -1,6 +1,6 @@
 class Claims::ClaimsQuery < ApplicationQuery
   def call
-    scope = Claims::Claim.visible
+    scope = Claims::Claim.submitted
     scope = school_condition(scope)
     scope = provider_condition(scope)
     scope.order_created_at_desc

--- a/spec/queries/claims/claims_query_spec.rb
+++ b/spec/queries/claims/claims_query_spec.rb
@@ -8,10 +8,10 @@ describe Claims::ClaimsQuery do
   describe "#call" do
     it "returns all visible claims, ordered by created at date descending" do
       _internal_claim = create(:claim)
-      draft_claim = create(:claim, :draft, created_at: Date.parse("29 March 2024"))
+      _draft_claim = create(:claim, :draft, created_at: Date.parse("29 March 2024"))
       submitted_claim = create(:claim, :submitted, created_at: Date.parse("28 March 2024"))
 
-      expect(claims_query).to eq([draft_claim, submitted_claim])
+      expect(claims_query).to eq([submitted_claim])
     end
 
     context "when given school ids" do

--- a/spec/system/claims/support/claims/view_claims_spec.rb
+++ b/spec/system/claims/support/claims/view_claims_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "View claims", type: :system, service: :claims do
 
   scenario "Support user visits the claims index page" do
     when_i_visit_claim_index_page
-    i_see_a_list_of_claims
+    then_i_see_a_list_of_submitted_claims
   end
 
   private
@@ -26,17 +26,14 @@ RSpec.describe "View claims", type: :system, service: :claims do
     click_on("Claims")
   end
 
-  def i_see_a_list_of_claims
+  def then_i_see_a_list_of_submitted_claims
     expect(page).to have_content("ID")
     expect(page).to have_content("Status")
-    expect(page).to have_selector("tbody tr", count: 2)
+    expect(page).to have_selector("tbody tr", count: 1)
+
+    expect(page).not_to have_selector("td", text: claim_1.id)
 
     within("tbody tr:nth-child(1)") do
-      expect(page).to have_selector("td", text: claim_1.id)
-      expect(page).to have_selector("td", text: "Draft")
-    end
-
-    within("tbody tr:nth-child(2)") do
       expect(page).to have_selector("td", text: claim_2.id)
       expect(page).to have_selector("td", text: "Submitted")
     end


### PR DESCRIPTION
## Context

We should only show submitted claims on this page.

## Changes proposed in this pull request

Change the query when viewing to only show submitted claims

## Guidance to review

- Create a draft claim
- The view the Support user claims page
- You should not see any draft claims

## Link to Trello card

https://trello.com/c/caVosYbs/319-show-only-submitted-claims-on-support-claims

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
