### PR TITLE
Add autocomplete select component

### DIFF
--- a/app/components/autocomplete_select_form_component.html.erb
+++ b/app/components/autocomplete_select_form_component.html.erb
@@ -29,10 +29,6 @@
       <% end %>
 
       <%= f.govuk_submit t(".continue") %>
-
-      <p class="govuk-body">
-        <%= govuk_link_to(t(".cancel"), back_link, no_visited_state: true) %>
-      </p>
     </div>
   </div>
 <% end %>

--- a/app/components/autocomplete_select_form_component.html.erb
+++ b/app/components/autocomplete_select_form_component.html.erb
@@ -1,0 +1,38 @@
+<%= form_with(
+  model:,
+  scope:,
+  url:,
+  method: "get",
+  data: {
+    turbo: data[:turbo],
+    controller: data[:controller],
+    autocomplete_path_value: data[:autocomplete_path_value],
+    autocomplete_return_attributes_value: data[:autocomplete_return_attributes_value],
+  },
+  builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= content_tag(:div, class: class_names("govuk-form-group", "govuk-form-group--error": f.object.errors.present?)) do %>
+        <%= f.govuk_text_field input[:field_name], value: input[:value],
+                                                   label: { text: input[:label], size: "l" },
+                                                   caption: { text: input[:caption], size: "l" },
+                                                   data: { autocomplete_target: "serverInput",
+                                                           previous_search: input[:previous_search] } %>
+
+        <div class="govuk-!-margin-bottom-7" data-autocomplete-target="input"
+          data-input-name="<%= data[:input_name] %>"
+          data-action="focusin->autocomplete#clearUndefinedSuggestions click->autocomplete#clearUndefinedSuggestions">
+        </div>
+      <% end %>
+
+      <%= f.govuk_submit t(".continue") %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to(t(".cancel"), back_link, no_visited_state: true) %>
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/app/components/autocomplete_select_form_component.rb
+++ b/app/components/autocomplete_select_form_component.rb
@@ -1,0 +1,61 @@
+class AutocompleteSelectFormComponent < ApplicationComponent
+  attr_reader :model, :scope, :url, :back_link, :data, :input
+
+  # data: { :turbo, :controller, :autocomplete_path_value,
+  #         :autocomplete_return_attributes_value, :input_name }
+  # input: { :field_name, :value, :label, :caption, :previous_search }
+
+  def initialize(model:, scope:, url:, back_link:, data: {},
+                 input: {}, classes: [], html_attributes: {})
+    super(classes:, html_attributes:)
+
+    @model = model
+    @scope = scope
+    @url = url
+    @data = data
+    @back_link = back_link
+    @input = input
+
+    setup_default_data
+    validate_data
+    setup_default_input_field
+  end
+
+  private
+
+  def setup_default_data
+    @data[:turbo] ||= false
+    @data[:controller] ||= "autocomplete"
+    @data[:input_name] ||= "#{scope}[name]"
+  end
+
+  def validate_data
+    if @data[:autocomplete_path_value].blank?
+      raise InvalidComponentError,
+            I18n.t(
+              "components.autocomplete_select_form_component.errors" \
+                ".data.autocomplete_path_value.blank",
+            )
+    end
+
+    if @data[:autocomplete_return_attributes_value].blank?
+      raise InvalidComponentError,
+            I18n.t(
+              "components.autocomplete_select_form_component.errors" \
+                ".data.autocomplete_return_attributes_value.blank",
+            )
+    end
+  end
+
+  def setup_default_input_field
+    @input[:field_name] ||= :id
+    @input[:label] ||= I18n.t(
+      "components.autocomplete_select_form_component.label",
+    )
+    @input[:caption] ||= I18n.t(
+      "components.autocomplete_select_form_component.caption",
+    )
+  end
+end
+
+class InvalidComponentError < StandardError; end

--- a/app/components/autocomplete_select_form_component.rb
+++ b/app/components/autocomplete_select_form_component.rb
@@ -1,11 +1,11 @@
 class AutocompleteSelectFormComponent < ApplicationComponent
-  attr_reader :model, :scope, :url, :back_link, :data, :input
+  attr_reader :model, :scope, :url, :data, :input
 
   # data: { :turbo, :controller, :autocomplete_path_value,
   #         :autocomplete_return_attributes_value, :input_name }
   # input: { :field_name, :value, :label, :caption, :previous_search }
 
-  def initialize(model:, scope:, url:, back_link:, data: {},
+  def initialize(model:, scope:, url:, data: {},
                  input: {}, classes: [], html_attributes: {})
     super(classes:, html_attributes:)
 
@@ -13,7 +13,6 @@ class AutocompleteSelectFormComponent < ApplicationComponent
     @scope = scope
     @url = url
     @data = data
-    @back_link = back_link
     @input = input
 
     setup_default_data

--- a/app/forms/provider_onboarding_form.rb
+++ b/app/forms/provider_onboarding_form.rb
@@ -5,7 +5,7 @@ class ProviderOnboardingForm < ApplicationForm
   validate :provider_exists?
   validate :provider_already_onboarded?
 
-  delegate :id, :name, to: :provider, allow_nil: true, prefix: true
+  delegate :name, to: :provider, allow_nil: true
 
   def persist
     provider.update!(placements_service: true)

--- a/app/forms/provider_onboarding_form.rb
+++ b/app/forms/provider_onboarding_form.rb
@@ -5,6 +5,8 @@ class ProviderOnboardingForm < ApplicationForm
   validate :provider_exists?
   validate :provider_already_onboarded?
 
+  delegate :id, :name, to: :provider, allow_nil: true, prefix: true
+
   def persist
     provider.update!(placements_service: true)
   end

--- a/app/forms/school_onboarding_form.rb
+++ b/app/forms/school_onboarding_form.rb
@@ -6,6 +6,8 @@ class SchoolOnboardingForm < ApplicationForm
   validate :school_exists?
   validate :school_already_onboarded?
 
+  delegate :id, :name, to: :school, allow_nil: true, prefix: true
+
   def persist
     school.update!("#{service}_service" => true)
   end

--- a/app/forms/school_onboarding_form.rb
+++ b/app/forms/school_onboarding_form.rb
@@ -6,7 +6,7 @@ class SchoolOnboardingForm < ApplicationForm
   validate :school_exists?
   validate :school_already_onboarded?
 
-  delegate :id, :name, to: :school, allow_nil: true, prefix: true
+  delegate :name, to: :school, allow_nil: true
 
   def persist
     school.update!("#{service}_service" => true)

--- a/app/views/claims/support/schools/new.html.erb
+++ b/app/views/claims/support/schools/new.html.erb
@@ -10,7 +10,6 @@
     model: @school_form,
     scope: :school,
     url: check_claims_support_schools_path,
-    back_link: claims_support_schools_path,
     data: {
       autocomplete_path_value: "/api/school_suggestions",
       autocomplete_return_attributes_value: %w[town postcode],
@@ -22,4 +21,8 @@
       previous_search: @school_form&.school&.id,
     },
   ) %>
+
+  <p class="govuk-body">
+    <%= govuk_link_to(t(".cancel"), claims_support_schools_path, no_visited_state: true) %>
+  </p>
 </div>

--- a/app/views/claims/support/schools/new.html.erb
+++ b/app/views/claims/support/schools/new.html.erb
@@ -6,41 +6,20 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <%= form_with(
+  <%= render AutocompleteSelectFormComponent.new(
     model: @school_form,
     scope: :school,
     url: check_claims_support_schools_path,
-    method: "get",
+    back_link: claims_support_schools_path,
     data: {
-      turbo: false,
-      controller: "autocomplete",
       autocomplete_path_value: "/api/school_suggestions",
       autocomplete_return_attributes_value: %w[town postcode],
     },
-  ) do |f| %>
-
-    <%= f.govuk_error_summary %>
-
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <%= content_tag(:div, class: class_names("govuk-form-group", "govuk-form-group--error": f.object.errors.present?)) do %>
-          <%= f.govuk_text_field :id, value: @school_form&.school&.name,
-                                      label: { text: t(".title"), size: "l" },
-                                      caption: { text: t(".caption"), size: "l" },
-                                      data: { autocomplete_target: "serverInput",
-                                              previous_search: @school_form&.school&.id } %>
-
-          <div class="govuk-!-margin-bottom-7" data-autocomplete-target="input" data-input-name="school[name]"
-            data-action="focusin->autocomplete#clearUndefinedSuggestions click->autocomplete#clearUndefinedSuggestions">
-          </div>
-        <% end %>
-
-        <%= f.govuk_submit t(".continue") %>
-
-        <p class="govuk-body">
-          <%= govuk_link_to(t(".cancel"), claims_support_schools_path, no_visited_state: true) %>
-        </p>
-      </div>
-    </div>
-  <% end %>
+    input: {
+      value: @school_form&.school&.name,
+      label: t(".title"),
+      caption: t(".caption"),
+      previous_search: @school_form&.school&.id,
+    },
+  ) %>
 </div>

--- a/app/views/claims/support/schools/new.html.erb
+++ b/app/views/claims/support/schools/new.html.erb
@@ -15,10 +15,10 @@
       autocomplete_return_attributes_value: %w[town postcode],
     },
     input: {
-      value: @school_form.school_name,
+      value: @school_form.name,
       label: t(".title"),
       caption: t(".caption"),
-      previous_search: @school_form.school_id,
+      previous_search: @school_form.id,
     },
   ) %>
 

