### PR TITLE
Add breadcrumbs to our static pages

### DIFF
--- a/app/views/claims/pages/accessibility.en.html.erb
+++ b/app/views/claims/pages/accessibility.en.html.erb
@@ -1,4 +1,5 @@
-<% content_for :page_title, "Accessibility statement for Claim funding for mentor training" %>
+<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: { t("home") => claims_root_path, t(".page_title") => claims_accessibility_path }, collapse_on_mobile: true) %>
+<% content_for :page_title, t(".page_title") %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">

--- a/app/views/claims/pages/cookies.en.html.erb
+++ b/app/views/claims/pages/cookies.en.html.erb
@@ -1,4 +1,5 @@
-<% content_for :page_title, "Cookies on Claim funding for mentor training" %>
+<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: { t("home") => claims_root_path, t(".page_title") => claims_cookies_path }, collapse_on_mobile: true) %>
+<% content_for :page_title, t(".page_title") %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">

--- a/app/views/claims/pages/grant_conditions.html.erb
+++ b/app/views/claims/pages/grant_conditions.html.erb
@@ -1,1 +1,3 @@
+<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: { t("home") => claims_root_path, t(".page_title") => claims_grant_conditions_path }, collapse_on_mobile: true) %>
+
 <%= render partial: "claims/schools/grant_conditions", locals: { with_contents: true, page_title: t(".page_title") } %>

--- a/app/views/claims/pages/privacy.en.html.erb
+++ b/app/views/claims/pages/privacy.en.html.erb
@@ -1,3 +1,4 @@
+<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: { t("home") => claims_root_path, t(".page_title") => claims_privacy_path }, collapse_on_mobile: true) %>
 <% content_for :page_title, t(".page_title") %>
 
 <div class="govuk-width-container">

--- a/app/views/claims/pages/terms.en.html.erb
+++ b/app/views/claims/pages/terms.en.html.erb
@@ -1,4 +1,5 @@
-<% content_for :page_title, "Terms and conditions" %>
+<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: { t("home") => claims_root_path, t(".page_title") => claims_terms_path }, collapse_on_mobile: true) %>
+<% content_for :page_title, t(".page_title") %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,6 +44,10 @@
 
     <%= yield :primary_navigation_content %>
 
+    <% if content_for?(:breadcrumbs) %>
+      <%= tag.div yield(:breadcrumbs), class: "govuk-width-container" %>
+    <% end %>
+
     <div class="govuk-width-container">
       <%= yield :before_content %>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,7 @@ en:
   you_cannot_perform_this_action: You cannot perform this action
   you_do_not_have_access_to_this_service: You do not have access to this service
   none: None
+  home: Home
   cancel: Cancel
   continue: Continue
   change: Change

--- a/config/locales/en/claims/pages.yml
+++ b/config/locales/en/claims/pages.yml
@@ -9,3 +9,7 @@ en:
         page_title: General mentor training conditions of grant for early adopters
       feedback:
         page_title: Give feedback on Claim funding for mentor training
+      accessibility:
+        page_title: Accessibility statement for Claim funding for mentor training
+      terms:
+        page_title: Terms and conditions


### PR DESCRIPTION
## Context

We want a way for the user to get back to the home page from our static pages. So the breadcrumbs will contain the current page and a home page.

The home page link will go to the school/claims index page if normal the user is logged in.

For support users it will redirect to organisations index page. This is because we redirect from the root path to these pages if a user is signed in.

## Changes proposed in this pull request

Pages controller, views, locals

## Guidance to review

Go through the static pages and check the breadcrumbs


## Screenshots



https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/74c7e7b8-78e6-42f3-b0f0-7bcce573bb6e

