### PR TITLE
Add feature flag to disable onboarding emails

### DIFF
--- a/app/services/user/invite.rb
+++ b/app/services/user/invite.rb
@@ -9,8 +9,8 @@ class User::Invite
   attr_reader :user, :organisation, :service
 
   def call
-    return unless user.service == :claims ||
-      Flipflop.enabled?(:user_onboarding_emails)
+    return if user.service == :placements && 
+      !Flipflop.enabled?(:placements_user_onboarding_emails)
 
     UserMailer.with(service: user.service).user_membership_created_notification(user, organisation).deliver_later
   end

--- a/app/services/user/invite.rb
+++ b/app/services/user/invite.rb
@@ -9,6 +9,9 @@ class User::Invite
   attr_reader :user, :organisation, :service
 
   def call
+    return unless user.service == :claims ||
+      Flipflop.enabled?(:user_onboarding_emails)
+
     UserMailer.with(service: user.service).user_membership_created_notification(user, organisation).deliver_later
   end
 end

--- a/app/services/user/invite.rb
+++ b/app/services/user/invite.rb
@@ -9,7 +9,7 @@ class User::Invite
   attr_reader :user, :organisation, :service
 
   def call
-    return if user.service == :placements && 
+    return if user.service == :placements &&
       !Flipflop.enabled?(:placements_user_onboarding_emails)
 
     UserMailer.with(service: user.service).user_membership_created_notification(user, organisation).deliver_later

--- a/app/services/user/remove.rb
+++ b/app/services/user/remove.rb
@@ -10,8 +10,8 @@ class User::Remove
 
   def call
     user_membership.destroy!
-    return unless user.service == :claims ||
-      Flipflop.enabled?(:user_onboarding_emails)
+    return if user.service == :placements &&
+      !Flipflop.enabled?(:placements_user_onboarding_emails)
 
     UserMailer.with(service: user.service).user_membership_destroyed_notification(user, organisation).deliver_later
   end

--- a/app/services/user/remove.rb
+++ b/app/services/user/remove.rb
@@ -10,6 +10,8 @@ class User::Remove
 
   def call
     user_membership.destroy!
+    return unless user.service == :claims ||
+      Flipflop.enabled?(:user_onboarding_emails)
 
     UserMailer.with(service: user.service).user_membership_destroyed_notification(user, organisation).deliver_later
   end

--- a/config/features.rb
+++ b/config/features.rb
@@ -3,4 +3,11 @@ Flipflop.configure do
   strategy :default
 
   feature :test_feature, description: "This is a test feature"
+
+  group :placements do
+    feature :user_onboarding_emails,
+            description: "Dispatch emails to users when they have been" \
+            " onboarded onto the placements service",
+            default: false
+  end
 end

--- a/config/features.rb
+++ b/config/features.rb
@@ -7,7 +7,7 @@ Flipflop.configure do
   group :placements do
     feature :placements_user_onboarding_emails,
             description: "Dispatch emails to users when they have been" \
-            " onboarded onto the placements service",
+            " onboarded on to or removed from the placements service",
             default: false
   end
 end

--- a/config/features.rb
+++ b/config/features.rb
@@ -5,7 +5,7 @@ Flipflop.configure do
   feature :test_feature, description: "This is a test feature"
 
   group :placements do
-    feature :user_onboarding_emails,
+    feature :placements_user_onboarding_emails,
             description: "Dispatch emails to users when they have been" \
             " onboarded onto the placements service",
             default: false

--- a/spec/services/user/invite_spec.rb
+++ b/spec/services/user/invite_spec.rb
@@ -20,12 +20,12 @@ RSpec.describe User::Invite do
     end
 
     context "when the user's service is Placements" do
-      context "when 'user_onboarding_emails' feature flag is enabled" do
+      context "when 'placements_user_onboarding_emails' feature flag is enabled" do
         let(:feature_flags) { Flipflop::FeatureSet.current.test! }
 
-        before { feature_flags.switch!(:user_onboarding_emails, true) }
+        before { feature_flags.switch!(:placements_user_onboarding_emails, true) }
 
-        after { feature_flags.switch!(:user_onboarding_emails, false) }
+        after { feature_flags.switch!(:placements_user_onboarding_emails, false) }
 
         describe "when the organisation is a school" do
           let(:user) { create(:placements_user) }
@@ -46,7 +46,7 @@ RSpec.describe User::Invite do
         end
       end
 
