### PR TITLE
Add dfe-analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,8 @@ DFE_SIGN_IN_ISSUER_URL=https://dev-oidc.signin.education.gov.uk
 TEACHING_RECORD_BASE_URL=https://preprod.teacher-qualifications-api.education.gov.uk
 TEACHING_RECORD_API_KEY=get-this-from-a-developer
 TEACHING_RECORD_API_MINOR_VERSION=20240101
+
+BIGQUERY_TABLE_NAME=events
+BIGQUERY_PROJECT_ID=rugged-abacus-218110
+BIGQUERY_DATASET=itt_mentor_events_test
+BIGQUERY_API_JSON_KEY=

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN apk add --update --no-cache tzdata && \
 # build-base: dependencies for bundle
 # yarn: node package manager
 # postgresql-dev: postgres driver and libraries
-RUN apk add --no-cache build-base yarn postgresql13-dev
+# git: to install dfe-analytics
+RUN apk add --no-cache build-base yarn postgresql13-dev git
 
 # Install gems defined in Gemfile
 COPY .ruby-version Gemfile Gemfile.lock ./

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-git_source(:github) { |_repo| "https://github.com/#{repo}.git" }
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.3.0"
 
@@ -95,6 +95,9 @@ gem "geocoder"
 
 # Audit trail
 gem "audited"
+
+# BigQuery
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.12.4"
 
 group :development do
   gem "annotate", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/DFE-Digital/dfe-analytics.git
+  revision: 3e078f9fdd0e890449f90e7cd2f151c392d570ac
+  tag: v1.12.4
+  specs:
+    dfe-analytics (1.12.4)
+      google-cloud-bigquery (~> 1.38)
+      request_store_rails (~> 2)
+
+GIT
   remote: https://github.com/DFE-Digital/rspec-retry.git
   revision: 306b42b8d5853303982e1a165e82d04744c20ea3
   branch: main
@@ -156,6 +165,7 @@ GEM
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    declarative (0.0.20)
     diff-lcs (1.5.1)
     discard (1.3.0)
       activerecord (>= 4.2, < 8)
@@ -215,6 +225,36 @@ GEM
       fugit (>= 1.1)
       railties (>= 6.0.0)
       thor (>= 0.14.1)
+    google-apis-bigquery_v2 (0.67.0)
+      google-apis-core (>= 0.14.0, < 2.a)
+    google-apis-core (0.14.1)
+      addressable (~> 2.5, >= 2.5.1)
+      googleauth (~> 1.9)
+      httpclient (>= 2.8.1, < 3.a)
+      mini_mime (~> 1.0)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.a)
+      rexml
+    google-cloud-bigquery (1.49.0)
+      concurrent-ruby (~> 1.0)
+      google-apis-bigquery_v2 (~> 0.62)
+      google-apis-core (~> 0.13)
+      google-cloud-core (~> 1.6)
+      googleauth (~> 1.9)
+      mini_mime (~> 1.0)
+    google-cloud-core (1.7.0)
+      google-cloud-env (>= 1.0, < 3.a)
+      google-cloud-errors (~> 1.0)
+    google-cloud-env (2.1.1)
+      faraday (>= 1.0, < 3.a)
+    google-cloud-errors (1.4.0)
+    googleauth (1.11.0)
+      faraday (>= 1.0, < 3.a)
+      google-cloud-env (~> 2.1)
+      jwt (>= 1.4, < 3.0)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (>= 0.16, < 2.a)
     govuk-components (5.3.1)
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (>= 6, < 8)
@@ -235,6 +275,7 @@ GEM
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
+    httpclient (2.8.3)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     imagen (0.1.8)
@@ -292,6 +333,7 @@ GEM
       money (~> 6.13)
       railties (>= 3.0)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     multi_xml (0.6.0)
     mutex_m (0.2.0)
     net-imap (0.4.10)
@@ -335,6 +377,7 @@ GEM
       validate_email
       validate_url
       webfinger (~> 2.0)
+    os (1.1.4)
     pagy (7.0.11)
     parallel (1.24.0)
     parser (3.3.0.5)
@@ -435,8 +478,15 @@ GEM
     regexp_parser (2.9.0)
     reline (0.5.2)
       io-console (~> 0.5)
+    representable (3.2.0)
+      declarative (< 0.1.0)
+      trailblazer-option (>= 0.1.1, < 0.2.0)
+      uber (< 0.2.0)
     request_store (1.6.0)
       rack (>= 1.4)
