### PR TITLE
Fix claims rejected page for support

### DIFF
--- a/app/views/claims/support/schools/claims/rejected.html.erb
+++ b/app/views/claims/support/schools/claims/rejected.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, t(".page_title") %>
-<% render "claims/schools/primary_navigation", school: @school, current: :claims %>
+<% render "claims/support/primary_navigation", current: :organisations %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">


### PR DESCRIPTION
## Context

Previously we were using the primary navigation for normal users in the support rejected page

## Changes proposed in this pull request

Render correct partial

## Guidance to review

Add a claim for mentors that have been claimed for already, for that provider

## Screenshots

https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/db8b6606-cc46-460f-aa26-67460f0ff295


Before this change


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/44314372-845e-4177-8396-bb03b3549d61



