### PR TITLE
Add mentors empty state page for claim flow

### DIFF
--- a/app/controllers/claims/schools/claims/mentors_controller.rb
+++ b/app/controllers/claims/schools/claims/mentors_controller.rb
@@ -8,13 +8,17 @@ class Claims::Schools::Claims::MentorsController < Claims::ApplicationController
 
   def create
     if claim_mentors_form.save
-      redirect_to(
-        edit_claims_school_claim_mentor_training_path(
-          @school,
-          claim,
-          claim.mentor_trainings.without_hours.first,
-        ),
-      )
+      if claim.mentor_trainings.without_hours.any?
+        redirect_to(
+          edit_claims_school_claim_mentor_training_path(
+            @school,
+            claim,
+            claim.mentor_trainings.without_hours.first,
+          ),
+        )
+      else
+        redirect_to check_claims_school_claim_path(@school, claim)
+      end
     else
       render :new
     end

--- a/app/views/claims/schools/claims/check.html.erb
+++ b/app/views/claims/schools/claims/check.html.erb
@@ -27,6 +27,7 @@
                                @school,
                                @claim,
                              ),
+                             visually_hidden_text: Claims::Claim.human_attribute_name(:accredited_provider),
                              html_attributes: {
                                class: "govuk-link--no-visited-state",
                              }) %>
@@ -43,6 +44,7 @@
           <% end %>
           <% row.with_action(text: t("change"),
                              href: edit_claims_school_claim_mentor_path(@school, @claim),
+                             visually_hidden_text: Claims::Claim.human_attribute_name(:mentors),
                              html_attributes: {
                                class: "govuk-link--no-visited-state",
                              }) %>
@@ -62,6 +64,7 @@
                                  @claim,
                                  mentor_training,
                                ),
+                               visually_hidden_text: "Hours of training for #{mentor_training.mentor.full_name}",
                                html_attributes: {
                                  class: "govuk-link--no-visited-state",
                                }) %>

--- a/app/views/claims/schools/claims/mentors/_form.html.erb
+++ b/app/views/claims/schools/claims/mentors/_form.html.erb
@@ -1,9 +1,11 @@
-  <%= form_with model: claim_mentors_form, url: form_url, method: do |f| %>
-    <%= f.govuk_error_summary %>
+<%= form_with model: claim_mentors_form, url: form_url, method: do |f| %>
+  <%= f.govuk_error_summary %>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <span class="govuk-caption-l"><%= t(".add_claim") %></span>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".add_claim") %></span>
+
+      <% if claim_mentors_form.mentors_with_claimable_hours.any? %>
         <h1 class="govuk-heading-l"><%= t(".heading", provider_name: claim_mentors_form.claim.provider_name) %></h1>
 
         <%= render Claims::Claim::MentorsForm::DisclaimerComponent.new(mentors_form: claim_mentors_form) %>
@@ -19,8 +21,21 @@
         ) %>
 
         <%= f.govuk_submit t("continue") %>
+
         <p class="govuk-body">
           <%= govuk_link_to(t("cancel"), claims_school_claims_path(school), no_visited_state: true) %>
         </p>
+      <% else %>
+        <h1 class="govuk-heading-l"><%= t(".heading_empty", provider_name: claim_mentors_form.claim.provider_name) %></h1>
+
+        <p class="govuk-body">
+          <%= t(".no_mentors_with_claimable_hours", provider_name: claim_mentors_form.claim.provider_name) %>
+        </p>
+
+        <p class="govuk-body">
+          <%= govuk_link_to t(".change_provider"), new_claims_school_claim_path(school, id: claim_mentors_form.claim.id) %>
+        </p>
+      <% end %>
     </div>
-  <% end %>
+  </div>
+<% end %>

--- a/app/views/claims/support/schools/claims/check.html.erb
+++ b/app/views/claims/support/schools/claims/check.html.erb
@@ -22,6 +22,7 @@
                                @school,
                                @claim,
                              ),
+                             visually_hidden_text: Claims::Claim.human_attribute_name(:accredited_provider),
                              html_attributes: {
                                class: "govuk-link--no-visited-state",
                              }) %>
@@ -38,6 +39,7 @@
           <% end %>
           <% row.with_action(text: t("change"),
                              href: edit_claims_support_school_claim_mentor_path(@school, @claim),
+                             visually_hidden_text: Claims::Claim.human_attribute_name(:mentors),
                              html_attributes: {
                                class: "govuk-link--no-visited-state",
                              }) %>
@@ -57,6 +59,7 @@
                                  @claim,
                                  mentor_training,
                                ),
+                               visually_hidden_text: "Hours of training for #{mentor_training.mentor.full_name}",
                                html_attributes: {
                                  class: "govuk-link--no-visited-state",
                                }) %>

