### PR TITLE
Update Claim details pages

### DIFF
--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -2,6 +2,7 @@
 @import "autocomplete";
 @import "content_header";
 @import "header";
+@import "heading";
 @import "link";
 @import "organisation_list_item";
 @import "phase_banner";

--- a/app/assets/stylesheets/components/_heading.scss
+++ b/app/assets/stylesheets/components/_heading.scss
@@ -1,0 +1,8 @@
+.govuk-heading-l {
+  .govuk-heading-group {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: govuk-spacing(2);
+  }
+}

--- a/app/views/claims/schools/claims/show.html.erb
+++ b/app/views/claims/schools/claims/show.html.erb
@@ -9,10 +9,17 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l"><%= t(".page_title", reference: @claim.reference) %></h1>
+      <h1 class="govuk-heading-l">
+        <div class="govuk-heading-group">
+          <%= t(".page_title", reference: @claim.reference) %>
+          <%= render Claim::StatusTagComponent.new(claim: @claim) %>
+        </div>
+      </h1>
 
       <% if policy(@claim).submit? %>
         <%= govuk_button_to t(".submit"), submit_claims_school_claim_path(@school, @claim) %>
+      <% else %>
+        <p class="govuk-body"><%= t(".submitted_by", name: @claim.submitted_by.full_name, date: l(@claim.submitted_on, format: :long)) %></p>
       <% end %>
 
       <%= govuk_summary_list do |summary_list| %>
@@ -42,21 +49,6 @@
               <% end %>
             </ul>
           <% end %>
-        <% end %>
-
-        <% summary_list.with_row do |row| %>
-          <% row.with_key(text: Claims::Claim.human_attribute_name(:status)) %>
-          <% row.with_value(text: render(Claim::StatusTagComponent.new(claim: @claim))) %>
-        <% end %>
-
-        <% summary_list.with_row do |row| %>
-          <% row.with_key(text: Claims::Claim.human_attribute_name(:submitted_by)) %>
-          <% row.with_value(text: text_or_dash(@claim.submitted_by_full_name)) %>
-        <% end %>
-
-        <% summary_list.with_row do |row| %>
-          <% row.with_key(text: Claims::Claim.human_attribute_name(:date_submitted)) %>
-          <% row.with_value(text: safe_l(@claim.submitted_on, format: :long)) %>
         <% end %>
       <% end %>
 

--- a/app/views/claims/support/claims/_details.html.erb
+++ b/app/views/claims/support/claims/_details.html.erb
@@ -1,0 +1,75 @@
+<%= govuk_summary_list do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: Claims::Claim.human_attribute_name(:school)) %>
+    <% row.with_value(text: claim.school.name) %>
+  <% end %>
+
+  <% if claim.provider %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key(text: Claims::Claim.human_attribute_name(:accredited_provider)) %>
+      <% row.with_value(text: claim.provider.name) %>
+      <% if policy(claim).edit? %>
+        <% row.with_action(text: t("change"),
+                           href: edit_claims_support_school_claim_path(claim.school, claim),
+                           html_attributes: {
+                              class: "govuk-link--no-visited-state",
+                              }) %>
+      <% end %>
+    <% end %>
+  <% else %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key(text: Claims::Claim.human_attribute_name(:accredited_provider)) %>
+      <% row.with_value(text: t("none")) %>
+    <% end %>
+  <% end %>
+
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t(".mentors")) %>
+    <% row.with_value do %>
+      <ul class="govuk-list">
+        <% claim.mentors.each do |mentor| %>
+          <li><%= mentor.full_name %></li>
+        <% end %>
+      </ul>
+    <% end %>
+    <% if policy(claim).edit? %>
+      <% row.with_action(text: t("change"),
+                         href: edit_claims_support_school_claim_mentor_path(claim.school, claim),
+                         html_attributes: {
+                  class: "govuk-link--no-visited-state",
+                }) %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<h2 class="govuk-heading-m"><%= t(".hours_of_training") %></h2>
+  <%= govuk_summary_list do |summary_list| %>
+   <%= claim.mentor_trainings.order_by_mentor_full_name.each do |mentor_training| %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key(text: mentor_training.mentor.full_name) %>
+      <% row.with_value(text: "#{mentor_training.hours_completed} #{t(".hours")}") %>
+      <% if policy(claim).edit? %>
+        <% row.with_action(text: t("change"),
+                           href: edit_claims_support_school_claim_mentor_training_path(
+                            claim.school,
+                            claim,
+                            mentor_training,
+                            params: {
+                              claims_support_claim_mentor_training_form: { hours_completed: mentor_training.hours_completed },
+                            },
+                          ),
+                           html_attributes: {
+                            class: "govuk-link--no-visited-state",
+                          }) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<h2 class="govuk-heading-m"><%= t(".grant_funding") %></h2>
+<%= govuk_summary_list do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: Claims::Claim.human_attribute_name(:claim_amount)) %>
+    <% row.with_value(text: humanized_money_with_symbol(claim.amount)) %>
+  <% end %>
+<% end %>

