### PR TITLE
[RFC] Create app_table helper to extend govuk_table helper

### DIFF
--- a/app/helpers/table_helper.rb
+++ b/app/helpers/table_helper.rb
@@ -1,0 +1,7 @@
+module TableHelper
+  def app_table(*args, **kwargs, &block)
+    content_tag(:div, class: "overflow-auto") do
+      govuk_table(*args, **kwargs, &block)
+    end
+  end
+end

--- a/app/views/claims/pages/cookies.html.erb
+++ b/app/views/claims/pages/cookies.html.erb
@@ -21,7 +21,7 @@
         Essential cookies keep your information secure while you use Claim funding for mentor training. We do not need to ask permission to use them.
       </p>
 
-      <%= govuk_table do |table| %>
+      <%= app_table do |table| %>
         <% table.with_head do |head| %>
           <% head.with_row do |row| %>
             <% row.with_cell(header: true, text: "Name") %>
@@ -66,7 +66,7 @@
         <li>what you click on while you’re visiting the site</li>
       </ul>
 
-      <%= govuk_table do |table| %>
+      <%= app_table do |table| %>
         <% table.with_head do |head| %>
           <% head.with_row do |row| %>
             <% row.with_cell(header: true, text: "Name") %>

--- a/app/views/claims/schools/_grant_conditions.html.erb
+++ b/app/views/claims/schools/_grant_conditions.html.erb
@@ -113,7 +113,7 @@
       <p class="govuk-body">For each mentor that completes the full 20 hours of training, the table below sets out how much a school can claim.</p>
       <p class="govuk-body">If a mentor undertakes fewer than 20 hours of training, the funding is calculated per hour. For example, if a mentor in a school outside London completed 10 hours of training, the school can claim £438. This is calculated at £43.80 (per hour) x 10 (hours of training).</p>
 
-      <%= govuk_table do |table| %>
+      <%= app_table do |table| %>
         <% table.with_head do |head| %>
           <% head.with_row do |row| %>
             <% row.with_cell(header: true, text: "Funding available per mentor") %>

--- a/app/views/claims/schools/claims/index.html.erb
+++ b/app/views/claims/schools/claims/index.html.erb
@@ -15,39 +15,37 @@
   <% end %>
 
   <% if @claims.any? %>
-    <div class="overflow-auto">
-      <%= govuk_table do |table| %>
-        <% table.with_head do |head| %>
-          <% head.with_row do |row| %>
-            <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:reference)) %>
-            <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:accredited_provider)) %>
-            <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:mentors)) %>
-            <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:claim_amount)) %>
-            <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:submitted_at)) %>
-            <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:status)) %>
-          <% end %>
+    <%= app_table do |table| %>
+      <% table.with_head do |head| %>
+        <% head.with_row do |row| %>
+          <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:reference)) %>
+          <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:accredited_provider)) %>
+          <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:mentors)) %>
+          <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:claim_amount)) %>
+          <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:submitted_at)) %>
+          <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:status)) %>
         <% end %>
+      <% end %>
 
-        <% table.with_body do |body| %>
-          <% @claims.each do |claim| %>
-            <% body.with_row do |row| %>
-              <% row.with_cell(text: govuk_link_to(claim.reference, claims_school_claim_path(id: claim.id))) %>
-              <% row.with_cell(text: claim.provider_name) %>
-              <% row.with_cell do %>
-                <ul class="govuk-list">
-                  <% claim.mentors.each do |mentor| %>
-                    <li><%= mentor.full_name %></li>
-                  <% end %>
-                </ul>
-              <% end %>
-              <% row.with_cell(text: humanized_money_with_symbol(claim.amount)) %>
-              <% row.with_cell(text: safe_l(claim.submitted_on, format: :short)) %>
-              <% row.with_cell(text: render(Claim::StatusTagComponent.new(claim:))) %>
+      <% table.with_body do |body| %>
+        <% @claims.each do |claim| %>
+          <% body.with_row do |row| %>
+            <% row.with_cell(text: govuk_link_to(claim.reference, claims_school_claim_path(id: claim.id))) %>
+            <% row.with_cell(text: claim.provider_name) %>
+            <% row.with_cell do %>
+              <ul class="govuk-list">
+                <% claim.mentors.each do |mentor| %>
+                  <li><%= mentor.full_name %></li>
+                <% end %>
+              </ul>
             <% end %>
