### PR TITLE
Normalize User first_name, last_name, and email attributes

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,9 @@ class User < ApplicationRecord
 
   has_many :user_memberships, dependent: :destroy
 
+  normalizes :first_name, :last_name, with: ->(value) { value.strip }
+  normalizes :email, with: ->(value) { value.strip.downcase }
+
   validates :first_name, presence: true
   validates :last_name, presence: true
   validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }, unless: :support_user?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_many(:user_memberships).dependent(:destroy) }
   end
 
+  describe "normalizations" do
+    it { is_expected.to normalize(:first_name).from("  Jane  ").to("Jane") }
+    it { is_expected.to normalize(:last_name).from("  Doe  ").to("Doe") }
+    it { is_expected.to normalize(:email).from("  Jane.Doe@Example.com  ").to("jane.doe@example.com") }
+  end
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:email) }
     it { is_expected.to validate_uniqueness_of(:email).scoped_to(:type).case_insensitive }


### PR DESCRIPTION
## Context

When inputting user details, we want to make sure there are no extra spaces around their name or email address and their email address should always be lowercase.

## Changes proposed in this pull request

- Trim whitespaces around `User#first_name` and `User#last_name`.
- Trim whitespaces and downcase `User.email`.

## Guidance to review

- Try adding a user with extra spaces around the inputted data.
- It should go through without issue.