--- a/app/views/claims/support/claims/show.html.erb
+++ b/app/views/claims/support/claims/show.html.erb
@@ -1,5 +1,5 @@
 <%= render "claims/support/primary_navigation", current: :claims %>
-<% content_for(:page_title) { t(".heading") } %>
+<% content_for(:page_title) { t(".page_title", school_name: @claim.school.name) } %>
 
 <% content_for(:before_content) do %>
   <%= govuk_back_link href: claims_support_claims_path %>
@@ -8,40 +8,20 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l"><%= t(".heading") %> <%= @claim.id %></h1>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></span>
 
-      <%= govuk_summary_list do |summary_list| %>
-        <% summary_list.with_row do |row| %>
-          <% row.with_key(text: t(".status")) %>
-          <% row.with_value(text: render(Claim::StatusTagComponent.new(claim: @claim))) %>
-        <% end %>
+        <div class="govuk-heading-group">
+          <%= t(".page_title", school_name: @claim.school.name) %>
+          <%= render Claim::StatusTagComponent.new(claim: @claim) %>
+        </div>
+      </h1>
 
-        <% if @claim.provider %>
-          <% summary_list.with_row do |row| %>
-            <% row.with_key(text: t(".provider")) %>
-            <% row.with_value(text: @claim.provider.name) %>
-          <% end %>
-        <% else %>
-          <% summary_list.with_row do |row| %>
-            <% row.with_key(text: t(".provider")) %>
-            <% row.with_value(text: t("none")) %>
-          <% end %>
-        <% end %>
-
-        <% if @claim.mentors.any? %>
-          <%= @claim.mentors.each_with_index do |mentor, index| %>
-            <% summary_list.with_row do |row| %>
-              <% row.with_key(text: t(".mentor_with_index", index: index + 1)) %>
-              <% row.with_value(text: mentor.full_name) %>
-            <% end %>
-          <% end %>
-        <% else %>
-          <% summary_list.with_row do |row| %>
-            <% row.with_key(text: t(".mentor")) %>
-            <% row.with_value(text: t("none")) %>
-          <% end %>
-        <% end %>
+      <% if @claim.submitted? %>
+        <p class="govuk-body"><%= t(".submitted_by", name: @claim.submitted_by.full_name, date: l(@claim.submitted_on, format: :long)) %></p>
       <% end %>
+
+      <%= render "claims/support/claims/details", claim: @claim %>
     </div>
   </div>
 </div>

--- a/app/views/claims/support/schools/claims/show.html.erb
+++ b/app/views/claims/support/schools/claims/show.html.erb
@@ -9,99 +9,20 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-l"><%= t(".page_caption", school_name: @school.name) %></span>
-      <h1 class="govuk-heading-l"><%= t(".page_title", reference: @claim.reference) %></h1>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t(".page_caption", school_name: @claim.school.name) %></span>
 
