### PR TITLE
Stop wrapping the claim card header section

### DIFF
--- a/app/assets/stylesheets/components/claim/card.scss
+++ b/app/assets/stylesheets/components/claim/card.scss
@@ -10,7 +10,7 @@
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    flex-wrap: wrap;
+    gap: govuk-spacing(2);
 
     .claim-card__header__name {
       display: flex;


### PR DESCRIPTION
## Context

We want to ensure the status tag is always on the top-right corner of the card.

## Changes proposed in this pull request

- Remove the flex-wrap.

## Guidance to review

- Check the screenshot.
- or try adding a claim to a school with a long name in the review environment of this PR.

## Screenshots

![CleanShot 2024-05-17 at 14 27 41](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/8b1bb532-bffb-466c-a362-4f1d8e7e8dab)
