### PR TITLE
Snagging for provider placements index

### DIFF
--- a/app/components/placement/summary_component.html.erb
+++ b/app/components/placement/summary_component.html.erb
@@ -1,5 +1,5 @@
 <li class="app-search-results__item">
-  <div class="govuk-grid-column-three-quarters govuk-!-padding-left-0">
+  <div class="govuk-grid-column-full govuk-!-padding-left-0">
     <h2 class="app-search-result__item-title">
       <%= govuk_link_to(placements_placement_path(placement), no_visited_state: true) do %>
         <span><%= school.name %></span>
@@ -9,9 +9,12 @@
     </h2>
   </div>
 
-  <div class="govuk-grid-column-one-quarter">
-    <%= render Placement::StatusTagComponent.new(placement:) %>
-  </div>
+  <dl class="app-result-detail">
+    <div class="app-result-detail__row">
+      <%= render Placement::StatusTagComponent.new(placement:) %>
+    </div>
+  </dl>
+
   <dl class="app-result-detail">
     <% if location_coordinates.present? %>
       <div class="app-result-detail__row">

--- a/app/views/placements/placements/_filter.html.erb
+++ b/app/views/placements/placements/_filter.html.erb
@@ -26,6 +26,38 @@
             </div>
           </div>
 
+          <% if filter_form.only_partner_schools.present? %>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".partner_schools") %></h3>
+            <ul class="app-filter-tags">
+              <li>
+                <%= govuk_link_to(
+                      t(".partner_schools"),
+                      filter_form.index_path_without_filter(
+                        filter: "only_partner_schools",
+                        value: true,
+                        search_location:,
+                      ),
+                      class: "app-filter__tag",
+                      no_visited_state: true,
+                    ) %>
+              </li>
+            </ul>
+          <% end %>
+
+          <% if filter_form.only_available_placements.present? %>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".availability") %></h3>
+            <ul class="app-filter-tags">
+              <li>
+                <%= govuk_link_to(
+                      t(".availability"),
+                      filter_form.index_path_without_filter(filter: "only_available_placements", value: true),
+                      class: "app-filter__tag",
+                      no_visited_state: true,
+                    ) %>
+              </li>
+            </ul>
+          <% end %>
+
           <% if filter_form.school_ids.present? %>
             <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".school") %></h3>
             <ul class="app-filter-tags">
@@ -83,38 +115,6 @@
                   ) %>
                 </li>
               <% end %>
-            </ul>
-          <% end %>
-
-          <% if filter_form.only_partner_schools.present? %>
-            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".partner_schools") %></h3>
-            <ul class="app-filter-tags">
-              <li>
-                <%= govuk_link_to(
-                      t(".partner_schools"),
-                      filter_form.index_path_without_filter(
-                        filter: "only_partner_schools",
-                        value: true,
-                        search_location:,
-                      ),
-                      class: "app-filter__tag",
-                      no_visited_state: true,
-                    ) %>
-              </li>
-            </ul>
-          <% end %>
-
-          <% if filter_form.only_available_placements.present? %>
-            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".availability") %></h3>
-            <ul class="app-filter-tags">
-              <li>
-                <%= govuk_link_to(
-                      t(".availability"),
-                      filter_form.index_path_without_filter(filter: "only_available_placements", value: true),
-                      class: "app-filter__tag",
-                      no_visited_state: true,
-                    ) %>
-              </li>
             </ul>
           <% end %>
         </div>

--- a/app/views/placements/placements/index.html.erb
+++ b/app/views/placements/placements/index.html.erb
@@ -3,13 +3,15 @@
 
 <div class="govuk-width-container" data-controller="filter">
   <h1 class="govuk-heading-l">
-    <span class="govuk-caption-l"><%= t(".find_placements") %></span>
+    <%= t(".placements") %>
+  </h1>
+  <h2 class="govuk-heading-m">
     <% if @placements.any? %>
       <%= t(".placements_found", placements_count: @placements.count) %>
     <% else %>
       <%= t(".no_placements_found") %>
     <% end %>
-  </h1>
+  </h2>
   <div>
     <button class="govuk-button govuk-button--secondary show-filter-button" type="button" data-action="click->filter#open">
       <%= t("show_filter") %>

--- a/config/locales/en/placements/providers/placements.yml
+++ b/config/locales/en/placements/providers/placements.yml
@@ -16,7 +16,7 @@ en:
         subject: Subject
         school_phase: School phase
         establishment_group: Establishment group
-        availability: Placements Available
+        availability: Placements available
         available_text: Only show placements open to accepting trainees
         gender: Gender
         religious_character: Religious character

--- a/spec/system/placements/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/placements/view_placements_list_spec.rb
@@ -109,8 +109,8 @@ RSpec.describe "Placements / Placements / View placements list",
         when_i_visit_the_placements_index_page({ filters: { only_available_placements: true } })
         then_i_can_see_a_placement_for_placement_1
         and_i_cannot_see_a_placement_for_placement_2
-        and_i_can_see_a_preset_filter("Placements Available", "Available")
-        when_i_click_to_remove_filter("Placements Available", "Available")
+        and_i_can_see_a_preset_filter("Placements available", "Placements available")
+        when_i_click_to_remove_filter("Placements available", "Placements available")
         then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
         and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
         and_i_can_not_see_any_selected_filters
@@ -176,7 +176,7 @@ RSpec.describe "Placements / Placements / View placements list",
         )
         then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
         and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
-        and_i_can_see_a_preset_filter("Placements Available", "Placements Available")
+        and_i_can_see_a_preset_filter("Placements available", "Placements available")
         and_i_can_see_a_preset_filter("Partner schools", "Partner schools")
         and_i_can_see_a_preset_filter("School", "Primary School")
         and_i_can_see_a_preset_filter("Subject", "Primary with mathematics")
@@ -240,7 +240,7 @@ RSpec.describe "Placements / Placements / View placements list",
         and_i_navigate_to("2")
         when_i_click_on_the_first_placement
         and_i_click_on("Back")
-        then_i_can_see_a_preset_filter("Placements Available", "Placements Available")
+        then_i_can_see_a_preset_filter("Placements available", "Placements available")
         and_i_can_see_search_location_is_set_as("London")
         and_the_pagination_remains_selected("2")
       end


### PR DESCRIPTION
## Context

- Resolve snagging issues on the Provider Placements index page.

## Changes proposed in this pull request

- Change `<h1>` heading to "Placements"
- Change `caption` to `<h2>` containing "XX placements found" or "No school placements found" (Below the `<h1>` heading.
- Downcase the "A" in "Placements Available" to "Placements available".
- Move status tag of placements to sit below the title.
- Reorder the selected filters to match the order of the filers.

## Guidance to review

- Sign in as Patricia (Provider user)
- Navigate to "Placements" using the Navbar
- Check the Index page appears as desired

## Link to Trello card

https://trello.com/c/W9o6b52Z/404-provider-%E2%86%92-placements-search-page

## Screenshots

![screencapture-placements-localhost-3000-placements-2024-05-28-17_25_46](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/4cb755c3-833b-4f4b-9702-00b8036e160f)


