### PR TITLE
Update schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -68,6 +68,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_20_143732) do
     t.index ["submitted_by_type", "submitted_by_id"], name: "index_claims_on_submitted_by"
   end
 
+  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
+  end
+
   create_table "flipflop_features", force: :cascade do |t|
     t.string "key", null: false
     t.boolean "enabled", default: false, null: false


### PR DESCRIPTION
Changes made in #659 caused the `schema.rb` file to change.

A new `data_migrations` table was added by the `data_migrate` gem.
