### PR TITLE
Update email templates to respect service names

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -16,8 +16,16 @@ class ApplicationMailer < Mail::Notify::Mailer
     "[#{HostingEnvironment.env.upcase}] "
   end
 
+  def service
+    params[:service]
+  end
+
   def service_name
-    I18n.t("#{params[:service]}.service_name")
+    I18n.t("#{service}.service_name")
+  end
+
+  def support_email
+    I18n.t("#{service}.support_email")
   end
 
   def default_url_options
@@ -29,7 +37,7 @@ class ApplicationMailer < Mail::Notify::Mailer
   end
 
   def host
-    case params[:service].to_s
+    case service.to_s
     when "claims"
       ENV["CLAIMS_HOST"]
     when "placements"

--- a/app/mailers/support_user_mailer.rb
+++ b/app/mailers/support_user_mailer.rb
@@ -1,24 +1,37 @@
 class SupportUserMailer < ApplicationMailer
+  TEAM_SLACK_CHANNEL_URLS = {
+    claims: "https://ukgovernmentdfe.slack.com/archives/C0657JE64HX",
+    placements: "https://ukgovernmentdfe.slack.com/archives/C04MLBVP876",
+  }.with_indifferent_access.freeze
+
   def support_user_invitation(support_user)
-    subject = t(".subject", service_name: t("#{support_user.service}.service_name"))
+    subject = t(".subject", service_name:)
     body = t(
       ".body",
       user_name: support_user.first_name,
-      service_name: t("#{support_user.service}.service_name"),
+      service_name:,
       sign_in_url:,
+      slack_url:,
     )
 
     notify_email to: support_user.email, subject:, body:
   end
 
   def support_user_removal_notification(support_user)
-    subject = t(".subject", service_name: t("#{support_user.service}.service_name"))
+    subject = t(".subject", service_name:)
     body = t(
       ".body",
       user_name: support_user.first_name,
-      service_name: t("#{support_user.service}.service_name"),
+      service_name:,
+      slack_url:,
     )
 
     notify_email to: support_user.email, subject:, body:
+  end
+
+  private
+
+  def slack_url
+    TEAM_SLACK_CHANNEL_URLS.fetch(service)
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -2,13 +2,26 @@ class UserMailer < ApplicationMailer
   def user_membership_created_notification(user, organisation)
     notify_email to: user.email,
                  subject: t(".subject", service_name:),
-                 body: t(".body", user_name: user.first_name, organisation_name: organisation.name, service_name:, sign_in_url:)
+                 body: t(
+                   ".body",
+                   user_name: user.first_name,
+                   organisation_name: organisation.name,
+                   service_name:,
+                   support_email:,
+                   sign_in_url:,
+                 )
   end
 
   def user_membership_destroyed_notification(user, organisation)
     notify_email to: user.email,
                  subject: t(".subject", service_name:),
-                 body: t(".body", user_name: user.first_name, organisation_name: organisation.name, service_name:)
+                 body: t(
+                   ".body",
+                   user_name: user.first_name,
+                   organisation_name: organisation.name,
+                   service_name:,
+                   support_email:,
+                 )
   end
 
   def claim_submitted_notification(user, claim)
@@ -16,24 +29,30 @@ class UserMailer < ApplicationMailer
 
     notify_email to: user.email,
                  subject: t(".subject"),
-                 body: t(".body",
-                         user_name: user.first_name,
-                         organisation_name: claim.school.name,
-                         reference: claim.reference,
-                         amount: claim.amount.format(symbol: true, decimal_mark: ".", no_cents: false),
-                         link_to_claim:)
+                 body: t(
+                   ".body",
+                   user_name: user.first_name,
+                   organisation_name: claim.school.name,
+                   reference: claim.reference,
+                   amount: claim.amount.format(symbol: true, decimal_mark: ".", no_cents: false),
+                   support_email:,
+                   link_to_claim:,
+                 )
   end
 
   def claim_created_support_notification(claim, user)
     link_to_claim = claims_school_claim_url(id: claim.id, school_id: claim.school.id)
 
-    notify_email(to: user.email,
+    notify_email to: user.email,
                  subject: t(".subject"),
-                 body: t(".body",
-                         user_name: user.first_name,
-                         organisation_name: claim.school.name,
-                         reference: claim.reference,
-                         amount: claim.amount.format(symbol: true, decimal_mark: ".", no_cents: false),
-                         link_to_claim:))
+                 body: t(
+                   ".body",
+                   user_name: user.first_name,
+                   organisation_name: claim.school.name,
+                   reference: claim.reference,
+                   amount: claim.amount.format(symbol: true, decimal_mark: ".", no_cents: false),
+                   support_email:,
+                   link_to_claim:,
+                 )
   end
 end