-      context "when 'user_onboarding_emails' feature flag is disabled" do
+      context "when 'placements_user_onboarding_emails' feature flag is disabled" do
         describe "when the organisation is a school" do
           let(:user) { create(:placements_user) }
           let(:organisation) { create(:placements_school) }

--- a/spec/services/user/remove_spec.rb
+++ b/spec/services/user/remove_spec.rb
@@ -25,12 +25,12 @@ RSpec.describe User::Remove do
       let(:organisation) { create(:placements_school) }
       let!(:membership) { create(:user_membership, user:, organisation:) }
 
-      context "when 'user_onboarding_emails' feature flag is enabled" do
+      context "when 'placements_user_onboarding_emails' feature flag is enabled" do
         let(:feature_flags) { Flipflop::FeatureSet.current.test! }
 
-        before { feature_flags.switch!(:user_onboarding_emails, true) }
+        before { feature_flags.switch!(:placements_user_onboarding_emails, true) }
 
-        after { feature_flags.switch!(:user_onboarding_emails, false) }
+        after { feature_flags.switch!(:placements_user_onboarding_emails, false) }
 
         it "calls mailer with correct params" do
           expect { remove_user_service }.to have_enqueued_mail(UserMailer, :user_membership_destroyed_notification).with(params: { service: :placements }, args: [user, organisation])
@@ -39,7 +39,7 @@ RSpec.describe User::Remove do
         end
       end
 
-      context "when 'user_onboarding_emails' feature flag is disabled" do
+      context "when 'placements_user_onboarding_emails' feature flag is disabled" do
         it "calls mailer with correct params" do
           expect { remove_user_service }.not_to have_enqueued_mail(UserMailer, :user_membership_destroyed_notification)
 

--- a/spec/system/placements/organisations/users/add_users_spec.rb
+++ b/spec/system/placements/organisations/users/add_users_spec.rb
@@ -13,46 +13,100 @@ RSpec.describe "Placements users invite other users to organisations", type: :sy
   let(:mary) { create(:placements_user, :mary) }
   let(:another_school) { create(:placements_school, name: "Another School") }
   let(:new_user) { create(:placements_user) }
+  let(:feature_flags) { Flipflop::FeatureSet.current.test! }
 
-  describe "Ann invites a member successfully " do
-    context "with provider" do
-      scenario "user invites a member to a provider" do
-        given_i_am_logged_in_as_a_user_with_one_organisation(one_provider)
-        when_i_click_users
-        then_i_see_the_users_page
-        when_i_click_add_user
-        and_i_enter_valid_user_details
-        and_user_is_selected_in_provider_primary_navigation
-        then_i_can_check_my_answers(one_provider)
-        when_i_click_back
-        then_i_see_prepopulated_form
-        when_i_change_user_details
-        then_i_see_changes_in_check_form
-        and_user_is_selected_in_provider_primary_navigation
-        when_i_click_add_user
-        then_the_user_is_added(one_provider)
-        and_user_is_selected_in_provider_primary_navigation
+  describe "Ann invites a member successfully" do
+    context "when 'user_onboarding_emails' feature flag is enabled" do
+      before { feature_flags.switch!(:user_onboarding_emails, true) }
+
+      after { feature_flags.switch!(:user_onboarding_emails, false) }
+
+      context "with provider" do
+        scenario "user invites a member to a provider" do
+          given_i_am_logged_in_as_a_user_with_one_organisation(one_provider)
+          when_i_click_users
+          then_i_see_the_users_page
+          when_i_click_add_user
+          and_i_enter_valid_user_details
+          and_user_is_selected_in_provider_primary_navigation
+          then_i_can_check_my_answers(one_provider)
+          when_i_click_back
+          then_i_see_prepopulated_form
+          when_i_change_user_details
+          then_i_see_changes_in_check_form
+          and_user_is_selected_in_provider_primary_navigation
+          when_i_click_add_user
+          then_the_user_is_added(one_provider)
+          and_an_email_is_sent("firsty_lasty@email.co.uk", one_provider)
+          and_user_is_selected_in_provider_primary_navigation
+        end
+      end
+
+      context "with school" do
+        scenario "user invites a member to a school" do
+          given_i_am_logged_in_as_a_user_with_one_organisation(one_school)
+          when_i_click_users
+          then_i_see_the_users_page
+          and_user_is_selected_in_school_primary_navigation
+          when_i_click_add_user
+          and_user_is_selected_in_school_primary_navigation
+          and_i_enter_valid_user_details
+          then_i_can_check_my_answers(one_school)
+          when_i_click_back
+          then_i_see_prepopulated_form
+          and_user_is_selected_in_school_primary_navigation
+          when_i_change_user_details
+          then_i_see_changes_in_check_form
+          and_user_is_selected_in_school_primary_navigation
+          when_i_click_add_user
+          then_the_user_is_added(one_school)
+          and_an_email_is_sent("firsty_lasty@email.co.uk", one_school)
+        end
       end
     end
 
