### PR TITLE
Fix spec after updating claim status enum

### DIFF
--- a/spec/services/claims/claim/remove_empty_mentor_training_hours_spec.rb
+++ b/spec/services/claims/claim/remove_empty_mentor_training_hours_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe Claims::Claim::RemoveEmptyMentorTrainingHours do
   subject(:service) { described_class.call(claim:) }
 
-  let!(:claim) { create(:claim, reference: nil, status: :internal, school:) }
+  let!(:claim) { create(:claim, reference: nil, status: :internal_draft, school:) }
   let(:school) { create(:claims_school, urn: "1234") }
 
   it_behaves_like "a service object" do


### PR DESCRIPTION
## Context

The PR that changed the claim status https://github.com/DFE-Digital/itt-mentor-services/pull/434 broke a spec that used the old status. This PR fixes the spec


## Changes proposed in this pull request

Spec Claims::Claim::RemoveEmptyMentorTrainingHours

## Guidance to review

Do specs pass?
