### PR TITLE
Remove pii information from analytics.yml

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -24,9 +24,6 @@ shared:
     - created_at
     - updated_at
   :users:
-    - first_name
-    - last_name
-    - email
     - created_at
     - updated_at
     - id
@@ -75,8 +72,6 @@ shared:
     - updated_at
   :mentors:
     - id
-    - first_name
-    - last_name
     - trn
     - created_at
     - updated_at
@@ -149,8 +144,6 @@ shared:
     - name
     - ukprn
     - urn
-    - email_address
-    - telephone
     - website
     - address1
     - address2

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -82,3 +82,13 @@ shared:
     - job_class
     - error_event
     - labels
+  :users:
+    - first_name
+    - last_name
+    - email
+  :mentors:
+    - first_name
+    - last_name
+  :providers:
+    - email_address
+    - telephone


### PR DESCRIPTION
## Context

BigQuery doesn't handle the pii information. Previously we were sending
this information and this caused the production pipeline to fail.

Adding them to the block list should fix this because we won't send pii
information

## Changes proposed in this pull request

analitycs.yml files

## Guidance to review

Review code