-    context "with school" do
-      scenario "user invites a member to a school" do
-        given_i_am_logged_in_as_a_user_with_one_organisation(one_school)
-        when_i_click_users
-        then_i_see_the_users_page
-        and_user_is_selected_in_school_primary_navigation
-        when_i_click_add_user
-        and_user_is_selected_in_school_primary_navigation
-        and_i_enter_valid_user_details
-        then_i_can_check_my_answers(one_school)
-        when_i_click_back
-        then_i_see_prepopulated_form
-        and_user_is_selected_in_school_primary_navigation
-        when_i_change_user_details
-        then_i_see_changes_in_check_form
-        and_user_is_selected_in_school_primary_navigation
-        when_i_click_add_user
-        then_the_user_is_added(one_school)
+    context "when 'user_onboarding_emails' feature flag is disabled" do
+      context "with provider" do
+        scenario "user invites a member to a provider" do
+          given_i_am_logged_in_as_a_user_with_one_organisation(one_provider)
+          when_i_click_users
+          then_i_see_the_users_page
+          when_i_click_add_user
+          and_i_enter_valid_user_details
+          and_user_is_selected_in_provider_primary_navigation
+          then_i_can_check_my_answers(one_provider)
+          when_i_click_back
+          then_i_see_prepopulated_form
+          when_i_change_user_details
+          then_i_see_changes_in_check_form
+          and_user_is_selected_in_provider_primary_navigation
+          when_i_click_add_user
+          then_the_user_is_added(one_provider)
+          and_an_email_is_not_sent("firsty_lasty@email.co.uk", one_provider)
+          and_user_is_selected_in_provider_primary_navigation
+        end
+      end
+
+      context "with school" do
+        scenario "user invites a member to a school" do
+          given_i_am_logged_in_as_a_user_with_one_organisation(one_school)
+          when_i_click_users
+          then_i_see_the_users_page
+          and_user_is_selected_in_school_primary_navigation
+          when_i_click_add_user
+          and_user_is_selected_in_school_primary_navigation
+          and_i_enter_valid_user_details
+          then_i_can_check_my_answers(one_school)
+          when_i_click_back
+          then_i_see_prepopulated_form
+          and_user_is_selected_in_school_primary_navigation
+          when_i_change_user_details
+          then_i_see_changes_in_check_form
+          and_user_is_selected_in_school_primary_navigation
+          when_i_click_add_user
+          then_the_user_is_added(one_school)
+          and_an_email_is_not_sent("firsty_lasty@email.co.uk", one_school)
+        end
       end
     end
   end
@@ -64,17 +118,42 @@ RSpec.describe "Placements users invite other users to organisations", type: :sy
       create(:user_membership, user: mary, organisation: one_provider)
     end
 
-    scenario "user adds a user to multiple organisations" do
-      given_i_am_logged_in_as_a_user_with_multiple_organisations
-      and_user_is_already_assigned_to_a_school
-      when_i_navigate_to_that_schools_users
-      then_i_see_the_user_on_that_schools_user_list
-      when_i_change_organisation(another_school)
-      and_i_try_to_add_the_user
-      then_the_user_is_added_successfully(another_school)
-      when_i_change_organisation(one_provider)
-      and_i_try_to_add_the_user
-      then_the_user_is_added_successfully(one_provider)
+    context "when 'user_onboarding_emails' feature flag is enabled" do
+      before { feature_flags.switch!(:user_onboarding_emails, true) }
+
+      after { feature_flags.switch!(:user_onboarding_emails, false) }
+
+      scenario "user adds a user to multiple organisations" do
+        given_i_am_logged_in_as_a_user_with_multiple_organisations
+        and_user_is_already_assigned_to_a_school
+        when_i_navigate_to_that_schools_users
+        then_i_see_the_user_on_that_schools_user_list
+        when_i_change_organisation(another_school)
+        and_i_try_to_add_the_user
+        then_the_user_is_added_successfully(another_school)
+        and_an_email_is_sent(new_user.email, another_school)
+        when_i_change_organisation(one_provider)
+        and_i_try_to_add_the_user
+        then_the_user_is_added_successfully(one_provider)
+        and_an_email_is_sent(new_user.email, one_provider)
+      end
+    end
+
+    context "when 'user_onboarding_emails' feature flag is disabled" do
+      scenario "user adds a user to multiple organisations" do
+        given_i_am_logged_in_as_a_user_with_multiple_organisations
+        and_user_is_already_assigned_to_a_school
+        when_i_navigate_to_that_schools_users
+        then_i_see_the_user_on_that_schools_user_list
+        when_i_change_organisation(another_school)
+        and_i_try_to_add_the_user
+        then_the_user_is_added_successfully(another_school)
+        and_an_email_is_not_sent(new_user.email, another_school)
+        when_i_change_organisation(one_provider)
+        and_i_try_to_add_the_user
+        then_the_user_is_added_successfully(one_provider)
+        and_an_email_is_not_sent(new_user.email, one_provider)
+      end
     end
   end
 