--- a/app/views/claims/support/schools/new.html.erb
+++ b/app/views/claims/support/schools/new.html.erb
@@ -15,10 +15,10 @@
       autocomplete_return_attributes_value: %w[town postcode],
     },
     input: {
-      value: @school_form&.school&.name,
+      value: @school_form.school_name,
       label: t(".title"),
       caption: t(".caption"),
-      previous_search: @school_form&.school&.id,
+      previous_search: @school_form.school_id,
     },
   ) %>
 

--- a/app/views/placements/support/providers/new.html.erb
+++ b/app/views/placements/support/providers/new.html.erb
@@ -5,40 +5,20 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <%= form_with(
+  <%= render AutocompleteSelectFormComponent.new(
     model: @provider_form,
     scope: :provider,
     url: check_placements_support_providers_path,
-    method: "get",
+    back_link: placements_support_organisations_path,
     data: {
-      turbo: false,
-      controller: "autocomplete",
       autocomplete_path_value: "/api/provider_suggestions",
       autocomplete_return_attributes_value: %w[code],
     },
-  ) do |f| %>
-    <%= f.govuk_error_summary %>
-
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <%= content_tag(:div, class: class_names("govuk-form-group", "govuk-form-group--error": f.object.errors.present?)) do %>
-          <%= f.govuk_text_field :id, value: @provider_form&.provider&.name,
-                                      label: { text: t(".title"), size: "l" },
-                                      caption: { text: t(".caption"), size: "l" },
-                                      data: { autocomplete_target: "serverInput",
-                                              previous_search: @provider_form&.provider&.id } %>
-
-          <div class="govuk-!-margin-bottom-7" data-autocomplete-target="input"
-            data-input-name="provider[name]"
-            data-action="focusin->autocomplete#clearUndefinedSuggestions click->autocomplete#clearUndefinedSuggestions"></div>
-        <% end %>
-
-        <%= f.govuk_submit t(".continue") %>
-
-        <p class="govuk-body">
-          <%= govuk_link_to(t(".cancel"), placements_support_organisations_path, no_visited_state: true) %>
-        </p>
-      </div>
-    </div>
-  <% end %>
+    input: {
+      value: @provider_form&.provider&.name,
+      label: t(".title"),
+      caption: t(".caption"),
+      previous_search: @provider_form&.provider&.id,
+    },
+  ) %>
 </div>

