### PR TITLE
Only show mentors with remaining claimable hours in claim flow

### DIFF
--- a/app/components/claims/claim/mentors_form/disclaimer_component.rb
+++ b/app/components/claims/claim/mentors_form/disclaimer_component.rb
@@ -1,0 +1,30 @@
+class Claims::Claim::MentorsForm::DisclaimerComponent < ApplicationComponent
+  attr_reader :mentors_form
+
+  def initialize(mentors_form:, classes: [], html_attributes: {})
+    super(classes:, html_attributes:)
+
+    @mentors_form = mentors_form
+  end
+
+  def call
+    govuk_inset_text do
+      tag.p(sanitize(t(".disclaimer", provider_name:))) +
+        tag.p(sanitize(t(".disclaimer_contact", email_link:)))
+    end
+  end
+
+  def render?
+    !mentors_form.all_school_mentors_visible?
+  end
+
+  private
+
+  def provider_name
+    mentors_form.claim.provider_name
+  end
+
+  def email_link
+    govuk_mail_to t("claims.support_email")
+  end
+end

--- a/app/controllers/claims/schools/claims/mentors_controller.rb
+++ b/app/controllers/claims/schools/claims/mentors_controller.rb
@@ -33,7 +33,7 @@ class Claims::Schools::Claims::MentorsController < Claims::ApplicationController
   private
 
   def claim_params
-    params.require(:claims_claim).permit(mentor_ids: [])
+    params.require(:claims_claim_mentors_form).permit(mentor_ids: [])
   end
 
   def claim
@@ -42,7 +42,7 @@ class Claims::Schools::Claims::MentorsController < Claims::ApplicationController
 
   def claim_mentors_form
     @claim_mentors_form ||=
-      if params[:claims_claim].present?
+      if params[:claims_claim_mentors_form].present?
         Claims::Claim::MentorsForm.new(claim:, mentor_ids: claim_params[:mentor_ids])
       else
         Claims::Claim::MentorsForm.new(claim:)

--- a/app/controllers/claims/schools/claims_controller.rb
+++ b/app/controllers/claims/schools/claims_controller.rb
@@ -28,9 +28,6 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
       @school,
       @claim,
       last_mentor_training,
-      params: {
-        claims_claim_mentor_training_form: { hours_completed: last_mentor_training.hours_completed },
-      },
     )
     Claims::Claim::RemoveEmptyMentorTrainingHours.call(claim: @claim)
   end

--- a/app/controllers/claims/support/schools/claims/mentors_controller.rb
+++ b/app/controllers/claims/support/schools/claims/mentors_controller.rb
@@ -33,7 +33,7 @@ class Claims::Support::Schools::Claims::MentorsController < Claims::ApplicationC
   private
 
   def claim_params
-    params.require(:claims_claim).permit(mentor_ids: [])
+    params.require(:claims_support_claim_mentors_form).permit(mentor_ids: [])
   end
 
   def claim
@@ -42,7 +42,7 @@ class Claims::Support::Schools::Claims::MentorsController < Claims::ApplicationC
 
   def claim_mentors_form
     @claim_mentors_form ||=
-      if params[:claims_claim].present?
+      if params[:claims_support_claim_mentors_form].present?
         Claims::Support::Claim::MentorsForm.new(claim:, mentor_ids: claim_params[:mentor_ids])
       else
         Claims::Support::Claim::MentorsForm.new(claim:)

--- a/app/forms/claims/claim/mentors_form.rb
+++ b/app/forms/claims/claim/mentors_form.rb
@@ -3,6 +3,8 @@ class Claims::Claim::MentorsForm < ApplicationForm
 
   validates :mentor_ids, presence: true
 
+  delegate :school, :provider, to: :claim
+
   def initialize(attributes = {})
     super
 
@@ -25,6 +27,14 @@ class Claims::Claim::MentorsForm < ApplicationForm
     else
       check_claims_school_claim_path(claim.school, claim)
     end
+  end
+
+  def mentors_with_claimable_hours
+    @mentors_with_claimable_hours ||= Claims::MentorsWithRemainingClaimableHoursQuery.call(params: { school:, provider:, claim: })
+  end
+
+  def all_school_mentors_visible?
+    @all_school_mentors_visible ||= claim.school.mentors.count == mentors_with_claimable_hours.count
   end
 
   private

