### PR TITLE
[BUGFIX] Prevent ApplicationSlackNotifier from failing when PORT is missing

### DIFF
--- a/app/slack_notifiers/application_slack_notifier.rb
+++ b/app/slack_notifiers/application_slack_notifier.rb
@@ -6,7 +6,7 @@ class ApplicationSlackNotifier < SlackNotifier
   private
 
   def default_url_options
-    { host:, port: ENV.fetch("PORT") }
+    { host:, port: ENV["PORT"] }
   end
 
   def host


### PR DESCRIPTION
## Context

The `ApplicationSlackNotifier` is failing when `ENV["PORT"]` is missing.

The `ApplicationSlackNotifier` should default to no specific port, i.e. be port-less (port 80 by default on browsers).

## Changes proposed in this pull request

- Use `ENV["PORT"]` instead of `ENV.fetch("PORT")` and allow `nil` for missing `PORT` env var.

## Guidance to review

- Remove `PORT` from your local env vars, it should now work fine.
  - The host for urls built in the slack notifier will be `claims.localhost` instead of `claims.localhost:3000` (if your PORT is set to 3000). In Production, this is the intended behaviour.