### PR TITLE
Add Provider to Placement

### DIFF
--- a/app/components/autocomplete_select_form_component.html.erb
+++ b/app/components/autocomplete_select_form_component.html.erb
@@ -2,7 +2,7 @@
   model:,
   scope:,
   url:,
-  method: "get",
+  method:,
   data: {
     turbo: data[:turbo],
     controller: data[:controller],

--- a/app/components/autocomplete_select_form_component.rb
+++ b/app/components/autocomplete_select_form_component.rb
@@ -1,17 +1,18 @@
 class AutocompleteSelectFormComponent < ApplicationComponent
-  attr_reader :model, :scope, :url, :data, :input
+  attr_reader :model, :scope, :url, :method, :data, :input
 
   # data: { :turbo, :controller, :autocomplete_path_value,
   #         :autocomplete_return_attributes_value, :input_name }
   # input: { :field_name, :value, :label, :caption, :previous_search }
 
-  def initialize(model:, scope:, url:, data: {},
+  def initialize(model:, scope:, url:, method: :get, data: {},
                  input: {}, classes: [], html_attributes: {})
     super(classes:, html_attributes:)
 
     @model = model
     @scope = scope
     @url = url
+    @method = method
     @data = data
     @input = input
 

--- a/app/controllers/placements/schools/placements_controller.rb
+++ b/app/controllers/placements/schools/placements_controller.rb
@@ -1,6 +1,6 @@
 class Placements::Schools::PlacementsController < ApplicationController
   before_action :set_school
-  before_action :set_placement, only: %i[show remove destroy]
+  before_action :set_placement, only: %i[show edit_provider update remove destroy]
   before_action :set_decorated_placement, only: %i[show remove]
 
   def index
@@ -11,6 +11,20 @@ class Placements::Schools::PlacementsController < ApplicationController
   def show; end
 
   def remove; end
+
+  def edit_provider
+    @providers = Provider.all
+  end
+
+  def update
+    @placement.provider = Provider.find(provider_params[:provider_id]) if provider_params[:provider_id].present?
+
+    if @placement.save!
+      redirect_to placements_school_placement_path(@school, @placement), flash: { success: t(".success") }
+    else
+      render :edit_provider
+    end
+  end
 
   def destroy
     @placement.destroy!
@@ -29,5 +43,9 @@ class Placements::Schools::PlacementsController < ApplicationController
 
   def set_decorated_placement
     @placement = @placement.decorate
+  end
+
+  def provider_params
+    params.require(:provider).permit(:provider_id)
   end
 end

--- a/app/controllers/placements/schools/placements_controller.rb
+++ b/app/controllers/placements/schools/placements_controller.rb
@@ -18,12 +18,9 @@ class Placements::Schools::PlacementsController < ApplicationController
 
   def update
     @placement.provider = provider_params[:provider_name].present? ? Provider.find(provider_params[:provider_id]) : nil
+    @placement.save!
 
-    if @placement.save!
-      redirect_to placements_school_placement_path(@school, @placement), flash: { success: t(".success") }
-    else
-      render :edit_provider
-    end
+    redirect_to placements_school_placement_path(@school, @placement), flash: { success: t(".success") }
   end
 
   def destroy

--- a/app/controllers/placements/schools/placements_controller.rb
+++ b/app/controllers/placements/schools/placements_controller.rb
@@ -17,7 +17,7 @@ class Placements::Schools::PlacementsController < ApplicationController
   end
 
   def update
-    @placement.provider = Provider.find(provider_params[:provider_id]) if provider_params[:provider_id].present?
+    @placement.provider = provider_params[:provider_name].present? ? Provider.find(provider_params[:provider_id]) : nil
 
     if @placement.save!
       redirect_to placements_school_placement_path(@school, @placement), flash: { success: t(".success") }
@@ -46,6 +46,6 @@ class Placements::Schools::PlacementsController < ApplicationController
   end
 
   def provider_params
-    params.require(:provider).permit(:provider_id)
+    params.require(:provider).permit(:provider_id, :provider_name)
   end
 end

--- a/app/decorators/placement_decorator.rb
+++ b/app/decorators/placement_decorator.rb
@@ -21,4 +21,8 @@ class PlacementDecorator < Draper::Decorator
   def school_level
     subjects.pick(:subject_area).titleize
   end
+
+  def provider_name
+    provider&.name || I18n.t("placements.schools.placements.not_known_yet")
+  end
 end

--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -27,12 +27,14 @@ class Placement < ApplicationRecord
   has_many :subjects, through: :placement_subject_joins
 
   belongs_to :school, class_name: "Placements::School"
-  belongs_to :provider, optional: true
+  belongs_to :provider, optional: true, class_name: "::Provider"
 
   accepts_nested_attributes_for :mentors, allow_destroy: true
   accepts_nested_attributes_for :subjects, allow_destroy: true
 
   validates :school, :status, presence: true
+
+  delegate :name, to: :provider, prefix: true, allow_nil: true
 
   scope :order_by_subject_school_name, -> { includes(:subjects, :school).order("subjects.name", "schools.name") }
 end

--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -2,18 +2,21 @@
 #
 # Table name: placements
 #
-#  id         :uuid             not null, primary key
-#  status     :enum             default("draft")
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  school_id  :uuid
+#  id          :uuid             not null, primary key
+#    status      :enum             default("draft")
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  provider_id :uuid
+#  school_id   :uuid
 #
 # Indexes
 #
-#  index_placements_on_school_id  (school_id)
+#  index_placements_on_provider_id  (provider_id)
+#  index_placements_on_school_id    (school_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (provider_id => providers.id)
 #  fk_rails_...  (school_id => schools.id)
 #
 class Placement < ApplicationRecord
@@ -24,6 +27,7 @@ class Placement < ApplicationRecord
   has_many :subjects, through: :placement_subject_joins
 
   belongs_to :school, class_name: "Placements::School"
+  belongs_to :provider, optional: true
 
   accepts_nested_attributes_for :mentors, allow_destroy: true
   accepts_nested_attributes_for :subjects, allow_destroy: true

--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -3,7 +3,7 @@
 # Table name: placements
 #
 #  id          :uuid             not null, primary key
-#    status      :enum             default("draft")
+#  status      :enum             default("draft")
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  provider_id :uuid

--- a/app/models/placements/provider.rb
+++ b/app/models/placements/provider.rb
@@ -36,4 +36,5 @@ class Placements::Provider < Provider
   has_many :partner_schools,
            through: :partnerships,
            source: :school
+  has_many :placements
 end

--- a/app/models/placements/schools/placements/build/placement.rb
+++ b/app/models/placements/schools/placements/build/placement.rb
@@ -2,18 +2,21 @@
 #
 # Table name: placements
 #
-#  id         :uuid             not null, primary key
-#  status     :enum             default("draft")
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  school_id  :uuid
+#  id          :uuid             not null, primary key
+#    status      :enum             default("draft")
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  provider_id :uuid
+#  school_id   :uuid
 #
 # Indexes
 #
-#  index_placements_on_school_id  (school_id)
+#  index_placements_on_provider_id  (provider_id)
+#  index_placements_on_school_id    (school_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (provider_id => providers.id)
 #  fk_rails_...  (school_id => schools.id)
 #
 class Placements::Schools::Placements::Build::Placement < Placement
@@ -24,6 +27,7 @@ class Placements::Schools::Placements::Build::Placement < Placement
   has_many :subjects, through: :placement_subject_joins
 
   belongs_to :school, class_name: "Placements::School"
+  belongs_to :provider, optional: true
 
   validates :school, :status, presence: true
 

--- a/app/models/placements/schools/placements/build/placement.rb
+++ b/app/models/placements/schools/placements/build/placement.rb
@@ -3,7 +3,7 @@
 # Table name: placements
 #
 #  id          :uuid             not null, primary key
-#    status      :enum             default("draft")
+#  status      :enum             default("draft")
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  provider_id :uuid

--- a/app/views/placements/schools/placements/edit_provider.html.erb
+++ b/app/views/placements/schools/placements/edit_provider.html.erb
@@ -1,0 +1,31 @@
+<% content_for :page_title, @placement.errors.any? ? t(".title_with_error") : t(".title") %>
+<%= render "placements/schools/primary_navigation", school: @school, current_navigation: :placements %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: :back) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= render AutocompleteSelectFormComponent.new(
+    model: @placement,
+    scope: :provider,
+    url: placements_school_placement_path(@school, @placement),
+    method: :patch,
+    data: {
+      autocomplete_path_value: "/api/provider_suggestions",
+      autocomplete_return_attributes_value: %w[code],
+      input_name: "provider[provider_name]",
+    },
+    input: {
+      field_name: :provider_id,
+      value: @placement.provider_name,
+      label: t(".title"),
+      caption: "Edit Placement",
+      previous_search: @placement.provider_id,
+    },
+  ) %>
+
+  <p class="govuk-body">
+    <%= govuk_link_to(t(".cancel"), placements_school_placement_path(@school, @placement), no_visited_state: true) %>
+  </p>
+</div>

--- a/app/views/placements/schools/placements/show.html.erb
+++ b/app/views/placements/schools/placements/show.html.erb
@@ -50,11 +50,16 @@
             <%= render Placement::StatusTagComponent.new(@placement.status) %>
           <% end %>
         <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".attributes.placements.provider")) %>
