### PR TITLE
Rename claim status internal to internal_draft

### DIFF
--- a/app/forms/claim/provider_form.rb
+++ b/app/forms/claim/provider_form.rb
@@ -20,7 +20,7 @@ class Claim::ProviderForm < ApplicationForm
   def updated_claim
     @updated_claim ||= begin
       claim.provider_id = provider_id
-      claim.status = :internal
+      claim.status = :internal_draft
       claim.created_by = current_user
       claim
     end

--- a/app/models/claims/claim.rb
+++ b/app/models/claims/claim.rb
@@ -49,7 +49,7 @@ class Claims::Claim < ApplicationRecord
   scope :order_created_at_desc, -> { order(created_at: :desc) }
 
   enum :status,
-       { internal: "internal", draft: "draft", submitted: "submitted" },
+       { internal_draft: "internal_draft", draft: "draft", submitted: "submitted" },
        validate: true
 
   delegate :name, to: :provider, prefix: true, allow_nil: true

--- a/app/policies/claims/claim_policy.rb
+++ b/app/policies/claims/claim_policy.rb
@@ -20,11 +20,11 @@ class Claims::ClaimPolicy < Claims::ApplicationPolicy
   end
 
   def draft?
-    user.support_user? && record.internal?
+    user.support_user? && record.internal_draft?
   end
 
   def check?
-    record.draft? || record.internal?
+    record.draft? || record.internal_draft?
   end
 
   def download_csv?

--- a/db/migrate/20240402144630_rename_claim_internal_to_internal_draft.rb
+++ b/db/migrate/20240402144630_rename_claim_internal_to_internal_draft.rb
@@ -1,0 +1,5 @@
+class RenameClaimInternalToInternalDraft < ActiveRecord::Migration[7.1]
+  def change
+    rename_enum_value :claim_status, from: "internal", to: "internal_draft"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_25_095831) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_02_144630) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
-  create_enum "claim_status", ["internal", "draft", "submitted"]
+  create_enum "claim_status", ["internal_draft", "draft", "submitted"]
   create_enum "mentor_training_type", ["refresher", "initial"]
   create_enum "placement_status", ["draft", "published"]
   create_enum "provider_type", ["scitt", "lead_school", "university"]

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -34,7 +34,7 @@ FactoryBot.define do
     association :provider
     association :created_by, factory: :claims_user
 
-    status { :internal }
+    status { :internal_draft }
 
     trait :draft do
       status { :draft }

--- a/spec/forms/claim/provider_form_spec.rb
+++ b/spec/forms/claim/provider_form_spec.rb
@@ -39,25 +39,25 @@ describe Claim::ProviderForm, type: :model do
 
   describe "save" do
     context "when claim doesn't exist" do
-      it "creates an internal claim with a provider" do
+      it "creates an internal draft claim with a provider" do
         form = described_class.new(provider_id: provider.id, school:, current_user:)
 
         expect {
           form.save!
         }.to change { form.claim.provider }.to provider
-        expect(form.claim.internal?).to be(true)
+        expect(form.claim.internal_draft?).to be(true)
         expect(form.claim.created_by).to eq(current_user)
       end
     end
 
     context "when claim does exist" do
-      it "creates an internal claim with a provider" do
+      it "creates an internal draft claim with a provider" do
         form = described_class.new(id: claim.id, provider_id: provider.id, school:, current_user:)
 
         expect {
           form.save!
         }.to change { claim.reload.provider }.to provider
-        expect(claim.internal?).to be(true)
+        expect(claim.internal_draft?).to be(true)
         expect(form.claim.created_by).to eq(current_user)
       end
     end

--- a/spec/models/claims/claim_spec.rb
+++ b/spec/models/claims/claim_spec.rb
@@ -63,18 +63,18 @@ RSpec.describe Claims::Claim, type: :model do
 
     it "defines the expected values" do
       expect(claim).to define_enum_for(:status)
-        .with_values(internal: "internal", draft: "draft", submitted: "submitted")
+        .with_values(internal_draft: "internal_draft", draft: "draft", submitted: "submitted")
         .backed_by_column_of_type(:enum)
     end
   end
 
   describe "scopes" do
     describe "#visible" do
-      it "returns the claims that dont have status internal" do
+      it "returns the claims that dont have status internal_draft" do
         create(:claim)
         claim1 = create(:claim, :draft)
         claim2 = create(:claim, :submitted)
