### PR TITLE
Make the claims filters responsive

### DIFF
--- a/app/assets/stylesheets/filter-form.scss
+++ b/app/assets/stylesheets/filter-form.scss
@@ -7,30 +7,18 @@
   @include govuk-clearfix;
 }
 
-.app-filter-layout__filter {
-  @include govuk-media-query($from: desktop) {
-    float: left;
-    margin-right: govuk-spacing(6);
-    max-width: 310px;
-    min-width: 260px;
-    width: 100%;
-  }
-}
-
 .app-filter-layout__filter:focus {
-
   outline: $govuk-focus-width solid $govuk-focus-colour;
   outline-offset: 0;
 
   @include govuk-media-query(desktop) {
     outline: none;
   }
-
 }
 
 @include govuk-media-query($until: desktop) {
   .js-enabled .app-filter-layout__filter {
-    background-color: govuk-colour("white");
+    background-color: govuk-colour("light-grey");
     position: fixed; top: govuk-spacing(1); right: govuk_spacing(1); bottom: govuk_spacing(1);
     overflow-y: scroll;
     z-index: 100;
@@ -40,6 +28,7 @@
 .app-filter-layout__content {
   overflow: hidden;
   overflow-x: auto;
+  background-color: govuk-colour("light-grey");
 }
 
 .app-filter__header {
@@ -58,7 +47,6 @@
   @include govuk-media-query($from: desktop) {
     position: static;
   }
-
 }
 
 // JavaScript
@@ -151,7 +139,6 @@
     vertical-align: middle;
     width: 14px;
   }
-
 }
 
 .app-filter-layout__selected {
@@ -165,7 +152,6 @@
   ul:last-of-type {
     margin-bottom: 0; // IE9 +
   }
-
 }
 
 .app-filter__selected-heading {
@@ -263,6 +249,7 @@
   max-height: 200px;
   overflow-x: hidden;
   overflow-y: auto;
+  padding-left: govuk-spacing(2);
 }
 
 .app-filter__option input[type=search] {
@@ -280,3 +267,22 @@
   }
 }
 
+@include govuk-media-query(desktop) {
+  .display-initial {
+     display: initial;
+  }
+
+  .app-filter__close {
+    display: none;
+  }
+
+  .show-filter-button {
+    display: none;
+  }
+}
+
+@include govuk-media-query($until: desktop) {
+  .display-none-on-mobile {
+     display: none;
+  }
+}

--- a/app/assets/stylesheets/search-form.scss
+++ b/app/assets/stylesheets/search-form.scss
@@ -16,3 +16,14 @@
 .clear-search {
   margin-top: -20px;
 }
+
+@include govuk-media-query($until: desktop) {
+  .search-form {
+    display: block;
+  }
+
+  .search-form button {
+    margin-left: 0;
+    margin-top: govuk-spacing(2);
+  }
+}

--- a/app/javascript/controllers/filter_controller.js
+++ b/app/javascript/controllers/filter_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="filter"
+export default class extends Controller {
+  static targets = [ "filter" ]
+
+  close() {
+    this.filterTarget.classList.add("display-none-on-mobile")
+    this.filterTarget.classList.remove("display-initial")
+  }
+
+  open() {
+    this.filterTarget.classList.add("display-initial")
+    this.filterTarget.classList.remove("display-none-on-mobile")
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,11 +4,14 @@
 
 import { application } from "./application"
 
-import ClaimsSupportFilterSearchController from "./claims_support_filter_search_controller"
-application.register("claims-support-filter-search", ClaimsSupportFilterSearchController )
-
 import AutocompleteController from "./autocomplete_controller"
 application.register("autocomplete", AutocompleteController)
+
+import ClaimsSupportFilterSearchController from "./claims_support_filter_search_controller"
+application.register("claims-support-filter-search", ClaimsSupportFilterSearchController)
+
+import FilterController from "./filter_controller"
+application.register("filter", FilterController)
 
 import SelectAutocompleteController from "./select_autocomplete_controller"
 application.register("select-autocomplete", SelectAutocompleteController)

--- a/app/views/claims/support/claims/_filter.html.erb
+++ b/app/views/claims/support/claims/_filter.html.erb
@@ -1,10 +1,12 @@
-<div class="app-filter-layout">
+<div class="app-filter-layout display-none-on-mobile " data-filter-target="filter">
   <div class="app-filter-layout__filter">
     <div class="app-filter__header">
       <div class="app-filter__header-title">
         <h2 class="govuk-heading-m"><%= t("filter") %></h2>
       </div>
-      <div class="app-filter__header-action"></div>
+      <div class="app-filter__header-action">
+        <button class="app-filter__close" type="button" data-action="click->filter#close"><%= t("close") %></button>
+      </div>
     </div>
     <div class="app-filter-layout__content">
       <% if filter_form.filters_selected? %>

--- a/app/views/claims/support/claims/index.html.erb
+++ b/app/views/claims/support/claims/index.html.erb
@@ -1,10 +1,13 @@
 <%= render "claims/support/primary_navigation", current: :claims %>
 <%= content_for :page_title, t(".heading", count: @pagy.count) %>
 
-<div class="govuk-width-container">
+<div class="govuk-width-container" data-controller="filter">
   <h1 class="govuk-heading-l"><%= t(".heading", count: @pagy.count) %></h1>
 
   <%= govuk_link_to t(".download_csv"), download_csv_claims_support_claims_path(**request.query_parameters), class: "govuk-button", method: :get %>
+  <div>
+    <button class="govuk-button govuk-button--secondary show-filter-button" type="button" data-action="click->filter#open"><%= t("show_filter") %></button>
+  </div>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,8 @@ en:
   cancel: Cancel
   continue: Continue
   change: Change
+  close: Close
+  show_filter: Show filter 
   filter: Filter
   apply_filters: Apply filters
   selected_filters: Selected filters


### PR DESCRIPTION
## Context

The filters need to disappear and a show filter button needs to be
showed on a mobile view. This commit adds a basic stimulus controller
that will show/hide the filters using some CSS classes.

This should replicate how the prototype handles different screen sizes

## Changes proposed in this pull request

Stimulus controller
Filter CSS changes

## Guidance to review

Go on support claims index and resize your window. It should be relatively responsive.


## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/70d70754-3138-4039-a061-d9b77547fe80



<!-- Sceenshots to aid with reviewing if needed-->
