### PR TITLE
Add service to calculate remaining hours available to claim for a mentor

### DIFF
--- a/app/services/claims/mentor/calculate_remaining_mentor_training_hours_for_provider.rb
+++ b/app/services/claims/mentor/calculate_remaining_mentor_training_hours_for_provider.rb
@@ -1,0 +1,18 @@
+class Claims::Mentor::CalculateRemainingMentorTrainingHoursForProvider
+  include ServicePattern
+
+  MAXIMUM_CLAIMABLE_HOURS_PER_PROVIDER = 20
+
+  def initialize(mentor:, provider:)
+    @mentor = mentor
+    @provider = provider
+  end
+
+  def call
+    MAXIMUM_CLAIMABLE_HOURS_PER_PROVIDER - Claims::Mentor::CalculateTotalMentorTrainingHoursForProvider.call(mentor:, provider:)
+  end
+
+  private
+
+  attr_reader :mentor, :provider
+end

--- a/app/services/claims/mentor/calculate_total_mentor_training_hours_for_provider.rb
+++ b/app/services/claims/mentor/calculate_total_mentor_training_hours_for_provider.rb
@@ -1,4 +1,4 @@
-class Claims::CalculateTotalMentorTrainingHoursForProvider
+class Claims::Mentor::CalculateTotalMentorTrainingHoursForProvider
   include ServicePattern
 
   def initialize(mentor:, provider:)

--- a/spec/services/claims/mentor/calculate_remaining_mentor_training_hours_for_provider_spec.rb
+++ b/spec/services/claims/mentor/calculate_remaining_mentor_training_hours_for_provider_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe Claims::Mentor::CalculateRemainingMentorTrainingHoursForProvider do
+  subject(:calculate_remaining_mentor_training_hours) { described_class.call(mentor:, provider:) }
+
+  let(:mentor) { create(:claims_mentor) }
+  let(:provider) { create(:claims_provider) }
+
+  it_behaves_like "a service object" do
+    let(:params) { { mentor:, provider: } }
+  end
+
+  it "returns the remaining claimable mentor training hours for a provider for a given mentor" do
+    create(:mentor_training, mentor:, provider:, hours_completed: 12)
+    create(:mentor_training, mentor:, provider:, hours_completed: 4)
+
+    create(:mentor_training, hours_completed: 15, mentor:)
+
+    expect(calculate_remaining_mentor_training_hours).to eq(4)
+  end
+end

--- a/spec/services/claims/mentor/calculate_total_mentor_training_hours_for_provider_spec.rb
+++ b/spec/services/claims/mentor/calculate_total_mentor_training_hours_for_provider_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-RSpec.describe Claims::CalculateTotalMentorTrainingHoursForProvider do
-  subject(:calculate_total_training_hours) { described_class.call(mentor: create(:mentor, :provider)) }
+RSpec.describe Claims::Mentor::CalculateTotalMentorTrainingHoursForProvider do
+  subject(:calculate_total_training_hours) { described_class.call(mentor:, provider:) }
 
   let!(:mentor) { create(:claims_mentor) }
 
@@ -17,12 +17,10 @@ RSpec.describe Claims::CalculateTotalMentorTrainingHoursForProvider do
 
   it "returns the total mentor training hours for a provider for a given mentor" do
     create(:mentor_training, provider:, claim:, hours_completed: 20, mentor:)
-    create(:mentor_training, provider:, claim:, hours_completed: 20, mentor:)
+    create(:mentor_training, provider:, claim:, hours_completed: 6, mentor:)
 
     create(:mentor_training, provider: provider_2, claim:, hours_completed: 20, mentor:)
 
-    result = described_class.call(mentor:, provider:)
-
-    expect(result).to eq(40)
+    expect(calculate_total_training_hours).to eq(26)
   end
 end


### PR DESCRIPTION
## Context

We need to add a validation to prevent a user from submitting claims that exceed the limit they can claim per provider.

This PR introduces a service to perform the calculations required to add the validation above.

> how many hours a mentor has spent training (which can be up to a maximum of 20 hours, per accredited ITT provider)

## Changes proposed in this pull request

- Move the `Claims::CalculateTotalMentorTrainingHoursForProvider` to `Claims::Mentor::CalculateTotalMentorTrainingHoursForProvider`.
- Add a `Claims::Mentor::CalculateRemainingMentorTrainingHoursForProvider` service.

## Guidance to review

- Check the logic and specs are correct.
