### PR TITLE
Backfill placement subject_id

### DIFF
--- a/db/data/20240523154417_backfill_placements_with_subject.rb
+++ b/db/data/20240523154417_backfill_placements_with_subject.rb
@@ -1,0 +1,11 @@
+class BackfillPlacementsWithSubject < ActiveRecord::Migration[7.1]
+  def up
+    Placement.where(subject_id: nil).find_each do |placement|
+      placement.update!(subject: placement.subjects.last)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20240522123948)
+DataMigrate::Data.define(version: 20240523154417)


### PR DESCRIPTION
## Context

- Add data migration to backfill all placements where they are missing a `subject_id`.

## Changes proposed in this pull request

- Add data migration to backfill all placements where they are missing a `subject_id`.

## Guidance to review

run: `bundle exec rake data:migrate`
All Placements should now have a `subject_id`

## Link to Trello card

https://trello.com/c/xIgJ213c/365-re-model-placement-subjects-part-1


