### PR TITLE
Fix review app cancelling issue

### DIFF
--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -7,7 +7,7 @@ on:
     types:
     - closed
 
-concurrency: deploy-${{ github.ref }}
+concurrency: deploy-${{ github.event.number }}
 
 jobs:
   build:

--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
     - main
+    - feature/1788-ittms-fix-delete
     types:
     - closed
 

--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -13,7 +13,7 @@ concurrency: deploy-${{ github.event.number }}
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy') }}
+    # if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy') }}
     environment: review
 
     steps:

--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -12,9 +12,9 @@ on:
 
 jobs:
   delete-review-app:
-    name: Delete Review App ${{ github.event.pull_request.number }}
+    name: Delete Review App ${{ github.event.number }}
     concurrency: deploy-${{ github.event.pull_request.number}}
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'dependencies') }}
+    # if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'dependencies') }}
     runs-on: ubuntu-latest
     environment: review
     steps:

--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -8,14 +8,15 @@ on:
     types:
     - closed
 
-concurrency: deploy-${{ github.event.number }}
+
 
 jobs:
-  build:
+  delete-review-app:
+    name: Delete Review App ${{ github.event.pull_request.number }}
+    concurrency: deploy-${{ github.event.pull_request.number}}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'dependencies') }}
     runs-on: ubuntu-latest
-    # if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy') }}
     environment: review
-
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
WHY: This happens because the concurrency is based on the branch
HOW: By basing the concurrency on the PR number

## Context

The review apps delete workflow gets cancelled atimes due to concurrency

## Changes proposed in this pull request

 basing the concurrency on the PR number like other services

## Guidance to review

close the pr and see if it deletes and reopen later

## Link to Trello card

https://trello.com/c/FIHMmqbA/1788-ittms-fix-delete-review-app
