### PR TITLE
Add show page for provider placements

### DIFF
--- a/app/components/placement/summary_component.html.erb
+++ b/app/components/placement/summary_component.html.erb
@@ -1,7 +1,6 @@
 <li class="app-search-results__item">
   <h2 class="app-search-result__item-title">
-    <!-- TODO: link to placement details -->
-    <%= govuk_link_to("", no_visited_state: true) do %>
+    <%= govuk_link_to(placements_provider_placement_path(@provider, placement), no_visited_state: true) do %>
       <span><%= school.name %></span>
       <br>
       <span><%= placement.subject_names %></span>

--- a/app/components/placement/summary_component.rb
+++ b/app/components/placement/summary_component.rb
@@ -1,11 +1,12 @@
 class Placement::SummaryComponent < ApplicationComponent
   with_collection_parameter :placement
-  attr_reader :placement, :school
+  attr_reader :placement, :school, :provider
 
-  def initialize(placement:, classes: [], html_attributes: {})
+  def initialize(provider:, placement:, classes: [], html_attributes: {})
     super(classes:, html_attributes:)
 
+    @provider = provider
     @placement = placement.decorate
-    @school = placement.school.decorate
+    @school = @placement.school
   end
 end

--- a/app/controllers/placements/providers/placements_controller.rb
+++ b/app/controllers/placements/providers/placements_controller.rb
@@ -15,6 +15,11 @@ class Placements::Providers::PlacementsController < ApplicationController
     )
   end
 
+  def show
+    @placement = Placement.find(params[:id]).decorate
+    @school = @placement.school
+  end
+
   private
 
   def set_provider

--- a/app/decorators/placement_decorator.rb
+++ b/app/decorators/placement_decorator.rb
@@ -1,5 +1,6 @@
 class PlacementDecorator < Draper::Decorator
   delegate_all
+  decorates_association :school
 
   def mentor_names
     if mentors.any?

--- a/app/views/placements/providers/placements/_mentor_details.html.erb
+++ b/app/views/placements/providers/placements/_mentor_details.html.erb
@@ -1,0 +1,17 @@
+<%# locals: (placement:) -%>
+<%= govuk_summary_list do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t(".mentor")) %>
+    <% row.with_value do %>
+      <% if @placement.mentors.any? %>
+        <ul class="govuk-list">
+          <% @placement.mentors.each do |mentor| %>
+            <li><%= mentor.full_name %></li>
+          <% end %>
+        </ul>
+      <% else %>
+        <%= t("placements.schools.placements.not_known_yet") %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/placements/providers/placements/_school_details.html.erb
+++ b/app/views/placements/providers/placements/_school_details.html.erb
@@ -1,0 +1,47 @@
+<%# locals: (school:, placement:) -%>
+<%= govuk_summary_list do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t(".school_type")) %>
+    <% row.with_value(text: school.type_of_establishment) %>
+  <% end %>
+
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t(".school_phase")) %>
+    <% row.with_value(text: school.phase) %>
+  <% end %>
+
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t(".gender")) %>
+    <% row.with_value(text: school.gender) %>
+  <% end %>
+
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t(".age_range")) %>
+    <% row.with_value(text: school.age_range) %>
+  <% end %>
+
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t(".religious_character")) %>
+    <% row.with_value(text: school.religious_character) %>
+  <% end %>
+
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t(".urban_or_rural")) %>
+    <% row.with_value(text: school.urban_or_rural) %>
+  <% end %>
+
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t(".admissions_policy")) %>
+    <% row.with_value(text: school.admissions_policy) %>
+  <% end %>
+
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t(".percentage_free_school_meals")) %>
+    <% row.with_value(text: school.percentage_free_school_meals) %>
+  <% end %>
+
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t(".ofsted_rating")) %>
+    <% row.with_value(text: school.rating) %>
+  <% end %>
+<% end %>

--- a/app/views/placements/providers/placements/index.html.erb
+++ b/app/views/placements/providers/placements/index.html.erb
@@ -23,7 +23,7 @@
     <div class="govuk-grid-column-two-thirds">
       <% if @placements.any? %>
         <ul class="app-search-results">
-          <%= render(Placement::SummaryComponent.with_collection(@placements)) %>
+          <%= render(Placement::SummaryComponent.with_collection(@placements, provider: @provider)) %>
         </ul>
         <%= render PaginationComponent.new(pagy: @pagy) %>
       <% else %>

