### PR TITLE
Add validation to change mentor flow

### DIFF
--- a/app/controllers/placements/schools/placements_controller.rb
+++ b/app/controllers/placements/schools/placements_controller.rb
@@ -27,7 +27,7 @@ class Placements::Schools::PlacementsController < ApplicationController
 
       redirect_to placements_school_placement_path(@school, @placement), flash: { success: t(".success") }
     else
-      @mentors = @school.mentors.all
+      @mentors = @school.mentors.all if params[:edit_path] == "edit_mentors"
 
       render params[:edit_path]
     end

--- a/app/controllers/placements/schools/placements_controller.rb
+++ b/app/controllers/placements/schools/placements_controller.rb
@@ -28,6 +28,7 @@ class Placements::Schools::PlacementsController < ApplicationController
       redirect_to placements_school_placement_path(@school, @placement), flash: { success: t(".success") }
     else
       @mentors = @school.mentors.all if params[:edit_path] == "edit_mentors"
+      @providers = @school.partner_providers.all if params[:edit_path] == "edit_provider"
 
       render params[:edit_path]
     end
@@ -54,7 +55,7 @@ class Placements::Schools::PlacementsController < ApplicationController
 
   def valid_attributes?
     if params[:edit_path] == "edit_provider"
-      placement_params[:provider_id].present?
+      valid_provider_id?
     else # params[:edit_path] == "edit_mentors"
       valid_mentor_ids?(placement_params[:mentor_ids].compact_blank)
     end
@@ -72,6 +73,13 @@ class Placements::Schools::PlacementsController < ApplicationController
       @placement.errors.add(:mentor_ids, :invalid)
       false
     end
+  end
+
+  def valid_provider_id?
+    return true if placement_params[:provider_id].present?
+
+    @placement.errors.add(:provider_id, :invalid)
+    false
   end
 
   def placement_params

--- a/app/controllers/placements/schools/placements_controller.rb
+++ b/app/controllers/placements/schools/placements_controller.rb
@@ -66,7 +66,7 @@ class Placements::Schools::PlacementsController < ApplicationController
       return true
     end
 
-    if mentor_ids.present? && mentor_ids.all? { |id| Placements::Mentor.exists?(id:) && @school.mentors.exists?(id:) }
+    if mentor_ids.present? && mentor_ids.all? { |id| @school.mentors.exists?(id:) }
       true
     else
       @placement.errors.add(:mentor_ids, :invalid)

--- a/app/controllers/placements/schools/placements_controller.rb
+++ b/app/controllers/placements/schools/placements_controller.rb
@@ -62,7 +62,10 @@ class Placements::Schools::PlacementsController < ApplicationController
   end
 
   def valid_mentor_ids?(mentor_ids)
-    return true if mentor_ids.include?("not_known")
+    if mentor_ids.include?("not_known")
+      params[:placement][:mentor_ids] = []
+      return true
+    end
 
     if mentor_ids.present? && mentor_ids.all? { |id| Placements::Mentor.exists?(id:) && @school.mentors.exists?(id:) }
       true

--- a/app/controllers/placements/schools/placements_controller.rb
+++ b/app/controllers/placements/schools/placements_controller.rb
@@ -22,11 +22,6 @@ class Placements::Schools::PlacementsController < ApplicationController
   end
 
   def update
-    unless valid_path?
-      redirect_to placements_school_placement_path(@school, @placement),
-                  flash: { alert: t("errors.internal_server_error.page_title") } and return
-    end
-
     if valid_attributes?
       @placement.update!(placement_params)
 
@@ -45,12 +40,6 @@ class Placements::Schools::PlacementsController < ApplicationController
 
   private
 
-  VALID_PATHS = %w[edit_provider edit_mentors].freeze
-
-  def valid_path?
-    VALID_PATHS.include?(params[:edit_path])
-  end
-
   def set_placement
     @placement = @school.placements.find(params.require(:id))
   end
@@ -66,7 +55,7 @@ class Placements::Schools::PlacementsController < ApplicationController
   def valid_attributes?
     if params[:edit_path] == "edit_provider"
       placement_params[:provider_id].present?
