### PR TITLE
Ask for DOB when adding a claim mentor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ DFE_SIGN_IN_ISSUER_URL=https://dev-oidc.signin.education.gov.uk
 
 TEACHING_RECORD_BASE_URL=https://preprod.teacher-qualifications-api.education.gov.uk
 TEACHING_RECORD_API_KEY=get-this-from-a-developer
-TEACHING_RECORD_API_MINOR_VERSION=20240101
+TEACHING_RECORD_API_MINOR_VERSION=20240416
 
 BIGQUERY_TABLE_NAME=events
 BIGQUERY_PROJECT_ID=rugged-abacus-218110

--- a/.env.test
+++ b/.env.test
@@ -17,6 +17,6 @@ PLACEMENTS_DFE_SIGN_IN_SECRET=secret
 
 SMOKE_TEST=false
 TEACHING_RECORD_BASE_URL=https://preprod.teacher-qualifications-api.education.gov.uk
-TEACHING_RECORD_API_MINOR_VERSION=20240101
+TEACHING_RECORD_API_MINOR_VERSION=20240416
 TEACHING_RECORD_API_KEY=secret
 GIAS_CSV_BASE_URL=https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public

--- a/app/controllers/claims/schools/mentors_controller.rb
+++ b/app/controllers/claims/schools/mentors_controller.rb
@@ -52,7 +52,7 @@ class Claims::Schools::MentorsController < Claims::ApplicationController
 
   def mentor_params
     params.require(:claims_mentor_form)
-          .permit(:first_name, :last_name, :trn)
+          .permit(:first_name, :last_name, :trn, :date_of_birth)
           .merge(default_params)
   end
 

--- a/app/controllers/claims/support/schools/mentors_controller.rb
+++ b/app/controllers/claims/support/schools/mentors_controller.rb
@@ -51,7 +51,7 @@ class Claims::Support::Schools::MentorsController < Claims::Support::Application
 
   def mentor_params
     params.require(:claims_mentor_form)
-          .permit(:first_name, :last_name, :trn)
+          .permit(:first_name, :last_name, :trn, :date_of_birth)
           .merge(default_params)
   end
 

--- a/app/services/claims/mentor_builder.rb
+++ b/app/services/claims/mentor_builder.rb
@@ -1,0 +1,30 @@
+class Claims::MentorBuilder
+  include ServicePattern
+
+  def initialize(trn:, first_name: nil, last_name: nil, date_of_birth: nil)
+    @trn = trn
+    @first_name = first_name
+    @last_name = last_name
+    @date_of_birth = date_of_birth
+  end
+
+  def call
+    mentor = Mentor.find_or_initialize_by(trn:).becomes(Claims::Mentor)
+    return mentor if mentor.invalid_attributes?(:trn) # Return mentor if basic validation fails
+    return mentor if date_of_birth.nil?
+
+    mentor.assign_attributes(
+      first_name: teacher["firstName"],
+      last_name: teacher["lastName"],
+    )
+    mentor
+  end
+
+  private
+
+  attr_accessor :trn, :first_name, :last_name, :date_of_birth
+
+  def teacher
+    @teacher ||= TeachingRecord::GetTeacher.call(trn:, date_of_birth: date_of_birth.to_s)
+  end
+end

--- a/app/services/teaching_record/get_teacher.rb
+++ b/app/services/teaching_record/get_teacher.rb
@@ -2,14 +2,21 @@ module TeachingRecord
   class GetTeacher
     include ServicePattern
 
-    def initialize(trn:)
+    def initialize(trn:, date_of_birth: nil)
       @trn = trn
+      @date_of_birth = date_of_birth
     end
 
     def call
-      RestClient.get("teachers/#{trn}")
+      RestClient.get("teachers/#{trn}#{query_params}")
     end
 
-    attr_reader :trn
+    attr_reader :trn, :date_of_birth
+
+    private
+
+    def query_params
+      date_of_birth.blank? ? "" : "?#{date_of_birth.to_query("dateOfBirth")}"
+    end
   end
 end

--- a/app/services/teaching_record/rest_client.rb
+++ b/app/services/teaching_record/rest_client.rb
@@ -6,7 +6,7 @@ module TeachingRecord
       headers "Accept" => "application/json",
               "Content-Type" => "application/json;odata.metadata=minimal",
               "Authorization" => "Bearer #{ENV.fetch("TEACHING_RECORD_API_KEY", "")}",
-              "X-Api-Version" => ENV.fetch("TEACHING_RECORD_API_MINOR_VERSION", "20240101")
+              "X-Api-Version" => ENV.fetch("TEACHING_RECORD_API_MINOR_VERSION", "20240416")
     end
 
     class TeacherNotFoundError < StandardError; end

--- a/app/views/claims/schools/mentors/check.html.erb
+++ b/app/views/claims/schools/mentors/check.html.erb
@@ -12,6 +12,7 @@
         <%= f.hidden_field :first_name, value: mentor_form.mentor.first_name %>
         <%= f.hidden_field :last_name, value: mentor_form.mentor.last_name %>
         <%= f.hidden_field :trn, value: mentor_form.trn %>