-      <%= govuk_summary_list do |summary_list| %>
-        <% summary_list.with_row do |row| %>
-          <% row.with_key(text: Claims::Claim.human_attribute_name(:school)) %>
-          <% row.with_value(text: @school.name) %>
-        <% end %>
+        <div class="govuk-heading-group">
+          <%= t(".page_title", reference: @claim.reference) %>
+          <%= render Claim::StatusTagComponent.new(claim: @claim) %>
+        </div>
+      </h1>
 
-        <% if @claim.provider %>
-          <% summary_list.with_row do |row| %>
-            <% row.with_key(text: Claims::Claim.human_attribute_name(:accredited_provider)) %>
-            <% row.with_value(text: @claim.provider.name) %>
-            <% if policy(@claim).edit? %>
-              <% row.with_action(text: t("change"),
-                                 href: edit_claims_support_school_claim_path(@school, @claim),
-                                 html_attributes: {
-                                    class: "govuk-link--no-visited-state",
-                                    }) %>
-            <% end %>
-          <% end %>
-        <% else %>
-          <% summary_list.with_row do |row| %>
-            <% row.with_key(text: Claims::Claim.human_attribute_name(:accredited_provider)) %>
-            <% row.with_value(text: t("none")) %>
-          <% end %>
-        <% end %>
-
-        <% summary_list.with_row do |row| %>
-          <% row.with_key(text: t(".mentors")) %>
-          <% row.with_value do %>
-            <ul class="govuk-list">
-              <% @claim.mentors.each do |mentor| %>
-                <li><%= mentor.full_name %></li>
-              <% end %>
-            </ul>
-          <% end %>
-          <% if policy(@claim).edit? %>
-            <% row.with_action(text: t("change"),
-                               href: edit_claims_support_school_claim_mentor_path(@school, @claim),
-                               html_attributes: {
-                        class: "govuk-link--no-visited-state",
-                      }) %>
-          <% end %>
-        <% end %>
-
-        <% summary_list.with_row do |row| %>
-          <% row.with_key(text: Claims::Claim.human_attribute_name(:status)) %>
-          <% row.with_value(text: render(Claim::StatusTagComponent.new(claim: @claim))) %>
-        <% end %>
-
-        <% summary_list.with_row do |row| %>
-          <% row.with_key(text: Claims::Claim.human_attribute_name(:date_submitted)) %>
-          <% row.with_value(text: safe_l(@claim.submitted_on, format: :long)) %>
-        <% end %>
-
-        <% summary_list.with_row do |row| %>
-          <% row.with_key(text: Claims::Claim.human_attribute_name(:submitted_by)) %>
-          <% row.with_value(text: text_or_dash(@claim.submitted_by_full_name)) %>
-        <% end %>
+      <% if @claim.submitted? %>
+        <p class="govuk-body"><%= t(".submitted_by", name: @claim.submitted_by.full_name, date: l(@claim.submitted_on, format: :long)) %></p>
       <% end %>
 
-      <h2 class="govuk-heading-m"><%= t(".hours_of_training") %></h2>
-        <%= govuk_summary_list do |summary_list| %>
-         <%= @claim.mentor_trainings.order_by_mentor_full_name.each do |mentor_training| %>
-          <% summary_list.with_row do |row| %>
-            <% row.with_key(text: mentor_training.mentor.full_name) %>
-            <% row.with_value(text: "#{mentor_training.hours_completed} #{t(".hours")}") %>
-            <% if policy(@claim).edit? %>
-              <% row.with_action(text: t("change"),
-                                 href: edit_claims_support_school_claim_mentor_training_path(
-                                  @school,
-                                  @claim,
-                                  mentor_training,
-                                  params: {
-                                    claims_support_claim_mentor_training_form: { hours_completed: mentor_training.hours_completed },
-                                  },
-                                ),
-                                 html_attributes: {
-                                  class: "govuk-link--no-visited-state",
-                                }) %>
-            <% end %>
-          <% end %>
-        <% end %>
-      <% end %>
-
-      <h2 class="govuk-heading-m"><%= t(".grant_funding") %></h2>
-        <%= govuk_summary_list do |summary_list| %>
-          <% summary_list.with_row do |row| %>
-            <% row.with_key(text: Claims::Claim.human_attribute_name(:claim_amount)) %>
-            <% row.with_value(text: humanized_money_with_symbol(@claim.amount)) %>
-          <% end %>
-        <% end %>
+      <%= render "claims/support/claims/details", claim: @claim %>
     </div>
   </div>
 

