### PR TITLE
Skip ApplicationController on healthcheck endpoint

### DIFF
--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -1,8 +1,7 @@
-class HeartbeatController < ApplicationController
-  skip_before_action :authenticate_user!
-
-  # disable DfE Analytics request logging for this controller
-  skip_after_action :trigger_request_event
+class HeartbeatController < ActionController::API
+  # Deliberately avoid inheriting from ApplicationController –
+  # we don't need user authentication, helper methods, or any of the other
+  # niceties afforded to user-facing controllers in the app.
 
   def healthcheck
     checks = { database: database_alive? }


### PR DESCRIPTION
A quick follow-on from #566. It [was suggested](https://ukgovernmentdfe.slack.com/archives/CQCHZUZ0F/p1714484008292679?thread_ts=1714483199.696549&cid=CQCHZUZ0F) that a simpler way to skip DfE Analytics would be to simply avoid inheriting from `ApplicationController` altogether.

## What this PR does

Refactors the HeartbeatController (which powers the `/healthcheck` endpoint) so it doesn't inherit from the `ApplicationController`.

This simplifies the controller because it no longer needs to explicitly skip undesirable functionality such as user authentication or integration with DfE Analytics.

This controller doesn't need all the magic and niceties of regular user-facing controllers.

By inheriting from [ActionController::API][1], the controller will now be as lightweight as possible. Which is ideal for this endpoint because it gets hit every second or thereabouts.

[1]: https://api.rubyonrails.org/classes/ActionController/API.html

## Link to Trello card

https://trello.com/c/ovSQ0LTO/133-exclude-heartbeat-requests-from-dfe-analytics
