### PR TITLE
Zone manage-school-placements added

### DIFF
--- a/terraform/domains/infrastructure/.terraform.lock.hcl
+++ b/terraform/domains/infrastructure/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "3.82.0"
   hashes = [
     "h1:Zo/EZdNd8Vubo3rSj5NTU4SwLqArsz1mqtefru/8DpQ=",
+    "h1:wIfGA8icS9CbbMfHQFRAUddF2/emdmvJbkTZxfEJTXg=",
     "zh:2042c5485476b0b9dbcebfc01d95e1cec50b37b2c443ffd9824a4fc6a7b293bd",
     "zh:3fc6753c039bac1866b90f5faf5f72edc7470cb64c1e84f830e71931dfced865",
     "zh:4760c4595a5e8a07c5eef08304877909f88252c1536432e443211ae668456459",

--- a/terraform/domains/infrastructure/config/zones.tfvars.json
+++ b/terraform/domains/infrastructure/config/zones.tfvars.json
@@ -1,23 +1,29 @@
 {
-    "hosted_zone": {
-        "claim-funding-for-mentor-training.education.gov.uk": {
-        "caa_records": {},
-        "txt_records": {
-            "@": {
-              "value": "v=spf1 -all"
-            },
-            "_dmarc": {
-              "value": "v=DMARC1;p=quarantine;sp=quarantine;pct=100;fo=1;rua=mailto:dmarc-rua@dmarc.service.gov.uk,mailto:dmarc-rua@education.gov.uk;ruf=mailto:DMARC.Forensic@education.gov.uk"
-            }
-          },
-        "resource_group_name": "s189p01-ittmsdomains-rg",
-        "front_door_name": "s189p01-ittmsdomains-fd"
-      }
+  "hosted_zone": {
+    "claim-funding-for-mentor-training.education.gov.uk": {
+      "caa_records": {},
+      "txt_records": {
+        "@": {
+          "value": "v=spf1 -all"
+        },
+        "_dmarc": {
+          "value": "v=DMARC1;p=quarantine;sp=quarantine;pct=100;fo=1;rua=mailto:dmarc-rua@dmarc.service.gov.uk,mailto:dmarc-rua@education.gov.uk;ruf=mailto:DMARC.Forensic@education.gov.uk"
+        }
+      },
+      "resource_group_name": "s189p01-ittmsdomains-rg",
+      "front_door_name": "s189p01-ittmsdomains-fd"
     },
-    "tags": {
-      "Product": "ITT mentor services",
-      "Service Offering": "ITT mentor services",
-      "Environment": "Sandbox"
-    },
-    "deploy_default_records": false
-  }
+    "manage-school-placements.education.gov.uk": {
+      "caa_records": {},
+      "txt_records": {},
+      "resource_group_name": "s189p01-ittmsdomains-rg",
+      "front_door_name": "s189p01-ittmssp-domains-fd"
+    }
+  },
+  "tags": {
+    "Product": "ITT mentor services",
+    "Service Offering": "ITT mentor services",
+    "Environment": "Sandbox"
+  },
+  "deploy_default_records": false
+}


### PR DESCRIPTION
## Context
   Add new DNS zone for  manage-school-placements.

## Changes proposed in this pull request

Added 'manage-school-placements.education.gov.uk' to domains.

## Guidance to review

Verify DNS zone with name from azure portal : manage-school-placements.education.gov.uk 

## Link to Trello card

https://trello.com/c/XVe4ftpa/1723-school-placement-domain

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
