### PR TITLE
Added doamins  for qa,sandbox and staging

### DIFF
--- a/terraform/domains/environment_domains/.terraform.lock.hcl
+++ b/terraform/domains/environment_domains/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "3.82.0"
   hashes = [
     "h1:Zo/EZdNd8Vubo3rSj5NTU4SwLqArsz1mqtefru/8DpQ=",
+    "h1:wIfGA8icS9CbbMfHQFRAUddF2/emdmvJbkTZxfEJTXg=",
     "zh:2042c5485476b0b9dbcebfc01d95e1cec50b37b2c443ffd9824a4fc6a7b293bd",
     "zh:3fc6753c039bac1866b90f5faf5f72edc7470cb64c1e84f830e71931dfced865",
     "zh:4760c4595a5e8a07c5eef08304877909f88252c1536432e443211ae668456459",

--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -17,6 +17,24 @@
             "to-domain": "claim-funding-for-mentor-training.education.gov.uk"
           }
         ]
+      },
+      "manage-school-placements.education.gov.uk": {
+        "front_door_name": "s189p01-ittmssp-domains-fd",
+        "resource_group_name": "s189p01-ittmsdomains-rg",
+        "domains": [
+          "apex", "www"
+        ],
+        "cached_paths": [
+          "/assets/*"
+        ],
+        "environment_short": "pd",
+        "origin_hostname": "manage-school-placements.teacherservices.cloud",
+        "redirect_rules": [
+          {
+            "from-domain": "www",
+            "to-domain": "manage-school-placements.education.gov.uk"
+          }
+        ]
       }
     }
   }

--- a/terraform/domains/environment_domains/config/qa.tfvars.json
+++ b/terraform/domains/environment_domains/config/qa.tfvars.json
@@ -11,6 +11,18 @@
         ],
         "environment_short": "qa",
         "origin_hostname": "track-and-pay-qa.test.teacherservices.cloud"
+      },
+      "manage-school-placements.education.gov.uk": {
+        "front_door_name": "s189p01-ittmssp-domains-fd",
+        "resource_group_name": "s189p01-ittmsdomains-rg",
+        "domains": [
+          "qa"
+        ],
+        "cached_paths": [
+          "/assets/*"
+        ],
+        "environment_short": "qa",
+        "origin_hostname": "manage-school-placements-qa.test.teacherservices.cloud"
       }
     }
 }

--- a/terraform/domains/environment_domains/config/sandbox.tfvars.json
+++ b/terraform/domains/environment_domains/config/sandbox.tfvars.json
@@ -11,6 +11,18 @@
         ],
         "environment_short": "sb",
         "origin_hostname": "track-and-pay-sandbox.teacherservices.cloud"
+      },
+      "manage-school-placements.education.gov.uk": {
+        "front_door_name": "s189p01-ittmssp-domains-fd",
+        "resource_group_name": "s189p01-ittmsdomains-rg",
+        "domains": [
+          "sandbox"
+        ],
+        "cached_paths": [
+          "/assets/*"
+        ],
+        "environment_short": "sandbox",
+        "origin_hostname": "manage-school-placements-sandbox.test.teacherservices.cloud"
       }
     }
   }

--- a/terraform/domains/environment_domains/config/staging.tfvars.json
+++ b/terraform/domains/environment_domains/config/staging.tfvars.json
@@ -11,6 +11,18 @@
         ],
         "environment_short": "stg",
         "origin_hostname": "track-and-pay-staging.test.teacherservices.cloud"
+      },
+      "manage-school-placements.education.gov.uk": {
+        "front_door_name": "s189p01-ittmssp-domains-fd",
+        "resource_group_name": "s189p01-ittmsdomains-rg",
+        "domains": [
+          "staging"
+        ],
+        "cached_paths": [
+          "/assets/*"
+        ],
+        "environment_short": "staging",
+        "origin_hostname": "manage-school-placements-staging.test.teacherservices.cloud"
       }
     }
 }


### PR DESCRIPTION
## Context

Added manage-school-placements domains  for qa,sandbox and staging

## Changes proposed in this pull request

New domians for manage-school-placements for all environments.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
 https://trello.com/c/XVe4ftpa/1723-school-placement-domain

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
