### PR TITLE
Fix back link when creating a claim

### DIFF
--- a/app/controllers/claims/schools/claims_controller.rb
+++ b/app/controllers/claims/schools/claims_controller.rb
@@ -25,6 +25,7 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
 
   def check
     last_mentor_training = @claim.mentor_trainings.order_by_mentor_full_name.last
+    Claims::Claim::Review.call(claim: @claim)
 
     @back_path = edit_claims_school_claim_mentor_training_path(
       @school,
@@ -38,7 +39,7 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
 
   def update
     if claim_provider_form.save
-      redirect_to check_claims_school_claim_path(@school, claim_provider_form.claim)
+      redirect_to claim_provider_form.update_success_path
     else
       render :edit
     end

--- a/app/controllers/claims/support/schools/claims_controller.rb
+++ b/app/controllers/claims/support/schools/claims_controller.rb
@@ -31,6 +31,7 @@ class Claims::Support::Schools::ClaimsController < Claims::Support::ApplicationC
 
   def check
     last_mentor_training = @claim.mentor_trainings.order_by_mentor_full_name.last
+    Claims::Claim::Review.call(claim: @claim)
 
     @back_path = edit_claims_support_school_claim_mentor_training_path(
       @school,
@@ -47,7 +48,7 @@ class Claims::Support::Schools::ClaimsController < Claims::Support::ApplicationC
 
   def update
     if claim_provider_form.save
-      redirect_to check_claims_support_school_claim_path(@school, claim_provider_form.claim)
+      redirect_to claim_provider_form.update_success_path
     else
       render :edit
     end
@@ -67,7 +68,7 @@ class Claims::Support::Schools::ClaimsController < Claims::Support::ApplicationC
   private
 
   def claim_params
-    params.require(:claims_claim_provider_form)
+    params.require(:claims_support_claim_provider_form)
       .permit(:id, :provider_id)
       .merge(default_params)
   end
@@ -86,10 +87,10 @@ class Claims::Support::Schools::ClaimsController < Claims::Support::ApplicationC
 
   def claim_provider_form
     @claim_provider_form ||=
-      if params[:claims_claim_provider_form].present?
-        Claims::Claim::ProviderForm.new(claim_params)
+      if params[:claims_support_claim_provider_form].present?
+        Claims::Support::Claim::ProviderForm.new(claim_params)
       else
-        Claims::Claim::ProviderForm.new(default_params.merge(id: claim_id))
+        Claims::Support::Claim::ProviderForm.new(default_params.merge(id: claim_id))
       end
   end
 

--- a/app/forms/claims/claim/mentors_form.rb
+++ b/app/forms/claims/claim/mentors_form.rb
@@ -17,6 +17,14 @@ class Claims::Claim::MentorsForm < ApplicationForm
     claim.save!
   end
 
+  def edit_back_path
+    if claim.reviewed?
+      check_claims_school_claim_path(claim.school, claim)
+    else
+      edit_claims_school_claim_path(claim.school, claim)
+    end
+  end
+
   def update_success_path
     if claim.mentor_trainings.without_hours.any?
       edit_claims_school_claim_mentor_training_path(

--- a/app/forms/claims/claim/provider_form.rb
+++ b/app/forms/claims/claim/provider_form.rb
@@ -10,7 +10,7 @@ class Claims::Claim::ProviderForm < ApplicationForm
   end
 
   def persist
-    return if claim.provider_id == provider_id
+    return true if claim.provider_id == provider_id
 
     ActiveRecord::Base.transaction do
       claim.provider_id = provider_id
@@ -18,6 +18,22 @@ class Claims::Claim::ProviderForm < ApplicationForm
       claim.status = :internal_draft if claim.status.nil?
       claim.created_by ||= current_user
       claim.save!
+    end
+  end
+
+  def edit_back_path
+    if claim.reviewed?
+      check_claims_school_claim_path(claim.school, claim)
+    else
+      claims_school_claims_path(claim.school)
+    end
+  end
+
+  def update_success_path
+    if claim.reviewed?
+      check_claims_school_claim_path(claim.school, claim)
+    else
+      edit_claims_school_claim_mentors_path(claim.school, claim)
     end
   end
 

--- a/app/forms/claims/support/claim/mentors_form.rb
+++ b/app/forms/claims/support/claim/mentors_form.rb
@@ -1,4 +1,12 @@
 class Claims::Support::Claim::MentorsForm < Claims::Claim::MentorsForm
+  def edit_back_path
+    if claim.reviewed?
+      check_claims_support_school_claim_path(claim.school, claim)
+    else
+      edit_claims_support_school_claim_path(claim.school, claim)
+    end
+  end
+
   def update_success_path
     if claim.mentor_trainings.without_hours.any?
       edit_claims_support_school_claim_mentor_training_path(

--- a/app/forms/claims/support/claim/provider_form.rb
+++ b/app/forms/claims/support/claim/provider_form.rb
@@ -1,0 +1,17 @@
+class Claims::Support::Claim::ProviderForm < Claims::Claim::ProviderForm
+  def edit_back_path
+    if claim.reviewed?
+      check_claims_support_school_claim_path(claim.school, claim)
+    else
+      claims_support_school_claims_path(claim.school)
+    end
+  end
+
+  def update_success_path
+    if claim.reviewed?
+      check_claims_support_school_claim_path(claim.school, claim)
+    else
+      edit_claims_support_school_claim_mentors_path(claim.school, claim)
+    end
+  end
+end

--- a/app/models/claims/claim.rb
+++ b/app/models/claims/claim.rb
@@ -14,6 +14,7 @@
 #  provider_id       :uuid
 #  school_id         :uuid             not null
 #  submitted_by_id   :uuid
+#  reviewed             :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/services/claims/claim/review.rb
+++ b/app/services/claims/claim/review.rb
@@ -1,0 +1,15 @@
+class Claims::Claim::Review
+  include ServicePattern
+
+  def initialize(claim:)
+    @claim = claim
+  end
+
+  def call
+    claim.update!(reviewed: true)
+  end
+
+  private
+
+  attr_reader :claim
+end

--- a/app/views/claims/schools/claims/edit.html.erb
+++ b/app/views/claims/schools/claims/edit.html.erb
@@ -2,7 +2,7 @@
 <% render "claims/schools/primary_navigation", school: @school, current: :claims %>
 
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: check_claims_school_claim_path(@school, claim_provider_form.claim)) %>
+  <%= govuk_back_link(href: claim_provider_form.edit_back_path) %>
 <% end %>
 
 <div class="govuk-width-container">

--- a/app/views/claims/schools/claims/mentors/edit.html.erb
+++ b/app/views/claims/schools/claims/mentors/edit.html.erb
@@ -2,7 +2,7 @@
 <% render "claims/schools/primary_navigation", school: @school, current: :claims %>
 
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: check_claims_school_claim_path(@school, claim_mentors_form.claim)) %>
+  <%= govuk_back_link(href: claim_mentors_form.edit_back_path) %>
 <% end %>
 
 <div class="govuk-width-container">

--- a/app/views/claims/support/schools/claims/edit.html.erb
+++ b/app/views/claims/support/schools/claims/edit.html.erb
@@ -2,7 +2,7 @@
 <% render "claims/support/primary_navigation", current: :organisations %>
 
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: check_claims_support_school_claim_path(@school, claim_provider_form.claim)) %>
+  <%= govuk_back_link(href: claim_provider_form.edit_back_path) %>
 <% end %>
 
 <div class="govuk-width-container">

--- a/app/views/claims/support/schools/claims/mentors/edit.html.erb
+++ b/app/views/claims/support/schools/claims/mentors/edit.html.erb
@@ -2,7 +2,7 @@
 <% render "claims/support/primary_navigation", current: :organisations %>
 
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: check_claims_support_school_claim_path(@school, claim_mentors_form.claim)) %>
+  <%= govuk_back_link(href: claim_mentors_form.edit_back_path) %>
 <% end %>
 
 <div class="govuk-width-container">

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -88,6 +88,7 @@ shared:
     - status
     - submitted_by_type
     - submitted_by_id