@@ -164,9 +243,7 @@ RSpec.describe "Placements users invite other users to organisations", type: :sy
     click_on "Add user"
   end
 
-  def then_the_user_is_added_successfully(organisation)
-    email_is_sent(new_user.email, organisation)
-
+  def then_the_user_is_added_successfully(_organisation)
     expect(page.find(".govuk-notification-banner__content")).to have_content("User added")
     expect(page).to have_content new_user.full_name
     expect(page).to have_content new_user.email
@@ -220,8 +297,7 @@ RSpec.describe "Placements users invite other users to organisations", type: :sy
     expect(page).to have_content "firsty_lasty@email.co.uk"
   end
 
-  def then_the_user_is_added(organisation)
-    email_is_sent("firsty_lasty@email.co.uk", organisation)
+  def then_the_user_is_added(_organisation)
     expect(page.find(".govuk-notification-banner__content")).to have_content("User added")
     expect(page).to have_content "New First Name Last Namey"
     expect(page).to have_content "firsty_lasty@email.co.uk"
@@ -244,11 +320,21 @@ RSpec.describe "Placements users invite other users to organisations", type: :sy
     end
   end
 
-  def email_is_sent(email, organisation)
-    email = ActionMailer::Base.deliveries.find do |delivery|
+  def email_invite_notification(email, organisation)
+    ActionMailer::Base.deliveries.find do |delivery|
       delivery.to.include?(email) && delivery.subject == "You have been invited to #{organisation.name}"
     end
+  end
 
-    expect(email).not_to be_nil
+  def and_an_email_is_sent(email, organisation)
+    invite_email = email_invite_notification(email, organisation)
+
+    expect(invite_email).not_to be_nil
+  end
+
+  def and_an_email_is_not_sent(email, organisation)
+    invite_email = email_invite_notification(email, organisation)
+
+    expect(invite_email).to be_nil
   end
 end

--- a/spec/system/placements/organisations/users/add_users_spec.rb
+++ b/spec/system/placements/organisations/users/add_users_spec.rb
@@ -16,10 +16,10 @@ RSpec.describe "Placements users invite other users to organisations", type: :sy
   let(:feature_flags) { Flipflop::FeatureSet.current.test! }
 
   describe "Ann invites a member successfully" do
-    context "when 'user_onboarding_emails' feature flag is enabled" do
-      before { feature_flags.switch!(:user_onboarding_emails, true) }
+    context "when 'placements_user_onboarding_emails' feature flag is enabled" do
+      before { feature_flags.switch!(:placements_user_onboarding_emails, true) }
 
-      after { feature_flags.switch!(:user_onboarding_emails, false) }
+      after { feature_flags.switch!(:placements_user_onboarding_emails, false) }
 
       context "with provider" do
         scenario "user invites a member to a provider" do
@@ -65,7 +65,7 @@ RSpec.describe "Placements users invite other users to organisations", type: :sy
       end
     end
 
-    context "when 'user_onboarding_emails' feature flag is disabled" do
+    context "when 'placements_user_onboarding_emails' feature flag is disabled" do
       context "with provider" do
         scenario "user invites a member to a provider" do
           given_i_am_logged_in_as_a_user_with_one_organisation(one_provider)
@@ -118,10 +118,10 @@ RSpec.describe "Placements users invite other users to organisations", type: :sy
       create(:user_membership, user: mary, organisation: one_provider)
     end
 
-    context "when 'user_onboarding_emails' feature flag is enabled" do
-      before { feature_flags.switch!(:user_onboarding_emails, true) }
+    context "when 'placements_user_onboarding_emails' feature flag is enabled" do
+      before { feature_flags.switch!(:placements_user_onboarding_emails, true) }
 
