### PR TITLE
Update declaration page for draft claim

### DIFF
--- a/app/controllers/claims/schools/claims_controller.rb
+++ b/app/controllers/claims/schools/claims_controller.rb
@@ -2,7 +2,7 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
   include Claims::BelongsToSchool
 
   before_action :has_school_accepted_grant_conditions?
-  before_action :set_claim, only: %i[show check confirmation submit edit update rejected create_revision]
+  before_action :set_claim, only: %i[show check confirmation submit edit update rejected create_revision remove destroy]
   before_action :authorize_claim
   before_action :get_valid_revision, only: :check
 
@@ -62,6 +62,14 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
   end
 
   def rejected; end
+
+  def remove; end
+
+  def destroy
+    @claim.destroy!
+
+    redirect_to claims_school_claims_path(@school, @claim), flash: { success: t(".success") }
+  end
 
   private
 

--- a/app/policies/claims/claim_policy.rb
+++ b/app/policies/claims/claim_policy.rb
@@ -20,7 +20,7 @@ class Claims::ClaimPolicy < Claims::ApplicationPolicy
   end
 
   def destroy?
-    user.support_user? && record.draft?
+    record.draft?
   end
 
   def confirmation?

--- a/app/views/claims/schools/claims/check.html.erb
+++ b/app/views/claims/schools/claims/check.html.erb
@@ -10,24 +10,26 @@
     <div class="govuk-grid-column-two-thirds">
       <label class="govuk-label govuk-label--l">
         <span class="govuk-caption-l"><%= @claim.draft? ? t(".caption_draft", reference: @claim.reference) : t(".caption") %></span>
-        <%= t(".page_title") %>
+        <%= @claim.draft? ? t(".declaration") : t(".page_title") %>
       </label>
 
       <%= govuk_summary_list do |summary_list| %>
         <% summary_list.with_row do |row| %>
-          <% row.with_key(text: Claims::Claim.human_attribute_name(:school_name)) %>
+          <% row.with_key(text: Claims::Claim.human_attribute_name(:school)) %>
           <% row.with_value(text: @school.name) %>
         <% end %>
 
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: Claims::Claim.human_attribute_name(:accredited_provider)) %>
           <% row.with_value(text: @claim.provider_name) %>
-          <% row.with_action(text: t("change"),
-                             href: create_revision_claims_school_claim_path(@school, @claim),
-                             visually_hidden_text: Claims::Claim.human_attribute_name(:accredited_provider),
-                             html_attributes: {
-                               class: "govuk-link--no-visited-state",
-                             }) %>
+          <% unless @claim.draft? %>
+            <% row.with_action(
+              text: t("change"),
+              href: create_revision_claims_school_claim_path(@school, @claim),
+              visually_hidden_text: Claims::Claim.human_attribute_name(:accredited_provider),
+              html_attributes: { class: "govuk-link--no-visited-state" },
+            ) %>
+         <% end %>
         <% end %>
 
         <% summary_list.with_row do |row| %>
@@ -39,12 +41,14 @@
               <% end %>
             </ul>
           <% end %>
-          <% row.with_action(text: t("change"),
-                             href: create_revision_claims_school_claim_mentors_path(@school, @claim),
-                             visually_hidden_text: Claims::Claim.human_attribute_name(:mentors),
-                             html_attributes: {
-                               class: "govuk-link--no-visited-state",
-                             }) %>
+          <% unless @claim.draft? %>
+          <% row.with_action(
+            text: t("change"),
+            href: create_revision_claims_school_claim_mentors_path(@school, @claim),
+            visually_hidden_text: Claims::Claim.human_attribute_name(:mentors),
+            html_attributes: { class: "govuk-link--no-visited-state" },
+          ) %>
+          <% end %>
         <% end %>
       <% end %>
 
@@ -55,16 +59,18 @@
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: mentor_training.mentor.full_name) %>
             <% row.with_value(text: pluralize(mentor_training.hours_completed, t(".hour"))) %>
-            <% row.with_action(text: t("change"),
-                               href: create_revision_claims_school_claim_mentor_training_path(
-                                 @school,
-                                 @claim,
-                                 mentor_training.mentor_id,
-                               ),
-                               visually_hidden_text: "Hours of training for #{mentor_training.mentor.full_name}",
-                               html_attributes: {
-                                 class: "govuk-link--no-visited-state",
-                               }) %>
+            <% unless @claim.draft? %>
+              <% row.with_action(
+                text: t("change"),
+                href: create_revision_claims_school_claim_mentor_training_path(
+                  @school,
+                  @claim,
+                  mentor_training.mentor_id,
+                ),
+                visually_hidden_text: "Hours of training for #{mentor_training.mentor.full_name}",
+                html_attributes: { class: "govuk-link--no-visited-state" },
+              ) %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>
@@ -87,7 +93,6 @@
           <% end %>
         <% end %>
 
-      <h3 class="govuk-heading-m"><%= t(".declaration") %></h3>
       <p class="govuk-body"><%= t(".disclaimer") %></p>
 
       <ul class="govuk-list govuk-list--bullet">

