### PR TITLE
Update subject and placement data model for additional subjects

### DIFF
--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -22,7 +22,8 @@
 #  fk_rails_...  (subject_id => subjects.id)
 #
 class Placement < ApplicationRecord
-  after_save :assign_subject # TODO: Remove when data migrated
+  # TODO: Remove when data migrated
+  after_save :assign_subject, unless: proc { |placement| placement.subject.present? }
 
   has_many :placement_mentor_joins, dependent: :destroy
   has_many :mentors, through: :placement_mentor_joins, class_name: "Placements::Mentor"
@@ -58,9 +59,7 @@ class Placement < ApplicationRecord
 
   # TODO: Remove after data migrated
   def assign_subject
-    return if subjects.blank? ||
-      subject.present? ||
-      subject == subjects.last
+    return if subjects.blank?
 
     update!(subject: subjects.last)
   end

--- a/app/models/placements/placement_additional_subject.rb
+++ b/app/models/placements/placement_additional_subject.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: placement_additional_subjects
+#
+#  id           :uuid             not null, primary key
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  placement_id :uuid             not null
+#  subject_id   :uuid             not null
+#
+# Indexes
+#
+#  index_placement_additional_subjects_on_placement_id  (placement_id)
+#  index_placement_additional_subjects_on_subject_id    (subject_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (placement_id => placements.id)
+#  fk_rails_...  (subject_id => subjects.id)
+#
+class Placements::PlacementAdditionalSubject < ApplicationRecord
+  belongs_to :subject
+  belongs_to :placement
+end

--- a/app/models/placements/schools/placements/build/placement.rb
+++ b/app/models/placements/schools/placements/build/placement.rb
@@ -7,16 +7,19 @@
 #  updated_at  :datetime         not null
 #  provider_id :uuid
 #  school_id   :uuid
+#  subject_id  :uuid
 #
 # Indexes
 #
 #  index_placements_on_provider_id  (provider_id)
 #  index_placements_on_school_id    (school_id)
+#  index_placements_on_subject_id   (subject_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (provider_id => providers.id)
 #  fk_rails_...  (school_id => schools.id)
+#  fk_rails_...  (subject_id => subjects.id)
 #
 class Placements::Schools::Placements::Build::Placement < Placement
   has_many :placement_mentor_joins, dependent: :destroy

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -2,16 +2,28 @@
 #
 # Table name: subjects
 #
-#  id           :uuid             not null, primary key
-#  code         :string
-#  name         :string           not null
-#  subject_area :enum
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
+#  id                :uuid             not null, primary key
+#  code              :string
+#  name              :string           not null
+#  subject_area      :enum
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  parent_subject_id :uuid
+#
+# Indexes
+#
+#  index_subjects_on_parent_subject_id  (parent_subject_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (parent_subject_id => subjects.id)
 #
 class Subject < ApplicationRecord
+  belongs_to :parent_subject, class_name: "Subject", optional: true
+
+  has_many :child_subjects, class_name: "Subject", foreign_key: :parent_subject_id, dependent: :destroy
   has_many :placement_subject_joins, dependent: :restrict_with_exception
-  has_many :placements, through: :placement_subject_joins
+  has_many :placements, through: :placement_subject_joins # TODO: Remove `through: :placement_subject_joins` after data migration
 
   enum :subject_area,
        { primary: "primary", secondary: "secondary" },

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -42,6 +42,7 @@ shared:
     - subject_area
     - name
     - code
+    - parent_subject_id
     - created_at
     - updated_at
   :regions:
@@ -158,6 +159,7 @@ shared:
   :placements:
     - id
     - school_id
+    - subject_id
     - created_at
     - updated_at
     - provider_id
@@ -166,5 +168,11 @@ shared:
     - name
     - email_address
     - school_id
+    - created_at
+    - updated_at
+  :placement_additional_subjects:
+    - id
+    - subject_id
+    - placement_id
     - created_at
     - updated_at

--- a/db/migrate/20240520141009_add_parent_subject_to_subjects.rb
+++ b/db/migrate/20240520141009_add_parent_subject_to_subjects.rb
@@ -1,0 +1,5 @@
+class AddParentSubjectToSubjects < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :subjects, :parent_subject, type: :uuid, foreign_key: { to_table: :subjects }
+  end
+end

--- a/db/migrate/20240520141421_add_subject_to_placements.rb
+++ b/db/migrate/20240520141421_add_subject_to_placements.rb
@@ -1,0 +1,5 @@
+class AddSubjectToPlacements < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :placements, :subject, type: :uuid, foreign_key: true
+  end
+end

