### PR TITLE
Update placement provider management

### DIFF
--- a/app/controllers/placements/schools/placements/build_controller.rb
+++ b/app/controllers/placements/schools/placements/build_controller.rb
@@ -27,7 +27,7 @@ class Placements::Schools::Placements::BuildController < ApplicationController
     @placement = initialize_placement
     @phase = session.dig(:add_a_placement, "phase")
     @selected_mentor_text = if @placement.mentors.empty?
-                              t(".not_known_yet")
+                              t(".not_yet_known")
                             else
                               @placement.mentors.map(&:full_name).to_sentence
                             end

--- a/app/controllers/placements/schools/placements_controller.rb
+++ b/app/controllers/placements/schools/placements_controller.rb
@@ -13,7 +13,7 @@ class Placements::Schools::PlacementsController < ApplicationController
   def remove; end
 
   def edit_provider
-    @providers = Provider.all
+    @providers = @school.partner_providers.all
   end
 
   def edit_mentors

--- a/app/decorators/placement_decorator.rb
+++ b/app/decorators/placement_decorator.rb
@@ -6,7 +6,7 @@ class PlacementDecorator < Draper::Decorator
     if mentors.any?
       mentors.map(&:full_name).sort.to_sentence
     else
-      I18n.t("placements.schools.placements.not_known_yet")
+      I18n.t("placements.schools.placements.not_yet_known")
     end
   end
 
@@ -14,7 +14,7 @@ class PlacementDecorator < Draper::Decorator
     if subjects.any?
       subjects.pluck(:name).sort.to_sentence
     else
-      I18n.t("placements.schools.placements.not_known_yet")
+      I18n.t("placements.schools.placements.not_yet_known")
     end
   end
 
@@ -23,6 +23,6 @@ class PlacementDecorator < Draper::Decorator
   end
 
   def provider_name
-    provider&.name || I18n.t("placements.schools.placements.not_known_yet")
+    provider&.name || I18n.t("placements.schools.placements.not_yet_known")
   end
 end

--- a/app/views/placements/providers/placements/_mentor_details.html.erb
+++ b/app/views/placements/providers/placements/_mentor_details.html.erb
@@ -10,7 +10,7 @@
           <% end %>
         </ul>
       <% else %>
-        <%= t("placements.schools.placements.not_known_yet") %>
+        <%= t("placements.schools.placements.not_yet_known") %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/placements/schools/placements/edit_provider.html.erb
+++ b/app/views/placements/schools/placements/edit_provider.html.erb
@@ -13,12 +13,12 @@
       <div class="govuk-grid-column-two-thirds">
         <span class="govuk-caption-l"><%= t(".caption") %></span>
 
-        <%= f.govuk_radio_buttons_fieldset :subject_ids, legend: { size: "l", text: t(".provider") } do %>
+        <%= f.govuk_radio_buttons_fieldset :provider_id, legend: { size: "l", text: t(".provider") } do %>
           <% @providers.each do |provider| %>
             <%= f.govuk_radio_button :provider_id, provider.id, label: { text: provider.name }, checked: @placement.provider == provider %>
           <% end %>
           <%= f.govuk_radio_divider %>
-          <%= f.govuk_radio_button :provider_id, nil, label: { text: t(".not_known") }, checked: @placement.provider.nil?, exclusive: true %>
+          <%= f.govuk_radio_button :provider_id, nil, label: { text: t(".not_known") }, checked: @placement.provider.nil? %>
         <% end %>
 
         <%= f.govuk_submit t(".continue") %>

