### PR TITLE
Update not_an_integer error message for mentor training hours

### DIFF
--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -39,7 +39,7 @@ en:
             hours_completed:
               greater_than: Enter the number of hours between 1 and 20
               less_than_or_equal_to: Enter the number of hours between 1 and 20
-              not_an_integer: Enter the number of hours between 1 and 20
+              not_an_integer: Enter whole numbers only
         user:
           attributes:
             first_name:

--- a/spec/system/claims/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/schools/claims/create_claim_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     then_i_see_the_error("Enter the number of hours between 1 and 20")
     when_i_choose_other_amount_and_input_hours(0.5)
     when_i_click("Continue")
-    then_i_see_the_error("Enter the number of hours between 1 and 20")
+    then_i_see_the_error("Enter whole numbers only")
   end
 
   scenario "Anne creates a claim and tries to edit it" do

--- a/spec/system/claims/support/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/create_claim_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     then_i_see_the_error("Enter the number of hours between 1 and 20")
     when_i_choose_other_amount_and_input_hours(0.5)
     when_i_click("Continue")
-    then_i_see_the_error("Enter the number of hours between 1 and 20")
+    then_i_see_the_error("Enter whole numbers only")
   end
 
   private


### PR DESCRIPTION
## Context

We need to provide a clearer error message when users submit decimal numbers.

## Changes proposed in this pull request

- Update error message text.

## Guidance to review

- Try entering a non-whole number into the claim mentor hours completed input.

## Screenshots

![CleanShot 2024-04-19 at 11 48 54](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/1a9073b0-3c5f-4247-a249-ff7f078a59ac)
