### PR TITLE
Update content for start page and claims page

### DIFF
--- a/app/views/claims/pages/start.html.erb
+++ b/app/views/claims/pages/start.html.erb
@@ -8,6 +8,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <p class="govuk-body"><%= t(".claim_guidance") %></p>
+      <p class="govuk-body"><%= t(".closing_date_html") %></p>
       <p class="govuk-body"><%= t(".training_guidance") %></p>
 
       <h2 class="govuk-heading-m"><%= t(".before_you_start") %></h2>
@@ -19,15 +20,6 @@
       </ul>
 
       <%= govuk_start_button(text: t(".start_now"), href: sign_in_path) %>
-
-      <h2 class="govuk-heading-m"><%= t(".get_an_account") %></h2>
-      <p class="govuk-body"><%= t(".account_guidance") %></p>
-      <p class="govuk-body">
-        <%= t(
-          ".setup_organisation_guidance_html",
-          link_to: govuk_mail_to(t("claims.support_email")),
-        ) %>
-      </p>
     </div>
 
     <div class="govuk-grid-column-one-third">

--- a/app/views/claims/schools/claims/index.html.erb
+++ b/app/views/claims/schools/claims/index.html.erb
@@ -5,10 +5,13 @@
   <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 
   <% if @school.mentors.any? %>
-    <p class="govuk-inset-text"><%= t(".guidance") %></p>
+    <p class="govuk-body"><%= t(".guidance") %></p>
+    <p class="govuk-body"><%= t(".final_date") %></p>
     <%= govuk_link_to t(".add_claim"), new_claims_school_claim_path, class: "govuk-button" %>
   <% else %>
     <p class="govuk-inset-text"><%= t(".add_mentor_guidance_html", link_to: govuk_link_to(t(".add_a_mentor"), claims_school_mentors_path(@school))) %></p>
+    <p class="govuk-body"><%= t(".guidance") %></p>
+    <p class="govuk-body"><%= t(".final_date") %></p>
   <% end %>
 
   <% if @claims.any? %>

--- a/config/locales/en/claims/pages.yml
+++ b/config/locales/en/claims/pages.yml
@@ -4,16 +4,14 @@ en:
       start:
         page_title: Claim funding for mentor training
         claim_guidance: You can claim funding for mentors who supported trainee teachers from September 2023 to July 2024.
+        closing_date_html: "Final closing date for claims: <b>19 July 2024 11:59pm<b/>"
         training_guidance: Training that took place from April 2024 for the school year starting September 2024 can only be claimed for from May 2025.
         before_you_start: Before you start
         you_will_be_asked: "You’ll be asked for:"
-        itt_provider: initial teacher training (ITT) provider details
-        trn: your mentors’ teacher reference numbers (TRN)
-        hours_of_training: hours of training each mentor completed
+        itt_provider: Initial Teacher Training provider name
+        trn: the mentors’ Teacher Reference Numbers (TRN)
+        hours_of_training: hours of training the mentor completed
         start_now: Start now
-        get_an_account: Get an account to claim funding for mentor training
-        account_guidance: Ask a colleague within your organisation to add you if you do not have an account.
-        setup_organisation_guidance_html: If your organisation has not been set up to claim funding for mentor training, send an email to %{link_to}.
         provider_guidance_link: Guidance for providers on initial teacher training (ITT)
         trn_guidance_link: Find out what a teacher reference number (TRN) is and how to find or request a TRN
         related_content: Related content

--- a/config/locales/en/claims/schools/claims.yml
+++ b/config/locales/en/claims/schools/claims.yml
@@ -14,7 +14,7 @@ en:
           guidance: We will check your claim before processing payment. If we need to contact you for further information, we will use the email you used to access this service.
         check:
           page_title: Check your answers
-          warning: You will not be able to change any of the claim details once you have submitted it.
+          warning: You will be able to change the details of this claim up to and including July 19 2024
           submit: Submit claim
           add_claim: Add claim
           declaration: Declaration
