### PR TITLE
Update warning message for inviting/removing a user

### DIFF
--- a/app/views/claims/schools/users/check.html.erb
+++ b/app/views/claims/schools/users/check.html.erb
@@ -39,7 +39,7 @@
 
         <div class="govuk-warning-text">
           <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-          <strong class="govuk-warning-text__text"><%= t(".warning", school_name: @school.name) %></strong>
+          <strong class="govuk-warning-text__text"><%= t(".warning", user_name: "#{@user_form.first_name} #{@user_form.last_name}", school_name: @school.name) %></strong>
         </div>
 
         <%= f.govuk_submit t(".add_user") %>

--- a/app/views/claims/schools/users/remove.html.erb
+++ b/app/views/claims/schools/users/remove.html.erb
@@ -11,7 +11,7 @@
       <span class="govuk-caption-l"><%= t(".caption", user_name: @user.full_name) %></span>
       <h2 class="govuk-heading-l"><%= t(".heading") %></h2>
 
-      <%= govuk_warning_text(text: t(".warning", school_name: @school.name)) %>
+      <%= govuk_warning_text(text: t(".warning", user_name: @user.full_name, school_name: @school.name)) %>
 
       <%= govuk_button_to t(".remove_user"), claims_school_user_path(@school, @user), warning: true, method: :delete %>
 

--- a/app/views/claims/support/schools/users/check.html.erb
+++ b/app/views/claims/support/schools/users/check.html.erb
@@ -78,7 +78,7 @@
 
         <div class="govuk-warning-text">
           <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-          <strong class="govuk-warning-text__text"><%= t(".warning", school_name: @school.name) %></strong>
+          <strong class="govuk-warning-text__text"><%= t(".warning", user_name: "#{@user_form.first_name} #{@user_form.last_name}", school_name: @school.name) %></strong>
         </div>
 
         <%= f.govuk_submit t(".add_user") %>

--- a/app/views/claims/support/schools/users/remove.html.erb
+++ b/app/views/claims/support/schools/users/remove.html.erb
@@ -11,7 +11,7 @@
       <span class="govuk-caption-l"><%= t(".caption", user_name: @user.full_name, school_name: @school.name) %></span>
       <h2 class="govuk-heading-l"><%= t(".heading") %></h2>
 
-      <%= govuk_warning_text(text: t(".warning", school_name: @school.name)) %>
+      <%= govuk_warning_text(text: t(".warning", user_name: @user.full_name, school_name: @school.name)) %>
 
       <%= govuk_button_to t(".remove_user"), claims_support_school_user_path(@school, @user), warning: true, method: :delete %>
 

--- a/app/views/claims/support/support_users/check.html.erb
+++ b/app/views/claims/support/support_users/check.html.erb
@@ -43,7 +43,7 @@
 
         <div class="govuk-warning-text">
           <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-          <strong class="govuk-warning-text__text"><%= t(".warning") %></strong>
+          <strong class="govuk-warning-text__text"><%= t(".warning", user_name: "#{@support_user_form.first_name} #{@support_user_form.last_name}") %></strong>
         </div>
 
         <%= f.govuk_submit t(".submit") %>

--- a/app/views/claims/support/support_users/remove.html.erb
+++ b/app/views/claims/support/support_users/remove.html.erb
@@ -13,7 +13,7 @@
           <%= t(".title") %>
         </label>
 
-        <%= govuk_warning_text(text: t(".warning")) %>
+        <%= govuk_warning_text(text: t(".warning", user_name: @support_user.full_name)) %>
 
         <%= f.govuk_submit t(".submit"), warning: true %>
 

--- a/config/locales/en/claims/schools/users.yml
+++ b/config/locales/en/claims/schools/users.yml
@@ -19,7 +19,7 @@ en:
           caption: Add user
           add_user: Add user
           cancel: Cancel
-          warning: "The user will be sent an email to tell them you’ve added them to %{school_name}."
+          warning: "%{user_name} will be sent an email to tell them you’ve added them to %{school_name}."
           change: Change
         create:
           success: User added