--- a/app/views/placements/providers/placements/show.html.erb
+++ b/app/views/placements/providers/placements/show.html.erb
@@ -1,0 +1,26 @@
+<% content_for(:page_title) { t(".page_title", school_name: @school.name, subject_name: @placement.subject_names) } %>
+<%= render "placements/providers/primary_navigation", provider: @provider, current_navigation: :placements %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: placements_provider_placements_path) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <h1 class="govuk-heading-l">
+    <span class="govuk-caption-l"><%= t(".placement", school_name: @school.name) %></span>
+    <%= @placement.subject_names %>
+  </h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "school_details", school: @school, placement: @placement %>
+      <h2 class="govuk-heading-m govuk-!-margin-top-9">
+        <%= t(".mentor_details") %>
+      </h2>
+      <%= render "mentor_details", placement: @placement %>
+      <h2 class="govuk-heading-m govuk-!-margin-top-9">
+        <%= t(".contact_details") %>
+      </h2>
+      <%= render "shared/organisations/contact_details", organisation: @school %>
+    </div>
+  </div>
+</div>

--- a/config/locales/en/placements/providers/placements.yml
+++ b/config/locales/en/placements/providers/placements.yml
@@ -17,3 +17,20 @@ en:
           gender: Gender
           religious_character: Religious character
           ofsted_rating: Ofsted rating
+        show:
+          page_title: "%{subject_name} - Placements - %{school_name}"
+          placement: "Placement - %{school_name}"
+          mentor_details: Mentor details
+          contact_details: Contact details
+        school_details:
+          school_type: School type
+          school_phase: School phase
+          gender: Gender
+          age_range: Age range
+          religious_character: Religious character
+          urban_or_rural: Urban or rural
+          admissions_policy: Admissions policy
+          percentage_free_school_meals: Percentage free school meals
+          ofsted_rating: Ofsted rating
+        mentor_details:
+          mentor: Mentor

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -118,7 +118,7 @@ scope module: :placements,
         end
       end
 
-      resources :placements, only: %i[index]
+      resources :placements, only: %i[index show]
     end
   end
 end

--- a/spec/components/placement/summary_component_spec.rb
+++ b/spec/components/placement/summary_component_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Placement::SummaryComponent, type: :component do
   subject(:component) do
-    described_class.with_collection(placements)
+    described_class.with_collection(placements, provider:)
   end
 
   let(:subject_1) { create(:subject, name: "Biology") }
@@ -23,6 +23,7 @@ RSpec.describe Placement::SummaryComponent, type: :component do
   end
   let(:placement_1) { create(:placement, school:, subjects:, mentors:) }
   let(:placement_2) { create(:placement, school:, subjects: [subject_2], mentors:) }
+  let(:provider) { create(:provider) }
 
   context "when given multiple placements" do
     let(:subjects) { [subject_1] }

--- a/spec/components/previews/placement/summary_component_preview.rb
+++ b/spec/components/previews/placement/summary_component_preview.rb
@@ -1,5 +1,6 @@
 class Placement::SummaryComponentPreview < ApplicationComponentPreview
   def default