--- a/app/forms/claims/claim/provider_form.rb
+++ b/app/forms/claims/claim/provider_form.rb
@@ -10,10 +10,15 @@ class Claims::Claim::ProviderForm < ApplicationForm
   end
 
   def persist
-    claim.provider_id = provider_id
-    claim.status = :internal_draft if claim.status.nil?
-    claim.created_by = current_user
-    claim.save!
+    return if claim.provider_id == provider_id
+
+    ActiveRecord::Base.transaction do
+      claim.provider_id = provider_id
+      claim.mentor_trainings.update_all(provider_id:)
+      claim.status = :internal_draft if claim.status.nil?
+      claim.created_by ||= current_user
+      claim.save!
+    end
   end
 
   def claim

--- a/app/queries/claims/mentors_with_remaining_claimable_hours_query.rb
+++ b/app/queries/claims/mentors_with_remaining_claimable_hours_query.rb
@@ -1,0 +1,17 @@
+class Claims::MentorsWithRemainingClaimableHoursQuery < ApplicationQuery
+  def call
+    scope = params[:school].mentors.order_by_full_name
+
+    remaining_claimable_hours_condition(scope)
+  end
+
+  private
+
+  def remaining_claimable_hours_condition(scope)
+    mentor_with_claimable_hours = scope.filter do |mentor|
+      Claims::Mentor::CalculateRemainingMentorTrainingHoursForProvider.call(mentor:, provider: params[:provider], claim: params[:claim]).positive?
+    end
+
+    scope.where(id: mentor_with_claimable_hours)
+  end
+end

--- a/app/services/claims/mentor/calculate_remaining_mentor_training_hours_for_provider.rb
+++ b/app/services/claims/mentor/calculate_remaining_mentor_training_hours_for_provider.rb
@@ -3,10 +3,10 @@ class Claims::Mentor::CalculateRemainingMentorTrainingHoursForProvider
 
   MAXIMUM_CLAIMABLE_HOURS_PER_PROVIDER = 20
 
-  def initialize(mentor:, provider:, mentor_training: nil)
+  def initialize(mentor:, provider:, claim: nil, mentor_training: nil)
     @mentor = mentor
     @provider = provider
-    @mentor_training = mentor_training
+    @mentor_training = claim ? claim.mentor_trainings.find_by(mentor:, provider:) : mentor_training
   end
 
   def call

--- a/app/views/claims/schools/claims/mentors/_form.html.erb
+++ b/app/views/claims/schools/claims/mentors/_form.html.erb
@@ -11,7 +11,6 @@
           :id,
           :full_name,
           :trn,
-          include_hidden: false,
           legend: { text: t(".heading"), size: "l" },
           hint: { text: t(".select_all_that_apply") },
         ) %>

--- a/app/views/claims/schools/claims/mentors/_form.html.erb
+++ b/app/views/claims/schools/claims/mentors/_form.html.erb
@@ -3,15 +3,18 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <span class="govuk-caption-l"><%= t(".add_claim", provider: claim_mentors_form.claim.provider_name) %></span>
+        <span class="govuk-caption-l"><%= t(".add_claim") %></span>
+        <h1 class="govuk-heading-l"><%= t(".heading", provider_name: claim_mentors_form.claim.provider_name) %></h1>
+
+        <%= render Claims::Claim::MentorsForm::DisclaimerComponent.new(mentors_form: claim_mentors_form) %>
 
         <%= f.govuk_collection_check_boxes(
           :mentor_ids,
-          school.mentors.order_by_full_name,
+          claim_mentors_form.mentors_with_claimable_hours,
           :id,
           :full_name,
           :trn,
-          legend: { text: t(".heading"), size: "l" },
+          legend: { text: t(".label"), size: "s" },
           hint: { text: t(".select_all_that_apply") },
         ) %>
 