+            <% row.with_cell(text: humanized_money_with_symbol(claim.amount)) %>
+            <% row.with_cell(text: safe_l(claim.submitted_on, format: :short)) %>
+            <% row.with_cell(text: render(Claim::StatusTagComponent.new(claim:))) %>
           <% end %>
         <% end %>
       <% end %>
-    </div>
+    <% end %>
 
     <%= render PaginationComponent.new(pagy: @pagy) %>
   <% else %>

--- a/app/views/claims/schools/mentors/index.html.erb
+++ b/app/views/claims/schools/mentors/index.html.erb
@@ -9,7 +9,7 @@
       <%= govuk_button_to(t(".add_mentor"), new_claims_school_mentor_path, method: :get) %>
 
       <% if @mentors.any? %>
-        <%= govuk_table do |table| %>
+        <%= app_table do |table| %>
           <% table.with_head do |head| %>
             <% head.with_row do |row| %>
               <% row.with_cell(header: true, text: Mentor.human_attribute_name(:name)) %>

--- a/app/views/claims/schools/users/index.html.erb
+++ b/app/views/claims/schools/users/index.html.erb
@@ -6,7 +6,7 @@
     <div class="govuk-grid-column-two-thirds">
       <%= govuk_button_to(t(".add_user"), new_claims_school_user_path, method: :get) %>
       <% if @users.any? %>
-        <%= govuk_table do |table| %>
+        <%= app_table do |table| %>
           <% table.with_head do |head| %>
             <% head.with_row do |row| %>
               <% row.with_cell(header: true, text: User.human_attribute_name("full_name")) %>

--- a/app/views/claims/support/schools/claims/index.html.erb
+++ b/app/views/claims/support/schools/claims/index.html.erb
@@ -14,7 +14,7 @@
   <% end %>
 
   <% if @claims.any? %>
-    <%= govuk_table do |table| %>
+    <%= app_table do |table| %>
       <% table.with_head do |head| %>
         <% head.with_row do |row| %>
           <% row.with_cell(header: true, text: Claims::Claim.human_attribute_name(:reference)) %>

--- a/app/views/claims/support/schools/mentors/index.html.erb
+++ b/app/views/claims/support/schools/mentors/index.html.erb
@@ -14,7 +14,7 @@
       <%= govuk_button_to(t(".add_mentor"), new_claims_support_school_mentor_path, method: :get) %>
 
       <% if @mentors.any? %>
-        <%= govuk_table do |table| %>
+        <%= app_table do |table| %>
           <% table.with_head do |head| %>
             <% head.with_row do |row| %>
               <% row.with_cell(header: true, text: Mentor.human_attribute_name(:name)) %>

--- a/app/views/claims/support/support_users/index.html.erb
+++ b/app/views/claims/support/support_users/index.html.erb
@@ -9,7 +9,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <% if @support_users.any? %>
-        <%= govuk_table do |table| %>
+        <%= app_table do |table| %>
           <% table.with_head do |head| %>
             <% head.with_row do |row| %>
               <% row.with_cell(text: User.human_attribute_name(:name), width: "govuk-!-width-one-third") %>

--- a/app/views/placements/organisations/users/_list.html.erb
+++ b/app/views/placements/organisations/users/_list.html.erb
@@ -1,5 +1,5 @@
 <% if users.any? %>
-  <%= govuk_table do |table| %>
+  <%= app_table do |table| %>
     <% table.with_head do |head| %>
       <% head.with_row do |row| %>
         <% row.with_cell(header: true, text: t(".name")) %>

--- a/app/views/placements/providers/partner_schools/index.html.erb
+++ b/app/views/placements/providers/partner_schools/index.html.erb
@@ -7,7 +7,7 @@
     <div class="govuk-grid-column-two-thirds">
       <%= govuk_button_to(t(".add_partner_school"), new_placements_provider_partner_school_path, method: :get) %>
       <% if @partner_schools.any? %>
-        <%= govuk_table do |table| %>
+        <%= app_table do |table| %>
           <% table.with_head do |head| %>
             <% head.with_row do |row| %>
               <% row.with_cell(header: true, text: t(".attributes.partner_schools.name")) %>

--- a/app/views/placements/schools/mentors/index.html.erb
+++ b/app/views/placements/schools/mentors/index.html.erb
@@ -10,7 +10,7 @@
       <%= govuk_button_to(t(".add_mentor"), new_placements_school_mentor_path, method: :get) %>
 
       <% if @mentors.any? %>