+        <%= f.govuk_date_field :date_of_birth, hidden: true, date_of_birth: true %>
 
         <label class="govuk-label govuk-label--l">
           <span class="govuk-caption-l"><%= t(".add_mentor") %></span>
@@ -36,8 +37,29 @@
                                  class: "govuk-link--no-visited-state",
                                }) %>
           <% end %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".date_of_birth")) %>
+            <% row.with_value(text: safe_l(mentor_form.date_of_birth, format: :short)) %>
+            <% row.with_action(text: t(".change"),
+                               href: new_claims_school_mentor_path(params: mentor_form.as_form_params),
+                               html_attributes: {
+                                 class: "govuk-link--no-visited-state",
+                               }) %>
+          <% end %>
         <% end %>
-        <%= f.govuk_submit t(".add_mentor") %>
+        <%= govuk_inset_text(
+          text: t(
+            ".disclaimer_html",
+            mentor_name: mentor_form.mentor.full_name,
+            privacy_link: govuk_link_to(
+              t(".privacy_link"),
+              claims_privacy_path,
+              new_tab: true,
+              no_visited_state: true,
+            ),
+          ),
+        ) %>
+        <%= f.govuk_submit t(".save_mentor") %>
         <p class="govuk-body">
           <%= govuk_link_to(t(".cancel"), claims_school_mentors_path(@school), no_visited_state: true) %>
         </p>

--- a/app/views/claims/schools/mentors/new.html.erb
+++ b/app/views/claims/schools/mentors/new.html.erb
@@ -12,17 +12,26 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <div class="govuk-form-group">
-          <%= f.govuk_text_field :trn, width: "two-thirds", label: -> do %>
-            <span class="govuk-caption-l"><%= t(".add_mentor") %></span>
-            <h2 class="govuk-heading-l"><%= t(".enter_a_trn") %></h2>
+          <span class="govuk-caption-l"><%= t(".add_mentor") %></span>
+          <h2 class="govuk-heading-l"><%= t(".find_teacher") %></h2>
+          <%= f.govuk_text_field :trn,
+                                  width: "two-thirds",
+                                  label: { text: t(".trn"), size: "s" },
+                                  hint: { text: t(".trn_hint") } %>
+          <%= govuk_details(summary_text: t(".help_with_the_trn")) do %>
+            <p>
+              <%= t(".guidance_html", guidance_link: govuk_link_to(t(".guidance_link_text"), "https://www.gov.uk/guidance/teacher-reference-number-trn", new_tab: true, no_visited_state: true)) %>
+            </p>
           <% end %>
+
+          <%= f.govuk_date_field(
+            :date_of_birth,
+            maxlength_enabled: true,
+            legend: { text: Mentor.human_attribute_name(:date_of_birth), size: "s" },
+            hint: { text: t(".date_of_birth_hint"), size: "s" },
+          ) %>
         </div>
 
-        <%= govuk_details(summary_text: t(".help_with_the_trn")) do %>
-          <p>
-            <%= t(".guidance_html", guidance_link: govuk_link_to(t(".guidance_link_text"), "https://www.gov.uk/guidance/teacher-reference-number-trn", new_tab: true, no_visited_state: true)) %>
-          </p>
-        <% end %>
         <%= f.govuk_submit t(".continue") %>
         <p class="govuk-body">
           <%= govuk_link_to(t(".cancel"), claims_school_mentors_path(@school), no_visited_state: true) %>

--- a/app/views/claims/support/schools/mentors/check.html.erb
+++ b/app/views/claims/support/schools/mentors/check.html.erb
@@ -12,6 +12,7 @@
         <%= f.hidden_field :first_name, value: mentor_form.mentor.first_name %>
         <%= f.hidden_field :last_name, value: mentor_form.mentor.last_name %>
         <%= f.hidden_field :trn, value: mentor_form.trn %>
+        <%= f.govuk_date_field :date_of_birth, hidden: true, date_of_birth: true %>
 
         <label class="govuk-label govuk-label--l">
           <span class="govuk-caption-l"><%= t(".add_mentor_with_school_name", school_name: @school.name) %></span>
@@ -36,8 +37,17 @@
                                  class: "govuk-link--no-visited-state",
                                }) %>
           <% end %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".date_of_birth")) %>
+            <% row.with_value(text: safe_l(mentor_form.date_of_birth, format: :short)) %>
+            <% row.with_action(text: t(".change"),
+                               href: new_claims_school_mentor_path(params: mentor_form.as_form_params),
+                               html_attributes: {
+                                 class: "govuk-link--no-visited-state",
+                               }) %>
+          <% end %>
         <% end %>
