### PR TITLE
Prevent school user add placements until school contacts are added

### DIFF
--- a/app/controllers/placements/schools/placements/build_controller.rb
+++ b/app/controllers/placements/schools/placements/build_controller.rb
@@ -1,5 +1,6 @@
 class Placements::Schools::Placements::BuildController < ApplicationController
   before_action :setup_session, except: :new
+  before_action :authorize_placement
 
   def new
     reset_session
@@ -187,5 +188,9 @@ class Placements::Schools::Placements::BuildController < ApplicationController
 
   def mentor_ids_params
     params.dig(:placements_schools_placements_build_placement, :mentor_ids).compact_blank
+  end
+
+  def authorize_placement
+    authorize Placement.new(school:)
   end
 end

--- a/app/controllers/placements/schools/placements_controller.rb
+++ b/app/controllers/placements/schools/placements_controller.rb
@@ -2,6 +2,7 @@ class Placements::Schools::PlacementsController < ApplicationController
   before_action :set_school
   before_action :set_placement, only: %i[show edit_provider edit_mentors update remove destroy]
   before_action :set_decorated_placement, only: %i[show remove]
+  before_action :authorize_placement, only: %i[edit_provider edit_mentors update]
 
   def index
     @pagy, placements = pagy(@school.placements.includes(:subjects, :mentors).order("subjects.name"))
@@ -47,5 +48,9 @@ class Placements::Schools::PlacementsController < ApplicationController
 
   def placement_params
     params.require(:placement).permit(:provider_id, mentor_ids: [])
+  end
+
+  def authorize_placement
+    authorize @placement
   end
 end

--- a/app/models/placements/school_contact.rb
+++ b/app/models/placements/school_contact.rb
@@ -19,6 +19,14 @@
 #
 class Placements::SchoolContact < ApplicationRecord
   belongs_to :school
+  before_destroy :prevent_destroy
 
   validates :email_address, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+
+  def prevent_destroy
+    raise ActiveRecord::RecordNotDestroyed,
+          I18n.t(
+            "activerecord.errors.models.placements/school_contact.can_not_be_destroyed",
+          )
+  end
 end

--- a/app/policies/placement_policy.rb
+++ b/app/policies/placement_policy.rb
@@ -1,0 +1,15 @@
+class PlacementPolicy < ApplicationPolicy
+  def new?
+    record.school.school_contact.present?
+  end
+  alias_method :add_phase?, :new?
+  alias_method :add_subject?, :new?
+  alias_method :add_mentors?, :new?
+  alias_method :check_your_answers?, :new?
+
+  def update?
+    record.school.school_contact.present?
+  end
+  alias_method :edit_provider?, :update?
+  alias_method :edit_mentors?, :update?
+end

--- a/app/views/placements/schools/placements/index.html.erb
+++ b/app/views/placements/schools/placements/index.html.erb
@@ -4,33 +4,48 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l"><%= t(".placements") %></h1>
-      <%= govuk_button_to(t(".add_placement"), new_placements_school_placement_build_path(@school, placement_id: "new_placement"), method: :get) %>
+      <% if @school.school_contact.present? %>
+        <%= govuk_button_to(t(".add_placement"), new_placements_school_placement_build_path(@school, placement_id: "new_placement"), method: :get) %>
 
-      <% if @placements.any? %>
-        <%= app_table do |table| %>
-          <% table.with_head do |head| %>
-            <% head.with_row do |row| %>
-              <% row.with_cell(header: true, text: t(".subject")) %>
-              <% row.with_cell(header: true, text: t(".mentor")) %>
+        <% if @placements.any? %>
+          <%= app_table do |table| %>
+            <% table.with_head do |head| %>
+              <% head.with_row do |row| %>
+                <% row.with_cell(header: true, text: t(".subject")) %>
+                <% row.with_cell(header: true, text: t(".mentor")) %>
+              <% end %>
             <% end %>
