### PR TITLE
Use the FormObject directly when adding a provider to a claim

### DIFF
--- a/app/controllers/claims/schools/claims_controller.rb
+++ b/app/controllers/claims/schools/claims_controller.rb
@@ -56,7 +56,7 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
   private
 
   def claim_params
-    params.require(:claims_claim)
+    params.require(:claims_claim_provider_form)
       .permit(:id, :provider_id)
       .merge(default_params)
   end
@@ -67,7 +67,7 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
 
   def claim_provider_form
     @claim_provider_form ||=
-      if params[:claims_claim].present?
+      if params[:claims_claim_provider_form].present?
         Claims::Claim::ProviderForm.new(claim_params)
       else
         Claims::Claim::ProviderForm.new(default_params.merge(id: claim_id))

--- a/app/controllers/claims/support/schools/claims_controller.rb
+++ b/app/controllers/claims/support/schools/claims_controller.rb
@@ -63,7 +63,7 @@ class Claims::Support::Schools::ClaimsController < Claims::Support::ApplicationC
   private
 
   def claim_params
-    params.require(:claims_claim)
+    params.require(:claims_claim_provider_form)
       .permit(:id, :provider_id)
       .merge(default_params)
   end
@@ -82,7 +82,7 @@ class Claims::Support::Schools::ClaimsController < Claims::Support::ApplicationC
 
   def claim_provider_form
     @claim_provider_form ||=
-      if params[:claims_claim].present?
+      if params[:claims_claim_provider_form].present?
         Claims::Claim::ProviderForm.new(claim_params)
       else
         Claims::Claim::ProviderForm.new(default_params.merge(id: claim_id))

--- a/app/forms/claims/claim/provider_form.rb
+++ b/app/forms/claims/claim/provider_form.rb
@@ -1,41 +1,22 @@
 class Claims::Claim::ProviderForm < ApplicationForm
   attr_accessor :id, :provider_id, :school, :current_user
 
-  validate :validate_provider
+  validates :provider_id, presence: true
 
-  def persist
-    updated_claim.save!
+  def initialize(attributes = {})
+    super
+
+    self.provider_id ||= claim.provider_id
   end
 
-  def to_model
-    claim
+  def persist
+    claim.provider_id = provider_id
+    claim.status = :internal_draft if claim.status.nil?
+    claim.created_by = current_user
+    claim.save!
   end
 
   def claim
     @claim ||= school.claims.find_or_initialize_by(id:)
-  end
-
-  private
-
-  def updated_claim
-    @updated_claim ||= begin
-      claim.provider_id = provider_id
-      claim.status = :internal_draft if claim.status.nil?
-      claim.created_by = current_user
-      claim
-    end
-  end
-
-  def validate_provider
-    if updated_claim.provider_id.nil?
-      updated_claim.errors.add(:provider_id, :blank)
-      add_errors_to_form
-    end
-  end
-
-  def add_errors_to_form
-    updated_claim.errors.each do |err|
-      errors.add(err.attribute, err.message)
-    end
   end
 end

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -10,6 +10,10 @@ en:
               blank: Enter the number of hours
             hours_completed:
               blank: Select the number of hours
+        claims/claim/provider_form:
+          attributes:
+            provider_id:
+              blank: Select a provider
         placements/mentor_form:
           attributes:
             trn:
@@ -40,12 +44,11 @@ en:
               option_blank: Select a school
         placements/partnership_form:
           attributes:
-            school_id: 
+            school_id:
               already_added: "%{school_name} has already been added. Try another school"
               blank: Enter a school name, URN or postcode
               option_blank: Select a school
-            provider_id: 
+            provider_id:
               already_added: "%{provider_name} has already been added. Try another provider"
               blank: Enter a provider name, UKPRN, URN or postcode
               option_blank: Select a provider
-

--- a/spec/forms/claims/claim/provider_form_spec.rb
+++ b/spec/forms/claims/claim/provider_form_spec.rb
@@ -16,13 +16,6 @@ describe Claims::Claim::ProviderForm, type: :model do
     end
   end
 
-  describe "#to_model" do
-    it "returns an instance of a Claims::Claim" do
-      form = described_class.new(school:)
-      expect(form.to_model).to be_a Claims::Claim
-    end
-  end
-
   describe "#claim" do
     it "returns an instance of a Claims::Claim" do
       form = described_class.new(school:)


### PR DESCRIPTION
## Context

The `Claims::Claim::ProviderForm` can be simplified.

## Changes proposed in this pull request

- Use `validates` directly. No need for custom validators.
- No need to forward the errors from the underlying model to the form object.

## Guidance to review

- It still works as expected.
- Tests pass.
