### PR TITLE
Allow support user to edit draft claim

### DIFF
--- a/app/controllers/claims/support/schools/claims_controller.rb
+++ b/app/controllers/claims/support/schools/claims_controller.rb
@@ -54,9 +54,10 @@ class Claims::Support::Schools::ClaimsController < Claims::Support::ApplicationC
   end
 
   def draft
+    success_message = @claim.draft? ? t(".update_success") : t(".add_success")
     Claims::Claim::CreateDraft.call(claim: @claim)
 
-    redirect_to claims_support_school_claims_path(@school), flash: { success: t(".success") }
+    redirect_to claims_support_school_claims_path(@school), flash: { success: success_message }
   end
 
   private

--- a/app/forms/claims/claim/mentor_training_form.rb
+++ b/app/forms/claims/claim/mentor_training_form.rb
@@ -14,9 +14,7 @@ class Claims::Claim::MentorTrainingForm < ApplicationForm
   end
 
   def back_path
-    if claim.ready_to_be_checked?
-      check_claims_school_claim_path(claim.school, claim)
-    elsif mentor_trainings.index(mentor_training).zero?
+    if mentor_trainings.index(mentor_training).zero?
       edit_claims_school_claim_mentor_path(claim.school, claim, mentor_training.mentor_id)
     else
       previous_mentor_training = mentor_trainings[mentor_trainings.index(mentor_training) - 1]

--- a/app/forms/claims/claim/provider_form.rb
+++ b/app/forms/claims/claim/provider_form.rb
@@ -20,7 +20,7 @@ class Claims::Claim::ProviderForm < ApplicationForm
   def updated_claim
     @updated_claim ||= begin
       claim.provider_id = provider_id
-      claim.status = :internal_draft
+      claim.status = :internal_draft if claim.status.nil?
       claim.created_by = current_user
       claim
     end

--- a/app/forms/claims/support/claim/mentor_training_form.rb
+++ b/app/forms/claims/support/claim/mentor_training_form.rb
@@ -1,8 +1,6 @@
 class Claims::Support::Claim::MentorTrainingForm < Claims::Claim::MentorTrainingForm
   def back_path
-    if claim.ready_to_be_checked?
-      check_claims_support_school_claim_path(claim.school, claim)
-    elsif mentor_trainings.index(mentor_training).zero?
+    if mentor_trainings.index(mentor_training).zero?
       edit_claims_support_school_claim_mentor_path(claim.school, claim, mentor_training.mentor_id)
     else
       previous_mentor_training = mentor_trainings[mentor_trainings.index(mentor_training) - 1]

--- a/app/models/claims/claim.rb
+++ b/app/models/claims/claim.rb
@@ -63,8 +63,4 @@ class Claims::Claim < ApplicationRecord
   def amount
     Claims::Claim::CalculateAmount.call(claim: self)
   end
-
-  def ready_to_be_checked?
-    mentors.present? && mentor_trainings.without_hours.blank?
-  end
 end

--- a/app/policies/claims/claim_policy.rb
+++ b/app/policies/claims/claim_policy.rb
@@ -19,8 +19,9 @@ class Claims::ClaimPolicy < Claims::ApplicationPolicy
     !user.support_user? && record.submitted?
   end
 
+  # TODO: Remove record.draft? and not create drafts for existing drafts
   def draft?
-    user.support_user? && record.internal_draft?
+    user.support_user? && (record.internal_draft? || record.draft?)
   end
 
   def check?

--- a/app/views/claims/support/schools/claims/check.html.erb
+++ b/app/views/claims/support/schools/claims/check.html.erb
@@ -75,7 +75,7 @@
           <% end %>
         <% end %>
 
-      <%= govuk_button_to t(".submit"), draft_claims_support_school_claim_path(@school, @claim) %>
+      <%= govuk_button_to (@claim.draft? ? t(".update") : t(".submit")), draft_claims_support_school_claim_path(@school, @claim) %>
 
       <p class="govuk-body">
         <%= govuk_link_to t("cancel"), claims_support_school_claims_path(@school), no_visited_state: true %>

--- a/app/views/claims/support/schools/claims/show.html.erb
+++ b/app/views/claims/support/schools/claims/show.html.erb
@@ -22,6 +22,13 @@
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: Claims::Claim.human_attribute_name(:accredited_provider)) %>
             <% row.with_value(text: @claim.provider.name) %>
+            <% if policy(@claim).edit? %>
+              <% row.with_action(text: t("change"),
+                                 href: edit_claims_support_school_claim_path(@school, @claim),
+                                 html_attributes: {
+                                    class: "govuk-link--no-visited-state",
+                                    }) %>
+            <% end %>
           <% end %>
         <% else %>
           <% summary_list.with_row do |row| %>
@@ -38,6 +45,13 @@
                 <li><%= mentor.full_name %></li>
               <% end %>
             </ul>
