### PR TITLE
Fix Hours of training form incorrect error stylings

### DIFF
--- a/app/views/claims/schools/claims/mentor_trainings/edit.html.erb
+++ b/app/views/claims/schools/claims/mentor_trainings/edit.html.erb
@@ -41,12 +41,12 @@
             checked: mentor_training_form.custom_hours?,
             label: { text: t(".other_amount") },
           ) do %>
-            <h5 class="govuk-heading-s govuk-!-margin-bottom-1"><%= t(".number_of_hours") %></h5>
             <%= f.govuk_number_field(
               :custom_hours_completed,
               value: mentor_training_form.custom_hours? ? mentor_training_form.mentor_training.hours_completed : nil,
               class: "govuk-input--width-2",
-              label: { text: t(".enter_whole_numbers") },
+              label: { text: t(".number_of_hours"), class: "govuk-!-font-weight-bold" },
+              hint: { text: t(".enter_whole_numbers") },
             ) %>
           <% end %>
         <% end %>

--- a/app/views/claims/support/schools/claims/mentor_trainings/edit.html.erb
+++ b/app/views/claims/support/schools/claims/mentor_trainings/edit.html.erb
@@ -41,12 +41,12 @@
             checked: mentor_training_form.custom_hours?,
             label: { text: t(".other_amount") },
           ) do %>
-            <h5 class="govuk-heading-s govuk-!-margin-bottom-1"><%= t(".number_of_hours") %></h5>
             <%= f.govuk_number_field(
               :custom_hours_completed,
               value: mentor_training_form.custom_hours? ? mentor_training_form.mentor_training.hours_completed : nil,
               class: "govuk-input--width-2",
-              label: { text: t(".enter_whole_numbers") },
+              label: { text: t(".number_of_hours"), class: "govuk-!-font-weight-bold" },
+              hint: { text: t(".enter_whole_numbers") },
             ) %>
           <% end %>
         <% end %>

--- a/spec/system/claims/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/schools/claims/create_claim_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe "Create claim", type: :system, service: :claims do
 
   def when_i_choose_other_amount_and_input_hours(hours)
     page.choose("Another amount")
-    fill_in("Enter whole numbers up to a maximum of 20 hours", with: hours)
+    fill_in("Number of hours", with: hours)
   end
 
   def then_i_check_my_answers

--- a/spec/system/claims/support/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/create_claim_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "Create claim", type: :system, service: :claims do
 
   def when_i_choose_other_amount_and_input_hours(hours)
     page.choose("Another amount")
-    fill_in("Enter whole numbers up to a maximum of 20 hours", with: hours)
+    fill_in("Number of hours", with: hours)
   end
 
   def then_i_check_my_answers

--- a/spec/system/claims/support/schools/claims/edit_draft_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/edit_draft_claim_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Edit a draft claim", type: :system, service: :claims do
   def then_i_edit_the_hours_of_training
     all("a", text: "Change")[2].click
     page.choose("Another amount")
-    fill_in("Enter whole numbers up to a maximum of 20 hours", with: 11)
+    fill_in("Number of hours", with: 11)
     click_on("Continue")
     expect(page).to have_content("Barry Garlow11 hoursChange")
   end


### PR DESCRIPTION
## Context

When the form errors due to no hours provided or is now between 1 and 20 the error styling is incorrect, this PR fixes that.

## Changes proposed in this pull request

Use the `hint` field and override the label css class

## Guidance to review

- Sign in as a support and normal user
- Create a claim
- When at the adding hours screen don't enter an amount or enter a number outside of 1-20
 
## Link to Trello card

https://trello.com/c/wq0VocAA/373-fix-red-line-error-on-hours-of-training-form

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots
Before
<img width="1305" alt="Screenshot 2024-04-16 at 13 29 16" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/4c08a5f7-b20b-4504-bc83-d6f07ff30131">

Afrer
<img width="989" alt="Screenshot 2024-04-16 at 13 25 24" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/ecd13b83-cddd-4ed5-a9e9-68ec73260a0d">

<!-- Sceenshots to aid with reviewing if needed-->
