### PR TITLE
Split the claim forms into 2

### DIFF
--- a/app/controllers/claims/support/schools/claims/mentor_trainings_controller.rb
+++ b/app/controllers/claims/support/schools/claims/mentor_trainings_controller.rb
@@ -7,17 +7,7 @@ class Claims::Support::Schools::Claims::MentorTrainingsController < Claims::Appl
 
   def update
     if mentor_training_form.save
-      path = if claim.mentor_trainings.without_hours.any?
-               edit_claims_support_school_claim_mentor_training_path(
-                 claim.school,
-                 claim,
-                 claim.mentor_trainings.without_hours.first,
-               )
-             else
-               check_claims_support_school_claim_path(claim.school, claim)
-             end
-
-      redirect_to path
+      redirect_to mentor_training_form.success_path
     else
       render :edit
     end
@@ -27,15 +17,15 @@ class Claims::Support::Schools::Claims::MentorTrainingsController < Claims::Appl
 
   def mentor_training_form
     @mentor_training_form ||=
-      if params[:claims_claim_mentor_training_form].present?
-        Claims::Claim::MentorTrainingForm.new(mentor_training_params)
+      if params[:claims_support_claim_mentor_training_form].present?
+        Claims::Support::Claim::MentorTrainingForm.new(mentor_training_params)
       else
-        Claims::Claim::MentorTrainingForm.new(default_params)
+        Claims::Support::Claim::MentorTrainingForm.new(default_params)
       end
   end
 
   def mentor_training_params
-    params.require(:claims_claim_mentor_training_form).permit(
+    params.require(:claims_support_claim_mentor_training_form).permit(
       :hours_completed,
       :custom_hours_completed,
     ).merge(default_params)

--- a/app/controllers/claims/support/schools/claims/mentors_controller.rb
+++ b/app/controllers/claims/support/schools/claims/mentors_controller.rb
@@ -24,17 +24,7 @@ class Claims::Support::Schools::Claims::MentorsController < Claims::ApplicationC
 
   def update
     if claim_mentors_form.save
-      path = if claim.mentor_trainings.without_hours.any?
-               edit_claims_support_school_claim_mentor_training_path(
-                 claim.school,
-                 claim,
-                 claim.mentor_trainings.without_hours.first,
-               )
-             else
-               check_claims_support_school_claim_path(claim.school, claim)
-             end
-
-      redirect_to path
+      redirect_to claim_mentors_form.update_success_path
     else
       render :edit
     end
@@ -53,9 +43,9 @@ class Claims::Support::Schools::Claims::MentorsController < Claims::ApplicationC
   def claim_mentors_form
     @claim_mentors_form ||=
       if params[:claims_claim].present?
-        Claims::Claim::MentorsForm.new(claim:, mentor_ids: claim_params[:mentor_ids])
+        Claims::Support::Claim::MentorsForm.new(claim:, mentor_ids: claim_params[:mentor_ids])
       else
-        Claims::Claim::MentorsForm.new(claim:)
+        Claims::Support::Claim::MentorsForm.new(claim:)
       end
   end
 

--- a/app/controllers/claims/support/schools/claims_controller.rb
+++ b/app/controllers/claims/support/schools/claims_controller.rb
@@ -37,9 +37,10 @@ class Claims::Support::Schools::ClaimsController < Claims::Support::ApplicationC
       @claim,
       last_mentor_training,
       params: {
-        claims_claim_mentor_training_form: { hours_completed: last_mentor_training.hours_completed },
+        claims_support_claim_mentor_training_form: { hours_completed: last_mentor_training.hours_completed },
       },
     )
+    Claims::Claim::RemoveEmptyMentorTrainingHours.call(claim: @claim)
   end
 
   def edit; end

--- a/app/forms/claims/support/claim/mentor_training_form.rb
+++ b/app/forms/claims/support/claim/mentor_training_form.rb
@@ -1,0 +1,31 @@
+class Claims::Support::Claim::MentorTrainingForm < Claims::Claim::MentorTrainingForm
+  def back_path
+    if claim.ready_to_be_checked?
+      check_claims_support_school_claim_path(claim.school, claim)
+    elsif mentor_trainings.index(mentor_training).zero?
+      edit_claims_support_school_claim_mentor_path(claim.school, claim, mentor_training.mentor_id)
+    else
+      previous_mentor_training = mentor_trainings[mentor_trainings.index(mentor_training) - 1]
+      edit_claims_support_school_claim_mentor_training_path(
+        claim.school,
+        claim,
+        previous_mentor_training,
+        params: {
+          claims_support_claim_mentor_training_form: { hours_completed: previous_mentor_training.hours_completed },
+        },
+      )
+    end
+  end
+
+  def success_path
+    if claim.mentor_trainings.without_hours.any?
+      edit_claims_support_school_claim_mentor_training_path(
+        claim.school,
+        claim,
+        claim.mentor_trainings.without_hours.first,
+      )
+    else
+      check_claims_support_school_claim_path(claim.school, claim)
+    end
+  end
+end