--- a/app/views/placements/schools/placements/edit_provider.html.erb
+++ b/app/views/placements/schools/placements/edit_provider.html.erb
@@ -6,24 +6,34 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <%= render AutocompleteSelectFormComponent.new(
-    model: @placement,
-    scope: :placement,
-    url: placements_school_placement_path(@school, @placement),
-    method: :patch,
-    data: {
-      autocomplete_path_value: "/api/provider_suggestions",
-      autocomplete_return_attributes_value: %w[code],
-      input_name: "placement[provider_name]",
-    },
-    input: {
-      field_name: :provider_id,
-      value: @placement.provider_name,
-      label: t(".title"),
-      caption: "Edit Placement",
-      previous_search: @placement.provider_id,
-    },
-  ) %>
+  <%= form_for(@placement, url: placements_school_placement_path(@school, @placement), method: :put) do |f| %>
+    <%= f.govuk_error_summary %>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <span class="govuk-caption-l"><%= t(".caption") %></span>
+
+        <%= f.govuk_radio_buttons_fieldset :subject_ids, legend: { size: "l", text: t(".provider") } do %>
+          <% @providers.each do |provider| %>
+            <%= f.govuk_radio_button :provider_id, provider.id, label: { text: provider.name }, checked: @placement.provider == provider %>
+          <% end %>
+          <%= f.govuk_radio_divider %>
+          <%= f.govuk_radio_button :provider_id, nil, label: { text: t(".not_known") }, checked: @placement.provider.nil?, exclusive: true %>
+        <% end %>
+
+        <%= f.govuk_submit t(".continue") %>
+      </div>
+    </div>
+
+    <%= govuk_details(summary_text: t(".help_with_providers")) do %>
+      <p>
+        <%= t(".details_text_part_one") %>
+        <%= govuk_link_to(
+              t(".details_text_part_two"), placements_school_partner_providers_path(@school), no_visited_state: true
+            ) %>
+      </p>
+    <% end %>
+  <% end %>
 
   <p class="govuk-body">
     <%= govuk_link_to(t(".cancel"), placements_school_placement_path(@school, @placement), no_visited_state: true) %>

--- a/app/views/placements/schools/placements/show.html.erb
+++ b/app/views/placements/schools/placements/show.html.erb
@@ -40,7 +40,7 @@
                 <% end %>
               </ul>
             <% else %>
-              <%= t("placements.schools.placements.not_known_yet") %>
+              <%= t("placements.schools.placements.not_yet_known") %>
             <% end %>
           <% end %>
           <% row.with_action(text: t(".change"), href: edit_mentors_placements_school_placement_path(@school, @placement), visually_hidden_text: t(".attributes.placements.provider")) %>

--- a/app/views/placements/support/schools/placements/show.html.erb
+++ b/app/views/placements/support/schools/placements/show.html.erb
@@ -41,7 +41,7 @@
                 <% end %>
               </ul>
             <% else %>
-              <%= t("placements.schools.placements.not_known_yet") %>
+              <%= t("placements.schools.placements.not_yet_known") %>
             <% end %>
           <% end %>
         <% end %>

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -7,7 +7,7 @@ en:
             phase:
               invalid: Select a phase
             mentor_ids:
-              invalid: Select a mentor or not known
+              invalid: Select a mentor or not yet known
             subject_ids:
               invalid: Select a subject
             provider_id:
@@ -40,7 +40,7 @@ en:
             continue: Continue
             cancel: Cancel
             mentors: Mentors
-            not_known: Not known yet
+            not_known: Not yet known
           check_your_answers:
             title: Check your answers - Add placement
             add_placement: Add placement
@@ -54,18 +54,20 @@ en:
             info_text: When a placement is published, it will be visible to accredited providers and lead partners.
             publish_placement: Publish placement
             cancel: Cancel
-            not_known_yet: Not known yet
+            not_yet_known: Not yet known
           update:
             success: Placement added
         edit_provider:
           title_with_error: "Error: Select a provider"
-          title: Provider - Edit placement
-          caption: Edit Placement
-          edit_placement: Edit placement
+          title: Provider - Manage a placement
+          caption: Manage a placement
           provider: Provider
-          not_known: Not known yet
+          not_known: Not yet known
           continue: Continue
           cancel: Cancel
+          help_with_providers: My provider is not listed
+          details_text_part_one: You will first need to
+          details_text_part_two: add a provider
         edit_mentors:
           title: Mentors - Edit placement
           title_with_error: "Error: Select mentor or not known"
@@ -74,12 +76,12 @@ en:
           continue: Continue
           cancel: Cancel
           mentors: Mentors - Edit Placement
-          not_known: Not known yet
+          not_known: Not yet known
         terms:
           autumn: Autumn
           spring: Spring
           summer: Summer
-        not_known_yet: Not known yet
+        not_yet_known: Not yet known
         index:
           page_title: Placements
           placements: Placements