--- a/app/views/placements/support/providers/new.html.erb
+++ b/app/views/placements/support/providers/new.html.erb
@@ -14,10 +14,10 @@
       autocomplete_return_attributes_value: %w[code],
     },
     input: {
-      value: @provider_form.provider_name,
+      value: @provider_form.name,
       label: t(".title"),
       caption: t(".caption"),
-      previous_search: @provider_form.provider_id,
+      previous_search: @provider_form.id,
     },
   ) %>
 

--- a/app/views/placements/support/providers/new.html.erb
+++ b/app/views/placements/support/providers/new.html.erb
@@ -9,7 +9,6 @@
     model: @provider_form,
     scope: :provider,
     url: check_placements_support_providers_path,
-    back_link: placements_support_organisations_path,
     data: {
       autocomplete_path_value: "/api/provider_suggestions",
       autocomplete_return_attributes_value: %w[code],
@@ -21,4 +20,8 @@
       previous_search: @provider_form&.provider&.id,
     },
   ) %>
+
+  <p class="govuk-body">
+    <%= govuk_link_to(t(".cancel"), placements_support_organisations_path, no_visited_state: true) %>
+  </p>
 </div>

--- a/app/views/placements/support/providers/new.html.erb
+++ b/app/views/placements/support/providers/new.html.erb
@@ -14,10 +14,10 @@
       autocomplete_return_attributes_value: %w[code],
     },
     input: {
-      value: @provider_form&.provider&.name,
+      value: @provider_form.provider_name,
       label: t(".title"),
       caption: t(".caption"),
-      previous_search: @provider_form&.provider&.id,
+      previous_search: @provider_form.provider_id,
     },
   ) %>
 