-    elsif params[:edit_path] == "edit_mentors"
+    else # params[:edit_path] == "edit_mentors"
       valid_mentor_ids?(placement_params[:mentor_ids].compact_blank)
     end
   end

--- a/app/views/placements/schools/placements/edit_mentors.html.erb
+++ b/app/views/placements/schools/placements/edit_mentors.html.erb
@@ -20,7 +20,7 @@
             <%= f.govuk_check_box :mentor_ids, mentor.id, label: { text: mentor.full_name }, checked: @placement.mentors.include?(mentor) %>
           <% end %>
           <%= f.govuk_check_box_divider %>
-          <%= f.govuk_check_box :mentor_ids, [], label: { text: t(".not_known") }, checked: @placement.mentors.empty?, exclusive: true %>
+          <%= f.govuk_check_box :mentor_ids, %w[not_known], label: { text: t(".not_known") }, checked: @placement.mentors.empty?, exclusive: true %>
         <% end %>
 
         <%= govuk_details(

--- a/app/views/placements/schools/placements/edit_mentors.html.erb
+++ b/app/views/placements/schools/placements/edit_mentors.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <%= form_for(@placement, url: placements_school_placement_path(@school, @placement), method: :put) do |f| %>
+  <%= form_for(@placement, url: placements_school_placement_path(@school, @placement, edit_path: :edit_mentors), method: :put) do |f| %>
     <%= f.govuk_error_summary %>
 
     <div class="govuk-grid-row">

--- a/app/views/placements/schools/placements/edit_provider.html.erb
+++ b/app/views/placements/schools/placements/edit_provider.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <%= form_for(@placement, url: placements_school_placement_path(@school, @placement), method: :put) do |f| %>
+  <%= form_for(@placement, url: placements_school_placement_path(@school, @placement, edit_path: :edit_provider), method: :put) do |f| %>
     <%= f.govuk_error_summary %>
 
     <div class="govuk-grid-row">

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -16,6 +16,12 @@ en:
               invalid: Select a provider
             year_group:
               invalid: Select a year group
+        placement:
+          attributes:
+            mentor_ids:
+              invalid: Select a mentor or not yet known
+            provider_id:
+              invalid: Select a provider or not yet known
   placements:
     schools:
       placements:

--- a/spec/requests/placements/schools/placements/placements_spec.rb
+++ b/spec/requests/placements/schools/placements/placements_spec.rb
@@ -25,5 +25,18 @@ RSpec.describe "Placements", type: :request, service: :placements do
         expect(response.body).to include("Select a mentor or not yet known")
       end
     end
+
+    context "when editing a provider" do
+      it "returns an error message when the provider_id is not present" do
+        placement = create(:placement, school:)
+
+        patch placements_school_placement_path(school, placement), params: {
+          placement: { provider_id: "" },
+          edit_path: "edit_provider",
+        }
+
+        expect(response.body).to include("Select a provider")
+      end
+    end
   end
 end

--- a/spec/requests/placements/schools/placements/placements_spec.rb
+++ b/spec/requests/placements/schools/placements/placements_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "Placements", type: :request, service: :placements do
+  describe "PATCH /update" do
+    let!(:school) { create(:placements_school, name: "School 1", phase: "Primary") }
+
+    before do
+      user = create(:placements_user, schools: [school])
+      user_exists_in_dfe_sign_in(user:)
+
+      get "/auth/dfe/callback"
+
+      follow_redirect!
+    end
+
+    context "when editing mentors" do
+      it "returns an error message when the mentor_ids are invalid" do
+        placement = create(:placement, school:)
+
+        patch placements_school_placement_path(school, placement), params: {
+          placement: { mentor_ids: [] },
+          edit_path: "edit_mentors",
+        }
+
+        expect(response.body).to include("Select a mentor or not yet known")
+      end
+    end
+  end
+end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -22,6 +22,11 @@ end
 
 Capybara.javascript_driver = :selenium_chrome_headless
 
+# Allow Capybara to click a <label> even if its corresponding <input> isn't visible on screen.
+# This needs to be enabled when using custom-styled checkboxes and radios, such as those
+# in the GOV.UK Design System.
+Capybara.automatic_label_click = true
+
 RSpec.configure do |config|
   config.around(:each, type: :system, smoke_test: true) do |example|
     Capybara.current_driver = Capybara.javascript_driver

--- a/spec/system/placements/schools/placements/edit_a_provider_spec.rb
+++ b/spec/system/placements/schools/placements/edit_a_provider_spec.rb
@@ -181,6 +181,16 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
     end
   end
 
+  def then_i_should_see_an_error_message
+    within(".govuk-error-summary__title") do
+      expect(page).to have_content("There is a problem")
+    end
+
+    within(".govuk-error-summary__body") do
+      expect(page).to have_content("Select a provider or not yet known")
+    end
+  end
+
   def given_the_placement_has_a_provider(provider)
     placement.update!(provider:)
   end

--- a/spec/system/placements/schools/placements/edit_a_provider_spec.rb
+++ b/spec/system/placements/schools/placements/edit_a_provider_spec.rb
@@ -181,16 +181,6 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
     end
   end
 
-  def then_i_should_see_an_error_message
-    within(".govuk-error-summary__title") do
-      expect(page).to have_content("There is a problem")
-    end
-
-    within(".govuk-error-summary__body") do
-      expect(page).to have_content("Select a provider or not yet known")
-    end
-  end
-
   def given_the_placement_has_a_provider(provider)
     placement.update!(provider:)
   end

--- a/spec/system/placements/schools/placements/edit_mentors_spec.rb
+++ b/spec/system/placements/schools/placements/edit_mentors_spec.rb
@@ -171,6 +171,16 @@ RSpec.describe "Placements / Schools / Placements / Edit mentors",
     end
   end
 
+  context "when I tamper with the form URL", js: true do
+    scenario "I see an error message" do
+      when_i_visit_the_placement_show_page
+      when_i_click_on_change
+      then_i_tamper_with_the_form_url
+      and_i_click_on("Continue")
+      then_i_should_see_the_placement_show_page_with_notice
+    end
+  end
+
   private
 
   def and_there_is_an_existing_user_for(user_name)
@@ -258,6 +268,15 @@ RSpec.describe "Placements / Schools / Placements / Edit mentors",
   end
   def when_i_uncheck(text)
     uncheck(text)
+  end
+
+  def then_i_tamper_with_the_form_url
+    page.execute_script("document.querySelector('form').action = '/schools/#{school.id}/placements/#{placement.id}?edit_path=fake_path'")
+  end
+
+  def then_i_should_see_the_placement_show_page_with_notice
+    expect(page).to have_current_path(placements_school_placement_path(school, placement))
+    expect(page).to have_content("Sorry, there’s a problem with the service")
   end
 
   alias_method :and_i_click_on, :when_i_click_on

--- a/spec/system/placements/schools/placements/edit_mentors_spec.rb
+++ b/spec/system/placements/schools/placements/edit_mentors_spec.rb
@@ -42,10 +42,9 @@ RSpec.describe "Placements / Schools / Placements / Edit mentors",
         )
         then_i_should_see_the_edit_mentors_page
         when_i_uncheck("Not yet known")
