### PR TITLE
It's provider, not prvoider

### DIFF
--- a/config/locales/en/claims/support/claims.yml
+++ b/config/locales/en/claims/support/claims.yml
@@ -13,8 +13,8 @@ en:
           submitted_before: Submitted before
           submitted_before_hint: For example, 31 7 2024
           school_ids: School
-          provider_ids: Accredited prvoider
-          provider: Accredited prvoider
+          provider_ids: Accredited provider
+          provider: Accredited provider
           submit: Search
           clear: Clear search
         show:

--- a/spec/system/claims/support/claims/view_claims_spec.rb
+++ b/spec/system/claims/support/claims/view_claims_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe "View claims", type: :system, service: :claims, js: true do
   end
 
   def when_i_search_the_provider_filer_with(provider_name)
-    fill_in("Accredited prvoider", with: provider_name)
+    fill_in("Accredited provider", with: provider_name)
   end
 
   def then_i_see_only_my_filter_school_as_an_option
@@ -152,6 +152,6 @@ RSpec.describe "View claims", type: :system, service: :claims, js: true do
   end
 
   def then_i_see_my_search_provider_filter_populated(provider_name)
-    expect(page).to have_field("Accredited prvoider", with: provider_name)
+    expect(page).to have_field("Accredited provider", with: provider_name)
   end
 end


### PR DESCRIPTION
## Context

Oli, Lizzie and I were looking at the support section of the website and we found this spelling error.

## Changes proposed in this pull request

Fix the spelling of 'provider'

## Guidance to review

Assume it's correct!

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