--- a/spec/components/placement/summary_component_spec.rb
+++ b/spec/components/placement/summary_component_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Placement::SummaryComponent, type: :component do
       expect(page).to have_content("Classics", count: 1)
 
       # Mentor details
-      expect(page).to have_content("Not known yet", count: 2)
+      expect(page).to have_content("Not yet known", count: 2)
     end
   end
 

--- a/spec/decorators/placement_decorator_spec.rb
+++ b/spec/decorators/placement_decorator_spec.rb
@@ -3,10 +3,10 @@ require "rails_helper"
 RSpec.describe PlacementDecorator do
   describe "#mentor_names" do
     context "when the placement has no mentors" do
-      it "returns Not known yet" do
+      it "returns Not yet known" do
         placement = build(:placement)
 
-        expect(placement.decorate.mentor_names).to eq("Not known yet")
+        expect(placement.decorate.mentor_names).to eq("Not yet known")
       end
     end
 
@@ -38,10 +38,10 @@ RSpec.describe PlacementDecorator do
 
   describe "#subject_names" do
     context "when the placement has no subjects" do
-      it "returns Not known yet" do
+      it "returns Not yet known" do
         placement = build(:placement)
 
-        expect(placement.decorate.subject_names).to eq("Not known yet")
+        expect(placement.decorate.subject_names).to eq("Not yet known")
       end
     end
 
@@ -78,7 +78,7 @@ RSpec.describe PlacementDecorator do
       it "returns Not known yet" do
         placement = build(:placement)
 
-        expect(placement.decorate.provider_name).to eq("Not known yet")
+        expect(placement.decorate.provider_name).to eq("Not yet known")
       end
     end
 

--- a/spec/system/placements/providers/placements/view_a_placement_spec.rb
+++ b/spec/system/placements/providers/placements/view_a_placement_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe "Placements / Providers / Placements / View a placement",
 
   def and_i_see_no_mentor_details
     expect(page).to have_content("Mentor details")
-    expect(page).to have_content("Not known yet")
+    expect(page).to have_content("Not yet known")
   end
 
   def and_i_see_contact_details_for_the_school

--- a/spec/system/placements/schools/placements/add_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/add_a_placement_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
       when_i_choose_a_subject(subject_1.name)
       and_i_click_on("Continue")
       then_i_see_the_add_a_placement_mentor_page
-      when_i_check_a_mentor("Not known")
+      when_i_check_a_mentor("Not yet known")
       and_i_click_on("Continue")
       then_i_see_the_check_your_answers_page(school.phase, nil)
       when_i_change_my_mentor
@@ -120,7 +120,7 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
         and_i_click_on("Continue")
         and_i_click_on("Continue")
         then_i_see_the_add_a_placement_mentor_page
-        and_i_see_the_error_message("Select a mentor or not known")
+        and_i_see_the_error_message("Select a mentor or not yet known")
       end
 
       context "when I tamper with the form URL", js: true do
@@ -453,7 +453,7 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
   end
 
   def then_see_that_not_known_is_selected
-    expect(page).to have_checked_field("Not known yet")
+    expect(page).to have_checked_field("Not yet known")
   end
 
   def and_i_cannot_change_the_phase

--- a/spec/system/placements/schools/placements/edit_a_provider_spec.rb
+++ b/spec/system/placements/schools/placements/edit_a_provider_spec.rb
@@ -4,14 +4,16 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
                type: :system, service: :placements do
   let!(:school) { create(:placements_school, name: "School 1", phase: "Primary") }
   let!(:placement) { create(:placement, school:) }
-  let!(:provider_1) { create(:provider, name: "Provider 1") }
-  let!(:provider_2) { create(:provider, name: "Provider 2") }
+  let!(:provider_1) { create(:provider, :placements, name: "Provider 1") }
+  let!(:provider_2) { create(:provider, :placements, name: "Provider 2") }
 
   before do
+    create(:placements_partnership, school:, provider: provider_1)
+    create(:placements_partnership, school:, provider: provider_2)
     given_i_sign_in_as_anne
   end
 
-  context "with no provider", js: true do
+  context "with no provider" do
     scenario "User edits the provider" do
       when_i_visit_the_placement_show_page
       then_i_should_see_the_provider_is_not_known_yet_in_the_placement_details
