### PR TITLE
Add nonce to <script> tags to comply with CSP header

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
   </head>
 
   <body class="govuk-template__body">
-    <script>
+    <script nonce="<%= content_security_policy_nonce %>">
       document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
     </script>
 

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -19,7 +19,7 @@
   </head>
 
   <body class="govuk-template__body">
-    <script>
+    <script nonce="<%= content_security_policy_nonce %>">
       document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
     </script>
 


### PR DESCRIPTION
## Context

Our `<script>` tags are failing to run due to the introduced CSP headers. Introducing a `nonce` attribute will allow our inline script to run.

Read more: https://content-security-policy.com/nonce/

```
Refused to execute inline script because it violates the following Content Security Policy directive: "script-src 'self' https: 'nonce-0a72447c9cb151a11bd8f9e838221385'". Either the 'unsafe-inline' keyword, a hash ('sha256-B7RcigeAzKunsdJAeUuN6QlBWFIF5z5Tq/oPFk4GrLM='), or a nonce ('nonce-...') is required to enable inline execution.
```

This will then prevent the `govuk-frontend-supported` class from being added to the document body.

```
SupportError: GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet
```

Which prevents GOV.UK Frontend JavaScript from registering correctly.

## Changes proposed in this pull request

- ~Convert `<script>` tags into Rails' `javascript_tag` helper with `nonce: true`.~
  
  Turns out that ERB Lint doesn't like `javascript_tag`.

- Add `nonce="<%= content_security_policy_nonce %>"` to `<script>` tags.

## Guidance to review

- Try removing the `nonce` attribute and you'll see errors in the JS console.

## Screenshots

| Before | After |
| ------ | ----- |
| ![CleanShot 2024-05-02 at 06 59 22](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/38216551-4081-4e89-a885-744b9559c69e) | ![CleanShot 2024-05-02 at 06 59 29](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/064062f7-9a91-4cdd-a6af-ae094a861536) |
