### PR TITLE
Make footer more accessible

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,10 +1,10 @@
 <%= govuk_footer meta_items: footer_meta_items, meta_licence: false do |footer| %>
   <%= footer.with_content_before_meta_items do %>
-    <h2 class="govuk-heading-m"><%= t(".get_help") %></h2>
+    <h3 class="govuk-heading-m"><%= t(".get_help") %></h3>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h3 class="govuk-heading-3 govuk-!-margin-top-0 govuk-!-margin-bottom-1"><%= t(".email.heading") %></h3>
+        <h4 class="govuk-heading-3 govuk-!-margin-top-0 govuk-!-margin-bottom-1"><%= t(".email.heading") %></h4>
 
         <p class="govuk-!-font-size-16 govuk-!-margin-bottom-1">
           <%= govuk_footer_link_to t("#{current_service}.support_email"), "mailto:#{t("#{current_service}.support_email")}?subject=#{t("#{current_service}.service_name")}%20support" %>


### PR DESCRIPTION
## Context

Regarding this comment: https://github.com/DFE-Digital/itt-mentor-services/pull/444#pullrequestreview-1982467656

Update h2 tag to allow for  better accessibility

## Guidance to review

- View the footer HTMl via the chrome dev tools 

## Link to Trello card

https://trello.com/c/14qOEqVR/351-double-h2-tags-in-footer

## Screenshots

Before:

<img width="1035" alt="Screenshot 2024-04-05 at 13 33 47" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/998dd00e-0846-4a56-b3f7-fdf97d2cb014">

After:
<img width="529" alt="Screenshot 2024-04-05 at 13 34 44" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/9c5475c8-a263-44fd-8b5b-0d00e50fe6d0">