-      after { feature_flags.switch!(:user_onboarding_emails, false) }
+      after { feature_flags.switch!(:placements_user_onboarding_emails, false) }
 
       scenario "user adds a user to multiple organisations" do
         given_i_am_logged_in_as_a_user_with_multiple_organisations
@@ -139,7 +139,7 @@ RSpec.describe "Placements users invite other users to organisations", type: :sy
       end
     end
 
-    context "when 'user_onboarding_emails' feature flag is disabled" do
+    context "when 'placements_user_onboarding_emails' feature flag is disabled" do
       scenario "user adds a user to multiple organisations" do
         given_i_am_logged_in_as_a_user_with_multiple_organisations
         and_user_is_already_assigned_to_a_school

--- a/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
+++ b/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
@@ -20,10 +20,10 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
       end
     end
 
-    context "when 'user_onboarding_emails' feature flag is enabled" do
-      before { feature_flags.switch!(:user_onboarding_emails, true) }
+    context "when 'placements_user_onboarding_emails' feature flag is enabled" do
+      before { feature_flags.switch!(:placements_user_onboarding_emails, true) }
 
-      after { feature_flags.switch!(:user_onboarding_emails, false) }
+      after { feature_flags.switch!(:placements_user_onboarding_emails, false) }
 
       scenario "user is removed from a school" do
         given_i_am_signed_in_as_mary
@@ -40,7 +40,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
       end
     end
 
-    context "when 'user_onboarding_emails' feature flag is disabled" do
+    context "when 'placements_user_onboarding_emails' feature flag is disabled" do
       scenario "user is removed from a school" do
         given_i_am_signed_in_as_mary
         and_i_visit_the_user_page(anne)
@@ -74,10 +74,10 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
       end
     end
 
-    context "when 'user_onboarding_emails' feature flag is enabled" do
-      before { feature_flags.switch!(:user_onboarding_emails, true) }
+    context "when 'placements_user_onboarding_emails' feature flag is enabled" do
+      before { feature_flags.switch!(:placements_user_onboarding_emails, true) }
 
-      after { feature_flags.switch!(:user_onboarding_emails, false) }
+      after { feature_flags.switch!(:placements_user_onboarding_emails, false) }
 
       scenario "user is removed from a provider" do
         given_i_am_signed_in_as_mary
@@ -94,7 +94,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
       end
     end
 
-    context "when 'user_onboarding_emails' feature flag is disabled" do
+    context "when 'placements_user_onboarding_emails' feature flag is disabled" do
       scenario "user is removed from a provider" do
         given_i_am_signed_in_as_mary
         and_i_visit_the_user_page(anne)

--- a/spec/system/placements/support/users/support_user_invites_a_new_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_invites_a_new_user_spec.rb
@@ -15,24 +15,49 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
            last_name: "User",
            email: "test@example.com")
   end
+  let(:feature_flags) { Flipflop::FeatureSet.current.test! }
 
   before do
     given_i_am_signed_in_as_a_support_user
   end
 
   describe "School" do
-    scenario "Support User invites a new user to a school" do
-      when_i_visit_the_users_page_for(organisation: school)
-      then_i_see_the_navigation_bars_with_organisations_and_users_selected(school)
-      and_i_click("Add user")
-      then_i_see_support_navigation_with_organisation_selected
-      and_i_enter_the_details_for_a_new_user
-      and_i_click("Continue")
-      then_i_see_support_navigation_with_organisation_selected
-      then_i_see_the_new_users_details
-      and_i_click("Add user")
-      then_i_see_support_navigation_with_organisation_selected
-      then_i_see_the_new_user_has_been_added(school)
+    context "when 'user_onboarding_emails' feature flag is enabled" do
+      before { feature_flags.switch!(:user_onboarding_emails, true) }
+
+      after { feature_flags.switch!(:user_onboarding_emails, false) }
+
+      scenario "Support User invites a new user to a school" do
+        when_i_visit_the_users_page_for(organisation: school)
+        then_i_see_the_navigation_bars_with_organisations_and_users_selected(school)
+        and_i_click("Add user")
+        then_i_see_support_navigation_with_organisation_selected
+        and_i_enter_the_details_for_a_new_user
+        and_i_click("Continue")
+        then_i_see_support_navigation_with_organisation_selected
+        then_i_see_the_new_users_details
+        and_i_click("Add user")
+        then_i_see_support_navigation_with_organisation_selected
+        then_i_see_the_new_user_has_been_added(school)
+        and_email_is_sent("test@example.com", school)
+      end
+    end
+
+    context "when 'user_onboarding_emails' feature flag is disabled" do
+      scenario "Support User invites a new user to a school" do
+        when_i_visit_the_users_page_for(organisation: school)
+        then_i_see_the_navigation_bars_with_organisations_and_users_selected(school)
+        and_i_click("Add user")
+        then_i_see_support_navigation_with_organisation_selected
+        and_i_enter_the_details_for_a_new_user
+        and_i_click("Continue")
+        then_i_see_support_navigation_with_organisation_selected
+        then_i_see_the_new_users_details
+        and_i_click("Add user")
+        then_i_see_support_navigation_with_organisation_selected
+        then_i_see_the_new_user_has_been_added(school)
+        and_email_is_not_sent("test@example.com", school)
+      end
     end
 
     scenario "Support user edits new user details before submitting" do
