### PR TITLE
Add partner school toggle

### DIFF
--- a/app/controllers/placements/providers/placements_controller.rb
+++ b/app/controllers/placements/providers/placements_controller.rb
@@ -5,7 +5,7 @@ class Placements::Providers::PlacementsController < ApplicationController
   def index
     @subjects = Subject.order_by_name.select(:id, :name)
     @school_types = compact_school_attribute_values(:type_of_establishment)
-    @schools = schools_scope.select(:id, :name)
+    @schools = schools_scope.order_by_name.select(:id, :name)
 
     @pagy, @placements = pagy(
       Placements::PlacementsQuery.call(
@@ -22,7 +22,7 @@ class Placements::Providers::PlacementsController < ApplicationController
   private
 
   def schools_scope
-    if filter_params[:only_partner_schools] && filter_params[:only_partner_schools].present?
+    if filter_params[:only_partner_schools].present?
       @provider.partner_schools
     else
       Placements::School.all

--- a/app/controllers/placements/providers/placements_controller.rb
+++ b/app/controllers/placements/providers/placements_controller.rb
@@ -22,7 +22,7 @@ class Placements::Providers::PlacementsController < ApplicationController
   private
 
   def schools_scope
-    if filter_params[:only_partner_schools]&.compact_blank&.empty?
+    if filter_params[:only_partner_schools] && filter_params[:only_partner_schools].empty?
       @provider.partner_schools
     else
       Placements::School.all

--- a/app/controllers/placements/providers/placements_controller.rb
+++ b/app/controllers/placements/providers/placements_controller.rb
@@ -54,13 +54,6 @@ class Placements::Providers::PlacementsController < ApplicationController
     }
   end
 
-  def query_params
-    {
-      filters: filter_form.query_params,
-      current_provider: @provider,
-    }
-  end
-
   def all_schools
     @all_schools ||= School.all
   end

--- a/app/controllers/placements/providers/placements_controller.rb
+++ b/app/controllers/placements/providers/placements_controller.rb
@@ -22,7 +22,7 @@ class Placements::Providers::PlacementsController < ApplicationController
   private
 
   def schools_scope
-    if filter_params[:only_partner_schools] && filter_params[:only_partner_schools].empty?
+    if filter_params[:only_partner_schools] && filter_params[:only_partner_schools].present?
       @provider.partner_schools
     else
       Placements::School.all

--- a/app/controllers/placements/providers/placements_controller.rb
+++ b/app/controllers/placements/providers/placements_controller.rb
@@ -5,8 +5,7 @@ class Placements::Providers::PlacementsController < ApplicationController
   def index
     @subjects = Subject.order_by_name.select(:id, :name)
     @school_types = compact_school_attribute_values(:type_of_establishment)
-    @schools = Placements::School.select(:id, :name)
-    @partner_schools = @provider.partner_schools.select(:id, :name)
+    set_schools
 
     @pagy, @placements = pagy(
       Placements::PlacementsQuery.call(
@@ -21,6 +20,22 @@ class Placements::Providers::PlacementsController < ApplicationController
   end
 
   private
+
+  def set_schools
+    @schools = partner_schools_present? ? partner_schools : all_placements_schools
+  end
+
+  def partner_schools_present?
+    filter_params[:partner_schools]&.compact_blank.present?
+  end
+
+  def partner_schools
+    @provider.partner_schools.select(:id, :name)
+  end
+
+  def all_placements_schools
+    Placements::School.select(:id, :name)
+  end
 
   def set_provider
     @provider = Placements::Provider.find(params[:provider_id])

--- a/app/forms/placements/placements/filter_form.rb
+++ b/app/forms/placements/placements/filter_form.rb
@@ -4,7 +4,7 @@ class Placements::Placements::FilterForm < ApplicationForm
   attribute :school_ids, default: []
   attribute :subject_ids, default: []
   attribute :school_types, default: []
-  attribute :partner_schools, default: []
+  attribute :only_partner_schools, :boolean, default: false
   attribute :only_available_placements, :boolean, default: false
 
   def initialize(params = {})
@@ -39,7 +39,7 @@ class Placements::Placements::FilterForm < ApplicationForm
       school_ids:,
       subject_ids:,
       school_types:,
-      partner_schools:,
+      only_partner_schools:,
       only_available_placements:,
     }
   end
@@ -54,7 +54,7 @@ class Placements::Placements::FilterForm < ApplicationForm
 
   private
 
-  BOOLEAN_ATTRIBUTES = %w[only_available_placements].freeze
+  BOOLEAN_ATTRIBUTES = %w[only_available_placements only_partner_schools].freeze
 
   def compacted_attributes
     @compacted_attributes ||= attributes.compact_blank

--- a/app/forms/placements/placements/filter_form.rb
+++ b/app/forms/placements/placements/filter_form.rb
@@ -4,7 +4,7 @@ class Placements::Placements::FilterForm < ApplicationForm
   attribute :school_ids, default: []
   attribute :subject_ids, default: []
   attribute :school_types, default: []
-  attribute :partner_school_ids, default: []
+  attribute :partner_schools, default: []
   attribute :only_available_placements, :boolean, default: false
 
   def initialize(params = {})
@@ -39,7 +39,7 @@ class Placements::Placements::FilterForm < ApplicationForm
       school_ids:,
       subject_ids:,
       school_types:,
-      partner_school_ids:,
+      partner_schools:,
       only_available_placements:,
     }
   end
@@ -50,10 +50,6 @@ class Placements::Placements::FilterForm < ApplicationForm
 
   def subjects
     @subjects ||= Subject.where(id: subject_ids).order_by_name
-  end
-
-  def partner_schools
-    @partner_schools ||= School.where(id: partner_school_ids).order_by_name
   end
 
   private

--- a/app/queries/placements/placements_query.rb
+++ b/app/queries/placements/placements_query.rb
@@ -33,7 +33,8 @@ class Placements::PlacementsQuery < ApplicationQuery
   def partner_school_condition(scope)
     return scope if filter_params[:only_partner_schools].blank?
 
-    scope.where(school_id: filter_params[:partner_school_ids])
+    provider = params[:current_provider]
+    scope.where(school_id: provider.partner_schools.select(:id))
   end
 
   def only_available_placements_condition(scope)

--- a/app/queries/placements/placements_query.rb
+++ b/app/queries/placements/placements_query.rb
@@ -1,7 +1,9 @@
 class Placements::PlacementsQuery < ApplicationQuery
   def call
-    scope = set_initial_scope
+    scope = Placement.includes(:school, :subjects)
+
     scope = school_condition(scope)
+    scope = partner_school_condition(scope)
     scope = subject_condition(scope)
     scope = school_type_condition(scope)
     scope = only_available_placements_condition(scope)
@@ -9,23 +11,6 @@ class Placements::PlacementsQuery < ApplicationQuery
   end
 
   private
-
-  def set_initial_scope
-    if partner_schools_present?
-      scope_with_partner_schools
-    else
-      Placement.includes(:school, :subjects)
-    end
-  end
-
-  def scope_with_partner_schools
-    provider = Placements::Provider.find(params[:partner_schools].first)
-    Placement.where(school_id: provider.partner_schools.ids).includes(:school, :subjects)
-  end
-
-  def partner_schools_present?
-    params[:partner_schools]&.compact_blank!.present?
-  end
 
   def school_condition(scope)
     return scope if filter_params[:school_ids].blank?

--- a/app/queries/placements/placements_query.rb
+++ b/app/queries/placements/placements_query.rb
@@ -31,7 +31,7 @@ class Placements::PlacementsQuery < ApplicationQuery
   end
 
   def partner_school_condition(scope)
-    return scope if filter_params[:partner_school_ids].blank?
+    return scope if filter_params[:only_partner_schools].blank?
 
     scope.where(school_id: filter_params[:partner_school_ids])
   end

--- a/app/queries/placements/placements_query.rb
+++ b/app/queries/placements/placements_query.rb
@@ -1,16 +1,31 @@
 class Placements::PlacementsQuery < ApplicationQuery
   def call
-    scope = Placement.includes(:school, :subjects)
-
+    scope = set_initial_scope
     scope = school_condition(scope)
     scope = subject_condition(scope)
     scope = school_type_condition(scope)
-    scope = partner_school_condition(scope)
     scope = only_available_placements_condition(scope)
     scope.order_by_subject_school_name
   end
 
   private
+
+  def set_initial_scope
+    if partner_schools_present?
+      scope_with_partner_schools
+    else
+      Placement.includes(:school, :subjects)
+    end
+  end
+
+  def scope_with_partner_schools
+    provider = Placements::Provider.find(params[:partner_schools].first)
+    Placement.where(school_id: provider.partner_schools.ids).includes(:school, :subjects)
+  end
+
+  def partner_schools_present?
+    params[:partner_schools]&.compact_blank!.present?
+  end
 
   def school_condition(scope)
     return scope if filter_params[:school_ids].blank?

--- a/app/views/placements/providers/placements/_filter.html.erb
+++ b/app/views/placements/providers/placements/_filter.html.erb
@@ -74,13 +74,13 @@
             </ul>
           <% end %>
 
-          <% if filter_form.partner_schools.present? %>
+          <% if filter_form.only_partner_schools.present? %>
             <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= "Partner schools" %></h3>
             <ul class="app-filter-tags">
               <li>
                 <%= govuk_link_to(
                       "Partner schools",
-                      filter_form.index_path_without_filter(provider: @provider, filter: "partner_schools", value: @provider.id),
+                      filter_form.index_path_without_filter(provider: @provider, filter: "only_partner_schools", value: true),
                       class: "app-filter__tag",
                       no_visited_state: true,
                     ) %>
@@ -116,15 +116,17 @@
 
           <div class="app-filter__option">
             <%= form.govuk_check_boxes_fieldset(
-              :partner_schools,
+              :only_partner_schools,
               legend: { text: "Partner schools", size: "s" },
               small: true,
+              multiple: false,
             ) do %>
 
-              <%= form.govuk_check_box :partner_schools,
-                                       @provider.id,
+              <%= form.govuk_check_box :only_partner_schools,
+                                       true,
                                        label: { text: "Only show placements offered by my partner schools" },
-                                       checked: filter_form.partner_schools.present? %>
+                                       checked: filter_form.only_partner_schools == true %>
+
             <% end %>
           </div>
 

--- a/app/views/placements/providers/placements/_filter.html.erb
+++ b/app/views/placements/providers/placements/_filter.html.erb
@@ -26,22 +26,6 @@
             </div>
           </div>
 
-          <% if filter_form.partner_school_ids.present? %>
-            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".partner_school") %></h3>
-            <ul class="app-filter-tags">
-              <% filter_form.partner_schools.each do |partner_school| %>
-                <li>
-                  <%= govuk_link_to(
-                    partner_school.name,
-                    filter_form.index_path_without_filter(provider: @provider, filter: "partner_school_ids", value: partner_school.id),
-                    class: "app-filter__tag",
-                    no_visited_state: true,
-                  ) %>
-                </li>
-              <% end %>
-            </ul>
-          <% end %>
-
           <% if filter_form.school_ids.present? %>
             <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".school") %></h3>
             <ul class="app-filter-tags">