-        <%= f.govuk_submit t(".add_mentor") %>
+        <%= f.govuk_submit t(".save_mentor") %>
         <p class="govuk-body">
           <%= govuk_link_to(t(".cancel"), claims_support_school_mentors_path(@school), no_visited_state: true) %>
         </p>

--- a/app/views/claims/support/schools/mentors/new.html.erb
+++ b/app/views/claims/support/schools/mentors/new.html.erb
@@ -12,17 +12,25 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <div class="govuk-form-group">
-          <%= f.govuk_text_field :trn, width: "two-thirds", label: -> do %>
-            <span class="govuk-caption-l"><%= t(".add_mentor_with_school_name", school_name: @school.name) %></span>
-            <h2 class="govuk-heading-l"><%= t(".enter_a_trn") %></h2>
+          <span class="govuk-caption-l"><%= t(".add_mentor") %></span>
+          <h2 class="govuk-heading-l"><%= t(".find_teacher") %></h2>
+          <%= f.govuk_text_field :trn,
+                                  width: "two-thirds",
+                                  label: { text: t(".trn"), size: "s" },
+                                  hint: { text: t(".trn_hint") } %>
+          <%= govuk_details(summary_text: t(".help_with_the_trn")) do %>
+            <p>
+              <%= t(".guidance_html", guidance_link: govuk_link_to(t(".guidance_link_text"), "https://www.gov.uk/guidance/teacher-reference-number-trn", new_tab: true, no_visited_state: true)) %>
+            </p>
           <% end %>
-        </div>
 
-        <%= govuk_details(summary_text: t(".help_with_the_trn")) do %>
-          <p>
-            <%= t(".guidance_html", guidance_link: govuk_link_to(t(".guidance_link_text"), "https://www.gov.uk/guidance/teacher-reference-number-trn", new_tab: true, no_visited_state: true)) %>
-          </p>
-        <% end %>
+          <%= f.govuk_date_field(
+            :date_of_birth,
+            maxlength_enabled: true,
+            legend: { text: Mentor.human_attribute_name(:date_of_birth), size: "s" },
+            hint: { text: t(".date_of_birth_hint"), size: "s" },
+          ) %>
+        </div>
 
         <%= f.govuk_submit t(".continue") %>
         <p class="govuk-body">

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -29,6 +29,8 @@ en:
           attributes:
             trn:
               taken: The mentor has already been added
+            date_of_birth:
+              blank: Enter a date of birth
         user_invite_form:
           attributes:
             email:

--- a/config/locales/en/claims/schools/mentors.yml
+++ b/config/locales/en/claims/schools/mentors.yml
@@ -15,22 +15,29 @@ en:
             mentors:
               trn: Teacher reference number (TRN)
         new:
+          trn: Teacher reference number (TRN)
+          trn_hint: It’s a 7 digit number. For example, 1234567
           page_title: Enter a teacher reference number (TRN) - Add mentor
           page_title_with_error: "Error: Enter a teacher reference number (TRN) - Add mentor"
           add_mentor: Add mentor
           cancel: Cancel
           continue: Continue
-          enter_a_trn: Enter a teacher reference number (TRN)
-          help_with_the_trn: Help with the teacher reference number (TRN)
-          guidance_html: If you don’t have a TRN, read the %{guidance_link} to find a lost TRN, or apply for one.
-          guidance_link_text: Teacher reference number (TRN) guidance
+          date_of_birth_hint: For example, 31 3 1980
+          find_teacher: Find teacher
+          help_with_the_trn: Check that you typed in the teacher reference number (TRN) and date of birth correctly.
+          guidance_html: If your mentor does not have a TRN, share the %{guidance_link} to find a lost TRN, or apply for one.
+          guidance_link_text: teacher reference number (TRN) guidance
         check:
           page_title: Check your answers - Add mentor
+          save_mentor: Save mentor
           add_mentor: Add mentor
           cancel: Cancel
           change: Change
           check_your_answers: Check your answers
           trn: Teacher reference number (TRN)
+          date_of_birth: Date of birth
+          privacy_link: privacy notice
+          disclaimer_html: I confirm that %{mentor_name} has been informed that the Department for Education will store their information in line with the %{privacy_link} and have provided them with a copy of this notice for reference.
         no_results:
           page_title: No results found for ‘%{trn}’ - Add mentor
           add_mentor: Add mentor

--- a/config/locales/en/claims/support/schools/mentors.yml
+++ b/config/locales/en/claims/support/schools/mentors.yml
@@ -16,16 +16,23 @@ en:
               mentors:
                 trn: Teacher reference number (TRN)
           new:
+            trn: Teacher reference number (TRN)
+            trn_hint: It’s a 7 digit number. For example, 1234567
             page_title: Enter a teacher reference number (TRN) - Add mentor - %{school_name}
             page_title_with_error: "Error: Enter a teacher reference number (TRN) - Add mentor - %{school_name}"
             add_mentor_with_school_name: Add mentor - %{school_name}
             cancel: Cancel