--- a/config/locales/en/claims/schools/claims.yml
+++ b/config/locales/en/claims/schools/claims.yml
@@ -49,5 +49,6 @@ en:
           grant_funding: Grant funding
           hours: hours
           submit: Submit claim
+          submitted_by: Submitted by %{name} on %{date}.
         edit:
           page_title: Accredited provider - Add claim

--- a/config/locales/en/claims/support/claims.yml
+++ b/config/locales/en/claims/support/claims.yml
@@ -18,8 +18,15 @@ en:
           submit: Search
           clear: Clear search
         show:
-          heading: Claim
+          page_caption: Claim - %{reference}
+          page_title: Claim - %{school_name}
           status: Status
           provider: Accredited provider
           mentor_with_index: Mentor %{index}
           mentor: Mentor
+          submitted_by: Submitted by %{name} on %{date}.
+        details:
+          mentors: Mentors
+          hours_of_training: Hours of training
+          hours: hours
+          grant_funding: Grant funding

--- a/config/locales/en/claims/support/schools/claims.yml
+++ b/config/locales/en/claims/support/schools/claims.yml
@@ -4,7 +4,7 @@ en:
       schools:
         claims:
           draft:
-            add_success:  Claim added
+            add_success: Claim added
             update_success: Claim updated
           edit:
             page_title: Accredited provider - Add claim
@@ -24,13 +24,10 @@ en:
             add_mentor_guidance_html: You need to %{link_to} before creating a claim.</p>
             add_a_mentor: add a mentor
           show:
-            mentors: Mentors
             page_title: Claim - %{reference}
-            hours_of_training: Hours of training
-            grant_funding: Grant funding
-            hours: hours
             page_caption: Claims - %{school_name}
             remove_claim: Remove claim
+            submitted_by: Submitted by %{name} on %{date}.
           new:
             page_title: Accredited provider - Add claim
           remove:

--- a/spec/system/claims/schools/claims/view_claim_spec.rb
+++ b/spec/system/claims/schools/claims/view_claim_spec.rb
@@ -63,27 +63,25 @@ RSpec.describe "View a claim", type: :system, service: :claims do
   end
 
   def then_i_can_then_see_the_submitted_claim_details
-    expect(page).to have_content("Claim - 12345678")
+    expect(page).to have_content("Claim - #{submitted_claim.reference}")
     expect(page).to have_content("SchoolA School")
+    expect(page).to have_content("Submitted")
+    expect(page).to have_content("Submitted by #{anne.full_name} on 5 March 2024.")
     expect(page).to have_content("Accredited providerBest Practice Network")
     expect(page).to have_content("Mentors\nBarry Garlow")
     expect(page).to have_content("Hours of training")
-    expect(page).to have_content("StatusSubmitted")
-    expect(page).to have_content("Submitted by#{anne.full_name}")
-    expect(page).to have_content("Date submitted 5 March 2024")
     expect(page).to have_content("Barry Garlow#{mentor_training.hours_completed} hours")
     expect(page).to have_content("Claim amount£321.60")
   end
 
   def then_i_can_then_see_the_draft_claim_details
-    expect(page).to have_content("Claim - 88888888")
+    expect(page).to have_content("Claim - #{draft_claim.reference}")
     expect(page).to have_content("SchoolA School")
+    expect(page).to have_content("Draft")
+    expect(page).not_to have_content("Submitted by")
     expect(page).to have_content("Accredited providerBest Practice Network")
     expect(page).to have_content("Mentors\nBarry Garlow")
     expect(page).to have_content("Hours of training")
