### PR TITLE
Add Proof of Concept for responsive tables

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,6 +5,7 @@ $govuk-assets-path: "";
 
 @import "govuk-frontend/dist/govuk/all";
 @import "components/all";
+@import "utils/all";
 @import "accessible-autocomplete/dist/accessible-autocomplete.min";
 @import "search-form";
 @import "filter-form";

--- a/app/assets/stylesheets/utils/_all.scss
+++ b/app/assets/stylesheets/utils/_all.scss
@@ -1,0 +1,1 @@
+@import "overflow";

--- a/app/assets/stylesheets/utils/_overflow.scss
+++ b/app/assets/stylesheets/utils/_overflow.scss
@@ -1,0 +1,3 @@
+.overflow-auto {
+  overflow: auto;
+}

--- a/app/views/claims/schools/claims/index.html.erb
+++ b/app/views/claims/schools/claims/index.html.erb
@@ -15,37 +15,39 @@
   <% end %>
 
   <% if @claims.any? %>
-    <%= govuk_table do |table| %>
-      <% table.with_head do |head| %>
-        <% head.with_row do |row| %>
-          <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:reference)) %>
-          <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:accredited_provider)) %>
-          <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:mentors)) %>
-          <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:claim_amount)) %>
-          <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:submitted_at)) %>
-          <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:status)) %>
+    <div class="overflow-auto">
+      <%= govuk_table do |table| %>
+        <% table.with_head do |head| %>
+          <% head.with_row do |row| %>
+            <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:reference)) %>
+            <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:accredited_provider)) %>
+            <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:mentors)) %>
+            <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:claim_amount)) %>
+            <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:submitted_at)) %>
+            <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:status)) %>
+          <% end %>
         <% end %>
-      <% end %>
 
-      <% table.with_body do |body| %>
-        <% @claims.each do |claim| %>
-          <% body.with_row do |row| %>
-            <% row.with_cell(text: govuk_link_to(claim.reference, claims_school_claim_path(id: claim.id))) %>
-            <% row.with_cell(text: claim.provider_name) %>
-            <% row.with_cell do %>
-              <ul class="govuk-list">
-                <% claim.mentors.each do |mentor| %>
-                  <li><%= mentor.full_name %></li>
-                <% end %>
-              </ul>
+        <% table.with_body do |body| %>
+          <% @claims.each do |claim| %>
+            <% body.with_row do |row| %>
+              <% row.with_cell(text: govuk_link_to(claim.reference, claims_school_claim_path(id: claim.id))) %>
+              <% row.with_cell(text: claim.provider_name) %>
+              <% row.with_cell do %>
+                <ul class="govuk-list">
+                  <% claim.mentors.each do |mentor| %>
+                    <li><%= mentor.full_name %></li>
+                  <% end %>
+                </ul>
+              <% end %>
+              <% row.with_cell(text: humanized_money_with_symbol(claim.amount)) %>
+              <% row.with_cell(text: safe_l(claim.submitted_on, format: :short)) %>
+              <% row.with_cell(text: render(Claim::StatusTagComponent.new(claim:))) %>
             <% end %>
-            <% row.with_cell(text: humanized_money_with_symbol(claim.amount)) %>
-            <% row.with_cell(text: safe_l(claim.submitted_on, format: :short)) %>
-            <% row.with_cell(text: render(Claim::StatusTagComponent.new(claim:))) %>
           <% end %>
         <% end %>
       <% end %>
-    <% end %>
+    </div>
 
     <%= render PaginationComponent.new(pagy: @pagy) %>
   <% else %>


### PR DESCRIPTION
## Context

Wider tables are overflowing on mobile devices.

## Changes proposed in this pull request

- Add a `utils` scss directory.
- ~Add a `responsive-table` utility class. Inspired from Bootstrap.~
- Add a `overflow-auto` utility class. Inspired from TailwindCSS. This allows the utility to be atomic and used in any component that requires this utility.

## Guidance to review

- Visit the `/schools/:school_id/claims` path with some claims on mobile. Only the table should be scrollable.

If well received, this may be a contender for an option (or default) of the `govuk_table` helper/component.

## Screenshots

https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/68744b69-ed7e-48a9-a425-0acbe4ecdfba
