### PR TITLE
Remove internal_draft claims after midnight

### DIFF
--- a/app/jobs/claims/remove_internal_draft_claims_job.rb
+++ b/app/jobs/claims/remove_internal_draft_claims_job.rb
@@ -1,0 +1,9 @@
+class Claims::RemoveInternalDraftClaimsJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Audited.audit_class.as_user("System") do
+      Claims::Claim::RemoveInternalDrafts.call
+    end
+  end
+end

--- a/app/services/claims/claim/remove_internal_drafts.rb
+++ b/app/services/claims/claim/remove_internal_drafts.rb
@@ -1,0 +1,7 @@
+class Claims::Claim::RemoveInternalDrafts
+  include ServicePattern
+
+  def call
+    Claims::Claim.internal_draft.where(updated_at: ..1.day.ago).destroy_all
+  end
+end

--- a/config/scheduled_jobs.yml
+++ b/config/scheduled_jobs.yml
@@ -25,3 +25,8 @@ publish_subject_sync:
   cron: "0 0 * * *"
   class: "PublishTeacherTraining::Subject::SyncAllJob"
   description: "Sync all subjects with data imported from Publish Teacher Training"
+
+remove_internal_draft_claims:
+  cron: "10 0 * * *"
+  class: "Claims::RemoveInternalDraftClaimsJob"
+  description: "Remove all internal_draft claims"

--- a/spec/jobs/claims/remove_internal_draft_claims_job_spec.rb
+++ b/spec/jobs/claims/remove_internal_draft_claims_job_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe Claims::RemoveInternalDraftClaimsJob, type: :job do
+  describe "#perform" do
+    it "calls the Claims::Claim::RemoveInternalDrafts service" do
+      expect(Audited.audit_class).to receive(:as_user).with("System").and_yield
+      expect(Claims::Claim::RemoveInternalDrafts).to receive(:call)
+      described_class.perform_now
+    end
+
+    it "enqueues the job in the default queue" do
+      expect {
+        described_class.perform_later
+      }.to have_enqueued_job(described_class).on_queue("default")
+    end
+  end
+end

--- a/spec/services/claims/claim/remove_internal_drafts_spec.rb
+++ b/spec/services/claims/claim/remove_internal_drafts_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe Claims::Claim::RemoveInternalDrafts do
+  subject(:service) { described_class.call }
+
+  let!(:draft_claim) { create(:claim, status: :draft) }
+  let!(:active_internal_draft_claim) { create(:claim, status: :internal_draft) }
+  let!(:submitted_claim) { create(:claim, status: :submitted) }
+
+  it_behaves_like "a service object"
+
+  describe "#call" do
+    it "removes internal draft claims that haven't changed in at least 24 hours" do
+      create(:claim, status: :internal_draft, updated_at: 1.day.ago)
+
+      expect { service }.to change(Claims::Claim, :count).from(4).to(3)
+      expect(Claims::Claim.all).to eq(
+        [draft_claim, active_internal_draft_claim, submitted_claim],
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Context

Internal draft claims are claims that are incomplete, these claims can be created
by a user who doesn't submit/add a claim. Meaning they didn't go through the whole
claim form, they stopped half way.

These claims will just be in our DB if we don't remove them, they cannot be
picked up again.

This commit adds a job to remove the internal draft claims every day after
midnight. We only remove the internal draft claims that have been last updated
`1 day ago`, just in case we remove a claim that's in the process of being submitted.

## Changes proposed in this pull request

Remove internal draft claims job and service
Specs

## Guidance to review

Sign in as Colin
Create a few internal draft claims with `updated_at` more than 1 day ago
Go to http://claims.localhost:3000/good_job/cron_entries?locale=en
Run the `Claims::RemoveInternalDraftClaimsJob` manually
The internal draft claims should be removed from your DB

## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/c89a64b0-1fc5-4eb4-940d-386b95578952