--- a/app/views/claims/support/schools/claims/mentors/_form.html.erb
+++ b/app/views/claims/support/schools/claims/mentors/_form.html.erb
@@ -4,14 +4,17 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <span class="govuk-caption-l"><%= t(".add_claim", school: @school.name) %></span>
+        <h1 class="govuk-heading-l"><%= t(".heading", provider_name: claim_mentors_form.claim.provider_name) %></h1>
+
+        <%= render Claims::Claim::MentorsForm::DisclaimerComponent.new(mentors_form: claim_mentors_form) %>
 
         <%= f.govuk_collection_check_boxes(
           :mentor_ids,
-          school.mentors.order_by_full_name,
+          claim_mentors_form.mentors_with_claimable_hours,
           :id,
           :full_name,
           :trn,
-          legend: { text: t(".heading"), size: "l" },
+          legend: { text: t(".label"), size: "s" },
           hint: { text: t(".select_all_that_apply") },
         ) %>
 

--- a/app/views/claims/support/schools/claims/mentors/_form.html.erb
+++ b/app/views/claims/support/schools/claims/mentors/_form.html.erb
@@ -11,7 +11,6 @@
           :id,
           :full_name,
           :trn,
-          include_hidden: false,
           legend: { text: t(".heading"), size: "l" },
           hint: { text: t(".select_all_that_apply") },
         ) %>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -17,6 +17,10 @@ en:
           attributes:
             provider_id:
               blank: Select a provider
+        claims/claim/mentors_form:
+          attributes:
+            mentor_ids:
+              blank: Select a mentor
         placements/mentor_form:
           attributes:
             trn:

--- a/config/locales/en/claims/schools/claims/mentors.yml
+++ b/config/locales/en/claims/schools/claims/mentors.yml
@@ -4,9 +4,10 @@ en:
       claims:
         mentors:
           form:
-            heading: Mentor
+            heading: Mentors for %{provider_name}
+            label: Mentor
             select_all_that_apply: Select all that apply
-            add_claim: Add claim - %{provider}
+            add_claim: Add claim
           new:
             page_title: Mentor - Add claim
           edit:

--- a/config/locales/en/claims/support/schools/claims/mentors.yml
+++ b/config/locales/en/claims/support/schools/claims/mentors.yml
@@ -5,7 +5,8 @@ en:
         claims:
           mentors:
             form:
-              heading: Mentor
+              heading: Mentors for %{provider_name}
+              label: Mentor
               select_all_that_apply: Select all that apply
               add_claim: Add claim - %{school}
             new:

--- a/config/locales/en/components/claims/claim/mentors_form/disclaimer_component.yml
+++ b/config/locales/en/components/claims/claim/mentors_form/disclaimer_component.yml
@@ -1,0 +1,8 @@
+en:
+  components:
+    claims:
+      claim:
+        mentors_form:
+          disclaimer_component:
+            disclaimer: This list includes all mentors who can be included on a claim. If a mentor you have added is not showing in this list, that is because they have already had 20 hours of training claimed for with %{provider_name}.
+            disclaimer_contact: Contact %{email_link} if you think there is a problem.

--- a/spec/components/claims/claim/mentors_form/disclaimer_component_spec.rb
+++ b/spec/components/claims/claim/mentors_form/disclaimer_component_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe Claims::Claim::MentorsForm::DisclaimerComponent, type: :component do
+  let(:mentors_form) { Claims::Claim::MentorsForm.new(claim:) }
+
+  let(:school) { create(:claims_school) }
+  let(:claim) { create(:claim, school:) }
+
+  before do
+    school.mentors << create(:claims_mentor)
+    school.mentors << create(:claims_mentor)
+  end
+
+  context "when all mentors have no previous claims" do
+    it "does not render" do
+      render_inline described_class.new(mentors_form:)
+
+      expect(page).not_to have_css(".govuk-inset-text")
+    end
+  end
+
+  context "when a mentor has a previous claim of all 20 hours" do
+    before do
+      create(:mentor_training, claim: create(:claim, :submitted, school:), mentor: school.mentors.first, provider: claim.provider, hours_completed: 20)
+    end
+
+    it "renders an inset text block with information about why a mentor is missing from the list" do
+      render_inline described_class.new(mentors_form:)
+
+      expect(page).to have_css(".govuk-inset-text")
+      expect(page).to have_content "This list includes all mentors who can be included on a claim. If a mentor you have added is not showing in this list, that is because they have already had 20 hours of training claimed for with #{claim.provider.name}."
+      expect(page).to have_content "Contact ittmentor.funding@education.gov.uk if you think there is a problem."
+    end
+  end
+end

