### PR TITLE
Allow DSI user to actually sign out

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -21,6 +21,6 @@ class SessionsController < ApplicationController
   def destroy
     DfESignInUser.end_session!(session)
 
-    redirect_to after_sign_out_path
+    redirect_to sign_in_user.logout_url(request), allow_other_host: true
   end
 end

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -46,6 +46,14 @@ class DfESignInUser
     )
   end
 
+  def logout_url(request)
+    if signed_in_from_dfe?
+      dfe_logout_url(request)
+    else
+      "/auth/developer/sign-out"
+    end
+  end
+
   def user
     @user ||= user_by_uid || user_by_email
   end
@@ -86,5 +94,18 @@ class DfESignInUser
     when :claims
       Claims::User
     end
+  end
+
+  def signed_in_from_dfe?
+    @provider == "dfe"
+  end
+
+  def dfe_logout_url(request)
+    uri = URI("#{ENV["DFE_SIGN_IN_ISSUER_URL"]}/session/end")
+    uri.query = {
+      id_token_hint: @id_token,
+      post_logout_redirect_uri: "#{request.base_url}/auth/dfe/sign-out",
+    }.to_query
+    uri.to_s
   end
 end

--- a/spec/models/dfe_sign_in_user_spec.rb
+++ b/spec/models/dfe_sign_in_user_spec.rb
@@ -73,6 +73,51 @@ describe DfESignInUser do
     end
   end
 
+  describe "#logout_url" do
+    context "when dfe sign in on" do
+      it "returns the dfe logout url" do
+        session = {
+          "dfe_sign_in_user" => {
+            "first_name" => "Example",
+            "last_name" => "User",
+            "email" => "example_user@example.com",
+            "last_active_at" => 1.hour.ago,
+            "dfe_sign_in_uid" => "123",
+            "id_token" => "123",
+            "provider" => "dfe",
+          },
+        }
+        dfe_sign_in_user = described_class.load_from_session(session, service: :claims)
+        request = instance_double(ActionDispatch::Request, base_url: "dfe_url")
+
+        expect(dfe_sign_in_user.logout_url(request)).to eq(
+          "https://dev-oidc.signin.education.gov.uk/session/end?id_token_hint="\
+          "123&post_logout_redirect_uri=dfe_url%2Fauth%2Fdfe%2Fsign-out",
+        )
+      end
+    end
+
+    context "when dfe sign in off" do
+      it "returns the developer sign out" do
+        session = {
+          "dfe_sign_in_user" => {
+            "first_name" => "Example",
+            "last_name" => "User",
+            "email" => "example_user@example.com",
+            "last_active_at" => 1.hour.ago,
+            "dfe_sign_in_uid" => "123",
+            "id_token" => "123",
+            "provider" => nil,
+          },
+        }
+        dfe_sign_in_user = described_class.load_from_session(session, service: :claims)
+        request = instance_double(ActionDispatch::Request, base_url: "dfe_url")
+
+        expect(dfe_sign_in_user.logout_url(request)).to eq("/auth/developer/sign-out")
+      end
+    end
+  end
+
   describe "#user" do
     describe "claims service" do
       it "returns the current Claims::User" do

--- a/spec/system/claims/sign_out_as_claims_user_spec.rb
+++ b/spec/system/claims/sign_out_as_claims_user_spec.rb
@@ -3,6 +3,12 @@ require "rails_helper"
 RSpec.describe "Sign out as a Claims User", type: :system, service: :claims do
   let(:colin) { create(:claims_support_user, :colin) }
 
+  before do
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(DfESignInUser).to receive(:logout_url).and_return("/auth/dfe/sign-out")
+    # rubocop:enable RSpec/AnyInstance
+  end
+
   scenario "I sign out" do
     given_there_is_an_existing_claims_user_with_a_school_for(colin)
     when_i_visit_the_sign_in_path
@@ -10,6 +16,8 @@ RSpec.describe "Sign out as a Claims User", type: :system, service: :claims do
     i_should_see_a_sign_out_button
     when_i_click_sign_out
     i_expect_to_be_on_sign_in_page
+    when_i_visit_claims_schools_details_path
+    then_i_am_unable_to_access_the_page
   end
 
   private
@@ -42,5 +50,13 @@ RSpec.describe "Sign out as a Claims User", type: :system, service: :claims do
   def i_expect_to_be_on_sign_in_page
     expect(page).to have_content("Sign in to Claim funding for mentor training")
     expect(page).to have_content("Sign in using DfE Sign In")
+  end
+
+  def when_i_visit_claims_schools_details_path
+    visit claims_schools_path
+  end
+
+  def then_i_am_unable_to_access_the_page
+    expect(page).to have_current_path(sign_in_path, ignore_query: true)
   end
 end

--- a/spec/system/placements/sign_out_as_a_placements_user_spec.rb
+++ b/spec/system/placements/sign_out_as_a_placements_user_spec.rb
@@ -3,6 +3,12 @@ require "rails_helper"
 RSpec.describe "Sign out as a Placements User", type: :system, service: :placements do
   let(:colin) { create(:placements_support_user, :colin) }
 
+  before do
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(DfESignInUser).to receive(:logout_url).and_return("/auth/dfe/sign-out")
+    # rubocop:enable RSpec/AnyInstance
+  end
+
   scenario "I sign out" do
     given_there_is_an_existing_placements_user_with_a_school_for(colin)
     when_i_visit_the_sign_in_path
@@ -10,6 +16,8 @@ RSpec.describe "Sign out as a Placements User", type: :system, service: :placeme
     i_should_see_a_sign_out_button
     when_i_click_sign_out
     i_expect_to_be_on_sign_in_page
+    when_i_visit_placements_schools_details_path
+    then_i_am_unable_to_access_the_page
   end
 
   private
@@ -42,5 +50,13 @@ RSpec.describe "Sign out as a Placements User", type: :system, service: :placeme
   def i_expect_to_be_on_sign_in_page
     expect(page).to have_content("Sign in to Manage school placements")
     expect(page).to have_content("Sign in using DfE Sign In")
+  end
+
+  def when_i_visit_placements_schools_details_path
+    visit placements_organisations_path
+  end
+
+  def then_i_am_unable_to_access_the_page
+    expect(page).to have_current_path(sign_in_path, ignore_query: true)
   end
 end


### PR DESCRIPTION
## Context

Previously, the sign out link didn't actually comunicated with DSI to
log out the user. It would still keep them logged in, on their end.

This commit will send a request to DSI to logout the user and redirect
back to our own sign out path

## Changes proposed in this pull request

New logout URL in the app

The logout URL has changed in the DSI console, for both placements and claims
![Screenshot from 2024-04-15 16-15-34](https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/72a1ccd1-9b79-4e2c-a23a-4b5f45b9d891)


## Guidance to review

Sign in with dfe sign in on local
Sign out
You should get the sign in form again

## Screenshots

Current:

https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/c28adb19-ca9b-4802-983a-19b02007f81d



Previously:


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/2dd9c9f6-6693-494d-9297-62011e7d5a5b




