### PR TITLE
Implement claim revisions on claim form

### DIFF
--- a/app/controllers/claims/schools/claims/mentor_trainings_controller.rb
+++ b/app/controllers/claims/schools/claims/mentor_trainings_controller.rb
@@ -3,6 +3,17 @@ class Claims::Schools::Claims::MentorTrainingsController < Claims::ApplicationCo
   before_action :authorize_claim
   helper_method :mentor_training_form
 
+  def create_revision
+    revision = Claims::Claim::CreateRevision.call(claim: @claim)
+    mentor_training = revision.mentor_trainings.find_by(mentor_id: params.require(:id))
+
+    redirect_to edit_claims_school_claim_mentor_training_path(
+      @school,
+      revision,
+      mentor_training,
+    )
+  end
+
   def edit; end
 
   def update

--- a/app/controllers/claims/schools/claims/mentors_controller.rb
+++ b/app/controllers/claims/schools/claims/mentors_controller.rb
@@ -24,6 +24,11 @@ class Claims::Schools::Claims::MentorsController < Claims::ApplicationController
     end
   end
 
+  def create_revision
+    revision = Claims::Claim::CreateRevision.call(claim: @claim)
+    redirect_to edit_claims_school_claim_mentors_path(@school, revision)
+  end
+
   def edit; end
 
   def update

--- a/app/controllers/claims/schools/claims_controller.rb
+++ b/app/controllers/claims/schools/claims_controller.rb
@@ -2,8 +2,9 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
   include Claims::BelongsToSchool
 
   before_action :has_school_accepted_grant_conditions?
-  before_action :set_claim, only: %i[show check confirmation submit edit update rejected]
+  before_action :set_claim, only: %i[show check confirmation submit edit update rejected create_revision]
   before_action :authorize_claim
+  before_action :get_valid_revision, only: :check
 
   helper_method :claim_provider_form
 
@@ -19,6 +20,11 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
     else
       render :new
     end
+  end
+
+  def create_revision
+    revision = Claims::Claim::CreateRevision.call(claim: @claim)
+    redirect_to edit_claims_school_claim_path(@school, revision)
   end
 
   def show; end
@@ -88,5 +94,11 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
 
   def authorize_claim
     authorize @claim || Claims::Claim
+  end
+
+  def get_valid_revision
+    revision = @claim.get_valid_revision
+
+    redirect_to check_claims_school_claim_path(@school, revision) if revision != @claim
   end
 end

--- a/app/controllers/claims/support/schools/claims/mentor_trainings_controller.rb
+++ b/app/controllers/claims/support/schools/claims/mentor_trainings_controller.rb
@@ -3,6 +3,17 @@ class Claims::Support::Schools::Claims::MentorTrainingsController < Claims::Appl
   before_action :authorize_claim
   helper_method :mentor_training_form
 
+  def create_revision
+    revision = Claims::Claim::CreateRevision.call(claim: @claim)
+    mentor_training = revision.mentor_trainings.find_by(mentor_id: params.require(:id))
+
+    redirect_to edit_claims_support_school_claim_mentor_training_path(
+      @school,
+      revision,
+      mentor_training,
+    )
+  end
+
   def edit; end
 
   def update

--- a/app/controllers/claims/support/schools/claims/mentors_controller.rb
+++ b/app/controllers/claims/support/schools/claims/mentors_controller.rb
@@ -20,6 +20,11 @@ class Claims::Support::Schools::Claims::MentorsController < Claims::ApplicationC
     end
   end
 
+  def create_revision
+    revision = Claims::Claim::CreateRevision.call(claim: @claim)
+    redirect_to edit_claims_support_school_claim_mentors_path(@school, revision)
+  end
+
   def edit; end
 
   def update

--- a/app/policies/claims/claim_policy.rb
+++ b/app/policies/claims/claim_policy.rb
@@ -7,6 +7,10 @@ class Claims::ClaimPolicy < Claims::ApplicationPolicy
     edit?
   end
 
+  def create_revision?
+    edit?
+  end
+
   def submit?
     !user.support_user? && !record.submitted?
   end