@@ -52,7 +54,7 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
   end
 
   context "with a provider" do
-    scenario "User edits the provider", js: true do
+    scenario "User edits the provider" do
       given_the_placement_has_a_provider(provider_1)
       when_i_visit_the_placement_show_page
       then_i_should_see_the_provider_name_in_the_placement_details("Provider 1")
@@ -63,15 +65,15 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
       then_i_should_see_the_provider_name_in_the_placement_details("Provider 2")
     end
 
-    scenario "User does not select a provider", js: true do
+    scenario "User does not select a provider" do
       given_the_placement_has_a_provider(provider_1)
       when_i_visit_the_placement_show_page
       then_i_should_see_the_provider_name_in_the_placement_details("Provider 1")
       when_i_click_on_change
       then_i_should_see_the_edit_provider_page
-      when_i_remove_the_provider_from_the_search_box
+      when_i_choose_not_yet_known
       and_i_click_on("Continue")
-      then_i_should_see_the_provider_name_in_the_placement_details("Not known yet")
+      then_i_should_see_the_provider_name_in_the_placement_details("Not yet known")
     end
   end
 
@@ -103,18 +105,17 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
 
   def then_i_should_see_the_provider_is_not_known_yet_in_the_placement_details
     within(".govuk-summary-list") do
-      expect(page).to have_content("Not known yet")
+      expect(page).to have_content("Not yet known")
       expect(page).to have_content("Change")
     end
   end
 
   def then_i_should_see_the_edit_provider_page
-    expect(page).to have_content("Edit placement")
+    expect(page).to have_content("Manage a placement")
   end
 
   def when_i_select_provider_2
-    fill_in "Provider - Edit placement", with: provider_2.name
-    find("#placement-provider-id-field__option--0").click
+    choose provider_2.name
   end
 
   def and_i_click_on(text)
@@ -136,8 +137,8 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
     placement.update!(provider:)
   end
 
-  def when_i_remove_the_provider_from_the_search_box
-    fill_in "Provider - Edit placement", with: ""
+  def when_i_choose_not_yet_known
+    choose "Not yet known"
   end
 
   alias_method :when_i_click_on, :and_i_click_on

--- a/spec/system/placements/schools/placements/edit_mentors_spec.rb
+++ b/spec/system/placements/schools/placements/edit_mentors_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Placements / Schools / Placements / Edit mentors",
   context "with no mentors" do
     scenario "User edits the mentors" do
       when_i_visit_the_placement_show_page
-      then_i_should_see_the_mentor_is_not_known_yet_in_the_placement_details
+      then_i_should_see_the_mentor_is_not_yet_known_in_the_placement_details
       when_i_click_on_change
       then_i_should_see_the_edit_mentors_page
       when_i_select_mentor_2
@@ -25,30 +25,30 @@ RSpec.describe "Placements / Schools / Placements / Edit mentors",
 
     scenario "User does not select a mentor" do
       when_i_visit_the_placement_show_page
-      then_i_should_see_the_mentor_is_not_known_yet_in_the_placement_details
+      then_i_should_see_the_mentor_is_not_yet_known_in_the_placement_details
       when_i_click_on_change
       then_i_should_see_the_edit_mentors_page
       and_i_click_on("Continue")
-      then_i_should_see_the_mentor_is_not_known_yet_in_the_placement_details
+      then_i_should_see_the_mentor_is_not_yet_known_in_the_placement_details
     end
 
     scenario "User edits the mentor and cancels" do
       when_i_visit_the_placement_show_page
-      then_i_should_see_the_mentor_is_not_known_yet_in_the_placement_details
+      then_i_should_see_the_mentor_is_not_yet_known_in_the_placement_details
       when_i_click_on_change
       then_i_should_see_the_edit_mentors_page
       when_i_select_mentor_2
       and_i_click_on("Cancel")
-      then_i_should_see_the_mentor_is_not_known_yet_in_the_placement_details
+      then_i_should_see_the_mentor_is_not_yet_known_in_the_placement_details
     end
 
     scenario "User clicks on back" do
       when_i_visit_the_placement_show_page