-      when_i_select_mentor_2
-      and_i_click_on("Continue")
-      then_i_should_see_the_mentor_name_in_the_placement_details(mentor_name: mentor_2.full_name,
-        )
+        when_i_select_mentor_2
+        and_i_click_on("Continue")
+        then_i_should_see_the_mentor_name_in_the_placement_details(mentor_name: mentor_2.full_name)
       end
 
       scenario "User does not select a mentor" do
@@ -56,10 +55,10 @@ RSpec.describe "Placements / Schools / Placements / Edit mentors",
           href: edit_mentors_placements_school_placement_path(school, placement),
         )
         when_i_uncheck("Not yet known")
-      then_i_should_see_the_edit_mentors_page
-      and_i_click_on("Continue")
-      then_i_should_see_an_error_message
-    end
+        then_i_should_see_the_edit_mentors_page
+        and_i_click_on("Continue")
+        then_i_should_see_an_error_message
+      end
 
       scenario "User edits the mentor and cancels" do
         when_i_visit_the_placement_show_page
@@ -118,12 +117,9 @@ RSpec.describe "Placements / Schools / Placements / Edit mentors",
         )
         then_i_should_see_the_edit_mentors_page
         when_i_uncheck(mentor_1.full_name)
-      and_i_uncheck("Not yet known")
+        and_i_uncheck("Not yet known")
         and_i_click_on("Continue")
