### PR TITLE
Force and assume SSL

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,8 +44,12 @@ Rails.application.configure do
   # config.action_cable.url = "wss://example.com/cable"
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
+  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
+  # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
+  config.assume_ssl = true
+
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).


### PR DESCRIPTION
## Context

This will ensure the app always uses secure cookies and Strict-Transport-Security headers but allow for non-secure requests at the application layer as we encrypt traffic at our ingress layer.

## Changes proposed in this pull request

- Set `config.force_ssl = true` and `config.assume_ssl = true` in `config/environments/production.rb`.

## Guidance to review

- Visit the review app.
- Check the headers.
- The cookie should have `secure` set on it.
- The `Strict-Transport-Security` header should be set.

## Trello Card

- https://trello.com/c/FJUKdouv/417-when-the-session-cookie-is-set-it-should-be-marked-secure
- https://trello.com/c/gTL5sMZj/418-setup-our-security-headers