+    provider = FactoryBot.create(:provider)
     subject_1 = FactoryBot.build(:subject, name: "Biology")
     subject_2 = FactoryBot.build(:subject, name: "Classics")
     school_1 = FactoryBot.create(
@@ -60,6 +61,7 @@ class Placement::SummaryComponentPreview < ApplicationComponentPreview
 
     render(Placement::SummaryComponent.with_collection(
              [placement_1, placement_2, placement_3],
+             provider:,
            ))
   end
 end

--- a/spec/system/placements/providers/placements/view_a_placement_spec.rb
+++ b/spec/system/placements/providers/placements/view_a_placement_spec.rb
@@ -1,0 +1,175 @@
+require "rails_helper"
+
+RSpec.describe "Placements / Providers / Placements / View a placement",
+               type: :system,
+               service: :placements,
+               js: true do
+  let(:provider) { create(:placements_provider, name: "Provider") }
+  let(:school) do
+    create(
+      :placements_school,
+      name: "London Secondary School",
+      phase: "Secondary",
+      gender: "Mixed",
+      minimum_age: 4,
+      maximum_age: 11,
+      religious_character: "Jewish",
+      urban_or_rural: "(England/Wales) Urban city and town",
+      admissions_policy: "Not applicable",
+      percentage_free_school_meals: 11,
+      rating: "Good",
+      telephone: "01234567890",
+      website: "www.a-london-example-school.com",
+      email_address: "user@london-example-school.com",
+      address1: "London Secondary School",
+      address2: "London",
+      address3: "City of London",
+      postcode: "LN01 2LN",
+    )
+  end
+  let!(:subject_1) { create(:subject, name: "Biology") }
+  let!(:subject_2) { create(:subject, name: "Chemistry") }
+  let!(:placement) do
+    create(:placement, subjects:, school:, mentors:)
+  end
+
+  before { given_i_sign_in_as_patricia }
+
+  context "when the placement has one subject" do
+    let(:subjects) { [subject_1] }
+    let(:mentors) { [] }
+
+    scenario "User views a placement details" do
+      when_i_visit_the_placement_show_page
+      then_i_see_details_for_the_school
+      and_i_see_the_subject_name("Biology")
+      and_i_see_no_mentor_details
+      and_i_see_contact_details_for_the_school
+    end
+  end
+
+  context "with mentors" do
+    let(:subjects) { [subject_1] }
+    let(:mentor_1) { create(:placements_mentor, first_name: "Joe", last_name: "Bloggs") }
+    let(:mentor_2) { create(:placements_mentor, first_name: "Jane", last_name: "Doe") }
+
+    before do
+      create(
+        :mentor_membership,
+        :placements,
+        mentor: mentor_1,
+        school:,
+      )
+
+      create(
+        :mentor_membership,
+        :placements,
+        mentor: mentor_2,
+        school:,
+      )
+    end
+
+    context "when one mentor is associated with the placement" do
+      let(:mentors) { [mentor_1] }
+
+      scenario "User views a placement and mentor details" do
+        when_i_visit_the_placement_show_page
+        then_i_see_details_for_the_school
+        and_i_see_the_subject_name("Biology")
+        and_i_see_details_for_mentor(mentor_1)
+        and_i_do_not_see_details_for_mentor(mentor_2)
+        and_i_see_contact_details_for_the_school
+      end
+    end
+
+    context "when multiple mentors are associated with the placement" do
+      let(:mentors) { [mentor_1, mentor_2] }
+
+      scenario "User views a placement and multiple mentors details" do
+        when_i_visit_the_placement_show_page
+        then_i_see_details_for_the_school
+        and_i_see_the_subject_name("Biology")
+        and_i_see_details_for_mentor(mentor_1)
+        and_i_see_details_for_mentor(mentor_2)
+        and_i_see_contact_details_for_the_school
+      end
+    end
+  end
+
+  context "with multiple subjects" do
+    let(:subjects) { [subject_1, subject_2] }
+    let(:mentors) { [] }
+
+    scenario "User views a placement and multiple subject details" do
+      when_i_visit_the_placement_show_page
+      then_i_see_details_for_the_school
+      and_i_see_the_subject_name("Biology and Chemistry")
+      and_i_see_no_mentor_details
+      and_i_see_contact_details_for_the_school
+    end
+  end
+
+  private
+
+  def given_i_sign_in_as_patricia
+    user = create(:placements_user, :patricia)
+    create(:user_membership, user:, organisation: provider)
+    user_exists_in_dfe_sign_in(user:)
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def when_i_visit_the_placement_show_page
+    visit placements_provider_placement_path(provider, placement)
+
+    expect_placements_to_be_selected_in_primary_navigation
+  end
+
+  def expect_placements_to_be_selected_in_primary_navigation
+    nav = page.find(".app-primary-navigation__nav")
+
+    within(nav) do
+      expect(page).to have_link "Placements", current: "page"
+      expect(page).to have_link "Partner schools", current: "false"
+      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Organisation details", current: "false"
+    end
+  end
+
+  def then_i_see_details_for_the_school
+    expect(page).to have_content("Placement - London Secondary School")
+    expect(page).to have_content("Secondary")
+    expect(page).to have_content("Mixed")
+    expect(page).to have_content("4 to 11")
+    expect(page).to have_content("Jewish")
+    expect(page).to have_content("(England/Wales) Urban city and town")
+    expect(page).to have_content("Not applicable")
+    expect(page).to have_content("11")
+    expect(page).to have_content("Good")
+  end
+
+  def and_i_see_no_mentor_details
+    expect(page).to have_content("Mentor details")
+    expect(page).to have_content("Not known yet")
+  end
+
+  def and_i_see_contact_details_for_the_school
+    expect(page).to have_content("Contact details")
+    expect(page).to have_content("01234567890")
+    expect(page).to have_content("www.a-london-example-school.com")
+    expect(page).to have_content("user@london-example-school.com")
+    expect(page).to have_content("London Secondary School\nLondon\nCity of London\nLN01 2LN")
+  end
+
+  def and_i_see_details_for_mentor(mentor)
+    expect(page).to have_content(mentor.full_name)
+  end
+
+  def and_i_do_not_see_details_for_mentor(mentor)
+    expect(page).not_to have_content(mentor.full_name)
+  end
+
+  def and_i_see_the_subject_name(subject_name)
+    expect(page.find(".govuk-heading-l")).to have_content(subject_name)
+  end
+end


### PR DESCRIPTION
## Context

- Add show page for Providers to view the details of a placement

## Changes proposed in this pull request

- Added routes/controllers/views/etc. to allow Provider users the ability to view a placement.

## Guidance to review

- Sign in as Provider User Patricia
- Navigate to "Placements"
- Select a placement

## Link to Trello card

https://trello.com/c/IYG33bcm/286-build-placement-details-page-for-providers-from-search-results-page

## Screenshots
![screencapture-placements-localhost-3000-providers-001898be-80c9-486a-ac42-58a947343419-placements-0bb1a480-366b-4442-bef3-fe4e824fc55c-2024-04-26-15_45_08](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/eb4e8dba-56e2-4861-853d-7f352eb70c49)