-        then_i_see_link(
-          text: "Select a mentor",
-          href: edit_mentors_placements_school_placement_path(school, placement),
-        )
+        then_i_should_see_an_error_message
       end
 
       scenario "User edits the mentor and cancels" do
@@ -158,26 +154,21 @@ RSpec.describe "Placements / Schools / Placements / Edit mentors",
           mentor_name: mentor_1.full_name,
         )
       end
-    end
 
-    scenario "User selects not yet known" do
-      when_i_visit_the_placement_show_page
-      then_i_should_see_the_mentor_name_in_the_placement_details(mentor_1.full_name)
-      when_i_click_on_change
-      then_i_should_see_the_edit_mentors_page
-      when_i_select_not_yet_known
-      and_i_click_on("Continue")
-      then_i_should_see_the_mentor_is_not_yet_known_in_the_placement_details
-    end
-  end
-
-  context "when I tamper with the form URL", js: true do
-    scenario "I see an error message" do
-      when_i_visit_the_placement_show_page
-      when_i_click_on_change
-      then_i_tamper_with_the_form_url
-      and_i_click_on("Continue")
-      then_i_should_see_the_placement_show_page_with_notice
+      scenario "User selects not yet known" do
+        when_i_visit_the_placement_show_page
+        then_i_should_see_the_mentor_name_in_the_placement_details(
+          mentor_name: mentor_1.full_name,
+        )
+        when_i_click_link(
+          text: "Change",
+          href: edit_mentors_placements_school_placement_path(school, placement),
+        )
+        then_i_should_see_the_edit_mentors_page
+        when_i_select_not_yet_known
+        and_i_click_on("Continue")
+        then_i_should_see_the_mentor_is_not_yet_known_in_the_placement_details
+      end
     end
   end
 
@@ -266,6 +257,7 @@ RSpec.describe "Placements / Schools / Placements / Edit mentors",
   def then_i_see_link(text:, href:)
     expect(page).to have_link(text, href:)
   end
+
   def when_i_uncheck(text)
     uncheck(text)
   end

--- a/spec/system/placements/schools/placements/edit_mentors_spec.rb
+++ b/spec/system/placements/schools/placements/edit_mentors_spec.rb
@@ -41,10 +41,10 @@ RSpec.describe "Placements / Schools / Placements / Edit mentors",
           href: edit_mentors_placements_school_placement_path(school, placement),
         )
         then_i_should_see_the_edit_mentors_page
-        when_i_select_mentor_2
-        and_i_click_on("Continue")
-        then_i_should_see_the_mentor_name_in_the_placement_details(
-          mentor_name: mentor_2.full_name,
+        when_i_uncheck("Not yet known")
+      when_i_select_mentor_2
+      and_i_click_on("Continue")
+      then_i_should_see_the_mentor_name_in_the_placement_details(mentor_name: mentor_2.full_name,
         )
       end
 
@@ -55,10 +55,11 @@ RSpec.describe "Placements / Schools / Placements / Edit mentors",
           text: "Select a mentor",
           href: edit_mentors_placements_school_placement_path(school, placement),
         )
-        then_i_should_see_the_edit_mentors_page
-        and_i_click_on("Continue")
-        then_i_should_see_an_error_message
-      end
+        when_i_uncheck("Not yet known")
+      then_i_should_see_the_edit_mentors_page
+      and_i_click_on("Continue")
+      then_i_should_see_an_error_message
+    end
 
       scenario "User edits the mentor and cancels" do
         when_i_visit_the_placement_show_page
