### PR TITLE
Add auth/failure route

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,5 @@
 class SessionsController < ApplicationController
-  skip_before_action :authenticate_user!, only: %i[new callback]
+  skip_before_action :authenticate_user!, only: %i[new callback failure]
   before_action :redirect_to_after_sign_in_path, only: %i[new], if: :user_signed_in?
 
   def new; end
@@ -22,5 +22,14 @@ class SessionsController < ApplicationController
     DfESignInUser.end_session!(session)
 
     redirect_to sign_in_user.logout_url(request), allow_other_host: true
+  end
+
+  def failure
+    dfe_sign_in_uid = session.fetch("dfe_sign_in_user", {})["dfe_sign_in_uid"]
+    Sentry.capture_message("DSI failure with #{params[:message]} for dfe_sign_in_uid: #{dfe_sign_in_uid}")
+
+    DfESignInUser.end_session!(session)
+
+    redirect_to internal_server_error_path
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
     get "/404", to: "errors#not_found", as: :not_found
     get "/422", to: "errors#unprocessable_entity"
     get "/429", to: "errors#too_many_requests"
-    get "/500", to: "errors#internal_server_error"
+    get "/500", to: "errors#internal_server_error", as: :internal_server_error
   end
 
   # User Account Details
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
   else
     get("/auth/dfe/callback" => "sessions#callback")
     get("/auth/dfe/sign-out" => "sessions#destroy", as: :sign_out)
+    get "/auth/failure", to: "sessions#failure"
   end
 
   resources :service_updates, only: %i[index]

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -16,4 +16,16 @@ RSpec.describe "Sessions", type: :request do
       expect(response).to render_template("claims/schools/index")
     end
   end
+
+  describe "GET /auth/failure" do
+    it "returns http internal_server_error" do
+      allow(Sentry).to receive(:capture_message)
+
+      get "/auth/failure"
+      follow_redirect!
+
+      expect(response).to have_http_status(:internal_server_error)
+      expect(Sentry).to have_received(:capture_message)
+    end
+  end
 end

--- a/spec/support/dfe_sign_in_user_helper.rb
+++ b/spec/support/dfe_sign_in_user_helper.rb
@@ -24,6 +24,10 @@ module DfESignInUserHelper
     }
   end
 
+  def when_dsi_fails
+    OmniAuth.config.mock_auth[:dfe] = :invalid_credentials
+  end
+
   private
 
   def fake_dfe_sign_in_auth_hash(email:, dfe_sign_in_uid:, first_name:, last_name:)

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -1,1 +1,4 @@
 OmniAuth.config.test_mode = true
+OmniAuth.config.on_failure = proc { |env|
+  OmniAuth::FailureEndpoint.new(env).redirect_to_failure
+}

--- a/spec/system/claims/sign_in_as_a_claims_user_spec.rb
+++ b/spec/system/claims/sign_in_as_a_claims_user_spec.rb
@@ -57,6 +57,15 @@ RSpec.describe "Sign In as a Claims User", type: :system, service: :claims do
     end
   end
 
+  context "when dsi fails" do
+    scenario "I try to sign in as support user" do
+      when_dsi_fails
+      when_i_visit_the_sign_in_path
+      when_i_click_sign_in
+      then_i_am_redirect_to_internal_server_error
+    end
+  end
+
   private
 
   def given_there_is_an_existing_claims_user_with_a_school_for(user)
@@ -128,5 +137,9 @@ RSpec.describe "Sign In as a Claims User", type: :system, service: :claims do
 
   def i_do_not_have_access_to_support_page
     expect(page).to have_content "You cannot perform this action"
+  end
+
+  def then_i_am_redirect_to_internal_server_error
+    expect(page).to have_content("Sorry, there’s a problem with the service")
   end
 end

--- a/spec/system/placements/sign_in_as_a_placements_user_spec.rb
+++ b/spec/system/placements/sign_in_as_a_placements_user_spec.rb
@@ -57,6 +57,15 @@ RSpec.describe "Sign In as a Placements User", type: :system, service: :placemen
     end
   end
 
+  context "when dsi fails" do
+    scenario "I try to sign in as support user" do
+      when_dsi_fails
+      when_i_visit_the_sign_in_path
+      when_i_click_sign_in
+      then_i_am_redirect_to_internal_server_error
+    end
+  end
+
   private
 
   def given_there_is_an_existing_user_for(user_name)
@@ -144,5 +153,9 @@ RSpec.describe "Sign In as a Placements User", type: :system, service: :placemen
 
   def i_do_not_have_access_to_support_page
     expect(page).to have_content "You cannot perform this action"
+  end
+
+  def then_i_am_redirect_to_internal_server_error
+    expect(page).to have_content("Sorry, there’s a problem with the service")
   end
 end


### PR DESCRIPTION
## Context

In very edge cases, DSI will send an auth/failure request to our app with a message.

We need to handle this gracefully so we redirect the user to the sign in page, sign him our if they are signed in and display a message.

We also send a request to Sentry.

## Changes proposed in this pull request

New route and sessions controller method

## Guidance to review

Go to /auth/failure

## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/70d7cf0d-da5b-4a94-a049-bb6ee0f8df49



