### PR TITLE
Revert "Silence deprecation warning by monkey-patching Rack for Capybara"

### DIFF
--- a/config/initializers/capybara.rb
+++ b/config/initializers/capybara.rb
@@ -1,9 +1,0 @@
-# https://github.com/teamcapybara/capybara/issues/2705#issuecomment-1752093026
-
-if Rails.env.test?
-  require "rackup"
-
-  module Rack
-    Handler = ::Rackup::Handler
-  end
-end


### PR DESCRIPTION
Reverts DFE-Digital/itt-mentor-services#76

This monkey-patch was only required temporarily while we waited for teamcapybara/capybara#2706 to be packaged into a release. It was included in [Capybara release 3.40.0](https://github.com/teamcapybara/capybara/compare/3.39.2...3.40.0) which we've been using since #181.

So it should be safe to revert the mokey-patch now.