+          <% row.with_value(text: @placement.provider_name.presence || t("placements.schools.placements.not_known_yet")) %>
+          <% row.with_action(text: t(".change"), href: edit_provider_placements_school_placement_path(@school, @placement), visually_hidden_text: t(".attributes.placements.provider")) %>
+       <% end %>
       <% end %>
 
       <%= govuk_link_to t(".remove_placement"),
-        remove_placements_school_placement_path(@school, @placement),
-        class: "app-link app-link--destructive" %>
+                        remove_placements_school_placement_path(@school, @placement),
+                        class: "app-link app-link--destructive" %>
     </div>
   </div>
 </div>

--- a/app/views/placements/schools/placements/show.html.erb
+++ b/app/views/placements/schools/placements/show.html.erb
@@ -52,7 +52,7 @@
         <% end %>
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: t(".attributes.placements.provider")) %>
-          <% row.with_value(text: @placement.provider_name.presence || t("placements.schools.placements.not_known_yet")) %>
+          <% row.with_value(text: @placement.provider_name) %>
           <% row.with_action(text: t(".change"), href: edit_provider_placements_school_placement_path(@school, @placement), visually_hidden_text: t(".attributes.placements.provider")) %>
        <% end %>
       <% end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -166,3 +166,4 @@ shared:
     - school_id
     - created_at
     - updated_at
