### PR TITLE
Add external link to the feedback form

### DIFF
--- a/app/helpers/routes_helper.rb
+++ b/app/helpers/routes_helper.rb
@@ -1,6 +1,8 @@
 module RoutesHelper
   include Placements::Routes::OrganisationsHelper
 
+  CLAIMS_FEEDBACK_URL = "https://forms.office.com/e/0E3277Kqpi".freeze
+
   def root_path
     {
       claims: sign_in_path,
@@ -36,10 +38,10 @@ module RoutesHelper
     }.fetch HostingEnvironment.current_service(request)
   end
 
-  def feedback_path
+  def feedback_url
     {
-      claims: claims_feedback_path,
-      placements: placements_feedback_path,
+      claims: CLAIMS_FEEDBACK_URL,
+      placements: placements_feedback_url,
     }.fetch HostingEnvironment.current_service(request)
   end
 

--- a/app/views/claims/pages/feedback.html.erb
+++ b/app/views/claims/pages/feedback.html.erb
@@ -1,9 +1,0 @@
-<% content_for :page_title, t(".page_title") %>
-
-<div class="govuk-width-container">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l"><%= t(".page_title") %></h1>
-    </div>
-  </div>
-</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,7 +36,7 @@
 
     <div class="govuk-width-container">
       <%= govuk_phase_banner(tag: { text: hosting_environment_phase(current_service), colour: hosting_environment_color }, classes: [class_names("app-phase-banner", "app-phase-banner__env--#{HostingEnvironment.env}", "app-phase-banner--no-border-bottom": content_for(:no_phase_banner_border) || support_controller?)]) do %>
-        <%== t(".#{current_service}.phase_banner.description", feedback_link: govuk_link_to(t(".#{current_service}.phase_banner.feedback"), feedback_path, class: "govuk-link--no-visited-state")) %>
+        <%== t(".#{current_service}.phase_banner.description", feedback_link: govuk_link_to(t(".#{current_service}.phase_banner.feedback"), feedback_url, target: "_blank", rel: "noreferrer", class: "govuk-link--no-visited-state")) %>
       <% end %>
 
       <%= yield :header_content %>

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -7,7 +7,6 @@ scope module: :claims, as: :claims, constraints: { host: ENV["CLAIMS_HOST"] } do
     get :terms
     get :privacy
     get :grant_conditions
-    get :feedback
   end
 
   resources :schools, only: %i[index show] do

--- a/spec/helpers/routes_helper_spec.rb
+++ b/spec/helpers/routes_helper_spec.rb
@@ -80,18 +80,18 @@ describe RoutesHelper do
       end
     end
 
-    describe "#feedback_path" do
+    describe "#feedback_url" do
       context "when the current service is claims" do
-        it "returns the correct path" do
+        it "returns the correct url" do
           allow(HostingEnvironment).to receive(:current_service).and_return(:claims)
-          expect(helper.feedback_path).to eq(claims_feedback_path)
+          expect(helper.feedback_url).to eq("https://forms.office.com/e/0E3277Kqpi")
         end
       end
 
       context "when the current service is placements" do
-        it "returns the correct path" do
+        it "returns the correct url" do
           allow(HostingEnvironment).to receive(:current_service).and_return(:placements)
-          expect(helper.feedback_path).to eq(placements_feedback_path)
+          expect(helper.feedback_url).to eq(placements_feedback_url)
         end
       end
     end


### PR DESCRIPTION
## Context

Since we've decided to use MS forms for the feedback form, we've decided to link out to it here.

## Changes proposed in this pull request

- Update "feedback" link in phase banner to external MS form.

## Guidance to review

- Link should open the MS form for "Give feedback on Claim funding for mentor training" in a new tab.