### PR TITLE
Order resources by name on index pages

### DIFF
--- a/app/controllers/claims/schools/users_controller.rb
+++ b/app/controllers/claims/schools/users_controller.rb
@@ -6,7 +6,7 @@ class Claims::Schools::UsersController < Claims::ApplicationController
   before_action :authorize_user
 
   def index
-    @pagy, @users = pagy(@school.users)
+    @pagy, @users = pagy(@school.users.order_by_full_name)
   end
 
   def new

--- a/app/controllers/claims/schools_controller.rb
+++ b/app/controllers/claims/schools_controller.rb
@@ -5,7 +5,7 @@ class Claims::SchoolsController < Claims::ApplicationController
   before_action :has_school_accepted_grant_conditions?, only: :show
 
   def index
-    @schools = policy_scope(Claims::School)
+    @schools = policy_scope(Claims::School.order_by_name)
   end
 
   def show; end

--- a/app/controllers/claims/support/schools/mentors_controller.rb
+++ b/app/controllers/claims/support/schools/mentors_controller.rb
@@ -10,7 +10,7 @@ class Claims::Support::Schools::MentorsController < Claims::Support::Application
   helper_method :mentor_form
 
   def index
-    @pagy, @mentors = pagy(@school.mentors.order(:first_name, :last_name))
+    @pagy, @mentors = pagy(@school.mentors.order_by_full_name)
   end
 
   def new; end

--- a/app/controllers/claims/support/schools/users_controller.rb
+++ b/app/controllers/claims/support/schools/users_controller.rb
@@ -5,7 +5,7 @@ class Claims::Support::Schools::UsersController < Claims::Support::ApplicationCo
   before_action :authorize_user
 
   def index
-    @pagy, @users = pagy(@school.users)
+    @pagy, @users = pagy(@school.users.order_by_full_name)
   end
 
   def new

--- a/app/controllers/claims/support/schools_controller.rb
+++ b/app/controllers/claims/support/schools_controller.rb
@@ -4,7 +4,7 @@ class Claims::Support::SchoolsController < Claims::Support::ApplicationControlle
   before_action :authorize_school
 
   def index
-    @pagy, @schools = pagy(schools)
+    @pagy, @schools = pagy(schools.order_by_name)
   end
 
   def show; end

--- a/app/models/mentor.rb
+++ b/app/models/mentor.rb
@@ -23,7 +23,7 @@ class Mentor < ApplicationRecord
   validates :first_name, :last_name, presence: true
   validates :trn, presence: true, uniqueness: true, format: /\A\d{7}\z/
 
-  scope :order_by_full_name, -> { order(:first_name, :last_name) }
+  scope :order_by_full_name, -> { order(first_name: :asc, last_name: :asc) }
 
   def full_name
     "#{first_name} #{last_name}".strip

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,7 +33,7 @@ class User < ApplicationRecord
   validates :email, uniqueness: { scope: :type, case_sensitive: false }
 
   default_scope -> { kept }
-  scope :order_by_full_name, -> { order(:first_name, :last_name) }
+  scope :order_by_full_name, -> { order(first_name: :asc, last_name: :asc) }
 
   def full_name
     "#{first_name} #{last_name}".strip