+    - provider_id

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -10,6 +10,8 @@ en:
               invalid: Select a mentor or not known
             subject_ids:
               invalid: Select a subject
+            provider_id:
+              invalid: Select a provider
   placements:
     schools:
       placements:
@@ -55,6 +57,19 @@ en:
             not_known_yet: Not known yet
           update:
             success: Placement added
+        edit_provider:
+          title_with_error: "Error: Select a provider"
+          title: Provider - Edit placement
+          caption: Edit Placement
+          edit_placement: Edit placement
+          provider: Provider
+          not_known: Not known yet
+          continue: Continue
+          cancel: Cancel
+        terms:
+          autumn: Autumn
+          spring: Spring
+          summer: Summer
         not_known_yet: Not known yet
         index:
           page_title: Placements
@@ -72,6 +87,8 @@ en:
               subject: Subject
               mentor: Mentor
               status: Status
+              provider: Provider
+          change: Change
         remove:
           page_title: "Are you sure you want to remove this placement? - %{subject_names}"
           are_you_sure: Are you sure you want to remove this placement?
@@ -79,3 +96,5 @@ en:
           remove_placement: Remove placement
         destroy:
           placement_removed: Placement removed
+        update:
+          success: Placement updated

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -74,8 +74,9 @@ scope module: :placements,
         collection { get :check }
       end
 
