### PR TITLE
Remove ' - Add placement' from title

### DIFF
--- a/app/views/placements/schools/placements/build/check_your_answers.html.erb
+++ b/app/views/placements/schools/placements/build/check_your_answers.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, sanitize(t(".title")) %>
+<%= content_for :page_title, sanitize(t(".page_title")) %>
 <%= render "placements/schools/primary_navigation", school: @school, current_navigation: :placements %>
 
 <%= content_for(:before_content) do %>

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -45,7 +45,8 @@ en:
             you_need_to_add_a_mentor: "You will first need to %{link}."
             add_a_mentor: add a mentor
           check_your_answers:
-            title: Check your answers - Add placement
+            page_title: Check your answers - Add placement
+            title: Check your answers
             add_placement: Add placement
             phase: Phase
             add_phase: Add phase


### PR DESCRIPTION
## Context

- Correct "Check your answers" page title

## Changes proposed in this pull request

- Remove "- Add placement" from title displayed on the page.

## Link to Trello card

https://trello.com/c/mgdfYe6F/388-add-placement-check-your-answers-page

## Screenshots
_Before_

![screencapture-placements-localhost-3000-schools-000234da-70f4-4099-811b-0b989c1c4ec5-placements-new-placement-build-check-your-answers-2024-05-28-15_21_34](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/49bbcf2c-36d6-4316-b9bd-0c18c19d6c13)


_After_

![screencapture-placements-localhost-3000-schools-000234da-70f4-4099-811b-0b989c1c4ec5-placements-new-placement-build-check-your-answers-2024-05-28-15_20_39](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/325281fc-6128-4fb6-927f-3cd6175b2f4f)