-    expect(page).to have_content("StatusDraft")
-    expect(page).to have_content("Submitted by-")
-    expect(page).to have_content("Date submitted-")
     expect(page).to have_content("Barry Garlow#{draft_mentor_training.hours_completed} hours")
     expect(page).to have_content("Claim amount£321.60")
   end

--- a/spec/system/claims/support/claims/view_a_claim_spec.rb
+++ b/spec/system/claims/support/claims/view_a_claim_spec.rb
@@ -4,14 +4,20 @@ RSpec.describe "View claims", type: :system, service: :claims do
   let!(:support_user) { create(:claims_support_user) }
   let(:provider) { create(:claims_provider) }
   let(:mentor) { create(:claims_mentor) }
+  let(:user) { create(:claims_user) }
   let!(:claim) do
     create(
       :claim,
       :submitted,
       provider:,
+      school: create(:claims_school, region: regions(:inner_london)),
       mentors: [mentor],
+      submitted_by: user,
+      submitted_at: Time.zone.parse("2024-03-05 12:31:52"),
     )
   end
+
+  let!(:mentor_training) { create(:mentor_training, claim:, mentor:, hours_completed: 6) }
 
   before do
     user_exists_in_dfe_sign_in(user: support_user)
@@ -40,21 +46,14 @@ RSpec.describe "View claims", type: :system, service: :claims do
   end
 
   def then_i_can_see_the_details_of_a_submitted_claim
-    expect(page).to have_content("Claims")
-
-    within(".govuk-summary-list__row:nth-child(1)") do
-      expect(page).to have_content("Status")
-      expect(page).to have_content("Submitted")
-    end
-
-    within(".govuk-summary-list__row:nth-child(2)") do
-      expect(page).to have_content("Accredited provider")
-      expect(page).to have_content(provider.name)
-    end
-
-    within(".govuk-summary-list__row:nth-child(3)") do
-      expect(page).to have_content("Mentor 1")
-      expect(page).to have_content(mentor.full_name)
-    end
+    expect(page).to have_content("Claim - #{claim.reference}")
+    expect(page).to have_content("School#{claim.school.name}")
+    expect(page).to have_content("Submitted")
+    expect(page).to have_content("Submitted by #{user.full_name} on 5 March 2024.")
+    expect(page).to have_content("Accredited provider#{provider.name}")
+    expect(page).to have_content("Mentors\n#{mentor.full_name}")
+    expect(page).to have_content("Hours of training")
+    expect(page).to have_content("#{mentor.full_name}#{mentor_training.hours_completed} hours")
+    expect(page).to have_content("Claim amount£321.60")
   end
 end

--- a/spec/system/claims/support/schools/claims/view_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/view_claim_spec.rb
@@ -49,12 +49,11 @@ RSpec.describe "View a claim", type: :system, service: :claims do
   def then_i_can_then_see_the_claim_details
     expect(page).to have_content("Claim - 12345678")
     expect(page).to have_content("SchoolA School")
+    expect(page).to have_content("Submitted")
+    expect(page).to have_content("Submitted by #{colin.full_name} on 5 March 2024.")
     expect(page).to have_content("Accredited providerBest Practice Network")
     expect(page).to have_content("Mentors\nBarry Garlow")
-    expect(page).to have_content("Submitted by#{colin.full_name}")
-    expect(page).to have_content("Date submitted 5 March 2024")
     expect(page).to have_content("Hours of training")
-    expect(page).to have_content("StatusSubmitted")
     expect(page).to have_content("Barry Garlow#{mentor_training.hours_completed} hours")
     expect(page).to have_content("Claim amount£321.60")
   end


### PR DESCRIPTION
## Context

The claim details pages need to be updated to the latest design.

## Changes proposed in this pull request

- Update the claim details page.
- Create a partial to share between support pages.

## Guidance to review

- Claim details pages look the same throughout the app.
  - School / Claim
  - Support / School / Claim
  - Support / Claim

## Screenshots

![CleanShot 2024-04-18 at 13 56 34](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/44f6b1ea-23bf-4678-bdc3-e802d227750f)
