### PR TITLE
Add cookies page

### DIFF
--- a/app/controllers/placements/pages_controller.rb
+++ b/app/controllers/placements/pages_controller.rb
@@ -6,4 +6,10 @@ class Placements::PagesController < ApplicationController
       content: File.read(Rails.root.join("app/views/placements/pages/landing-page.md")),
     }
   end
+
+  def cookies
+    render locals: {
+      content: File.read(Rails.root.join("app/views/placements/pages/cookies.md")),
+    }
+  end
 end

--- a/app/helpers/footer_helper.rb
+++ b/app/helpers/footer_helper.rb
@@ -22,7 +22,7 @@ module FooterHelper
     [
       { text: t(".guidance"), href: "#" },
       { text: t(".accessibility"), href: "#" },
-      { text: t(".cookies"), href: "#" },
+      { text: t(".cookies"), href: placements_cookies_path },
       { text: t(".privacy_policy"), href: "#" },
       { text: t(".terms_and_conditions"), href: "#" },
     ]

--- a/app/views/placements/pages/cookies.html.erb
+++ b/app/views/placements/pages/cookies.html.erb
@@ -1,0 +1,15 @@
+<% content_for :breadcrumbs, govuk_breadcrumbs(
+  breadcrumbs: {
+    t("home") => placements_root_path,
+  },
+  collapse_on_mobile: true,
+) %>
+<% content_for :page_title, t(".page_title") %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render_markdown(content) %>
+    </div>
+  </div>
+</div>

--- a/app/views/placements/pages/cookies.md
+++ b/app/views/placements/pages/cookies.md
@@ -1,0 +1,17 @@
+# Cookies on Manage school placements
+
+Cookies are small files saved on your phone, tablet or computer when you visit a website.
+
+We use cookies to make Manage school placements work.
+
+## Essential cookies
+
+Essential cookies keep your information secure while you use Manage school placements work. We do not need to ask permission to use them.
+
+| Name | Purpose | Expires |
+| -------- | -------- | -------- |
+| _itt_mentor_services_session | Session cookie to identify the user of the service and their place on multi-step form journeys. | When the user's browser is closed. |
+
+Read more about how we process personal data in our [privacy notice](/privacy_notice).
+
+Last updated 10 May 2024

--- a/config/locales/en/placements/pages.yml
+++ b/config/locales/en/placements/pages.yml
@@ -9,3 +9,6 @@ en:
             Guidance on what schools need to do to offer trainee teacher placements
           how_to_find_a_trn: |
             Guidance on how to find or request a TRN
+      cookies:
+        cookies: Cookies
+        page_title: Cookies on Manage school placements

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -10,6 +10,7 @@ scope module: :placements,
 
   scope module: :pages do
     get :start
+    get :cookies
   end
 
   namespace :support do

--- a/spec/helpers/footer_helper_spec.rb
+++ b/spec/helpers/footer_helper_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe FooterHelper do
           [
             { href: "#", text: "Guidance" },
             { href: "#", text: "Accessibility" },
-            { href: "#", text: "Cookies" },
+            { href: "/cookies", text: "Cookies" },
             { href: "#", text: "Privacy notice" },
             { href: "#", text: "Terms and conditions" },
           ],

--- a/spec/system/placements/cookies_page_spec.rb
+++ b/spec/system/placements/cookies_page_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Start Page", type: :system, service: :placements do
+  include ActionView::Helpers::SanitizeHelper
+
+  scenario "User views the cookies page" do
+    when_i_visit_the_cookies_page
+    then_i_see_cookie_page_details
+  end
+
+  private
+
+  def when_i_visit_the_cookies_page
+    visit placements_cookies_path
+  end
+
+  def then_i_see_cookie_page_details
+    markdown = File.read(Rails.root.join("app/views/placements/pages/cookies.md"))
+    content = GovukMarkdown.render(markdown, headings_start_with: "l").html_safe
+
+    strip_tags(content).split("\n").each do |paragraph|
+      next if paragraph.blank?
+
+      expect(page).to have_content(paragraph.strip)
+    end
+  end
+end


### PR DESCRIPTION
## Context

- Add cookies page to the placements service footer.

## Changes proposed in this pull request

- Markdown file of cookies page content.
- HTML cookies page.

## Guidance to review

- Visit http://placements.localhost:3000/cookies

## Link to Trello card

https://trello.com/c/S8Pzj9iv/337-footer-content-cookies

## Screenshots
![screencapture-placements-localhost-3000-cookies-2024-05-14-17_01_53](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/ac8a8038-4ec9-45d0-a3b3-d35f6c4c417e)