--- a/app/views/claims/support/schools/claims/mentors/_form.html.erb
+++ b/app/views/claims/support/schools/claims/mentors/_form.html.erb
@@ -1,9 +1,11 @@
-  <%= form_with model: claim_mentors_form, url: form_url, method: do |f| %>
-    <%= f.govuk_error_summary %>
+<%= form_with model: claim_mentors_form, url: form_url, method: do |f| %>
+  <%= f.govuk_error_summary %>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <span class="govuk-caption-l"><%= t(".add_claim", school: @school.name) %></span>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".add_claim", school: @school.name) %></span>
+
+      <% if claim_mentors_form.mentors_with_claimable_hours.any? %>
         <h1 class="govuk-heading-l"><%= t(".heading", provider_name: claim_mentors_form.claim.provider_name) %></h1>
 
         <%= render Claims::Claim::MentorsForm::DisclaimerComponent.new(mentors_form: claim_mentors_form) %>
@@ -19,8 +21,21 @@
         ) %>
 
         <%= f.govuk_submit t("continue") %>
+
         <p class="govuk-body">
           <%= govuk_link_to(t("cancel"), claims_support_school_claims_path(school), no_visited_state: true) %>
         </p>
+      <% else %>
+        <h1 class="govuk-heading-l"><%= t(".heading_empty", provider_name: claim_mentors_form.claim.provider_name) %></h1>
+
+        <p class="govuk-body">
+          <%= t(".no_mentors_with_claimable_hours", provider_name: claim_mentors_form.claim.provider_name) %>
+        </p>
+
+        <p class="govuk-body">
+          <%= govuk_link_to t(".change_provider"), new_claims_school_claim_path(school, id: claim_mentors_form.claim.id) %>
+        </p>
+      <% end %>
     </div>
-  <% end %>
+  </div>
+<% end %>

--- a/config/locales/en/claims/schools/claims/mentors.yml
+++ b/config/locales/en/claims/schools/claims/mentors.yml
@@ -5,9 +5,12 @@ en:
         mentors:
           form:
             heading: Mentors for %{provider_name}
+            heading_empty: No mentors for %{provider_name}
             label: Mentor
             select_all_that_apply: Select all that apply
             add_claim: Add claim
+            no_mentors_with_claimable_hours: There are no mentors you can include in a claim because they have already had 20 hours of training claimed for with %{provider_name}.
+            change_provider: Change the accredited provider
           new:
             page_title: Mentor - Add claim
           edit:

--- a/config/locales/en/claims/support/schools/claims/mentors.yml
+++ b/config/locales/en/claims/support/schools/claims/mentors.yml
@@ -6,9 +6,12 @@ en:
           mentors:
             form:
               heading: Mentors for %{provider_name}
+              heading_empty: No mentors for %{provider_name}
               label: Mentor
               select_all_that_apply: Select all that apply
               add_claim: Add claim - %{school}
+              no_mentors_with_claimable_hours: There are no mentors you can include in a claim because they have already had 20 hours of training claimed for with %{provider_name}.
+              change_provider: Change the accredited provider
             new:
               page_title: Mentor - Add claim
             edit:

--- a/spec/system/claims/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/schools/claims/create_claim_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Create claim", type: :system, service: :claims do
       user_memberships: [create(:user_membership, organisation: school)],
     )
   end
-  let!(:provider) { create(:claims_provider, :best_practice_network) }
+  let!(:bpn) { create(:claims_provider, :best_practice_network) }
 
   before do
     user_exists_in_dfe_sign_in(user: anne)
@@ -20,7 +20,7 @@ RSpec.describe "Create claim", type: :system, service: :claims do
 
   scenario "Anne creates a claim" do
     when_i_click("Add claim")
-    when_i_choose_a_provider(provider)
+    when_i_choose_a_provider(bpn)
     when_i_click("Continue")
     when_i_select_all_mentors
     when_i_click("Continue")
@@ -42,7 +42,7 @@ RSpec.describe "Create claim", type: :system, service: :claims do
 
   scenario "Anne creates a claim with mentor training hours over the maximum limit per provider" do
     when_i_click("Add claim")
-    when_i_choose_a_provider(provider)
+    when_i_choose_a_provider(bpn)
     when_i_click("Continue")
     when_i_select_all_mentors
     when_i_click("Continue")
@@ -62,7 +62,7 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     when_i_click("Add claim")
     when_i_click("Continue")
     then_i_see_the_error("Select a provider")
-    when_i_choose_a_provider(provider)
+    when_i_choose_a_provider(bpn)
     when_i_click("Continue")
     when_i_click("Continue")
     then_i_see_the_error("Select a mentor")
@@ -86,7 +86,7 @@ RSpec.describe "Create claim", type: :system, service: :claims do
 
   scenario "Anne creates a claim and tries to edit it" do
     when_i_click("Add claim")
