### PR TITLE
As a support user I can remove a schools grant conditions agreement

### DIFF
--- a/app/controllers/claims/support/schools_controller.rb
+++ b/app/controllers/claims/support/schools_controller.rb
@@ -1,6 +1,6 @@
 class Claims::Support::SchoolsController < Claims::Support::ApplicationController
   before_action :redirect_to_school_options, only: :check, if: -> { javascript_disabled? }
-  before_action :set_school, only: %i[show]
+  before_action :set_school, only: %i[show remove_grant_conditions_acceptance_check remove_grant_conditions_acceptance]
   before_action :authorize_school
 
   def index
@@ -15,6 +15,13 @@ class Claims::Support::SchoolsController < Claims::Support::ApplicationControlle
                    else
                      SchoolOnboardingForm.new
                    end
+  end
+
+  def remove_grant_conditions_acceptance_check; end
+
+  def remove_grant_conditions_acceptance
+    @school.update!(claims_grant_conditions_accepted_at: nil, claims_grant_conditions_accepted_by: nil)
+    redirect_to claims_support_school_path(@school), flash: { success: t(".success") }
   end
 
   def school_options

--- a/app/models/claims/school.rb
+++ b/app/models/claims/school.rb
@@ -66,6 +66,8 @@
 #  fk_rails_...  (trust_id => trusts.id)
 #
 class Claims::School < School
+  audited
+
   default_scope { claims_service }
 
   has_many :users, through: :user_memberships

--- a/app/policies/claims/school_policy.rb
+++ b/app/policies/claims/school_policy.rb
@@ -7,6 +7,14 @@ class Claims::SchoolPolicy < Claims::ApplicationPolicy
     true
   end
 
+  def remove_grant_conditions_acceptance_check?
+    user != record && user.support_user?
+  end
+
+  def remove_grant_conditions_acceptance?
+    remove_grant_conditions_acceptance_check?
+  end
+
   class Scope < ApplicationPolicy::Scope
     def resolve
       if user.support_user?

--- a/app/views/claims/support/schools/remove_grant_conditions_acceptance_check.html.erb
+++ b/app/views/claims/support/schools/remove_grant_conditions_acceptance_check.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title, t(".page_title", user_name: @school.claims_grant_conditions_accepted_by.full_name) %>
+
+<% content_for(:before_content) do %>
+  <%= govuk_back_link(href: claims_support_school_path(@school)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".agreement") %></span>
+      <h1 class="govuk-heading-l"><%= t(".page_title", user_name: @school.claims_grant_conditions_accepted_by.full_name) %></h1>
+    </div>
+  </div>
+
+  <%= govuk_button_to(t(".remove_agreement"), remove_grant_conditions_acceptance_claims_support_school_path(@school), warning: true, method: :put, class: "govuk-button govuk-button--warning") %>
+
+  <%= govuk_link_to t(".cancel"), claims_support_school_path(@school), no_visited_state: true %>
+</div>

--- a/app/views/shared/organisations/_grant_conditions.html.erb
+++ b/app/views/shared/organisations/_grant_conditions.html.erb
@@ -9,7 +9,11 @@
       <% row.with_value(**details_field_args(l(organisation.claims_grant_conditions_accepted_at.to_date, format: :long))) %>
     <% end %>
   <% end %>
-  <p class="govuk-body"><%= govuk_link_to(t(".funding_link_text"), claims_grant_conditions_path) %></p>
+  <% if current_user.support_user? %>
+    <%= govuk_link_to t(".remove_agreement_text"), remove_grant_conditions_acceptance_check_claims_support_school_path(organisation), class: "app-link app-link--destructive" %>
+  <% else %>
+    <p class="govuk-body"><%= govuk_link_to(t(".funding_link_text"), claims_grant_conditions_path) %></p>
+  <% end %>
 <% else %>
   <p class="govuk-body"><%= t(".condtions_not_accepted") %></p>
 <% end %>