--- a/app/views/claims/schools/claims/remove.html.erb
+++ b/app/views/claims/schools/claims/remove.html.erb
@@ -1,0 +1,21 @@
+<% content_for(:page_title) { t(".page_title") } %>
+<% render "claims/schools/primary_navigation", school: @school, current: :claims %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: claims_school_claim_path(@school, @claim)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".caption", reference: @claim.reference) %></span>
+      <h2 class="govuk-heading-l"><%= t(".warning") %></h2>
+
+      <%= govuk_button_to t(".remove_claim"), claims_school_claim_path(@school, @claim), warning: true, method: :delete %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to(t(".cancel"), claims_school_claim_path(@school, @claim), no_visited_state: true) %>
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/claims/schools/claims/show.html.erb
+++ b/app/views/claims/schools/claims/show.html.erb
@@ -32,6 +32,12 @@
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: Claims::Claim.human_attribute_name(:accredited_provider)) %>
             <% row.with_value(text: @claim.provider.name) %>
+            <% row.with_action(
+              text: t("change"),
+              href: create_revision_claims_school_claim_path(@school, @claim),
+              visually_hidden_text: Claims::Claim.human_attribute_name(:accredited_provider),
+              html_attributes: { class: "govuk-link--no-visited-state" },
+            ) %>
           <% end %>
         <% else %>
           <% summary_list.with_row do |row| %>
@@ -49,6 +55,12 @@
               <% end %>
             </ul>
           <% end %>
+          <% row.with_action(
+            text: t("change"),
+            href: create_revision_claims_school_claim_mentors_path(@school, @claim),
+            visually_hidden_text: Claims::Claim.human_attribute_name(:mentors),
+            html_attributes: { class: "govuk-link--no-visited-state" },
+          ) %>
         <% end %>
       <% end %>
 
@@ -58,6 +70,14 @@
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: mentor_training.mentor.full_name) %>
             <% row.with_value(text: pluralize(mentor_training.hours_completed, t(".hour"))) %>
+            <% row.with_action(text: t("change"),
+                               href: create_revision_claims_school_claim_mentor_training_path(
+                @school,
+                @claim,
+                mentor_training.mentor_id,
+              ),
+                               visually_hidden_text: "Hours of training for #{mentor_training.mentor.full_name}",
+                               html_attributes: { class: "govuk-link--no-visited-state" }) %>
           <% end %>
         <% end %>
       <% end %>
@@ -78,6 +98,10 @@
             <% row.with_key(text: Claims::Claim.human_attribute_name(:claim_amount)) %>
             <% row.with_value(text: humanized_money_with_symbol(@claim.amount)) %>
           <% end %>
+        <% end %>
+
+        <% if policy(@claim).remove? %>
+          <%= govuk_link_to t(".remove_claim"), remove_claims_school_claim_path(@school, @claim), class: "app-link app-link--destructive" %>
         <% end %>
     </div>
   </div>

--- a/config/locales/en/claims/schools/claims.yml
+++ b/config/locales/en/claims/schools/claims.yml
@@ -53,8 +53,17 @@ en:
           add_a_mentor: add a mentor
         update:
           claim_updated: Claim updated
+        remove:
+          page_title: Are you sure you want to remove this claim?
+          caption: Claim - %{reference}
+          warning: Are you sure you want to remove this claim?
+          cancel: Cancel
+          remove_claim: Remove claim
+        destroy:
+          success: Claim has been removed
         show:
           mentors: Mentors