--- a/app/views/placements/support/schools/new.html.erb
+++ b/app/views/placements/support/schools/new.html.erb
@@ -5,40 +5,20 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <%= form_with(
+  <%= render AutocompleteSelectFormComponent.new(
     model: @school_form,
     scope: :school,
     url: check_placements_support_schools_path,
-    method: "get",
+    back_link: placements_support_organisations_path,
     data: {
-      turbo: false,
-      controller: "autocomplete",
       autocomplete_path_value: "/api/school_suggestions",
       autocomplete_return_attributes_value: %w[town postcode],
     },
-  ) do |f| %>
-    <%= f.govuk_error_summary %>
-
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <%= content_tag(:div, class: class_names("govuk-form-group", "govuk-form-group--error": f.object.errors.present?)) do %>
-          <%= f.govuk_text_field :id, value: @school_form&.school&.name,
-                                      label: { text: t(".title"), size: "l" },
-                                      caption: { text: t(".caption"), size: "l" },
-                                      data: { autocomplete_target: "serverInput",
-                                              previous_search: @school_form&.school&.id } %>
-
-          <div class="govuk-!-margin-bottom-7" data-autocomplete-target="input" data-input-name="school[name]"
-            data-action="focusin->autocomplete#clearUndefinedSuggestions click->autocomplete#clearUndefinedSuggestions">
-          </div>
-        <% end %>
-
-        <%= f.govuk_submit t(".continue") %>
-
-        <p class="govuk-body">
-          <%= govuk_link_to(t(".cancel"), placements_support_organisations_path, no_visited_state: true) %>
-        </p>
-      </div>
-    </div>
-  <% end %>
+    input: {
+      value: @school_form&.school&.name,
+      label: t(".title"),
+      caption: t(".caption"),
+      previous_search: @school_form&.school&.id,
+    },
+  ) %>
 </div>

--- a/app/views/placements/support/schools/new.html.erb
+++ b/app/views/placements/support/schools/new.html.erb
@@ -14,10 +14,10 @@
       autocomplete_return_attributes_value: %w[town postcode],
     },
     input: {
-      value: @school_form&.school&.name,
+      value: @school_form.school_name,
       label: t(".title"),
       caption: t(".caption"),
-      previous_search: @school_form&.school&.id,
+      previous_search: @school_form.school_id,
     },
   ) %>
 

--- a/app/views/placements/support/schools/new.html.erb
+++ b/app/views/placements/support/schools/new.html.erb
@@ -14,10 +14,10 @@
       autocomplete_return_attributes_value: %w[town postcode],
     },
     input: {
-      value: @school_form.school_name,
+      value: @school_form.name,
       label: t(".title"),
       caption: t(".caption"),
-      previous_search: @school_form.school_id,
+      previous_search: @school_form.id,
     },
   ) %>
 

--- a/app/views/placements/support/schools/new.html.erb
+++ b/app/views/placements/support/schools/new.html.erb
@@ -9,7 +9,6 @@
     model: @school_form,
     scope: :school,
     url: check_placements_support_schools_path,