--- a/app/forms/claims/support/claim/mentors_form.rb
+++ b/app/forms/claims/support/claim/mentors_form.rb
@@ -1,0 +1,13 @@
+class Claims::Support::Claim::MentorsForm < Claims::Claim::MentorsForm
+  def update_success_path
+    if claim.mentor_trainings.without_hours.any?
+      edit_claims_support_school_claim_mentor_training_path(
+        claim.school,
+        claim,
+        claim.mentor_trainings.without_hours.first,
+      )
+    else
+      check_claims_support_school_claim_path(claim.school, claim)
+    end
+  end
+end

--- a/app/views/claims/support/schools/claims/check.html.erb
+++ b/app/views/claims/support/schools/claims/check.html.erb
@@ -57,7 +57,7 @@
                                  @claim,
                                  mentor_training,
                                  params: {
-                                   claims_claim_mentor_training_form: { hours_completed: mentor_training.hours_completed },
+                                   claims_support_claim_mentor_training_form: { hours_completed: mentor_training.hours_completed },
                                  },
                                ),
                                html_attributes: {

--- a/app/views/claims/support/schools/claims/mentor_trainings/edit.html.erb
+++ b/app/views/claims/support/schools/claims/mentor_trainings/edit.html.erb
@@ -6,7 +6,7 @@
 <% render "claims/support/primary_navigation", current: :organisations %>
 
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: edit_claims_support_school_claim_mentor_path(@school, mentor_training_form.claim)) %>
+  <%= govuk_back_link(href: mentor_training_form.back_path) %>
 <% end %>
 
 <div class="govuk-width-container">

--- a/app/views/claims/support/schools/claims/mentors/edit.html.erb
+++ b/app/views/claims/support/schools/claims/mentors/edit.html.erb
@@ -2,7 +2,7 @@
 <% render "claims/support/primary_navigation", current: :organisations %>
 
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: edit_claims_support_school_claim_path(@school, claim_mentors_form.claim)) %>
+  <%= govuk_back_link(href: check_claims_support_school_claim_path(@school, claim_mentors_form.claim)) %>
 <% end %>
 
 <div class="govuk-width-container">