--- a/app/services/claims/claim/create_revision.rb
+++ b/app/services/claims/claim/create_revision.rb
@@ -1,0 +1,26 @@
+class Claims::Claim::CreateRevision
+  include ServicePattern
+
+  def initialize(claim:)
+    @claim = claim
+  end
+
+  def call
+    revision_record = deep_dup
+    revision_record.save!
+
+    revision_record
+  end
+
+  private
+
+  attr_reader :claim
+
+  def deep_dup
+    dup_record = claim.dup
+    dup_record.mentor_trainings = claim.mentor_trainings.map(&:dup)
+    dup_record.previous_revision_id = claim.id
+    dup_record.status = :internal_draft
+    dup_record
+  end
+end

--- a/app/services/claims/claim/update_draft.rb
+++ b/app/services/claims/claim/update_draft.rb
@@ -1,0 +1,34 @@
+class Claims::Claim::UpdateDraft
+  include ServicePattern
+
+  def initialize(claim:)
+    @claim = claim
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      updated_claim.save!
+      update_previous_revisions_to_internal_draft
+    end
+  end
+
+  private
+
+  attr_reader :claim
+
+  def update_previous_revisions_to_internal_draft
+    claim_record = updated_claim.previous_revision
+
+    while claim_record.present?
+      claim_record.update!(status: :internal_draft) if claim_record.draft?
+      claim_record = claim_record.previous_revision
+    end
+  end
+
+  def updated_claim
+    @updated_claim ||= begin
+      claim.status = :draft
+      claim
+    end
+  end
+end

--- a/app/services/claims/mentor/calculate_remaining_mentor_training_hours_for_provider.rb
+++ b/app/services/claims/mentor/calculate_remaining_mentor_training_hours_for_provider.rb
@@ -11,7 +11,7 @@ class Claims::Mentor::CalculateRemainingMentorTrainingHoursForProvider
 
   def call
     MAXIMUM_CLAIMABLE_HOURS_PER_PROVIDER -
-      Claims::Mentor::CalculateTotalMentorTrainingHoursForProvider.call(mentor:, provider:) +
+      Claims::Mentor::CalculateTotalMentorTrainingHoursForProvider.call(mentor:, provider:, claim: mentor_training&.claim) +
       current_mentor_training_hours
   end
 

--- a/app/services/claims/mentor/calculate_total_mentor_training_hours_for_provider.rb
+++ b/app/services/claims/mentor/calculate_total_mentor_training_hours_for_provider.rb
@@ -1,16 +1,17 @@
 class Claims::Mentor::CalculateTotalMentorTrainingHoursForProvider
   include ServicePattern
 
-  def initialize(mentor:, provider:)
+  def initialize(mentor:, provider:, claim: nil)
     @mentor = mentor
     @provider = provider
+    @claim = claim
   end
 
   def call
-    mentor.mentor_trainings.joins(:claim).merge(Claims::Claim.active).where(provider:).sum(:hours_completed)
+    mentor.mentor_trainings.joins(:claim).merge(Claims::Claim.active).where(provider:).where.not(claim_id: claim&.previous_revision_id).sum(:hours_completed)
   end
 
   private
 
-  attr_reader :mentor, :provider
+  attr_reader :mentor, :provider, :claim
 end

--- a/app/views/claims/schools/claims/check.html.erb
+++ b/app/views/claims/schools/claims/check.html.erb
@@ -17,16 +17,13 @@
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: Claims::Claim.human_attribute_name(:school_name)) %>
           <% row.with_value(text: @school.name) %>
