### PR TITLE
Add accessibility policy page

### DIFF
--- a/app/controllers/placements/pages_controller.rb
+++ b/app/controllers/placements/pages_controller.rb
@@ -7,9 +7,11 @@ class Placements::PagesController < ApplicationController
     }
   end
 
-  def cookies
+  def show
+    page = params[:page]
     render locals: {
-      content: File.read(Rails.root.join("app/views/placements/pages/cookies.md")),
+      page:,
+      content: File.read(Rails.root.join("app/views/placements/pages/#{page}.md")),
     }
   end
 end

--- a/app/helpers/footer_helper.rb
+++ b/app/helpers/footer_helper.rb
@@ -21,7 +21,7 @@ module FooterHelper
   def placements_footer_meta_items
     [
       { text: t(".guidance"), href: "#" },
-      { text: t(".accessibility"), href: "#" },
+      { text: t(".accessibility"), href: placements_accessibility_path },
       { text: t(".cookies"), href: placements_cookies_path },
       { text: t(".privacy_policy"), href: "#" },
       { text: t(".terms_and_conditions"), href: "#" },

--- a/app/views/placements/pages/accessibility.md
+++ b/app/views/placements/pages/accessibility.md
@@ -1,0 +1,40 @@
+# Accessibility statement for Manage school placements
+
+This service is run by the Becoming a Teacher team at the Department for Education. We want as many people as possible to be able to use the service. For example, that means users should be able to:
+
+-   change colours, contrast levels and fonts using browser or device settings
+-   zoom in up to 400% without the text spilling off the screen
+-   navigate most of the website using a keyboard or speech recognition software
+-   listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
+
+[AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have a disability.
+
+## Technical information about this website’s accessibility
+
+The Becoming a Teacher team (DfE) is committed to making Manage school placements accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+
+## Compliance status
+
+The service was designed using the [GOV.UK design system](https://design-system.service.gov.uk/), which conforms to the WCAG 2.2 AA standard. To ensure the service fully meets the WCAG 2.2 AA standard, we are currently arranging an accessibility audit. We will update this page following the audit, and publish details of any accessibility issues identified.
+
+## What we’re doing to improve accessibility
+
+We are working alongside other government departments and agencies to fix content which fails to meet the Web Content Accessibility Guidelines version 2.2 AA standard.
+
+## Reporting accessibility problems with Manage school placements
+
+If you think we’re not meeting accessibility requirements, or you’d like to access any information in a different format (such as accessible PDF, large print, easy read, audio recording or braille), contact [manage.schoolplacements@education.gov.uk](mailto:manage.schoolplacements@education.gov.uk). Include ‘Accessibility issues’ in the subject line of your email.
+
+## Enforcement procedure
+
+The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, [contact the Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).
+
+## Preparation of this accessibility statement
+
+This statement was prepared on 1 May 2024. It was last reviewed on 14 May 2024.
+
+This website will be tested against the WCAG 2.2 AA standard. This test of a representative sample of pages will be carried out by the Digital Accessibility Centre (DAC) in July 2024 in conjunction with the Claim funding for mentors service.
+
+We also used findings from our own testing and user research when preparing this accessibility statement.
+
+Last updated 14 May 2024

--- a/app/views/placements/pages/show.html.erb
+++ b/app/views/placements/pages/show.html.erb
@@ -4,7 +4,7 @@
   },
   collapse_on_mobile: true,
 ) %>
-<% content_for :page_title, t(".page_title") %>
+<% content_for :page_title, t(".#{page}.page_title") %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">

--- a/config/locales/en/placements/pages.yml
+++ b/config/locales/en/placements/pages.yml
@@ -9,6 +9,8 @@ en:
             Guidance on what schools need to do to offer trainee teacher placements
           how_to_find_a_trn: |
             Guidance on how to find or request a TRN
-      cookies:
-        cookies: Cookies
-        page_title: Cookies on Manage school placements
+      show:
+        cookies:
+          page_title: Cookies on Manage school placements
+        accessibility:
+          page_title: Accessibility statement for Manage school placements

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -10,7 +10,9 @@ scope module: :placements,
 
   scope module: :pages do
     get :start
-    get :cookies
+    get :cookies, action: :show, page: :cookies
+    get :privacy, action: :show, page: :privacy
+    get :accessibility, action: :show, page: :accessibility
   end
 
   namespace :support do

--- a/spec/helpers/footer_helper_spec.rb
+++ b/spec/helpers/footer_helper_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe FooterHelper do
         expect(helper.footer_meta_items).to eq(
           [
             { href: "#", text: "Guidance" },
-            { href: "#", text: "Accessibility" },
+            { href: "/accessibility", text: "Accessibility" },
             { href: "/cookies", text: "Cookies" },
             { href: "#", text: "Privacy notice" },
             { href: "#", text: "Terms and conditions" },

--- a/spec/system/placements/accessibility_page_spec.rb
+++ b/spec/system/placements/accessibility_page_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Accessibility Page", type: :system, service: :placements do
+  include ActionView::Helpers::SanitizeHelper
+
+  scenario "User views the accessibility page" do
+    when_i_visit_the_accessibility_page
+    then_i_see_accessibility_page_details
+  end
+
+  private
+
+  def when_i_visit_the_accessibility_page
+    visit placements_accessibility_path
+  end
+
+  def then_i_see_accessibility_page_details
+    markdown = File.read(Rails.root.join("app/views/placements/pages/accessibility.md"))
+    content = GovukMarkdown.render(markdown, headings_start_with: "l").html_safe
+
+    strip_tags(content).split("\n").each do |paragraph|
+      next if paragraph.blank?
+
+      expect(page).to have_content(paragraph.strip)
+    end
+  end
+end


### PR DESCRIPTION
## Context

- Add static accessibility policy page.

## Changes proposed in this pull request

- Add accessibility policy markdown.
- Change routes to use `action: :show` with a `page:` argument.

## Guidance to review

visit http://placements.localhost:3000/accessibility

## Link to Trello card

https://trello.com/c/LZ3Nu1rt/339-footer-content-accessibility-statement

## Screenshots

![screencapture-placements-localhost-3000-accessibility-2024-05-14-21_27_05](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/08ca3af2-f4ec-4302-b79d-d34a04b1e091)
