### PR TITLE
Allow multiple hosts for each service

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -6,10 +6,12 @@ PORT=3000
 DFE_SIGN_IN_ISSUER_URL=https://dev-oidc.signin.education.gov.uk
 
 CLAIMS_HOST=claims.localhost
+CLAIMS_HOSTS=claims.localhost
 CLAIMS_DFE_SIGN_IN_CLIENT_ID=123
 CLAIMS_DFE_SIGN_IN_SECRET=secret
 
 PLACEMENTS_HOST=placements.localhost
+PLACEMENTS_HOSTS=placements.localhost
 PLACEMENTS_DFE_SIGN_IN_CLIENT_ID=123
 PLACEMENTS_DFE_SIGN_IN_SECRET=secret
 

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -1,4 +1,6 @@
-scope module: :claims, as: :claims, constraints: { host: ENV["CLAIMS_HOST"] } do
+scope module: :claims, as: :claims, constraints: {
+  host: [ENV["CLAIMS_HOST"], *ENV.fetch("CLAIMS_HOSTS", "").split(",")],
+} do
   root to: "pages#start"
 
   scope module: :pages do

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -1,7 +1,10 @@
 scope module: :placements,
       as: :placements,
       constraints: {
-        host: ENV["PLACEMENTS_HOST"],
+        host: [
+          ENV["PLACEMENTS_HOST"],
+          *ENV.fetch("PLACEMENTS_HOSTS", "").split(","),
+        ],
       } do
   root to: redirect("/sign-in")
 

--- a/lib/hosting_environment.rb
+++ b/lib/hosting_environment.rb
@@ -49,9 +49,9 @@ module HostingEnvironment
 
   def self.current_service(request)
     case request.host
-    when ENV["CLAIMS_HOST"]
+    when ENV["CLAIMS_HOST"], *ENV.fetch("CLAIMS_HOSTS", "").split(",")
       :claims
-    when ENV["PLACEMENTS_HOST"]
+    when ENV["PLACEMENTS_HOST"], *ENV.fetch("PLACEMENTS_HOSTS", "").split(",")
       :placements
     end
   end

--- a/spec/system/claims/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/schools/claims/create_claim_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe "Create claim", type: :system, service: :claims do
   end
 
   def then_i_am_redirected_to_root_path_with_alert
-    expect(page.current_url).to eq(claims_school_claims_url(school))
+    expect(page).to have_current_path(claims_school_claims_path(school))
     expect(page).to have_content "You cannot perform this action"
   end
 end


### PR DESCRIPTION
## Context

We need to allow multiple entry domains per service. This is because we want to have access to the apps both behind Azure Front Door and directly to the application.

The app will function as-is without the new `#{service}_HOSTS` env vars, but to allow multiple entry domains, you must use the plural `_HOSTS` env var alongside the `_HOST` env var.

The `#{service}_HOST` env var is used for the base url of email link hrefs.

## Changes proposed in this pull request

- Add `CLAIMS_HOSTS` and `PLACEMENTS_HOSTS` comma-separated env vars.

## Guidance to review

**Case 1**

- Don't add any additional env vars to your setup. It should "just work" as-is. The review app should also work without env var changes.

**Case 2**

- Pull down the code.
- Add the following env vars:

  ```dotenv
  CLAIMS_HOSTS=claims.localhost,claims-2.localhost
  PLACEMENTS_HOSTS=placements.localhost,placements-2.localhost
  ```

- You can now visit the apps at `claims.localhost:3000`, `claims-2.localhost:3000`, `placements.localhost:3000`, and `placements-2.localhost:3000`.
  - You may need to update your local "hosts" file to point these domains to your localhost.