-        create(:claim, :internal)
+        create(:claim, :internal_draft)
 
         expect(described_class.visible).to eq(
           [claim1, claim2],

--- a/spec/policies/claims/claim_policy_spec.rb
+++ b/spec/policies/claims/claim_policy_spec.rb
@@ -5,14 +5,14 @@ describe Claims::ClaimPolicy do
 
   let(:user) { build(:claims_user) }
   let(:support_user) { build(:claims_support_user) }
-  let(:internal_claim) { build(:claim) }
+  let(:internal_draft_claim) { build(:claim) }
   let(:draft_claim) { build(:claim, :draft) }
   let(:submitted_claim) { build(:claim, :submitted) }
 
   permissions :edit? do
-    context "when user has an internal claim" do
+    context "when user has an internal draft claim" do
       it "grants access" do
-        expect(claim_policy).to permit(user, internal_claim)
+        expect(claim_policy).to permit(user, internal_draft_claim)
       end
     end
 
@@ -30,9 +30,9 @@ describe Claims::ClaimPolicy do
   end
 
   permissions :update? do
-    context "when user has an internal claim" do
+    context "when user has an internal draft claim" do
       it "grants access" do
-        expect(claim_policy).to permit(user, internal_claim)
+        expect(claim_policy).to permit(user, internal_draft_claim)
       end
     end
 
@@ -50,9 +50,9 @@ describe Claims::ClaimPolicy do
   end
 
   permissions :submit? do
-    context "when user has an internal claim" do
+    context "when user has an internal draft claim" do
       it "grants access" do
-        expect(claim_policy).to permit(user, internal_claim)
+        expect(claim_policy).to permit(user, internal_draft_claim)
       end
     end
 
@@ -82,9 +82,9 @@ describe Claims::ClaimPolicy do
       end
     end
 
-    context "when user has an internal claim" do
+    context "when user has an internal draft claim" do
       it "grants access" do
-        expect(claim_policy).not_to permit(user, internal_claim)
+        expect(claim_policy).not_to permit(user, internal_draft_claim)
       end
     end
 
@@ -102,9 +102,9 @@ describe Claims::ClaimPolicy do
   end
 
   permissions :draft? do
-    context "when user has an internal claim" do
+    context "when user has an internal draft claim" do
       it "grants access" do
-        expect(claim_policy).to permit(support_user, internal_claim)
+        expect(claim_policy).to permit(support_user, internal_draft_claim)
       end
     end
 
@@ -134,9 +134,9 @@ describe Claims::ClaimPolicy do
       end
     end
 
-    context "when user has an internal claim" do
+    context "when user has an internal draft claim" do
       it "grants access" do
-        expect(claim_policy).to permit(user, internal_claim)
+        expect(claim_policy).to permit(user, internal_draft_claim)
       end
     end
 

--- a/spec/services/claims/claim/create_draft_spec.rb
+++ b/spec/services/claims/claim/create_draft_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe Claims::Claim::CreateDraft do
   subject(:draft_service) { described_class.call(claim:) }
 
-  let!(:claim) { create(:claim, reference: nil, status: :internal, school:) }
+  let!(:claim) { create(:claim, reference: nil, status: :internal_draft, school:) }
   let(:school) { create(:claims_school, urn: "1234") }
 
   it_behaves_like "a service object" do

--- a/spec/services/claims/claim/submit_spec.rb
+++ b/spec/services/claims/claim/submit_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe Claims::Claim::Submit do
   subject(:submit_service) { described_class.call(claim:, user:) }
 
-  let!(:claim) { create(:claim, reference: nil, status: :internal, school:) }
+  let!(:claim) { create(:claim, reference: nil, status: :internal_draft, school:) }
 
   let(:submitted_at) { Time.new("2024-03-04 10:32:04 UTC") }
   let(:school) { create(:claims_school, urn: "1234") }

--- a/spec/system/claims/schools/claims/view_claims_spec.rb
+++ b/spec/system/claims/schools/claims/view_claims_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "View claims", type: :system, service: :claims do
   end
 
   before do
-    create(:claim, status: :internal, school:)
+    create(:claim, status: :internal_draft, school:)
   end
 
   scenario "Anne visits the claims index page with no mentors" do
@@ -62,16 +62,16 @@ RSpec.describe "View claims", type: :system, service: :claims do
     i_see_a_list_of_the_schools_claims
   end
 
-  scenario "Anne visits the claims index page with internal claims" do
+  scenario "Anne visits the claims index page with internal draft claims" do
     user_exists_in_dfe_sign_in(user: anne)
     given_i_sign_in
     vist_claims_index_page
-    i_do_not_see_any_internal_claims
+    i_do_not_see_any_internal_draft_claims
   end
 
   private
 
-  def i_do_not_see_any_internal_claims
+  def i_do_not_see_any_internal_draft_claims
     expect(page).to have_content("There are no claims for #{school.name}")
   end
 

--- a/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
 
   let(:mentor1) { create(:mentor, first_name: "Anne") }
   let(:mentor2) { create(:mentor, first_name: "Joe") }
-  let!(:claim) { create(:claim, :internal, school:, provider: provider1) }
+  let!(:claim) { create(:claim, :internal_draft, school:, provider: provider1) }
 
   before do
     user_exists_in_dfe_sign_in(user: colin)


### PR DESCRIPTION
## Context

This is not live data so chaining it in this way should be fine.

<!-- Why are you making this change? What might surprise someone about it? -->

`internal_draft` claims status is a much better status than just `internal`

## Guidance to review

Run migration
Check your existing internal claims.

## Screenshots

![Screenshot from 2024-04-02 16-06-48](https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/99783c8d-f2e8-4ddf-a497-c511777e1985)