--- a/db/migrate/20240520143732_create_placement_additional_subjects.rb
+++ b/db/migrate/20240520143732_create_placement_additional_subjects.rb
@@ -1,0 +1,9 @@
+class CreatePlacementAdditionalSubjects < ActiveRecord::Migration[7.1]
+  def change
+    create_table :placement_additional_subjects, id: :uuid do |t|
+      t.references :subject, null: false, foreign_key: true, type: :uuid
+      t.references :placement, null: false, foreign_key: true, type: :uuid
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_07_081604) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_20_143732) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -209,6 +209,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_07_081604) do
     t.index ["searchable_type", "searchable_id"], name: "index_pg_search_documents_on_searchable"
   end
 
+  create_table "placement_additional_subjects", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "subject_id", null: false
+    t.uuid "placement_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["placement_id"], name: "index_placement_additional_subjects_on_placement_id"
+    t.index ["subject_id"], name: "index_placement_additional_subjects_on_subject_id"
+  end
+
   create_table "placement_mentor_joins", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "mentor_id", null: false
     t.uuid "placement_id", null: false
@@ -232,8 +241,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_07_081604) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "provider_id"
+    t.uuid "subject_id"
     t.index ["provider_id"], name: "index_placements_on_provider_id"
     t.index ["school_id"], name: "index_placements_on_school_id"
+    t.index ["subject_id"], name: "index_placements_on_subject_id"
   end
 
   create_table "providers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -339,6 +350,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_07_081604) do
     t.string "code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "parent_subject_id"
+    t.index ["parent_subject_id"], name: "index_subjects_on_parent_subject_id"
   end
 
   create_table "trusts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -383,15 +396,19 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_07_081604) do
   add_foreign_key "mentor_trainings", "providers"
   add_foreign_key "partnerships", "providers"
   add_foreign_key "partnerships", "schools"
+  add_foreign_key "placement_additional_subjects", "placements"
+  add_foreign_key "placement_additional_subjects", "subjects"
   add_foreign_key "placement_mentor_joins", "mentors"
   add_foreign_key "placement_mentor_joins", "placements"
   add_foreign_key "placement_subject_joins", "placements"
   add_foreign_key "placement_subject_joins", "subjects"
   add_foreign_key "placements", "providers"
   add_foreign_key "placements", "schools"
+  add_foreign_key "placements", "subjects"
   add_foreign_key "school_contacts", "schools"
   add_foreign_key "schools", "regions"
   add_foreign_key "schools", "trusts"
   add_foreign_key "schools", "users", column: "claims_grant_conditions_accepted_by_id"
+  add_foreign_key "subjects", "subjects", column: "parent_subject_id"
   add_foreign_key "user_memberships", "users"
 end

--- a/spec/factories/placements.rb
+++ b/spec/factories/placements.rb
@@ -7,16 +7,19 @@
 #  updated_at  :datetime         not null
 #  provider_id :uuid
 #  school_id   :uuid
+#  subject_id  :uuid
 #
 # Indexes
 #
 #  index_placements_on_provider_id  (provider_id)
 #  index_placements_on_school_id    (school_id)
+#  index_placements_on_subject_id   (subject_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (provider_id => providers.id)
 #  fk_rails_...  (school_id => schools.id)
+#  fk_rails_...  (subject_id => subjects.id)
 #
 FactoryBot.define do
   factory :placement do

--- a/spec/factories/placements/placement_additional_subjects.rb
+++ b/spec/factories/placements/placement_additional_subjects.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: placement_additional_subjects
+#
+#  id           :uuid             not null, primary key
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  placement_id :uuid             not null
+#  subject_id   :uuid             not null
+#
+# Indexes
+#
+#  index_placement_additional_subjects_on_placement_id  (placement_id)
+#  index_placement_additional_subjects_on_subject_id    (subject_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (placement_id => placements.id)
+#  fk_rails_...  (subject_id => subjects.id)
+#
+FactoryBot.define do
+  factory :placement_additional_subject, class: "Placements::PlacementAdditionalSubject" do
+  end
+end

--- a/spec/factories/placements/placement_additional_subjects.rb
+++ b/spec/factories/placements/placement_additional_subjects.rb
@@ -20,5 +20,7 @@
 #
 FactoryBot.define do
   factory :placement_additional_subject, class: "Placements::PlacementAdditionalSubject" do
+    association :subject
+    association :placement
   end
 end

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -2,12 +2,21 @@
 #
 # Table name: subjects
 #