@@ -52,41 +77,98 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
   end
 
   describe "Provider" do
-    scenario "Support User invites a new user to a school" do
-      when_i_visit_the_users_page_for(organisation: provider)
-      then_i_see_the_navigation_bars_with_organisations_and_users_selected(provider)
-      and_i_click("Add user")
-      then_i_see_support_navigation_with_organisation_selected
-      and_i_enter_the_details_for_a_new_user
-      and_i_click("Continue")
-      then_i_see_support_navigation_with_organisation_selected
-      then_i_see_the_new_users_details
-      and_i_click("Add user")
-      then_i_see_support_navigation_with_organisation_selected
-      then_i_see_the_new_user_has_been_added(provider)
+    context "when 'user_onboarding_emails' feature flag is enabled" do
+      before { feature_flags.switch!(:user_onboarding_emails, true) }
+
+      after { feature_flags.switch!(:user_onboarding_emails, false) }
+
+      scenario "Support User invites a new user to a school" do
+        when_i_visit_the_users_page_for(organisation: provider)
+        then_i_see_the_navigation_bars_with_organisations_and_users_selected(provider)
+        and_i_click("Add user")
+        then_i_see_support_navigation_with_organisation_selected
+        and_i_enter_the_details_for_a_new_user
+        and_i_click("Continue")
+        then_i_see_support_navigation_with_organisation_selected
+        then_i_see_the_new_users_details
+        and_i_click("Add user")
+        then_i_see_support_navigation_with_organisation_selected
+        then_i_see_the_new_user_has_been_added(provider)
+        and_email_is_sent("test@example.com", provider)
+      end
+    end
+
+    context "when 'user_onboarding_emails' feature flag is disabled" do
+      scenario "Support User invites a new user to a school" do
+        when_i_visit_the_users_page_for(organisation: provider)
+        then_i_see_the_navigation_bars_with_organisations_and_users_selected(provider)
+        and_i_click("Add user")
+        then_i_see_support_navigation_with_organisation_selected
+        and_i_enter_the_details_for_a_new_user
+        and_i_click("Continue")
+        then_i_see_support_navigation_with_organisation_selected
+        then_i_see_the_new_users_details
+        and_i_click("Add user")
+        then_i_see_support_navigation_with_organisation_selected
+        then_i_see_the_new_user_has_been_added(provider)
+        and_email_is_not_sent("test@example.com", provider)
+      end
     end
   end
 
   describe "User can be member of multiple organisations" do
-    scenario "Support user invites the same user to multiple organisations" do
-      when_i_visit_the_users_page_for(organisation: provider)
-      and_i_click("Add user")
-      and_i_enter_the_details_for_a_new_user
-      and_i_click("Continue")
-      then_i_see_the_new_users_details
-      and_i_click("Add user")
-      then_i_see_the_new_user_has_been_added(provider)
+    context "when 'user_onboarding_emails' feature flag is enabled" do
+      before { feature_flags.switch!(:user_onboarding_emails, true) }
 
-      when_i_return_to_organisations_page
-      when_i_visit_the_users_page_for(organisation: school)
-      and_i_click("Add user")
-      and_i_enter_the_details_for_a_new_user
-      and_i_click("Continue")
-      then_i_see_the_new_users_details
-      and_i_click("Add user")
-      then_i_see_the_new_user_has_been_added(school)
+      after { feature_flags.switch!(:user_onboarding_emails, false) }
 