+    - reviewed
   :schools:
     - id
     - urn

--- a/db/migrate/20240501065503_add_reviewed_by_user_to_claim.rb
+++ b/db/migrate/20240501065503_add_reviewed_by_user_to_claim.rb
@@ -1,0 +1,5 @@
+class AddReviewedByUserToClaim < ActiveRecord::Migration[7.1]
+  def change
+    add_column(:claims, :reviewed, :boolean, default: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_29_133246) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_01_065503) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -58,6 +58,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_29_133246) do
     t.enum "status", enum_type: "claim_status"
     t.string "submitted_by_type"
     t.uuid "submitted_by_id"
+    t.boolean "reviewed", default: false
     t.index ["created_by_type", "created_by_id"], name: "index_claims_on_created_by"
     t.index ["provider_id"], name: "index_claims_on_provider_id"
     t.index ["reference"], name: "index_claims_on_reference", unique: true

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -14,6 +14,7 @@
 #  provider_id       :uuid
 #  school_id         :uuid             not null
 #  submitted_by_id   :uuid
+#  reviewed             :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/forms/claims/claim/mentors_form_spec.rb
+++ b/spec/forms/claims/claim/mentors_form_spec.rb
@@ -58,4 +58,27 @@ describe Claims::Claim::MentorsForm, type: :model do
       end
     end
   end
