### PR TITLE
When adding an Organisation (School), I should see their UKPRN and be able to "change" the school

### DIFF
--- a/app/views/claims/support/schools/check.html.erb
+++ b/app/views/claims/support/schools/check.html.erb
@@ -20,6 +20,15 @@
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".organisation_name")) %>
             <% row.with_value(text: @school.name) %>
+            <% row.with_action(text: t(".change"),
+                               href: new_claims_support_school_path(@school_form.as_form_params),
+                               html_attributes: {
+                                 class: "govuk-link--no-visited-state",
+                               }) %>
+          <% end %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".ukprn")) %>
+            <% row.with_value(text: @school.ukprn) %>
           <% end %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".urn")) %>

--- a/config/locales/en/claims/support/schools.yml
+++ b/config/locales/en/claims/support/schools.yml
@@ -31,9 +31,11 @@ en:
           save_organisation: Save organisation
           address: Address
           cancel: Cancel
+          change: Change
           contact_details: Contact details
           organisation_name: Organisation name
           telephone: Telephone number
           title: Check your answers
           urn: Unique reference number (URN)
+          ukprn: UK provider reference number (UKPRN)
           website: Website

--- a/spec/system/claims/support/schools/add_a_school_spec.rb
+++ b/spec/system/claims/support/schools/add_a_school_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Support User adds a School", type: :system, service: :claims do
     when_i_click_the_dropdown_item_for("School 1")
     and_i_click_continue
     then_i_see_the_check_details_page_for_school("School 1")
+    i_then_click_change_school_link
     when_i_click_save_organisation
     then_i_return_to_support_organisations_index
     and_a_school_is_listed(school_name: "School 1")
@@ -48,6 +49,12 @@ RSpec.describe "Support User adds a School", type: :system, service: :claims do
   end
 
   private
+
+  def i_then_click_change_school_link
+    click_on "Change"
+    expect(page).to have_content("Enter a school name, URN or postcode")
+    click_on "Continue"
+  end
 
   def and_there_is_an_existing_user_for(user_name)
     user = create(:claims_support_user, user_name.downcase.to_sym)


### PR DESCRIPTION
## Context

Provide more information about the org being added

## Changes proposed in this pull request

- Add the UKPRN number 
- Add change link to allow a user to go back and change the school

## Guidance to review

- Sign in as Colin
- Add an organisation
- On the check page you will see the new UKPRN field, and change link

## Link to Trello card

https://trello.com/c/T1TCIiM2/440-when-adding-an-organisation-school-i-should-see-their-ukprn-and-be-able-to-change-the-school

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
<img width="928" alt="Screenshot 2024-05-08 at 05 54 39" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/fdde86f3-68e0-406c-a4da-cbca9ea8003c">