-      resources :placements, only: %i[index show destroy] do
+      resources :placements, only: %i[index update show destroy] do
         member { get :remove }
+        get :edit_provider, on: :member
 
         scope module: :placements do
           resources :build do

--- a/db/migrate/20240424100627_add_provider_to_placement.rb
+++ b/db/migrate/20240424100627_add_provider_to_placement.rb
@@ -1,0 +1,5 @@
+class AddProviderToPlacement < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :placements, :provider, null: true, foreign_key: true, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -229,6 +229,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_29_133246) do
     t.uuid "school_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "provider_id"
+    t.index ["provider_id"], name: "index_placements_on_provider_id"
     t.index ["school_id"], name: "index_placements_on_school_id"
   end
 
@@ -374,6 +376,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_29_133246) do
   add_foreign_key "placement_mentor_joins", "placements"
   add_foreign_key "placement_subject_joins", "placements"
   add_foreign_key "placement_subject_joins", "subjects"
+  add_foreign_key "placements", "providers"
   add_foreign_key "placements", "schools"
   add_foreign_key "schools", "regions"
   add_foreign_key "schools", "trusts"

--- a/spec/decorators/placement_decorator_spec.rb
+++ b/spec/decorators/placement_decorator_spec.rb
@@ -72,4 +72,22 @@ RSpec.describe PlacementDecorator do
       expect(placement.decorate.school_level).to eq("Primary")
     end
   end
+
+  describe "#provider_name" do
+    context "when the placement has no provider" do
+      it "returns Not known yet" do
+        placement = build(:placement)
+
+        expect(placement.decorate.provider_name).to eq("Not known yet")
+      end
+    end
+
+    context "when the placement has a provider" do
+      it "returns the provider name" do
+        placement = build(:placement, provider: build(:provider, name: "Provider 1"))
+
+        expect(placement.decorate.provider_name).to eq("Provider 1")
+      end
+    end
+  end
 end

--- a/spec/factories/placements.rb
+++ b/spec/factories/placements.rb
@@ -3,7 +3,7 @@
 # Table name: placements
 #
 #  id          :uuid             not null, primary key
-#    status      :enum             default("draft")
+#  status      :enum             default("draft")
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  provider_id :uuid

--- a/spec/factories/placements.rb
+++ b/spec/factories/placements.rb
@@ -2,18 +2,21 @@
 #
 # Table name: placements
 #
-#  id         :uuid             not null, primary key
-#  status     :enum             default("draft")
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  school_id  :uuid
+#  id          :uuid             not null, primary key
+#    status      :enum             default("draft")
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  provider_id :uuid
+#  school_id   :uuid
 #
 # Indexes
 #
-#  index_placements_on_school_id  (school_id)
+#  index_placements_on_provider_id  (provider_id)
+#  index_placements_on_school_id    (school_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (provider_id => providers.id)
 #  fk_rails_...  (school_id => schools.id)
 #
 FactoryBot.define do

--- a/spec/models/placement_spec.rb
+++ b/spec/models/placement_spec.rb
@@ -2,18 +2,21 @@
 #
 # Table name: placements
 #
-#  id         :uuid             not null, primary key
-#  status     :enum             default("draft")
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  school_id  :uuid
+#  id          :uuid             not null, primary key
+#    status      :enum             default("draft")
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  provider_id :uuid
+#  school_id   :uuid
 #
 # Indexes
 #
