### PR TITLE
Update placement show page for providers

### DIFF
--- a/app/views/placements/placements/show.html.erb
+++ b/app/views/placements/placements/show.html.erb
@@ -15,11 +15,23 @@
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "school_details", school: @school, placement: @placement %>
-      <h2 class="govuk-heading-m govuk-!-margin-top-9">
-        <%= t(".contact_details") %>
+      <h2 class="govuk-heading-m govuk-!-margin-top-0">
+        <%= t(".itt_placement_contact") %>
       </h2>
-      <%= render "shared/organisations/contact_details", organisation: @school %>
+      <%= render "shared/schools/school_contact_details",
+        school: @school,
+        school_contact: @school.school_contact,
+        changeable: false %>
+
+      <h2 class="govuk-heading-m govuk-!-margin-top-0">
+        <%= t(".location") %>
+      </h2>
+      <%= render "shared/schools/location_details", school: @school %>
+
+      <h2 class="govuk-heading-m govuk-!-margin-top-0">
+        <%= t(".additional_details") %>
+      </h2>
+      <%= render "school_details", school: @school, placement: @placement %>
     </div>
   </div>
 </div>

--- a/app/views/shared/schools/_school_contact_details.html.erb
+++ b/app/views/shared/schools/_school_contact_details.html.erb
@@ -1,21 +1,27 @@
-<%# locals: (school:, school_contact:) -%>
-<%= govuk_summary_list(html_attributes: { id: "school-contact-details" }) do |summary_list| %>
-  <% summary_list.with_row do |row| %>
-    <% row.with_key(text: t(".full_name")) %>
-    <% row.with_value(**summary_row_value(value: school_contact.name)) %>
-    <% row.with_action(text: t(".change"),
-                       href: edit_placements_school_school_contact_path(school, school_contact),
-                       html_attributes: {
-                                class: "govuk-link--no-visited-state",
-                              }) %>
-  <% end %>
-  <% summary_list.with_row do |row| %>
-    <% row.with_key(text: t(".email")) %>
-    <% row.with_value(**summary_row_value(value: school_contact.email_address)) %>
-    <% row.with_action(text: t(".change"),
-                       href: edit_placements_school_school_contact_path(school, school_contact),
-                       html_attributes: {
-                                class: "govuk-link--no-visited-state",
-                              }) %>
+<%# locals: (school:, school_contact:, changeable: true) -%>
+<% if school_contact.present? %>
+  <%= govuk_summary_list(html_attributes: { id: "school-contact-details" }) do |summary_list| %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key(text: t(".full_name")) %>
+      <% row.with_value(**summary_row_value(value: school_contact.name)) %>
+      <% if changeable %>
+        <% row.with_action(text: t(".change"),
+                           href: edit_placements_school_school_contact_path(school, school_contact),
+                           html_attributes: {
+                                    class: "govuk-link--no-visited-state",
+                                  }) %>
+      <% end %>
+    <% end %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key(text: t(".email")) %>
+      <% row.with_value(**summary_row_value(value: school_contact.email_address)) %>
+      <% if changeable %>
+        <% row.with_action(text: t(".change"),
+                           href: edit_placements_school_school_contact_path(school, school_contact),
+                           html_attributes: {
+                                    class: "govuk-link--no-visited-state",
+                                  }) %>
+      <% end %>
+    <% end %>
   <% end %>
 <% end %>

--- a/config/locales/en/placements/providers/placements.yml
+++ b/config/locales/en/placements/providers/placements.yml
@@ -25,6 +25,9 @@ en:
         page_title: "%{subject_name} - Placements - %{school_name}"
         placement: "Placement - %{school_name}"
         contact_details: Contact details
+        itt_placement_contact: ITT placement contact
+        location: Location
+        additional_details: Additional details
       school_details:
         establishment_group: Establishment group
         school_phase: School phase

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -80,6 +80,15 @@ PublishTeacherTraining::Subject::Import.call
 
 # Create placements
 Placements::School.find_each do |school|
+  # A school must have a school contact before creating placements
+  if school.school_contact.blank?
+    Placements::SchoolContact.create!(
+      school:,
+      name: "ITT School Contact",
+      email_address: "itt_contact@example.com",
+    )
+  end
+
   next if school.placements.any?
 
   placement = Placement.create!(school:)

--- a/spec/system/placements/placements/view_a_placement_spec.rb
+++ b/spec/system/placements/placements/view_a_placement_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe "Placements / Placements / View a placement",
       when_i_visit_the_placement_show_page
       then_i_see_details_for_the_school
       and_i_see_the_subject_name("Biology")
-      and_i_see_contact_details_for_the_school
+      and_i_see_the_itt_placement_contact_details_for_the_school
+      and_i_see_location_details_for_the_school
     end
   end
 
@@ -53,7 +54,8 @@ RSpec.describe "Placements / Placements / View a placement",
       when_i_visit_the_placement_show_page
       then_i_see_details_for_the_school
       and_i_see_the_subject_name("Biology and Chemistry")
-      and_i_see_contact_details_for_the_school
+      and_i_see_the_itt_placement_contact_details_for_the_school
+      and_i_see_location_details_for_the_school
     end
   end
 
@@ -96,12 +98,15 @@ RSpec.describe "Placements / Placements / View a placement",
     expect(page).to have_content("Good")
   end
 
-  def and_i_see_contact_details_for_the_school
-    expect(page).to have_content("Contact details")
-    expect(page).to have_content("01234567890")
-    expect(page).to have_content("www.a-london-example-school.com")
-    expect(page).to have_content("user@london-example-school.com")
+  def and_i_see_location_details_for_the_school
+    expect(page).to have_content("Location")
     expect(page).to have_content("London Secondary School\nLondon\nCity of London\nLN01 2LN")
+  end
+
+  def and_i_see_the_itt_placement_contact_details_for_the_school
+    expect(page).to have_content("ITT placement contact")
+    expect(page).to have_content(school.school_contact.name)
+    expect(page).to have_content(school.school_contact.email_address)
   end
 
   def and_i_see_the_subject_name(subject_name)


### PR DESCRIPTION
## Context

- Changes to Provider view of Placements to align with the [Prototype](https://bat-school-placements-18b07385d8a1.herokuapp.com/provider-users/v1/placement-detail)/[Figma](https://www.figma.com/design/0MJTBT9nHaU0zBUWMwOeUQ/School-placements?node-id=60827-35576&t=WsTpsQU82FIlOzFP-0)

## Changes proposed in this pull request

- Add ITT placement contact to Placement show page
- Minimise School Details to Location and Additional Details

## Guidance to review

- Sign in as Patricia (Provider user)
- Navigate to "Placements" using the Navbar
- Click any placement to view it's details
- Placement details should display the ITT contact details, Location and Additional Details

## Link to Trello card

https://trello.com/c/4tDFWDZ6/405-provider-%E2%86%92-placement-details-page

## Screenshots

![screencapture-placements-localhost-3000-placements-7bb282b1-e9e4-4f36-b829-27624bedeec9-2024-05-28-13_44_27](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/a130a415-927b-49b9-aa70-4806d44be9f8)


