### PR TITLE
As a User & Support User, I want to see the breakdown of the claim amount

### DIFF
--- a/app/views/claims/schools/claims/check.html.erb
+++ b/app/views/claims/schools/claims/check.html.erb
@@ -55,7 +55,7 @@
         <% @claim.mentor_trainings.order_by_mentor_full_name.each do |mentor_training| %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: mentor_training.mentor.full_name) %>
-            <% row.with_value(text: t(".hours", hours: mentor_training.hours_completed)) %>
+            <% row.with_value(text: pluralize(mentor_training.hours_completed, t(".hour"))) %>
             <% row.with_action(text: t("change"),
                                href: edit_claims_school_claim_mentor_training_path(
                                  @school,
@@ -74,6 +74,16 @@
 
       <h2 class="govuk-heading-m"><%= t(".grant_funding") %></h2>
         <%= govuk_summary_list do |summary_list| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".total_hours")) %>
+            <% row.with_value(text: pluralize(@claim.mentor_trainings.sum(:hours_completed), t(".hour"))) %>
+          <% end %>
+
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".hourly_rate")) %>
+            <% row.with_value(text: humanized_money_with_symbol(@claim.school.region.funding_available_per_hour)) %>
+          <% end %>
+
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: Claims::Claim.human_attribute_name(:claim_amount)) %>
             <% row.with_value(text: humanized_money_with_symbol(@claim.amount)) %>

--- a/app/views/claims/schools/claims/show.html.erb
+++ b/app/views/claims/schools/claims/show.html.erb
@@ -57,13 +57,23 @@
          <%= @claim.mentor_trainings.order_by_mentor_full_name.each do |mentor_training| %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: mentor_training.mentor.full_name) %>
-            <% row.with_value(text: "#{mentor_training.hours_completed} #{t(".hours")}") %>
+            <% row.with_value(text: pluralize(mentor_training.hours_completed, t(".hour"))) %>
           <% end %>
         <% end %>
       <% end %>
 
       <h2 class="govuk-heading-m"><%= t(".grant_funding") %></h2>
         <%= govuk_summary_list do |summary_list| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".total_hours")) %>
+            <% row.with_value(text: pluralize(@claim.mentor_trainings.sum(:hours_completed), t(".hour"))) %>
+          <% end %>
+
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".hourly_rate")) %>
+            <% row.with_value(text: humanized_money_with_symbol(@claim.school.region.funding_available_per_hour)) %>
+          <% end %>
+
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: Claims::Claim.human_attribute_name(:claim_amount)) %>
             <% row.with_value(text: humanized_money_with_symbol(@claim.amount)) %>

--- a/app/views/claims/support/claims/_details.html.erb
+++ b/app/views/claims/support/claims/_details.html.erb
@@ -47,7 +47,7 @@
    <%= claim.mentor_trainings.order_by_mentor_full_name.each do |mentor_training| %>
     <% summary_list.with_row do |row| %>
       <% row.with_key(text: mentor_training.mentor.full_name) %>
-      <% row.with_value(text: "#{mentor_training.hours_completed} #{t(".hours")}") %>
+      <% row.with_value(text: pluralize(mentor_training.hours_completed, t(".hour"))) %>
       <% if policy(claim).edit? %>
         <% row.with_action(text: t("change"),
                            href: edit_claims_support_school_claim_mentor_training_path(
@@ -68,6 +68,16 @@
 
 <h2 class="govuk-heading-m"><%= t(".grant_funding") %></h2>
 <%= govuk_summary_list do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t(".total_hours")) %>
+    <% row.with_value(text: pluralize(claim.mentor_trainings.sum(:hours_completed), t(".hour"))) %>
+  <% end %>
+
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t(".hourly_rate")) %>
+    <% row.with_value(text: humanized_money_with_symbol(claim.school.region.funding_available_per_hour)) %>
+  <% end %>
+
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: Claims::Claim.human_attribute_name(:claim_amount)) %>
     <% row.with_value(text: humanized_money_with_symbol(claim.amount)) %>

--- a/app/views/claims/support/schools/claims/check.html.erb
+++ b/app/views/claims/support/schools/claims/check.html.erb
@@ -50,7 +50,7 @@
         <% @claim.mentor_trainings.order_by_mentor_full_name.each do |mentor_training| %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: mentor_training.mentor.full_name) %>
-            <% row.with_value(text: t(".hours", hours: mentor_training.hours_completed)) %>
+            <% row.with_value(text: pluralize(mentor_training.hours_completed, t(".hour"))) %>
             <% row.with_action(text: t("change"),
                                href: edit_claims_support_school_claim_mentor_training_path(
                                  @school,
@@ -69,6 +69,16 @@
 
       <h2 class="govuk-heading-m"><%= t(".grant_funding") %></h2>
         <%= govuk_summary_list do |summary_list| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".total_hours")) %>
+            <% row.with_value(text: pluralize(@claim.mentor_trainings.sum(:hours_completed), t(".hour"))) %>
+          <% end %>
+
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".hourly_rate")) %>
+            <% row.with_value(text: humanized_money_with_symbol(@claim.school.region.funding_available_per_hour)) %>
+          <% end %>
+
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: Claims::Claim.human_attribute_name(:claim_amount)) %>
             <% row.with_value(text: humanized_money_with_symbol(@claim.amount)) %>

--- a/config/locales/en/claims/schools/claims.yml
+++ b/config/locales/en/claims/schools/claims.yml
@@ -25,7 +25,9 @@ en:
           claim_on_behalf_of_school: I am authorised to claim on behalf of the school
           accurate_information: The information detailed above is accurate and the total I am claiming back has been used to support the cost of the mentor training
           provide_evidence: I will provide evidence to support this claim if requested by the Department for Education
