### PR TITLE
Disable DfE Analytics for the healthcheck endpoint

### DIFF
--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -1,6 +1,9 @@
 class HeartbeatController < ApplicationController
   skip_before_action :authenticate_user!
 
+  # disable DfE Analytics request logging for this controller
+  skip_after_action :trigger_request_event
+
   def healthcheck
     checks = { database: database_alive? }
     status = checks.values.all? ? :ok : :service_unavailable

--- a/spec/requests/dfe_analytics_spec.rb
+++ b/spec/requests/dfe_analytics_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+require "dfe/analytics/rspec/matchers"
+
+RSpec.describe "DfE Analytics integration", type: :request do
+  before do
+    # DfE Analytics is usually disabled in tests
+    # Switch it on just for these tests
+    allow(DfE::Analytics).to receive(:enabled?).and_return(true)
+  end
+
+  describe "requests to the app" do
+    it "sends a web_request event to dfe-analytics" do
+      expect { get "/" }.to have_sent_analytics_event_types(:web_request)
+    end
+  end
+
+  describe "requests to the healthcheck endpoint" do
+    it "does not send the request to dfe-analytics" do
+      expect { get "/healthcheck" }.not_to have_sent_analytics_event_types(:web_request)
+    end
+  end
+end


### PR DESCRIPTION
## Context

DfE Analytics automatically logs every web request received by the application. This happens because the top-level `ApplicationController` includes the `DfE::Analytics::Requests` concern, meaning every controller automatically inherits this behaviour.

For the most part, this is desirable behaviour. As described in the [dfe-analytics][1] README, the gem provides an _opinionated_ integration which is designed to send _every_ web request into BigQuery.

However, the `/healthcheck` endpoint is a special case. This endpoint is hit very frequently by our infrastructure layer to make sure the app is up, running, and healthy. From checking request logs, it looks like this is hit once every second.

It's not valuable to record these healthcheck requests in BigQuery. In fact it's quite wasteful of resources. In just a few days of having this integration enabled in our QA environment, we've already racked up ~500k jobs to push these requests into BigQuery (~3600 per hour, assuming no other traffic).

This change should save us a considerable amount of wasted CPU time, network traffic and disk usage in the database and BigQuery.

Unfortunately the gem doesn't provide a 'nicer' way to skip request logging on certain controllers. But since it's all powered by [controller callbacks][2], we can explicitly skip that callback in the same way we already do for user authentication.

I thought it was also valuable to add a test to prove that we _do_ send requests into DfE Analytics for other requests. Otherwise we could accidentally break the integration and the test suite would continue passing.

[1]: https://github.com/DFE-Digital/dfe-analytics
[2]: https://github.com/DFE-Digital/dfe-analytics/blob/656807c8ee97e74054ad752970313b3d6f8e86e0/lib/dfe/analytics/requests.rb#L9

## Changes proposed in this pull request

- Add test coverage for the DfE Analytics `web_request` integration
- Disable DfE Analytics logging for the `/healthcheck` endpoint

## Guidance to review

In the review app, log in as Colin (support user) and go to `/good_job`.

You should _not_ see any `DfE::Analytics::SendEvents` being queued up for requests to `/healthcheck`.

## Link to Trello card

https://trello.com/c/ovSQ0LTO/133-exclude-heartbeat-requests-from-dfe-analytics

## Screenshots

### 1. Dashboard

Before this PR, the GoodJob dashboard filled up with 3,600 jobs per hour, every hour, due to the healthcheck endpoint being hit once a second.

![GoodJob dashboard](https://github.com/DFE-Digital/itt-mentor-services/assets/7735945/b0b3a600-da83-44ea-a44e-b4fdc811c06c)

### 2. Job arguments

When you clicked in to a successful job to see the arguments, the `request_path` param was `/healthcheck` with a `request_user_agent` of `kube-probe/1.27`.

![Job details](https://github.com/DFE-Digital/itt-mentor-services/assets/7735945/9d7b502e-d2c1-4ad3-a24f-8d8de9132a1d)

Following the implementation of this PR, these requests will not be logged.