### PR TITLE
Change gias to import yesterday's download

### DIFF
--- a/app/services/gias/csv_downloader.rb
+++ b/app/services/gias/csv_downloader.rb
@@ -3,10 +3,10 @@ module Gias
     include ServicePattern
 
     def call
-      today = Time.zone.today.strftime("%Y%m%d")
-      gias_filename = "edubasealldata#{today}.csv"
+      yesterday = Time.zone.yesterday.strftime("%Y%m%d")
+      gias_filename = "edubasealldata#{yesterday}.csv"
 
-      Rails.logger.info "Downloading the new gias file for #{Time.zone.today}"
+      Rails.logger.info "Downloading the new gias file for #{Time.zone.yesterday}"
       file = Down.download("#{ENV["GIAS_CSV_BASE_URL"]}/#{gias_filename}")
 
       # GIAS CSVs are published with ISO-8859-1 character encoding.

--- a/spec/jobs/gias/sync_all_schools_job_spec.rb
+++ b/spec/jobs/gias/sync_all_schools_job_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe Gias::SyncAllSchoolsJob, type: :job do
 
   describe "integration test" do
     let(:gias_csv_url) do
-      today = Time.zone.today.strftime("%Y%m%d")
+      yesterday = Time.zone.yesterday.strftime("%Y%m%d")
       base_url = ENV.fetch("GIAS_CSV_BASE_URL")
-      "#{base_url}/edubasealldata#{today}.csv"
+      "#{base_url}/edubasealldata#{yesterday}.csv"
     end
 
     let(:gias_csv_file) { File.open("spec/fixtures/gias/gias_subset.csv") }

--- a/spec/services/gias/csv_downloader_spec.rb
+++ b/spec/services/gias/csv_downloader_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Gias::CsvDownloader do
 
   it_behaves_like "a service object"
 
-  it "downloads the GIAS CSV for today's date" do
-    today = Time.zone.today.strftime("%Y%m%d")
-    gias_filename = "edubasealldata#{today}.csv"
+  it "downloads the GIAS CSV for yesterday's date" do
+    yesterday = Time.zone.yesterday.strftime("%Y%m%d")
+    gias_filename = "edubasealldata#{yesterday}.csv"
 
     allow(Down).to receive(:download).with(
       "#{ENV["GIAS_CSV_BASE_URL"]}/#{gias_filename}",


### PR DESCRIPTION
## Context/Changes proposed in this pull request

- Change `Gias::CsvDownload` to download yesterdays import.

## Guidance to review

- Run `Gias::CsvDownloader.call`

## Link to Trello card

https://trello.com/c/8JaEOtcE/359-change-the-gias-csv-import-to-use-yesterdays-date

https://www.youtube.com/watch?v=wXTJBr9tt8Q