+          <% end %>
+          <% if policy(@claim).edit? %>
+            <% row.with_action(text: t("change"),
+                               href: edit_claims_support_school_claim_mentor_path(@school, @claim),
+                               html_attributes: {
+                        class: "govuk-link--no-visited-state",
+                      }) %>
           <% end %>
         <% end %>
 
@@ -63,6 +77,20 @@
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: mentor_training.mentor.full_name) %>
             <% row.with_value(text: "#{mentor_training.hours_completed} #{t(".hours")}") %>
+            <% if policy(@claim).edit? %>
+              <% row.with_action(text: t("change"),
+                                 href: edit_claims_support_school_claim_mentor_training_path(
+                                  @school,
+                                  @claim,
+                                  mentor_training,
+                                  params: {
+                                    claims_support_claim_mentor_training_form: { hours_completed: mentor_training.hours_completed },
+                                  },
+                                ),
+                                 html_attributes: {
+                                  class: "govuk-link--no-visited-state",
+                                }) %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/config/locales/en/claims/support/schools/claims.yml
+++ b/config/locales/en/claims/support/schools/claims.yml
@@ -4,12 +4,14 @@ en:
       schools:
         claims:
           draft:
-            success: Claim added
+            add_success:  Claim added
+            update_success: Claim updated
           edit:
             page_title: Accredited provider - Add claim
           check:
             page_title: Check your answers
             submit: Add claim
+            update: Update claim
             grant_funding: Grant funding
             add_claim: Add claim - %{school}
             hours: "%{hours} hours"

--- a/spec/models/claims/claim_spec.rb
+++ b/spec/models/claims/claim_spec.rb
@@ -110,26 +110,4 @@ RSpec.describe Claims::Claim, type: :model do
       end
     end
   end
-
-  describe "#ready_to_be_checked?" do
-    it "returns true if the claim's mentors all have their hours recorded" do
-      claim = create(:claim)
-      create(:mentor_training, hours_completed: 20, claim:)
-
-      expect(claim.ready_to_be_checked?).to eq(true)
-    end
-
-    it "returns false if the claim does have mentors" do
-      claim = build(:claim)
-
-      expect(claim.ready_to_be_checked?).to eq(false)
-    end
-
-    it "returns false if the claim does have mentor training hours" do
-      claim = create(:claim)
-      create(:mentor_training, hours_completed: nil, claim:)
-
-      expect(claim.ready_to_be_checked?).to eq(false)
-    end
-  end
 end

--- a/spec/policies/claims/claim_policy_spec.rb
+++ b/spec/policies/claims/claim_policy_spec.rb
@@ -110,7 +110,7 @@ describe Claims::ClaimPolicy do
 
     context "when user has a draft claim" do
       it "grants access" do
-        expect(claim_policy).not_to permit(support_user, draft_claim)
+        expect(claim_policy).to permit(support_user, draft_claim)
       end
     end
 

--- a/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
     when_i_click_change_training_hours_for_mentor
     then_i_expect_the_training_hours_to_be_selected("20")
     when_i_click("Back")
-    then_i_check_my_answers(provider1, [mentor1, mentor2], [20, 12])
+    then_i_see_the_list_of_mentors
   end
 
   scenario "Anne click the back link on the check page" do
@@ -108,6 +108,12 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
   end
 
   private
+
+  def then_i_see_the_list_of_mentors
+    expect(page).to have_content("#{mentor1.full_name}\n#{mentor1.trn}")
+    expect(page).to have_content("#{mentor2.full_name}\n#{mentor2.trn}")
+    expect(page).to have_content("#{mentor3.full_name}\n#{mentor3.trn}")
+  end
 
   def given_i_sign_in
     visit sign_in_path

--- a/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
     when_i_click_change_training_hours_for_mentor
     then_i_expect_the_training_hours_to_be_selected("20")
     when_i_click("Back")
-    then_i_check_my_answers(provider1, [mentor1, mentor2], [20, 12])
+    then_i_see_the_list_of_mentors
   end
 
   scenario "Collin click the back link on the check page" do
@@ -116,6 +116,12 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
   end
 
   private
+
+  def then_i_see_the_list_of_mentors
+    expect(page).to have_content("#{mentor1.full_name}\n#{mentor1.trn}")
+    expect(page).to have_content("#{mentor2.full_name}\n#{mentor2.trn}")
+    expect(page).to have_content("#{mentor3.full_name}\n#{mentor3.trn}")
+  end
 
   def given_i_sign_in
     visit sign_in_path

