### PR TITLE
Allow user to select ANY school or provider to create a partnership

### DIFF
--- a/app/controllers/api/placements/provider_suggestions_controller.rb
+++ b/app/controllers/api/placements/provider_suggestions_controller.rb
@@ -1,7 +1,0 @@
-class Api::Placements::ProviderSuggestionsController < Api::ProviderSuggestionsController
-  private
-
-  def model
-    Placements::Provider
-  end
-end

--- a/app/controllers/api/placements/school_suggestions_controller.rb
+++ b/app/controllers/api/placements/school_suggestions_controller.rb
@@ -1,7 +1,0 @@
-class Api::Placements::SchoolSuggestionsController < Api::SchoolSuggestionsController
-  private
-
-  def model
-    Placements::School
-  end
-end

--- a/app/controllers/api/provider_suggestions_controller.rb
+++ b/app/controllers/api/provider_suggestions_controller.rb
@@ -1,15 +1,11 @@
 class Api::ProviderSuggestionsController < ApplicationController
   def index
-    render json: model.search_name_urn_ukprn_postcode(query_params)
+    render json: Provider.search_name_urn_ukprn_postcode(query_params)
   end
 
   private
 
   def query_params
     params.require(:query)&.downcase
-  end
-
-  def model
-    Provider
   end
 end

--- a/app/controllers/api/school_suggestions_controller.rb
+++ b/app/controllers/api/school_suggestions_controller.rb
@@ -1,16 +1,11 @@
 class Api::SchoolSuggestionsController < ApplicationController
   def index
-    schools = model.search_name_urn_postcode(query_params)
-    render json: schools
+    render json: School.search_name_urn_postcode(query_params)
   end
 
   private
 
   def query_params
     params.require(:query)&.downcase
-  end
-
-  def model
-    School
   end
 end

--- a/app/forms/placements/partnership_form.rb
+++ b/app/forms/placements/partnership_form.rb
@@ -7,11 +7,11 @@ class Placements::PartnershipForm < ApplicationForm
   validate :partnership_already_exists?
 
   def provider
-    @provider ||= Placements::Provider.find_by(id: provider_id)
+    @provider ||= ::Provider.find_by(id: provider_id)
   end
 
   def school
-    @school ||= Placements::School.find_by(id: school_id)
+    @school ||= ::School.find_by(id: school_id)
   end
 
   def as_form_params

--- a/app/models/placements/partnership.rb
+++ b/app/models/placements/partnership.rb
@@ -20,8 +20,8 @@
 #  fk_rails_...  (school_id => schools.id)
 #
 class Placements::Partnership < ApplicationRecord
-  belongs_to :provider
-  belongs_to :school
+  belongs_to :provider, class_name: "::Provider"
+  belongs_to :school, class_name: "::School"
 
   validates :school_id, uniqueness: { scope: :provider_id }
 end

--- a/app/views/placements/providers/partner_schools/new.html.erb
+++ b/app/views/placements/providers/partner_schools/new.html.erb
@@ -10,7 +10,7 @@
     scope: :partnership,
     url: check_placements_provider_partner_schools_path,
     data: {
-      autocomplete_path_value: "/api/placements/school_suggestions",
+      autocomplete_path_value: "/api/school_suggestions",
       autocomplete_return_attributes_value: %w[town postcode],
       input_name: "partnership[school_name]",
     },

--- a/app/views/placements/schools/partner_providers/new.html.erb
+++ b/app/views/placements/schools/partner_providers/new.html.erb
@@ -10,7 +10,7 @@
     scope: :partnership,
     url: check_placements_school_partner_providers_path,
     data: {
-      autocomplete_path_value: "/api/placements/provider_suggestions",
+      autocomplete_path_value: "/api/provider_suggestions",
       autocomplete_return_attributes_value: %w[code],
       input_name: "partnership[provider_name]",
     },

--- a/spec/forms/placements/partnership_form_spec.rb
+++ b/spec/forms/placements/partnership_form_spec.rb
@@ -136,15 +136,8 @@ describe Placements::PartnershipForm, type: :model do
   describe "#school" do
     context "when given the id of an existing placement school" do
       it "returns the placement school associated with that id" do
-        school = create(:placements_school)
-        expect(described_class.new(school_id: school.id).school).to eq(school)
-      end
-    end
-
-    context "when given the id of a school not onboarded onto the placements service" do
-      it "returns nil" do
         school = create(:school)