--- a/app/views/claims/support/schools/claims/_form.html.erb
+++ b/app/views/claims/support/schools/claims/_form.html.erb
@@ -8,7 +8,7 @@
 
       <%= f.govuk_collection_radio_buttons(
         :provider_id,
-        Provider.private_beta_providers,
+        Provider.private_beta_providers.order_by_name,
         :id,
         :name,
         legend: { text: t(".heading"), size: "l" },

--- a/spec/system/claims/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/schools/claims/create_claim_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe "Create claim", type: :system, service: :claims do
 
   scenario "Anne creates a claim" do
     when_i_click("Add claim")
+    then_i_should_see_providers_ordered_by_name
     when_i_choose_a_provider(bpn)
     when_i_click("Continue")
     when_i_select_all_mentors
@@ -194,6 +195,10 @@ RSpec.describe "Create claim", type: :system, service: :claims do
   def when_i_choose_other_amount_and_input_hours(hours)
     page.choose("Another amount")
     fill_in("Number of hours", with: hours)
+  end
+
+  def then_i_should_see_providers_ordered_by_name
+    expect(page.body.index(bpn.name)).to be < page.body.index(niot.name)
   end
 
   def then_i_check_my_answers

--- a/spec/system/claims/schools/mentors/view_mentors_spec.rb
+++ b/spec/system/claims/schools/mentors/view_mentors_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "View a school's mentors", type: :system, service: :claims do
-  let!(:mentor1) { create(:mentor, first_name: "Bilbo", last_name: "Baggins") }
-  let!(:mentor2) { create(:mentor, first_name: "Bilbo", last_name: "Test") }
+  let!(:mentor1) { create(:mentor, first_name: "Bilbo", last_name: "Test") }
+  let!(:mentor2) { create(:mentor, first_name: "Bilbo", last_name: "Baggins") }
   let!(:mentor3) { create(:mentor, trn: "0123456") }
   let!(:school) { create(:claims_school, mentors: [mentor1, mentor2]) }
   let!(:another_school) { create(:claims_school) }
@@ -25,7 +25,7 @@ RSpec.describe "View a school's mentors", type: :system, service: :claims do
     user_exists_in_dfe_sign_in(user: anne)
     given_i_sign_in
     when_i_visit_the_school_mentors_page(school)
-    then_i_see_a_list_of_the_schools_mentors
+    then_i_see_a_list_of_the_schools_mentors_ordered_by_full_name
     and_i_dont_see_mentors_from_another_school
   end
 
@@ -47,18 +47,18 @@ RSpec.describe "View a school's mentors", type: :system, service: :claims do
     visit claims_school_mentors_path(school)
   end
 
-  def then_i_see_a_list_of_the_schools_mentors
+  def then_i_see_a_list_of_the_schools_mentors_ordered_by_full_name
     expect(page).to have_content("Name")
     expect(page).to have_content("Teacher reference number (TRN)")
 
     within("tbody tr:nth-child(1)") do
-      expect(page).to have_content(mentor1.full_name)
-      expect(page).to have_content(mentor1.trn)
+      expect(page).to have_content(mentor2.full_name)
+      expect(page).to have_content(mentor2.trn)
     end
 
     within("tbody tr:nth-child(2)") do
-      expect(page).to have_content(mentor2.full_name)
-      expect(page).to have_content(mentor2.trn)
+      expect(page).to have_content(mentor1.full_name)
+      expect(page).to have_content(mentor1.trn)
     end
   end
 

--- a/spec/system/claims/schools/users/view_users_spec.rb
+++ b/spec/system/claims/schools/users/view_users_spec.rb
@@ -6,12 +6,13 @@ RSpec.describe "Invite and view a users details", type: :system do
   let(:another_school) { create(:claims_school, :claims) }
 
   before do
-    setup_school_and_anne_membership
+    setup_school_memberships
   end
 
   scenario "I sign in as a lead mentor user and invite a user to a school and view that users details" do
     sign_in_as_lead_mentor_user
     visit_claims_school_users_page
+    then_i_see_a_list_of_users_ordered_by_full_name
     when_i_click("Add user")
     fill_in_user_details
     when_i_click("Save user")
@@ -20,9 +21,11 @@ RSpec.describe "Invite and view a users details", type: :system do
 
   private
 
-  def setup_school_and_anne_membership
-    create(:user_membership, user: anne, organisation: school)
-    user_exists_in_dfe_sign_in(user: anne)
+  def setup_school_memberships
+    school.users << anne
+    school.users << create(:claims_user, first_name: "Charles")
+    school.users << create(:claims_user, first_name: "Bobby", last_name: "G")
+    school.users << create(:claims_user, first_name: "Bobby", last_name: "A")
   end
 
   def sign_in_as_lead_mentor_user
@@ -33,6 +36,12 @@ RSpec.describe "Invite and view a users details", type: :system do
 
   def visit_claims_school_users_page
     visit claims_school_users_path(school)
+  end
+
+  def then_i_see_a_list_of_users_ordered_by_full_name
+    expect(page.body.index("Anne")).to be < page.body.index("Bobby A")
+    expect(page.body.index("Bobby A")).to be < page.body.index("Bobby G")
+    expect(page.body.index("Bobby G")).to be < page.body.index("Charles")
   end
 
   def fill_in_user_details

--- a/spec/system/claims/schools/view_school_spec.rb
+++ b/spec/system/claims/schools/view_school_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "School Page", type: :system do
-  let(:school1) { create(:school, :claims, name: "School1") }
-  let(:school2) { create(:school, :claims, name: "School2") }
+  let(:school1) { create(:school, :claims, name: "School B") }
+  let(:school2) { create(:school, :claims, name: "School A") }
 
   scenario "User visits his school" do
     user_exists_in_dfe_sign_in(
@@ -20,13 +20,14 @@ RSpec.describe "School Page", type: :system do
     and_user_has_multiple_schools(user)
     when_i_visit_the_sign_in_page
     when_i_click_sign_in
+    then_i_see_schools_ordered_by_name
 
-    i_go_to_school_details_page("School1")
+    i_go_to_school_details_page("School B")
     when_i_click_on_school_details
     then_i_see_the_school_details
 
     i_click_on_change_organisation
-    i_go_to_school_details_page("School2")
+    i_go_to_school_details_page("School A")
     when_i_click_on_school_details
     then_i_see_the_school_details
   end
@@ -57,6 +58,10 @@ RSpec.describe "School Page", type: :system do
     user = create(:claims_user, user_name.downcase.to_sym)
     create(:user_membership, user:, organisation: school1)
     user
+  end
+
+  def then_i_see_schools_ordered_by_name
+    expect(page.body.index("School A")).to be < page.body.index("School B")
   end
 
   def then_i_see_the_school_details


### PR DESCRIPTION
## Context

We want to order most of our (Claims) index pages alphabetically.

## Changes proposed in this pull request

- Order providers in Claim flow by name.
- Order users in index pages (support-user/end-user) by name.
- Order mentors in index pages (support-user/end-user) by name.
- Order schools in index pages (support-user/end-user) by name.

## Guidance to review

- The pages noted above should all be ordered by their names in alphabetical order.