-          <% end %>
+        <% end %>
 
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: Claims::Claim.human_attribute_name(:accredited_provider)) %>
           <% row.with_value(text: @claim.provider_name) %>
           <% row.with_action(text: t("change"),
-                             href: edit_claims_school_claim_path(
-                               @school,
-                               @claim,
-                             ),
+                             href: create_revision_claims_school_claim_path(@school, @claim),
                              visually_hidden_text: Claims::Claim.human_attribute_name(:accredited_provider),
                              html_attributes: {
                                class: "govuk-link--no-visited-state",
@@ -43,7 +40,7 @@
             </ul>
           <% end %>
           <% row.with_action(text: t("change"),
-                             href: edit_claims_school_claim_mentors_path(@school, @claim),
+                             href: create_revision_claims_school_claim_mentors_path(@school, @claim),
                              visually_hidden_text: Claims::Claim.human_attribute_name(:mentors),
                              html_attributes: {
                                class: "govuk-link--no-visited-state",
@@ -59,17 +56,17 @@
             <% row.with_key(text: mentor_training.mentor.full_name) %>
             <% row.with_value(text: pluralize(mentor_training.hours_completed, t(".hour"))) %>
             <% row.with_action(text: t("change"),
-                               href: edit_claims_school_claim_mentor_training_path(
+                               href: create_revision_claims_school_claim_mentor_training_path(
                                  @school,
                                  @claim,
-                                 mentor_training,
+                                 mentor_training.mentor_id,
                                ),
                                visually_hidden_text: "Hours of training for #{mentor_training.mentor.full_name}",
                                html_attributes: {
                                  class: "govuk-link--no-visited-state",
                                }) %>
-            <% end %>
           <% end %>
+        <% end %>
       <% end %>
 
       <h2 class="govuk-heading-m"><%= t(".grant_funding") %></h2>

--- a/app/views/claims/support/claims/_details.html.erb
+++ b/app/views/claims/support/claims/_details.html.erb
@@ -10,10 +10,10 @@
       <% row.with_value(text: claim.provider.name) %>
       <% if policy(claim).edit? %>
         <% row.with_action(text: t("change"),
-                           href: edit_claims_support_school_claim_path(claim.school, claim),
+                           href: create_revision_claims_support_school_claim_path(@school, claim),
                            html_attributes: {
-                              class: "govuk-link--no-visited-state",
-                              }) %>
+                class: "govuk-link--no-visited-state",
+                }) %>
       <% end %>
     <% end %>
   <% else %>
@@ -34,11 +34,11 @@
     <% end %>
     <% if policy(claim).edit? %>
       <% row.with_action(text: t("change"),
-                         href: edit_claims_support_school_claim_mentors_path(claim.school, claim),
+                         href: create_revision_claims_support_school_claim_mentors_path(@school, claim),
                          html_attributes: {
                   class: "govuk-link--no-visited-state",
                 }) %>
-    <% end %>
+                <% end %>
   <% end %>
 <% end %>
 
@@ -50,11 +50,11 @@
       <% row.with_value(text: pluralize(mentor_training.hours_completed, t(".hour"))) %>
       <% if policy(claim).edit? %>
         <% row.with_action(text: t("change"),
-                           href: edit_claims_support_school_claim_mentor_training_path(
-                            claim.school,
-                            claim,
-                            mentor_training,
-                          ),
+                           href: create_revision_claims_support_school_claim_mentor_training_path(
+                             @school,
+                             claim,
+                             mentor_training.mentor_id,
+                           ),
                            html_attributes: {
                             class: "govuk-link--no-visited-state",
                           }) %>

--- a/app/views/claims/support/schools/claims/check.html.erb
+++ b/app/views/claims/support/schools/claims/check.html.erb
@@ -18,10 +18,7 @@
           <% row.with_key(text: Claims::Claim.human_attribute_name(:accredited_provider)) %>
           <% row.with_value(text: @claim.provider_name) %>
           <% row.with_action(text: t("change"),
-                             href: edit_claims_support_school_claim_path(
-                               @school,
-                               @claim,
-                             ),
+                             href: create_revision_claims_support_school_claim_path(@school, @claim),
                              visually_hidden_text: Claims::Claim.human_attribute_name(:accredited_provider),
                              html_attributes: {
                                class: "govuk-link--no-visited-state",
@@ -38,7 +35,7 @@
             </ul>
           <% end %>
           <% row.with_action(text: t("change"),
-                             href: edit_claims_support_school_claim_mentors_path(@school, @claim),
+                             href: create_revision_claims_support_school_claim_mentors_path(@school, @claim),
                              visually_hidden_text: Claims::Claim.human_attribute_name(:mentors),
                              html_attributes: {
                                class: "govuk-link--no-visited-state",
@@ -54,17 +51,17 @@
             <% row.with_key(text: mentor_training.mentor.full_name) %>
             <% row.with_value(text: pluralize(mentor_training.hours_completed, t(".hour"))) %>
             <% row.with_action(text: t("change"),
-                               href: edit_claims_support_school_claim_mentor_training_path(
+                               href: create_revision_claims_support_school_claim_mentor_training_path(
                                  @school,
                                  @claim,
-                                 mentor_training,
+                                 mentor_training.mentor_id,
                                ),
                                visually_hidden_text: "Hours of training for #{mentor_training.mentor.full_name}",
                                html_attributes: {
                                  class: "govuk-link--no-visited-state",
                                }) %>
-            <% end %>
           <% end %>
+        <% end %>
       <% end %>
 
       <h2 class="govuk-heading-m"><%= t(".grant_funding") %></h2>
@@ -85,7 +82,7 @@
           <% end %>
         <% end %>
 
-      <%= govuk_button_to (@claim.draft? ? t(".update") : t(".submit")), draft_claims_support_school_claim_path(@school, @claim) %>
+      <%= govuk_button_to (@claim.was_draft? ? t(".update") : t(".submit")), draft_claims_support_school_claim_path(@school, @claim) %>
 
       <p class="govuk-body">
         <%= govuk_link_to t("cancel"), claims_support_school_claims_path(@school), no_visited_state: true %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -89,6 +89,7 @@ shared:
     - submitted_by_type
     - submitted_by_id
     - reviewed
+    - previous_revision_id
   :schools:
     - id
     - urn

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -14,13 +14,22 @@ scope module: :claims, as: :claims, constraints: {
   resources :schools, only: %i[index show] do
     scope module: :schools do
       resources :claims, except: %i[destroy] do
-        resource :mentors, only: %i[new create edit update], module: :claims
-        resources :mentor_trainings, only: %i[edit update], module: :claims
+        resource :mentors, only: %i[new create edit update], module: :claims do
+          member do
+            get :create_revision
+          end
+        end
+        resources :mentor_trainings, only: %i[edit update], module: :claims do
+          member do
+            get :create_revision
+          end
+        end
 
         member do
           get :check
           get :confirmation
           get :rejected
+          get :create_revision
           post :submit
         end
       end
@@ -60,14 +69,23 @@ scope module: :claims, as: :claims, constraints: {
 
       scope module: :schools do
         resources :claims do
-          resource :mentors, only: %i[new create edit update], module: :claims
-          resources :mentor_trainings, only: %i[edit update], module: :claims
+          resource :mentors, only: %i[new create edit update], module: :claims do
+            member do
+              get :create_revision
+            end
+          end
+          resources :mentor_trainings, only: %i[edit update], module: :claims do
+            member do
+              get :create_revision
+            end
+          end
 
           member do
             get :remove
             get :check
             get :rejected
             post :draft
+            get :create_revision
           end
         end
 

--- a/db/migrate/20240419100125_add_revisions_to_claims.rb
+++ b/db/migrate/20240419100125_add_revisions_to_claims.rb
@@ -1,0 +1,6 @@
+class AddRevisionsToClaims < ActiveRecord::Migration[7.1]
+  def change
+    add_column :claims, :previous_revision_id, :uuid, null: true
+    add_index :claims, :previous_revision_id
+  end
+end

--- a/db/migrate/20240422135851_remove_claim_reference_unique_constraint.rb
+++ b/db/migrate/20240422135851_remove_claim_reference_unique_constraint.rb
@@ -1,0 +1,6 @@
+class RemoveClaimReferenceUniqueConstraint < ActiveRecord::Migration[7.1]
+  def change
+    remove_index(:claims, :reference, unique: true)
+    add_index(:claims, :reference)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -59,9 +59,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_01_065503) do
     t.string "submitted_by_type"
     t.uuid "submitted_by_id"
     t.boolean "reviewed", default: false
+    t.uuid "previous_revision_id"
     t.index ["created_by_type", "created_by_id"], name: "index_claims_on_created_by"
+    t.index ["previous_revision_id"], name: "index_claims_on_previous_revision_id"
     t.index ["provider_id"], name: "index_claims_on_provider_id"
-    t.index ["reference"], name: "index_claims_on_reference", unique: true
+    t.index ["reference"], name: "index_claims_on_reference"
     t.index ["school_id"], name: "index_claims_on_school_id"
     t.index ["submitted_by_type", "submitted_by_id"], name: "index_claims_on_submitted_by"
   end

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -2,27 +2,29 @@
 #
 # Table name: claims
 #
-#  id                :uuid             not null, primary key
-#  created_by_type   :string
-#  reference         :string
-#  status            :enum
-#  submitted_at      :datetime
-#  submitted_by_type :string
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  created_by_id     :uuid
-#  provider_id       :uuid
-#  school_id         :uuid             not null
-#  submitted_by_id   :uuid
+#  id                   :uuid             not null, primary key
+#  created_by_type      :string
+#  reference            :string
 #  reviewed             :boolean          default(FALSE)
+#  status               :enum
+#  submitted_at         :datetime
+#  submitted_by_type    :string
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  created_by_id        :uuid
+#  previous_revision_id :uuid
+#  provider_id          :uuid
+#  school_id            :uuid             not null
+#  submitted_by_id      :uuid
 #
 # Indexes
 #
-#  index_claims_on_created_by    (created_by_type,created_by_id)
-#  index_claims_on_provider_id   (provider_id)
-#  index_claims_on_reference     (reference) UNIQUE
-#  index_claims_on_school_id     (school_id)
-#  index_claims_on_submitted_by  (submitted_by_type,submitted_by_id)
+#  index_claims_on_created_by            (created_by_type,created_by_id)
+#  index_claims_on_previous_revision_id  (previous_revision_id)
+#  index_claims_on_provider_id           (provider_id)
+#  index_claims_on_reference             (reference)
+#  index_claims_on_school_id             (school_id)
+#  index_claims_on_submitted_by          (submitted_by_type,submitted_by_id)
 #
 # Foreign Keys
 #
@@ -34,6 +36,7 @@ FactoryBot.define do
     association :school, factory: :claims_school
     association :provider
     association :created_by, factory: :claims_user
+    association :submitted_by, factory: :claims_user
 
     status { :internal_draft }
 

--- a/spec/services/claims/claim/create_revision_spec.rb
+++ b/spec/services/claims/claim/create_revision_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+describe Claims::Claim::CreateRevision do
+  subject(:service) { described_class.call(claim:) }
+
+  let!(:claim) { create(:claim, reference: nil, status: :internal_draft, school:) }
+  let(:school) { create(:claims_school, urn: "1234") }
+
+  it_behaves_like "a service object" do
+    let(:params) { { claim: } }
+  end
+
+  describe "#call" do
+    it "creates a revision of the claim, with associations" do
+      anne = create(:claims_user, :anne)
+      claim = create(:claim, :draft, submitted_by: anne, created_by: anne)
+      attributes = claim.attributes.except(
+        "id",
+        "created_at",
+        "updated_at",
+        "status",
+        "previous_revision_id",
+      ).keys
+      revision = described_class.call(claim:)
+
+      expect(revision.mentor_trainings).to eq(claim.mentor_trainings)
+      expect(revision.previous_revision_id).to eq(claim.id)
+      expect(revision.status).to eq("internal_draft")
+
+      attributes.each do |attribute|
+        expect(revision.public_send(attribute)).to eq(claim.public_send(attribute))
+      end
+    end
+  end
+end

--- a/spec/services/claims/claim/update_draft_spec.rb
+++ b/spec/services/claims/claim/update_draft_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe Claims::Claim::UpdateDraft do
+  subject(:draft_service) { described_class.call(claim:) }
+
+  let!(:previous_revision) { create(:claim, :draft) }
+  let!(:claim) { create(:claim, :internal_draft, previous_revision:) }
+
+  it_behaves_like "a service object" do
+    let(:params) { { claim: } }
+  end
+
+  describe "#call" do
+    it "updates draft claim and sets the previous revisions to internal_draft status" do
+      expect { draft_service }.to change(claim, :status).from("internal_draft").to("draft")
+      expect(claim.previous_revision.status).to eq("internal_draft")
+    end
+  end
+end

--- a/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
@@ -24,26 +24,19 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
     create(:mentor_training, mentor: mentor2, provider: provider1, claim:, hours_completed: 12)
   end
 
-  scenario "Anne changes the provider on claim on check page" do
+  scenario "Anne changes the provider on claim on check page and doesn't need to add the mentor hours again" do
     given_i_visit_claim_check_page
     when_i_click_change_provider
     then_i_expect_the_provider_to_be_checked(provider1)
     when_i_change_the_provider
     then_i_expect_the_provider_to_be_checked(provider2)
     when_i_click("Continue")
-    then_i_check_my_answers(provider2, [mentor1, mentor2], [20, 12])
+    then_i_check_my_answers(claim, provider2, [mentor1, mentor2], [20, 12])
+    when_i_click_change_mentors
+    when_i_click("Continue")
+    then_i_check_my_answers(claim, provider2, [mentor1, mentor2], [20, 12])
     when_i_click("Submit claim")
     then_i_get_a_claim_reference(claim)
-  end
-
-  scenario "Anne does not have a provider selected when editing a claim from check page" do
-    given_i_visit_claim_check_page
-    when_i_click_change_provider
-    then_i_expect_the_provider_to_be_checked(provider1)
-    when_i_remove_the_provider_from_the_claim
-    then_i_reload_the_page
-    when_i_click("Continue")
-    then_i_see_the_error("Select a provider")
   end
 
   scenario "Anne changes the mentors on claim on check page" do
@@ -55,7 +48,12 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
     then_i_see_the_error("Select a mentor")
     when_i_check_the_mentor(mentor2)
     when_i_click("Continue")
-    then_i_check_my_answers(provider1, [mentor2], [12])
+    then_i_check_my_answers(
+      Claims::Claim.find_by(previous_revision_id: claim.id),
+      provider1,
+      [mentor2],
+      [12],
+    )
     when_i_click("Submit claim")
     then_i_get_a_claim_reference(claim)
   end
@@ -73,7 +71,21 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
     when_i_click("Back")
     then_i_expect_the_mentors_to_be_checked([mentor1, mentor2, mentor3])
     when_i_click("Back")
-    then_i_check_my_answers(provider1, [mentor1, mentor2], [20, 12])
+    then_i_check_my_answers(claim, provider1, [mentor1, mentor2], [20, 12])
+    then_i_cant_see_the_mentor(mentor3)
+  end
+
+  scenario "Anne changes the mentors on claim without inputting hours for any mentor" do
+    given_i_visit_claim_check_page
+    when_i_click_change_mentors
+    then_i_expect_the_mentors_to_be_checked([mentor1, mentor2])
+    when_i_uncheck_the_mentors([mentor1, mentor2])
+    when_i_check_the_mentor(mentor3)
+    when_i_click("Continue")
+    when_i_click("Back")
+    then_i_expect_the_mentors_to_be_checked([mentor3])
+    when_i_click("Back")
+    then_i_check_my_answers(claim, provider1, [mentor1, mentor2], [20, 12])
     then_i_cant_see_the_mentor(mentor3)
   end
 
@@ -86,7 +98,12 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
     then_i_see_the_error("Enter the number of hours")
     when_i_choose_other_amount_and_input_hours(6, with_error: true)
     when_i_click("Continue")
-    then_i_check_my_answers(provider1, [mentor1, mentor2], [6, 12])
+    then_i_check_my_answers(
+      Claims::Claim.find_by(previous_revision_id: claim.id),
+      provider1,
+      [mentor1, mentor2],
+      [6, 12],
+    )
   end
 
   scenario "Anne intends to change the training hours but clicks back link" do
@@ -123,7 +140,7 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
   def when_i_click_change_provider
     within("dl.govuk-summary-list:nth(1)") do
       within(".govuk-summary-list__row:nth(2)") do
-        click_on("Change")
+        click_link("Change")
       end
     end
   end
@@ -131,7 +148,7 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
   def when_i_click_change_mentors
     within("dl.govuk-summary-list:nth(1)") do
       within(".govuk-summary-list__row:nth(3)") do
-        click_on("Change")
+        click_link("Change")
       end
     end
   end
@@ -139,7 +156,7 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
   def when_i_click_change_training_hours_for_mentor
     within("dl.govuk-summary-list:nth(2)") do
       within(".govuk-summary-list__row:nth(1)") do
-        click_on("Change")
+        click_link("Change")
       end
     end
   end
@@ -199,7 +216,7 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
     find("#claims-claim-mentor-training-form-hours-completed-#{hours}-field").checked?
   end
 
-  def then_i_check_my_answers(provider, mentors, mentor_hours)
+  def then_i_check_my_answers(claim_record, provider, mentors, mentor_hours)
     expect(page).to have_content("Check your answers")
     expect(page).to have_content("Hours of training")
     expect(page).to have_content("Grant funding")
@@ -219,7 +236,7 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
     end
 
     within("dl.govuk-summary-list:nth(2)") do
-      claim.mentor_trainings.each_with_index do |mentor_training, index|
+      claim_record.mentor_trainings.each_with_index do |mentor_training, index|
         expect(page).to have_content(mentor_training.mentor.full_name)
         expect(page).to have_content(mentor_hours[index])
       end
@@ -227,7 +244,7 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
 
     within("dl.govuk-summary-list:nth(3)") do
       within(".govuk-summary-list__row:nth(1)") do
-        expect(page).to have_content("Total hours#{claim.mentor_trainings.sum(:hours_completed)} hours")
+        expect(page).to have_content("Total hours#{claim_record.mentor_trainings.sum(:hours_completed)} hours")
       end
 
       within(".govuk-summary-list__row:nth(2)") do
@@ -236,7 +253,7 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
 
       within(".govuk-summary-list__row:nth(3)") do
         expect(page).to have_content("Claim amount")
-        expect(page).to have_content(claim.amount.format(symbol: true, decimal_mark: ".", no_cents: true))
+        expect(page).to have_content(claim_record.amount.format(symbol: true, decimal_mark: ".", no_cents: true))
       end
     end
   end
@@ -259,14 +276,5 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
     within(".govuk-panel") do
       expect(page).to have_content("Claim submitted\nYour reference number\n#{claim.reference}")
     end
-  end
-
-  def when_i_remove_the_provider_from_the_claim
-    claim.provider_id = nil
-    claim.save!(validate: false)
-  end
-
-  def then_i_reload_the_page
-    refresh
   end
 end


### PR DESCRIPTION
## Context

In testing the claim form we concluded that we cannot edit the same claim record on the check page when creating a claim.Issues were found when the user would click the back buttons to go back to the check page after completing half their changes. The changes they did were being saved. Even if they backed off from doing them.

To solve this issue and many others, we are implementing a revision system on the claim.

Creating a revision every time a user wants to edit a claim from the check page. If they back off half way through their changes we revert back to the last valid claim revision.

This implementation will increase the audit records and possibly pollute some of them with `system changes` i.e. changes to `previous_revision_id` which the user doesn't care about.

This should fix the issue where a support user edits a draft claim and with every edit, the draft claim is updated for everyone.

The way this works is by using the `internal_draft` status. A generated revision starts with `internal_draft` as its status and is changed to draft when the support user finishes editing the draft claim. The previous revision is then set to `internal_draft`, to not show more than 1 claim per reference.

## Changes proposed in this pull request

Claim model
Claim form
Claim support form

## Guidance to review
Normal User: 
- Create a claim as a normal user and try to edit it on the check page
- Click all back buttons
- Add mentors without training hours and click back button until you get back to the check page.

Support User:
Do the same things as the normal user
Edit a draft claim
Edit a draft claim and click back buttons
Your changes to the draft claim should only be saved after you click `Update claim`

## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/f7543371-f786-4e7a-8381-dfe1f5577154