--- a/app/services/support_user/remove.rb
+++ b/app/services/support_user/remove.rb
@@ -19,6 +19,6 @@ class SupportUser::Remove
   private
 
   def send_email_notification
-    SupportUserMailer.support_user_removal_notification(support_user).deliver_later
+    SupportUserMailer.with(service: support_user.service).support_user_removal_notification(support_user).deliver_later
   end
 end

--- a/config/locales/en/support_user_mailer.yml
+++ b/config/locales/en/support_user_mailer.yml
@@ -1,11 +1,11 @@
 en:
   support_user_mailer:
     support_user_invitation:
-      subject: "Invitation to join Claim funding for mentor training"
+      subject: "Invitation to join %{service_name}"
       body: |
         Dear %{user_name},
 
-        You have been invited to join the Claim funding for mentor training service
+        You have been invited to join the %{service_name} service
 
         # Sign in to the support site
 
@@ -19,21 +19,21 @@ en:
 
         # Give feedback or report a problem
 
-        If you have any questions or feedback, please [contact the service team on Slack](https://ukgovernmentdfe.slack.com/archives/C0657JE64HX)
+        If you have any questions or feedback, please [contact the service team on Slack](%{slack_url})
 
         Regards
 
-        Claim funding for mentor training team
+        %{service_name} team
 
     support_user_removal_notification:
-      subject: "You have been removed from Claim funding for mentor training"
+      subject: "You have been removed from %{service_name}"
       body: |
         Dear %{user_name},
 
-        You have been removed from the Claim funding for mentor training service.
+        You have been removed from the %{service_name} service.
 
-        If you think this was a mistake, [contact the service team on Slack](https://ukgovernmentdfe.slack.com/archives/C0657JE64HX).
+        If you think this was a mistake, [contact the service team on Slack](%{slack_url}).
 
         Regards
 
-        Claim funding for mentor training team
+        %{service_name} team

--- a/config/locales/en/user_mailer.yml
+++ b/config/locales/en/user_mailer.yml
@@ -1,7 +1,7 @@
 en:
   user_mailer:
     user_membership_created_notification:
-      subject: Invitation to join Claim funding for mentor training
+      subject: Invitation to join %{service_name}
       body: |
         Dear %{user_name},
 
@@ -19,26 +19,26 @@ en:
 
         # Give feedback or report a problem
 
-        If you have any questions or feedback, please contact the team at [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk).
+        If you have any questions or feedback, please contact the team at [%{support_email}](mailto:%{support_email}).
 
         Regards
 
-        Claim funding for mentor training team
+        %{service_name} team
 
     user_membership_destroyed_notification:
-      subject: You have been removed from Claim funding for mentor training
+      subject: You have been removed from %{service_name}
       body: |
         Dear %{user_name},
 
-        You have been removed from the Claim funding for mentor training service for %{organisation_name}.
+        You have been removed from the %{service_name} service for %{organisation_name}.
 
         # Give feedback or report a problem
 
-        If you have any questions or feedback, please contact the team at [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk).
+        If you have any questions or feedback, please contact the team at [%{support_email}](mailto:%{support_email}).
 
         Regards
 
-        Claim funding for mentor training team
+        %{service_name} team
 
     claim_submitted_notification:
       subject: Thank you for submitting your claim for mentor training
@@ -55,7 +55,7 @@ en:
 
         # Give feedback or report a problem
 
-        If you have any questions or feedback, please contact the team at [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk).
+        If you have any questions or feedback, please contact the team at [%{support_email}](mailto:%{support_email}).
 
         Regards
 
@@ -75,7 +75,7 @@ en:
 
         # Give feedback or report a problem
 
-        If you have any questions or feedback, please contact the team at [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk).
+        If you have any questions or feedback, please contact the team at [%{support_email}](mailto:%{support_email}).
 
         Regards
 

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -24,4 +24,38 @@ RSpec.describe ApplicationMailer, type: :mailer do
       end
     end
   end
+
+  describe "#host" do
+    subject(:email) { example_mailer_class.with(service:).example_email }
+
+    let(:example_mailer_class) do
+      Class.new(ApplicationMailer) do
+        def example_email
+          mail(body: "host: #{host.inspect}")
+        end
+      end
+    end
+
+    let(:service) { nil }
+
+    it "returns a 'nil' host" do
+      expect(email.body).to eq("host: nil")
+    end
+
+    context "when given the 'claims' service" do
+      let(:service) { "claims" }
+
+      it "returns the CLAIMS_HOST" do
+        expect(email.body).to eq("host: \"claims.localhost\"")
+      end
+    end
+
+    context "when given the 'placements' service" do
+      let(:service) { "placements" }
+
+      it "returns the PLACEMENTS_HOST" do
+        expect(email.body).to eq("host: \"placements.localhost\"")
+      end
+    end
+  end
 end

--- a/spec/mailers/support_user_mailer_spec.rb
+++ b/spec/mailers/support_user_mailer_spec.rb
@@ -63,11 +63,11 @@ RSpec.describe SupportUserMailer, type: :mailer do
 
       it "is addressed to the user's email and contains a link to the placements sign in url" do
         expect(invite_email.to).to contain_exactly(user.email)
-        expect(invite_email.subject).to eq("Invitation to join Claim funding for mentor training")
+        expect(invite_email.subject).to eq("Invitation to join Manage school placements")
         expect(invite_email.body).to have_content <<~EMAIL
           Dear John,
 
-          You have been invited to join the Claim funding for mentor training service
+          You have been invited to join the Manage school placements service
 
           # Sign in to the support site
 
@@ -81,11 +81,11 @@ RSpec.describe SupportUserMailer, type: :mailer do
 
           # Give feedback or report a problem
 
-          If you have any questions or feedback, please [contact the service team on Slack](https://ukgovernmentdfe.slack.com/archives/C0657JE64HX)
+          If you have any questions or feedback, please [contact the service team on Slack](https://ukgovernmentdfe.slack.com/archives/C04MLBVP876)
 
           Regards
 
-          Claim funding for mentor training team
+          Manage school placements team
         EMAIL
       end
 
@@ -95,7 +95,7 @@ RSpec.describe SupportUserMailer, type: :mailer do
         end
 
         it "does not prepend the hosting environment to the subject" do
-          expect(invite_email.subject).to eq("Invitation to join Claim funding for mentor training")
+          expect(invite_email.subject).to eq("Invitation to join Manage school placements")
         end
       end
 
@@ -105,7 +105,7 @@ RSpec.describe SupportUserMailer, type: :mailer do
         end
 
         it "prepends the hosting environment to the subject" do
-          expect(invite_email.subject).to eq("[STAGING] Invitation to join Claim funding for mentor training")
+          expect(invite_email.subject).to eq("[STAGING] Invitation to join Manage school placements")
         end
       end
     end
@@ -161,17 +161,17 @@ RSpec.describe SupportUserMailer, type: :mailer do
 
       it "is addressed to the user's email and contains a link to the placements sign in url" do
         expect(removal_email.to).to contain_exactly(user.email)
-        expect(removal_email.subject).to eq("You have been removed from Claim funding for mentor training")
+        expect(removal_email.subject).to eq("You have been removed from Manage school placements")
         expect(removal_email.body).to have_content <<~EMAIL
           Dear John,
 
-          You have been removed from the Claim funding for mentor training service.
+          You have been removed from the Manage school placements service.
 
-          If you think this was a mistake, [contact the service team on Slack](https://ukgovernmentdfe.slack.com/archives/C0657JE64HX).
+          If you think this was a mistake, [contact the service team on Slack](https://ukgovernmentdfe.slack.com/archives/C04MLBVP876).
 
           Regards
 
-          Claim funding for mentor training team
+          Manage school placements team
         EMAIL
       end
 
@@ -181,7 +181,7 @@ RSpec.describe SupportUserMailer, type: :mailer do
         end
 
         it "does not prepend the hosting environment to the subject" do
-          expect(removal_email.subject).to eq("You have been removed from Claim funding for mentor training")
+          expect(removal_email.subject).to eq("You have been removed from Manage school placements")
         end
       end
 
@@ -191,7 +191,7 @@ RSpec.describe SupportUserMailer, type: :mailer do
         end
 
         it "prepends the hosting environment to the subject" do
-          expect(removal_email.subject).to eq("[STAGING] You have been removed from Claim funding for mentor training")
+          expect(removal_email.subject).to eq("[STAGING] You have been removed from Manage school placements")
         end
       end
     end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe UserMailer, type: :mailer do
 
         it "sends invitation email" do
           expect(invite_email.to).to contain_exactly(user.email)
-          expect(invite_email.subject).to eq("Invitation to join Claim funding for mentor training")
+          expect(invite_email.subject).to eq("Invitation to join Manage school placements")
           expect(invite_email.body).to have_content <<~EMAIL
             Dear #{user.first_name},
 
@@ -82,11 +82,11 @@ RSpec.describe UserMailer, type: :mailer do
 
             # Give feedback or report a problem
 
-            If you have any questions or feedback, please contact the team at [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk).
+            If you have any questions or feedback, please contact the team at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
 
             Regards
 
-            Claim funding for mentor training team
+            Manage school placements team
           EMAIL
         end
 
@@ -96,7 +96,7 @@ RSpec.describe UserMailer, type: :mailer do
           end
 
           it "does not prepend the hosting environment to the subject" do
-            expect(invite_email.subject).to eq("Invitation to join Claim funding for mentor training")
+            expect(invite_email.subject).to eq("Invitation to join Manage school placements")
           end
         end
 
@@ -106,7 +106,7 @@ RSpec.describe UserMailer, type: :mailer do
           end
 
           it "prepends the hosting environment to the subject" do
-            expect(invite_email.subject).to eq("[STAGING] Invitation to join Claim funding for mentor training")
+            expect(invite_email.subject).to eq("[STAGING] Invitation to join Manage school placements")
           end
         end
       end
@@ -117,7 +117,7 @@ RSpec.describe UserMailer, type: :mailer do
 
         it "sends invitation email" do
           expect(invite_email.to).to contain_exactly(user.email)
-          expect(invite_email.subject).to eq("Invitation to join Claim funding for mentor training")
+          expect(invite_email.subject).to eq("Invitation to join Manage school placements")
           expect(invite_email.body).to have_content <<~EMAIL
             Dear #{user.first_name},
 
@@ -135,11 +135,11 @@ RSpec.describe UserMailer, type: :mailer do
 
             # Give feedback or report a problem
 
-            If you have any questions or feedback, please contact the team at [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk).
+            If you have any questions or feedback, please contact the team at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
 
             Regards
 
-            Claim funding for mentor training team
+            Manage school placements team
           EMAIL
         end
 
@@ -149,7 +149,7 @@ RSpec.describe UserMailer, type: :mailer do
           end
 
           it "does not prepend the hosting environment to the subject" do
-            expect(invite_email.subject).to eq("Invitation to join Claim funding for mentor training")
+            expect(invite_email.subject).to eq("Invitation to join Manage school placements")
           end
         end
 
@@ -159,7 +159,7 @@ RSpec.describe UserMailer, type: :mailer do
           end
 
           it "prepends the hosting environment to the subject" do
-            expect(invite_email.subject).to eq("[STAGING] Invitation to join Claim funding for mentor training")
+            expect(invite_email.subject).to eq("[STAGING] Invitation to join Manage school placements")
           end
         end
       end
@@ -219,19 +219,19 @@ RSpec.describe UserMailer, type: :mailer do
 
         it "sends expected message to user" do
           expect(removal_email.to).to contain_exactly user.email
-          expect(removal_email.subject).to eq "You have been removed from Claim funding for mentor training"
+          expect(removal_email.subject).to eq "You have been removed from Manage school placements"
           expect(removal_email.body).to have_content <<~EMAIL
             Dear #{user.first_name},
 
-            You have been removed from the Claim funding for mentor training service for #{organisation.name}.
+            You have been removed from the Manage school placements service for #{organisation.name}.
 
             # Give feedback or report a problem
 
-            If you have any questions or feedback, please contact the team at [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk).
+            If you have any questions or feedback, please contact the team at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
 
             Regards
 
-            Claim funding for mentor training team
+            Manage school placements team
           EMAIL
         end
 
@@ -241,7 +241,7 @@ RSpec.describe UserMailer, type: :mailer do
           end
 
           it "does not prepend the hosting environment to the subject" do
-            expect(removal_email.subject).to eq("You have been removed from Claim funding for mentor training")
+            expect(removal_email.subject).to eq("You have been removed from Manage school placements")
           end
         end
 
@@ -251,7 +251,7 @@ RSpec.describe UserMailer, type: :mailer do
           end
 
           it "prepends the hosting environment to the subject" do
-            expect(removal_email.subject).to eq("[STAGING] You have been removed from Claim funding for mentor training")
+            expect(removal_email.subject).to eq("[STAGING] You have been removed from Manage school placements")
           end
         end
       end
@@ -262,19 +262,19 @@ RSpec.describe UserMailer, type: :mailer do
 
         it "sends expected message to user" do
           expect(removal_email.to).to contain_exactly user.email
-          expect(removal_email.subject).to eq "You have been removed from Claim funding for mentor training"
+          expect(removal_email.subject).to eq "You have been removed from Manage school placements"
           expect(removal_email.body).to have_content <<~EMAIL
             Dear #{user.first_name},
 
-            You have been removed from the Claim funding for mentor training service for #{organisation.name}.
+            You have been removed from the Manage school placements service for #{organisation.name}.
 
             # Give feedback or report a problem
 
-            If you have any questions or feedback, please contact the team at [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk).
+            If you have any questions or feedback, please contact the team at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
 
             Regards
 
-            Claim funding for mentor training team
+            Manage school placements team
           EMAIL
         end
 
@@ -284,7 +284,7 @@ RSpec.describe UserMailer, type: :mailer do
           end
 
           it "does not prepend the hosting environment to the subject" do
-            expect(removal_email.subject).to eq("You have been removed from Claim funding for mentor training")
+            expect(removal_email.subject).to eq("You have been removed from Manage school placements")
           end
         end
 
@@ -294,7 +294,7 @@ RSpec.describe UserMailer, type: :mailer do
           end
 
           it "prepends the hosting environment to the subject" do
-            expect(removal_email.subject).to eq("[STAGING] You have been removed from Claim funding for mentor training")
+            expect(removal_email.subject).to eq("[STAGING] You have been removed from Manage school placements")
           end
         end
       end

--- a/spec/system/claims/schools/users/invite_a_user_to_a_school_spec.rb
+++ b/spec/system/claims/schools/users/invite_a_user_to_a_school_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe "Invite a user to a school", type: :system do
 
   def email_is_sent(email, _school)
     email = ActionMailer::Base.deliveries.find do |delivery|
-      delivery.to.include?(email) && delivery.subject =~ /Invitation to join Claim funding for mentor training/
+      delivery.to.include?(email) && delivery.subject == "Invitation to join Claim funding for mentor training"
     end
 
     expect(email).not_to be_nil

--- a/spec/system/claims/support/schools/invite_a_user_to_a_school_spec.rb
+++ b/spec/system/claims/support/schools/invite_a_user_to_a_school_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe "Invite a user to a school", type: :system do
 
   def email_is_sent(email, _school)
     email = ActionMailer::Base.deliveries.find do |delivery|
-      delivery.to.include?(email) && delivery.subject =~ /Invitation to join Claim funding for mentor training/
+      delivery.to.include?(email) && delivery.subject == "Invitation to join Claim funding for mentor training"
     end
 
     expect(email).not_to be_nil

--- a/spec/system/claims/support/support_users/add_a_support_user_spec.rb
+++ b/spec/system/claims/support/support_users/add_a_support_user_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe "Add a support user", type: :system do
 
   def and_an_email_is_sent_to_the_support_user(email_address:)
     email = ActionMailer::Base.deliveries.find do |delivery|
-      delivery.to.include?(email_address) && delivery.subject =~ /Invitation to join Claim funding for mentor training/
+      delivery.to.include?(email_address) && delivery.subject == "Invitation to join Claim funding for mentor training"
     end
 
     expect(email).not_to be_nil

--- a/spec/system/claims/support/support_users/re_add_a_discarded_support_user_spec.rb
+++ b/spec/system/claims/support/support_users/re_add_a_discarded_support_user_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe "Re-add a discarded support user", type: :system do
   def and_an_email_is_sent_to_the_support_user(email_address:)
     email = ActionMailer::Base.deliveries.find do |delivery|
       delivery.to.include?(email_address) &&
-        delivery.subject =~ /Invitation to join Claim funding for mentor training/
+        delivery.subject == "Invitation to join Claim funding for mentor training"
     end
 
     expect(email).not_to be_nil

--- a/spec/system/claims/support/support_users/remove_a_support_user_spec.rb
+++ b/spec/system/claims/support/support_users/remove_a_support_user_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Remove a support user", type: :system do
 
   def then_an_email_is_sent(email)
     email = ActionMailer::Base.deliveries.find do |delivery|
-      delivery.to.include?(email) && delivery.subject =~ /You have been removed from Claim funding for mentor training/
+      delivery.to.include?(email) && delivery.subject == "You have been removed from Claim funding for mentor training"
     end
 
     expect(email).not_to be_nil

--- a/spec/system/placements/organisations/users/add_users_spec.rb
+++ b/spec/system/placements/organisations/users/add_users_spec.rb
@@ -322,7 +322,7 @@ RSpec.describe "Placements users invite other users to organisations", type: :sy
 
   def email_invite_notification(email, _organisation)
     ActionMailer::Base.deliveries.find do |delivery|
-      delivery.to.include?(email) && delivery.subject =~ /Invitation to join Claim funding for mentor training/
+      delivery.to.include?(email) && delivery.subject == "Invitation to join Manage school placements"
     end
   end
 

--- a/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
+++ b/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
 
   def email_removal_notification(email, _organisation)
     ActionMailer::Base.deliveries.find do |delivery|
-      delivery.to.include?(email) && delivery.subject =~ /You have been removed from Claim funding for mentor training/
+      delivery.to.include?(email) && delivery.subject == "You have been removed from Manage school placements"
     end
   end
 

--- a/spec/system/placements/support/support_users/support_user_adds_a_support_user_spec.rb
+++ b/spec/system/placements/support/support_users/support_user_adds_a_support_user_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe "Placements / Support Users / Support user adds a support user",
 
   def and_an_email_is_sent_to_the_support_user(email_address:)
     email = ActionMailer::Base.deliveries.find do |delivery|
-      delivery.to.include?(email_address) && delivery.subject =~ /Invitation to join Claim funding for mentor training/
+      delivery.to.include?(email_address) && delivery.subject == "Invitation to join Manage school placements"
     end
 
     expect(email).not_to be_nil

--- a/spec/system/placements/support/support_users/support_user_re_adds_a_discarded_support_user_spec.rb
+++ b/spec/system/placements/support/support_users/support_user_re_adds_a_discarded_support_user_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe "Placements / Support Users / Support user re-adds a discarded su
   def and_an_email_is_sent_to_the_support_user(email_address:)
     email = ActionMailer::Base.deliveries.find do |delivery|
       delivery.to.include?(email_address) &&
-        delivery.subject =~ /Invitation to join Claim funding for mentor training/
+        delivery.subject == "Invitation to join Manage school placements"
     end
 
     expect(email).not_to be_nil

--- a/spec/system/placements/support/support_users/support_user_removes_a_support_user_spec.rb
+++ b/spec/system/placements/support/support_users/support_user_removes_a_support_user_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Placements / Support Users / Support users removes a support use
 
   def then_an_email_is_sent(email)
     email = ActionMailer::Base.deliveries.find do |delivery|
-      delivery.to.include?(email) && delivery.subject =~ /You have been removed from Claim funding for mentor training/
+      delivery.to.include?(email) && delivery.subject == "You have been removed from Manage school placements"
     end
 
     expect(email).not_to be_nil

--- a/spec/system/placements/support/users/support_user_invites_a_new_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_invites_a_new_user_spec.rb
@@ -293,7 +293,7 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
 
   def email_invite_notification(email, _organisation)
     ActionMailer::Base.deliveries.find do |delivery|
-      delivery.to.include?(email) && delivery.subject =~ /Invitation to join Claim funding for mentor training/
+      delivery.to.include?(email) && delivery.subject == "Invitation to join Manage school placements"
     end
   end
 

--- a/spec/system/placements/support/users/support_user_removes_a_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_removes_a_user_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
 
   def email_removal_notification(email, _organisation)
     ActionMailer::Base.deliveries.find do |delivery|
-      delivery.to.include?(email) && delivery.subject =~ /You have been removed from Claim funding for mentor training/
+      delivery.to.include?(email) && delivery.subject == "You have been removed from Manage school placements"
     end
   end
 


### PR DESCRIPTION
## Context

When we updated the email templates for launch, we snuck in some tech debt by hardcoding the "Claims" service name.

We now need to update the templates to respect which service is calling them.

/* In the future, we may need separate templates/mailer classes for each service.

## Changes proposed in this pull request

- Update templates to use `service` and `service_name` where suitable.

## Guidance to review

- Specs pass.
- @DFE-Digital/school-placements is happy? :D
