### PR TITLE
Update sub nav items

### DIFF
--- a/app/views/placements/support/_secondary_navigation.html.erb
+++ b/app/views/placements/support/_secondary_navigation.html.erb
@@ -2,6 +2,4 @@
   <% component.with_navigation_item t(".details"), placements_support_organisation_path(organisation) %>
   <% component.with_navigation_item t(".users"), placements_support_users_path(organisation) %>
   <% component.with_navigation_item t(".partner_schools"), placements_support_provider_partner_schools_path(organisation) %>
-  <% component.with_navigation_item t(".placements"), "#" %>
-  <% component.with_navigation_item t(".providers"), "#" %>
 <% end %>

--- a/spec/system/placements/support/providers/partner_schools/support_user_adds_a_partner_school_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/support_user_adds_a_partner_school_spec.rb
@@ -101,8 +101,6 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
     within(".app-secondary-navigation__list") do
       expect(page).to have_link "Details", current: "false"
       expect(page).to have_link "Users", current: "false"
-      expect(page).to have_link "Providers", current: "false"
-      expect(page).to have_link "Placements", current: "false"
       expect(page).to have_link "Partner schools", current: "page"
     end
   end

--- a/spec/system/placements/support/providers/partner_schools/support_user_remove_a_partner_school_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/support_user_remove_a_partner_school_spec.rb
@@ -79,8 +79,6 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
     within(".app-secondary-navigation__list") do
       expect(page).to have_link "Details", current: "false"
       expect(page).to have_link "Users", current: "false"
-      expect(page).to have_link "Providers", current: "false"
-      expect(page).to have_link "Placements", current: "false"
       expect(page).to have_link "Partner schools", current: "page"
     end
   end

--- a/spec/system/placements/support/providers/partner_schools/view_a_partner_school_as_support_user_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/view_a_partner_school_as_support_user_spec.rb
@@ -69,8 +69,6 @@ RSpec.describe "Placements / Support/ Providers / Partner schools / View a partn
     within(".app-secondary-navigation__list") do
       expect(page).to have_link "Details", current: "false"
       expect(page).to have_link "Users", current: "false"
-      expect(page).to have_link "Providers", current: "false"
-      expect(page).to have_link "Placements", current: "false"
       expect(page).to have_link "Partner schools", current: "page"
     end
   end

--- a/spec/system/placements/support/providers/partner_schools/view_partner_school_list_as_support_user_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/view_partner_school_list_as_support_user_spec.rb
@@ -71,8 +71,6 @@ RSpec.describe "Placements / Support / Providers / Partner schools / View a part
     within(".app-secondary-navigation__list") do
       expect(page).to have_link "Details", current: "false"
       expect(page).to have_link "Users", current: "false"
-      expect(page).to have_link "Providers", current: "false"
-      expect(page).to have_link "Placements", current: "false"
       expect(page).to have_link "Partner schools", current: "page"
     end
   end

--- a/spec/system/placements/support/users/support_user_invites_a_new_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_invites_a_new_user_spec.rb
@@ -247,12 +247,12 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
       expect(page).to have_link "Details", current: "false"
       expect(page).to have_link "Users", current: "page"
       if organisation.is_a?(Provider)
-        expect(page).to have_link "Providers", current: "false"
+        expect(page).to have_link "Partner schools", current: "false"
       else
         expect(page).to have_link "Mentors", current: "false"
         expect(page).to have_link "Partner providers", current: "false"
+        expect(page).to have_link "Placements", current: "false"
       end
-      expect(page).to have_link "Placements", current: "false"
     end
   end
 

--- a/spec/system/placements/support/users/support_user_removes_a_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_removes_a_user_spec.rb
@@ -173,13 +173,12 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
       expect(page).to have_link "Details", current: "false"
       expect(page).to have_link "Users", current: "page"
       if organisation.is_a?(Provider)
-        expect(page).to have_link "Providers", current: "false"
         expect(page).to have_link "Partner schools", current: "false"
       else
         expect(page).to have_link "Mentors", current: "false"
         expect(page).to have_link "Partner providers", current: "false"
+        expect(page).to have_link "Placements", current: "false"
       end
-      expect(page).to have_link "Placements", current: "false"
     end
   end
 


### PR DESCRIPTION
## Context

The sub navigation for support users hasn't matched designs for a while, these changes bring the build back into line with the prototypes.

## Changes proposed in this pull request

- [x] Reorganise sub nav items
- [x] Remove sub nav items that are not needed for providers
- [x] Remove the removed sub nav items from specs 

## Guidance to review

### Viewing a Provider
- Sign in as Colin
- Select a provider from the organisation list
- See that the sub navigation matches the designs

### Viewing a school
- Sign in as Colin
- Select a school from the organisation list
- See that the sub navigation matches the designs     

## Link to Trello card

[Tidy up redundant navbar items across the app](https://trello.com/c/BFBK5fqz)

## Screenshots

Support viewing a provider:
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/539dc58c-9550-4e62-bb47-9347b3e09069)

Support viewing a school:
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/0d7ed773-e337-4f28-bddc-a0422f98bcd1)