-      and_the_user_has_multiple_memberships
+      scenario "Support user invites the same user to multiple organisations" do
+        when_i_visit_the_users_page_for(organisation: provider)
+        and_i_click("Add user")
+        and_i_enter_the_details_for_a_new_user
+        and_i_click("Continue")
+        then_i_see_the_new_users_details
+        and_i_click("Add user")
+        then_i_see_the_new_user_has_been_added(provider)
+        and_email_is_sent("test@example.com", provider)
+
+        when_i_return_to_organisations_page
+        when_i_visit_the_users_page_for(organisation: school)
+        and_i_click("Add user")
+        and_i_enter_the_details_for_a_new_user
+        and_i_click("Continue")
+        then_i_see_the_new_users_details
+        and_i_click("Add user")
+        then_i_see_the_new_user_has_been_added(school)
+        and_email_is_sent("test@example.com", school)
+
+        and_the_user_has_multiple_memberships
+      end
+    end
+
+    context "when 'user_onboarding_emails' feature flag is disabled" do
+      scenario "Support user invites the same user to multiple organisations" do
+        when_i_visit_the_users_page_for(organisation: provider)
+        and_i_click("Add user")
+        and_i_enter_the_details_for_a_new_user
+        and_i_click("Continue")
+        then_i_see_the_new_users_details
+        and_i_click("Add user")
+        then_i_see_the_new_user_has_been_added(provider)
+        and_email_is_not_sent("test@example.com", provider)
+
+        when_i_return_to_organisations_page
+        when_i_visit_the_users_page_for(organisation: school)
+        and_i_click("Add user")
+        and_i_enter_the_details_for_a_new_user
+        and_i_click("Continue")
+        then_i_see_the_new_users_details
+        and_i_click("Add user")
+        then_i_see_the_new_user_has_been_added(school)
+        and_email_is_not_sent("test@example.com", school)
+
+        and_the_user_has_multiple_memberships
+      end
     end
   end
 
@@ -202,19 +284,28 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
 
   alias_method :and_i_see_the_new_users_details, :then_i_see_the_new_users_details
 
-  def then_i_see_the_new_user_has_been_added(organisation)
-    and_email_is_sent("test@example.com", organisation)
+  def then_i_see_the_new_user_has_been_added(_organisation)
     expect(page.find(".govuk-notification-banner__content")).to have_content("User added")
     then_i_see_support_navigation_with_organisation_selected
     and_i_see_the_new_users_details
   end
 
-  def and_email_is_sent(email, organisation)
-    email = ActionMailer::Base.deliveries.find do |delivery|
+  def email_invite_notification(email, organisation)
+    ActionMailer::Base.deliveries.find do |delivery|
       delivery.to.include?(email) && delivery.subject == "You have been invited to #{organisation.name}"
     end
+  end
 
-    expect(email).not_to be_nil
+  def and_email_is_sent(email, organisation)
+    invite_email = email_invite_notification(email, organisation)
+
+    expect(invite_email).not_to be_nil
+  end
+
+  def and_email_is_not_sent(email, organisation)
+    invite_email = email_invite_notification(email, organisation)
+
+    expect(invite_email).to be_nil
   end
 
   def and_the_user_has_multiple_memberships

--- a/spec/system/placements/support/users/support_user_invites_a_new_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_invites_a_new_user_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
   end
 
   describe "School" do
-    context "when 'user_onboarding_emails' feature flag is enabled" do
-      before { feature_flags.switch!(:user_onboarding_emails, true) }
+    context "when 'placements_user_onboarding_emails' feature flag is enabled" do
+      before { feature_flags.switch!(:placements_user_onboarding_emails, true) }
 
-      after { feature_flags.switch!(:user_onboarding_emails, false) }
+      after { feature_flags.switch!(:placements_user_onboarding_emails, false) }
 
       scenario "Support User invites a new user to a school" do
         when_i_visit_the_users_page_for(organisation: school)
@@ -43,7 +43,7 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
       end
     end
 
-    context "when 'user_onboarding_emails' feature flag is disabled" do
+    context "when 'placements_user_onboarding_emails' feature flag is disabled" do
       scenario "Support User invites a new user to a school" do
         when_i_visit_the_users_page_for(organisation: school)
         then_i_see_the_navigation_bars_with_organisations_and_users_selected(school)
@@ -77,10 +77,10 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
   end
 
   describe "Provider" do
-    context "when 'user_onboarding_emails' feature flag is enabled" do
-      before { feature_flags.switch!(:user_onboarding_emails, true) }
+    context "when 'placements_user_onboarding_emails' feature flag is enabled" do
+      before { feature_flags.switch!(:placements_user_onboarding_emails, true) }
 
-      after { feature_flags.switch!(:user_onboarding_emails, false) }
+      after { feature_flags.switch!(:placements_user_onboarding_emails, false) }
 
       scenario "Support User invites a new user to a school" do
         when_i_visit_the_users_page_for(organisation: provider)