+
+  describe "#edit_back_path" do
+    context "when reviewed is false" do
+      it "returns the path to the mentor training hours form" do
+        form = described_class.new(claim:)
+
+        expect(form.edit_back_path).to eq(
+          "/schools/#{claim.school.id}/claims/#{claim.id}/edit",
+        )
+      end
+    end
+
+    context "when reviewed is true" do
+      it "returns the path to the claim check page" do
+        claim_reviewed = create(:claim, reviewed: true)
+        form = described_class.new(claim: claim_reviewed)
+
+        expect(form.update_success_path).to eq(
+          "/schools/#{claim_reviewed.school.id}/claims/#{claim_reviewed.id}/check",
+        )
+      end
+    end
+  end
 end

--- a/spec/forms/claims/support/claim/mentors_form_spec.rb
+++ b/spec/forms/claims/support/claim/mentors_form_spec.rb
@@ -58,4 +58,27 @@ describe Claims::Support::Claim::MentorsForm, type: :model do
       end
     end
   end
+
+  describe "#edit_back_path" do
+    context "when reviewed is nil" do
+      it "returns the path to the mentor training hours form" do
+        form = described_class.new(claim:)
+
+        expect(form.edit_back_path).to eq(
+          "/support/schools/#{claim.school.id}/claims/#{claim.id}/edit",
+        )
+      end
+    end
+
+    context "when reviewed is true" do
+      it "returns the path to the claim check page" do
+        claim_reviewed = create(:claim, reviewed: true)
+        form = described_class.new(claim: claim_reviewed)
+
+        expect(form.update_success_path).to eq(
+          "/support/schools/#{claim_reviewed.school.id}/claims/#{claim_reviewed.id}/check",
+        )
+      end
+    end
+  end
 end

--- a/spec/forms/claims/support/claim/provider_form_spec.rb
+++ b/spec/forms/claims/support/claim/provider_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Claims::Claim::ProviderForm, type: :model do
+describe Claims::Support::Claim::ProviderForm, type: :model do
   let(:school) { create(:claims_school) }
   let(:existing_claim) { create(:claim, school:) }
 
@@ -75,7 +75,7 @@ describe Claims::Claim::ProviderForm, type: :model do
         form = described_class.new(id: existing_claim.id, school:)
 
         expect(form.edit_back_path).to eq(
-          "/schools/#{school.id}/claims",
+          "/support/schools/#{school.id}/claims",
         )
       end
     end
@@ -86,7 +86,7 @@ describe Claims::Claim::ProviderForm, type: :model do
         form = described_class.new(id: claim.id, school:)
 
         expect(form.edit_back_path).to eq(
-          "/schools/#{school.id}/claims/#{claim.id}/check",
+          "/support/schools/#{school.id}/claims/#{claim.id}/check",
         )
       end
     end
@@ -98,7 +98,7 @@ describe Claims::Claim::ProviderForm, type: :model do
         form = described_class.new(id: existing_claim.id, school:)
 
         expect(form.update_success_path).to eq(
-          "/schools/#{school.id}/claims/#{existing_claim.id}/mentors/edit",
+          "/support/schools/#{school.id}/claims/#{existing_claim.id}/mentors/edit",
         )
       end
     end
@@ -109,7 +109,7 @@ describe Claims::Claim::ProviderForm, type: :model do
         form = described_class.new(id: claim.id, school:)
 
         expect(form.update_success_path).to eq(
-          "/schools/#{school.id}/claims/#{claim.id}/check",
+          "/support/schools/#{school.id}/claims/#{claim.id}/check",
         )
       end
     end

--- a/spec/models/claims/claim_spec.rb
+++ b/spec/models/claims/claim_spec.rb
@@ -14,6 +14,7 @@
 #  provider_id       :uuid
 #  school_id         :uuid             not null
 #  submitted_by_id   :uuid
+#  reviewed             :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/services/claims/claim/review_spec.rb
+++ b/spec/services/claims/claim/review_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+describe Claims::Claim::Review do
+  subject(:service) { described_class.call(claim:) }
+
+  let!(:claim) { create(:claim, reference: nil, status: :internal_draft, school:) }
+  let(:school) { create(:claims_school, urn: "1234") }
+
+  it_behaves_like "a service object" do
+    let(:params) { { claim: } }
+  end
+
+  describe "#call" do
+    it "sets the reviewed attribute to true" do
+      expect { service }.to change(claim, :reviewed).from(false).to(true)
+    end
+  end
+end

--- a/spec/system/claims/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/schools/claims/create_claim_spec.rb
@@ -41,6 +41,26 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     then_i_get_a_claim_reference_and_see_next_steps(Claims::Claim.submitted.first)
   end
 