--- a/config/locales/en/claims/support/schools/remove_grant_conditions_acceptance_check.yml
+++ b/config/locales/en/claims/support/schools/remove_grant_conditions_acceptance_check.yml
@@ -1,0 +1,11 @@
+en:
+  claims:
+    support:
+      schools:
+        remove_grant_conditions_acceptance_check:
+          page_title: Are you sure you want to remove %{user_name}'s agreement?
+          agreement: Agreement to grant conditions
+          remove_agreement: Remove agreement
+          cancel: Cancel
+        remove_grant_conditions_acceptance:
+          success: Agreement to grant conditions removed

--- a/config/locales/en/shared/organisations/grant_funding.yml
+++ b/config/locales/en/shared/organisations/grant_funding.yml
@@ -10,3 +10,4 @@ en:
         agreed_on: Agreed on
         funding_link_text: View grant conditions
         condtions_not_accepted: This school has not agreed to the grant conditions
+        remove_agreement_text: Remove user's agreement to the grant conditions

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -61,6 +61,11 @@ scope module: :claims, as: :claims, constraints: {
     end
 
     resources :schools, except: %i[destroy update] do
+      member do
+        put :remove_grant_conditions_acceptance, path: "remove-grant-conditions-acceptance"
+        get :remove_grant_conditions_acceptance_check, path: "remove-grant-conditions-acceptance"
+      end
+
       collection do
         get :check
         get :check_school_option

--- a/spec/system/claims/support/schools/remove_grant_conditions_spec.rb
+++ b/spec/system/claims/support/schools/remove_grant_conditions_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe "Remove a users agreement to the grant conditions for a school", type: :system do
+  let!(:support_user) { create(:claims_support_user, :colin) }
+  let!(:claims_user) { create(:claims_user, first_name: "George", last_name: "Barlow") }
+
+  let!(:school) { create(:claims_school, claims_grant_conditions_accepted_at: Time.zone.now, claims_grant_conditions_accepted_by_id: claims_user.id) }
+
+  before do
+    school.users << claims_user
+  end
+
+  scenario "When a support user removes a schools agreement to grant conditions" do
+    given_i_sign_in_as(support_user)
+    and_i_visit_the_school_page(school)
+    i_see_the_school_details(school)
+    click_on "Remove user's agreement to the grant conditions"
+    i_then_see_the_remove_agreement_check_page
+    click_on "Remove agreement"
+    then_see_the_agreement_has_been_removed
+  end
+
+  private
+
+  def then_see_the_agreement_has_been_removed
+    expect(page).to have_content("Agreement to grant conditions removed")
+    expect(page).to have_content("This school has not agreed to the grant conditions")
+  end
+
+  def i_then_see_the_remove_agreement_check_page
+    expect(page).to have_content("Are you sure you want to remove George Barlow's agreement?")
+  end
+
+  def and_i_visit_the_school_page(school)
+    click_on school.name
+  end
+
+  def i_see_the_school_details(school)
+    expect(page).to have_selector("h1", text: school.name)
+  end
+
+  def i_see_the_schools_details_sections_without_grant_conditions_accepted
+    expect(page).to have_content("This school has not agreed to the grant conditions")
+  end
+end


### PR DESCRIPTION
## Context

As a support user I should be able to remove the accepted grant conditions

## Changes proposed in this pull request

Add a link to allow a support user to remove a schools grant conditions

## Guidance to review

- Sign in as a school
- Accept the grant conditions
- Sign in as a support user
- Visit that school and follow the flow

## Link to Trello card

https://trello.com/c/kwsmnRfQ/486-as-a-support-user-i-can-remove-a-schools-grant-conditions-agreement



## Screenshots
<img width="655" alt="Screenshot 2024-05-12 at 17 33 30" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/eeb3a213-6ae6-460e-8ed6-a97a9b7d4ba0">

<!-- Sceenshots to aid with reviewing if needed-->
<img width="864" alt="Screenshot 2024-05-12 at 17 33 37" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/109e78dd-1cc6-42de-ada4-709b653b5c5d">
<img width="911" alt="Screenshot 2024-05-12 at 17 33 43" src="https://github.com/DFE-Digital/itt-mentor-services/assets/152905657/1af88417-4186-49c0-9799-65aae4a66392">

