### PR TITLE
Placement index page for support [1/4]

### DIFF
--- a/app/controllers/placements/support/schools/placements_controller.rb
+++ b/app/controllers/placements/support/schools/placements_controller.rb
@@ -1,0 +1,14 @@
+class Placements::Support::Schools::PlacementsController < Placements::Support::ApplicationController
+  before_action :set_school
+
+  def index
+    @pagy, placements = pagy(@school.placements.includes(:subjects, :mentors).order("subjects.name"))
+    @placements = placements.decorate
+  end
+
+  private
+
+  def set_school
+    @school = Placements::School.find(params.fetch(:school_id))
+  end
+end

--- a/app/views/placements/support/schools/_secondary_navigation.html.erb
+++ b/app/views/placements/support/schools/_secondary_navigation.html.erb
@@ -2,6 +2,6 @@
   <% component.with_navigation_item t(".details"), placements_support_school_path(school) %>
   <% component.with_navigation_item t(".users"), placements_support_school_users_path(school) %>
   <% component.with_navigation_item t(".mentors"), placements_support_school_mentors_path(school) %>
-  <% component.with_navigation_item t(".placements"), "#" %>
+  <% component.with_navigation_item t(".placements"), placements_support_school_placements_path(school) %>
   <% component.with_navigation_item t(".providers"), "#" %>
 <% end %>

--- a/app/views/placements/support/schools/placements/index.html.erb
+++ b/app/views/placements/support/schools/placements/index.html.erb
@@ -1,0 +1,42 @@
+<% content_for :page_title, t(".page_title") %>
+<%= render "placements/support/primary_navigation", current_navigation: :organisations %>
+<div class="govuk-width-container">
+  <h1 class="govuk-heading-l"><%= @school.name %></h1>
+
+  <%= render "placements/support/schools/secondary_navigation", school: @school %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= t(".placements") %></h1>
+      <% if @placements.any? %>
+        <%= govuk_table do |table| %>
+          <% table.with_head do |head| %>
+            <% head.with_row do |row| %>
+              <% row.with_cell(header: true, text: t(".subject")) %>
+              <% row.with_cell(header: true, text: t(".mentor")) %>
+              <% row.with_cell(header: true, text: t(".window")) %>
+              <% row.with_cell(header: true, text: Placement.human_attribute_name(:status)) %>
+            <% end %>
+          <% end %>
+          <% table.with_body do |body| %>
+            <% @placements.each do |placement| %>
+              <% body.with_row do |row| %>
+                <% row.with_cell(text: placement.subject_names) %>
+                <% row.with_cell(text: placement.mentor_names) %>
+                <% row.with_cell(text: placement.window) %>
+                <% row.with_cell do %>
+                  <%= render Placement::StatusTagComponent.new(placement.status) %>
+                <% end %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+        <%= render PaginationComponent.new(pagy: @pagy) %>
+      <% else %>
+        <p>
+          <%= t("no_records_for", records: "placements", for: @school.name) %>
+        </p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/placements/support/schools/placements/index.html.erb
+++ b/app/views/placements/support/schools/placements/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t(".page_title") %>
+<% content_for :page_title, @school.name %>
 <%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 <div class="govuk-width-container">
   <h1 class="govuk-heading-l"><%= @school.name %></h1>

--- a/config/locales/en/placements/support/schools/placements.yml
+++ b/config/locales/en/placements/support/schools/placements.yml
@@ -1,0 +1,14 @@
+en:
+  placements:
+    support:
+      schools:
+        placements:
+          index:
+            page_title: Placements
+            placements: Placements
+            subject: Subject
+            mentor: Mentor
+            window: Window
+            status: Status
+            not_entered: Not entered
+            add_placement: Add placement

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -37,6 +37,11 @@ scope module: :placements,
           member { get :remove }
           collection { get :check }
         end
+
+        resources :placements, only: %i[index new create show destroy] do
+          member { get :remove }
+          collection { get :check }
+        end
       end
     end
 