-#  id           :uuid             not null, primary key
-#  code         :string
-#  name         :string           not null
-#  subject_area :enum
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
+#  id                :uuid             not null, primary key
+#  code              :string
+#  name              :string           not null
+#  subject_area      :enum
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  parent_subject_id :uuid
+#
+# Indexes
+#
+#  index_subjects_on_parent_subject_id  (parent_subject_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (parent_subject_id => subjects.id)
 #
 FactoryBot.define do
   factory :subject do

--- a/spec/models/placement_spec.rb
+++ b/spec/models/placement_spec.rb
@@ -110,8 +110,8 @@ RSpec.describe Placement, type: :model do
       end
     end
 
-    context "when a subject has been associated with the placement" do
-      context "when the subject is not same as the already associated subject" do
+    context "when subjects have been associated with the placement" do
+      context "when subject is nil" do
         let(:subjects) { [create(:subject)] }
         let(:a_subject) { nil }
 
@@ -120,9 +120,9 @@ RSpec.describe Placement, type: :model do
         end
       end
 
-      context "when the subject is same as the already associated subject" do
+      context "when subject is not nil" do
         let(:subjects) { [create(:subject)] }
-        let(:a_subject) { subjects.last }
+        let(:a_subject) { create(:subject) }
 
         it "keeps the original subject assigned to the placement" do
           expect(placement.subject).to eq(a_subject)

--- a/spec/models/placements/placement_additional_subject_spec.rb
+++ b/spec/models/placements/placement_additional_subject_spec.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: placement_additional_subjects
+#
+#  id           :uuid             not null, primary key
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  placement_id :uuid             not null
+#  subject_id   :uuid             not null
+#
+# Indexes
+#
+#  index_placement_additional_subjects_on_placement_id  (placement_id)
+#  index_placement_additional_subjects_on_subject_id    (subject_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (placement_id => placements.id)
+#  fk_rails_...  (subject_id => subjects.id)
+#
+require "rails_helper"
+
+RSpec.describe Placements::PlacementAdditionalSubject, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:placement) }
+    it { is_expected.to belong_to(:subject) }
+  end
+end

--- a/spec/models/placements/schools/placements/build/placement_spec.rb
+++ b/spec/models/placements/schools/placements/build/placement_spec.rb
@@ -7,16 +7,19 @@
 #  updated_at  :datetime         not null
 #  provider_id :uuid
 #  school_id   :uuid
+#  subject_id  :uuid
 #
 # Indexes
 #
 #  index_placements_on_provider_id  (provider_id)
 #  index_placements_on_school_id    (school_id)
+#  index_placements_on_subject_id   (subject_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (provider_id => providers.id)
 #  fk_rails_...  (school_id => schools.id)
+#  fk_rails_...  (subject_id => subjects.id)
 #
 require "rails_helper"
 

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -2,17 +2,29 @@
 #
 # Table name: subjects
 #
-#  id           :uuid             not null, primary key
-#  code         :string
-#  name         :string           not null
-#  subject_area :enum
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
+#  id                :uuid             not null, primary key
+#  code              :string
+#  name              :string           not null
+#  subject_area      :enum
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  parent_subject_id :uuid
+#
+# Indexes
+#
+#  index_subjects_on_parent_subject_id  (parent_subject_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (parent_subject_id => subjects.id)
 #
 require "rails_helper"
 
 RSpec.describe Subject, type: :model do
   describe "associations" do
+    it { is_expected.to belong_to(:parent_subject).optional }
+
+    it { is_expected.to have_many(:child_subjects) }
     it { is_expected.to have_many(:placement_subject_joins).dependent(:restrict_with_exception) }
     it { is_expected.to have_many(:placements).through(:placement_subject_joins) }
   end


### PR DESCRIPTION
## Context

- With the redesign to include "Additional Subjects", the data model has been changed to allow the following:
  - Subjects belongs to a Parent Subject (optional)
  - A Subject has many Child Subjects
  - A Placement belongs to a Subject (optional for now, but filled by `after_save`)
  - A Placement has many Placement Additional Subjects
  - A Placement has many Additional Subjects, through Placement Additional Subjects

## Changes proposed in this pull request

- Changes to Subject and Placement models to allow for Placements to have Additional Subjects
- Changes to Placement so that it belongs to a Subject

## Guidance to review

in the rails console:

```ruby
placement = Placement.new(school: Placements::School.last, subjects: [Subject.last])
placement.save!
placement.subject # This should return the same record as Subject.last
```

## Link to Trello card

https://trello.com/c/N1R0wbsY/369-update-the-data-model-to-support-parent-child-associations-on-subjects

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

