### PR TITLE
Move Claims form objects into the Claims namespace

### DIFF
--- a/app/controllers/claims/schools/claims/mentor_trainings_controller.rb
+++ b/app/controllers/claims/schools/claims/mentor_trainings_controller.rb
@@ -17,15 +17,15 @@ class Claims::Schools::Claims::MentorTrainingsController < Claims::ApplicationCo
 
   def mentor_training_form
     @mentor_training_form ||=
-      if params[:claim_mentor_training_form].present?
-        Claim::MentorTrainingForm.new(mentor_training_params)
+      if params[:claims_claim_mentor_training_form].present?
+        Claims::Claim::MentorTrainingForm.new(mentor_training_params)
       else
-        Claim::MentorTrainingForm.new(default_params)
+        Claims::Claim::MentorTrainingForm.new(default_params)
       end
   end
 
   def mentor_training_params
-    params.require(:claim_mentor_training_form).permit(
+    params.require(:claims_claim_mentor_training_form).permit(
       :hours_completed,
       :custom_hours_completed,
     ).merge(default_params)

--- a/app/controllers/claims/schools/claims/mentors_controller.rb
+++ b/app/controllers/claims/schools/claims/mentors_controller.rb
@@ -43,9 +43,9 @@ class Claims::Schools::Claims::MentorsController < Claims::ApplicationController
   def claim_mentors_form
     @claim_mentors_form ||=
       if params[:claims_claim].present?
-        Claim::MentorsForm.new(claim:, mentor_ids: claim_params[:mentor_ids])
+        Claims::Claim::MentorsForm.new(claim:, mentor_ids: claim_params[:mentor_ids])
       else
-        Claim::MentorsForm.new(claim:)
+        Claims::Claim::MentorsForm.new(claim:)
       end
   end
 

--- a/app/controllers/claims/schools/claims_controller.rb
+++ b/app/controllers/claims/schools/claims_controller.rb
@@ -29,7 +29,7 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
       @claim,
       last_mentor_training,
       params: {
-        claim_mentor_training_form: { hours_completed: last_mentor_training.hours_completed },
+        claims_claim_mentor_training_form: { hours_completed: last_mentor_training.hours_completed },
       },
     )
     Claims::Claim::RemoveEmptyMentorTrainingHours.call(claim: @claim)
@@ -68,9 +68,9 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
   def claim_provider_form
     @claim_provider_form ||=
       if params[:claims_claim].present?
-        Claim::ProviderForm.new(claim_params)
+        Claims::Claim::ProviderForm.new(claim_params)
       else
-        Claim::ProviderForm.new(default_params.merge(id: claim_id))
+        Claims::Claim::ProviderForm.new(default_params.merge(id: claim_id))
       end
   end
 

--- a/app/controllers/claims/support/schools/claims/mentor_trainings_controller.rb
+++ b/app/controllers/claims/support/schools/claims/mentor_trainings_controller.rb
@@ -27,15 +27,15 @@ class Claims::Support::Schools::Claims::MentorTrainingsController < Claims::Appl
 
   def mentor_training_form
     @mentor_training_form ||=
-      if params[:claim_mentor_training_form].present?
-        Claim::MentorTrainingForm.new(mentor_training_params)
+      if params[:claims_claim_mentor_training_form].present?
+        Claims::Claim::MentorTrainingForm.new(mentor_training_params)
       else
-        Claim::MentorTrainingForm.new(default_params)
+        Claims::Claim::MentorTrainingForm.new(default_params)
       end
   end
 
   def mentor_training_params
-    params.require(:claim_mentor_training_form).permit(
+    params.require(:claims_claim_mentor_training_form).permit(
       :hours_completed,
       :custom_hours_completed,
     ).merge(default_params)

--- a/app/controllers/claims/support/schools/claims/mentors_controller.rb
+++ b/app/controllers/claims/support/schools/claims/mentors_controller.rb
@@ -53,9 +53,9 @@ class Claims::Support::Schools::Claims::MentorsController < Claims::ApplicationC
   def claim_mentors_form
     @claim_mentors_form ||=
       if params[:claims_claim].present?
-        Claim::MentorsForm.new(claim:, mentor_ids: claim_params[:mentor_ids])
+        Claims::Claim::MentorsForm.new(claim:, mentor_ids: claim_params[:mentor_ids])
       else
-        Claim::MentorsForm.new(claim:)
+        Claims::Claim::MentorsForm.new(claim:)
       end
   end
 

--- a/app/controllers/claims/support/schools/claims_controller.rb
+++ b/app/controllers/claims/support/schools/claims_controller.rb
@@ -37,7 +37,7 @@ class Claims::Support::Schools::ClaimsController < Claims::Support::ApplicationC
       @claim,
       last_mentor_training,
       params: {
-        claim_mentor_training_form: { hours_completed: last_mentor_training.hours_completed },
+        claims_claim_mentor_training_form: { hours_completed: last_mentor_training.hours_completed },
       },
     )
   end