-          <% end %>
-          <% table.with_body do |body| %>
-            <% @placements.each do |placement| %>
-              <% body.with_row do |row| %>
-                <% row.with_cell(text: govuk_link_to(
-                  placement.subject_names,
-                  placements_school_placement_path(@school, placement),
-                )) %>
-                <% row.with_cell(text: placement.mentor_names) %>
+            <% table.with_body do |body| %>
+              <% @placements.each do |placement| %>
+                <% body.with_row do |row| %>
+                  <% row.with_cell(text: govuk_link_to(
+                    placement.subject_names,
+                    placements_school_placement_path(@school, placement),
+                  )) %>
+                  <% row.with_cell(text: placement.mentor_names) %>
+                <% end %>
               <% end %>
             <% end %>
           <% end %>
+          <%= render PaginationComponent.new(pagy: @pagy) %>
+        <% else %>
+          <p>
+            <%= t("no_records_for", records: "placements", for: @school.name) %>
+          </p>
         <% end %>
-        <%= render PaginationComponent.new(pagy: @pagy) %>
       <% else %>
-        <p>
-          <%= t("no_records_for", records: "placements", for: @school.name) %>
-        </p>
+        <%= govuk_inset_text(
+          text: embedded_link_text(
+            t(
+              ".you_must_add_itt_placement_contact",
+              link_to: govuk_link_to(
+                t(".itt_placement_contact"),
+                new_placements_school_school_contact_path,
+                no_visited_state: true,
+              ),
+            ),
+          ),
+        ) %>
       <% end %>
     </div>
   </div>

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -52,3 +52,4 @@ en:
             email_address:
               blank: Enter an email address
               invalid: Enter an email address in the correct format, like name@example.com
+          can_not_be_destroyed: School contact can not be destroyed!

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -90,6 +90,9 @@ en:
           status: Status
           not_entered: Not entered
           add_placement: Add placement
+          you_must_add_itt_placement_contact: |
+            You must add the %{link_to} email before adding a placement
+          itt_placement_contact: ITT placement contact
         show:
           remove_placement: Remove placement
           attributes:

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -87,6 +87,14 @@ FactoryBot.define do
 
     factory :placements_school,
             class: "Placements::School",
-            parent: :school, traits: %i[placements]
+            parent: :school, traits: %i[placements] do
+      transient do
+        with_school_contact { true }
+      end
+
+      after(:build) do |school, evaluator|
+        create(:school_contact, school:) if evaluator.with_school_contact
+      end
+    end
   end
 end

--- a/spec/models/placements/school_contact_spec.rb
+++ b/spec/models/placements/school_contact_spec.rb
@@ -29,5 +29,19 @@ RSpec.describe Placements::SchoolContact, type: :model do
     it { is_expected.to allow_value("name@education.gov.uk").for(:email_address) }
     it { is_expected.to allow_value("name@example.com").for(:email_address) }
     it { is_expected.not_to allow_value("name").for(:email_address) }
+
+    describe "#check_placement_exist" do
+      let(:school) { create(:placements_school) }
+      let(:school_contact) { school.school_contact }
+
+      before { school_contact }
+
+      it "can not be destroyed" do
+        expect { school_contact.destroy! }.to raise_error(
+          ActiveRecord::RecordNotDestroyed,
+          "School contact can not be destroyed!",
+        )
+      end
+    end
   end
 end

--- a/spec/models/placements/school_contact_spec.rb
+++ b/spec/models/placements/school_contact_spec.rb
@@ -31,10 +31,7 @@ RSpec.describe Placements::SchoolContact, type: :model do
     it { is_expected.not_to allow_value("name").for(:email_address) }
 
     describe "#check_placement_exist" do
