### PR TITLE
Remove PORT from .env.test

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -2,7 +2,6 @@ HOSTING_ENV=test
 PUBLISH_BASE_URL=https://www.publish-teacher-training-courses.service.gov.uk
 GOVUK_NOTIFY_API_KEY=
 SIGN_IN_METHOD=dfe-sign-in
-PORT=3000
 DFE_SIGN_IN_ISSUER_URL=https://dev-oidc.signin.education.gov.uk
 
 CLAIMS_HOST=claims.localhost

--- a/spec/mailers/support_user_mailer_spec.rb
+++ b/spec/mailers/support_user_mailer_spec.rb
@@ -19,11 +19,11 @@ RSpec.describe SupportUserMailer, type: :mailer do
 
           If you have a DfE Sign-in account, you can use it to sign in:
 
-          [http://claims.localhost:3000/sign-in](http://claims.localhost:3000/sign-in)
+          [http://claims.localhost/sign-in](http://claims.localhost/sign-in)
 
           If you need to create a DfE Sign-in account, you can do this after clicking "Sign in using DfE Sign-in"
 
-          After creating a DfE Sign-in account, you will need to return to this email and [sign in to access the service](http://claims.localhost:3000/sign-in).
+          After creating a DfE Sign-in account, you will need to return to this email and [sign in to access the service](http://claims.localhost/sign-in).
 
           # Give feedback or report a problem
 
@@ -73,11 +73,11 @@ RSpec.describe SupportUserMailer, type: :mailer do
 
           If you have a DfE Sign-in account, you can use it to sign in:
 
-          [http://placements.localhost:3000/sign-in](http://placements.localhost:3000/sign-in)
+          [http://placements.localhost/sign-in](http://placements.localhost/sign-in)
 
           If you need to create a DfE Sign-in account, you can do this after clicking "Sign in using DfE Sign-in"
 
-          After creating a DfE Sign-in account, you will need to return to this email and [sign in to access the service](http://placements.localhost:3000/sign-in).
+          After creating a DfE Sign-in account, you will need to return to this email and [sign in to access the service](http://placements.localhost/sign-in).
 
           # Give feedback or report a problem
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -20,11 +20,11 @@ RSpec.describe UserMailer, type: :mailer do
 
           If you have a DfE Sign-in account, you can use it to sign in:
 
-          [http://claims.localhost:3000/sign-in](http://claims.localhost:3000/sign-in)
+          [http://claims.localhost/sign-in](http://claims.localhost/sign-in)
 
           If you need to create a DfE Sign-in account, you can do this after clicking "Sign in using DfE Sign-in"
 
-          After creating a DfE Sign-in account, you will need to return to this email and [sign in to access the service](http://claims.localhost:3000/sign-in).
+          After creating a DfE Sign-in account, you will need to return to this email and [sign in to access the service](http://claims.localhost/sign-in).
 
           # Give feedback or report a problem
 
@@ -74,11 +74,11 @@ RSpec.describe UserMailer, type: :mailer do
 
             If you have a DfE Sign-in account, you can use it to sign in:
 
-            [http://placements.localhost:3000/sign-in](http://placements.localhost:3000/sign-in)
+            [http://placements.localhost/sign-in](http://placements.localhost/sign-in)
 
             If you need to create a DfE Sign-in account, you can do this after clicking "Sign in using DfE Sign-in"
 
-            After creating a DfE Sign-in account, you will need to return to this email and [sign in to access the service](http://placements.localhost:3000/sign-in).
+            After creating a DfE Sign-in account, you will need to return to this email and [sign in to access the service](http://placements.localhost/sign-in).
 
             # Give feedback or report a problem
 
@@ -127,11 +127,11 @@ RSpec.describe UserMailer, type: :mailer do
 
             If you have a DfE Sign-in account, you can use it to sign in:
 
-            [http://placements.localhost:3000/sign-in](http://placements.localhost:3000/sign-in)
+            [http://placements.localhost/sign-in](http://placements.localhost/sign-in)
 
             If you need to create a DfE Sign-in account, you can do this after clicking "Sign in using DfE Sign-in"
 
-            After creating a DfE Sign-in account, you will need to return to this email and [sign in to access the service](http://placements.localhost:3000/sign-in).
+            After creating a DfE Sign-in account, you will need to return to this email and [sign in to access the service](http://placements.localhost/sign-in).
 
             # Give feedback or report a problem
 
@@ -323,7 +323,7 @@ RSpec.describe UserMailer, type: :mailer do
 
           You can view your claim on Claim funding for mentor training:
 
-          http://claims.localhost:3000/schools/#{school.id}/claims/#{claim.id}
+          http://claims.localhost/schools/#{school.id}/claims/#{claim.id}
 
           # Give feedback or report a problem
 
@@ -380,7 +380,7 @@ RSpec.describe UserMailer, type: :mailer do
 
           You can view the claim, edit and submit it on Claim funding for mentor training:
 
-          http://claims.localhost:3000/schools/#{school.id}/claims/#{claim.id}
+          http://claims.localhost/schools/#{school.id}/claims/#{claim.id}
 
           # Give feedback or report a problem
 
@@ -436,7 +436,7 @@ RSpec.describe UserMailer, type: :mailer do
 
           You are receiving this notification because #{source_organisation.name} has added #{partner_organisation.name} to its list of partner providers.
 
-          View or manage your list of partner schools http://placements.localhost:3000/providers/#{partner_organisation.id}/partner_schools
+          View or manage your list of partner schools http://placements.localhost/providers/#{partner_organisation.id}/partner_schools
         EMAIL
       end
     end
@@ -457,7 +457,7 @@ RSpec.describe UserMailer, type: :mailer do
 
           You are receiving this notification because #{source_organisation.name} has added #{partner_organisation.name} to its list of partner schools.
 
-          View or manage your list of partner providers http://placements.localhost:3000/schools/#{partner_organisation.id}/partner_providers
+          View or manage your list of partner providers http://placements.localhost/schools/#{partner_organisation.id}/partner_providers
         EMAIL
       end
     end
@@ -496,7 +496,7 @@ RSpec.describe UserMailer, type: :mailer do
 
           You are receiving this notification because #{source_organisation.name} has removed #{partner_organisation.name} from its list of partner providers.
 
-          View or manage your list of partner schools http://placements.localhost:3000/providers/#{partner_organisation.id}/partner_schools
+          View or manage your list of partner schools http://placements.localhost/providers/#{partner_organisation.id}/partner_schools
         EMAIL
       end
     end
@@ -517,7 +517,7 @@ RSpec.describe UserMailer, type: :mailer do
 
           You are receiving this notification because #{source_organisation.name} has removed #{partner_organisation.name} from its list of partner schools.
 
-          View or manage your list of partner providers http://placements.localhost:3000/schools/#{partner_organisation.id}/partner_providers
+          View or manage your list of partner providers http://placements.localhost/schools/#{partner_organisation.id}/partner_providers
         EMAIL
       end
     end

--- a/spec/slack_notifiers/application_slack_notifier_spec.rb
+++ b/spec/slack_notifiers/application_slack_notifier_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ApplicationSlackNotifier do
       end
 
       it "builds claims urls" do
-        expect(claims_slack_notifier_class.root_url_notification.text).to eq("http://claims.localhost:3000/")
+        expect(claims_slack_notifier_class.root_url_notification.text).to eq("http://claims.localhost/")
       end
     end
 
@@ -30,7 +30,7 @@ RSpec.describe ApplicationSlackNotifier do
       end
 
       it "builds placements urls" do
-        expect(placements_slack_notifier_class.root_url_notification.text).to eq("http://placements.localhost:3000/")
+        expect(placements_slack_notifier_class.root_url_notification.text).to eq("http://placements.localhost/")
       end
     end
 


### PR DESCRIPTION
## Context

The PORT env var is not expected in production, so we should mirror that behaviour in test.

## Changes proposed in this pull request

- Remove `PORT` from `.env.test`

## Guidance to review

- Tests should pass. Ports should be missing.