### PR TITLE
Update feedback link text to tell user that it will open in a new tab

### DIFF
--- a/app/views/claims/schools/claims/confirm.html.erb
+++ b/app/views/claims/schools/claims/confirm.html.erb
@@ -23,7 +23,7 @@
 
       <h4 class="govuk-heading-m"><%= t(".give_us_feedback") %></h4>
       <p class="govuk-body">
-        <%= t(".feedback_link_html", feedback_link: govuk_link_to(t(".what_do_you_think"), feedback_url, target: "_blank", rel: "noreferrer", class: "govuk-link--no-visited-state")) %>
+        <%= govuk_link_to(t(".what_do_you_think"), feedback_url, target: "_blank", rel: "noreferrer", class: "govuk-link--no-visited-state") %>
       </p>
     <div>
   <div>

--- a/config/locales/en/claims/schools/claims.yml
+++ b/config/locales/en/claims/schools/claims.yml
@@ -8,8 +8,8 @@ en:
           processing_your_claim: Processing your claim
           processing_your_claim_guidance: We will process this claim at the end of July 2024 and all payments will be paid from September 2024.
           give_us_feedback: Give us feedback
-          what_do_you_think: What do you think of this service?
-          feedback_link_html: "%{feedback_link} (takes 30 seconds)"
+          what_do_you_think: What do you think of this service? (opens in a new tab)
+          feedback_link_html: "%{feedback_link}"
           your_reference_number_id: Your reference number
           what_happens_next: What happens next
           view_claims: View claims

--- a/config/locales/en/layouts/application.yml
+++ b/config/locales/en/layouts/application.yml
@@ -9,7 +9,7 @@ en:
       claims:
         phase_banner:
           description: This is a new service &ndash; your %{feedback_link} will help us to improve it.
-          feedback: feedback
+          feedback: feedback (opens in a new tab)
 
       placements:
         phase_banner:


### PR DESCRIPTION
## Context

We want to tell users that the feedback link will open in a new tab.

## Changes proposed in this pull request

- Update feedback link text to include `(opens in a new tab)`.

## Guidance to review

- Check screenshots and compare to prototype.

## Screenshots

![CleanShot 2024-04-25 at 13 31 56](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/8be647d5-b13d-430a-a023-be66bf3d6136)

![CleanShot 2024-04-25 at 13 32 13](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/94922843-7453-484c-9669-cbbeba2b2b3e)