+            date_of_birth_hint: For example, 31 3 1980
+            find_teacher: Find teacher
             continue: Continue
             enter_a_trn: Enter a teacher reference number (TRN)
-            help_with_the_trn: Help with the teacher reference number (TRN)
-            guidance_html: If you don’t have a TRN, read the %{guidance_link} to find a lost TRN, or apply for one.
-            guidance_link_text: Teacher reference number (TRN) guidance
+            help_with_the_trn: Check that you typed in the teacher reference number (TRN) and date of birth correctly.
+            guidance_html: If your mentor does not have a TRN, share the %{guidance_link} to find a lost TRN, or apply for one.
+            guidance_link_text: teacher reference number (TRN) guidance
+            add_mentor: Add mentor
           check:
+            save_mentor: Save mentor
+            date_of_birth: Date of birth
             page_title: Check your answers - Add mentor - %{school_name}
             add_mentor: Add mentor
             add_mentor_with_school_name: Add mentor - %{school_name}

--- a/spec/jobs/teaching_record/sync_mentor_job_spec.rb
+++ b/spec/jobs/teaching_record/sync_mentor_job_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe TeachingRecord::SyncMentorJob, type: :job do
           "Authorization" => "Bearer secret",
           "Content-Type" => "application/json;odata.metadata=minimal",
           "User-Agent" => "Ruby",
