### PR TITLE
Fix the claim mentors route

### DIFF
--- a/app/controllers/claims/schools/claims_controller.rb
+++ b/app/controllers/claims/schools/claims_controller.rb
@@ -15,7 +15,7 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
 
   def create
     if claim_provider_form.save
-      redirect_to new_claims_school_claim_mentor_path(@school, claim_provider_form.claim)
+      redirect_to new_claims_school_claim_mentors_path(@school, claim_provider_form.claim)
     else
       render :new
     end

--- a/app/controllers/claims/support/schools/claims_controller.rb
+++ b/app/controllers/claims/support/schools/claims_controller.rb
@@ -23,7 +23,7 @@ class Claims::Support::Schools::ClaimsController < Claims::Support::ApplicationC
 
   def create
     if claim_provider_form.save
-      redirect_to new_claims_support_school_claim_mentor_path(@school, claim_provider_form.claim)
+      redirect_to new_claims_support_school_claim_mentors_path(@school, claim_provider_form.claim)
     else
       render :new
     end

--- a/app/forms/claims/claim/mentor_training_form.rb
+++ b/app/forms/claims/claim/mentor_training_form.rb
@@ -43,7 +43,7 @@ class Claims::Claim::MentorTrainingForm < ApplicationForm
 
   def back_path
     if mentor_trainings.index(mentor_training).zero?
-      edit_claims_school_claim_mentor_path(school, claim, mentor_training.mentor_id)
+      edit_claims_school_claim_mentors_path(school, claim)
     else
       edit_claims_school_claim_mentor_training_path(school, claim, previous_mentor_training)
     end

--- a/app/forms/claims/support/claim/mentor_training_form.rb
+++ b/app/forms/claims/support/claim/mentor_training_form.rb
@@ -1,7 +1,7 @@
 class Claims::Support::Claim::MentorTrainingForm < Claims::Claim::MentorTrainingForm
   def back_path
     if mentor_trainings.index(mentor_training).zero?
-      edit_claims_support_school_claim_mentor_path(school, claim, mentor_training.mentor_id)
+      edit_claims_support_school_claim_mentors_path(school, claim)
     else
       edit_claims_support_school_claim_mentor_training_path(school, claim, previous_mentor_training)
     end

--- a/app/views/claims/schools/claims/check.html.erb
+++ b/app/views/claims/schools/claims/check.html.erb
@@ -43,7 +43,7 @@
             </ul>
           <% end %>
           <% row.with_action(text: t("change"),
-                             href: edit_claims_school_claim_mentor_path(@school, @claim),
+                             href: edit_claims_school_claim_mentors_path(@school, @claim),
                              visually_hidden_text: Claims::Claim.human_attribute_name(:mentors),
                              html_attributes: {
                                class: "govuk-link--no-visited-state",

--- a/app/views/claims/schools/claims/mentors/edit.html.erb
+++ b/app/views/claims/schools/claims/mentors/edit.html.erb
@@ -10,7 +10,7 @@
     partial: "form",
     locals: {
       claim_mentors_form:,
-      form_url: claims_school_claim_mentor_path(@school, claim_mentors_form.claim),
+      form_url: claims_school_claim_mentors_path(@school, claim_mentors_form.claim),
       method: :patch,
       school: @school,
     },

--- a/app/views/claims/support/claims/_details.html.erb
+++ b/app/views/claims/support/claims/_details.html.erb
@@ -34,7 +34,7 @@
     <% end %>
     <% if policy(claim).edit? %>
       <% row.with_action(text: t("change"),
-                         href: edit_claims_support_school_claim_mentor_path(claim.school, claim),
+                         href: edit_claims_support_school_claim_mentors_path(claim.school, claim),
                          html_attributes: {
                   class: "govuk-link--no-visited-state",
                 }) %>

--- a/app/views/claims/support/schools/claims/check.html.erb
+++ b/app/views/claims/support/schools/claims/check.html.erb
@@ -38,7 +38,7 @@
             </ul>
           <% end %>
           <% row.with_action(text: t("change"),
-                             href: edit_claims_support_school_claim_mentor_path(@school, @claim),
+                             href: edit_claims_support_school_claim_mentors_path(@school, @claim),
                              visually_hidden_text: Claims::Claim.human_attribute_name(:mentors),
                              html_attributes: {
                                class: "govuk-link--no-visited-state",

--- a/app/views/claims/support/schools/claims/mentors/edit.html.erb
+++ b/app/views/claims/support/schools/claims/mentors/edit.html.erb
@@ -10,7 +10,7 @@
     partial: "form",
     locals: {
       claim_mentors_form:,
-      form_url: claims_support_school_claim_mentor_path(@school, claim_mentors_form.claim),
+      form_url: claims_support_school_claim_mentors_path(@school, claim_mentors_form.claim),
       method: :patch,
       school: @school,
     },

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -14,7 +14,7 @@ scope module: :claims, as: :claims, constraints: {
   resources :schools, only: %i[index show] do
     scope module: :schools do
       resources :claims, except: %i[destroy] do
-        resources :mentors, only: %i[new create edit update], module: :claims
+        resource :mentors, only: %i[new create edit update], module: :claims
         resources :mentor_trainings, only: %i[edit update], module: :claims
 
         member do
@@ -60,7 +60,7 @@ scope module: :claims, as: :claims, constraints: {
 
       scope module: :schools do
         resources :claims do
-          resources :mentors, only: %i[new create edit update], module: :claims
+          resource :mentors, only: %i[new create edit update], module: :claims
           resources :mentor_trainings, only: %i[edit update], module: :claims
 
           member do

--- a/spec/forms/claims/claim/mentor_training_form_spec.rb
+++ b/spec/forms/claims/claim/mentor_training_form_spec.rb
@@ -113,7 +113,7 @@ describe Claims::Claim::MentorTrainingForm, type: :model do
     context "when we are on the alphabetically-first mentor training hours page" do
       it "returns the path to the mentors check list" do
         expect(mentor_training_form.back_path).to eq(
-          "/schools/#{mentor_training.claim.school_id}/claims/#{mentor_training.claim.id}/mentors/#{mentor_training.mentor_id}/edit",
+          "/schools/#{mentor_training.claim.school_id}/claims/#{mentor_training.claim.id}/mentors/edit",
         )
       end
     end

--- a/spec/forms/claims/support/claim/mentor_training_form_spec.rb
+++ b/spec/forms/claims/support/claim/mentor_training_form_spec.rb
@@ -113,7 +113,7 @@ describe Claims::Support::Claim::MentorTrainingForm, type: :model do
     context "when we are on the alphabetically-first mentor training hours page" do
       it "returns the path to the mentors check list" do
         expect(mentor_training_form.back_path).to eq(
-          "/support/schools/#{mentor_training.claim.school_id}/claims/#{mentor_training.claim.id}/mentors/#{mentor_training.mentor_id}/edit",
+          "/support/schools/#{mentor_training.claim.school_id}/claims/#{mentor_training.claim.id}/mentors/edit",
         )
       end
     end


### PR DESCRIPTION
## Context

Previously the claims mentors edit route was not a collection so when editing the mentor list on the claim the url was `/schools/:school_id/claims/:claims_id/mentors/:mentor_id/edit`

Now is `/schools/:school_id/claims/:claims_id/mentors/edit` as we are editing a collection of mentors not a particular one

## Changes proposed in this pull request

Changed mentors route

## Guidance to review

Create a claim and edit the mentors on the check page.
The URL should not contain any mentor id

Do the same as support user

## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/f4e7a42b-9c9e-460c-bfe9-464909461787

