### PR TITLE
Change staging PUBLISH_BASE_URL app env to point to staging environment

### DIFF
--- a/terraform/application/config/staging_app_env.yml
+++ b/terraform/application/config/staging_app_env.yml
@@ -1,7 +1,7 @@
 ---
 SIGN_IN_METHOD: dfe-sign-in
 GIAS_CSV_BASE_URL: https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public
-PUBLISH_BASE_URL: https://api.publish-teacher-training-courses.service.gov.uk
+PUBLISH_BASE_URL: https://staging.api.publish-teacher-training-courses.service.gov.uk
 HOSTING_ENV: staging
 TEACHING_RECORD_BASE_URL: https://preprod.teacher-qualifications-api.education.gov.uk
 TEACHING_RECORD_API_MINOR_VERSION: 20240101


### PR DESCRIPTION
## Context

In staging, we can point to _other_ staging environments. This will ensure production services are intact while we perform any testing.

## Changes proposed in this pull request

- Update `PUBLISH_BASE_URL` to point to `staging.api.publish-teacher-training-courses.service.gov.uk`

## Guidance to review

- Try updating your local setup to point to `staging.api.`, it should work as it does now.