-          "X-Api-Version" => "20240101",
+          "X-Api-Version" => "20240416",
         },
       )
       .to_return(
@@ -87,7 +87,7 @@ RSpec.describe TeachingRecord::SyncMentorJob, type: :job do
           "Authorization" => "Bearer secret",
           "Content-Type" => "application/json;odata.metadata=minimal",
           "User-Agent" => "Ruby",
-          "X-Api-Version" => "20240101",
+          "X-Api-Version" => "20240416",
         },
       )
       .to_return(
@@ -106,7 +106,7 @@ RSpec.describe TeachingRecord::SyncMentorJob, type: :job do
           "Authorization" => "Bearer secret",
           "Content-Type" => "application/json;odata.metadata=minimal",
           "User-Agent" => "Ruby",
-          "X-Api-Version" => "20240101",
+          "X-Api-Version" => "20240416",
         },
       )
       .to_return(

--- a/spec/services/claims/mentor_builder_spec.rb
+++ b/spec/services/claims/mentor_builder_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+RSpec.describe Claims::MentorBuilder do
+  it_behaves_like "a service object" do
+    let(:params) { { trn: "1234567" } }
+  end
+
+  context "with invalid trn provided" do
+    let(:trn) { "ab" }
+
+    it "returns mentor object with error on trn" do
+      mentor = described_class.call(trn:)
+      expect(mentor.class).to eq(Claims::Mentor)
+      expect(mentor.errors[:trn]).to include "Enter a valid teacher reference number (TRN)"
+    end
+  end
+
+  context "with empty trn provided" do
+    let(:trn) { nil }
+
+    it "returns mentor object with error on trn" do
+      mentor = described_class.call(trn:)
+      expect(mentor.class).to eq(Claims::Mentor)
+      expect(mentor.errors[:trn]).to include "Enter a teacher reference number (TRN)"
+    end
+  end
+
+  context "with empty date of birth is provided" do
+    let(:trn) { "1234567" }
+    let(:date_of_birth) { nil }
+
+    it "returns mentor object" do
+      mentor = described_class.call(trn:, date_of_birth:)
+      expect(mentor.class).to eq(Claims::Mentor)
+    end
+  end
+
+  context "when mentor with trn already exists" do
+    let(:existing_mentor) { create(:claims_mentor) }
+    let(:trn) { existing_mentor.trn }
+
+    it "returns existing mentor" do
+      mentor = described_class.call(trn:)
+      expect(mentor).to eq existing_mentor
+    end
+  end
+
+  context "when mentor does not exist and valid trn is provided" do
+    let(:trn) { "1234567" }
+    let(:date_of_birth) { Date.new(1986, 11, 12) }
+
+    before "fetches teacher record from teaching record service" do
+      allow(TeachingRecord::GetTeacher).to receive(:call).with(trn:, date_of_birth: date_of_birth.to_s)
+        .once.and_return(teacher_object)
+    end
+
+    it "returns initialized mentor record without errors" do
+      mentor = described_class.call(trn:, date_of_birth:)
+      expect(mentor.trn).to eq trn
+      expect(mentor.first_name).to eq teacher_object["firstName"]
+      expect(mentor.last_name).to eq teacher_object["lastName"]
+      expect(mentor.persisted?).to eq false
+      expect(mentor.errors.none?).to eq true
+    end
+  end
+
+  context "when mentor does exist but dob doesn't match" do
+    let(:existing_mentor) { create(:mentor, trn: "1234567") }
+    let(:trn) { existing_mentor.trn }
+    let(:date_of_birth) { Date.new(1999, 11, 12) }
+
+    before "fetches teacher record from teaching record service" do
+      allow(TeachingRecord::GetTeacher).to receive(:call).with(trn:, date_of_birth: date_of_birth.to_s)
+        .once.and_return(teacher_object)
+    end
+
+    it "returns initialized mentor record without errors" do
+      mentor = described_class.call(trn:, date_of_birth:)
+      expect(mentor.trn).to eq trn
+      expect(mentor.first_name).to eq teacher_object["firstName"]
+      expect(mentor.last_name).to eq teacher_object["lastName"]
+      expect(mentor.persisted?).to eq true
+      expect(mentor.errors.none?).to eq true
+    end
+  end
+
+  def teacher_object
+    { "trn" => "1234554",
+      "firstName" => "Elizabeth",
+      "middleName" => "Elaine",
+      "lastName" => "Milner-Lee",
+      "dateOfBirth" => "1986-11-12" }
+  end
+end

--- a/spec/system/claims/support/schools/mentors/support_user_adds_a_mentor_spec.rb
+++ b/spec/system/claims/support/schools/mentors/support_user_adds_a_mentor_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Claims support user adds mentors to schools", type: :system, ser
     given_i_navigate_to_schools_mentors_list(school)
     and_i_click_on("Add mentor")
     when_i_click_on("Continue")
-    then_i_see_the_error("Enter a teacher reference number (TRN)")
+    then_i_see_errors(["Enter a teacher reference number (TRN)", "Enter a date of birth"])
   end
 
   scenario "I enter an invalid trn" do
@@ -38,7 +38,7 @@ RSpec.describe "Claims support user adds mentors to schools", type: :system, ser
     and_i_click_on("Add mentor")
     when_i_enter_trn("12a")
     and_i_click_on("Continue")
-    then_i_see_the_error("Enter a valid teacher reference number (TRN)")
+    then_i_see_errors(["Enter a valid teacher reference number (TRN)"])
   end
 
   scenario "I enter a trn of mentor who already exists for this school" do
@@ -47,47 +47,86 @@ RSpec.describe "Claims support user adds mentors to schools", type: :system, ser
     and_i_click_on("Add mentor")
     when_i_enter_trn(another_claims_mentor.trn)
     and_i_click_on("Continue")
-    then_i_see_the_error("The mentor has already been added")
+    then_i_see_errors(["The mentor has already been added"])
   end
 
-  scenario "I enter the trn of an existing claims mentor" do
-    given_a_claims_mentor_exists
-    given_i_navigate_to_schools_mentors_list(school)
-    and_i_click_on("Add mentor")
-    when_i_enter_trn(claims_mentor.trn)
-    and_i_click_on("Continue")
-    then_i_see_check_page_for(claims_mentor)
-    when_i_click_on("Back")
-    then_i_see_form_with_trn(claims_mentor.trn)
-    when_i_click_on("Continue")
-    then_i_see_check_page_for(claims_mentor)
-    when_i_click_on("Change")
-    then_i_see_form_with_trn(claims_mentor.trn)
-    when_i_click_on("Continue")
-    then_i_see_check_page_for(claims_mentor)
-    when_i_click_on("Add mentor")
-    then_mentor_is_added(claims_mentor.full_name)
+  describe "Use trn of an existing claim mentor" do
+    before do
+      allow(TeachingRecord::GetTeacher).to receive(:call)
+       .with(trn: claims_mentor.trn, date_of_birth: "1986-11-12")
+       .and_return teaching_record_valid_response(new_mentor, "1986-11-12")
+    end
+
+    scenario "I enter the trn of an existing claims mentor" do
+      given_a_claims_mentor_exists
+      given_i_navigate_to_schools_mentors_list(school)
+      and_i_click_on("Add mentor")
+      when_i_enter_trn(claims_mentor.trn)
+      when_i_enter_date_of_birth(12, 11, 1986)
+      and_i_click_on("Continue")
+      then_i_see_check_page_for(new_mentor)
+      when_i_click_on("Back")
+      then_i_see_form_with_trn(claims_mentor.trn)
+      then_i_see_form_with_dob("12", "11", "1986")
+      when_i_click_on("Continue")
+      then_i_see_check_page_for(new_mentor)
+      when_i_click_on("Change")
+      then_i_see_form_with_trn(claims_mentor.trn)
+      then_i_see_form_with_dob("12", "11", "1986")
+      when_i_click_on("Continue")
+      then_i_see_check_page_for(new_mentor)
+      when_i_click_on("Save mentor")
+      then_mentor_is_added(claims_mentor.full_name)
+    end
   end
 
-  scenario "I enter the trn of an existing claims mentor from another school" do
-    given_a_another_claims_mentor_exists(another_school, another_claims_mentor)
-    given_i_navigate_to_schools_mentors_list(school)
-    and_i_click_on("Add mentor")
-    when_i_enter_trn(another_claims_mentor.trn)
-    and_i_click_on("Continue")
-    then_i_see_check_page_for(another_claims_mentor)
-    when_i_click_on("Back")
-    then_i_see_form_with_trn(another_claims_mentor.trn)
-    when_i_click_on("Continue")
-    then_i_see_check_page_for(another_claims_mentor)
-    when_i_click_on("Add mentor")
-    then_mentor_is_added(another_claims_mentor.full_name)
+  describe "Use trn of an existing claim mentor with wrong date of birth" do
+    before do
+      allow(TeachingRecord::GetTeacher).to receive(:call)
+       .with(trn: claims_mentor.trn, date_of_birth: "1999-11-12")
+       .and_raise TeachingRecord::RestClient::TeacherNotFoundError
+    end
+
+    scenario "I enter the trn of an existing claims mentor" do
+      given_a_claims_mentor_exists
+      given_i_navigate_to_schools_mentors_list(school)
+      and_i_click_on("Add mentor")
+      when_i_enter_trn(claims_mentor.trn)
+      when_i_enter_date_of_birth(12, 11, 1999)
+      and_i_click_on("Continue")
+      then_i_see_no_results_page(school.name, claims_mentor.trn)
+    end
+  end
+
+  describe "Use trn of an existing placements mentor from another school" do
+    before do
+      allow(TeachingRecord::GetTeacher).to receive(:call)
+       .with(trn: another_claims_mentor.trn, date_of_birth: "1987-09-14")
+       .and_return teaching_record_valid_response(another_claims_mentor, "1987-9-14")
+    end
+
+    scenario "I enter the trn of an existing claims mentor from another school" do
+      given_a_another_claims_mentor_exists(another_school, another_claims_mentor)
+      given_i_navigate_to_schools_mentors_list(school)
+      and_i_click_on("Add mentor")
+      when_i_enter_trn(another_claims_mentor.trn)
+      when_i_enter_date_of_birth(14, 9, 1987)
+      and_i_click_on("Continue")
+      then_i_see_check_page_for(another_claims_mentor)
+      when_i_click_on("Back")
+      then_i_see_form_with_trn(another_claims_mentor.trn)
+      then_i_see_form_with_dob("14", "9", "1987")
+      when_i_click_on("Continue")
+      then_i_see_check_page_for(another_claims_mentor)
+      when_i_click_on("Save mentor")
+      then_mentor_is_added(another_claims_mentor.full_name)
+    end
   end
 
   describe "when trn is valid-looking, but does not exists in Teaching Record Service" do
     before do
       allow(TeachingRecord::GetTeacher).to receive(:call)
-                                             .with(trn: new_mentor.trn)
+                                             .with(trn: new_mentor.trn, date_of_birth: "1986-11-12")
                                              .and_raise TeachingRecord::RestClient::TeacherNotFoundError
     end
 
@@ -95,28 +134,51 @@ RSpec.describe "Claims support user adds mentors to schools", type: :system, ser
       given_i_navigate_to_schools_mentors_list(school)
       and_i_click_on("Add mentor")
       when_i_enter_trn(new_mentor.trn)
+      when_i_enter_date_of_birth(12, 11, 1986)
       and_i_click_on("Continue")
       then_i_see_no_results_page(school.name, new_mentor.trn)
       when_i_click_on "Change your search"
       then_i_see_form_with_trn(new_mentor.trn)
+      then_i_see_form_with_dob("12", "11", "1986")
     end
   end
 
   describe "when trn is valid-looking and mentor is found on Teaching Record Service" do
     before do
       allow(TeachingRecord::GetTeacher).to receive(:call)
-                                             .with(trn: new_mentor.trn)
-                                             .and_return teaching_record_valid_response(new_mentor)
+                                             .with(trn: new_mentor.trn, date_of_birth: "1986-11-12")
+                                             .and_return teaching_record_valid_response(new_mentor, "1986-11-12")
     end
 
     scenario "I enter a valid-looking trn that does exist on the Teaching Record Service" do
       given_i_navigate_to_schools_mentors_list(school)
       and_i_click_on("Add mentor")
       when_i_enter_trn(new_mentor.trn)
+      when_i_enter_date_of_birth(12, 11, 1986)
       and_i_click_on("Continue")
       then_i_see_check_page_for(new_mentor)
-      when_i_click_on("Add mentor")
+      when_i_click_on("Save mentor")
       then_mentor_is_added(new_mentor.full_name)
+    end
+  end
+
+  describe "when trn is valid-looking and mentor is found on Teaching Record Service but dob is wrong" do
+    before do
+      allow(TeachingRecord::GetTeacher).to receive(:call)
+                                             .with(trn: new_mentor.trn, date_of_birth: "1999-11-12")
+                                             .and_raise TeachingRecord::RestClient::TeacherNotFoundError
+    end
+
+    scenario "I enter a valid-looking trn that does exist on the Teaching Record Service with wrong dob" do
+      given_i_navigate_to_schools_mentors_list(school)
+      and_i_click_on("Add mentor")
+      when_i_enter_trn(new_mentor.trn)
+      when_i_enter_date_of_birth(12, 11, 1999)
+      and_i_click_on("Continue")
+      then_i_see_no_results_page(school.name, new_mentor.trn)
+      when_i_click_on "Change your search"
+      then_i_see_form_with_trn(new_mentor.trn)
+      then_i_see_form_with_dob("12", "11", "1999")
     end
   end
 
@@ -143,11 +205,14 @@ RSpec.describe "Claims support user adds mentors to schools", type: :system, ser
   end
 
   def when_i_click_on(text)
-    click_on text
+    click_on(text, match: :first)
   end
 
   def when_i_click_on_help_text
-    find("span", text: "Help with the teacher reference number (TRN)").click
+    find(
+      "span",
+      text: "Check that you typed in the teacher reference number (TRN) and date of birth correctly.",
+    ).click
   end
 
   def then_i_see_check_page_for(mentor)
@@ -179,23 +244,39 @@ RSpec.describe "Claims support user adds mentors to schools", type: :system, ser
     fill_in "claims-mentor-form-trn-field", with: trn
   end
 
+  def when_i_enter_date_of_birth(day, month, year)
+    within_fieldset("Date of birth") do
+      fill_in("Day", with: day)
+      fill_in("Month", with: month)
+      fill_in("Year", with: year)
+    end
+  end
+
   def then_i_see_the_index_page(school)
     expect(page).to have_current_path claims_support_school_mentors_path(school), ignore_query: true
   end
 
-  def then_i_see_the_error(message)
+  def then_i_see_errors(errors)
     expect(page).to have_title "Error: Enter a teacher reference number (TRN)"
     within(".govuk-error-summary") do
-      expect(page).to have_content message
+      expect(page).to have_content errors.join("")
     end
 
-    within(".govuk-form-group--error") do
-      expect(page).to have_content message
+    errors.each_with_index do |error, index|
+      within("div.govuk-form-group--error:nth(#{index + 1})") do
+        expect(page).to have_content error
+      end
     end
   end
 
   def then_i_see_form_with_trn(trn)
     expect(page.find("#claims-mentor-form-trn-field").value).to eq(trn)
+  end
+
+  def then_i_see_form_with_dob(day, month, year)
+    expect(page.find("#claims_mentor_form_date_of_birth_1i").value).to eq(year)
+    expect(page.find("#claims_mentor_form_date_of_birth_2i").value).to eq(month)
+    expect(page.find("#claims_mentor_form_date_of_birth_3i").value).to eq(day)
   end
 
   def then_i_see_no_results_page(_school_name, trn)
@@ -204,18 +285,19 @@ RSpec.describe "Claims support user adds mentors to schools", type: :system, ser
     expect(page).to have_content "No results found for ‘#{trn}’"
   end
 
-  def teaching_record_valid_response(mentor)
+  def teaching_record_valid_response(mentor, date_of_birth)
     {
       "trn" => mentor.trn.to_s,
       "firstName" => mentor.first_name.to_s,
       "middleName" => "",
       "lastName" => mentor.last_name.to_s,
+      "dateOfBirth" => date_of_birth,
     }
   end
 
   def then_i_see_link_to_trn_guidance
-    expect(page).to have_content "If you don’t have a TRN, read the Teacher reference number (TRN) guidance (opens in new tab) to find a lost TRN, or apply for one."
-    expect(page).to have_link("Teacher reference number (TRN) guidance (opens in new tab)", href: "https://www.gov.uk/guidance/teacher-reference-number-trn")
+    expect(page).to have_content "If your mentor does not have a TRN, share the teacher reference number (TRN) guidance (opens in new tab) to find a lost TRN, or apply for one."
+    expect(page).to have_link("teacher reference number (TRN) guidance (opens in new tab)", href: "https://www.gov.uk/guidance/teacher-reference-number-trn")
   end
 
   alias_method :and_i_click_on, :when_i_click_on

--- a/terraform/application/config/dv_review_app_env.yml
+++ b/terraform/application/config/dv_review_app_env.yml
@@ -4,4 +4,4 @@ GIAS_CSV_BASE_URL: https://ea-edubase-api-prod.azurewebsites.net/edubase/downloa
 PUBLISH_BASE_URL: https://qa.api.publish-teacher-training-courses.service.gov.uk
 HOSTING_ENV: review
 TEACHING_RECORD_BASE_URL: https://preprod.teacher-qualifications-api.education.gov.uk
-TEACHING_RECORD_API_MINOR_VERSION: 20240101
+TEACHING_RECORD_API_MINOR_VERSION: 20240416

--- a/terraform/application/config/production_app_env.yml
+++ b/terraform/application/config/production_app_env.yml
@@ -4,7 +4,7 @@ GIAS_CSV_BASE_URL: https://ea-edubase-api-prod.azurewebsites.net/edubase/downloa
 PUBLISH_BASE_URL: https://api.publish-teacher-training-courses.service.gov.uk/
 HOSTING_ENV: production
 TEACHING_RECORD_BASE_URL: https://teacher-qualifications-api.education.gov.uk/
-TEACHING_RECORD_API_MINOR_VERSION: 20240101
+TEACHING_RECORD_API_MINOR_VERSION: 20240416
 CLAIMS_DFE_SIGN_IN_CLIENT_ID: ittMentorTrackPay
 DFE_SIGN_IN_ISSUER_URL: https://oidc.signin.education.gov.uk
 PLACEMENTS_DFE_SIGN_IN_CLIENT_ID: ittMentorSchoolPlacement

--- a/terraform/application/config/qa_app_env.yml
+++ b/terraform/application/config/qa_app_env.yml
@@ -4,7 +4,7 @@ GIAS_CSV_BASE_URL: https://ea-edubase-api-prod.azurewebsites.net/edubase/downloa
 PUBLISH_BASE_URL: https://qa.api.publish-teacher-training-courses.service.gov.uk
 HOSTING_ENV: qa
 TEACHING_RECORD_BASE_URL: https://preprod.teacher-qualifications-api.education.gov.uk
-TEACHING_RECORD_API_MINOR_VERSION: 20240101
+TEACHING_RECORD_API_MINOR_VERSION: 20240416
 CLAIMS_HOSTS: qa.claim-funding-for-mentor-training.education.gov.uk,track-and-pay-qa.test.teacherservices.cloud
 CLAIMS_HOST: qa.claim-funding-for-mentor-training.education.gov.uk
 SKYLIGHT_ENV: qa

--- a/terraform/application/config/review_app_env.yml
+++ b/terraform/application/config/review_app_env.yml
@@ -4,4 +4,4 @@ GIAS_CSV_BASE_URL: https://ea-edubase-api-prod.azurewebsites.net/edubase/downloa
 PUBLISH_BASE_URL: https://qa.api.publish-teacher-training-courses.service.gov.uk
 HOSTING_ENV: review
 TEACHING_RECORD_BASE_URL: https://preprod.teacher-qualifications-api.education.gov.uk
-TEACHING_RECORD_API_MINOR_VERSION: 20240101
+TEACHING_RECORD_API_MINOR_VERSION: 20240416

--- a/terraform/application/config/sandbox_app_env.yml
+++ b/terraform/application/config/sandbox_app_env.yml
@@ -5,7 +5,7 @@ GIAS_CSV_BASE_URL: https://ea-edubase-api-prod.azurewebsites.net/edubase/downloa
 PUBLISH_BASE_URL: https://api.publish-teacher-training-courses.service.gov.uk
 HOSTING_ENV: sandbox
 TEACHING_RECORD_BASE_URL: https://preprod.teacher-qualifications-api.education.gov.uk
-TEACHING_RECORD_API_MINOR_VERSION: 20240101
+TEACHING_RECORD_API_MINOR_VERSION: 20240416
 CLAIMS_HOSTS: sandbox.claim-funding-for-mentor-training.education.gov.uk,track-and-pay-sandbox.teacherservices.cloud
 CLAIMS_HOST: sandbox.claim-funding-for-mentor-training.education.gov.uk
 BIGQUERY_TABLE_NAME: events

--- a/terraform/application/config/staging_app_env.yml
+++ b/terraform/application/config/staging_app_env.yml
@@ -4,7 +4,7 @@ GIAS_CSV_BASE_URL: https://ea-edubase-api-prod.azurewebsites.net/edubase/downloa
 PUBLISH_BASE_URL: https://staging.api.publish-teacher-training-courses.service.gov.uk
 HOSTING_ENV: staging
 TEACHING_RECORD_BASE_URL: https://preprod.teacher-qualifications-api.education.gov.uk
-TEACHING_RECORD_API_MINOR_VERSION: 20240101
+TEACHING_RECORD_API_MINOR_VERSION: 20240416
 CLAIMS_DFE_SIGN_IN_CLIENT_ID: ittMentorTrackPay
 DFE_SIGN_IN_ISSUER_URL: https://test-oidc.signin.education.gov.uk
 PLACEMENTS_DFE_SIGN_IN_CLIENT_ID: ittMentorSchoolPlacement


### PR DESCRIPTION
## Context

We want the user to input a date of birth when adding a mentor.
Otherwise its easy to guess your way to a trn and revealing personal
information about teachers.

The teacher record api can do this validation for us we just need to
update the version that we use and pass the DOB to the teacher record
api.

## Changes proposed in this pull request

New Claims Mentor builder
New DOB field
New env variable and edits to specs

## Guidance to review

Add a mentor as a normal and support user
Try to add mentors you already added.

Dob with trn examples
```
# 1986-11-12 1234568
# 1987-09-14 1234566
```

`TEACHING_RECORD_API_MINOR_VERSION` needs to be at least `20240416`

## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/e209ae63-95ff-4ab9-b9d6-b998cee9c5cc