+  scenario "Anne attempts to create a claim but backs off before the check page" do
+    when_i_click("Add claim")
+    when_i_choose_a_provider(bpn)
+    when_i_click("Continue")
+    when_i_select_all_mentors
+    when_i_click("Continue")
+    then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor1)
+    when_i_add_training_hours("20 hours")
+    when_i_click("Continue")
+    then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor2)
+    when_i_click("Back")
+    then_i_expect_the_training_hours_for(20, mentor1)
+    when_i_click("Back")
+    then_i_expect_the_mentors_to_be_checked([mentor1, mentor2])
+    when_i_click("Back")
+    then_i_expect_the_provider_to_be_checked(bpn)
+    when_i_click("Back")
+    then_i_expect_to_be_on_the_claims_index_page
+  end
+
   scenario "Anne creates a claim with mentor training hours over the maximum limit per provider" do
     when_i_click("Add claim")
     when_i_choose_a_provider(bpn)
@@ -279,5 +299,19 @@ RSpec.describe "Create claim", type: :system, service: :claims do
 
   def then_i_should_land_on_the_check_page
     expect(page).to have_content "Check your answers"
+  end
+
+  def then_i_expect_the_mentors_to_be_checked(mentors)
+    mentors.each do |mentor|
+      has_checked_field?("#claims-claim-mentor-ids-#{mentor.id}-field")
+    end
+  end
+
+  def then_i_expect_the_provider_to_be_checked(provider)
+    has_checked_field?("#claims-claim-provider-form-provider-id-#{provider.id}-field")
+  end
+
+  def then_i_expect_to_be_on_the_claims_index_page
+    expect(page).to have_current_path(claims_school_claims_path(school))
   end
 end

--- a/spec/system/claims/support/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/create_claim_spec.rb
@@ -43,6 +43,28 @@ RSpec.describe "Create claim", type: :system, service: :claims do
     then_i_am_redirectd_to_index_page(Claims::Claim.draft.first)
   end
 
+  scenario "Colin attempts to create a claim but backs off before the check page" do
+    when_i_click(school.name)
+    when_i_click_on_claims
+    when_i_click("Add claim")
+    when_i_choose_a_provider(bpn)
+    when_i_click("Continue")
+    when_i_select_all_mentors
+    when_i_click("Continue")
+    then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor1)
+    when_i_add_training_hours("20 hours")
+    when_i_click("Continue")
+    then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor2)
+    when_i_click("Back")
+    then_i_expect_the_training_hours_for(20, mentor1)
+    when_i_click("Back")
+    then_i_expect_the_mentors_to_be_checked([mentor1, mentor2])
+    when_i_click("Back")
+    then_i_expect_the_provider_to_be_checked(bpn)
+    when_i_click("Back")
+    then_i_expect_to_be_on_the_claims_index_page
+  end
+
   scenario "Colin creates a claim with mentor training hours over the maximum limit per provider" do
     when_i_click(school.name)
     when_i_click_on_claims
@@ -248,5 +270,19 @@ RSpec.describe "Create claim", type: :system, service: :claims do
 
   def then_i_should_land_on_the_check_page
     expect(page).to have_content "Check your answers"
+  end
+
+  def then_i_expect_the_mentors_to_be_checked(mentors)
+    mentors.each do |mentor|
+      has_checked_field?("#claims-claim-mentor-ids-#{mentor.id}-field")
+    end
+  end
+
+  def then_i_expect_the_provider_to_be_checked(provider)
+    has_checked_field?("#claims-claim-provider-form-provider-id-#{provider.id}-field")
+  end
+
+  def then_i_expect_to_be_on_the_claims_index_page
+    expect(page).to have_current_path(claims_support_school_claims_path(school))
   end
 end

--- a/spec/system/claims/support/schools/claims/edit_draft_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/edit_draft_claim_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe "Edit a draft claim", type: :system, service: :claims do
     first("a", text: "Change").click
     page.choose(niot_provider.name)
     click_on("Continue")
+    click_on("Continue")
     expect(page).to have_content("Accredited providerNIoT: National Institute of Teaching, founded by the School-Led Development TrustChange")
   end
 


### PR DESCRIPTION
## Context

When creating a claim you can end up on the edit page of a claim, or mentors list.

These edit pages were programmed to always go to the check page, so when a user would click them it would try to redirect them to the check page.

This commit fixes this with a reviewed boolean field which is set to true when the user lands on the check page.

We use this boolean to know where to redirect the user, back to the check page or through the steps ending on the index page.

Once a user lands on the check page, the back buttons should always redirect him to the check page.

## Changes proposed in this pull request

Reviewed boolean
Change back links
Change update success path(The continue buttons) 

## Guidance to review

Create a claim and right before getting to the check page, click the back links all the way to the index page

Create a claim and right before getting to the check page, click back link until the provider step then go forward.

Create a claim normally and edit it on the check page.


## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/41b2b36c-62b5-4964-88ee-84c6d5c204e0

