### PR TITLE
Rename 'Users' primary menu item in Support console to 'Support Users'

### DIFF
--- a/app/views/claims/support/_primary_navigation.html.erb
+++ b/app/views/claims/support/_primary_navigation.html.erb
@@ -1,8 +1,8 @@
 <% content_for(:primary_navigation_content) do %>
   <%= render PrimaryNavigationComponent.new do |component| %>
     <% component.with_navigation_item t(".organisations"), claims_support_schools_path, current: local_assigns[:current] == :organisations %>
-    <% component.with_navigation_item t(".users"), claims_support_support_users_path, current: local_assigns[:current] == :users %>
     <% component.with_navigation_item t(".claims"), claims_support_claims_path, current: local_assigns[:current] == :claims %>
+    <% component.with_navigation_item t(".support_users"), claims_support_support_users_path, current: local_assigns[:current] == :users %>
   <% end %>
 
   <% content_for(:no_phase_banner_border, true) %>

--- a/config/locales/en/claims/support/primary_navigation.yml
+++ b/config/locales/en/claims/support/primary_navigation.yml
@@ -4,4 +4,4 @@ en:
       primary_navigation:
         claims: Claims
         organisations: Organisations
-        users: Users
+        support_users: Support users

--- a/config/locales/en/claims/support/support_users.yml
+++ b/config/locales/en/claims/support/support_users.yml
@@ -3,7 +3,7 @@ en:
     support:
       support_users:
         index:
-          page_title: Users
+          page_title: Support users
           add_user: Add user
           heading: Users
         new:

--- a/spec/system/claims/support/schools/mentors/support_user_adds_a_mentor_spec.rb
+++ b/spec/system/claims/support/schools/mentors/support_user_adds_a_mentor_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe "Claims support user adds mentors to schools", type: :system, ser
   def expect_organisations_to_be_selected_in_primary_navigation
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Organisations", current: "page"
-      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Support users", current: "false"
     end
   end
 

--- a/spec/system/claims/support/support_users/add_a_support_user_spec.rb
+++ b/spec/system/claims/support/support_users/add_a_support_user_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Add a support user", type: :system do
 
   def and_i_visit_the_support_users_page
     within(".app-primary-navigation nav") do
-      click_on "Users"
+      click_on "Support users"
     end
   end
 

--- a/spec/system/claims/support/support_users/re_add_a_discarded_support_user_spec.rb
+++ b/spec/system/claims/support/support_users/re_add_a_discarded_support_user_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe "Re-add a discarded support user", type: :system do
 
   def and_i_visit_the_support_users_page
     within(".app-primary-navigation nav") do
-      click_on "Users"
+      click_on "Support users"
     end
   end
 

--- a/spec/system/claims/support/support_users/remove_a_support_user_spec.rb
+++ b/spec/system/claims/support/support_users/remove_a_support_user_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Remove a support user", type: :system do
 
   def and_i_visit_the_support_users_page
     within(".app-primary-navigation nav") do
-      click_on "Users"
+      click_on "Support users"
     end
   end
 

--- a/spec/system/claims/support/support_users/view_a_support_user_spec.rb
+++ b/spec/system/claims/support/support_users/view_a_support_user_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "View a support user", type: :system do
 
   def and_i_visit_the_support_users_page
     within(".app-primary-navigation nav") do
-      click_on "Users"
+      click_on "Support users"
     end
   end
 

--- a/spec/system/claims/support/support_users/view_support_users_spec.rb
+++ b/spec/system/claims/support/support_users/view_support_users_spec.rb
@@ -6,19 +6,20 @@ RSpec.describe "View support users", type: :system do
 
   scenario "View list of all support users" do
     given_i_sign_in_as(support_user)
-    and_i_visit_the_support_users_page
-    i_see_the_list_of_all_support_users_ordered_by_latest_created_at_first
+    when_i_visit_the_support_users_page
+    then_i_see_the_list_of_all_support_users_ordered_by_latest_created_at_first
+    and_the_page_title_is("Support users - Claim funding for mentor training - GOV.UK")
   end
 
   private
 
-  def and_i_visit_the_support_users_page
+  def when_i_visit_the_support_users_page
     within(".app-primary-navigation nav") do
-      click_on "Users"
+      click_on "Support users"
     end
   end
 
-  def i_see_the_list_of_all_support_users_ordered_by_latest_created_at_first
+  def then_i_see_the_list_of_all_support_users_ordered_by_latest_created_at_first
     expect(page).to have_selector("tbody tr", count: 2)
 
     within("tbody tr:nth-child(1)") do
@@ -30,5 +31,9 @@ RSpec.describe "View support users", type: :system do
       expect(page).to have_selector("td", text: support_user_2.full_name)
       expect(page).to have_selector("td", text: support_user_2.email)
     end
+  end
+
+  def and_the_page_title_is(title)
+    expect(page).to have_title title
   end
 end


### PR DESCRIPTION
## Context

Changed the primary nav for a support user

## Changes proposed in this pull request

- Changed the order of the nav bar
- Renamed 'Users' primary menu item in Support console to 'Support Users'

## Guidance to review

- Sign in as a support user 

## Link to Trello card

https://trello.com/c/s0WdT1IS/328-rename-users-primary-menu-item-in-support-console-to-support-users

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
<img width="1041" alt="Screenshot 2024-04-03 at 13 49 46" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/856492ec-62cf-4f99-9f85-8f312379d232">
