### PR TITLE
Require user declaration when submitting draft claims

### DIFF
--- a/app/views/claims/schools/claims/check.html.erb
+++ b/app/views/claims/schools/claims/check.html.erb
@@ -9,7 +9,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <label class="govuk-label govuk-label--l">
-        <span class="govuk-caption-l"><%= t(".add_claim") %></span>
+        <span class="govuk-caption-l"><%= @claim.draft? ? t(".caption_draft", reference: @claim.reference) : t(".caption") %></span>
         <%= t(".page_title") %>
       </label>
 

--- a/app/views/claims/schools/claims/check.html.erb
+++ b/app/views/claims/schools/claims/check.html.erb
@@ -92,6 +92,7 @@
 
       <ul class="govuk-list govuk-list--bullet">
         <li><%= t(".claim_on_behalf_of_school") %></li>
+        <li><%= t(".read_and_accepted_grant_conditions") %></li>
         <li><%= t(".accurate_information") %></li>
         <li><%= t(".provide_evidence") %></li>
       </ul>

--- a/app/views/claims/schools/claims/show.html.erb
+++ b/app/views/claims/schools/claims/show.html.erb
@@ -17,7 +17,7 @@
       </h1>
 
       <% if policy(@claim).submit? %>
-        <%= govuk_button_to t(".submit"), submit_claims_school_claim_path(@school, @claim) %>
+        <%= govuk_button_to t(".submit"), check_claims_school_claim_path(@school, @claim), method: :get %>
       <% else %>
         <p class="govuk-body"><%= t(".submitted_by", name: @claim.submitted_by.full_name, date: l(@claim.submitted_on, format: :long)) %></p>
       <% end %>

--- a/config/locales/en/claims/schools/claims.yml
+++ b/config/locales/en/claims/schools/claims.yml
@@ -17,9 +17,10 @@ en:
           guidance: We will check your claim before processing payment. If we need to contact you for further information, we will use the email you used to access this service.
         check:
           page_title: Check your answers
+          caption: Add claim
+          caption_draft: Claim - %{reference}
           warning: You will not be able to change any of the claim details once you have submitted it.
           submit: Submit claim
-          add_claim: Add claim
           declaration: Declaration
           disclaimer: "By submitting this claim, I confirm that:"
           claim_on_behalf_of_school: I am authorised to claim on behalf of the school

--- a/config/locales/en/claims/schools/claims.yml
+++ b/config/locales/en/claims/schools/claims.yml
@@ -23,7 +23,8 @@ en:
           declaration: Declaration
           disclaimer: "By submitting this claim, I confirm that:"
           claim_on_behalf_of_school: I am authorised to claim on behalf of the school
-          accurate_information: The information detailed above is accurate and the total I am claiming back has been used to support the cost of the mentor training
+          read_and_accepted_grant_conditions: I have read and accepted the grant terms and conditions
+          accurate_information: the information detailed above is accurate and the total I am claiming back has been used to support the cost of the mentor training
           provide_evidence: I will provide evidence to support this claim if requested by the Department for Education
           total_hours: Total hours
           hourly_rate: Hourly rate

--- a/spec/system/claims/schools/claims/submit_draft_claim_spec.rb
+++ b/spec/system/claims/schools/claims/submit_draft_claim_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "View a claim", type: :system, service: :claims do
+RSpec.describe "Submit a draft claim", type: :system, service: :claims do
   let(:school) { create(:claims_school, name: "A School", region: regions(:inner_london)) }
 
   let(:anne) do
@@ -14,18 +14,6 @@ RSpec.describe "View a claim", type: :system, service: :claims do
   let!(:provider) { create(:claims_provider, :best_practice_network) }
   let!(:mentor) { create(:claims_mentor, first_name: "Barry", last_name: "Garlow") }
 
-  let!(:submitted_claim) do
-    create(
-      :claim,
-      :submitted,
-      school:,
-      reference: "12345678",
-      submitted_at: Time.new(2024, 3, 5, 12, 31, 52, "+00:00"),
-      provider:,
-      submitted_by: anne,
-    )
-  end
-
   let!(:draft_claim) do
     create(
       :claim,
@@ -36,43 +24,23 @@ RSpec.describe "View a claim", type: :system, service: :claims do
     )
   end
 
