### PR TITLE
Add data migration to associate modern language child subjects

### DIFF
--- a/db/data/20240522123948_update_modern_language_child_subjects.rb
+++ b/db/data/20240522123948_update_modern_language_child_subjects.rb
@@ -1,0 +1,55 @@
+class UpdateModernLanguageChildSubjects < ActiveRecord::Migration[7.1]
+  def up
+    api_response = PublishTeacherTraining::Subject::Api.call
+    child_subject_ids = modern_language_child_subject_ids(api_response.fetch("data"))
+
+    subjects_data = api_response.fetch("included")
+
+    assign_parent_subject(parent_subject: modern_languages, child_subject_ids:, subjects_data:)
+  end
+
+  def down
+    return if modern_languages.blank?
+
+    Subject.where(parent_subject: modern_languages).update_all(parent_subject_id: nil)
+  end
+
+  private
+
+  def modern_languages
+    @modern_languages ||= Subject.find_by(name: "Modern Languages")
+  end
+
+  def modern_language_child_subject_ids(data)
+    subject_ids = []
+
+    modern_language_subject_area = data.find do |subject_area|
+      subject_area["id"] == "ModernLanguagesSubject"
+    end
+
+    modern_language_subject_area.dig("relationships", "subjects", "data").each do |subject_data|
+      subject_ids << subject_data["id"]
+    end
+
+    subject_ids
+  end
+
+  def assign_parent_subject(parent_subject:, child_subject_ids:, subjects_data:)
+    return if parent_subject.blank?
+
+    child_subjects_data = subjects_data.select do |subject|
+      child_subject_ids.include?(subject["id"])
+    end
+
+    child_subjects_data.each do |child_subject_data|
+      subject_attributes = child_subject_data["attributes"]
+      child_subject = Subject.find_by(
+        name: subject_attributes["name"],
+        code: subject_attributes["code"],
+      )
+      next if child_subject.blank?
+
+      child_subject.update!(parent_subject:)
+    end
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,0 +1,1 @@
+DataMigrate::Data.define(version: 20240522123948)

--- a/spec/services/publish_teacher_training/subject/import_spec.rb
+++ b/spec/services/publish_teacher_training/subject/import_spec.rb
@@ -16,15 +16,20 @@ RSpec.describe PublishTeacherTraining::Subject::Import do
           described_class.call
         }.to change(Subject.primary, :count).by(2).and change(
           Subject.secondary, :count
-        ).by(3)
+        ).by(4)
 
         expect(Subject.primary.pluck(:name)).to match_array([
           "Primary", "Primary with English"
         ])
 
         expect(Subject.secondary.pluck(:name)).to match_array([
-          "Art and design", "Science", "French"
+          "Art and design", "Science", "French", "Modern Languages"
         ])
+
+        modern_languages = Subject.find_by(name: "Modern Languages")
+        expect(modern_languages.child_subjects.pluck(:name)).to match_array(
+          %w[French],
+        )
       end
 
       context "when a subject already exists" do
@@ -33,7 +38,7 @@ RSpec.describe PublishTeacherTraining::Subject::Import do
 
           expect {
             described_class.call
-          }.to change(Subject, :count).by(4)
+          }.to change(Subject, :count).by(5)
         end
       end
     end
@@ -147,6 +152,10 @@ RSpec.describe PublishTeacherTraining::Subject::Import do
                   "type" => "subjects",
                   "id" => "4",
                 },
+                {
+                  "type" => "subjects",
+                  "id" => "7",
+                },
               ],
             },
           },
@@ -207,6 +216,14 @@ RSpec.describe PublishTeacherTraining::Subject::Import do
           "attributes" => {
             "name" => "Science",
             "code" => "F0",
+          },
+        },
+        {
+          "id" => "7",
+          "type" => "subjects",
+          "attributes" => {
+            "name" => "Modern Languages",
+            "code" => nil,
           },
         },
         {


### PR DESCRIPTION
## Context

- Changes to update Subjects, related to the "Modern Languages", to associated them with the parent subject "Modern Languages" 

## Changes proposed in this pull request

- `PublishTeacherTraining::Subject::Import` considers `ModernLanguagesSubject` its own subject area.
- `PublishTeacherTraining::Subject::Import` assigns subjects within the `ModernLanguagesSubject` subject area with the parent subject "Modern Languages"
- Added Data Migration to backfill database with child subject associations for "Modern Languages" associated subjects.

## Guidance to review

- run `bundle exec rake data:migrate`
- This will backfill and language subjects with the parent subject "Modern Languages"
- in the rails console run: `Subject.find_by(name: "Modern Languages").child_subjects`
- This should return [French, German...]

- run `bundle exec rake db:drop db:create db:setup`
- in the rails console run: `Subject.find_by(name: "Modern Languages").child_subjects`
- This should return [French, German...]

 in the rails console run:
```ruby
# Remove all parent subjects
Subject.update_all(parent_subject_id: nil)

# Run the subject importer
PublishTeacherTraining::Subject::Import.call

Subject.find_by(name: "Modern Languages").child_subjects
# This should return [French, German...]
```

## Link to Trello card

https://trello.com/c/BQwACPHr/372-update-subjects-to-use-parent-child-associations

