### PR TITLE
Calculate total mentor training hours for a mentor for a given provider

### DIFF
--- a/app/models/claims/mentor.rb
+++ b/app/models/claims/mentor.rb
@@ -15,6 +15,7 @@
 #
 class Claims::Mentor < Mentor
   has_many :mentor_memberships
+  has_many :mentor_trainings
   has_many :schools, through: :mentor_memberships
 
   default_scope { joins(:mentor_memberships).distinct }

--- a/app/services/claims/calculate_total_mentor_training_hours_for_provider.rb
+++ b/app/services/claims/calculate_total_mentor_training_hours_for_provider.rb
@@ -1,0 +1,16 @@
+class Claims::CalculateTotalMentorTrainingHoursForProvider
+  include ServicePattern
+
+  def initialize(mentor:, provider:)
+    @mentor = mentor
+    @provider = provider
+  end
+
+  def call
+    mentor.mentor_trainings.where(provider:).sum(:hours_completed)
+  end
+
+  private
+
+  attr_reader :mentor, :provider
+end

--- a/spec/models/claims/mentor_spec.rb
+++ b/spec/models/claims/mentor_spec.rb
@@ -18,6 +18,7 @@ require "rails_helper"
 RSpec.describe Claims::Mentor, type: :model do
   context "with associations" do
     it { is_expected.to have_many(:mentor_memberships) }
+    it { is_expected.to have_many(:mentor_trainings) }
     it { is_expected.to have_many(:schools).through(:mentor_memberships) }
   end
 

--- a/spec/services/claims/calculate_total_mentor_training_hours_for_provider_spec.rb
+++ b/spec/services/claims/calculate_total_mentor_training_hours_for_provider_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe Claims::CalculateTotalMentorTrainingHoursForProvider do
+  subject(:calculate_total_training_hours) { described_class.call(mentor: create(:mentor, :provider)) }
+
+  let!(:mentor) { create(:claims_mentor) }
+
+  let!(:provider) { create(:claims_provider, :niot) }
+  let!(:provider_2) { create(:claims_provider, :best_practice_network) }
+
+  let!(:school) { create(:claims_school, :claims, name: "School name 1", region: regions(:inner_london), urn: "1234", local_authority_name: "blah", local_authority_code: "BLA", group: "Academy") }
+  let!(:claim) { create(:claim, school:, reference: "12345678") }
+
+  it_behaves_like "a service object" do
+    let(:params) { { mentor:, provider: } }
+  end
+
+  it "returns the total mentor training hours for a provider for a given mentor" do
+    create(:mentor_training, provider:, claim:, hours_completed: 20, mentor:)
+    create(:mentor_training, provider:, claim:, hours_completed: 20, mentor:)
+
+    create(:mentor_training, provider: provider_2, claim:, hours_completed: 20, mentor:)
+
+    result = described_class.call(mentor:, provider:)
+
+    expect(result).to eq(40)
+  end
+end


### PR DESCRIPTION
## Context

We should not allow a mentor to submit over 20 hours of training hours. Currently a mentor can submit 20 hours per claim meaning they can submit over 20 hours in total. 

## Changes proposed in this pull request

This change creates a service `Claims::CalculateTotalMentorTrainingHoursForProvider` which returns the total number of mentor training hours for a mentor. This logic will be used in the scenario where a mentor already has submitted 20 hours on a claim, and potentially attempts to submit another 20 hours on another claim for the same provider.

**NOTE: They can submit 20 hours in total per provider**

## Guidance to review

- Run the tests

## Link to Trello card

https://trello.com/c/B637194w/372-set-up-logic-to-only-allow-a-mentor-to-claim-up-to-20-hours-per-provider