-  let!(:mentor_training) { create(:mentor_training, claim: submitted_claim, mentor:, hours_completed: 6) }
   let!(:draft_mentor_training) { create(:mentor_training, claim: draft_claim, mentor:, hours_completed: 6) }
-
-  scenario "Anne visits the show page of a submitted claim" do
-    user_exists_in_dfe_sign_in(user: anne)
-    given_i_sign_in
-    when_i_visit_the_claim_show_page(submitted_claim)
-    then_i_can_then_see_the_submitted_claim_details
-    then_i_cant_see_submit_button
-  end
 
   scenario "Anne visits the show page of a draft claim" do
     user_exists_in_dfe_sign_in(user: anne)
     given_i_sign_in
     when_i_visit_the_claim_show_page(draft_claim)
     then_i_can_then_see_the_draft_claim_details
-    then_i_can_see_submit_button
+    when_i_click_submit_button
+    then_i_see_a_check_page_with_a_declaration
+    when_i_click_submit_button
+    then_i_get_a_claim_reference(draft_claim)
   end
 
   private
 
   def when_i_visit_the_claim_show_page(claim)
     click_on claim.reference
-  end
-
-  def then_i_can_then_see_the_submitted_claim_details
-    expect(page).to have_content("Claim - #{submitted_claim.reference}")
-    expect(page).to have_content("SchoolA School")
-    expect(page).to have_content("Submitted")
-    expect(page).to have_content("Submitted by #{anne.full_name} on 5 March 2024.")
-    expect(page).to have_content("Accredited providerBest Practice Network")
-    expect(page).to have_content("Mentors\nBarry Garlow")
-    expect(page).to have_content("Hours of training")
-    expect(page).to have_content("Barry Garlow#{mentor_training.hours_completed} hours")
-    expect(page).to have_content("Total hours6 hours")
-    expect(page).to have_content("Hourly rate£53.60")
-    expect(page).to have_content("Claim amount£321.60")
   end
 
   def then_i_can_then_see_the_draft_claim_details
@@ -94,11 +62,24 @@ RSpec.describe "View a claim", type: :system, service: :claims do
     click_on "Sign in using DfE Sign In"
   end
 
-  def then_i_cant_see_submit_button
-    expect(page).not_to have_button("Submit claim")
+  def when_i_click_submit_button
+    click_on "Submit claim"
   end
 
-  def then_i_can_see_submit_button
-    expect(page).to have_button("Submit claim")
+  def then_i_see_a_check_page_with_a_declaration
+    expect(page).to have_content("Check your answers")
+    expect(page).to have_content("Declaration")
+    expect(page).to have_content("By submitting this claim, I confirm that:")
+    expect(page).to have_content("I am authorised to claim on behalf of the school")
+    expect(page).to have_content("I have read and accepted the grant terms and conditions")
+    expect(page).to have_content("the information detailed above is accurate and the total I am claiming back has been used to support the cost of the mentor training")
+    expect(page).to have_content("I will provide evidence to support this claim if requested by the Department for Education")
+    expect(page).to have_content("You will not be able to change any of the claim details once you have submitted it.")
+  end
+
+  def then_i_get_a_claim_reference(claim)
+    within(".govuk-panel") do
+      expect(page).to have_content("Claim submitted\nYour reference number\n#{claim.reference}")
+    end
   end
 end

--- a/spec/system/claims/schools/claims/submit_draft_claim_spec.rb
+++ b/spec/system/claims/schools/claims/submit_draft_claim_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe "Submit a draft claim", type: :system, service: :claims do
   end
 
   def then_i_see_a_check_page_with_a_declaration
+    expect(page).to have_content("Claim - #{draft_claim.reference}")
     expect(page).to have_content("Check your answers")
     expect(page).to have_content("Declaration")
     expect(page).to have_content("By submitting this claim, I confirm that:")


### PR DESCRIPTION
## Context

When a User submits a claim, they must always be presented with the declaration first.

## Changes proposed in this pull request

- Add "grant conditions" prerequisite to claim declaration.
- When a User submits a "draft" claim, they will be taken to the check page with the declaration.

## Guidance to review

- Create a "draft" claim as a Support User.
- Submit that "draft" claim as the end User.
- You should see the declaration.

## Screenshots

![CleanShot 2024-04-29 at 12 17 55](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/e6de0b11-6653-490c-b2a5-ef807dd86e89)