@@ -81,9 +81,9 @@ class Claims::Support::Schools::ClaimsController < Claims::Support::ApplicationC
   def claim_provider_form
     @claim_provider_form ||=
       if params[:claims_claim].present?
-        Claim::ProviderForm.new(claim_params)
+        Claims::Claim::ProviderForm.new(claim_params)
       else
-        Claim::ProviderForm.new(default_params.merge(id: claim_id))
+        Claims::Claim::ProviderForm.new(default_params.merge(id: claim_id))
       end
   end
 

--- a/app/forms/claims/claim/mentor_training_form.rb
+++ b/app/forms/claims/claim/mentor_training_form.rb
@@ -1,4 +1,4 @@
-class Claim::MentorTrainingForm < ApplicationForm
+class Claims::Claim::MentorTrainingForm < ApplicationForm
   DEFAULT_HOURS_COMPLETED = %w[6 20].freeze
   attr_accessor :claim, :mentor_training, :hours_completed, :custom_hours_completed
 
@@ -25,7 +25,7 @@ class Claim::MentorTrainingForm < ApplicationForm
         claim,
         previous_mentor_training,
         params: {
-          claim_mentor_training_form: { hours_completed: previous_mentor_training.hours_completed },
+          claims_claim_mentor_training_form: { hours_completed: previous_mentor_training.hours_completed },
         },
       )
     end

--- a/app/forms/claims/claim/mentors_form.rb
+++ b/app/forms/claims/claim/mentors_form.rb
@@ -1,4 +1,4 @@
-class Claim::MentorsForm < ApplicationForm
+class Claims::Claim::MentorsForm < ApplicationForm
   attr_accessor :claim, :mentor_ids
 
   validate :mentor_presence

--- a/app/forms/claims/claim/provider_form.rb
+++ b/app/forms/claims/claim/provider_form.rb
@@ -1,4 +1,4 @@
-class Claim::ProviderForm < ApplicationForm
+class Claims::Claim::ProviderForm < ApplicationForm
   attr_accessor :id, :provider_id, :school, :current_user
 
   validate :validate_provider