@@ -90,12 +74,26 @@
             </ul>
           <% end %>
 
+          <% if filter_form.partner_schools.present? %>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= "Partner schools" %></h3>
+            <ul class="app-filter-tags">
+              <li>
+                <%= govuk_link_to(
+                      "Partner schools",
+                      filter_form.index_path_without_filter(provider: @provider, filter: "partner_schools", value: @provider.id),
+                      class: "app-filter__tag",
+                      no_visited_state: true,
+                    ) %>
+              </li>
+            </ul>
+          <% end %>
+
           <% if filter_form.only_available_placements.present? %>
             <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".availability") %></h3>
             <ul class="app-filter-tags">
               <li>
                 <%= govuk_link_to(
-                      "Available",
+                      t(".availability"),
                       filter_form.index_path_without_filter(provider: @provider, filter: "only_available_placements", value: true),
                       class: "app-filter__tag",
                       no_visited_state: true,
@@ -118,6 +116,20 @@
 
           <div class="app-filter__option">
             <%= form.govuk_check_boxes_fieldset(
+              :partner_schools,
+              legend: { text: "Partner schools", size: "s" },
+              small: true,
+            ) do %>
+
+              <%= form.govuk_check_box :partner_schools,
+                                       @provider.id,
+                                       label: { text: "Only show placements offered by my partner schools" },
+                                       checked: filter_form.partner_schools.present? %>
+            <% end %>
+          </div>
+
+          <div class="app-filter__option">
+            <%= form.govuk_check_boxes_fieldset(
               :only_available_placements,
               legend: { text: t(".availability"), size: "s" },
               small: true,
@@ -131,33 +143,6 @@
                                        multiple: false %>
             <% end %>
           </div>
-
-          <% if @partner_schools.any? %>
-            <div class="app-filter__option">
-              <%= form.govuk_text_field(
-                :search_partner_school,
-                type: :search,
-                data: {
-                  placements_filter_search_target: "partnerSchoolInput",
-                  action: "input->placements-filter-search#searchPartnerSchool",
-                },
-                label: { text: t(".partner_school"), size: "s" },
-              ) %>
-
-              <%= form.govuk_check_boxes_fieldset(
-                :school_ids,
-                legend: { hidden: "true" },
-                data: { placements_filter_search_target: "partnerSchoolList" },
-                small: true,
-              ) do %>
-                <% @partner_schools.each do |partner_school| %>
-                  <%= form.govuk_check_box :partner_school_ids,
-                    partner_school.id,
-                    label: { text: partner_school.name } %>
-                <% end %>
-              <% end %>
-            </div>
-          <% end %>
 
           <div class="app-filter__option">
             <%= form.govuk_text_field(

--- a/app/views/placements/providers/placements/_filter.html.erb
+++ b/app/views/placements/providers/placements/_filter.html.erb
@@ -79,7 +79,7 @@
             <ul class="app-filter-tags">
               <li>
                 <%= govuk_link_to(
-                      "Partner schools",
+                      t(".partner_schools"),
                       filter_form.index_path_without_filter(provider: @provider, filter: "only_partner_schools", value: true),
                       class: "app-filter__tag",
                       no_visited_state: true,

--- a/app/views/placements/providers/placements/_filter.html.erb
+++ b/app/views/placements/providers/placements/_filter.html.erb
@@ -75,7 +75,7 @@
           <% end %>
 
           <% if filter_form.only_partner_schools.present? %>
-            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= "Partner schools" %></h3>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".partner_schools") %></h3>
             <ul class="app-filter-tags">
               <li>
                 <%= govuk_link_to(
@@ -117,14 +117,15 @@
           <div class="app-filter__option">
             <%= form.govuk_check_boxes_fieldset(
               :only_partner_schools,
-              legend: { text: "Partner schools", size: "s" },
-              small: true,
+              legend: { text: t(".partner_schools"), size: "s" },
               multiple: false,
+              small: true,
             ) do %>
 
               <%= form.govuk_check_box :only_partner_schools,
                                        true,
-                                       label: { text: "Only show placements offered by my partner schools" },
+                                       label: { text: t(".only_show_partner_schools") },
+                                       multiple: false,
                                        checked: filter_form.only_partner_schools == true %>
 
             <% end %>

--- a/config/locales/en/placements/providers/placements.yml
+++ b/config/locales/en/placements/providers/placements.yml
@@ -9,7 +9,8 @@ en:
           placements: Placements
           no_results_for_filters: There are no results for the selected filter.
         filter:
-          partner_school: Partner school
+          partner_schools: Partner schools
+          only_show_partner_schools: Only show placements offered by my partner schools
           school: School
           subject: Subject
           school_phase: School phase

--- a/spec/forms/placements/placements/filter_form_spec.rb
+++ b/spec/forms/placements/placements/filter_form_spec.rb
@@ -41,7 +41,7 @@ describe Placements::Placements::FilterForm, type: :model do
     end
 
     context "when given partner school params" do
-      let(:params) { { partner_schools: %w[partner_schools] } }
+      let(:params) { { only_partner_schools: true } }
 
       it "returns true" do
         expect(filter_form).to eq(true)
@@ -110,15 +110,15 @@ describe Placements::Placements::FilterForm, type: :model do
 
     context "when removing partner school id params" do
       let(:params) do
-        { partner_schools: [provider.id] }
+        { only_partner_schools: true }
       end
 
       it "returns the placements index page path without the given school id param" do
         expect(
           filter_form.index_path_without_filter(
             provider:,
-            filter: "partner_schools",
-            value: provider.id,
+            filter: "only_partner_schools",
+            value: false,
           ),
         ).to eq(
           placements_provider_placements_path(provider, filters: {
@@ -170,11 +170,11 @@ describe Placements::Placements::FilterForm, type: :model do
   end
 
   describe "#query_params" do
-    it "returns { partner_schools: [], school_ids: [], subject_ids: [], school_types: [] }" do
+    it "returns { only_partner_schools: false, school_ids: [], subject_ids: [], school_types: [] }" do
       expect(described_class.new.query_params).to eq(
         {
           school_ids: [],
-          partner_schools: [],
+          only_partner_schools: false,
           school_types: [],
           subject_ids: [],
           only_available_placements: false,

--- a/spec/forms/placements/placements/filter_form_spec.rb
+++ b/spec/forms/placements/placements/filter_form_spec.rb
@@ -41,7 +41,7 @@ describe Placements::Placements::FilterForm, type: :model do
     end
 
     context "when given partner school params" do
-      let(:params) { { partner_school_ids: %w[partner_school_id] } }
+      let(:params) { { partner_schools: %w[partner_schools] } }
 
       it "returns true" do
         expect(filter_form).to eq(true)
@@ -110,19 +110,19 @@ describe Placements::Placements::FilterForm, type: :model do
 
     context "when removing partner school id params" do
       let(:params) do
-        { partner_school_ids: %w[school_id_1 school_id_2] }
+        { partner_schools: [provider.id] }
       end
 
       it "returns the placements index page path without the given school id param" do
         expect(
           filter_form.index_path_without_filter(
             provider:,
-            filter: "partner_school_ids",
-            value: "school_id_1",
+            filter: "partner_schools",
+            value: provider.id,
           ),
         ).to eq(
           placements_provider_placements_path(provider, filters: {
-            partner_school_ids: %w[school_id_2],
+            partner_schools: [],
           }),
         )
       end
@@ -170,11 +170,11 @@ describe Placements::Placements::FilterForm, type: :model do
   end
 
   describe "#query_params" do
-    it "returns { partner_school_ids: [], school_ids: [], subject_ids: [], school_types: [] }" do
+    it "returns { partner_schools: [], school_ids: [], subject_ids: [], school_types: [] }" do
       expect(described_class.new.query_params).to eq(
         {
           school_ids: [],
-          partner_school_ids: [],
+          partner_schools: [],
           school_types: [],
           subject_ids: [],
           only_available_placements: false,
@@ -200,17 +200,6 @@ describe Placements::Placements::FilterForm, type: :model do
       expect(
         described_class.new(subject_ids: subjects.pluck(:id)).subjects,
       ).to match_array(subjects)
-    end
-  end
-
-  describe "#partner_schools" do
-    it "returns the partner schools associated with the partner_school_id params given" do
-      schools = create_list(:school, 2)
-      provider.partner_schools << schools
-
-      expect(
-        described_class.new(partner_school_ids: schools.pluck(:id)).partner_schools,
-      ).to match_array(schools)
     end
   end
 end

--- a/spec/forms/placements/placements/filter_form_spec.rb
+++ b/spec/forms/placements/placements/filter_form_spec.rb
@@ -108,7 +108,7 @@ describe Placements::Placements::FilterForm, type: :model do
       end
     end
 
-    context "when removing partner school id params" do
+    context "when removing the partner schools filter" do
       let(:params) do
         { only_partner_schools: true }
       end
@@ -121,9 +121,7 @@ describe Placements::Placements::FilterForm, type: :model do
             value: false,
           ),
         ).to eq(
-          placements_provider_placements_path(provider, filters: {
-            partner_schools: [],
-          }),
+          placements_provider_placements_path(provider, filters: {}),
         )
       end
     end

--- a/spec/system/placements/providers/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/providers/placements/view_placements_list_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe "Placements / Providers / Placements / View placements list",
         when_i_visit_the_placements_index_page(
           {
             filters: {
-              only_partner_schools: %w[true],
+              only_partner_schools: [true],
               school_ids: [primary_school.id],
               subject_ids: [subject_1.id],
               school_types: ["Free school"],

--- a/spec/system/placements/providers/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/providers/placements/view_placements_list_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Placements / Providers / Placements / View placements list",
       when_i_visit_the_placements_index_page
       then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
       and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
-      when_i_check_filter_option("partner-school-ids", primary_school.id)
+      when_i_check_filter_option("partner-schools", provider.id)
       and_i_click_on("Apply filters")
       then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
       and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
@@ -114,11 +114,11 @@ RSpec.describe "Placements / Providers / Placements / View placements list",
 
       scenario "User can remove a partner school filter" do
         given_a_partnership_exists_between(provider, primary_school)
-        when_i_visit_the_placements_index_page({ filters: { partner_school_ids: [primary_school.id] } })
+        when_i_visit_the_placements_index_page({ filters: { partner_schools: [provider.id] } })
         then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
         and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
-        and_i_can_see_a_preset_filter("Partner school", "Primary School")
-        when_i_click_to_remove_filter("Partner school", "Primary School")
+        and_i_can_see_a_preset_filter("Partner schools", "Partner schools")
+        when_i_click_to_remove_filter("Partner schools", "Partner schools")
         then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
         and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
         and_i_can_not_see_any_selected_filters
@@ -158,10 +158,11 @@ RSpec.describe "Placements / Providers / Placements / View placements list",
       end
 
       scenario "User can clear all filters" do
+        given_a_partnership_exists_between(provider, primary_school)
         when_i_visit_the_placements_index_page(
           {
             filters: {
-              partner_school_ids: [primary_school.id],
+              partner_schools: [provider.id],
               school_ids: [primary_school.id],
               subject_ids: [subject_1.id],
               school_types: ["Free school"],
@@ -170,7 +171,7 @@ RSpec.describe "Placements / Providers / Placements / View placements list",
         )
         then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
         and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
-        and_i_can_see_a_preset_filter("Partner school", "Primary School")
+        and_i_can_see_a_preset_filter("Partner schools", "Partner schools")
         and_i_can_see_a_preset_filter("School", "Primary School")
         and_i_can_see_a_preset_filter("Subject", "Primary with mathematics")
         and_i_can_see_a_preset_filter("School type", "Free school")

--- a/spec/system/placements/providers/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/providers/placements/view_placements_list_spec.rb
@@ -162,6 +162,7 @@ RSpec.describe "Placements / Providers / Placements / View placements list",
         when_i_visit_the_placements_index_page(
           {
             filters: {
+              only_available_placements: true,
               only_partner_schools: true,
               school_ids: [primary_school.id],
               subject_ids: [subject_1.id],

--- a/spec/system/placements/providers/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/providers/placements/view_placements_list_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Placements / Providers / Placements / View placements list",
       when_i_visit_the_placements_index_page
       then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
       and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
-      when_i_check_filter_option("only-partner-schools", "true")
+      when_i_check_filter_option("only-partner-schools", true)
       and_i_click_on("Apply filters")
       then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
       and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
@@ -114,7 +114,7 @@ RSpec.describe "Placements / Providers / Placements / View placements list",
 
       scenario "User can remove a partner school filter" do
         given_a_partnership_exists_between(provider, primary_school)
-        when_i_visit_the_placements_index_page({ filters: { only_partner_schools: %w[true] } })
+        when_i_visit_the_placements_index_page({ filters: { only_partner_schools: true } })
         then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
         and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
         and_i_can_see_a_preset_filter("Partner schools", "Partner schools")
@@ -162,7 +162,7 @@ RSpec.describe "Placements / Providers / Placements / View placements list",
         when_i_visit_the_placements_index_page(
           {
             filters: {
-              only_partner_schools: [true],
+              only_partner_schools: true,
               school_ids: [primary_school.id],
               subject_ids: [subject_1.id],
               school_types: ["Free school"],

--- a/spec/system/placements/providers/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/providers/placements/view_placements_list_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Placements / Providers / Placements / View placements list",
       when_i_visit_the_placements_index_page
       then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
       and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
-      when_i_check_filter_option("partner-schools", provider.id)
+      when_i_check_filter_option("only-partner-schools", "true")
       and_i_click_on("Apply filters")
       then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
       and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
@@ -114,7 +114,7 @@ RSpec.describe "Placements / Providers / Placements / View placements list",
 
       scenario "User can remove a partner school filter" do
         given_a_partnership_exists_between(provider, primary_school)
-        when_i_visit_the_placements_index_page({ filters: { partner_schools: [provider.id] } })
+        when_i_visit_the_placements_index_page({ filters: { only_partner_schools: %w[true] } })
         then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
         and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
         and_i_can_see_a_preset_filter("Partner schools", "Partner schools")
@@ -162,7 +162,7 @@ RSpec.describe "Placements / Providers / Placements / View placements list",
         when_i_visit_the_placements_index_page(
           {
             filters: {
-              partner_schools: [provider.id],
+              only_partner_schools: %w[true],
               school_ids: [primary_school.id],
               subject_ids: [subject_1.id],
               school_types: ["Free school"],


### PR DESCRIPTION
## Context

Schools need to be able to filter by their partner providers to help them find placements

## Changes proposed in this pull request

Adds a new partner providers filter to the find a placement page

## Guidance to review

Log in as Patricia and navigate to placements. Selecting the filter will only show partner schools. Both the clear all filters and the partner schools pill will clear this filter.

## Link to Trello card

[Change 'partner school' filter to a toggle](https://trello.com/c/bOmsoFoY)

## Screenshots

![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/8dc9cb12-ce4a-412e-a489-30c79de0f82c)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/a6a33004-c1d7-4e02-b34b-fe5f4a27b0c8)
