### PR TITLE
Downgrade dfe-analytics to 1.12.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,7 +97,7 @@ gem "geocoder"
 gem "audited"
 
 # BigQuery
-gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.12.4"
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.12.3"
 
 group :development do
   gem "annotate", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: 3e078f9fdd0e890449f90e7cd2f151c392d570ac
-  tag: v1.12.4
+  revision: 80015465040513020d0c2b3a2ae45d4f05f3b547
+  tag: v1.12.3
   specs:
-    dfe-analytics (1.12.4)
+    dfe-analytics (1.12.3)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
 


### PR DESCRIPTION
## Context

The 1.12.4 has some changes that breaks the importing of entities to BigQuery. I will raise an issue with the dfe-analytics team but for now 1.12.3 should work for us.

The issue seems to be in this PR https://github.com/DFE-Digital/dfe-analytics/pull/132

The SQL syntax seems to be incorrect looking at https://dfe-teacher-services.sentry.io/issues/5259551627/events/76d8bafa5cc44fa3b063a78fbfeb4183/

```
ActiveRecord::StatementInvalid
PG::SyntaxError: ERROR:  syntax error at or near "2024" (ActiveRecord::StatementInvalid)
LINE 7: ...ships".updated_at) < DATE_TRUNC('milliseconds', ''2024-04-26...
```

## Changes proposed in this pull request

Downgrade the gem to 1.12.3

## Guidance to review

Review

![Screenshot from 2024-04-26 12-00-37](https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/a21fa364-dd54-4bd0-a5d7-701143810f33)

