### PR TITLE
Showing X of Y content should be above pagination

### DIFF
--- a/app/components/pagination_component.html.erb
+++ b/app/components/pagination_component.html.erb
@@ -1,5 +1,5 @@
-<%= govuk_pagination(pagy:) %>
-
 <p>
   <%= t("pagination_info", from: pagy.from, to: pagy.to, count: pagy.count) %>
 </p>
+
+<%= govuk_pagination(pagy:) %>


### PR DESCRIPTION
## Context

The content needed to be above the pagination buttons

## Changes proposed in this pull request

Moves the `Showing X of Y` content above the pagination buttons

## Guidance to review

- Create claims to allow for pagination
- The content should now be above the pagination toggle

## Link to Trello card

https://trello.com/c/Kfn0pOvi/401-pagination