@@ -33,8 +33,9 @@ en:
         index:
           heading: Claims
           add_claim: Add claim
-          guidance: You can only claim for the academic year September 2023 to July 2024.
-          add_mentor_guidance_html: You need to %{link_to} before creating a claim.</p>
+          guidance: Claims can only be made for the school year September 2023 to July 2024.
+          final_date: The final date to submit a claim is 19 July 2024.
+          add_mentor_guidance_html: Before you can start a claim, you need to %{link_to}.</p>
           add_a_mentor: add a mentor
         update:
           claim_updated: Claim updated

--- a/spec/system/claims/schools/claims/view_claims_spec.rb
+++ b/spec/system/claims/schools/claims/view_claims_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "View claims", type: :system, service: :claims do
   def i_can_see_the_add_a_mentor_guidance
     within(".govuk-inset-text") do
       expect(page).to have_content(
-        "You need to add a mentor before creating a claim.",
+        "Before you can start a claim, you need to add a mentor.",
       )
       expect(page).to have_link("add a mentor", href: "/schools/#{school.id}/mentors")
     end
@@ -95,9 +95,9 @@ RSpec.describe "View claims", type: :system, service: :claims do
   end
 
   def i_can_see_the_claim_guidance
-    within(".govuk-inset-text") do
+    within(first(".govuk-body")) do
       expect(page).to have_content(
-        "You can only claim for the academic year September 2023 to July 2024.",
+        "Claims can only be made for the school year September 2023 to July 2024.",
       )
     end
   end

--- a/spec/system/claims/start_page_spec.rb
+++ b/spec/system/claims/start_page_spec.rb
@@ -63,6 +63,8 @@ RSpec.describe "Start Page", type: :system, service: :claims do
       expect(page).to have_content("Claim funding for mentor training")
     end
 
+    expect(page).to have_content("Final closing date for claims: 19 July 2024 11:59pm")
+
     expect(page).to have_content(
       "You can claim funding for mentors who supported trainee teachers from "\
        "September 2023 to July 2024.",
@@ -74,15 +76,9 @@ RSpec.describe "Start Page", type: :system, service: :claims do
     expect(page).to have_content(
       "Before you start\n"\
       "You’ll be asked for:\n"\
-      "initial teacher training (ITT) provider details "\
-      "your mentors’ teacher reference numbers (TRN) "\
-      "hours of training each mentor completed",
-    )
-    expect(page).to have_content(
-      "Get an account to claim funding for mentor training\n"\
-      "Ask a colleague within your organisation to add you if you do not have an account.\n"\
-      "If your organisation has not been set up to claim funding for mentor training, "\
-      "send an email to ittmentor.funding@education.gov.uk.",
+      "Initial Teacher Training provider name "\
+      "the mentors’ Teacher Reference Numbers (TRN) "\
+      "hours of training the mentor completed",
     )
     expect(page).to have_content("Related content")
     expect(page).to have_link(


### PR DESCRIPTION
## Context

Update content to match designs
Figma: https://www.figma.com/file/xWtG7TR9y1f9pvPMzOZ81a/Track-and-pay?type=design&node-id=60489-25307&mode=design
## Changes proposed in this pull request

Update content

## Guidance to review

- Visit start page and compare content and design to Figma and Prototype
- Visit claims page and compare content and design to Figma and Prototype

## Link to Trello card

https://trello.com/c/0GdeZEF5/364-add-19th-july-as-closing-date-to-submit-claim-to-start-page-and-elsewhere

## Things to check

## Screenshots
With no mentors
<img width="793" alt="Screenshot 2024-04-10 at 17 47 17" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/b7b77507-15df-4251-a9c9-f35920b32c94">

With mentors 
<img width="808" alt="Screenshot 2024-04-10 at 17 47 29" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/12ba2a9b-6c53-49fb-bc68-5c44df28da64">

Start page
<img width="905" alt="Screenshot 2024-04-10 at 17 57 05" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/4fbad09a-a285-4548-812d-4e5858e495f1">

<!-- Sceenshots to aid with reviewing if needed-->
