### PR TITLE
Snagging changes to placements mentor pages

### DIFF
--- a/app/views/placements/schools/placements/build/add_mentors.html.erb
+++ b/app/views/placements/schools/placements/build/add_mentors.html.erb
@@ -15,13 +15,23 @@
           <%= t(".add_placement") %>
         </span>
 
-        <%= f.govuk_check_boxes_fieldset :mentor_ids, legend: { size: "l", text: t(".mentors") } do %>
+        <%= f.govuk_check_boxes_fieldset :mentor_ids, legend: { size: "l", text: t(".mentor") } do %>
           <% @school.mentors.each do |mentor| %>
             <%= f.govuk_check_box :mentor_ids, mentor.id, label: { text: mentor.full_name }, checked: @selected_mentors&.include?(mentor) %>
           <% end %>
           <%= f.govuk_check_box_divider %>
           <%= f.govuk_check_box :mentor_ids, :not_known, label: { text: t(".not_known") }, checked: @selected_mentors&.include?(:not_known), exclusive: true %>
         <% end %>
+
+        <%= govuk_details(
+          summary_text: t(".mentor_not_listed"),
+          text: embedded_link_text(
+            t(".you_need_to_add_a_mentor",
+              link: govuk_link_to(
+                t(".add_a_mentor"), new_placements_school_mentor_path, no_visited_state: true
+              )),
+          ),
+        ) %>
 
         <%= f.govuk_submit t(".continue") %>
       </div>

--- a/app/views/placements/schools/placements/edit_mentors.html.erb
+++ b/app/views/placements/schools/placements/edit_mentors.html.erb
@@ -15,13 +15,23 @@
           <%= t(".add_placement") %>
         </span>
 
-        <%= f.govuk_check_boxes_fieldset :mentor_ids, legend: { size: "l", text: t(".mentors") } do %>
+        <%= f.govuk_check_boxes_fieldset :mentor_ids, legend: { size: "l", text: t(".mentor") } do %>
           <% @mentors.each do |mentor| %>
             <%= f.govuk_check_box :mentor_ids, mentor.id, label: { text: mentor.full_name }, checked: @placement.mentors.include?(mentor) %>
           <% end %>
           <%= f.govuk_check_box_divider %>
           <%= f.govuk_check_box :mentor_ids, [], label: { text: t(".not_known") }, checked: @placement.mentors.empty?, exclusive: true %>
         <% end %>
+
+        <%= govuk_details(
+          summary_text: t(".mentor_not_listed"),
+          text: embedded_link_text(
+            t(".you_need_to_add_a_mentor",
+              link: govuk_link_to(
+                t(".add_a_mentor"), new_placements_school_mentor_path, no_visited_state: true
+              )),
+          ),
+        ) %>
 
         <%= f.govuk_submit t(".continue") %>
       </div>

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -18,7 +18,7 @@ en:
         build:
           add_phase:
             title: Phase - Add placement
-            title_with_error: "Error: Select a phase"
+            title_with_error: "Error: Phase - Add placement"
             add_placement: Add placement
             phase: Phase
             primary: Primary
@@ -27,20 +27,23 @@ en:
             cancel: Cancel
           add_subject:
             title: Subject - Add placement
-            title_with_error: "Error: Select a subject"
+            title_with_error: "Error: Subject - Add placement"
             add_placement: Add placement
             subject: Subject
             continue: Continue
             cancel: Cancel
           add_mentors:
-            title: Mentors - Add placement
-            title_with_error: "Error: Select mentor or not known"
+            title: Mentor - Add placement
+            title_with_error: "Error: Mentor - Add placement"
             add_placement: Add placement
             mentor: Mentor
             continue: Continue
             cancel: Cancel
             mentors: Mentors
             not_known: Not yet known
+            mentor_not_listed: My mentor is not listed
+            you_need_to_add_a_mentor: "You will first need to %{link}."
+            add_a_mentor: add a mentor
           check_your_answers:
             title: Check your answers - Add placement
             add_placement: Add placement
@@ -58,7 +61,7 @@ en:
           update:
             success: Placement added
         edit_provider:
-          title_with_error: "Error: Select a provider"
+          title_with_error: "Error: Provider - Manage a placement"
           title: Provider - Manage a placement
           caption: Manage a placement
           provider: Provider
@@ -69,14 +72,17 @@ en:
           details_text_part_one: You will first need to
           details_text_part_two: add a provider
         edit_mentors:
-          title: Mentors - Edit placement
-          title_with_error: "Error: Select mentor or not known"
-          add_placement: Edit placement
+          title: Mentor - Manage a placement
+          title_with_error: "Error: Mentor - Manage a placement"
+          add_placement: Manage a placement
           mentor: Mentor
           continue: Continue
           cancel: Cancel
-          mentors: Mentors - Edit Placement
+          mentors: Mentors
           not_known: Not yet known
+          mentor_not_listed: My mentor is not listed
+          you_need_to_add_a_mentor: "You will first need to %{link}."
+          add_a_mentor: add a mentor
         terms:
           autumn: Autumn
           spring: Spring

--- a/spec/system/placements/schools/placements/edit_mentors_spec.rb
+++ b/spec/system/placements/schools/placements/edit_mentors_spec.rb
@@ -149,7 +149,8 @@ RSpec.describe "Placements / Schools / Placements / Edit mentors",
   end
 
   def then_i_should_see_the_edit_mentors_page
-    expect(page).to have_content("Edit placement")
+    expect(page).to have_content("Manage a placement")
+    expect(page).to have_content("Mentor")
   end
 
   def when_i_select_mentor_2


### PR DESCRIPTION
## Context

- Changes to the placements mentor pages to align with the prototype.

## Changes proposed in this pull request

- Page Titles now align with the rest of the service.
- Titles changed from "Mentors" to "Mentor".
- Add mentor not listed component.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/0aDtsAV2/386-add-edit-placement-mentors-page

## Screenshots

![screencapture-placements-localhost-3000-schools-000596cf-f4c4-4c19-801e-c48621ae11bd-placements-new-placement-build-add-mentors-2024-05-24-16_19_12](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/2b3a2c55-df9c-4322-8ed0-5949a5b62c92)

![screencapture-placements-localhost-3000-schools-000596cf-f4c4-4c19-801e-c48621ae11bd-placements-c31431aa-c1a0-4f2b-9efb-6818504b6e11-edit-mentors-2024-05-24-16_18_55](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/9d2152ee-9d3c-4468-aa1a-fa34cad9a9c3)

