### PR TITLE
Update breadcrumbs

### DIFF
--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: { t("home") => claims_root_path }, collapse_on_mobile: true) %>
 <% content_for(:page_title) { t(".page_title") } %>
 
 <div class="govuk-width-container">

--- a/app/views/claims/pages/accessibility.en.html.erb
+++ b/app/views/claims/pages/accessibility.en.html.erb
@@ -1,4 +1,4 @@
-<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: { t("home") => claims_root_path, t(".page_title") => claims_accessibility_path }, collapse_on_mobile: true) %>
+<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: { t("home") => claims_root_path }, collapse_on_mobile: true) %>
 <% content_for :page_title, t(".page_title") %>
 
 <div class="govuk-width-container">

--- a/app/views/claims/pages/cookies.en.html.erb
+++ b/app/views/claims/pages/cookies.en.html.erb
@@ -1,4 +1,4 @@
-<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: { t("home") => claims_root_path, t(".page_title") => claims_cookies_path }, collapse_on_mobile: true) %>
+<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: { t("home") => claims_root_path }, collapse_on_mobile: true) %>
 <% content_for :page_title, t(".page_title") %>
 
 <div class="govuk-width-container">

--- a/app/views/claims/pages/grant_conditions.html.erb
+++ b/app/views/claims/pages/grant_conditions.html.erb
@@ -1,3 +1,3 @@
-<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: { t("home") => claims_root_path, t(".page_title") => claims_grant_conditions_path }, collapse_on_mobile: true) %>
+<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: { t("home") => claims_root_path }, collapse_on_mobile: true) %>
 
 <%= render partial: "claims/schools/grant_conditions", locals: { with_contents: true, page_title: t(".page_title") } %>

--- a/app/views/claims/pages/privacy.en.html.erb
+++ b/app/views/claims/pages/privacy.en.html.erb
@@ -1,4 +1,4 @@
-<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: { t("home") => claims_root_path, t(".page_title") => claims_privacy_path }, collapse_on_mobile: true) %>
+<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: { t("home") => claims_root_path }, collapse_on_mobile: true) %>
 <% content_for :page_title, t(".page_title") %>
 
 <div class="govuk-width-container">

--- a/app/views/claims/pages/terms.en.html.erb
+++ b/app/views/claims/pages/terms.en.html.erb
@@ -1,4 +1,4 @@
-<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: { t("home") => claims_root_path, t(".page_title") => claims_terms_path }, collapse_on_mobile: true) %>
+<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: { t("home") => claims_root_path }, collapse_on_mobile: true) %>
 <% content_for :page_title, t(".page_title") %>
 
 <div class="govuk-width-container">


### PR DESCRIPTION
## Context

Update breadcrumbs 

## Changes proposed in this pull request

Only show the home breadcrumb 

## Guidance to review

Sign in and view the footer links and account page

## Link to Trello card

- https://trello.com/c/PWJf3EfE/481-remove-the-current-page-from-all-breadcrumbs
- https://trello.com/c/DcDzalt6/482-add-a-home-breadcrumb-to-the-your-account-page