--- a/spec/components/previews/claims/claim/mentors_form/disclaimer_component_preview.rb
+++ b/spec/components/previews/claims/claim/mentors_form/disclaimer_component_preview.rb
@@ -1,0 +1,15 @@
+class Claims::Claim::MentorsForm::DisclaimerComponentPreview < ApplicationComponentPreview
+  def default
+    render Claims::Claim::MentorsForm::DisclaimerComponent.new(mentors_form:)
+  end
+
+  private
+
+  def mentors_form
+    Claims::Claim::MentorsForm.new(claim:)
+  end
+
+  def claim
+    Claims::Claim.first
+  end
+end

--- a/spec/forms/claims/claim/mentors_form_spec.rb
+++ b/spec/forms/claims/claim/mentors_form_spec.rb
@@ -15,13 +15,6 @@ describe Claims::Claim::MentorsForm, type: :model do
     end
   end
 
-  describe "#to_model" do
-    it "returns an instance of a Claims::Claim" do
-      form = described_class.new(claim:)
-      expect(form.to_model).to be_a Claims::Claim
-    end
-  end
-
   describe "save" do
     it "creates mentor trainings on the claim" do
       mentor_ids = [mentor1, mentor2].map(&:id)

--- a/spec/forms/claims/claim/provider_form_spec.rb
+++ b/spec/forms/claims/claim/provider_form_spec.rb
@@ -1,10 +1,8 @@
 require "rails_helper"
 
 describe Claims::Claim::ProviderForm, type: :model do
-  let!(:school) { create(:claims_school) }
-  let!(:provider) { create(:claims_provider, :best_practice_network) }
-  let!(:claim) { create(:claim, school:) }
-  let!(:current_user) { create(:claims_user) }
+  let(:school) { create(:claims_school) }
+  let(:existing_claim) { create(:claim, school:) }
 
   describe "validations" do
     context "when provider is not set" do
@@ -24,34 +22,49 @@ describe Claims::Claim::ProviderForm, type: :model do
 
     context "when claim already exists" do
       it "returns the existing claim" do
-        form = described_class.new(id: claim.id, school:)
-        expect(form.claim).to eq(claim)
+        form = described_class.new(id: existing_claim.id, school:)
+        expect(form.claim).to eq(existing_claim)
       end
     end
   end
 
-  describe "save" do
+  describe "#save" do
+    let(:provider) { create(:claims_provider, :best_practice_network) }
+    let(:current_user) { create(:claims_user) }
+
+    before do
+      existing_claim.mentor_trainings << create(:mentor_training, provider:)
+    end
+
     context "when claim doesn't exist" do
       it "creates an internal draft claim with a provider" do
         form = described_class.new(provider_id: provider.id, school:, current_user:)
 
-        expect {
-          form.save!
-        }.to change { form.claim.provider }.to provider
+        expect { form.save! }.to change { form.claim.provider }.to provider
+
         expect(form.claim.internal_draft?).to be(true)
         expect(form.claim.created_by).to eq(current_user)
       end
     end
 
     context "when claim does exist" do
-      it "creates an internal draft claim with a provider" do
-        form = described_class.new(id: claim.id, provider_id: provider.id, school:, current_user:)
+      it "updates the claim with the new provider" do
+        form = described_class.new(id: existing_claim.id, provider_id: provider.id, school:, current_user:)
 
