### PR TITLE
Scope MentorMembershipPolicy destroy? to school

### DIFF
--- a/app/controllers/claims/schools/mentors_controller.rb
+++ b/app/controllers/claims/schools/mentors_controller.rb
@@ -3,7 +3,10 @@ class Claims::Schools::MentorsController < Claims::ApplicationController
 
   before_action :has_school_accepted_grant_conditions?
   before_action :set_mentor, only: %i[show remove destroy]
+  before_action :set_mentor_membership, only: %i[remove destroy]
+
   before_action :authorize_mentor
+  before_action :authorize_mentor_membership
 
   helper_method :mentor_form
 
@@ -42,8 +45,16 @@ class Claims::Schools::MentorsController < Claims::ApplicationController
     @mentor = @school.mentors.find(params.require(:id))
   end
 
+  def set_mentor_membership
+    @mentor_membership = @mentor.mentor_memberships.find_by!(school: @school)
+  end
+
   def authorize_mentor
     authorize @mentor || Claims::Mentor
+  end
+
+  def authorize_mentor_membership
+    authorize @mentor_membership || Claims::MentorMembership
   end
 
   def default_params

--- a/app/controllers/claims/support/schools/mentors_controller.rb
+++ b/app/controllers/claims/support/schools/mentors_controller.rb
@@ -2,6 +2,9 @@ class Claims::Support::Schools::MentorsController < Claims::Support::Application
   include Claims::BelongsToSchool
 
   before_action :set_mentor, only: %i[show remove destroy]
+  before_action :set_mentor_membership, only: %i[remove destroy]
+
+  before_action :authorize_mentor_membership
   before_action :authorize_mentor
 
   helper_method :mentor_form
@@ -41,8 +44,16 @@ class Claims::Support::Schools::MentorsController < Claims::Support::Application
     @mentor = @school.mentors.find(params.require(:id))
   end
 
+  def set_mentor_membership
+    @mentor_membership = @mentor.mentor_memberships.find_by!(school: @school)
+  end
+
   def authorize_mentor
     authorize @mentor || Claims::Mentor
+  end
+
+  def authorize_mentor_membership
+    authorize @mentor_membership || Claims::MentorMembership
   end
 
   def default_params

--- a/app/policies/claims/mentor_membership_policy.rb
+++ b/app/policies/claims/mentor_membership_policy.rb
@@ -1,0 +1,9 @@
+class Claims::MentorMembershipPolicy < Claims::ApplicationPolicy
+  def destroy?
+    !Claims::Claim.active.joins(:mentor_trainings).where(mentor_trainings: { mentor_id: record.mentor_id }).where(claims: { school_id: record.school_id }).exists?
+  end
+
+  def remove?
+    true
+  end
+end

--- a/app/policies/claims/mentor_policy.rb
+++ b/app/policies/claims/mentor_policy.rb
@@ -1,9 +1,5 @@
 class Claims::MentorPolicy < Claims::ApplicationPolicy
   def destroy?
-    !Claims::Claim.active.joins(:mentor_trainings).where(mentor_trainings: { mentor_id: record }).exists?
-  end
-
-  def remove?
     true
   end
 end

--- a/app/views/claims/schools/mentors/remove.html.erb
+++ b/app/views/claims/schools/mentors/remove.html.erb
@@ -4,7 +4,7 @@
   <%= govuk_back_link(href: claims_school_mentor_path(id: @mentor.id)) %>
 <% end %>
 
-<% if policy(@mentor).destroy? %>
+<% if policy(@mentor_membership).destroy? %>
   <%= render partial: "claims/schools/mentors/remove_mentor" %>
 <% else %>
   <%= render partial: "claims/schools/mentors/cannot_remove_mentor" %>

--- a/app/views/claims/support/schools/mentors/remove.html.erb
+++ b/app/views/claims/support/schools/mentors/remove.html.erb
@@ -4,7 +4,7 @@
   <%= govuk_back_link(href: claims_support_school_mentor_path(id: @mentor.id)) %>
 <% end %>
 
-<% if policy(@mentor).destroy? %>
+<% if policy(@mentor_membership).destroy? %>
   <%= render partial: "claims/schools/mentors/remove_mentor" %>
 <% else %>
   <%= render partial: "claims/schools/mentors/cannot_remove_mentor" %>


### PR DESCRIPTION
We need to scope to the school. So to active claims of a school can't have that mentor. Not all active claims.