### PR TITLE
While a Mentor is associated with an "active" Claim, it cannot be "removed"

### DIFF
--- a/app/policies/claims/mentor_policy.rb
+++ b/app/policies/claims/mentor_policy.rb
@@ -1,5 +1,9 @@
 class Claims::MentorPolicy < Claims::ApplicationPolicy
   def destroy?
+    !Claims::Claim.active.joins(:mentor_trainings).where(mentor_trainings: { mentor_id: record }).exists?
+  end
+
+  def remove?
     true
   end
 end

--- a/app/views/claims/schools/mentors/_cannot_remove_mentor.erb
+++ b/app/views/claims/schools/mentors/_cannot_remove_mentor.erb
@@ -1,0 +1,13 @@
+<% content_for :page_title, t(".page_title") %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= @mentor.full_name %></span>
+      <h1 class="govuk-heading-l"><%= t(".cant_remove_mentor") %></h1>
+      <p class="govuk-body"><%= t(".included_in_claim") %></p>
+      <p class="govuk-body"><%= t(".can_remove_when_claim_processed") %></p>
+    </div>
+  </div>
+
+  <%= govuk_link_to t(".cancel"), claims_school_mentors_path(@school), no_visited_state: true %>

--- a/app/views/claims/schools/mentors/_remove_mentor.html.erb
+++ b/app/views/claims/schools/mentors/_remove_mentor.html.erb
@@ -1,0 +1,13 @@
+<% content_for :page_title, "#{t(".page_title")} - #{@mentor.full_name}" %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= @mentor.full_name %></span>
+      <h1 class="govuk-heading-l"><%= t(".are_you_sure") %></h1>
+    </div>
+  </div>
+
+  <%= govuk_button_to(t(".remove_mentor"), claims_school_mentor_path(@school, @mentor), warning: true, method: :delete, class: "govuk-button govuk-button--warning") %>
+
+  <%= govuk_link_to t(".cancel"), claims_school_mentors_path(@school), no_visited_state: true %>

--- a/app/views/claims/schools/mentors/remove.html.erb
+++ b/app/views/claims/schools/mentors/remove.html.erb
@@ -1,19 +1,11 @@
-<% content_for :page_title, "#{t(".page_title")} - #{@mentor.full_name}" %>
 <% render "claims/schools/primary_navigation", school: @school, current: :mentors %>
 
 <% content_for(:before_content) do %>
   <%= govuk_back_link(href: claims_school_mentor_path(id: @mentor.id)) %>
 <% end %>
 
-<div class="govuk-width-container">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-l"><%= @mentor.full_name %></span>
-      <h1 class="govuk-heading-l"><%= t(".are_you_sure") %></h1>
-    </div>
-  </div>
-
-  <%= govuk_button_to(t(".remove_mentor"), claims_school_mentor_path(@school, @mentor), warning: true, method: :delete, class: "govuk-button govuk-button--warning") %>
-
-  <%= govuk_link_to t(".cancel"), claims_school_mentors_path(@school), no_visited_state: true %>
-</div>
+<% if policy(@mentor).destroy? %>
+  <%= render partial: "claims/schools/mentors/remove_mentor" %>
+<% else %>
+  <%= render partial: "claims/schools/mentors/cannot_remove_mentor" %>
+<% end %>

--- a/app/views/claims/support/schools/mentors/_cannot_remove_mentor.html.erb
+++ b/app/views/claims/support/schools/mentors/_cannot_remove_mentor.html.erb
@@ -1,0 +1,13 @@
+<% content_for :page_title, t(".page_title") %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= @mentor.full_name %></span>
+      <h1 class="govuk-heading-l"><%= t(".cant_remove_mentor") %></h1>
+      <p class="govuk-body"><%= t(".included_in_claim") %></p>
+      <p class="govuk-body"><%= t(".can_remove_when_claim_processed") %></p>
+    </div>
+  </div>
+
+  <%= govuk_link_to t(".cancel"), claims_support_school_mentors_path(@school), no_visited_state: true %>

