### PR TITLE
Placement show page for support [2/4]

### DIFF
--- a/app/controllers/placements/support/schools/placements_controller.rb
+++ b/app/controllers/placements/support/schools/placements_controller.rb
@@ -1,14 +1,23 @@
 class Placements::Support::Schools::PlacementsController < Placements::Support::ApplicationController
   before_action :set_school
+  before_action :set_placement, only: %i[show]
 
   def index
     @pagy, placements = pagy(@school.placements.includes(:subjects, :mentors).order("subjects.name"))
     @placements = placements.decorate
   end
 
+  def show
+    @placement = @school.placements.find(params.fetch(:id)).decorate
+  end
+
   private
 
   def set_school
     @school = Placements::School.find(params.fetch(:school_id))
+  end
+
+  def set_placement
+    @placement = @school.placements.find(params.fetch(:id))
   end
 end

--- a/app/views/placements/support/schools/placements/index.html.erb
+++ b/app/views/placements/support/schools/placements/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, @school.name %>
+<% content_for :page_title, t(".page_title") %>
 <%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 <div class="govuk-width-container">
   <h1 class="govuk-heading-l"><%= @school.name %></h1>

--- a/app/views/placements/support/schools/placements/index.html.erb
+++ b/app/views/placements/support/schools/placements/index.html.erb
@@ -21,7 +21,10 @@
           <% table.with_body do |body| %>
             <% @placements.each do |placement| %>
               <% body.with_row do |row| %>
-                <% row.with_cell(text: placement.subject_names) %>
+                <% row.with_cell(text: govuk_link_to(
+                  placement.subject_names,
+                  placements_support_school_placement_path(@school, placement),
+                )) %>
                 <% row.with_cell(text: placement.mentor_names) %>
                 <% row.with_cell(text: placement.window) %>
                 <% row.with_cell do %>

--- a/app/views/placements/support/schools/placements/show.html.erb
+++ b/app/views/placements/support/schools/placements/show.html.erb
@@ -1,0 +1,61 @@
+<%= content_for :page_title, sanitize(t(".page_title", placement_name: @placement.subject_names, school_name: @school.name)) %>
+
+<%= render "placements/support/primary_navigation", current_navigation: :organisations %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: placements_support_school_placements_path) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".caption", school_name: @school.name) %></span>
+      <h2 class="govuk-heading-l">
+        <%= @placement.subject_names %>
+      </h2>
+
+      <%= govuk_summary_list do |summary_list| %>
+        <% if !@school.primary_or_secondary_only? %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".attributes.placements.school_level")) %>
+            <% row.with_value(text: @placement.school_level) %>
+          <% end %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".attributes.placements.subject")) %>
+          <% row.with_value do %>
+            <ul class="govuk-list">
+              <% @placement.subjects.each do |subject| %>
+                <li><%= subject.name %></li>
+              <% end %>
+            </ul>
+          <% end %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".attributes.placements.mentor")) %>
+          <% row.with_value do %>
+            <% if @placement.mentors.any? %>
+              <ul class="govuk-list">
+                <% @placement.mentors.each do |mentor| %>
+                  <li><%= mentor.full_name %></li>
+                <% end %>
+              </ul>
+            <% else %>
+              <%= t("placements.schools.placements.not_known_yet") %>
+            <% end %>
+          <% end %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".attributes.placements.window")) %>
+          <% row.with_value(text: @placement.window) %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".attributes.placements.status")) %>
+          <% row.with_value do %>
+            <%= render Placement::StatusTagComponent.new(@placement.status) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/locales/en/placements/support/schools/placements.yml
+++ b/config/locales/en/placements/support/schools/placements.yml
@@ -12,3 +12,14 @@ en:
             status: Status
             not_entered: Not entered
             add_placement: Add placement
+          show:
+            page_title: "%{placement_name} - Placements - %{school_name}"
+            caption: "Placements - %{school_name}"
+            attributes:
+              placements:
+                school_level: School level
+                subject: Subject
+                mentor: Mentor
+                window: Window
+                status: Status
+

--- a/spec/system/placements/support/schools/placements/support_user_views_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/support_user_views_a_placement_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe "Placements / Support / Schools / Placement / Support User views a placement",
+               type: :system, service: :placements do
+  let(:school) { create(:placements_school, name: "School 1", phase: "Nursery") }
+  let(:placement) do
+    create(:placement, school:, mentors: [mentor], subjects: [subject], status: "published", start_date: nil,
+                       end_date: nil)
+  end
+  let(:mentor) { create(:placements_mentor) }
+  let(:subject) { create(:subject, name: "Maths", subject_area: :primary) }
+
+  before do
+    school
+    given_i_sign_in_as_colin
+  end
+
+  scenario "Support User views a school placement's details" do
+    when_i_visit_the_support_show_page_for(school, placement)
+    then_i_see_the_placement_details(
+      school_name: "School 1",
+      school_level: "Primary",
+      subjects: "Maths",
+      mentors: placement.mentors.map(&:full_name).to_sentence,
+      window: "Not known",
+      status: "Published",
+    )
+  end
+
+  private
+
+  def and_there_is_an_existing_user_for(user_name)
+    user = create(:placements_support_user, user_name.downcase.to_sym)
+    user_exists_in_dfe_sign_in(user:)
+  end
+
+  def and_i_visit_the_sign_in_path
+    visit sign_in_path
+  end
+
+  def and_i_click_sign_in
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def given_i_sign_in_as_colin
+    and_there_is_an_existing_user_for("Colin")
+    and_i_visit_the_sign_in_path
+    and_i_click_sign_in
+  end
+
+  def when_i_visit_the_support_show_page_for(school, placement)
+    visit placements_support_school_placement_path(school, placement)
+  end
+
+  def then_i_see_the_placement_details(school_name:, school_level:, subjects:, mentors:, window:, status:)
+    expect(page).to have_content(school_name)
+    expect(page).to have_content(subjects)
+
+    within(".govuk-summary-list") do
+      expect(page).to have_content(school_level)
+      expect(page).to have_content(subjects)
+      expect(page).to have_content(mentors)
+      expect(page).to have_content(window)
+      expect(page).to have_content(status)
+    end
+  end
+end

--- a/spec/system/placements/support/schools/placements/support_user_views_placements_spec.rb
+++ b/spec/system/placements/support/schools/placements/support_user_views_placements_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Placements / Support / Schools / Placements / Support User views
     expect(page).to have_content("Status")
 
     within("tbody tr:nth-child(1)") do
-      expect(page).to have_content(placement1.subjects.map(&:name).to_sentence)
+      expect(page).to have_link(placement1.subjects.map(&:name).to_sentence, href: placements_support_school_placement_path(school, placement1))
       expect(page).to have_content(placement1.mentors.map(&:full_name).to_sentence)
       expect(page).to have_content("Not known")
       expect(page).to have_content(placement1.status.titleize)


### PR DESCRIPTION
## Context

Support users need to be able to view the placements that a school has in the support area.

## Changes proposed in this pull request

- [x] Adds the show page for placements when signed in as a support user
- [x] Adds the show controller action
- [x] Adds a system test for the show page
- [x] Updates the index page to link to the show page
- [x] Updates the system test for the index page. 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[Placement show page for support users](https://trello.com/c/jlfU86Ym)

## Screenshots

![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/68547f3a-22bd-45da-8dc2-b1e0140ca387)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/fbbce0a5-daf3-4cdd-8c85-293a692314ab)