-    when_i_choose_a_provider(provider)
+    when_i_choose_a_provider(bpn)
     when_i_click("Continue")
     when_i_select_a_mentor(mentor1)
     when_i_click("Continue")
@@ -99,9 +99,9 @@ RSpec.describe "Create claim", type: :system, service: :claims do
   end
 
   scenario "School attempts to create a claim when their mentors have all been claimed for" do
-    given_my_school_has_fully_claimed_for_all_mentors_for_provider(provider)
+    given_my_school_has_fully_claimed_for_all_mentors_for_provider(bpn)
     when_i_click("Add claim")
-    when_i_choose_a_provider(provider)
+    when_i_choose_a_provider(bpn)
     when_i_click("Continue")
     then_i_should_see_the_message("There are no mentors you can include in a claim because they have already had 20 hours of training claimed for with Best Practice Network.")
   end
@@ -161,7 +161,7 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     within("dl.govuk-summary-list:nth(1)") do
       within(".govuk-summary-list__row:nth(2)") do
         expect(page).to have_content("Accredited provider")
-        expect(page).to have_content(provider.name)
+        expect(page).to have_content(bpn.name)
       end
 
       within(".govuk-summary-list__row:nth(3)") do
@@ -240,9 +240,9 @@ RSpec.describe "Create claim", type: :system, service: :claims do
   end
 
   def when_another_claim_with_same_mentors_has_been_created(mentors)
-    claim = create(:claim, :submitted, provider:)
+    claim = create(:claim, :submitted, provider: bpn)
     mentors.each do |mentor|
-      create(:mentor_training, claim:, hours_completed: 20, mentor:, provider:)
+      create(:mentor_training, claim:, hours_completed: 20, mentor:, provider: bpn)
     end
   end
 

--- a/spec/system/claims/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/schools/claims/create_claim_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     )
   end
   let!(:bpn) { create(:claims_provider, :best_practice_network) }
+  let!(:niot) { create(:claims_provider, :niot) }
 
   before do
     user_exists_in_dfe_sign_in(user: anne)
@@ -104,6 +105,28 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     when_i_choose_a_provider(bpn)
     when_i_click("Continue")
     then_i_should_see_the_message("There are no mentors you can include in a claim because they have already had 20 hours of training claimed for with Best Practice Network.")
+  end
+
+  scenario "School attempts to create a claim then changes the provider to an invalid one" do
+    given_my_school_has_fully_claimed_for_all_mentors_for_provider(bpn)
+    when_i_click("Add claim")
+    when_i_choose_a_provider(niot)
+    when_i_click("Continue")
+    when_i_select_a_mentor(mentor1)
+    when_i_click("Continue")
+    then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor1)
+    when_i_add_training_hours("20 hours")
+    when_i_click("Continue")
+    when_i_click("Change Accredited provider")
+    when_i_choose_a_provider(bpn)
+    when_i_click("Continue")
+    when_i_click("Change Mentors")
+    then_i_should_see_the_message("There are no mentors you can include in a claim because they have already had 20 hours of training claimed for with Best Practice Network.")
+    when_i_click("Change the accredited provider")
+    when_i_choose_a_provider(niot)
+    when_i_click("Continue")
+    when_i_click("Continue")
+    then_i_should_land_on_the_check_page
   end
 
   private
@@ -252,5 +275,9 @@ RSpec.describe "Create claim", type: :system, service: :claims do
 
   def then_i_should_see_the_message(message)
     expect(page).to have_content(message)
+  end
+
+  def then_i_should_land_on_the_check_page
+    expect(page).to have_content "Check your answers"
   end
 end

--- a/spec/system/claims/support/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/create_claim_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Create claim", type: :system, service: :claims do
       user_memberships: [create(:user_membership, organisation: school)],
     )
   end
-  let!(:provider) { create(:claims_provider, :best_practice_network) }
+  let!(:bpn) { create(:claims_provider, :best_practice_network) }
 
   before do
     user_exists_in_dfe_sign_in(user: colin)
@@ -22,7 +22,7 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     when_i_click(school.name)
     when_i_click_on_claims
     when_i_click("Add claim")
-    when_i_choose_a_provider(provider)
+    when_i_choose_a_provider(bpn)
     when_i_click("Continue")
     when_i_select_all_mentors
     when_i_click("Continue")
@@ -46,7 +46,7 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     when_i_click(school.name)
     when_i_click_on_claims
     when_i_click("Add claim")
-    when_i_choose_a_provider(provider)
+    when_i_choose_a_provider(bpn)
     when_i_click("Continue")
     when_i_select_all_mentors
     when_i_click("Continue")
@@ -68,7 +68,7 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     when_i_click("Add claim")
     when_i_click("Continue")
     then_i_see_the_error("Select a provider")
