### PR TITLE
Update ApplicationMailer to use "https" protocol for default url options in production and add CLAIM_HOST

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -15,7 +15,11 @@ class ApplicationMailer < Mail::Notify::Mailer
   end
 
   def default_url_options
-    { host:, port: ENV["PORT"] }
+    { host:, port: ENV["PORT"], protocol: }
+  end
+
+  def protocol
+    Rails.env.production? ? "https" : "http"
   end
 
   def host

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe ApplicationMailer, type: :mailer do
+  describe "#protocol" do
+    subject(:application_mailer) { described_class.new }
+
+    context "when Rails environment is production" do
+      before do
+        allow(Rails).to receive(:env).and_return("production".inquiry)
+      end
+
+      it 'returns "https"' do
+        expect(application_mailer.send(:protocol)).to eq("https")
+      end
+    end
+
+    context "when Rails environment is not production" do
+      before do
+        allow(Rails).to receive(:env).and_return("development".inquiry)
+      end
+
+      it 'returns "http"' do
+        expect(application_mailer.send(:protocol)).to eq("http")
+      end
+    end
+  end
+end

--- a/terraform/application/config/qa_app_env.yml
+++ b/terraform/application/config/qa_app_env.yml
@@ -6,4 +6,5 @@ HOSTING_ENV: qa
 TEACHING_RECORD_BASE_URL: https://preprod.teacher-qualifications-api.education.gov.uk
 TEACHING_RECORD_API_MINOR_VERSION: 20240101
 CLAIMS_HOSTS: qa.claim-funding-for-mentor-training.education.gov.uk,track-and-pay-qa.test.teacherservices.cloud
+CLAIMS_HOST: qa.claim-funding-for-mentor-training.education.gov.uk
 SKYLIGHT_ENV: qa

--- a/terraform/application/config/sandbox_app_env.yml
+++ b/terraform/application/config/sandbox_app_env.yml
@@ -7,3 +7,4 @@ HOSTING_ENV: sandbox
 TEACHING_RECORD_BASE_URL: https://preprod.teacher-qualifications-api.education.gov.uk
 TEACHING_RECORD_API_MINOR_VERSION: 20240101
 CLAIMS_HOSTS: sandbox.claim-funding-for-mentor-training.education.gov.uk,track-and-pay-sandbox.teacherservices.cloud
+CLAIMS_HOST: sandbox.claim-funding-for-mentor-training.education.gov.uk

--- a/terraform/application/config/staging_app_env.yml
+++ b/terraform/application/config/staging_app_env.yml
@@ -9,4 +9,5 @@ CLAIMS_DFE_SIGN_IN_CLIENT_ID: ittMentorTrackPay
 DFE_SIGN_IN_ISSUER_URL: https://test-oidc.signin.education.gov.uk
 PLACEMENTS_DFE_SIGN_IN_CLIENT_ID: ittMentorSchoolPlacement
 CLAIMS_HOSTS: staging.claim-funding-for-mentor-training.education.gov.uk,track-and-pay-staging.test.teacherservices.cloud
+CLAIMS_HOST: staging.claim-funding-for-mentor-training.education.gov.uk
 SKYLIGHT_ENV: staging


### PR DESCRIPTION
## Context

We need to use https in prod

## Changes proposed in this pull request

Update ApplicationMailer to use "https" protocol for default url options in production

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/ptxQVbba/234-update-applicationmailer-to-use-https-protocol-for-default-url-options-in-production

