### PR TITLE
Fix claim show page for normal users

### DIFF
--- a/app/views/claims/schools/claims/show.html.erb
+++ b/app/views/claims/schools/claims/show.html.erb
@@ -32,12 +32,14 @@
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: Claims::Claim.human_attribute_name(:accredited_provider)) %>
             <% row.with_value(text: @claim.provider.name) %>
-            <% row.with_action(
-              text: t("change"),
-              href: create_revision_claims_school_claim_path(@school, @claim),
-              visually_hidden_text: Claims::Claim.human_attribute_name(:accredited_provider),
-              html_attributes: { class: "govuk-link--no-visited-state" },
-            ) %>
+            <% if @claim.draft? %>
+              <% row.with_action(
+                text: t("change"),
+                href: create_revision_claims_school_claim_path(@school, @claim),
+                visually_hidden_text: Claims::Claim.human_attribute_name(:accredited_provider),
+                html_attributes: { class: "govuk-link--no-visited-state" },
+              ) %>
+            <% end %>
           <% end %>
         <% else %>
           <% summary_list.with_row do |row| %>
@@ -55,12 +57,14 @@
               <% end %>
             </ul>
           <% end %>
-          <% row.with_action(
-            text: t("change"),
-            href: create_revision_claims_school_claim_mentors_path(@school, @claim),
-            visually_hidden_text: Claims::Claim.human_attribute_name(:mentors),
-            html_attributes: { class: "govuk-link--no-visited-state" },
-          ) %>
+          <% if @claim.draft? %>
+            <% row.with_action(
+              text: t("change"),
+              href: create_revision_claims_school_claim_mentors_path(@school, @claim),
+              visually_hidden_text: Claims::Claim.human_attribute_name(:mentors),
+              html_attributes: { class: "govuk-link--no-visited-state" },
+            ) %>
+          <% end %>
         <% end %>
       <% end %>
 
@@ -70,14 +74,18 @@
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: mentor_training.mentor.full_name) %>
             <% row.with_value(text: pluralize(mentor_training.hours_completed, t(".hour"))) %>
-            <% row.with_action(text: t("change"),
-                               href: create_revision_claims_school_claim_mentor_training_path(
-                @school,
-                @claim,
-                mentor_training.mentor_id,
-              ),
-                               visually_hidden_text: "Hours of training for #{mentor_training.mentor.full_name}",
-                               html_attributes: { class: "govuk-link--no-visited-state" }) %>
+            <% if @claim.draft? %>
+              <% row.with_action(
+                text: t("change"),
+                href: create_revision_claims_school_claim_mentor_training_path(
+                  @school,
+                  @claim,
+                  mentor_training.mentor_id,
+                ),
+                visually_hidden_text: "Hours of training for #{mentor_training.mentor.full_name}",
+                html_attributes: { class: "govuk-link--no-visited-state" },
+              ) %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/spec/system/claims/schools/claims/view_claim_spec.rb
+++ b/spec/system/claims/schools/claims/view_claim_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe "View a claim", type: :system, service: :claims do
     expect(page).to have_content("Total hours6 hours")
     expect(page).to have_content("Hourly rate£53.60")
     expect(page).to have_content("Claim amount£321.60")
+    expect(page).not_to have_content("Change")
   end
 
   def then_i_can_then_see_the_draft_claim_details


### PR DESCRIPTION
## Context

Previously, the change button was shown on the show page for submitted claim, this button needs to only show for draft claims

This doesn't mean that users can change submitted claims. There are policies that don't permit this.

## Changes proposed in this pull request

Show the button only on for draft claims

## Guidance to review

Go on show page of a submitted claim1

## Screenshots


https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/4302fc15-f7db-4aca-abae-bee2f16b74d4