-#  index_placements_on_school_id  (school_id)
+#  index_placements_on_provider_id  (provider_id)
+#  index_placements_on_school_id    (school_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (provider_id => providers.id)
 #  fk_rails_...  (school_id => schools.id)
 #
 require "rails_helper"
@@ -27,6 +30,7 @@ RSpec.describe Placement, type: :model do
     it { is_expected.to have_many(:subjects).through(:placement_subject_joins) }
 
     it { is_expected.to belong_to(:school) }
+    it { is_expected.to belong_to(:provider).optional }
   end
 
   describe "validations" do

--- a/spec/models/placement_spec.rb
+++ b/spec/models/placement_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe Placement, type: :model do
     it { is_expected.to validate_presence_of(:status) }
   end
 
+  describe "delegations" do
+    it { is_expected.to delegate_method(:name).to(:provider).with_prefix(true).allow_nil }
+  end
+
   describe "scopes" do
     describe "#order_by_subject_school_name" do
       it "returns the placements ordered by their associated schools name" do

--- a/spec/models/placement_spec.rb
+++ b/spec/models/placement_spec.rb
@@ -3,7 +3,7 @@
 # Table name: placements
 #
 #  id          :uuid             not null, primary key
-#    status      :enum             default("draft")
+#  status      :enum             default("draft")
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  provider_id :uuid

--- a/spec/models/placements/provider_spec.rb
+++ b/spec/models/placements/provider_spec.rb
@@ -31,7 +31,9 @@
 require "rails_helper"
 
 RSpec.describe Placements::Provider do
-  context "with assocations" do
+  describe "associations" do
+    it { is_expected.to have_many(:placements) }
+
     describe "#users" do
       it { is_expected.to have_many(:users).through(:user_memberships) }
 

--- a/spec/models/placements/schools/placements/build/placement_spec.rb
+++ b/spec/models/placements/schools/placements/build/placement_spec.rb
@@ -3,7 +3,7 @@
 # Table name: placements
 #
 #  id          :uuid             not null, primary key
-#    status      :enum             default("draft")
+#  status      :enum             default("draft")
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  provider_id :uuid

--- a/spec/models/placements/schools/placements/build/placement_spec.rb
+++ b/spec/models/placements/schools/placements/build/placement_spec.rb
@@ -2,18 +2,21 @@
 #
 # Table name: placements
 #
-#  id         :uuid             not null, primary key
-#  status     :enum             default("draft")
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  school_id  :uuid
+#  id          :uuid             not null, primary key
+#    status      :enum             default("draft")
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  provider_id :uuid
+#  school_id   :uuid
 #
 # Indexes
 #
-#  index_placements_on_school_id  (school_id)
+#  index_placements_on_provider_id  (provider_id)
+#  index_placements_on_school_id    (school_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (provider_id => providers.id)
 #  fk_rails_...  (school_id => schools.id)
 #
 require "rails_helper"

--- a/spec/system/placements/schools/placements/edit_a_provider_spec.rb
+++ b/spec/system/placements/schools/placements/edit_a_provider_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
                type: :system, service: :placements do
   let!(:school) { create(:placements_school, name: "School 1", phase: "Primary") }
   let!(:placement) { create(:placement, school:) }
-  let!(:subject_1) { create(:subject, name: "Subject 1", subject_area: :primary) }
   let!(:provider_1) { create(:provider, name: "Provider 1") }
   let!(:provider_2) { create(:provider, name: "Provider 2") }
 
@@ -114,7 +113,7 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
   end
 
   def when_i_select_provider_2
-    fill_in "Provider - Edit placement", with: "Provider 2"
+    fill_in "Provider - Edit placement", with: provider_2.name
     find("#provider-provider-id-field__option--0").click
   end
 