@@ -98,7 +98,7 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
       end
     end
 
-    context "when 'user_onboarding_emails' feature flag is disabled" do
+    context "when 'placements_user_onboarding_emails' feature flag is disabled" do
       scenario "Support User invites a new user to a school" do
         when_i_visit_the_users_page_for(organisation: provider)
         then_i_see_the_navigation_bars_with_organisations_and_users_selected(provider)
@@ -117,10 +117,10 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
   end
 
   describe "User can be member of multiple organisations" do
-    context "when 'user_onboarding_emails' feature flag is enabled" do
-      before { feature_flags.switch!(:user_onboarding_emails, true) }
+    context "when 'placements_user_onboarding_emails' feature flag is enabled" do
+      before { feature_flags.switch!(:placements_user_onboarding_emails, true) }
 
-      after { feature_flags.switch!(:user_onboarding_emails, false) }
+      after { feature_flags.switch!(:placements_user_onboarding_emails, false) }
 
       scenario "Support user invites the same user to multiple organisations" do
         when_i_visit_the_users_page_for(organisation: provider)
@@ -146,7 +146,7 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
       end
     end
 
-    context "when 'user_onboarding_emails' feature flag is disabled" do
+    context "when 'placements_user_onboarding_emails' feature flag is disabled" do
       scenario "Support user invites the same user to multiple organisations" do
         when_i_visit_the_users_page_for(organisation: provider)
         and_i_click("Add user")

--- a/spec/system/placements/support/users/support_user_removes_a_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_removes_a_user_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
       create(:user_membership, user:, organisation: school)
     end
 
-    context "when 'user_onboarding_emails' feature flag is enabled" do
-      before { feature_flags.switch!(:user_onboarding_emails, true) }
+    context "when 'placements_user_onboarding_emails' feature flag is enabled" do
+      before { feature_flags.switch!(:placements_user_onboarding_emails, true) }
 
-      after { feature_flags.switch!(:user_onboarding_emails, false) }
+      after { feature_flags.switch!(:placements_user_onboarding_emails, false) }
 
       scenario "user is removed from a school" do
         given_i_am_signed_in_as_a_support_user
@@ -37,7 +37,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
       end
     end
 
-    context "when 'user_onboarding_emails' feature flag is disabled" do
+    context "when 'placements_user_onboarding_emails' feature flag is disabled" do
       scenario "user is removed from a school" do
         given_i_am_signed_in_as_a_support_user
         and_i_visit_the_user_page(school)
@@ -62,10 +62,10 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
       create(:user_membership, user:, organisation: provider)
     end
 
-    context "when 'user_onboarding_emails' feature flag is enabled" do
-      before { feature_flags.switch!(:user_onboarding_emails, true) }
+    context "when 'placements_user_onboarding_emails' feature flag is enabled" do
+      before { feature_flags.switch!(:placements_user_onboarding_emails, true) }
 
-      after { feature_flags.switch!(:user_onboarding_emails, false) }
+      after { feature_flags.switch!(:placements_user_onboarding_emails, false) }
 
       scenario "user is removed from a provider" do
         given_i_am_signed_in_as_a_support_user
@@ -82,7 +82,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
       end
     end
 
-    context "when 'user_onboarding_emails' feature flag is disabled" do
+    context "when 'placements_user_onboarding_emails' feature flag is disabled" do
       scenario "user is removed from a provider" do
         given_i_am_signed_in_as_a_support_user
         and_i_visit_the_user_page(provider)


### PR DESCRIPTION
## Context

- Due to a plan to onboard users/organisations onto the placements services prior to Day 1 release, we wish to disable onboarding emails being dispatched when being created/removed from the placements service.

## Changes proposed in this pull request

- Added a feature flag condition to disable onboarding emails for the placements service.

## Guidance to review

_Enabled_
- run `bin/rake "flipflop:turn_on[user_onboarding_emails, active_record]"`
- Follow the onboarding process for a user for a school/provider
- An email should be dispatched (check https://www.notifications.service.gov.uk/)

_Disabled_
- run `bin/rake "flipflop:turn_off[user_onboarding_emails, active_record]"` (Default is **OFF**)
- Follow the onboarding process for a user for a school/provider
- An email should **NOT** be dispatched (check https://www.notifications.service.gov.uk/)

## Link to Trello card

https://trello.com/c/DoETx9pz/270-feature-flag-to-switch-off-user-invitation-emails