-        expect {
-          form.save!
-        }.to change { claim.reload.provider }.to provider
-        expect(claim.internal_draft?).to be(true)
-        expect(form.claim.created_by).to eq(current_user)
+        expect { form.save! }.to change { existing_claim.reload.provider }.to provider
+
+        expect(existing_claim.internal_draft?).to be(true)
+        expect(existing_claim.created_by).not_to eq(current_user)
+        expect(existing_claim.mentor_trainings.pluck(:provider_id)).to all(eq(provider.id))
+      end
+
+      context "when selecting the same provider" do
+        it "doesn't update anything" do
+          form = described_class.new(id: existing_claim.id, provider_id: existing_claim.provider.id, school:, current_user:)
+
+          expect { form.save! }.to not_change { existing_claim.reload.provider }
+            .and(not_change { existing_claim.reload.mentor_trainings.pluck(:provider_id) })
+        end
       end
     end
   end

--- a/spec/forms/claims/support/claim/mentors_form_spec.rb
+++ b/spec/forms/claims/support/claim/mentors_form_spec.rb
@@ -15,13 +15,6 @@ describe Claims::Support::Claim::MentorsForm, type: :model do
     end
   end
 
-  describe "#to_model" do
-    it "returns an instance of a Claims::Claim" do
-      form = described_class.new(claim:)
-      expect(form.to_model).to be_a Claims::Claim
-    end
-  end
-
   describe "save" do
     it "creates mentor trainings on the claim" do
       mentor_ids = [mentor1, mentor2].map(&:id)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,6 +41,11 @@ SimpleCov.start "rails" do
   add_group "Validators", "app/validators"
 end
 
+# `expect(...).not_to matcher.and matcher` is not supported, since it creates a bit of an ambiguity.
+# Instead, define negated versions of whatever matchers you wish to negate with
+# `RSpec::Matchers.define_negated_matcher` and use `expect(...).to matcher.and matcher`.
+RSpec::Matchers.define_negated_matcher :not_change, :change
+
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
@@ -55,11 +55,7 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
     then_i_see_the_error("Select a mentor")
     when_i_check_the_mentor(mentor2)
     when_i_click("Continue")
-    when_i_click("Continue")
-    then_i_see_the_error("Select the number of hours")
-    when_i_add_training_hours("20 hours")
-    when_i_click("Continue")
-    then_i_check_my_answers(provider1, [mentor2], [20])
+    then_i_check_my_answers(provider1, [mentor2], [12])
     when_i_click("Submit claim")
     then_i_get_a_claim_reference(claim)
   end

--- a/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
@@ -55,11 +55,7 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
     then_i_see_the_error("Select a mentor")
     when_i_check_the_mentor(mentor2)
     when_i_click("Continue")
-    when_i_click("Continue")
-    then_i_see_the_error("Select the number of hours")
-    when_i_add_training_hours("20 hours")
-    when_i_click("Continue")
-    then_i_check_my_answers(provider1, [mentor2], [20])
+    then_i_check_my_answers(provider1, [mentor2], [12])
     when_i_click("Add claim")
     then_i_am_redirected_to_index_page(claim)
   end

--- a/spec/system/claims/support/schools/claims/edit_draft_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/edit_draft_claim_spec.rb
@@ -77,8 +77,6 @@ RSpec.describe "Edit a draft claim", type: :system, service: :claims do
     click_on("Continue")
     page.choose("20 hours")
     click_on("Continue")
-    page.choose("20 hours")
-    click_on("Continue")
 
     expect(page).to have_content("Laura Clark")
     expect(page).to have_content("Barry Garlow")


### PR DESCRIPTION
## Context

When a mentor has no remaining claimable hours, they cannot be added to a claim. To avoid confusion and limit paths of error, we want to remove them from a School's list of selectable mentors when they have claimed all of their claimable hours across all schools.

## Changes proposed in this pull request

- Refactored the `Claims::Claim::MentorsForm` to avoid the need to propagate errors.
  - We need to send in the blanks to trigger validations.
- Show only mentors with remaining hours to claim in the claim flow.
- Changed the `Claims::Mentor::CalculateRemainingMentorTrainingHoursForProvider` service to accept a `claim` argument and find the relevant `mentor_training` record from `mentor` and `provider`.

## Guidance to review

- Add a claim with a mentor and claim all 20 hours for that mentor.
- Try to make a claim for the same provider. The mentor should be missing and an inset text should show.

## Screenshots

![CleanShot 2024-04-25 at 12 48 20](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/8d84f56e-8d9c-4c3d-a59c-b03d16547906)
