### PR TITLE
Always show pence, even when amount is a whole pound

### DIFF
--- a/config/initializers/money.rb
+++ b/config/initializers/money.rb
@@ -20,6 +20,8 @@ MoneyRails.configure do |config|
     null: false,
     default: "GBP",
   }
+
+  config.no_cents_if_whole = false
 end
 
 Money.locale_backend = :i18n

--- a/spec/components/claim/card_component_spec.rb
+++ b/spec/components/claim/card_component_spec.rb
@@ -22,6 +22,6 @@ RSpec.describe Claim::CardComponent, type: :component do
 
     expect(page).to have_content(claim.provider.name)
     expect(page).to have_content("08/04/2024")
-    expect(page).to have_content("£1,072")
+    expect(page).to have_content("£1,072.00")
   end
 end


### PR DESCRIPTION
## Context

We want to always show `.00` in monetary values.

## Changes proposed in this pull request

- Set `no_cents_if_whole` to `false`.

## Guidance to review

- Whole pound values should now show `.00`. i.e. `£123` will be displayed as `£123.00`