-    when_i_choose_a_provider(provider)
+    when_i_choose_a_provider(bpn)
     when_i_click("Continue")
     when_i_click("Continue")
     then_i_see_the_error("Select a mentor")
@@ -91,11 +91,11 @@ RSpec.describe "Create claim", type: :system, service: :claims do
   end
 
   scenario "School attempts to create a claim when their mentors have all been claimed for" do
-    given_my_school_has_fully_claimed_for_all_mentors_for_provider(provider)
+    given_my_school_has_fully_claimed_for_all_mentors_for_provider(bpn)
     when_i_click(school.name)
     when_i_click_on_claims
     when_i_click("Add claim")
-    when_i_choose_a_provider(provider)
+    when_i_choose_a_provider(bpn)
     when_i_click("Continue")
     then_i_should_see_the_message("There are no mentors you can include in a claim because they have already had 20 hours of training claimed for with Best Practice Network.")
   end
@@ -156,7 +156,7 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     within("dl.govuk-summary-list:nth(1)") do
       within(".govuk-summary-list__row:nth(1)") do
         expect(page).to have_content("Accredited provider")
-        expect(page).to have_content(provider.name)
+        expect(page).to have_content(bpn.name)
       end
 
       within(".govuk-summary-list__row:nth(2)") do
@@ -203,9 +203,9 @@ RSpec.describe "Create claim", type: :system, service: :claims do
   end
 
   def when_another_claim_with_same_mentors_has_been_created(mentors)
-    claim = create(:claim, :submitted, provider:)
+    claim = create(:claim, :submitted, provider: bpn)
     mentors.each do |mentor|
-      create(:mentor_training, claim:, hours_completed: 20, mentor:, provider:)
+      create(:mentor_training, claim:, hours_completed: 20, mentor:, provider: bpn)
     end
   end
 

--- a/spec/system/claims/support/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/create_claim_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     )
   end
   let!(:bpn) { create(:claims_provider, :best_practice_network) }
+  let!(:niot) { create(:claims_provider, :niot) }
 
   before do
     user_exists_in_dfe_sign_in(user: colin)
@@ -100,6 +101,30 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     then_i_should_see_the_message("There are no mentors you can include in a claim because they have already had 20 hours of training claimed for with Best Practice Network.")
   end
 
+  scenario "School attempts to create a claim then changes the provider to an invalid one" do
+    given_my_school_has_fully_claimed_for_all_mentors_for_provider(bpn)
+    when_i_click(school.name)
+    when_i_click_on_claims
+    when_i_click("Add claim")
+    when_i_choose_a_provider(niot)
+    when_i_click("Continue")
+    when_i_select_a_mentor(mentor1)
+    when_i_click("Continue")
+    then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor1)
+    when_i_add_training_hours("20 hours")
+    when_i_click("Continue")
+    when_i_click("Change Accredited provider")
+    when_i_choose_a_provider(bpn)
+    when_i_click("Continue")
+    when_i_click("Change Mentors")
+    then_i_should_see_the_message("There are no mentors you can include in a claim because they have already had 20 hours of training claimed for with Best Practice Network.")
+    when_i_click("Change the accredited provider")
+    when_i_choose_a_provider(niot)
+    when_i_click("Continue")
+    when_i_click("Continue")
+    then_i_should_land_on_the_check_page
+  end
+
   private
 
   def given_i_sign_in
@@ -130,6 +155,10 @@ RSpec.describe "Create claim", type: :system, service: :claims do
   def when_i_select_all_mentors
     page.check(mentor1.full_name)
     page.check(mentor2.full_name)
+  end
+
+  def when_i_select_a_mentor(mentor)
+    page.check(mentor.full_name)
   end
 
   def then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor)
@@ -215,5 +244,9 @@ RSpec.describe "Create claim", type: :system, service: :claims do
 
   def then_i_should_see_the_message(message)
     expect(page).to have_content(message)
+  end
+
+  def then_i_should_land_on_the_check_page
+    expect(page).to have_content "Check your answers"
   end
 end


### PR DESCRIPTION
## Context

When a User attempts to select mentors for a claim that have all fully been claimed for with the provider selected, we should show a message that stops users from proceeding further.

## Changes proposed in this pull request

- Add a variant of the mentor select page that shows an error message when 
- Update `spec/system/claims/support/schools/claims/create_claim_spec.rb` to only create a single school. This removes the flakiness of this spec suite when it randomly creates 2 schools with the same name.

## Guidance to review

- Fully claim all hours for a school's mentors against a provider.
- Try to claim for a mentor against that provider.
- It should say that you have no mentors you can claim for.

## Screenshots

![CleanShot 2024-05-01 at 15 25 15](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/d76511b3-8851-4337-bade-3ffa5896ef38)

https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/13de0a64-6395-4472-a110-44646b26aea2