--- a/spec/system/placements/support/schools/placements/support_user_views_placements_spec.rb
+++ b/spec/system/placements/support/schools/placements/support_user_views_placements_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+RSpec.describe "Placements / Support / Schools / Placements / Support User views placements",
+               type: :system,
+               service: :placements do
+  let!(:subject1) { create(:subject, name: "English") }
+  let!(:subject2) { create(:subject, name: "Science") }
+  let!(:subject3) { create(:subject, name: "Maths") }
+  let!(:mentor1) { create(:placements_mentor, first_name: "Bilbo", last_name: "Baggins") }
+  let!(:mentor2) { create(:placements_mentor, first_name: "Bilbo", last_name: "Test") }
+  let!(:mentor3) { create(:placements_mentor, trn: "1231233") }
+  let!(:placement1) { create(:placement, mentors: [mentor1], subjects: [subject1], school:, start_date: nil, end_date: nil) }
+  let!(:placement2) { create(:placement, mentors: [mentor2], subjects: [subject2], school:, start_date: nil, end_date: nil) }
+  let!(:placement3) { create(:placement, mentors: [mentor3], subjects: [subject3], start_date: nil, end_date: nil) }
+  let!(:school) { create(:placements_school, mentors: [mentor1, mentor2]) }
+  let!(:another_school) { create(:placements_school) }
+  let!(:colin) { create(:placements_support_user, :colin) }
+
+  scenario "View a school's placements as a support user" do
+    user_exists_in_dfe_sign_in(user: colin)
+    given_i_sign_in
+    when_i_visit_the_support_school_placements_page(school)
+    then_i_see_a_list_of_the_schools_placements
+    and_i_dont_see_placements_from_another_school
+  end
+
+  scenario "View a school's empty placements list" do
+    user_exists_in_dfe_sign_in(user: colin)
+    given_i_sign_in
+    when_i_visit_the_support_school_placements_page(another_school)
+    then_i_see_no_results
+  end
+
+  private
+
+  def given_i_sign_in
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def when_i_visit_the_support_school_placements_page(school)
+    visit placements_support_school_placements_path(school)
+  end
+
+  def then_i_see_a_list_of_the_schools_placements
+    expect(page).to have_content("Subject")
+    expect(page).to have_content("Mentor")
+    expect(page).to have_content("Window")
+    expect(page).to have_content("Status")
+
+    within("tbody tr:nth-child(1)") do
+      expect(page).to have_content(placement1.subjects.map(&:name).to_sentence)
+      expect(page).to have_content(placement1.mentors.map(&:full_name).to_sentence)
+      expect(page).to have_content("Not known")
+      expect(page).to have_content(placement1.status.titleize)
+    end
+
+    within("tbody tr:nth-child(2)") do
+      expect(page).to have_content(placement2.subjects.map(&:name).to_sentence)
+      expect(page).to have_content(placement2.mentors.map(&:full_name).to_sentence)
+      expect(page).to have_content("Not known")
+      expect(page).to have_content(placement2.status.titleize)
+    end
+  end
+
+  def and_i_dont_see_placements_from_another_school
+    expect(page).not_to have_content(placement3.subjects.map(&:name).to_sentence)
+    expect(page).not_to have_content(placement3.mentors.map(&:full_name).to_sentence)
+  end
+
+  def then_i_see_no_results
+    expect(page).to have_content("There are no placements for #{another_school.name}.")
+  end
+end


### PR DESCRIPTION
## Context

Support users need to be able to view the placements that a school has in the support area.

## Changes proposed in this pull request

- [x] Adds the support/schools/placements controller for the area
- [x] Adds new support/schools/placements route 
- [x] Adds relevant views & locales
- [x] Adds a new system spec 

## Guidance to review

Check out the code locally, log in as Colin, selected an organisation and view the placements tab.

## Link to Trello card

[Placement index page for support users](https://trello.com/c/TXGNEorg)

## Screenshots

<img width="1000" alt="image" src="https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/e197d088-5f72-4847-9580-cb2de19be892">