-        expect(described_class.new(school_id: school.id).school).to eq(nil)
+        expect(described_class.new(school_id: school.id).school).to eq(school)
       end
     end
 
@@ -158,15 +151,8 @@ describe Placements::PartnershipForm, type: :model do
   describe "#provider" do
     context "when given the id of an existing placement provider" do
       it "returns the placement school associated with that id" do
-        provider = create(:placements_provider)
-        expect(described_class.new(provider_id: provider.id).provider).to eq(provider)
-      end
-    end
-
-    context "when given the id of a provider not onboarded onto the placements service" do
-      it "returns nil" do
         provider = create(:provider)
-        expect(described_class.new(provider_id: provider.id).provider).to eq(nil)
+        expect(described_class.new(provider_id: provider.id).provider).to eq(provider)
       end
     end
 

--- a/spec/models/placements/provider_spec.rb
+++ b/spec/models/placements/provider_spec.rb
@@ -54,15 +54,20 @@ RSpec.describe Placements::Provider do
     describe "#partner_schools" do
       it { is_expected.to have_many(:partner_schools).through(:partnerships) }
 
-      it "returns only Placements::School records" do
+      it "returns School records" do
         placements_provider = create(:placements_provider)
-        placements_school = create(:placements_school)
+        placements_school = create(:school, :placements)
+        claims_school = create(:school, :claims)
+        school = create(:school)
 
-        placements_provider.partner_schools << create(:claims_school)
+        placements_provider.partner_schools << claims_school
         placements_provider.partner_schools << placements_school
+        placements_provider.partner_schools << school
 
-        expect(placements_provider.partner_schools).to contain_exactly(placements_school)
-        expect(placements_provider.partner_schools).to all(be_a(Placements::School))
+        expect(placements_provider.partner_schools).to match_array(
+          [placements_school, claims_school, school],
+        )
+        expect(placements_provider.partner_schools).to all(be_a(School))
       end
     end
   end

--- a/spec/models/placements/school_spec.rb
+++ b/spec/models/placements/school_spec.rb
@@ -92,14 +92,17 @@ RSpec.describe Placements::School do
       it { is_expected.to have_many(:partner_providers).through(:partnerships) }
 
       it "returns only Placements::Provider records" do
-        placements_provider = create(:placements_provider)
         placements_school = create(:placements_school)
+        placements_provider = create(:provider, :placements)
+        provider = create(:provider)
 
-        placements_school.partner_providers << create(:claims_provider)
         placements_school.partner_providers << placements_provider
+        placements_school.partner_providers << provider
 
-        expect(placements_school.partner_providers).to contain_exactly(placements_provider)
-        expect(placements_school.partner_providers).to all(be_a(Placements::Provider))
+        expect(placements_school.partner_providers).to match_array(
+          [placements_provider, provider],
+        )
+        expect(placements_school.partner_providers).to all(be_a(Provider))
       end
     end
   end


### PR DESCRIPTION
## Context

- Allow any Provider/School to be linked in a partnership, regardless of if they have been onboarded to the Placements service.

## Changes proposed in this pull request

- Delete Placements specific API controllers.
- Changes to model and form, to allow ANY `Provider` and `School` to be joined in partnership, regardless of Placements service onboarding.

## Guidance to review
_For Provider_
- Sign in as Provider User Patricia
- Click "Partner schools" from top Navigation.
- Click "Add partner school"
- You should now be able to search from a full list of Schools (Not just those onboarded on the Placements service)
- Select a school
- Continue through the check and creation process
- You should now see a Partnership has been made with the selected school (even if they are not onboarded onto the Placements service)

_For School_
- Sign in as School User Anne
- Click "Partner providers" from top Navigation.
- Click "Add partner provider"
- You should now be able to search from a full list of Providers (Not just those onboarded on the Placements service)
- Select a provider
- Continue through the check and creation process
- You should now see a Partnership has been made with the selected provider (even if they are not onboarded onto the Placements service)

## Link to Trello card

https://trello.com/c/uqTdN7hy/259-define-functionality-for-adding-removing-partnerships

## Screenshots

https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/0a80856d-80bb-4b9c-a69a-bff9c9be1fb7

https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/50eec799-f119-4caa-96c9-9869307a25b5