-          hours: "%{hours} hours"
+          total_hours: Total hours
+          hourly_rate: Hourly rate
+          hour: hour
           grant_funding: Grant funding
           hours_of_training: Hours of training
         form:
@@ -47,7 +49,9 @@ en:
           page_title: Claim - %{reference}
           hours_of_training: Hours of training
           grant_funding: Grant funding
-          hours: hours
+          total_hours: Total hours
+          hourly_rate: Hourly rate
+          hour: hour
           submit: Submit claim
           submitted_by: Submitted by %{name} on %{date}.
         edit:

--- a/config/locales/en/claims/support/claims.yml
+++ b/config/locales/en/claims/support/claims.yml
@@ -26,7 +26,9 @@ en:
           mentor: Mentor
           submitted_by: Submitted by %{name} on %{date}.
         details:
+          hour: hour
+          hourly_rate: Hourly rate
+          total_hours: Total hours
           mentors: Mentors
           hours_of_training: Hours of training
-          hours: hours
           grant_funding: Grant funding

--- a/config/locales/en/claims/support/schools/claims.yml
+++ b/config/locales/en/claims/support/schools/claims.yml
@@ -14,7 +14,9 @@ en:
             update: Update claim
             grant_funding: Grant funding
             add_claim: Add claim - %{school}
-            hours: "%{hours} hours"
+            hour: hour
+            hourly_rate: Hourly rate
+            total_hours: Total hours
             hours_of_training: Hours of training
           index:
             heading: Claims

--- a/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
@@ -231,6 +231,14 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
 
     within("dl.govuk-summary-list:nth(3)") do
       within(".govuk-summary-list__row:nth(1)") do
+        expect(page).to have_content("Total hours#{claim.mentor_trainings.sum(:hours_completed)} hours")
+      end
+
+      within(".govuk-summary-list__row:nth(2)") do
+        expect(page).to have_content("Hourly rate£53.60")
+      end
+
+      within(".govuk-summary-list__row:nth(3)") do
         expect(page).to have_content("Claim amount")
         expect(page).to have_content(claim.amount.format(symbol: true, decimal_mark: ".", no_cents: true))
       end

--- a/spec/system/claims/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/schools/claims/create_claim_spec.rb
@@ -153,6 +153,14 @@ RSpec.describe "Create claim", type: :system, service: :claims do
 
     within("dl.govuk-summary-list:nth(3)") do
       within(".govuk-summary-list__row:nth(1)") do
+        expect(page).to have_content("Total hours32 hours")
+      end
+
+      within(".govuk-summary-list__row:nth(2)") do
+        expect(page).to have_content("Hourly rate£53.60")
+      end
+
+      within(".govuk-summary-list__row:nth(3)") do
         expect(page).to have_content("Claim amount")
         expect(page).to have_content("£1,715.20")
       end

--- a/spec/system/claims/schools/claims/view_claim_spec.rb
+++ b/spec/system/claims/schools/claims/view_claim_spec.rb
@@ -71,6 +71,8 @@ RSpec.describe "View a claim", type: :system, service: :claims do
     expect(page).to have_content("Mentors\nBarry Garlow")
     expect(page).to have_content("Hours of training")
     expect(page).to have_content("Barry Garlow#{mentor_training.hours_completed} hours")
+    expect(page).to have_content("Total hours6 hours")
+    expect(page).to have_content("Hourly rate£53.60")
     expect(page).to have_content("Claim amount£321.60")
   end
 
@@ -83,6 +85,8 @@ RSpec.describe "View a claim", type: :system, service: :claims do
     expect(page).to have_content("Mentors\nBarry Garlow")
     expect(page).to have_content("Hours of training")
     expect(page).to have_content("Barry Garlow#{draft_mentor_training.hours_completed} hours")
+    expect(page).to have_content("Total hours6 hours")
+    expect(page).to have_content("Hourly rate£53.60")
     expect(page).to have_content("Claim amount£321.60")
   end
 

--- a/spec/system/claims/support/claims/view_a_claim_spec.rb
+++ b/spec/system/claims/support/claims/view_a_claim_spec.rb
@@ -54,6 +54,8 @@ RSpec.describe "View claims", type: :system, service: :claims do
     expect(page).to have_content("Mentors\n#{mentor.full_name}")
     expect(page).to have_content("Hours of training")
     expect(page).to have_content("#{mentor.full_name}#{mentor_training.hours_completed} hours")
+    expect(page).to have_content("Total hours6 hours")
+    expect(page).to have_content("Hourly rate£53.60")
     expect(page).to have_content("Claim amount£321.60")
   end
 end

--- a/spec/system/claims/support/schools/claims/view_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/view_claim_spec.rb
@@ -55,6 +55,8 @@ RSpec.describe "View a claim", type: :system, service: :claims do
     expect(page).to have_content("Mentors\nBarry Garlow")
     expect(page).to have_content("Hours of training")
     expect(page).to have_content("Barry Garlow#{mentor_training.hours_completed} hours")
+    expect(page).to have_content("Total hours6 hours")
+    expect(page).to have_content("Hourly rate£53.60")
     expect(page).to have_content("Claim amount£321.60")
   end
 


### PR DESCRIPTION
## Context

We need to ensure we show the claim amount breakdown on a claim

## Changes proposed in this pull request

Add the hourly rate and total hours to the claim views

## Guidance to review

- Create, edit and view claims as a support user
- Create, edit and view claims as a normal user

## Link to Trello card

https://trello.com/c/BDuId4kG/403-as-a-user-support-user-i-want-to-see-the-breakdown-of-the-claim-amount