-    back_link: placements_support_organisations_path,
     data: {
       autocomplete_path_value: "/api/school_suggestions",
       autocomplete_return_attributes_value: %w[town postcode],
@@ -21,4 +20,8 @@
       previous_search: @school_form&.school&.id,
     },
   ) %>
+
+  <p class="govuk-body">
+    <%= govuk_link_to(t(".cancel"), placements_support_organisations_path, no_visited_state: true) %>
+  </p>
 </div>

--- a/config/locales/en/components/autocomplete_select_form_component.yml
+++ b/config/locales/en/components/autocomplete_select_form_component.yml
@@ -1,0 +1,13 @@
+en:
+  components:
+    autocomplete_select_form_component:
+      errors:
+        data:
+          autocomplete_path_value:
+            blank: "data[:autocomplete_path_value] can't be blank."
+          autocomplete_return_attributes_value:
+            blank: "data[:autocomplete_return_attributes_value] can't be blank."
+      continue: Continue
+      cancel: Cancel
+      caption: Caption
+      label: Label

--- a/config/locales/en/components/autocomplete_select_form_component.yml
+++ b/config/locales/en/components/autocomplete_select_form_component.yml
@@ -8,6 +8,5 @@ en:
           autocomplete_return_attributes_value:
             blank: "data[:autocomplete_return_attributes_value] can't be blank."
       continue: Continue
-      cancel: Cancel
       caption: Caption
       label: Label

--- a/spec/components/autocomplete_select_form_component_spec.rb
+++ b/spec/components/autocomplete_select_form_component_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe AutocompleteSelectFormComponent, type: :component do
       model:,
       scope:,
       url:,
-      back_link:,
       data:,
       input:,
     )
@@ -16,7 +15,6 @@ RSpec.describe AutocompleteSelectFormComponent, type: :component do
     let(:model) { User.new }
     let(:scope) { :form }
     let(:url) { "" }
-    let(:back_link) { "" }
     let(:input) { {} }
 
     describe "data attribute validation" do
@@ -63,7 +61,6 @@ RSpec.describe AutocompleteSelectFormComponent, type: :component do
     let(:model) { SchoolOnboardingForm.new }
     let(:scope) { :school }
     let(:url) { "" }
