### PR TITLE
WIP: Make organisation name linkable to school

### DIFF
--- a/app/views/shared/organisations/_organisation_details.html.erb
+++ b/app/views/shared/organisations/_organisation_details.html.erb
@@ -1,7 +1,7 @@
 <%= govuk_summary_list(html_attributes: { id: "organisation-details" }) do |summary_list| %>
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: t(".organisation_name")) %>
-    <% row.with_value(**details_field_args(organisation.name)) %>
+    <% row.with_value(**details_field_args(link_to(organisation.name, claims_school_path(organisation)))) %>
   <% end %>
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: t(".ukprn")) %>


### PR DESCRIPTION
## Context

Make it easier for a support user to view a schools details

## Changes proposed in this pull request

Make the organisation name for a support user linkable to a school

## Guidance to review

- View a school as a support user

<!-- Sceenshots to aid with reviewing if needed-->
<img width="738" alt="Screenshot 2024-05-02 at 15 08 49" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/18593efb-9126-4ec9-8f85-333eaae0f6c1">

