### PR TITLE
Jc/backfill modern langauge placements

### DIFF
--- a/db/data/20240523162025_backfill_modern_language_placements_with_additional_subjects.rb
+++ b/db/data/20240523162025_backfill_modern_language_placements_with_additional_subjects.rb
@@ -1,0 +1,31 @@
+class BackfillModernLanguagePlacementsWithAdditionalSubjects < ActiveRecord::Migration[7.1]
+  def up
+    return if modern_languages.blank?
+
+    Placement.where(subject: modern_languages.child_subjects).find_each do |placement|
+      additional_subject = placement.subject
+      placement.update!(
+        subject: modern_languages,
+        additional_subjects: [additional_subject],
+      )
+    end
+  end
+
+  def down
+    return if modern_languages.blank?
+
+    additional_subjects = Placements::PlacementAdditionalSubject.where(
+      subject: modern_languages.child_subjects,
+    )
+    additional_subjects.find_each do |additional_subject|
+      additional_subject.placement.update!(subject: additional_subject.subject)
+      additional_subject.destroy!
+    end
+  end
+
+  private
+
+  def modern_languages
+    @modern_languages ||= Subject.find_by(name: "Modern Languages")
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20240523154417)
+DataMigrate::Data.define(version: 20240523162025)


### PR DESCRIPTION
## Changes proposed in this pull request

- Data migration to update Placements with "Modern Languages" child subjects, so the Placement's subject is "Modern Languages", with the original subject as an additional subject.

## Guidance to review

run `bundle exec rake db:migrate`
All placements with a subject, which is a "Modern Language" child subject, are updated with the subject "Modern Languages" with the child subject as an additional subject.

## Link to Trello card

https://trello.com/c/5XCQQMJ2/370-re-model-placement-subjects-part-2
