### PR TITLE
Change placements support email address

### DIFF
--- a/config/locales/en/placements.yml
+++ b/config/locales/en/placements.yml
@@ -1,4 +1,4 @@
 en:
   placements:
     service_name: Manage school placements
-    support_email: becomingateacher@digital.education.gov.uk
+    support_email: Manage.SchoolPlacements@education.gov.uk

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe UserMailer, type: :mailer do
 
             # Give feedback or report a problem
 
-            If you have any questions or feedback, please contact the team at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+            If you have any questions or feedback, please contact the team at [Manage.SchoolPlacements@education.gov.uk](mailto:Manage.SchoolPlacements@education.gov.uk).
 
             Regards
 
@@ -135,7 +135,7 @@ RSpec.describe UserMailer, type: :mailer do
 
             # Give feedback or report a problem
 
-            If you have any questions or feedback, please contact the team at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+            If you have any questions or feedback, please contact the team at [Manage.SchoolPlacements@education.gov.uk](mailto:Manage.SchoolPlacements@education.gov.uk).
 
             Regards
 
@@ -227,7 +227,7 @@ RSpec.describe UserMailer, type: :mailer do
 
             # Give feedback or report a problem
 
-            If you have any questions or feedback, please contact the team at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+            If you have any questions or feedback, please contact the team at [Manage.SchoolPlacements@education.gov.uk](mailto:Manage.SchoolPlacements@education.gov.uk).
 
             Regards
 
@@ -270,7 +270,7 @@ RSpec.describe UserMailer, type: :mailer do
 
             # Give feedback or report a problem
 
-            If you have any questions or feedback, please contact the team at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+            If you have any questions or feedback, please contact the team at [Manage.SchoolPlacements@education.gov.uk](mailto:Manage.SchoolPlacements@education.gov.uk).
 
             Regards
 

--- a/spec/system/error_pages_spec.rb
+++ b/spec/system/error_pages_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "Error pages", type: :system do
     if self.class.metadata[:service] == :claims
       "ittmentor.funding@education.gov.uk"
     else
-      "becomingateacher@digital.education.gov.uk"
+      "Manage.SchoolPlacements@education.gov.uk"
     end
   end
 end


### PR DESCRIPTION
## Context

- Change support email address to `[Manage.SchoolPlacements@education.gov.uk](mailto:Manage.SchoolPlacements@education.gov.uk)`

## Guidance to review

- Check the footer of the Placements service.

## Link to Trello card

https://trello.com/c/brM05Q5W/412-update-the-support-email-link-in-the-footer

## Screenshots

![Screenshot 2024-05-29 at 10 48 17](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/bb49ff7b-d6e7-4360-bdf8-6ea1f0bc0cd6)