+    request_store_rails (2.0.0)
+      concurrent-ruby (~> 1.0)
+    retriable (3.1.2)
     reverse_markdown (2.1.1)
       nokogiri
     rexml (3.2.6)
@@ -520,6 +570,11 @@ GEM
       concurrent-ruby (~> 1.0, >= 1.0.2)
     shoulda-matchers (6.2.0)
       activesupport (>= 5.2.0)
+    signet (0.19.0)
+      addressable (~> 2.8)
+      faraday (>= 0.17.5, < 3.a)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -574,8 +629,10 @@ GEM
     tilt (2.3.0)
     timecop (0.9.8)
     timeout (0.4.1)
+    trailblazer-option (0.1.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    uber (0.1.0)
     undercover (0.5.0)
       bigdecimal
       imagen (>= 0.1.8)
@@ -635,6 +692,7 @@ DEPENDENCIES
   climate_control
   cssbundling-rails
   debug
+  dfe-analytics!
   discard
   dotenv-rails
   down (~> 5.4)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  include DfE::Analytics::Requests
   include ApplicationHelper
   include RoutesHelper
   include Pagy::Backend

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -1,0 +1,168 @@
+---
+shared: 
+  :partnerships:
+  - id
+  - school_id
+  - provider_id
+  - created_at
+  - updated_at
+  :mentor_trainings:
+  - id
+  - training_type
+  - hours_completed
+  - date_completed
+  - claim_id
+  - mentor_id
+  - provider_id
+  - created_at
+  - updated_at
+  :user_memberships:
+  - id
+  - user_id
+  - organisation_type
+  - organisation_id
+  - created_at
+  - updated_at
+  :users:
+  - first_name
+  - last_name
+  - email
+  - created_at
+  - updated_at
+  - id
+  - type
+  - dfe_sign_in_uid
+  - last_signed_in_at
+  - discarded_at
+  :trusts:
+  - id
+  - uid
+  - name
+  - created_at
+  - updated_at
+  :subjects:
+  - id
+  - subject_area
+  - name
+  - code
+  - created_at
+  - updated_at
+  :regions:
+  - id
+  - name
+  - claims_funding_available_per_hour_pence
+  - claims_funding_available_per_hour_currency
+  - created_at
+  - updated_at
+  :placement_subject_joins:
+  - id
+  - subject_id
+  - placement_id
+  - created_at
+  - updated_at
+  :placement_mentor_joins:
+  - id
+  - mentor_id
+  - placement_id
+  - created_at
+  - updated_at
+  :mentor_memberships:
+  - id
+  - type
+  - mentor_id
+  - school_id
+  - created_at
+  - updated_at
+  :mentors:
+  - id
+  - first_name
+  - last_name
+  - trn
+  - created_at
+  - updated_at
+  :claims:
+  - id
+  - school_id
+  - created_at
+  - updated_at
+  - provider_id
+  - reference
+  - submitted_at
+  - created_by_type
+  - created_by_id
+  - status
+  - submitted_by_type
+  - submitted_by_id
+  :schools:
+  - id
+  - urn
+  - placements_service
+  - claims_service
+  - created_at
+  - updated_at
+  - name
+  - postcode
+  - town
+  - ukprn
+  - telephone
+  - website
+  - address1
+  - address2
+  - address3
+  - group
+  - type_of_establishment
+  - phase
+  - gender
+  - minimum_age
+  - maximum_age
+  - religious_character
+  - admissions_policy
+  - urban_or_rural
+  - school_capacity
+  - total_pupils
+  - total_girls
+  - total_boys
+  - percentage_free_school_meals
+  - special_classes
+  - send_provision
+  - training_with_disabilities
+  - rating
+  - last_inspection_date
+  - email_address
+  - district_admin_name
+  - district_admin_code
+  - region_id
+  - trust_id
+  - longitude
+  - latitude
+  - local_authority_name
+  - local_authority_code
+  :providers:
+  - id
+  - code
+  - created_at
+  - updated_at
+  - placements_service
+  - provider_type
+  - name
+  - ukprn
+  - urn
+  - email_address
+  - telephone
+  - website
+  - address1
+  - address2
+  - address3
+  - town
+  - city
+  - county
+  - postcode
+  - accredited
+  :placements:
+  - id
+  - status
+  - start_date
+  - end_date
+  - school_id
+  - created_at
+  - updated_at

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -1,0 +1,84 @@
+---
+shared:
+  :flipflop_features:
+  - id
+  - key
+  - enabled
+  - created_at
+  - updated_at
+  :audits:
+  - id
+  - auditable_id
+  - auditable_type
+  - associated_id
+  - associated_type
+  - user_id
+  - user_type
+  - username
+  - action
+  - audited_changes
+  - version
+  - comment
+  - remote_address
+  - request_uuid
+  - created_at
+  :good_job_settings:
+  - id
+  - created_at
+  - updated_at
+  - key
+  - value
+  :good_job_processes:
+  - id
+  - created_at
+  - updated_at
+  - state
+  :good_job_executions:
+  - id
+  - created_at
+  - updated_at
+  - active_job_id
+  - job_class
+  - queue_name
+  - serialized_params
+  - scheduled_at
+  - finished_at
+  - error
+  - error_event
+  :good_job_batches:
+  - id
+  - created_at
+  - updated_at
+  - description
+  - serialized_properties
+  - on_finish
+  - on_success
+  - on_discard
+  - callback_queue_name
+  - callback_priority
+  - enqueued_at
+  - discarded_at
+  - finished_at
+  :good_jobs:
+  - id
+  - queue_name
+  - priority
+  - serialized_params
+  - scheduled_at
+  - performed_at
+  - finished_at
+  - error
+  - created_at
+  - updated_at
+  - active_job_id
+  - concurrency_key
+  - cron_key
+  - retried_good_job_id
+  - cron_at
+  - batch_id
+  - batch_callback_id
+  - is_discrete
+  - executions_count
+  - job_class
+  - error_event
+  - labels

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -1,0 +1,12 @@
+---
+shared: 
+  :users:
+  - first_name
+  - last_name
+  - email
+  :mentors:
+  - first_name
+  - last_name
+  :providers:
+  - email_address
+  - telephone

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -1,0 +1,75 @@
+ALLOWED_ENVS = %w[production qa sandbox staging].freeze
+DfE::Analytics.configure do |config|
+  # Whether to log events instead of sending them to BigQuery.
+  #
+  # config.log_only = true
+
+  # Whether to use ActiveJob or dispatch events immediately.
+  #
+  # config.async = true
+
+  # Which ActiveJob queue to put events on
+  #
+  config.queue = :dfe_analytics
+
+  # The name of the BigQuery table we’re writing to.
+  #
+  # config.bigquery_table_name = ENV['BIGQUERY_TABLE_NAME']
+
+  # The name of the BigQuery project we’re writing to.
+  #
+  # config.bigquery_project_id = ENV['BIGQUERY_PROJECT_ID']
+
+  # The name of the BigQuery dataset we're writing to.
+  #
+  # config.bigquery_dataset = ENV['BIGQUERY_DATASET']
+
+  # Service account JSON key for the BigQuery API. See
+  # https://cloud.google.com/bigquery/docs/authentication/service-account-file
+  #
+  # config.bigquery_api_json_key = ENV['BIGQUERY_API_JSON_KEY']
+
+  # Passed directly to the retries: option on the BigQuery client
+  #
+  # config.bigquery_retries = 3
+
+  # Passed directly to the timeout: option on the BigQuery client
+  #
+  # config.bigquery_timeout = 120
+
+  # A proc which returns true or false depending on whether you want to
+  # enable analytics. You might want to hook this up to a feature flag or
+  # environment variable.
+  #
+  config.enable_analytics = proc { ALLOWED_ENVS.include?(ENV.fetch("HOSTING_ENV", "development")) }
+
+  # The environment we’re running in. This value will be attached
+  # to all events we send to BigQuery.
+  #
+  # config.environment = ENV.fetch('RAILS_ENV', 'development')
+
+  # A proc which will be called with the user object, and which should
+  # return the identifier for the user. This is useful for systems with
+  # users that don't use the id field.
+  #
+  # config.user_identifier = proc { |user| user&.id }
+
+  # Whether to pseudonymise the user_id field in the web request event.
+  #
+  # config.pseudonymise_web_request_user_id = false
+
+  # Whether to run entity table checksum job.
+  #
+  config.entity_table_checks_enabled = true
+
+  # A proc which will be called with the rack env, and which should
+  # return a boolean indicating whether the page is cached and will
+  # be served by rack middleware.
+  #
+  # config.rack_page_cached = proc { |_rack_env| false }
+
+  # Schedule a maintenance window during which no events are streamed to BigQuery
+  # in the format of '22-01-2024 19:30..22-01-2024 20:30' (UTC).
+  #
+  # config.bigquery_maintenance_window = ENV['BIGQUERY_MAINTENANCE_WINDOW']
+end

--- a/config/scheduled_jobs.yml
+++ b/config/scheduled_jobs.yml
@@ -30,3 +30,9 @@ remove_internal_draft_claims:
   cron: "10 0 * * *"
   class: "Claims::RemoveInternalDraftClaimsJob"
   description: "Remove all internal_draft claims"
+
+send_entity_table_checks_to_bigquery:
+  cron: "30 0 * * *"  # Every day at 00:30.
+  class: "DfE::Analytics::EntityTableCheckJob"
+  queue: dfe_analytics
+  description: "Syncs the entity table in BigQuery with the database"

--- a/spec/services/concerns/service_pattern_spec.rb
+++ b/spec/services/concerns/service_pattern_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "./app/services/concerns/service_pattern" # needed until DFE-Digital/dfe-analytics#136 is fixed
 
 RSpec.describe ServicePattern do
   describe "#call" do

--- a/terraform/application/config/production_app_env.yml
+++ b/terraform/application/config/production_app_env.yml
@@ -10,3 +10,6 @@ DFE_SIGN_IN_ISSUER_URL: https://oidc.signin.education.gov.uk
 PLACEMENTS_DFE_SIGN_IN_CLIENT_ID: ittMentorSchoolPlacement
 CLAIMS_HOSTS: claim-funding-for-mentor-training.education.gov.uk,track-and-pay-production.teacherservices.cloud
 CLAIMS_HOST: claim-funding-for-mentor-training.education.gov.uk
+BIGQUERY_TABLE_NAME: events
+BIGQUERY_PROJECT_ID: rugged-abacus-218110
+BIGQUERY_DATASET: itt_mentor_events_production

--- a/terraform/application/config/qa_app_env.yml
+++ b/terraform/application/config/qa_app_env.yml
@@ -8,3 +8,6 @@ TEACHING_RECORD_API_MINOR_VERSION: 20240101
 CLAIMS_HOSTS: qa.claim-funding-for-mentor-training.education.gov.uk,track-and-pay-qa.test.teacherservices.cloud
 CLAIMS_HOST: qa.claim-funding-for-mentor-training.education.gov.uk
 SKYLIGHT_ENV: qa
+BIGQUERY_TABLE_NAME: events
+BIGQUERY_PROJECT_ID: rugged-abacus-218110
+BIGQUERY_DATASET: itt_mentor_events_qa

--- a/terraform/application/config/sandbox_app_env.yml
+++ b/terraform/application/config/sandbox_app_env.yml
@@ -8,3 +8,6 @@ TEACHING_RECORD_BASE_URL: https://preprod.teacher-qualifications-api.education.g
 TEACHING_RECORD_API_MINOR_VERSION: 20240101
 CLAIMS_HOSTS: sandbox.claim-funding-for-mentor-training.education.gov.uk,track-and-pay-sandbox.teacherservices.cloud
 CLAIMS_HOST: sandbox.claim-funding-for-mentor-training.education.gov.uk
+BIGQUERY_TABLE_NAME: events
+BIGQUERY_PROJECT_ID: rugged-abacus-218110
+BIGQUERY_DATASET: itt_mentor_events_sandbox

--- a/terraform/application/config/staging_app_env.yml
+++ b/terraform/application/config/staging_app_env.yml
@@ -11,3 +11,6 @@ PLACEMENTS_DFE_SIGN_IN_CLIENT_ID: ittMentorSchoolPlacement
 CLAIMS_HOSTS: staging.claim-funding-for-mentor-training.education.gov.uk,track-and-pay-staging.test.teacherservices.cloud
 CLAIMS_HOST: staging.claim-funding-for-mentor-training.education.gov.uk
 SKYLIGHT_ENV: staging
+BIGQUERY_TABLE_NAME: events
+BIGQUERY_PROJECT_ID: rugged-abacus-218110
+BIGQUERY_DATASET: itt_mentor_events_staging


### PR DESCRIPTION
## Context

This will send data on every web request and whenever a table in config/analytics is updated/created. Regardless of domain. We don't have a way to distinguish between them at the moment, though the web requests do contain the domain.

A scheduled job is also going to run every day after midnight to keep in sync the BigQuery data with our own data.

We will send data to dfe-analytics in Production, Sandbox, Staging and QA.

I have included every table that we have apart from the ones that our gems generate. Some contain personal information, they have been included in `config/analytics_pii.yml` to handle the sensitive information. 

## Changes proposed in this pull request

Dfe analytics setup

## Guidance to review

Review code.
This will only work when the envs have the secret keys


## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/afbe1544-0ed2-452b-8e87-107b15785ee2