@@ -116,7 +117,8 @@ RSpec.describe "Placements / Schools / Placements / Edit mentors",
           href: edit_mentors_placements_school_placement_path(school, placement),
         )
         then_i_should_see_the_edit_mentors_page
-        when_i_select_not_yet_known
+        when_i_uncheck(mentor_1.full_name)
+      and_i_uncheck("Not yet known")
         and_i_click_on("Continue")
         then_i_see_link(
           text: "Select a mentor",
@@ -156,6 +158,16 @@ RSpec.describe "Placements / Schools / Placements / Edit mentors",
           mentor_name: mentor_1.full_name,
         )
       end
+    end
+
+    scenario "User selects not yet known" do
+      when_i_visit_the_placement_show_page
+      then_i_should_see_the_mentor_name_in_the_placement_details(mentor_1.full_name)
+      when_i_click_on_change
+      then_i_should_see_the_edit_mentors_page
+      when_i_select_not_yet_known
+      and_i_click_on("Continue")
+      then_i_should_see_the_mentor_is_not_yet_known_in_the_placement_details
     end
   end
 
@@ -244,4 +256,10 @@ RSpec.describe "Placements / Schools / Placements / Edit mentors",
   def then_i_see_link(text:, href:)
     expect(page).to have_link(text, href:)
   end
+  def when_i_uncheck(text)
+    uncheck(text)
+  end
+
+  alias_method :and_i_click_on, :when_i_click_on
+  alias_method :and_i_uncheck, :when_i_uncheck
 end

--- a/spec/system/placements/schools/placements/edit_mentors_spec.rb
+++ b/spec/system/placements/schools/placements/edit_mentors_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "Placements / Schools / Placements / Edit mentors",
         )
         then_i_should_see_the_edit_mentors_page
         and_i_click_on("Continue")
-        then_i_should_see_the_mentor_is_not_yet_known_in_the_placement_details
+        then_i_should_see_an_error_message
       end
 
       scenario "User edits the mentor and cancels" do
@@ -199,6 +199,16 @@ RSpec.describe "Placements / Schools / Placements / Edit mentors",
   )
     within(".govuk-summary-list") do
       expect(page).to have_content(change_link)
+    end
+  end
+
+  def then_i_should_see_an_error_message
+    within(".govuk-error-summary__title") do
+      expect(page).to have_content("There is a problem")
+    end
+
+    within(".govuk-error-summary__body") do
+      expect(page).to have_content("Select a mentor or not yet known")
     end
   end
 

--- a/spec/system/placements/schools/placements/edit_mentors_spec.rb
+++ b/spec/system/placements/schools/placements/edit_mentors_spec.rb
@@ -262,15 +262,6 @@ RSpec.describe "Placements / Schools / Placements / Edit mentors",
     uncheck(text)
   end
 
-  def then_i_tamper_with_the_form_url
-    page.execute_script("document.querySelector('form').action = '/schools/#{school.id}/placements/#{placement.id}?edit_path=fake_path'")
-  end
-
-  def then_i_should_see_the_placement_show_page_with_notice
-    expect(page).to have_current_path(placements_school_placement_path(school, placement))
-    expect(page).to have_content("Sorry, there’s a problem with the service")
-  end
-
   alias_method :and_i_click_on, :when_i_click_on
   alias_method :and_i_uncheck, :when_i_uncheck
 end


### PR DESCRIPTION
## Context

Validation already exists in the add a placement flow, but when editing mentors the validation is missing. Whilst this did not cause an issue with the data, it did provide a lack of consistency for users.

## Changes proposed in this pull request

Adds the validation to the change mentor flow.

## Guidance to review

Log in as Anne
View a placement
Change the mentor
Deselect all checkboxes
Click on continue
See validation message

## Link to Trello card

[Bug: When managing/editing a placement's mentor, selecting nothing does not error](https://trello.com/c/3FHL9VvO/408-bug-when-managing-editing-a-placements-mentor-selecting-nothing-does-not-error)

## Screenshots

![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/0bbf0e4e-dbe1-4245-b2be-604de17d16be)