--- a/app/views/claims/schools/claims/check.html.erb
+++ b/app/views/claims/schools/claims/check.html.erb
@@ -62,7 +62,7 @@
                                  @claim,
                                  mentor_training,
                                  params: {
-                                   claim_mentor_training_form: { hours_completed: mentor_training.hours_completed },
+                                   claims_claim_mentor_training_form: { hours_completed: mentor_training.hours_completed },
                                  },
                                ),
                                html_attributes: {

--- a/app/views/claims/support/schools/claims/check.html.erb
+++ b/app/views/claims/support/schools/claims/check.html.erb
@@ -57,7 +57,7 @@
                                  @claim,
                                  mentor_training,
                                  params: {
-                                   claim_mentor_training_form: { hours_completed: mentor_training.hours_completed },
+                                   claims_claim_mentor_training_form: { hours_completed: mentor_training.hours_completed },
                                  },
                                ),
                                html_attributes: {

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -4,7 +4,7 @@ en:
       messages:
         record_invalid: "Validation failed: %{errors}"
       models:
-        claim/mentor_training_form:
+        claims/claim/mentor_training_form:
           attributes:
             custom_hours_completed:
               blank: Enter the number of hours

--- a/spec/forms/claims/claim/mentor_training_form_spec.rb
+++ b/spec/forms/claims/claim/mentor_training_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Claim::MentorTrainingForm, type: :model do
+describe Claims::Claim::MentorTrainingForm, type: :model do
   let!(:claim) { create(:claim) }
   let!(:mentor_training) { create(:mentor_training, claim:, mentor:, hours_completed: 6) }
   let(:mentor) { create(:mentor, first_name: "Anne") }
@@ -86,7 +86,7 @@ describe Claim::MentorTrainingForm, type: :model do
           form = described_class.new(claim:, mentor_training: second_mentor_training)
 
           expect(form.back_path).to eq(
-            "/schools/#{claim.school_id}/claims/#{claim.id}/mentor_trainings/#{mentor_training.id}/edit?claim_mentor_training_form%5Bhours_completed%5D=#{mentor_training.hours_completed}",
+            "/schools/#{claim.school_id}/claims/#{claim.id}/mentor_trainings/#{mentor_training.id}/edit?claims_claim_mentor_training_form%5Bhours_completed%5D=#{mentor_training.hours_completed}",
           )
         end
       end

--- a/spec/forms/claims/claim/mentors_form_spec.rb
+++ b/spec/forms/claims/claim/mentors_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Claim::MentorsForm, type: :model do
+describe Claims::Claim::MentorsForm, type: :model do
   let!(:claim) { create(:claim) }
   let!(:mentor1) { create(:mentor) }
   let!(:mentor2) { create(:mentor) }

--- a/spec/forms/claims/claim/provider_form_spec.rb
+++ b/spec/forms/claims/claim/provider_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Claim::ProviderForm, type: :model do
+describe Claims::Claim::ProviderForm, type: :model do
   let!(:school) { create(:claims_school) }
   let!(:provider) { create(:claims_provider, :best_practice_network) }
   let!(:claim) { create(:claim, school:) }

--- a/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
@@ -144,19 +144,19 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
     page.choose("Another amount")
 
     if with_error
-      fill_in("claim-mentor-training-form-custom-hours-completed-field-error", with: hours)
+      fill_in("claims-claim-mentor-training-form-custom-hours-completed-field-error", with: hours)
     else
-      fill_in("claim-mentor-training-form-custom-hours-completed-field", with: hours)
+      fill_in("claims-claim-mentor-training-form-custom-hours-completed-field", with: hours)
     end
   end
 
   def then_i_expect_the_provider_to_be_checked(provider)
-    has_checked_field?("#claim-provider-form-provider-id-#{provider.id}-field")
+    has_checked_field?("#claims-claim-provider-form-provider-id-#{provider.id}-field")
   end
 
   def then_i_expect_the_mentors_to_be_checked(mentors)
     mentors.each do |mentor|
-      has_checked_field?("#claim-mentor-ids-#{mentor.id}-field")
+      has_checked_field?("#claims-claim-mentor-ids-#{mentor.id}-field")
     end
   end
 
@@ -183,12 +183,12 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
   end
 
   def then_i_expect_the_training_hours_to_be_selected(hours)
-    find("#claim-mentor-training-form-hours-completed-#{hours}-field").checked?
+    find("#claims-claim-mentor-training-form-hours-completed-#{hours}-field").checked?
   end
 
   def then_i_expect_the_training_hours_for(hours, mentor)
     expect(page).to have_content("Hours of training for #{mentor.full_name}")
-    find("#claim-mentor-training-form-hours-completed-#{hours}-field").checked?
+    find("#claims-claim-mentor-training-form-hours-completed-#{hours}-field").checked?
   end
 
   def then_i_check_my_answers(provider, mentors, mentor_hours)

--- a/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
@@ -126,9 +126,9 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
     page.choose("Another amount")
 
     if with_error
-      fill_in("claim-mentor-training-form-custom-hours-completed-field-error", with: hours)
+      fill_in("claims-claim-mentor-training-form-custom-hours-completed-field-error", with: hours)
     else
-      fill_in("claim-mentor-training-form-custom-hours-completed-field", with: hours)
+      fill_in("claims-claim-mentor-training-form-custom-hours-completed-field", with: hours)
     end
   end
 
@@ -165,7 +165,7 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
   end
 
   def then_i_expect_the_training_hours_to_be_selected(hours)
-    find("#claim-mentor-training-form-hours-completed-#{hours}-field").checked?
+    find("#claims-claim-mentor-training-form-hours-completed-#{hours}-field").checked?
   end
 
   def then_i_check_my_answers(provider, mentors, mentor_hours)


### PR DESCRIPTION
## Context

To ensure our form objects follow the correct pattern ` <ServiceNamespace>[::Resource]::<Name>Form`

## Changes proposed in this pull request

Moved the form objects into the correct folders 

## Link to Trello card

https://trello.com/c/SF3DGsjC/327-move-claims-form-objects-into-the-claims-namespace

