### PR TITLE
Refactor dsi redirect in omniauth

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -31,12 +31,10 @@ when "dfe-sign-in"
   end
 
   SETUP_PROC = lambda do |env|
-    service = HostingEnvironment.current_service(Rack::Request.new(env))
+    request = Rack::Request.new(env)
+    service = HostingEnvironment.current_service(request)
 
-    dfe_sign_in_redirect_uri = URI.join(
-      HostingEnvironment.application_url(service),
-      "/auth/dfe/callback",
-    )
+    dfe_sign_in_redirect_uri = URI.join(request.base_url, "/auth/dfe/callback")
 
     env["omniauth.strategy"].options.client_options = {
       port: dfe_sign_in_issuer_uri&.port,

--- a/lib/hosting_environment.rb
+++ b/lib/hosting_environment.rb
@@ -14,11 +14,6 @@ module HostingEnvironment
     placements: ENV["PLACEMENTS_DFE_SIGN_IN_SECRET"],
   }.with_indifferent_access.freeze
 
-  SERVICE_HOST = {
-    claims: ENV["CLAIMS_HOST"],
-    placements: ENV["PLACEMENTS_HOST"],
-  }.with_indifferent_access.freeze
-
   def self.env
     @env ||= ActiveSupport::EnvironmentInquirer.new(ENV["HOSTING_ENV"].presence || "development")
   end
@@ -37,14 +32,6 @@ module HostingEnvironment
 
   def self.dfe_sign_in_secret(current_service)
     DFE_SIGN_IN_CLIENT_SECRETS.fetch(current_service)
-  end
-
-  def self.application_url(current_service)
-    if Rails.env.development?
-      "http://#{SERVICE_HOST.fetch(current_service)}:#{ENV.fetch("PORT", 3000)}"
-    else
-      "https://#{SERVICE_HOST.fetch(current_service)}"
-    end
   end
 
   def self.current_service(request)

--- a/spec/lib/hosting_environment_spec.rb
+++ b/spec/lib/hosting_environment_spec.rb
@@ -88,42 +88,6 @@ RSpec.describe HostingEnvironment do
     end
   end
 
-  describe ".application_url" do
-    it "returns the application url for claims" do
-      current_service = "claims"
-      expect(described_class.application_url(current_service)).to eq(
-        "https://claims.localhost",
-      )
-    end
-
-    it "returns the application url for placements" do
-      current_service = "placements"
-      expect(described_class.application_url(current_service)).to eq(
-        "https://placements.localhost",
-      )
-    end
-
-    context "when env is development" do
-      it "returns the application url for claims with port" do
-        allow(Rails.env).to receive(:development?).and_return(true)
-        current_service = "claims"
-
-        expect(described_class.application_url(current_service)).to eq(
-          "http://claims.localhost:3000",
-        )
-      end
-
-      it "returns the application url for placements with port" do
-        allow(Rails.env).to receive(:development?).and_return(true)
-        current_service = "placements"
-
-        expect(described_class.application_url(current_service)).to eq(
-          "http://placements.localhost:3000",
-        )
-      end
-    end
-  end
-
   describe ".current_service" do
     it "returns the current service for claims" do
       request = instance_double("Rack::Request", host: ENV["CLAIMS_HOST"])


### PR DESCRIPTION
## Context

We need the dsi redirect to be more flexible, to allow more hosts to user DFE sign in so this commit just gets the base url from the request i.e. http://host:port and we can append `auth/dfe/callback` to it.
## Changes proposed in this pull request

Omniauth dsi redirect URL
HostingEnvironment methods cleanup 

## Guidance to review

Use DFE sign-in on your local
It should work as normal

