### PR TITLE
Update footer email SLA & footer item wording

### DIFF
--- a/config/locales/en/layouts/footer.yml
+++ b/config/locales/en/layouts/footer.yml
@@ -11,5 +11,5 @@ en:
       guidance: Guidance
       accessibility: Accessibility
       cookies: Cookies
-      privacy_policy: Policy notice
+      privacy_policy: Privacy notice
       terms_and_conditions: Terms and conditions

--- a/config/locales/en/layouts/footer.yml
+++ b/config/locales/en/layouts/footer.yml
@@ -5,7 +5,7 @@ en:
 
       email:
         heading: Email
-        disclaimer_html: You'll get a response within 5 working days, <b>or one working day for urgent requests.</b>
+        disclaimer_html: You’ll get a response within 5 working days.
 
       grant_conditions: Grant conditions
       guidance: Guidance

--- a/spec/helpers/footer_helper_spec.rb
+++ b/spec/helpers/footer_helper_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe FooterHelper do
             { href: "/grant_conditions", text: "Grant conditions" },
             { href: "/accessibility", text: "Accessibility" },
             { href: "/cookies", text: "Cookies" },
-            { href: "/privacy", text: "Policy notice" },
+            { href: "/privacy", text: "Privacy notice" },
             { href: "/terms", text: "Terms and conditions" },
           ],
         )
@@ -27,7 +27,7 @@ RSpec.describe FooterHelper do
             { href: "#", text: "Guidance" },
             { href: "#", text: "Accessibility" },
             { href: "#", text: "Cookies" },
-            { href: "#", text: "Policy notice" },
+            { href: "#", text: "Privacy notice" },
             { href: "#", text: "Terms and conditions" },
           ],
         )


### PR DESCRIPTION
## Context

- We won't commit to 1-day responses.
- The privacy policy is a privacy notice.

## Changes proposed in this pull request

- Remove "one day" clause from footer email SLA.
- Update footer item from "Privacy policy" to "Privacy notice".

## Guidance to review

- Review screenshot.

## Screenshots

![CleanShot 2024-04-29 at 10 53 08](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/e0809e5b-2828-4080-82e6-4d75c234a21b)

