### PR TITLE
Fix review app cancelling issue

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -31,6 +31,7 @@ jobs:
 
   deploy_review:
     name: Deploy to review environment
+    concurrency: deploy_review_${{ github.event.pull_request.number }}
     runs-on: ubuntu-latest
     if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy') }}
     needs: [build]

--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -7,14 +7,13 @@ on:
     types:
     - closed
 
-concurrency: deploy-${{ github.ref }}
-
 jobs:
-  build:
+  delete-review-app:
+    name: Delete Review App ${{ github.event.pull_request.number }}
+    concurrency: deploy_review_${{ github.event.pull_request.number }}
     runs-on: ubuntu-latest
     if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy') }}
     environment: review
-
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION

Context
The review apps delete workflow gets cancelled atimes due to concurrency

Changes proposed in this pull request
basing the concurrency on the PR number like other services

Guidance to review
close the pr and see if it deletes and reopen later

Link to Trello card
https://trello.com/c/FIHMmqbA/1788-ittms-fix-delete-review-app