--- a/spec/forms/claims/support/claim/mentor_training_form_spec.rb
+++ b/spec/forms/claims/support/claim/mentor_training_form_spec.rb
@@ -1,0 +1,179 @@
+require "rails_helper"
+
+describe Claims::Support::Claim::MentorTrainingForm, type: :model do
+  let!(:claim) { create(:claim) }
+  let!(:mentor_training) { create(:mentor_training, claim:, mentor:, hours_completed: 6) }
+  let(:mentor) { create(:mentor, first_name: "Anne") }
+  let(:hours_completed) { 20 }
+
+  describe "validations" do
+    context "when hours_completed is blank" do
+      it "returns invalid" do
+        form = described_class.new(claim:, mentor_training:)
+        expect(form.valid?).to eq(false)
+        expect(form.errors.messages[:hours_completed]).to include("Select the number of hours")
+      end
+    end
+
+    context "when custom_hours_completed is blank and user clicked on custom hours radio button" do
+      it "returns invalid" do
+        form = described_class.new(claim:, mentor_training:, hours_completed: "on")
+        expect(form.valid?).to eq(false)
+        expect(form.errors.messages[:custom_hours_completed]).to include("Enter the number of hours")
+      end
+    end
+  end
+
+  describe "save" do
+    it "adds hours completed to the mentor_training " do
+      mentor_training_with_custom_hours = create(
+        :mentor_training,
+        claim:,
+        mentor: create(:mentor),
+      )
+
+      form = described_class.new(
+        claim:,
+        mentor_training: mentor_training_with_custom_hours,
+        hours_completed: "20",
+      )
+
+      expect {
+        form.save!
+      }.to change { mentor_training_with_custom_hours.hours_completed }.to eq(20)
+    end
+
+    context "when custom_hours_completed is available" do
+      it "adds hours custom_hours_completed to the mentor_training " do
+        mentor_training_with_completed_hours = create(
+          :mentor_training,
+          hours_completed: 20,
+          claim:,
+          mentor: create(:mentor),
+        )
+
+        form = described_class.new(
+          claim:,
+          mentor_training: mentor_training_with_completed_hours,
+          hours_completed: "on",
+          custom_hours_completed: "12",
+        )
+
+        expect {
+          form.save!
+        }.to change { mentor_training_with_completed_hours.hours_completed }.to eq(12)
+      end
+    end
+
+    describe "#back_path" do
+      context "when we are on the first mentor training hours page" do
+        it "returns the path to the mentors check list" do
+          form = described_class.new(claim:, mentor_training:)
+
+          expect(form.back_path).to eq(
+            "/support/schools/#{claim.school_id}/claims/#{claim.id}/mentors/#{mentor_training.mentor_id}/edit",
+          )
+        end
+      end
+
+      context "when we are on the second mentor training hours page" do
+        it "returns the path to the first mentor training" do
+          second_mentor_training = create(
+            :mentor_training,
+            claim:,
+            mentor: create(:mentor, first_name: "John"),
+          )
+          form = described_class.new(claim:, mentor_training: second_mentor_training)
+
+          expect(form.back_path).to eq(
+            "/support/schools/#{claim.school_id}/claims/#{claim.id}/mentor_trainings/#{mentor_training.id}/edit?claims_support_claim_mentor_training_form%5Bhours_completed%5D=#{mentor_training.hours_completed}",
+          )
+        end
+      end
+    end
+
+    describe "#success_path" do
+      context "when there are no more mentor trainings without hours completed" do
+        it "returns the path to the check page" do
+          form = described_class.new(claim:, mentor_training:)
+
+          expect(form.success_path).to eq(
+            "/support/schools/#{claim.school_id}/claims/#{claim.id}/check",
+          )
+        end
+      end
+
+      context "when there are mentor trainings without hours completed" do
+        it "returns the path to the next mentor training hours" do
+          mentor_training_without_hours = create(
+            :mentor_training,
+            claim:,
+            mentor: create(:mentor),
+          )
+          form = described_class.new(claim:, mentor_training:)
+
+          expect(form.success_path).to eq(
+            "/support/schools/#{claim.school_id}/claims/#{claim.id}/mentor_trainings/#{mentor_training_without_hours.id}/edit",
+          )
+        end
+      end
+    end
+
+    describe "#custom_hours?" do
+      context "when user choosed the radio button to input custom hours" do
+        it "returns true" do
+          form = described_class.new(claim:, mentor_training:, hours_completed: "on")
+          expect(form.custom_hours?).to eq(true)
+        end
+      end
+
+      context "when the mentor training has custom_hours_completed" do
+        it "returns true" do
+          mentor_training_with_custom_hours = create(
+            :mentor_training,
+            hours_completed: 12,
+            claim:,
+            mentor: create(:mentor),
+          )
+
+          form = described_class.new(
+            claim:,
+            mentor_training: mentor_training_with_custom_hours,
+            hours_completed: "12",
+          )
+          expect(form.custom_hours?).to eq(true)
+        end
+      end
+
+      context "when the mentor training has pre-determened hours_completed" do
+        it "returns false" do
+          form = described_class.new(claim:, mentor_training:, hours_completed: "20")
+          expect(form.custom_hours?).to eq(false)
+        end
+      end
+    end
+  end
+
+  describe "#custom_hours?" do
+    context "when user inputs pre selected hours" do
+      it "returns false" do
+        form = described_class.new(claim:, mentor_training:, hours_completed: "20")
+        expect(form.custom_hours?).to eq(false)
+      end
+    end
+
+    context "when user inputs custom hours" do
+      it "returns true" do
+        form = described_class.new(claim:, mentor_training:, hours_completed: "on")
+        expect(form.custom_hours?).to eq(true)
+      end
+    end
+
+    context "when user edits custom hours" do
+      it "returns true" do
+        form = described_class.new(claim:, mentor_training:, hours_completed: "12")
+        expect(form.custom_hours?).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/forms/claims/support/claim/mentors_form_spec.rb
+++ b/spec/forms/claims/support/claim/mentors_form_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+describe Claims::Support::Claim::MentorsForm, type: :model do
+  let!(:claim) { create(:claim) }
+  let!(:mentor1) { create(:mentor) }
+  let!(:mentor2) { create(:mentor) }
+
+  describe "validations" do
+    context "when mentors is blank" do
+      it "returns invalid" do
+        form = described_class.new(claim:)
+        expect(form.valid?).to eq(false)
+        expect(form.errors.messages[:mentor_ids]).to include("Select a mentor")
+      end
+    end
+  end
+
+  describe "#to_model" do
+    it "returns an instance of a Claims::Claim" do
+      form = described_class.new(claim:)
+      expect(form.to_model).to be_a Claims::Claim
+    end
+  end
+
+  describe "save" do
+    it "creates mentor trainings on the claim" do
+      mentor_ids = [mentor1, mentor2].map(&:id)
+      form = described_class.new(claim:, mentor_ids:)
+
+      expect {
+        form.save!
+      }.to change { claim.reload.mentor_trainings }.to match_array([
+        have_attributes(mentor_id: mentor1.id, provider_id: claim.provider_id),
+        have_attributes(mentor_id: mentor2.id, provider_id: claim.provider_id),
+      ])
+    end
+  end
+
+  describe "#update_success_path" do
+    context "when there are mentors without mentor training hours" do
+      it "returns the path to the mentor training hours form" do
+        mentor_training = create(
+          :mentor_training,
+          claim:,
+          mentor: mentor1,
+        )
+        form = described_class.new(claim:)
+
+        expect(form.update_success_path).to eq(
+          "/support/schools/#{claim.school_id}/claims/#{claim.id}/mentor_trainings/#{mentor_training.id}/edit",
+        )
+      end
+    end
+
+    context "when all mentors have mentor training hours" do
+      it "returns the path to the claim check page" do
+        if claim.mentor_trainings
+          claim.mentor_trainings.update_all(hours_completed: 20)
+        end
+        form = described_class.new(claim:)
+
+        expect(form.update_success_path).to eq(
+          "/support/schools/#{claim.school_id}/claims/#{claim.id}/check",
+        )
+      end
+    end
+  end
+end