--- a/spec/system/claims/support/schools/claims/edit_draft_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/edit_draft_claim_spec.rb
@@ -1,0 +1,125 @@
+require "rails_helper"
+
+RSpec.describe "Edit a draft claim", type: :system, service: :claims do
+  let!(:claims_mentor) { create(:claims_mentor, first_name: "Barry", last_name: "Garlow") }
+  let!(:another_claims_mentor) { create(:claims_mentor, first_name: "Laura", last_name: "Clark") }
+
+  let(:school) { create(:claims_school, name: "A School", region: regions(:inner_london), mentors: [claims_mentor, another_claims_mentor]) }
+  let!(:colin) { create(:claims_support_user, :colin) }
+
+  let!(:best_practice_network_provider) { create(:claims_provider, :best_practice_network) }
+  let!(:niot_provider) { create(:claims_provider, :niot) }
+
+  let!(:draft_claim) do
+    create(
+      :claim,
+      :draft,
+      school:,
+      reference: "12345678",
+      provider: best_practice_network_provider,
+      submitted_by: colin,
+    )
+  end
+
+  let!(:submitted_claim) do
+    create(
+      :claim,
+      :submitted,
+      school:,
+      reference: "12345679",
+      submitted_at: Time.new(2024, 3, 5, 12, 31, 52, "+00:00"),
+      provider: best_practice_network_provider,
+      submitted_by: colin,
+    )
+  end
+
+  let!(:draft_mentor_training) { create(:mentor_training, claim: draft_claim, mentor: claims_mentor, hours_completed: 6) }
+  let!(:submitted_mentor_training) { create(:mentor_training, claim: submitted_claim, mentor: claims_mentor, hours_completed: 6) }
+
+  scenario "A support user I can edit a draft claim" do
+    user_exists_in_dfe_sign_in(user: colin)
+    given_i_sign_in
+    when_i_select_a_school
+    when_i_click_on_claims
+    when_i_visit_the_draft_claim_show_page
+    then_i_edit_the_provider
+    then_i_edit_the_mentors
+    then_i_edit_the_hours_of_training
+    then_i_update_the_claim
+  end
+
+  scenario "A support user I can't edit a non draft claim" do
+    user_exists_in_dfe_sign_in(user: colin)
+    given_i_sign_in
+    when_i_select_a_school
+    when_i_click_on_claims
+    then_i_cant_edit_the_submitted_claim
+  end
+
+  private
+
+  def then_i_update_the_claim
+    click_on("Update claim")
+    expect(page).to have_content("Claim updated")
+  end
+
+  def then_i_edit_the_hours_of_training
+    all("a", text: "Change")[2].click
+    page.choose("Another amount")
+    fill_in("Enter whole numbers up to a maximum of 20 hours", with: 11)
+    click_on("Continue")
+    expect(page).to have_content("Barry Garlow11 hoursChange")
+  end
+
+  def then_i_edit_the_mentors
+    all("a", text: "Change")[1].click
+    page.check(another_claims_mentor.full_name)
+    click_on("Continue")
+    page.choose("20 hours")
+    click_on("Continue")
+    page.choose("20 hours")
+    click_on("Continue")
+
+    expect(page).to have_content("Laura Clark")
+    expect(page).to have_content("Barry Garlow")
+  end
+
+  def then_i_edit_the_provider
+    expect(page).to have_content("Accredited providerBest Practice NetworkChange")
+    first("a", text: "Change").click
+    page.choose(niot_provider.name)
+    click_on("Continue")
+    expect(page).to have_content("Accredited providerNIoT: National Institute of Teaching, founded by the School-Led Development TrustChange")
+  end
+
+  def when_i_visit_the_draft_claim_show_page
+    click_on draft_claim.reference
+
+    expect(page).to have_content("Best Practice NetworkChange")
+    expect(page).to have_content("Barry Garlow\nChange")
+    expect(page).to have_content("Barry Garlow#{draft_mentor_training.hours_completed} hoursChange")
+  end
+
+  def then_i_cant_edit_the_submitted_claim
+    click_on submitted_claim.reference
+
+    expect(page).not_to have_content("Best Practice NetworkChange")
+    expect(page).not_to have_content("Barry Garlow\nChange")
+    expect(page).not_to have_content("Barry Garlow#{submitted_mentor_training.hours_completed} hoursChange")
+  end
+
+  def when_i_select_a_school
+    click_on "A School"
+  end
+
+  def when_i_click_on_claims
+    within(".app-secondary-navigation__list") do
+      click_on("Claims")
+    end
+  end
+
+  def given_i_sign_in
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+end


### PR DESCRIPTION
## Context

We want to allow a support user to edit a draft claim

## Changes proposed in this pull request

Add change links.

As part of this PR we refactored the back links when making changes to a draft claim. Previously it was in an infinite loop with the back link. Now when a user clicks back, it will take the user back through the flow in the order of when you are creating a claim. This seems sensible and keeps the flow consistent when creating and editing a claim.

## Guidance to review

- Sign in as support user
- Create a claim for a school
- Submit it
- Visit that claims show page and use change links

## Link to Trello card

https://trello.com/c/IDz69VhK/271-allow-support-user-to-edit-draft-claim

## Screenshots

<!-- Sceenshots to aid with reviewing if neede
<img width="918" alt="Screenshot 2024-04-05 at 09 36 57" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/4da1c743-2e89-47c4-9c51-b29ebb65da70">
d-->