-      then_i_should_see_the_mentor_is_not_known_yet_in_the_placement_details
+      then_i_should_see_the_mentor_is_not_yet_known_in_the_placement_details
       when_i_click_on_change
       then_i_should_see_the_edit_mentors_page
       and_i_click_on("Back")
-      then_i_should_see_the_mentor_is_not_known_yet_in_the_placement_details
+      then_i_should_see_the_mentor_is_not_yet_known_in_the_placement_details
     end
   end
 
@@ -70,9 +70,9 @@ RSpec.describe "Placements / Schools / Placements / Edit mentors",
       then_i_should_see_the_mentor_name_in_the_placement_details(mentor_1.full_name)
       when_i_click_on_change
       then_i_should_see_the_edit_mentors_page
-      when_i_select_not_known_yet
+      when_i_select_not_yet_known
       and_i_click_on("Continue")
-      then_i_should_see_the_mentor_name_in_the_placement_details("Not known yet")
+      then_i_should_see_the_mentor_name_in_the_placement_details("Not yet known")
     end
 
     scenario "User edits the mentor and cancels" do
@@ -128,16 +128,16 @@ RSpec.describe "Placements / Schools / Placements / Edit mentors",
     end
   end
 
-  def then_i_should_see_the_mentor_is_not_known_yet_in_the_placement_details
+  def then_i_should_see_the_mentor_is_not_yet_known_in_the_placement_details
     within(".govuk-summary-list") do
-      expect(page).to have_content("Not known yet")
+      expect(page).to have_content("Not yet known")
       expect(page).to have_content("Change")
     end
   end
 
-  def when_i_select_not_known_yet
+  def when_i_select_not_yet_known
     uncheck mentor_1.full_name
-    check "Not known yet"
+    check "Not yet known"
   end
 
   def when_i_click_on(text)

--- a/spec/system/placements/schools/placements/view_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/view_a_placement_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
     scenario "User views a placement with no mentors" do
       given_a_placement_with_no_mentor
       when_i_visit_the_placement_show_page
-      then_i_the_mentor_is_not_known_yet_in_the_placement_details
+      then_i_the_mentor_is_not_yet_known_in_the_placement_details
     end
   end
 
@@ -195,9 +195,9 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
     end
   end
 
-  def then_i_the_mentor_is_not_known_yet_in_the_placement_details
+  def then_i_the_mentor_is_not_yet_known_in_the_placement_details
     within(".govuk-summary-list") do
-      expect(page).to have_content("Not known yet")
+      expect(page).to have_content("Not yet known")
     end
   end
 
@@ -226,7 +226,7 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
   end
 
   def then_i_see_the_provider_in_the_placement_details(provider: nil)
-    provider_text = provider&.name || "Not known yet"
+    provider_text = provider&.name || "Not yet known"
 
     within(".govuk-summary-list") do
       expect(page).to have_content(provider_text)

--- a/spec/system/placements/schools/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/schools/placements/view_placements_list_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Placement school user views a list of placements", type: :system
     scenario "where placement has no mentors attached" do
       given_a_placement_exists
       given_i_sign_in_as_anne
-      then_i_see_mentor_names("Not known yet")
+      then_i_see_mentor_names("Not yet known")
     end
   end
 

--- a/spec/system/placements/support/schools/placements/support_user_views_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/support_user_views_a_placement_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Placements / Support / Schools / Placement / Support User views 
         school_name: "School 1",
         school_level: "Primary",
         subjects: "Maths",
-        mentors: ["Not known"],
+        mentors: ["Not yet known"],
       )
     end
   end


### PR DESCRIPTION
## Context

Now that designs have been provided the "build" version of the page needs updating to match.

## Changes proposed in this pull request

- [x] Updates the manage provider page
- [x] Changes instances of "Not known yet" or "Not known" to "Not yet known" as per designs.

## Guidance to review

Create a placement
View the placement
Click on change next to provider
Make your changes
Click on continue

## Link to Trello card

[Update managing a provider for a placement](https://trello.com/c/vlDrAZt1/301-update-adding-a-provider-to-a-placement)

## Screenshots

<img width="996" alt="image" src="https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/dbbb02e1-7f87-48e0-8881-77943ee3f3bb">