--- a/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
@@ -101,6 +101,12 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
     then_i_check_my_answers(provider1, [mentor1, mentor2], [20, 12])
   end
 
+  scenario "Anne click the back link on the check page" do
+    given_i_visit_claim_check_page
+    when_i_click("Back")
+    then_i_expect_the_training_hours_for(20, mentor2)
+  end
+
   private
 
   def given_i_sign_in

--- a/spec/system/claims/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/schools/claims/create_claim_spec.rb
@@ -29,6 +29,11 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     when_i_click("Continue")
     then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor2)
     when_i_choose_other_amount_and_input_hours(12)
+    when_i_click("Back")
+    then_i_expect_the_training_hours_for(20, mentor1)
+    when_i_click("Continue")
+    then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor2)
+    when_i_choose_other_amount_and_input_hours(12)
     when_i_click("Continue")
     then_i_check_my_answers
     when_i_click("Submit claim")
@@ -158,6 +163,11 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     within(".govuk-panel") do
       expect(page).to have_content("Claim submitted\nYour reference number\n#{claim.reference}")
     end
+  end
+
+  def then_i_expect_the_training_hours_for(hours, mentor)
+    expect(page).to have_content("Hours of training for #{mentor.full_name}")
+    find("#claims-claim-mentor-training-form-hours-completed-#{hours}-field").checked?
   end
 
   def then_i_see_the_error(message)

--- a/spec/system/claims/support/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/create_claim_spec.rb
@@ -31,6 +31,11 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     when_i_click("Continue")
     then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor2)
     when_i_choose_other_amount_and_input_hours(12)
+    when_i_click("Back")
+    then_i_expect_the_training_hours_for(20, mentor1)
+    when_i_click("Continue")
+    then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor2)
+    when_i_choose_other_amount_and_input_hours(12)
     when_i_click("Continue")
     then_i_check_my_answers
     when_i_click("Add claim")
@@ -136,6 +141,11 @@ RSpec.describe "Create claim", type: :system, service: :claims do
         expect(page).to have_content("12 hours")
       end
     end
+  end
+
+  def then_i_expect_the_training_hours_for(hours, mentor)
+    expect(page).to have_content("Hours of training for #{mentor.full_name}")
+    find("#claims-support-claim-mentor-training-form-hours-completed-#{hours}-field").checked?
   end
 
   def then_i_am_redirectd_to_index_page(claim)


### PR DESCRIPTION
## Context

Previously the claim form was used for the support user and normal user journey. These journeys start to diverge a bit, mainly when redirecting the user so to make our code a bit more manageable we decided to split the claim forms into 2.

This commit also fixes some issues with redirecting the support user to the correct page

## Changes proposed in this pull request

Created new `::Support` claim forms with their redirect paths

## Guidance to review

Log in as Colin
Create a claim
On the check page change the mentors
Add a mentor and click continue
Hit the back link to not input any training hours
Hit the back link again
The Mentor you added without mentor training hours should not be on the check page again

## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/1f9d44d3-7ecb-4ff0-a7aa-7039a736bdf7
