### PR TITLE
Add disclaimer that claim will be shared with their provider

### DIFF
--- a/app/views/claims/schools/claims/confirmation.html.erb
+++ b/app/views/claims/schools/claims/confirmation.html.erb
@@ -12,6 +12,7 @@
       <p class="govuk-body"><%= t(".sent_email") %></p>
 
       <h2 class="govuk-heading-m"><%= t(".what_happens_next") %></h2>
+      <p class="govuk-body"><%= t(".shared_with_provider", provider_name: @claim.provider_name) %></p>
       <p class="govuk-body"><%= t(".guidance") %></p>
 
       <h3 class="govuk-heading-s"><%= t(".processing_your_claim") %></h3>

--- a/config/locales/en/claims/schools/claims.yml
+++ b/config/locales/en/claims/schools/claims.yml
@@ -14,6 +14,7 @@ en:
           what_happens_next: What happens next
           view_claims: View claims
           sent_email: We have emailed you a copy of your claim.
+          shared_with_provider: This claim will be shared with %{provider_name}.
           guidance: We will check your claim before processing payment. If we need to contact you for further information, we will use the email you used to access this service.
         check:
           page_title: Check your answers

--- a/spec/system/claims/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/schools/claims/create_claim_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     when_i_click("Continue")
     then_i_check_my_answers
     when_i_click("Submit claim")
-    then_i_get_a_claim_reference(Claims::Claim.submitted.first)
+    then_i_get_a_claim_reference_and_see_next_steps(Claims::Claim.submitted.first)
   end
 
   scenario "Anne does not fill the form correctly" do
@@ -75,7 +75,7 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     when_i_add_training_hours("20 hours")
     when_i_click("Continue")
     when_i_click("Submit claim")
-    then_i_get_a_claim_reference(Claims::Claim.submitted.last)
+    then_i_get_a_claim_reference_and_see_next_steps(Claims::Claim.submitted.last)
     given_i_visit_claim_check_page_after_submitting(Claims::Claim.submitted.last)
     then_i_am_redirected_to_root_path_with_alert
   end
@@ -167,10 +167,15 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     end
   end
 
-  def then_i_get_a_claim_reference(claim)
+  def then_i_get_a_claim_reference_and_see_next_steps(claim)
     within(".govuk-panel") do
       expect(page).to have_content("Claim submitted\nYour reference number\n#{claim.reference}")
     end
+
+    expect(page).to have_content("We have emailed you a copy of your claim.")
+    expect(page).to have_content("This claim will be shared with #{claim.provider_name}.")
+    expect(page).to have_content("We will check your claim before processing payment. If we need to contact you for further information, we will use the email you used to access this service.")
+    expect(page).to have_content("We will process this claim at the end of July 2024 and all payments will be paid from September 2024.")
   end
 
   def then_i_expect_the_training_hours_for(hours, mentor)


### PR DESCRIPTION
## Context

We need to show the user that their claim will be shared with their provider.

## Changes proposed in this pull request

- Add disclaimer to confirmation page.

## Guidance to review

- See screenshot.
- or try submitting a claim.

## Screenshots

![CleanShot 2024-04-29 at 13 00 58](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/32be6a81-825c-437e-9576-d7293335e6ab)