--- a/app/views/claims/support/schools/mentors/_remove_mentor.html.erb
+++ b/app/views/claims/support/schools/mentors/_remove_mentor.html.erb
@@ -1,0 +1,14 @@
+<%= content_for :page_title, sanitize(t(".page_title", user_name: @mentor.full_name, school_name: @school.name)) %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= @mentor.full_name %> - <%= @school.name %></span>
+      <h1 class="govuk-heading-l"><%= t(".are_you_sure") %></h1>
+    </div>
+  </div>
+
+  <%= govuk_button_to(t(".remove_mentor"), claims_support_school_mentor_path(@school, @mentor), warning: true, method: :delete, class: "govuk-button govuk-button--warning") %>
+
+  <%= govuk_link_to t(".cancel"), claims_support_school_mentors_path(@school), no_visited_state: true %>
+</div>

--- a/app/views/claims/support/schools/mentors/remove.html.erb
+++ b/app/views/claims/support/schools/mentors/remove.html.erb
@@ -1,20 +1,11 @@
-<%= content_for :page_title, sanitize(t(".page_title", user_name: @mentor.full_name, school_name: @school.name)) %>
-
 <% render "claims/support/primary_navigation", current: :organisations %>
 
 <% content_for(:before_content) do %>
   <%= govuk_back_link(href: claims_support_school_mentor_path(id: @mentor.id)) %>
 <% end %>
 
-<div class="govuk-width-container">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-l"><%= @mentor.full_name %> - <%= @school.name %></span>
-      <h1 class="govuk-heading-l"><%= t(".are_you_sure") %></h1>
-    </div>
-  </div>
-
-  <%= govuk_button_to(t(".remove_mentor"), claims_support_school_mentor_path(@school, @mentor), warning: true, method: :delete, class: "govuk-button govuk-button--warning") %>
-
-  <%= govuk_link_to t(".cancel"), claims_support_school_mentors_path(@school), no_visited_state: true %>
-</div>
+<% if policy(@mentor).destroy? %>
+  <%= render partial: "claims/schools/mentors/remove_mentor" %>
+<% else %>
+  <%= render partial: "claims/schools/mentors/cannot_remove_mentor" %>
+<% end %>

--- a/config/locales/en/claims/schools/mentors.yml
+++ b/config/locales/en/claims/schools/mentors.yml
@@ -39,10 +39,16 @@ en:
           no_results_found: No results found for ‘%{trn}’
         create:
           success: Mentor added
-        remove:
+        remove_mentor:
           page_title: Are you sure you want to remove this mentor? - %{user_name}
           are_you_sure: Are you sure you want to remove this mentor?
-          cancel: Cancel
           remove_mentor: Remove mentor
+          cancel: Cancel
+        cannot_remove_mentor:
+          page_title: You cannot remove this mentor
+          cancel: Cancel
+          cant_remove_mentor: You cannot remove this mentor
+          included_in_claim: You cannot remove this mentor because they are included in an active claim.
+          can_remove_when_claim_processed: You will be able to remove the mentor once we have processed the claim.
         destroy:
           success: Mentor removed

--- a/config/locales/en/claims/support/schools/mentors.yml
+++ b/config/locales/en/claims/support/schools/mentors.yml
@@ -41,11 +41,17 @@ en:
             no_results_found: No results found for ‘%{trn}’
           create:
             success: Mentor added
-          remove:
+          remove_mentor:
             page_title: Are you sure you want to remove this mentor? - %{user_name} - %{school_name}
             are_you_sure: Are you sure you want to remove this mentor?
             cancel: Cancel
             remove_mentor: Remove mentor
+          cannot_remove_mentor:
+            page_title: You cannot remove this mentor
+            cancel: Cancel
+            cant_remove_mentor: You cannot remove this mentor
+            included_in_claim: You cannot remove this mentor because they are included in an active claim.
+            can_remove_when_claim_processed: You will be able to remove the mentor once we have processed the claim.
           destroy:
             success: Mentor removed
 