--- a/spec/system/placements/schools/placements/edit_a_provider_spec.rb
+++ b/spec/system/placements/schools/placements/edit_a_provider_spec.rb
@@ -1,0 +1,141 @@
+require "rails_helper"
+
+RSpec.describe "Placements / Schools / Placements / View a placement",
+               type: :system, service: :placements do
+  let!(:school) { create(:placements_school, name: "School 1", phase: "Primary") }
+  let!(:placement) { create(:placement, school:) }
+  let!(:subject_1) { create(:subject, name: "Subject 1", subject_area: :primary) }
+  let!(:provider_1) { create(:provider, name: "Provider 1") }
+  let!(:provider_2) { create(:provider, name: "Provider 2") }
+
+  before do
+    given_i_sign_in_as_anne
+  end
+
+  context "with no provider", js: true do
+    scenario "User edits the provider" do
+      when_i_visit_the_placement_show_page
+      then_i_should_see_the_provider_is_not_known_yet_in_the_placement_details
+      when_i_click_on("Change")
+      then_i_should_see_the_edit_provider_page
+      when_i_select_provider_2
+      and_i_click_on("Continue")
+      then_i_should_see_the_provider_name_in_the_placement_details("Provider 2")
+    end
+
+    scenario "User does not select a provider" do
+      when_i_visit_the_placement_show_page
+      then_i_should_see_the_provider_is_not_known_yet_in_the_placement_details
+      when_i_click_on("Change")
+      then_i_should_see_the_edit_provider_page
+      and_i_click_on("Continue")
+      then_i_should_see_the_provider_is_not_known_yet_in_the_placement_details
+    end
+
+    scenario "User edits the provider and cancels" do
+      when_i_visit_the_placement_show_page
+      then_i_should_see_the_provider_is_not_known_yet_in_the_placement_details
+      when_i_click_on("Change")
+      then_i_should_see_the_edit_provider_page
+      when_i_select_provider_2
+      and_i_click_on("Cancel")
+      then_i_should_see_the_provider_is_not_known_yet_in_the_placement_details
+    end
+
+    scenario "User clicks on back" do
+      when_i_visit_the_placement_show_page
+      then_i_should_see_the_provider_is_not_known_yet_in_the_placement_details
+      when_i_click_on("Change")
+      then_i_should_see_the_edit_provider_page
+      and_i_click_on("Back")
+      then_i_should_see_the_provider_is_not_known_yet_in_the_placement_details
+    end
+  end
+
+  context "with a provider" do
+    scenario "User edits the provider", js: true do
+      given_the_placement_has_a_provider(provider_1)
+      when_i_visit_the_placement_show_page
+      then_i_should_see_the_provider_name_in_the_placement_details("Provider 1")
+      when_i_click_on("Change")
+      then_i_should_see_the_edit_provider_page
+      when_i_select_provider_2
+      and_i_click_on("Continue")
+      then_i_should_see_the_provider_name_in_the_placement_details("Provider 2")
+    end
+
+    scenario "User does not select a provider", js: true do
+      given_the_placement_has_a_provider(provider_1)
+      when_i_visit_the_placement_show_page
+      then_i_should_see_the_provider_name_in_the_placement_details("Provider 1")
+      when_i_click_on("Change")
+      then_i_should_see_the_edit_provider_page
+      when_i_remove_the_provider_from_the_search_box
+      and_i_click_on("Continue")
+      then_i_should_see_the_provider_name_in_the_placement_details("Not known yet")
+    end
+  end
+
+  private
+
+  def and_there_is_an_existing_user_for(user_name)
+    user = create(:placements_user, user_name.downcase.to_sym)
+    user_exists_in_dfe_sign_in(user:)
+    create(:user_membership, user:, organisation: school)
+  end
+
+  def and_i_visit_the_sign_in_path
+    visit sign_in_path
+  end
+
+  def and_i_click_sign_in
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def when_i_visit_the_placement_show_page
+    visit placements_school_placement_path(school, placement)
+  end
+
+  def given_i_sign_in_as_anne
+    and_there_is_an_existing_user_for("Anne")
+    and_i_visit_the_sign_in_path
+    and_i_click_sign_in
+  end
+
+  def then_i_should_see_the_provider_is_not_known_yet_in_the_placement_details
+    within(".govuk-summary-list") do
+      expect(page).to have_content("Not known yet")
+      expect(page).to have_content("Change")
+    end
+  end
+
+  def then_i_should_see_the_edit_provider_page
+    expect(page).to have_content("Edit placement")
+  end
+
+  def when_i_select_provider_2
+    fill_in "Provider - Edit placement", with: "Provider 2"
+    find("#provider-provider-id-field__option--0").click
+  end
+
+  def and_i_click_on(text)
+    click_on text
+  end
+
+  def then_i_should_see_the_provider_name_in_the_placement_details(provider_name)
+    within(".govuk-summary-list") do
+      expect(page).to have_content(provider_name)
+      expect(page).to have_content("Change")
+    end
+  end
+
+  def given_the_placement_has_a_provider(provider)
+    placement.update!(provider:)
+  end
+
+  def when_i_remove_the_provider_from_the_search_box
+    fill_in "Provider - Edit placement", with: ""
+  end
+
+  alias_method :when_i_click_on, :and_i_click_on
+end

