### PR TITLE
Add Claims service Slack notification when a Claim has been submitted

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -20,3 +20,5 @@ TEACHING_RECORD_BASE_URL=https://preprod.teacher-qualifications-api.education.go
 TEACHING_RECORD_API_MINOR_VERSION=20240416
 TEACHING_RECORD_API_KEY=secret
 GIAS_CSV_BASE_URL=https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public
+
+CLAIMS_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/secret

--- a/app/services/claims/claim/submit.rb
+++ b/app/services/claims/claim/submit.rb
@@ -11,6 +11,7 @@ class Claims::Claim::Submit
 
     if status_changed_to_submitted?
       send_claim_submitted_notification_email
+      send_claim_submitted_notification_slack_message
     end
   end
 
@@ -21,6 +22,10 @@ class Claims::Claim::Submit
   def send_claim_submitted_notification_email
     UserMailer.with(service: :claims)
       .claim_submitted_notification(user, claim).deliver_later
+  end
+
+  def send_claim_submitted_notification_slack_message
+    Claims::ClaimSlackNotifier.claim_submitted_notification(claim).deliver_later
   end
 
   def status_changed_to_submitted?

--- a/app/slack_notifiers/application_slack_notifier.rb
+++ b/app/slack_notifiers/application_slack_notifier.rb
@@ -1,0 +1,20 @@
+class ApplicationSlackNotifier < SlackNotifier
+  include Rails.application.routes.url_helpers
+
+  class_attribute :service
+
+  private
+
+  def default_url_options
+    { host:, port: ENV.fetch("PORT") }
+  end
+
+  def host
+    case service.to_s
+    when "claims"
+      ENV["CLAIMS_HOST"]
+    when "placements"
+      ENV["PLACEMENTS_HOST"]
+    end
+  end
+end

--- a/app/slack_notifiers/claims/application_slack_notifier.rb
+++ b/app/slack_notifiers/claims/application_slack_notifier.rb
@@ -1,0 +1,4 @@
+class Claims::ApplicationSlackNotifier < ApplicationSlackNotifier
+  self.service = :claims
+  self.endpoint_url = ENV["CLAIMS_SLACK_WEBHOOK_URL"]
+end

--- a/app/slack_notifiers/claims/claim_slack_notifier.rb
+++ b/app/slack_notifiers/claims/claim_slack_notifier.rb
@@ -1,0 +1,24 @@
+class Claims::ClaimSlackNotifier < Claims::ApplicationSlackNotifier
+  def claim_submitted_notification(claim)
+    message(
+      text: ":tada:  A new claim has been submitted.",
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: ":tada:  A new claim has been submitted.",
+          },
+          accessory: {
+            type: "button",
+            text: {
+              type: "plain_text",
+              text: "View Claim",
+            },
+            url: claims_support_claim_url(claim),
+          },
+        },
+      ],
+    )
+  end
+end

--- a/lib/slack_notifier.rb
+++ b/lib/slack_notifier.rb
@@ -1,0 +1,56 @@
+class SlackNotifier
+  class_attribute :endpoint_url
+
+  private_class_method :new
+
+  def message(text: nil, blocks: nil)
+    Message.new(endpoint_url:, text:, blocks:)
+  end
+
+  def self.method_missing(method, *args, **kwargs)
+    if public_method_defined?(method, false)
+      new.public_send(method, *args, **kwargs)
+    else
+      super
+    end
+  end
+
+  def self.respond_to_missing?(method, _include_private = false)
+    public_method_defined?(method, false)
+  end
+
+  class Message
+    attr_reader :endpoint_url, :text, :blocks
+
+    def initialize(endpoint_url:, text:, blocks: nil)
+      @endpoint_url = endpoint_url
+      @text = text
+      @blocks = blocks
+    end
+
+    def deliver_now
+      return unless endpoint_url
+
+      HTTParty.post(endpoint_url, body: body.to_json)
+    end
+
+    def deliver_later
+      DeliveryJob.perform_later(endpoint_url, text, blocks)
+    end
+
+    class DeliveryJob < ApplicationJob
+      def perform(endpoint_url, text, blocks)
+        Message.new(endpoint_url:, text:, blocks:).deliver_now
+      end
+    end
+
+    private
+
+    def body
+      {
+        text:,
+        blocks:,
+      }
+    end
+  end
+end