-        <%= govuk_table do |table| %>
+        <%= app_table do |table| %>
           <% table.with_head do |head| %>
             <% head.with_row do |row| %>
               <% row.with_cell(header: true, text: Mentor.human_attribute_name(:name)) %>

--- a/app/views/placements/schools/partner_providers/index.html.erb
+++ b/app/views/placements/schools/partner_providers/index.html.erb
@@ -7,7 +7,7 @@
     <div class="govuk-grid-column-two-thirds">
       <%= govuk_button_to(t(".add_partner_provider"), new_placements_school_partner_provider_path, method: :get) %>
       <% if @partner_providers.any? %>
-        <%= govuk_table do |table| %>
+        <%= app_table do |table| %>
           <% table.with_head do |head| %>
             <% head.with_row do |row| %>
               <% row.with_cell(header: true, text: t(".attributes.partner_providers.name")) %>

--- a/app/views/placements/schools/placements/index.html.erb
+++ b/app/views/placements/schools/placements/index.html.erb
@@ -7,7 +7,7 @@
       <%= govuk_button_to(t(".add_placement"), new_placements_school_placement_build_path(@school, placement_id: "new_placement"), method: :get) %>
 
       <% if @placements.any? %>
-        <%= govuk_table do |table| %>
+        <%= app_table do |table| %>
           <% table.with_head do |head| %>
             <% head.with_row do |row| %>
               <% row.with_cell(header: true, text: t(".subject")) %>

--- a/app/views/placements/support/providers/users/index.html.erb
+++ b/app/views/placements/support/providers/users/index.html.erb
@@ -13,7 +13,7 @@
       <%= govuk_button_to(t(".add_user"), new_placements_support_provider_user_path(@provider), method: :get) %>
 
       <% if @users.any? %>
-        <%= govuk_table do |table| %>
+        <%= app_table do |table| %>
           <% table.with_head do |head| %>
             <% head.with_row do |row| %>
               <% row.with_cell(header: true, text: t(".attributes.users.name")) %>

--- a/app/views/placements/support/schools/mentors/index.html.erb
+++ b/app/views/placements/support/schools/mentors/index.html.erb
@@ -14,7 +14,7 @@
       <%= govuk_button_to(t(".add_mentor"), new_placements_support_school_mentor_path, method: :get) %>
 
       <% if @mentors.any? %>
-        <%= govuk_table do |table| %>
+        <%= app_table do |table| %>
           <% table.with_head do |head| %>
             <% head.with_row do |row| %>
               <% row.with_cell(header: true, text: Mentor.human_attribute_name(:name)) %>

--- a/app/views/placements/support/schools/placements/index.html.erb
+++ b/app/views/placements/support/schools/placements/index.html.erb
@@ -9,7 +9,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l"><%= t(".placements") %></h1>
       <% if @placements.any? %>
-        <%= govuk_table do |table| %>
+        <%= app_table do |table| %>
           <% table.with_head do |head| %>
             <% head.with_row do |row| %>
               <% row.with_cell(header: true, text: t(".subject")) %>

--- a/app/views/placements/support/schools/users/index.html.erb
+++ b/app/views/placements/support/schools/users/index.html.erb
@@ -13,7 +13,7 @@
       <%= govuk_button_to(t(".add_user"), new_placements_support_school_user_path(@school), method: :get) %>
 
       <% if @users.any? %>
-        <%= govuk_table do |table| %>
+        <%= app_table do |table| %>
           <% table.with_head do |head| %>
             <% head.with_row do |row| %>
               <% row.with_cell(header: true, text: t(".attributes.users.name")) %>

--- a/app/views/placements/support/support_users/index.html.erb
+++ b/app/views/placements/support/support_users/index.html.erb
@@ -8,7 +8,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= govuk_table do |table| %>
+      <%= app_table do |table| %>
         <% table.with_head do |head| %>
           <% head.with_row do |row| %>
             <% row.with_cell(text: User.human_attribute_name(:name), width: "govuk-!-width-one-third") %>


### PR DESCRIPTION
## Context

We want to make sure tables are _always_ accessible on mobile and don't cause a page overflow.

## Changes proposed in this pull request

- Add a `app_table` helper that wraps a `govuk_table` in a `div` with the `overflow-auto` class.

  This makes the table responsive and viewable across all screen sizes.

## Guidance to review

- Try navigating throughout the services on mobile. Tables should be scrollable when they overflow and not scrollable when they do not overflow.
