### PR TITLE
Reject claims with invalid mentor training hours

### DIFF
--- a/app/controllers/claims/schools/claims_controller.rb
+++ b/app/controllers/claims/schools/claims_controller.rb
@@ -2,7 +2,7 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
   include Claims::BelongsToSchool
 
   before_action :has_school_accepted_grant_conditions?
-  before_action :set_claim, only: %i[show check confirmation submit edit update]
+  before_action :set_claim, only: %i[show check confirmation submit edit update rejected]
   before_action :authorize_claim
 
   helper_method :claim_provider_form
@@ -47,10 +47,14 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
   def confirmation; end
 
   def submit
+    return redirect_to rejected_claims_school_claim_path unless @claim.valid_mentor_training_hours?
+
     Claims::Claim::Submit.call(claim: @claim, user: current_user)
 
     redirect_to confirmation_claims_school_claim_path(@school, @claim)
   end
+
+  def rejected; end
 
   private
 

--- a/app/controllers/claims/support/schools/claims_controller.rb
+++ b/app/controllers/claims/support/schools/claims_controller.rb
@@ -1,7 +1,7 @@
 class Claims::Support::Schools::ClaimsController < Claims::Support::ApplicationController
   include Claims::BelongsToSchool
 
-  before_action :set_claim, only: %i[check draft show edit update remove destroy]
+  before_action :set_claim, only: %i[check draft show edit update remove destroy rejected]
   before_action :authorize_claim
   helper_method :claim_provider_form
 
@@ -54,11 +54,15 @@ class Claims::Support::Schools::ClaimsController < Claims::Support::ApplicationC
   end
 
   def draft
+    return redirect_to rejected_claims_support_school_claim_path unless @claim.valid_mentor_training_hours?
+
     success_message = @claim.draft? ? t(".update_success") : t(".add_success")
     Claims::Claim::CreateDraft.call(claim: @claim)
 
     redirect_to claims_support_school_claims_path(@school), flash: { success: success_message }
   end
+
+  def rejected; end
 
   private
 

--- a/app/policies/claims/claim_policy.rb
+++ b/app/policies/claims/claim_policy.rb
@@ -11,6 +11,10 @@ class Claims::ClaimPolicy < Claims::ApplicationPolicy
     !user.support_user? && !record.submitted?
   end
 
+  def rejected?
+    submit? || draft?
+  end
+
   def destroy?
     user.support_user? && record.draft?
   end

--- a/app/views/claims/schools/claims/rejected.html.erb
+++ b/app/views/claims/schools/claims/rejected.html.erb
@@ -1,0 +1,23 @@
+<% content_for :page_title, t(".page_title") %>
+<% render "claims/schools/primary_navigation", school: @school, current: :claims %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <label class="govuk-label govuk-label--l">
+        <span class="govuk-caption-l"> <%= t(".add_claim") %></span>
+        <%= t(".page_title") %>
+      </label>
+
+      <p class="govuk-body"><%= t(".reject_reason") %></p>
+
+      <p class="govuk-body">
+        <%= govuk_link_to t(".view_claims"), claims_school_claims_path(@school), no_visited_state: true %>
+      </p>
+
+      <p class="govuk-body">
+        <%= t(".guidance_html", support_email: mail_to(t("claims.support_email"), class: "govuk-link")) %>
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/claims/support/schools/claims/rejected.html.erb
+++ b/app/views/claims/support/schools/claims/rejected.html.erb
@@ -1,0 +1,19 @@
+<% content_for :page_title, t(".page_title") %>
+<% render "claims/schools/primary_navigation", school: @school, current: :claims %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <label class="govuk-label govuk-label--l">
+        <span class="govuk-caption-l"> <%= t(".add_claim") %></span>
+        <%= t(".page_title") %>
+      </label>
+
+      <p class="govuk-body"><%= t(".reject_reason") %></p>
+
+      <p class="govuk-body">
+        <%= govuk_link_to t(".view_claims"), claims_support_school_claims_path(@school), no_visited_state: true %>
+      </p>
+    </div>
+  </div>
+</div>

--- a/config/locales/en/claims/schools/claims.yml
+++ b/config/locales/en/claims/schools/claims.yml
@@ -16,6 +16,12 @@ en:
           sent_email: We have emailed you a copy of your claim.
           shared_with_provider: This claim will be shared with %{provider_name}.
           guidance: We will check your claim before processing payment. If we need to contact you for further information, we will use the email you used to access this service.
+        rejected:
+          page_title: You cannot submit the claim
+          add_claim: Add claim
+          reject_reason: You cannot submit the claim because your mentors’ information has recently changed.
+          view_claims: View claims
+          guidance_html: If you have any questions, email %{support_email}
         check:
           page_title: Check your answers
           caption: Add claim

--- a/config/locales/en/claims/support/schools/claims.yml
+++ b/config/locales/en/claims/support/schools/claims.yml
@@ -8,6 +8,11 @@ en:
             update_success: Claim updated
           edit:
             page_title: Accredited provider - Add claim
