### PR TITLE
Update grant conditions path to "/grant-conditions"

### DIFF
--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -8,7 +8,7 @@ scope module: :claims, as: :claims, constraints: {
     get :cookies
     get :terms
     get :privacy
-    get :grant_conditions
+    get :grant_conditions, path: "grant-conditions"
   end
 
   resources :schools, only: %i[index show] do

--- a/spec/helpers/footer_helper_spec.rb
+++ b/spec/helpers/footer_helper_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe FooterHelper do
         allow(HostingEnvironment).to receive(:current_service).and_return(:claims)
         expect(helper.footer_meta_items).to eq(
           [
-            { href: "/grant_conditions", text: "Grant conditions" },
+            { href: "/grant-conditions", text: "Grant conditions" },
             { href: "/accessibility", text: "Accessibility" },
             { href: "/cookies", text: "Cookies" },
             { href: "/privacy", text: "Privacy notice" },


### PR DESCRIPTION
## Context

We want to use dashed paths.

## Changes proposed in this pull request

- Change the `grant_conditions` path from `/grant_conditions` to `/grant-conditions`.

## Guidance to review

The "Grant Conditions" should now be accessible via `/grant-conditions` instead of `/grant_conditions`.