--- a/spec/system/placements/schools/placements/view_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/view_a_placement_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
   let!(:school) { create(:placements_school, name: "School 1", phase: "Primary") }
   let!(:placement) { create(:placement, school:) }
   let!(:subject_1) { create(:subject, name: "Subject 1", subject_area: :primary) }
+  let!(:provider) { create(:provider, name: "Provider 1") }
 
   before do
     given_i_sign_in_as_anne
@@ -111,6 +112,21 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
       given_a_placement_with_status("published")
       when_i_visit_the_placement_show_page
       then_see_the_status_in_the_placement_details(status: "Published")
+    end
+  end
+
+  context "with a provider" do
+    scenario "User views a placement with a provider" do
+      given_a_placement_with_a_provider(provider:)
+      when_i_visit_the_placement_show_page
+      then_i_see_the_provider_in_the_placement_details(provider:)
+    end
+  end
+
+  context "without a provider" do
+    scenario "User views a placement without a provider" do
+      when_i_visit_the_placement_show_page
+      then_i_see_the_provider_in_the_placement_details
     end
   end
 
@@ -221,6 +237,19 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
 
   def given_a_placement_with_status(status)
     placement.update!(status:)
+  end
+
+  def given_a_placement_with_a_provider(provider:)
+    placement.update!(provider:)
+  end
+
+  def then_i_see_the_provider_in_the_placement_details(provider: nil)
+    provider_text = provider&.name || "Not known yet"
+
+    within(".govuk-summary-list") do
+      expect(page).to have_content(provider_text)
+      expect(page).to have_content("Change")
+    end
   end
 
   def then_see_the_status_in_the_placement_details(status:)


### PR DESCRIPTION
## Context

School users should be able to select a provider for their placements then they know which provider will be assigned. This is an optional choice.

## Changes proposed in this pull request

- [x] Adds an optional `method` argument for the auto select form
- [x] Adds a new `name` delegation to `provider` for a Placement
- [x] Updates the Placement show page to display the provider and change link
- [x] Adds an edit page for editing providers on placements

## Guidance to review

- Create a new placement
- Click on the placement on the index page
- Click on Change in the provider row
- Select a provider
- Click on continue

## Link to Trello card

[Add Provider to Placement](https://trello.com/c/BSK7vNUk/269-provider-placements)

## Screenshots

![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/8220b79f-6ef0-4571-be3a-2e33e0b7fa97)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/0a8a93b9-de5a-4a57-a484-f8caa2982b63)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/76121999-ef5c-4852-a87d-fd83984609b8)