+          rejected:
+            page_title: You cannot submit the claim
+            add_claim: Add claim
+            reject_reason: You cannot submit the claim because your mentors’ information has recently changed.
+            view_claims: View claims
           check:
             page_title: Check your answers
             submit: Add claim

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -20,6 +20,7 @@ scope module: :claims, as: :claims, constraints: {
         member do
           get :check
           get :confirmation
+          get :rejected
           post :submit
         end
       end
@@ -65,6 +66,7 @@ scope module: :claims, as: :claims, constraints: {
           member do
             get :remove
             get :check
+            get :rejected
             post :draft
           end
         end

--- a/spec/models/claims/claim_spec.rb
+++ b/spec/models/claims/claim_spec.rb
@@ -47,6 +47,26 @@ RSpec.describe Claims::Claim, type: :model do
     it { is_expected.to validate_uniqueness_of(:reference).case_insensitive.allow_nil }
   end
 
+  describe "#valid_mentor_training_hours?" do
+    it "returns true when each mentor does not have more hours than maximum allocated per provider" do
+      claim = create(:claim, :submitted)
+      create(:mentor_training, claim:, hours_completed: 20)
+      create(:mentor_training, claim:, hours_completed: 20)
+
+      expect(claim.valid_mentor_training_hours?).to eq(true)
+    end
+
+    it "returns false when a mentor has more hours than maximum allocated per provider" do
+      provider = create(:provider)
+      claim = create(:claim, :submitted, provider:)
+      mentor = create(:claims_mentor)
+      create(:mentor_training, claim:, hours_completed: 20, mentor:, provider:)
+      create(:mentor_training, claim:, hours_completed: 20, mentor:, provider:)
+
+      expect(claim.valid_mentor_training_hours?).to eq(false)
+    end
+  end
+
   context "with delegations" do
     it { is_expected.to delegate_method(:name).to(:provider).with_prefix }
     it { is_expected.to delegate_method(:users).to(:school).with_prefix }

--- a/spec/policies/claims/claim_policy_spec.rb
+++ b/spec/policies/claims/claim_policy_spec.rb
@@ -75,6 +75,32 @@ describe Claims::ClaimPolicy do
     end
   end
 
+  permissions :rejected? do
+    context "when user has an internal draft claim" do
+      it "grants access" do
+        expect(claim_policy).to permit(user, internal_draft_claim)
+      end
+    end
+
+    context "when user has a draft claim" do
+      it "grants access" do
+        expect(claim_policy).to permit(user, draft_claim)
+      end
+    end
+
+    context "when user is a support user" do
+      it "grants access" do
+        expect(claim_policy).to permit(support_user, draft_claim)
+      end
+    end
+
+    context "when user has a subbitted claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, submitted_claim)
+      end
+    end
+  end
+
   permissions :confirmation? do
     context "when user has a submitted claim" do
       it "grants access" do

--- a/spec/system/claims/support/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/create_claim_spec.rb
@@ -42,6 +42,26 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     then_i_am_redirectd_to_index_page(Claims::Claim.draft.first)
   end
 
+  scenario "Colin creates a claim with mentor training hours over the maximum limit per provider" do
+    when_i_click(school.name)
+    when_i_click_on_claims
+    when_i_click("Add claim")
+    when_i_choose_a_provider
+    when_i_click("Continue")
+    when_i_select_all_mentors
+    when_i_click("Continue")
+    then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor1)
+    when_i_add_training_hours("20 hours")
+    when_i_click("Continue")
+    then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor2)
+    when_i_choose_other_amount_and_input_hours(12)
+    when_i_click("Continue")
+    then_i_check_my_answers
+    when_another_claim_with_same_mentors_has_been_created([mentor1, mentor2])
+    when_i_click("Add claim")
+    then_i_get_the_reject_page
+  end
+
   scenario "Colin does not fill the form correctly" do
     when_i_click(school.name)
     when_i_click_on_claims
@@ -164,5 +184,16 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     within(".govuk-form-group--error") do
       expect(page).to have_content message
     end
+  end
+
+  def when_another_claim_with_same_mentors_has_been_created(mentors)
+    claim = create(:claim, :submitted, provider:)
+    mentors.each do |mentor|
+      create(:mentor_training, claim:, hours_completed: 20, mentor:, provider:)
+    end
+  end
+
+  def then_i_get_the_reject_page
+    expect(page).to have_content "You cannot submit the claim"
   end
 end


### PR DESCRIPTION
## Context

We have a race condition where a user can create a claim for a mentor before someone else trying to do the same thing.

So you can end up with more mentor training hours per provider than the maximum 20 hours allowed, per provider.

This PR adds a validation step in the submit and draft controller actions and redirect the user to a reject page when this happens

This PR adds a validation step in the submit and draft controller actions and redirect the user to a reject page when this happens.

## Changes proposed in this pull request

Validation method on the claim model. This should not be used as a `validates` method, we want to have control over when this is called.

New reject route and page

## Guidance to review

Try replicating the example below 👇🏻 

## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/ba188aee-e8d6-4074-a0f4-dcc509a2bc74