@@ -29,7 +29,7 @@ en:
           page_title: Are you sure you want to remove this user? - %{user_name}
           caption: "%{user_name}"
           heading: Are you sure you want to remove this user?
-          warning: The user will be sent an email to tell them you removed them from %{school_name}.
+          warning: "%{user_name} will be sent an email to tell them you removed them from %{school_name}."
           remove_user: Remove user
           cancel: Cancel
         destroy:

--- a/config/locales/en/claims/support/schools/users.yml
+++ b/config/locales/en/claims/support/schools/users.yml
@@ -37,7 +37,7 @@ en:
             first_name: First name
             last_name: Last name
             email: Email address
-            warning: "The user will be sent an email to tell them you’ve added them to %{school_name}."
+            warning: "%{user_name} will be sent an email to tell them you’ve added them to %{school_name}."
             page_title: "Check your answers - Add user - %{school_name}"
             change: Change
           create:
@@ -46,7 +46,7 @@ en:
             page_title: Are you sure you want to remove this user? - %{user_name} - %{school_name}
             caption: "%{user_name} - %{school_name}"
             heading: Are you sure you want to remove this user?
-            warning: The user will be sent an email to tell them you removed them from %{school_name}.
+            warning: "%{user_name} will be sent an email to tell them you removed them from %{school_name}."
             remove_user: Remove user
             cancel: Cancel
           destroy:

--- a/config/locales/en/claims/support/support_users.yml
+++ b/config/locales/en/claims/support/support_users.yml
@@ -23,7 +23,7 @@ en:
           submit: Add user
           cancel: Cancel
           change: Change
-          warning: The user will be sent an email to tell them you’ve added them to Claim funding for mentor training.
+          warning: "%{user_name} will be sent an email to tell them you’ve added them to Claim funding for mentor training."
         create:
           success: User added
         show:
@@ -32,7 +32,7 @@ en:
         remove:
           page_title: Are you sure you want to remove this user? - %{user_name}
           title: Are you sure you want to remove this user?
-          warning: The user will be sent an email to tell them you removed them from Claim funding for mentor training.
+          warning: "%{user_name} will be sent an email to tell them you removed them from Claim funding for mentor training."
           submit: Remove user
           cancel: Cancel
         destroy:

--- a/config/locales/en/claims/support/users.yml
+++ b/config/locales/en/claims/support/users.yml
@@ -40,4 +40,4 @@ en:
           first_name: First name
           last_name: Last name
           email: Email
-          warning: "The user will be sent an email to tell them you’ve added them to %{school_name}."
+          warning: "%{user_name} will be sent an email to tell them you’ve added them to %{school_name}."

--- a/spec/system/claims/schools/users/remove_a_user_spec.rb
+++ b/spec/system/claims/schools/users/remove_a_user_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Remove a user", type: :system, service: :claims do
 
   def then_i_am_taken_to_a_removal_confirmation_page(school, user)
     expect(page).to have_content user.full_name
-    expect(page).to have_content "The user will be sent an email to tell them you removed them from #{school.name}."
+    expect(page).to have_content "#{user.full_name} will be sent an email to tell them you removed them from #{school.name}."
   end
 
   def then_the_user_has_been_removed_from_the_school(user)

--- a/spec/system/claims/support/schools/users/remove_a_user_spec.rb
+++ b/spec/system/claims/support/schools/users/remove_a_user_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Remove a user", type: :system, service: :claims do
 
   def then_i_am_taken_to_a_removal_confirmation_page(school, user)
     expect(page).to have_content "#{user.full_name} - #{school.name}"
-    expect(page).to have_content "The user will be sent an email to tell them you removed them from #{school.name}."
+    expect(page).to have_content "#{user.full_name} will be sent an email to tell them you removed them from #{school.name}."
   end
 
   def then_the_user_has_been_removed_from_the_school(_school, user)


### PR DESCRIPTION
## Context

So the user knows what user they are removing or adding

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

- Navigate through the app as a support and non support user
- Add and remove users
- Check the warning message now includes the users full name

## Link to Trello card

https://trello.com/c/F8gPhFIG/406-we-need-to-update-the-content-from-the-user-will-be-sent-sent-an-email-to-name-of-user-will-be-sent-an-email

