### PR TITLE
Add config for the School Placements domain name

### DIFF
--- a/terraform/application/config/production_app_env.yml
+++ b/terraform/application/config/production_app_env.yml
@@ -6,6 +6,11 @@ CLAIMS_HOST: claim-funding-for-mentor-training.education.gov.uk
 # Additional hostnames that may be used – e.g. the CDN origin (comma separated)
 CLAIMS_HOSTS: claim-funding-for-mentor-training.education.gov.uk,track-and-pay-production.teacherservices.cloud
 
+# Primary hostname for the School Placements service
+PLACEMENTS_HOST: manage-school-placements.education.gov.uk
+# Additional hostnames that may be used – e.g. the CDN origin (comma separated)
+PLACEMENTS_HOSTS: manage-school-placements.education.gov.uk,manage-school-placements-production.teacherservices.cloud
+
 # API integrations
 GIAS_CSV_BASE_URL: https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public
 PUBLISH_BASE_URL: https://api.publish-teacher-training-courses.service.gov.uk/

--- a/terraform/application/config/qa_app_env.yml
+++ b/terraform/application/config/qa_app_env.yml
@@ -7,6 +7,11 @@ CLAIMS_HOST: qa.claim-funding-for-mentor-training.education.gov.uk
 # Additional hostnames that may be used – e.g. the CDN origin (comma separated)
 CLAIMS_HOSTS: qa.claim-funding-for-mentor-training.education.gov.uk,track-and-pay-qa.test.teacherservices.cloud
 
+# Primary hostname for the School Placements service
+PLACEMENTS_HOST: qa.manage-school-placements.education.gov.uk
+# Additional hostnames that may be used – e.g. the CDN origin (comma separated)
+PLACEMENTS_HOSTS: qa.manage-school-placements.education.gov.uk,manage-school-placements-qa.test.teacherservices.cloud
+
 # API integrations
 GIAS_CSV_BASE_URL: https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public
 PUBLISH_BASE_URL: https://qa.api.publish-teacher-training-courses.service.gov.uk

--- a/terraform/application/config/sandbox_app_env.yml
+++ b/terraform/application/config/sandbox_app_env.yml
@@ -6,6 +6,11 @@ CLAIMS_HOST: sandbox.claim-funding-for-mentor-training.education.gov.uk
 # Additional hostnames that may be used – e.g. the CDN origin (comma separated)
 CLAIMS_HOSTS: sandbox.claim-funding-for-mentor-training.education.gov.uk,track-and-pay-sandbox.teacherservices.cloud
 
+# Primary hostname for the School Placements service
+PLACEMENTS_HOST: sandbox.manage-school-placements.education.gov.uk
+# Additional hostnames that may be used – e.g. the CDN origin (comma separated)
+PLACEMENTS_HOSTS: sandbox.manage-school-placements.education.gov.uk,manage-school-placements-sandbox.teacherservices.cloud
+
 # API integrations
 GIAS_CSV_BASE_URL: https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public
 PUBLISH_BASE_URL: https://api.publish-teacher-training-courses.service.gov.uk

--- a/terraform/application/config/staging_app_env.yml
+++ b/terraform/application/config/staging_app_env.yml
@@ -7,6 +7,11 @@ CLAIMS_HOST: staging.claim-funding-for-mentor-training.education.gov.uk
 # Additional hostnames that may be used – e.g. the CDN origin (comma separated)
 CLAIMS_HOSTS: staging.claim-funding-for-mentor-training.education.gov.uk,track-and-pay-staging.test.teacherservices.cloud
 
+# Primary hostname for the School Placements service
+PLACEMENTS_HOST: staging.manage-school-placements.education.gov.uk
+# Additional hostnames that may be used – e.g. the CDN origin (comma separated)
+PLACEMENTS_HOSTS: staging.manage-school-placements.education.gov.uk,manage-school-placements-staging.test.teacherservices.cloud
+
 # API integrations
 GIAS_CSV_BASE_URL: https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public
 PUBLISH_BASE_URL: https://staging.api.publish-teacher-training-courses.service.gov.uk


### PR DESCRIPTION
## Context

We need to configure our Rails app to accept traffic for the `manage-school-placements.education.gov.uk` hostname and route it to the correct service.

## Changes proposed in this pull request

I've added environment variable configuration for the School Placements domain name that will be used for private beta.

Configure the hostnames as follows:

| Environment | Hostname                                          |
|-------------|---------------------------------------------------|
| QA          | qa.manage-school-placements.education.gov.uk      |
| Staging     | staging.manage-school-placements.education.gov.uk |
| Sandbox     | sandbox.manage-school-placements.education.gov.uk |
| Production  | manage-school-placements.education.gov.uk         |

This mirrors the hostname configuration used by the Funding Mentors service.

## Guidance to review

I'm not sure how we'd test this without deploying it. Ideas welcome, otherwise please just review the code changes and we'll YOLO it.

The app already [accepts and expects](https://github.com/DFE-Digital/itt-mentor-services/blob/c4427b8d11f9877c9d9b30a110db5d9f387c6ec4/config/routes/placements.rb#L4-L7) to find the `PLACEMENTS_HOST` and `PLACEMENTS_HOSTS` environment variables. We aren't currently using the 'proper' hostnames yet, so I don't see this as a high-risk change.

**Note:** these hostnames are already pointing towards our hosting environment, but since the Rails app isn't configured to recognise them, they return a `500 Internal Server Error` response.

## Link to Trello card

https://trello.com/c/PgWuOlWL/330-configure-environment-variables-for-the-service-domain-name