### PR TITLE
Added a toggle for statuscake

### DIFF
--- a/terraform/application/statuscake.tf
+++ b/terraform/application/statuscake.tf
@@ -1,6 +1,8 @@
 module "statuscake" {
+    
+  count = var.enable_monitoring? 1 : 0
   source = "./vendor/modules/aks//monitoring/statuscake"
-  
+
   uptime_urls    = concat([module.web_application.probe_url], var.statuscake_alerts.website_url)
   ssl_urls       = var.statuscake_alerts.ssl_url
   contact_groups = var.statuscake_alerts.contact_groups


### PR DESCRIPTION
WHY: Status cake is not needed in all environments
HOW: By creating a new variable as enable_monitoring is not one to one

## Context

Status cake is not needed in all environments

## Changes proposed in this pull request

Add new toggle variable for statuscake as enable_monitoring is not one to one with it

## Guidance to review

check statuscake is not on qa

## Link to Trello card

https://trello.com/c/j0ZXrApw/1726-ittms-statuscake-monitoring
