### PR TITLE
Convert to browser back button behaviour to retain filters

### DIFF
--- a/app/views/placements/providers/placements/show.html.erb
+++ b/app/views/placements/providers/placements/show.html.erb
@@ -2,7 +2,7 @@
 <%= render "placements/providers/primary_navigation", provider: @provider, current_navigation: :placements %>
 
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: placements_provider_placements_path) %>
+  <%= govuk_back_link(href: :back) %>
 <% end %>
 
 <div class="govuk-width-container">

--- a/spec/system/placements/providers/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/providers/placements/view_placements_list_spec.rb
@@ -176,6 +176,7 @@ RSpec.describe "Placements / Providers / Placements / View placements list",
         )
         then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
         and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
+        and_i_can_see_a_preset_filter("Placements Available", "Placements Available")
         and_i_can_see_a_preset_filter("Partner schools", "Partner schools")
         and_i_can_see_a_preset_filter("School", "Primary School")
         and_i_can_see_a_preset_filter("Subject", "Primary with mathematics")
@@ -223,6 +224,17 @@ RSpec.describe "Placements / Providers / Placements / View placements list",
           and_i_can_see_search_location_is_set_as("London")
           and_i_see_placements_for(school_name: "Primary School", list_item: 0, distance: 0.0)
         end
+      end
+    end
+
+    context "when a user views a placement and returns to the index page" do
+      scenario "User filters are preserved when using the back button" do
+        when_i_visit_the_placements_index_page
+        when_i_check_filter_option("only-available-placements", true)
+        and_i_click_on("Apply filters")
+        and_i_navigate_to("Primary with mathematics")
+        and_i_click_on("Back")
+        then_i_can_see_a_preset_filter("Placements Available", "Placements Available")
       end
     end
   end
@@ -345,6 +357,10 @@ RSpec.describe "Placements / Providers / Placements / View placements list",
     end
   end
   alias_method :and_i_see_placements_for, :then_i_see_placements_for
+
+  def and_i_navigate_to(text)
+    click_link(text)
+  end
 
   def stub_london_geocoder_search
     geocoder_results = instance_double("geocoder_results")

--- a/spec/system/placements/providers/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/providers/placements/view_placements_list_spec.rb
@@ -228,13 +228,21 @@ RSpec.describe "Placements / Providers / Placements / View placements list",
     end
 
     context "when a user views a placement and returns to the index page" do
+      before do
+        stub_london_geocoder_search
+        create_list(:placement, 30, subjects: [subject_1], school: primary_school)
+      end
+
       scenario "User filters are preserved when using the back button" do
-        when_i_visit_the_placements_index_page
+        when_i_visit_the_placements_index_page({ search_location: "London" })
         when_i_check_filter_option("only-available-placements", true)
         and_i_click_on("Apply filters")
-        and_i_navigate_to("Primary with mathematics")
+        and_i_navigate_to("2")
+        when_i_click_on_the_first_placement
         and_i_click_on("Back")
         then_i_can_see_a_preset_filter("Placements Available", "Placements Available")
+        and_i_can_see_search_location_is_set_as("London")
+        and_the_pagination_remains_selected("2")
       end
     end
   end
@@ -360,6 +368,14 @@ RSpec.describe "Placements / Providers / Placements / View placements list",
 
   def and_i_navigate_to(text)
     click_link(text)
+  end
+
+  def when_i_click_on_the_first_placement
+    first(".app-search-results__item").click_link("Primary with mathematics")
+  end
+
+  def and_the_pagination_remains_selected(text)
+    expect(find(".govuk-pagination__item--current")).to have_content(text)
   end
 
   def stub_london_geocoder_search


### PR DESCRIPTION
https://trello.com/c/VDSgNUdW

## Context

When a user sets filters when finding a placement they are lost if the user views the placement and presses the back button.

## Changes proposed in this pull request

- [x] Use rails `:back` link to emulate browser back button behaviour which retains the filters in the URL.
- [x] Adds a presence check for a filter that was missed in a spec

## Guidance to review

- Log in as Patricia
- Navigate to Placements
- Set some flters
- View a placement
- Press the back button
- Confirm that filters are still present

## Link to Trello card

[The 'back' link on the placement details page should remember the user's search parameters](https://trello.com/c/VDSgNUdW)