### PR TITLE
Fix school contact cancel button

### DIFF
--- a/app/views/placements/schools/school_contacts/check.html.erb
+++ b/app/views/placements/schools/school_contacts/check.html.erb
@@ -43,7 +43,7 @@
         <% end %>
         <%= f.govuk_submit t(".add_the_itt_placement_contact") %>
         <p class="govuk-body">
-          <%= govuk_link_to(t(".cancel"), placements_school_mentors_path(@school), no_visited_state: true) %>
+          <%= govuk_link_to(t(".cancel"), placements_school_path(@school), no_visited_state: true) %>
         </p>
       <% end %>
     </div>


### PR DESCRIPTION
## Context

- Fix to School Contact "Cancel" button on "Check your answers" page.

## Guidance to review

- Cancel button on School Contact "Check your answers" page, should redirect you back to Organisation Details page.

## Screenshots

https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/10698acd-aad1-4246-be83-0f89beaa4d82

