### PR TITLE
Update placement navigation

### DIFF
--- a/app/views/placements/schools/placements/build/add_mentors.html.erb
+++ b/app/views/placements/schools/placements/build/add_mentors.html.erb
@@ -2,7 +2,7 @@
 <%= render "placements/schools/primary_navigation", school: @school, current_navigation: :placements %>
 
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: @back_link_path) %>
+  <%= govuk_back_link(href: :back) %>
 <% end %>
 
 <div class="govuk-width-container">

--- a/app/views/placements/schools/placements/build/add_phase.html.erb
+++ b/app/views/placements/schools/placements/build/add_phase.html.erb
@@ -2,7 +2,7 @@
 <%= render "placements/schools/primary_navigation", school: @school, current_navigation: :placements %>
 
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: @back_link_path) %>
+  <%= govuk_back_link(href: :back) %>
 <% end %>
 
 <div class="govuk-width-container">

--- a/app/views/placements/schools/placements/build/add_subject.html.erb
+++ b/app/views/placements/schools/placements/build/add_subject.html.erb
@@ -2,11 +2,7 @@
 <%= render "placements/schools/primary_navigation", school: @school, current_navigation: :placements %>
 
 <%= content_for(:before_content) do %>
-  <% if @school.primary_or_secondary_only? || @enable_quick_navigation %>
-    <%= govuk_back_link(href: @back_link_path) %>
-  <% else %>
-    <%= govuk_back_link(href: add_phase_placements_school_placement_build_index_path(@school, :add_phase)) %>
-  <% end %>
+  <%= govuk_back_link(href: :back) %>
 <% end %>
 
 <div class="govuk-width-container">

--- a/app/views/placements/schools/placements/build/check_your_answers.html.erb
+++ b/app/views/placements/schools/placements/build/check_your_answers.html.erb
@@ -2,7 +2,7 @@
 <%= render "placements/schools/primary_navigation", school: @school, current_navigation: :placements %>
 
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: @back_link_path) %>
+  <%= govuk_back_link(href: :back) %>
 <% end %>
 
 <div class="govuk-width-container">

--- a/spec/system/placements/schools/placements/add_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/add_a_placement_spec.rb
@@ -485,7 +485,7 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
   end
 
   def and_my_selection_has_not_changed_to(selection)
-    expect(page).to_not have_content(selection)
+    expect(page).not_to have_content(selection)
   end
 
   def when_i_click_on(text)

--- a/spec/system/placements/schools/placements/add_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/add_a_placement_spec.rb
@@ -230,7 +230,10 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
         then_i_see_the_add_a_placement_subject_page("Primary")
         when_i_choose_a_subject(subject_1.name)
         when_i_click_on("Continue")
+        then_i_see_the_add_a_placement_mentor_page
+        and_i_click_on("Continue")
         then_i_see_the_check_your_answers_page("Primary", mentor_1)
+        and_my_selection_has_changed_to("Primary")
       end
 
       scenario "I do not decide to change my phase" do
@@ -246,7 +249,12 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
         when_i_change_my_phase
         then_i_see_the_add_a_placement_add_phase_page
         and_i_click_on("Continue")
+        then_i_see_the_add_a_placement_subject_page("Secondary")
+        and_i_click_on("Continue")
+        then_i_see_the_add_a_placement_mentor_page
+        and_i_click_on("Continue")
         then_i_see_the_check_your_answers_page("Secondary", mentor_1)
+        and_my_selection_has_not_changed_to("Primary")
       end
     end
 
@@ -265,7 +273,10 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
         then_i_see_the_add_a_placement_subject_page("Secondary")
         when_i_check_the_subject(subject_3.name)
         and_i_click_on("Continue")
+        then_i_see_the_add_a_placement_mentor_page
+        and_i_click_on("Continue")
         then_i_see_the_check_your_answers_page("Secondary", mentor_1)
+        and_my_selection_has_changed_to(subject_3.name)
       end
 
       scenario "I do not decide to change my subject" do
@@ -281,7 +292,10 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
         when_i_change_my_subject
         then_i_see_the_add_a_placement_subject_page("Secondary")
         and_i_click_on("Continue")
+        then_i_see_the_add_a_placement_mentor_page
+        and_i_click_on("Continue")
         then_i_see_the_check_your_answers_page("Secondary", mentor_1)
+        and_my_selection_has_not_changed_to(subject_3.name)
       end
     end
 
@@ -464,6 +478,14 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
 
   def then_i_see_an_error_page
     expect(page).to have_content("Sorry, there’s a problem with the service")
+  end
+
+  def and_my_selection_has_changed_to(selection)
+    expect(page).to have_content(selection)
+  end
+
+  def and_my_selection_has_not_changed_to(selection)
+    expect(page).to_not have_content(selection)
   end
 
   def when_i_click_on(text)


### PR DESCRIPTION
## Context

Navigation was becoming complex and confusing for users on a simple creation page.

## Changes proposed in this pull request

- Updated the navigation flows based off of a discussion with design. It was decided that the back button duplicates the browser back button and the continue button always moves through steps for creating a placement, regardless of where you start the flow.

## Guidance to review

- The continue button will now always move to the next step, regardless of whether you've clicked on change. A primary school will always step through Subject -> Mentor -> Check your answers.
- The back button will mimic the browser back button

## Link to Trello card
[Update Add a Placement navigation](https://trello.com/c/3thwfUqj/264-update-add-a-placement-navigation)