+          remove_claim: Remove claim
           page_title: Claim - %{reference}
           hours_of_training: Hours of training
           grant_funding: Grant funding

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -13,7 +13,7 @@ scope module: :claims, as: :claims, constraints: {
 
   resources :schools, only: %i[index show] do
     scope module: :schools do
-      resources :claims, except: %i[destroy] do
+      resources :claims do
         resource :mentors, only: %i[new create edit update], module: :claims do
           member do
             get :create_revision
@@ -26,6 +26,7 @@ scope module: :claims, as: :claims, constraints: {
         end
 
         member do
+          get :remove
           get :check
           get :confirmation
           get :rejected

--- a/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
   let(:mentor1) { create(:mentor, first_name: "Anne") }
   let(:mentor2) { create(:mentor, first_name: "Joe") }
   let(:mentor3) { create(:mentor, first_name: "Joeana") }
-  let!(:claim) { create(:claim, :draft, school:, provider: provider1, reference: nil) }
+  let!(:claim) { create(:claim, :internal_draft, school:, provider: provider1, reference: nil) }
 
   before do
     user_exists_in_dfe_sign_in(user: anne)

--- a/spec/system/claims/schools/claims/remove_draft_claim_spec.rb
+++ b/spec/system/claims/schools/claims/remove_draft_claim_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+RSpec.describe "Create claim", type: :system, service: :claims do
+  let!(:school) { create(:claims_school, mentors: [mentor1, mentor2], name: "A School") }
+  let!(:anne) do
+    create(
+      :claims_user,
+      :anne,
+      user_memberships: [create(:user_membership, organisation: school)],
+    )
+  end
+  let!(:provider) { create(:provider, :best_practice_network) }
+
+  let(:claims_mentor) { create(:claims_mentor, first_name: "Barry", last_name: "Garlow") }
+
+  let!(:submitted_claim) do
+    create(
+      :claim,
+      :submitted,
+      school:,
+      reference: "12345678",
+      submitted_at: Time.new(2024, 3, 5, 12, 31, 52, "+00:00"),
+      provider:,
+    )
+  end
+
+  let!(:draft_claim) do
+    create(
+      :claim,
+      :draft,
+      school:,
+      reference: "111111111",
+      provider:,
+    )
+  end
+
+  let(:mentor1) { create(:mentor, first_name: "Anne") }
+  let(:mentor2) { create(:mentor, first_name: "Joe") }
+
+  let(:mentor_training) { create(:mentor_training, claim: submitted_claim, mentor: claims_mentor, hours_completed: 6) }
+  let(:mentor_training2) { create(:mentor_training, claim: draft_claim, mentor: claims_mentor, hours_completed: 6) }
+
+  before do
+    user_exists_in_dfe_sign_in(user: anne)
+    given_i_sign_in
+  end
+
+  scenario "When removing a draft claim" do
+    when_i_visit_the_draft_claim_show_page
+    when_i_click_remove_claim
+    when_i_confirm_removal
+    then_the_claim_has_been_deleted
+  end
+
+  private
+
+  def given_i_sign_in
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def when_i_visit_the_submitted_claim_show_page
+    click_on submitted_claim.reference
+  end
+
+  def when_i_visit_the_draft_claim_show_page
+    click_on draft_claim.reference
+  end
+
+  def when_i_click_remove_claim
+    click_on "Remove claim"
+  end
+
+  def when_i_confirm_removal
+    expect(page).to have_content("Are you sure you want to remove this claim?")
+    click_on "Remove claim"
+  end
+
+  def then_the_claim_has_been_deleted
+    expect(page).not_to have_content("111111111")
+    expect(page).to have_content("Claim has been removed")
+  end
+end

--- a/spec/system/claims/schools/claims/submit_draft_claim_spec.rb
+++ b/spec/system/claims/schools/claims/submit_draft_claim_spec.rb
@@ -68,7 +68,6 @@ RSpec.describe "Submit a draft claim", type: :system, service: :claims do
 
   def then_i_see_a_check_page_with_a_declaration
     expect(page).to have_content("Claim - #{draft_claim.reference}")
-    expect(page).to have_content("Check your answers")
     expect(page).to have_content("Declaration")
     expect(page).to have_content("By submitting this claim, I confirm that:")
     expect(page).to have_content("I am authorised to claim on behalf of the school")

--- a/spec/system/claims/schools/claims/view_claim_spec.rb
+++ b/spec/system/claims/schools/claims/view_claim_spec.rb
@@ -53,6 +53,9 @@ RSpec.describe "View a claim", type: :system, service: :claims do
     when_i_visit_the_claim_show_page(draft_claim)
     then_i_can_then_see_the_draft_claim_details
     then_i_can_see_submit_button
+    when_i_click("Submit claim")
+    then_i_can_see_submit_button
+    then_i_can_then_see_the_draft_claim_details_without_change_buttons
   end
 
   private
@@ -87,6 +90,21 @@ RSpec.describe "View a claim", type: :system, service: :claims do
     expect(page).to have_content("Total hours6 hours")
     expect(page).to have_content("Hourly rate£53.60")
     expect(page).to have_content("Claim amount£321.60")
+    expect(page).to have_content("Change", count: 3)
+  end
+
+  def then_i_can_then_see_the_draft_claim_details_without_change_buttons
+    expect(page).to have_content("Claim - #{draft_claim.reference}")
+    expect(page).to have_content("SchoolA School")
+    expect(page).not_to have_content("Submitted by")
+    expect(page).to have_content("Accredited providerBest Practice Network")
+    expect(page).to have_content("Mentors\nBarry Garlow")
+    expect(page).to have_content("Hours of training")
+    expect(page).to have_content("Barry Garlow#{draft_mentor_training.hours_completed} hours")
+    expect(page).to have_content("Total hours6 hours")
+    expect(page).to have_content("Hourly rate£53.60")
+    expect(page).to have_content("Claim amount£321.60")
+    expect(page).not_to have_content("Change")
   end
 
   def given_i_sign_in
@@ -100,5 +118,9 @@ RSpec.describe "View a claim", type: :system, service: :claims do
 
   def then_i_can_see_submit_button
     expect(page).to have_button("Submit claim")
+  end
+
+  def when_i_click(button)
+    click_on button
   end
 end


### PR DESCRIPTION
## Context

This mainly removes the change links on the check page for the draft claim, when a normal user tries to submit a draft claim.

The change links are on the show page now.

## Changes proposed in this pull request

This is for a draft claim for normal users

Added remove functionality to show claim
The check page does not have change links if the claim is draft
The show page has change links 

## Guidance to review

Submit a draft claim on the review app


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/b0b3f0a2-ce1e-46f0-9a87-a9fdef51a01c