--- a/spec/system/claims/schools/mentors/mentor_associated_to_active_claim_spec.rb
+++ b/spec/system/claims/schools/mentors/mentor_associated_to_active_claim_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe "When removing a mentor", type: :system, service: :claims do
+  let!(:mentor1) { create(:claims_mentor, first_name: "Bilbo", last_name: "Baggins") }
+  let!(:mentor2) { create(:claims_mentor, first_name: "Bilbo", last_name: "Testa") }
+
+  let!(:school) { create(:claims_school, mentors: [mentor1, mentor2], region: regions(:inner_london)) }
+
+  let!(:anne) do
+    create(
+      :claims_user,
+      :anne,
+      user_memberships: [create(:user_membership, organisation: school)],
+    )
+  end
+
+  scenario "When I try and remove a mentor who is already part of a submitted claim" do
+    create(:claim, school_id: school.id, reference: "12345678", status: :submitted, mentors: [mentor1])
+
+    user_exists_in_dfe_sign_in(user: anne)
+    given_i_sign_in
+    when_i_visit_the_school_mentors_page(school)
+    click_on mentor1.full_name
+    click_on "Remove mentor"
+    then_i_cant_remove_this_mentor
+  end
+
+  scenario "When I try and remove a mentor who is already part of a draft claim" do
+    create(:claim, school_id: school.id, reference: "12345671", status: :draft, mentors: [mentor2])
+
+    user_exists_in_dfe_sign_in(user: anne)
+    given_i_sign_in
+    when_i_visit_the_school_mentors_page(school)
+    click_on mentor2.full_name
+    click_on "Remove mentor"
+    then_i_cant_remove_this_mentor
+  end
+
+  private
+
+  def given_i_sign_in
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def when_i_visit_the_school_mentors_page(school)
+    visit claims_school_mentors_path(school)
+  end
+
+  def then_i_cant_remove_this_mentor
+    expect(page).to have_content("You cannot remove this mentor")
+  end
+end

--- a/spec/system/claims/support/schools/mentors/mentor_associated_to_active_claim_spec.rb
+++ b/spec/system/claims/support/schools/mentors/mentor_associated_to_active_claim_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe "When removing a mentor", type: :system, service: :claims do
+  let!(:mentor1) { create(:claims_mentor, first_name: "Bilbo", last_name: "Baggins") }
+  let!(:mentor2) { create(:claims_mentor, first_name: "Bilbo", last_name: "Testa") }
+
+  let!(:school) { create(:claims_school, mentors: [mentor1, mentor2], region: regions(:inner_london)) }
+
+  let!(:colin) { create(:claims_support_user, :colin) }
+
+  scenario "When I try and remove a mentor who is already part of a submitted claim" do
+    create(:claim, school_id: school.id, reference: "12345678", status: :submitted, mentors: [mentor1])
+
+    user_exists_in_dfe_sign_in(user: colin)
+    given_i_sign_in
+    when_i_visit_the_support_school_mentors_page(school)
+    click_on "Mentors"
+    click_on mentor1.full_name
+    click_on "Remove mentor"
+    then_i_cant_remove_this_mentor
+  end
+
+  private
+
+  def given_i_sign_in
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def when_i_visit_the_support_school_mentors_page(school)
+    visit claims_support_school_mentors_path(school)
+  end
+
+  def then_i_cant_remove_this_mentor
+    expect(page).to have_content("You cannot remove this mentor")
+  end
+end


### PR DESCRIPTION
## Context

We dont want to allow a user to remove a mentor who is part of an active claim

## Changes proposed in this pull request

Add a blocking flow if the user is part of an active claim

## Guidance to review

- Add a mentor
- Create a claim with that mentor
- Try and remove that mentor

## Link to Trello card

https://trello.com/c/s8hqOMUv/420-while-a-mentor-is-associated-with-an-active-claim-it-cannot-be-removed

