### PR TITLE
Add letter_opener gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,6 +98,7 @@ gem "audited"
 
 group :development do
   gem "annotate", require: false
+  gem "letter_opener"
   gem "prettier_print", require: false
   gem "rladr"
   gem "rubocop-govuk", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -262,6 +262,8 @@ GEM
     launchy (3.0.0)
       addressable (~> 2.8)
       childprocess (~> 5.0)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -650,6 +652,7 @@ DEPENDENCIES
   httparty
   jsbundling-rails
   launchy
+  letter_opener
   mail-notify
   money-rails (~> 1.12)
   omniauth

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,10 +36,9 @@ Rails.application.configure do
   # Use GoodJob adapter for Active Job.
   config.active_job.queue_adapter = :good_job
 
-  config.action_mailer.delivery_method = :notify
-  config.action_mailer.notify_settings = {
-    api_key: ENV.fetch("GOVUK_NOTIFY_API_KEY"),
-  }
+  # Use letter_opener to allow us to receive emails locally, without the need for Notify
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local


### PR DESCRIPTION
## Context

I have added the letter_opener gem in development. The reason for this is we can't view emails when sending them in development. By adding this gem when an email is sent, the browser will automatically open a new window with the content of that email.

https://trello.com/c/KlJz7bCg/394-add-letteropener-gem-to-view-letters-in-dev

## Changes proposed in this pull request

Add then gem to development, to ensure when an email is sent we can view it in the browser. We have 6 emails that can be sent.

## Guidance to review

- Add a user to an organisation


## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
<img width="1068" alt="Screenshot 2024-04-18 at 14 49 12" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/518898fb-490f-45dd-ac06-4071c0d21909">