--- a/spec/lib/slack_notifier_spec.rb
+++ b/spec/lib/slack_notifier_spec.rb
@@ -1,0 +1,102 @@
+require "rails_helper"
+
+RSpec.describe SlackNotifier do
+  let(:example_slack_notifier_class) do
+    Class.new(described_class) do
+      def text_message
+        message(text: "Hello, World!")
+      end
+    end
+  end
+
+  describe ".method_missing" do
+    context "when instance method is defined in subclass" do
+      subject(:method_missing_call) { example_slack_notifier_class.text_message }
+
+      it "returns a SlackNotifier::Message instance" do
+        expect(method_missing_call).to be_a(SlackNotifier::Message)
+        expect(method_missing_call).to have_attributes(text: "Hello, World!")
+      end
+    end
+
+    context "when instance method is not defined in subclass" do
+      subject(:method_missing_call) { example_slack_notifier_class.message }
+
+      it "raises a NoMethodError" do
+        expect { method_missing_call }.to raise_error(NoMethodError)
+      end
+    end
+  end
+
+  describe SlackNotifier::Message do
+    subject(:example_message) { described_class.new(endpoint_url:, text: "Hello, World!") }
+
+    describe "#deliver_now" do
+      subject(:deliver_now_call) { example_message.deliver_now }
+
+      context "when endpoint_url is present" do
+        let(:endpoint_url) { "https://hooks.slack.com/services/secret" }
+
+        before do
+          stub_slack_post_request
+        end
+
+        it "performs a HTTP post call to the provided endpoint_url" do
+          expect(HTTParty).to receive(:post).with(endpoint_url, body: "{\"text\":\"Hello, World!\",\"blocks\":null}")
+
+          deliver_now_call
+        end
+      end
+
+      context "when endpoint_url is nil" do
+        let(:endpoint_url) { nil }
+
+        it "does nothing" do
+          expect(deliver_now_call).to be_nil
+        end
+      end
+    end
+
+    describe "#deliver_later" do
+      subject(:deliver_later_call) { example_message.deliver_later }
+
+      let(:endpoint_url) { "https://hooks.slack.com/services/secret" }
+
+      it "enqueues a SlackNotifier::Message::DeliveryJob" do
+        expect { deliver_later_call }.to have_enqueued_job(SlackNotifier::Message::DeliveryJob).with(endpoint_url, "Hello, World!", nil)
+      end
+    end
+
+    describe SlackNotifier::Message::DeliveryJob do
+      subject(:example_delivery_job) { described_class.new }
+
+      describe "#perform" do
+        subject(:perform_call) { example_delivery_job.perform(endpoint_url, "Hello, World!", nil) }
+
+        let(:endpoint_url) { "https://hooks.slack.com/services/secret" }
+
+        before do
+          stub_slack_post_request
+        end
+
+        it "builds an instance of Message with its given arguments and call perform_now on the message" do
+          message = instance_double(SlackNotifier::Message, deliver_now: nil)
+
+          allow(SlackNotifier::Message).to receive(:new).with(endpoint_url:, text: "Hello, World!", blocks: nil).and_return(message)
+
+          perform_call
+
+          expect(message).to have_received(:deliver_now)
+        end
+      end
+    end
+  end
+
+  private
+
+  def stub_slack_post_request
+    stub_request(:post, "https://hooks.slack.com/services/secret")
+      .with(body: "{\"text\":\"Hello, World!\",\"blocks\":null}")
+      .to_return(status: 200, body: "ok")
+  end
+end

--- a/spec/slack_notifiers/application_slack_notifier_spec.rb
+++ b/spec/slack_notifiers/application_slack_notifier_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe ApplicationSlackNotifier do
+  describe "#default_url_options" do
+    context "when service is :claims" do
+      subject(:claims_slack_notifier_class) do
+        Class.new(described_class) do
+          self.service = :claims
+
+          def root_url_notification
+            message(text: claims_root_url)
+          end
+        end
+      end
+
+      it "builds claims urls" do
+        expect(claims_slack_notifier_class.root_url_notification.text).to eq("http://claims.localhost:3000/")
+      end
+    end
+
+    context "when service is :placements" do
+      subject(:placements_slack_notifier_class) do
+        Class.new(described_class) do
+          self.service = :placements
+
+          def root_url_notification
+            message(text: placements_root_url)
+          end
+        end
+      end
+
+      it "builds placements urls" do
+        expect(placements_slack_notifier_class.root_url_notification.text).to eq("http://placements.localhost:3000/")
+      end
+    end
+
+    context "when service is not provided" do
+      subject(:unknown_service_slack_notifier_class) do
+        Class.new(described_class) do
+          def sign_in_notification
+            message(text: sign_in_url)
+          end
+        end
+      end
+
+      it "builds placements urls" do
+        expect { unknown_service_slack_notifier_class.sign_in_notification }.to raise_error(
+          ArgumentError,
+          "Missing host to link to! Please provide the :host parameter, set default_url_options[:host], or set :only_path to true",
+        )
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,8 @@ end
 # Instead, define negated versions of whatever matchers you wish to negate with
 # `RSpec::Matchers.define_negated_matcher` and use `expect(...).to matcher.and matcher`.
 RSpec::Matchers.define_negated_matcher :not_change, :change
+RSpec::Matchers.define_negated_matcher :not_have_enqueued_mail, :have_enqueued_mail
+RSpec::Matchers.define_negated_matcher :not_have_enqueued_job, :have_enqueued_job
 
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|


### PR DESCRIPTION
## Context

We want to know when a Claim has been made.

## Changes proposed in this pull request

- Introduce a `SlackNotifier` library class.

  The `SlackNotifier` is app-agnostic and is therefore placed in the `lib` directory.

  The API signature mirrors `ActionMailer` and therefore should provide a very familiar developer experience.

  We could update the class to use a `defaults` method, as `ActionMailer` does, to set default values on the `message` call.

  Where `to` needs to be an array of email addresses for `ActionMailer`, `SlackNotifier` should be able to configure a `to` of a Slack channel ID. Alternatives, we could name the parameter `channel`. We also provide a `endpoint_url` value that acts as the _delivery_method_ (or SMTP configuration) comparable.

- To provide a clear separation of concerns between app-specific code vs app-agnostic code, add the "service" logic to an `ApplicationSlackNotifier`, as we do with `ActionMailer`.

- Add a `Claims::ApplicationSlackNotifier` class that sets `service` and `endpoint_url` for the "Claims" service usage.

- Add a `Claims::ClaimSlackNotifier` to send claim-subject notifications.

- Call `Claims::ClaimSlackNotifier` in the `Claims::Claim::Submit` service.

## Guidance to review

- Review the code and code architecture.
- Ping me for a user-based `webhook_url` and I'll provide you with one for local testing.

## Screenshots

![CleanShot 2024-05-19 at 23 50 17](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/e36149df-4168-4103-af49-8ad1b93cf531)