-      let(:school) { create(:placements_school) }
-      let(:school_contact) { school.school_contact }
-
-      before { school_contact }
+      let!(:school_contact) { create(:school_contact) }
 
       it "can not be destroyed" do
         expect { school_contact.destroy! }.to raise_error(

--- a/spec/policies/placement_policy_spec.rb
+++ b/spec/policies/placement_policy_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe PlacementPolicy do
+  subject(:placement_policy) { described_class }
+
+  let(:current_user) { create(:placements_user, schools: [school]) }
+  let(:placement) { Placement.new(school:) }
+
+  permissions :new?, :add_phase?, :add_subject?, :add_mentors?, :check_your_answers? do
+    context "when the placement's school has no school contact" do
+      let(:school) { create(:placements_school, with_school_contact: false) }
+
+      it "denies access" do
+        expect(placement_policy).not_to permit(current_user, placement)
+      end
+    end
+
+    context "when the placement's school has a school contact" do
+      let(:school) { create(:placements_school) }
+
+      it "denies access" do
+        expect(placement_policy).to permit(current_user, placement)
+      end
+    end
+  end
+
+  permissions :update?, :edit_provider?, :edit_mentors? do
+    context "when the placement's school has no school contact" do
+      let(:school) { create(:placements_school, with_school_contact: false) }
+
+      it "denies access" do
+        expect(placement_policy).not_to permit(current_user, placement)
+      end
+    end
+
+    context "when the placement's school has a school contact" do
+      let(:school) { create(:placements_school) }
+
+      it "denies access" do
+        expect(placement_policy).to permit(current_user, placement)
+      end
+    end
+  end
+end

--- a/spec/system/placements/organisations/view_organisations_spec.rb
+++ b/spec/system/placements/organisations/view_organisations_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 RSpec.describe "View organisations", type: :system, service: :placements do
-  let(:one_school) { create(:school, :placements, name: "One School") }
+  let(:one_school) { create(:placements_school, name: "One School") }
   let(:one_provider) { create(:placements_provider, name: "One Provider") }
-  let(:multi_org_school) { create(:school, :placements, name: "Placements School") }
+  let(:multi_org_school) { create(:placements_school, name: "Placements School") }
   let(:multi_org_provider) { create(:placements_provider, name: "Provider 1") }
   let(:claims_school) { create(:school, :claims, name: "Claims School") }
   let(:no_service_school) { create(:school, name: "No service school") }

--- a/spec/system/placements/schools/school_contacts/add_a_school_contact_spec.rb
+++ b/spec/system/placements/schools/school_contacts/add_a_school_contact_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Placements / Schools / School Contacts / Add a school contact",
                type: :system, service: :placements do
-  let(:school) { build(:placements_school) }
+  let(:school) { build(:placements_school, with_school_contact: false) }
 
   before do
     given_i_sign_in_as_anne

--- a/spec/system/placements/schools/school_contacts/edit_a_school_contact_spec.rb
+++ b/spec/system/placements/schools/school_contacts/edit_a_school_contact_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Placements / Schools / School Contacts / Edit a school contact",
                type: :system, service: :placements do
   let(:school) { build(:placements_school) }
-  let(:school_contact) { create(:school_contact, school:) }
+  let(:school_contact) { school.school_contact }
 
   before do
     given_i_sign_in_as_anne


### PR DESCRIPTION
## Context

- Prevent school users from adding placements until they have added School Contact details

## Changes proposed in this pull request

- Policy to allow/prevent school users adding placements until a School Contact has been added.
- Prevent School Contact records being destroyed.

## Guidance to review

- Sign in as Anne (School User)
- _Assumption is Anne's school does not have a school contact_
- Navigate to the placements index page.
- You should see "You must add the ITT placement contact email before adding a placement"
- Follow the process to add a School Contact
- Navigate to the placements index page.
- You should now see a button to allow you to "Add placement"

## Link to Trello card

https://trello.com/c/8EZ9v87N/326-stop-schools-from-creating-placements-if-the-itt-placement-contact-is-missing

## Screenshots

_No school contact_
![Screenshot 2024-05-13 at 15 11 15](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/cafd6771-6dc9-4230-b6da-d4e4b2cf05b4)

_With school contact_
![Screenshot 2024-05-13 at 15 11 31](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/696f60a2-03dc-49ce-8aac-a77f3371ec05)