-    let(:back_link) { "" }
     let(:data) do
       {
         turbo: false,
@@ -102,7 +99,6 @@ RSpec.describe AutocompleteSelectFormComponent, type: :component do
     let(:model) { ProviderOnboardingForm.new }
     let(:scope) { :provider }
     let(:url) { "" }
-    let(:back_link) { "" }
     let(:data) do
       {
         turbo: false,

--- a/spec/components/autocomplete_select_form_component_spec.rb
+++ b/spec/components/autocomplete_select_form_component_spec.rb
@@ -1,0 +1,139 @@
+require "rails_helper"
+
+RSpec.describe AutocompleteSelectFormComponent, type: :component do
+  subject(:component) do
+    described_class.new(
+      model:,
+      scope:,
+      url:,
+      back_link:,
+      data:,
+      input:,
+    )
+  end
+
+  context "with default attributes" do
+    let(:model) { User.new }
+    let(:scope) { :form }
+    let(:url) { "" }
+    let(:back_link) { "" }
+    let(:input) { {} }
+
+    describe "data attribute validation" do
+      context "when not given a autocomplete_path_value attribute" do
+        let(:data) { {} }
+
+        it "raises an error" do
+          expect { component }.to raise_error(
+            InvalidComponentError,
+            "data[:autocomplete_path_value] can't be blank.",
+          )
+        end
+      end
+
+      context "when not given a autocomplete_return_attributes_value attribute" do
+        let(:data) { { autocomplete_path_value: "#" } }
+
+        it "raises an error" do
+          expect { component }.to raise_error(
+            InvalidComponentError,
+            "data[:autocomplete_return_attributes_value] can't be blank.",
+          )
+        end
+      end
+    end
+
+    context "when given sufficent data attributes" do
+      let(:data) do
+        { autocomplete_path_value: "#", autocomplete_return_attributes_value: [:value] }
+      end
+
+      it "returns an autocomplete select form" do
+        render_inline(component)
+
+        expect(page.find(".govuk-label")).to have_content("Label")
+        expect(page.find(".govuk-caption-l")).to have_content("Caption")
+        expect(page).to have_field("form-id-field")
+        page.find("div[data-input-name='form[name]']")
+      end
+    end
+  end
+
+  context "with school onboarding attributes" do
+    let(:model) { SchoolOnboardingForm.new }
+    let(:scope) { :school }
+    let(:url) { "" }
+    let(:back_link) { "" }
+    let(:data) do
+      {
+        turbo: false,
+        controller: "autocomplete",
+        autocomplete_path_value: "/api/school_suggestions",
+        autocomplete_return_attributes_value: %w[town postcode],
+        input_name: "school[name]",
+      }
+    end
+    let(:input) do
+      {
+        field_name: :id,
+        value: nil,
+        label: "Enter a school name, URN or postcode",
+        caption: "Add organisation",
+        previous_search: nil,
+      }
+    end
+
+    it "returns an autocomplete select form for onboarding schools" do
+      render_inline(component)
+
+      page.find(
+        "form[data-controller='autocomplete']" \
+        "[data-autocomplete-path-value='/api/school_suggestions']" \
+        "[data-autocomplete-return-attributes-value='[\"town\",\"postcode\"]']",
+      )
+      expect(page.find(".govuk-label")).to have_content("Enter a school name, URN or postcode")
+      expect(page.find(".govuk-caption-l")).to have_content("Add organisation")
+      expect(page).to have_field("school-id-field")
+      page.find("div[data-input-name='school[name]']")
+    end
+  end
+
+  context "with provider onboarding attributes" do
+    let(:model) { ProviderOnboardingForm.new }
+    let(:scope) { :provider }
+    let(:url) { "" }
+    let(:back_link) { "" }
+    let(:data) do
+      {
+        turbo: false,
+        controller: "autocomplete",
+        autocomplete_path_value: "/api/provider_suggestions",
+        autocomplete_return_attributes_value: %w[code],
+        input_name: "provider[name]",
+      }
+    end
+    let(:input) do
+      {
+        field_name: :id,
+        value: nil,
+        label: "Enter a provider name, UKPRN, URN or postcode",
+        caption: "Add organisation",
+        previous_search: nil,
+      }
+    end
+
+    it "returns an autocomplete select form for onboarding schools" do
+      render_inline(component)
+
+      page.find(
+        "form[data-controller='autocomplete']" \
+        "[data-autocomplete-path-value='/api/provider_suggestions']" \
+        "[data-autocomplete-return-attributes-value='[\"code\"]']",
+      )
+      expect(page.find(".govuk-label")).to have_content("Enter a provider name, UKPRN, URN or postcode")
+      expect(page.find(".govuk-caption-l")).to have_content("Add organisation")
+      expect(page).to have_field("provider-id-field")
+      page.find("div[data-input-name='provider[name]']")
+    end
+  end
+end

--- a/spec/components/previews/autocomplete_select_form_component_preview.rb
+++ b/spec/components/previews/autocomplete_select_form_component_preview.rb
@@ -1,0 +1,47 @@
+class AutocompleteSelectFormComponentPreview < ApplicationComponentPreview
+  def school_onboarding_form
+    render AutocompleteSelectFormComponent.new(
+      model: SchoolOnboardingForm.new,
+      scope: :school,
+      url: "#",
+      back_link: "#",
+      data: {
+        turbo: false,
+        controller: "autocomplete",
+        autocomplete_path_value: "/api/school_suggestions",
+        autocomplete_return_attributes_value: %w[town postcode],
+        input_name: "school[name]",
+      },
+      input: {
+        field_name: :id,
+        value: nil,
+        label: "Enter a school name, URN or postcode",
+        caption: "Add organisation",
+        previous_search: nil,
+      },
+    )
+  end
+
+  def provider_onboarding_form
+    render AutocompleteSelectFormComponent.new(
+      model: ProviderOnboardingForm.new,
+      scope: :provider,
+      url: "#",
+      back_link: "#",
+      data: {
+        turbo: false,
+        controller: "autocomplete",
+        autocomplete_path_value: "/api/provider_suggestions",
+        autocomplete_return_attributes_value: %w[code],
+        input_name: "provider[name]",
+      },
+      input: {
+        field_name: :id,
+        value: nil,
+        label: "Enter a provider name, UKPRN, URN or postcode",
+        caption: "Add organisation",
+        previous_search: nil,
+      },
+    )
+  end
+end

--- a/spec/components/previews/autocomplete_select_form_component_preview.rb
+++ b/spec/components/previews/autocomplete_select_form_component_preview.rb
@@ -4,7 +4,6 @@ class AutocompleteSelectFormComponentPreview < ApplicationComponentPreview
       model: SchoolOnboardingForm.new,
       scope: :school,
       url: "#",
-      back_link: "#",
       data: {
         turbo: false,
         controller: "autocomplete",
@@ -27,7 +26,6 @@ class AutocompleteSelectFormComponentPreview < ApplicationComponentPreview
       model: ProviderOnboardingForm.new,
       scope: :provider,
       url: "#",
-      back_link: "#",
       data: {
         turbo: false,
         controller: "autocomplete",

--- a/spec/forms/provider_onboarding_form_spec.rb
+++ b/spec/forms/provider_onboarding_form_spec.rb
@@ -37,6 +37,25 @@ describe ProviderOnboardingForm, type: :model do
     end
   end
 
+  describe "delegations" do
+    describe "#name" do
+      context "when provider is nil" do
+        it "returns nil" do
+          form = described_class.new
+          expect(form.name).to eq(nil)
+        end
+      end
+
+      context "when provider exists" do
+        it "returns then name of the provider" do
+          provider = create(:provider, name: "Provider 1")
+          form = described_class.new(id: provider.id)
+          expect(form.name).to eq("Provider 1")
+        end
+      end
+    end
+  end
+
   describe "#provider" do
     context "when given the urn of an existing provider" do
       it "returns the provider associated with that urn" do

--- a/spec/forms/school_onboarding_form_spec.rb
+++ b/spec/forms/school_onboarding_form_spec.rb
@@ -47,6 +47,25 @@ describe SchoolOnboardingForm, type: :model do
     end
   end
 
+  describe "delegations" do
+    describe "#name" do
+      context "when school is nil" do
+        it "returns nil" do
+          form = described_class.new
+          expect(form.name).to eq(nil)
+        end
+      end
+
+      context "when school exists" do
+        it "returns then name of the school" do
+          school = create(:school, name: "School 1")
+          form = described_class.new(id: school.id)
+          expect(form.name).to eq("School 1")
+        end
+      end
+    end
+  end
+
   describe "#school" do
     context "when given the id of an existing school" do
       it "returns the school associated with that id" do


### PR DESCRIPTION
## Context

- For ease of coding and reuse. An AutocompleteSelectFormComponent has replaced the repetitive code.

## Changes proposed in this pull request

- Implement AutocompleteSelectFormComponent
- Replace existing duplicated code to use AutocompleteSelectFormComponent

## Guidance to review

_(Claims)_
- Sign in as Colin
- Test Onboarding Schools

_(Placements)_
- Sign in as Colin
- Test Onboarding Schools
- Test Onboarding Providers

_Previews available at_
http://placements.localhost:3000/rails/view_components
http://placements.localhost:3000/rails/view_components/autocomplete_select_form_component/provider_onboarding_form
http://placements.localhost:3000/rails/view_components/autocomplete_select_form_component/school_onboarding_form

http://claims.localhost:3000/rails/view_components
http://claims.localhost:3000/rails/view_components/autocomplete_select_form_component/provider_onboarding_form
http://claims.localhost:3000/rails/view_components/autocomplete_select_form_component/school_onboarding_form

## Link to Trello card

https://trello.com/c/8EINwpQR/231-implement-a-viewcomponent-for-autocomplete-select-forms

## Screenshots

https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/e7d8b5df-162e-42ae-a8a1-d27a2740a483

https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/3b60fe12-31f5-49c6-ac54-e439b2234fd9



