### PR TITLE
Add year group journey

### DIFF
--- a/app/controllers/placements/schools/placements/build_controller.rb
+++ b/app/controllers/placements/schools/placements/build_controller.rb
@@ -29,9 +29,7 @@ class Placements::Schools::Placements::BuildController < ApplicationController
 
   def add_year_group
     @placement = build_placement
-    @year_groups = Placements::Schools::Placements::Build::Placement.year_groups.map do |value, name|
-      OpenStruct.new value:, name:, description: t("placements.schools.placements.year_groups.#{value}_description")
-    end
+    year_groups_for_select
     @placement.year_group = session.dig(:add_a_placement, "year_group")
   end
 
@@ -118,9 +116,7 @@ class Placements::Schools::Placements::BuildController < ApplicationController
       if @placement.valid_year_group?
         session[:add_a_placement][:year_group] = year_group
       else
-        @year_groups = Placements::Schools::Placements::Build::Placement.year_groups.map do |value, name|
-          OpenStruct.new value:, name:, description: t("placements.schools.placements.year_groups.#{value}_description")
-        end
+        year_groups_for_select
         render :add_year_group and return
       end
     when :add_mentors
@@ -229,6 +225,12 @@ class Placements::Schools::Placements::BuildController < ApplicationController
 
   def skipped_steps
     session.dig(:add_a_placement, "skipped_steps") || []
+  end
+
+  def year_groups_for_select
+    @year_groups_for_select ||= Placements::Schools::Placements::Build::Placement.year_groups.map do |value, name|
+      OpenStruct.new value:, name:, description: t("placements.schools.placements.year_groups.#{value}_description")
+    end
   end
 
   def additional_subject_ids

--- a/app/controllers/placements/schools/placements/build_controller.rb
+++ b/app/controllers/placements/schools/placements/build_controller.rb
@@ -220,7 +220,7 @@ class Placements::Schools::Placements::BuildController < ApplicationController
   def setup_skipped_steps
     session[:add_a_placement][:skipped_steps] = []
     session[:add_a_placement][:skipped_steps] << "add_mentors" unless school.mentors.exists?
-    session[:add_a_placement][:skipped_steps] << "add_year_group" if school.phase == "Secondary"
+    session[:add_a_placement][:skipped_steps] << "add_year_group" unless placement.phase == "Primary"
   end
 
   def skipped_steps

--- a/app/controllers/placements/schools/placements/build_controller.rb
+++ b/app/controllers/placements/schools/placements/build_controller.rb
@@ -73,7 +73,7 @@ class Placements::Schools::Placements::BuildController < ApplicationController
       @placement.phase = phase_params
 
       if @placement.valid_phase?
-        session[:add_a_placement]["skipped_steps"] << "add_year_group" if @placement.phase != "Primary"
+        session[:add_a_placement]["skipped_steps"] << "add_year_group" unless @placement.phase == "Primary"
         session[:add_a_placement][:phase] = phase_params
       else
         render :add_phase and return
@@ -220,7 +220,7 @@ class Placements::Schools::Placements::BuildController < ApplicationController
   def setup_skipped_steps
     session[:add_a_placement][:skipped_steps] = []
     session[:add_a_placement][:skipped_steps] << "add_mentors" unless school.mentors.exists?
-    session[:add_a_placement][:skipped_steps] << "add_year_group" unless placement.phase == "Primary"
+    session[:add_a_placement][:skipped_steps] << "add_year_group" if school.phase == "Secondary"
   end
 
   def skipped_steps

--- a/app/controllers/placements/schools/placements/build_controller.rb
+++ b/app/controllers/placements/schools/placements/build_controller.rb
@@ -228,8 +228,8 @@ class Placements::Schools::Placements::BuildController < ApplicationController
   end
 
   def year_groups_for_select
-    @year_groups_for_select ||= Placements::Schools::Placements::Build::Placement.year_groups.map do |value, name|
-      OpenStruct.new value:, name:, description: t("placements.schools.placements.year_groups.#{value}_description")
+    @year_groups_for_select ||= Placement.year_groups.map do |_, value|
+      OpenStruct.new value:, name: t("placements.schools.placements.year_groups.#{value}"), description: t("placements.schools.placements.year_groups.#{value}_description")
     end
   end
 

--- a/app/controllers/placements/schools/placements/build_controller.rb
+++ b/app/controllers/placements/schools/placements/build_controller.rb
@@ -62,7 +62,7 @@ class Placements::Schools::Placements::BuildController < ApplicationController
         @placement.additional_subject_ids = additional_subject_ids
         @placement.build_additional_subjects(additional_subject_ids)
       end
-      @placement.year_group = session.dig(:add_a_placement, "year_group") if school.phase == "Primary"
+      @placement.year_group = session.dig(:add_a_placement, "year_group") if @placement.phase == "Primary"
       @placement.build_mentors(mentor_ids)
       @placement.save!
 

--- a/app/decorators/placement_decorator.rb
+++ b/app/decorators/placement_decorator.rb
@@ -1,4 +1,6 @@
 class PlacementDecorator < Draper::Decorator
+  include ActionView::Helpers::TextHelper
+
   delegate_all
   decorates_association :school
 

--- a/app/decorators/placement_decorator.rb
+++ b/app/decorators/placement_decorator.rb
@@ -1,6 +1,4 @@
 class PlacementDecorator < Draper::Decorator
-  include ActionView::Helpers::TextHelper
-
   delegate_all
   decorates_association :school
 

--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -41,6 +41,15 @@ class Placement < ApplicationRecord
   accepts_nested_attributes_for :mentors, allow_destroy: true
   accepts_nested_attributes_for :subjects, allow_destroy: true
 
+  enum :year_group, {
+    year_1: "year_1",
+    year_2: "year_2",
+    year_3: "year_3",
+    year_4: "year_4",
+    year_5: "year_5",
+    year_6: "year_6",
+  }, validate: { allow_nil: true }
+
   validates :school, presence: true
 
   delegate :name, to: :provider, prefix: true, allow_nil: true

--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -3,6 +3,7 @@
 # Table name: placements
 #
 #  id          :uuid             not null, primary key
+#  year_group  :enum
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  provider_id :uuid

--- a/app/models/placements/schools/placements/build/placement.rb
+++ b/app/models/placements/schools/placements/build/placement.rb
@@ -27,17 +27,6 @@ class Placements::Schools::Placements::Build::Placement < Placement
 
   attr_accessor :phase, :mentor_ids, :additional_subject_ids
 
-  def self.year_groups
-    [
-      [:year_1, "Year 1"],
-      [:year_2, "Year 2"],
-      [:year_3, "Year 3"],
-      [:year_4, "Year 4"],
-      [:year_5, "Year 5"],
-      [:year_6, "Year 6"],
-    ]
-  end
-
   def valid_phase?
     return true if [Placements::School::PRIMARY_PHASE, Placements::School::SECONDARY_PHASE].include?(phase)
 

--- a/app/models/placements/schools/placements/build/placement.rb
+++ b/app/models/placements/schools/placements/build/placement.rb
@@ -3,6 +3,7 @@
 # Table name: placements
 #
 #  id          :uuid             not null, primary key
+#  year_group  :enum
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  provider_id :uuid
@@ -25,6 +26,17 @@ class Placements::Schools::Placements::Build::Placement < Placement
   validates :school, presence: true
 
   attr_accessor :phase, :mentor_ids, :additional_subject_ids
+
+  def self.year_groups
+    [
+      [:year_1, "Year 1"],
+      [:year_2, "Year 2"],
+      [:year_3, "Year 3"],
+      [:year_4, "Year 4"],
+      [:year_5, "Year 5"],
+      [:year_6, "Year 6"],
+    ]
+  end
 
   def valid_phase?
     return true if [Placements::School::PRIMARY_PHASE, Placements::School::SECONDARY_PHASE].include?(phase)
@@ -59,6 +71,13 @@ class Placements::Schools::Placements::Build::Placement < Placement
       errors.add(:additional_subject_ids, :invalid)
       false
     end
+  end
+
+  def valid_year_group?
+    return true if school.phase != "Primary" || year_group.present?
+
+    errors.add(:year_group, :invalid)
+    false
   end
 
   def all_valid?

--- a/app/policies/placement_policy.rb
+++ b/app/policies/placement_policy.rb
@@ -5,6 +5,7 @@ class PlacementPolicy < ApplicationPolicy
   alias_method :add_phase?, :new?
   alias_method :add_subject?, :new?
   alias_method :add_additional_subjects?, :new?
+  alias_method :add_year_group?, :new?
   alias_method :add_mentors?, :new?
   alias_method :check_your_answers?, :new?
 

--- a/app/views/placements/schools/placements/build/add_year_group.html.erb
+++ b/app/views/placements/schools/placements/build/add_year_group.html.erb
@@ -1,0 +1,25 @@
+<% content_for :page_title, @placement.errors.any? ? t(".title_with_error") : t(".title") %>
+<%= render "placements/schools/primary_navigation", school: @school, current_navigation: :placements %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: :back) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= form_for(@placement, url: placements_school_placement_build_path(@school, id: :add_year_group), method: :put) do |f| %>
+    <%= f.govuk_error_summary %>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <span class="govuk-caption-l"><%= t(".add_placement") %></span>
+        <%= f.govuk_collection_radio_buttons :year_group, @year_groups, :value, :name, :description, legend: { size: "l", text: t(".year_group") } %>
+
+        <%= f.govuk_submit t(".continue") %>
+      </div>
+    </div>
+  <% end %>
+
+  <p class="govuk-body">
+    <%= govuk_link_to(t(".cancel"), placements_school_placements_path(@school), no_visited_state: true) %>
+  </p>
+</div>

--- a/app/views/placements/schools/placements/build/add_year_group.html.erb
+++ b/app/views/placements/schools/placements/build/add_year_group.html.erb
@@ -12,7 +12,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <span class="govuk-caption-l"><%= t(".add_placement") %></span>
-        <%= f.govuk_collection_radio_buttons :year_group, @year_groups, :value, :name, :description, legend: { size: "l", text: t(".year_group") } %>
+        <%= f.govuk_collection_radio_buttons :year_group, @year_groups_for_select, :value, :name, :description, legend: { size: "l", text: t(".year_group") } %>
 
         <%= f.govuk_submit t(".continue") %>
       </div>

--- a/app/views/placements/schools/placements/build/check_your_answers.html.erb
+++ b/app/views/placements/schools/placements/build/check_your_answers.html.erb
@@ -45,7 +45,7 @@
           <% if @placement.year_group.present? %>
             <% summary_list.with_row do |row| %>
               <% row.with_key(text: t(".year_group")) %>
-              <% row.with_value(text: @placement.decorate.formatted_year_group) %>
+              <% row.with_value(text: I18n.t("placements.schools.placements.year_groups.#{@placement.year_group}")) %>
               <% row.with_action(text: t(".change"), href: add_year_group_placements_school_placement_build_index_path(@school, :add_year_group), visually_hidden_text: t(".add_year_group")) %>
             <% end %>
           <% end %>

--- a/app/views/placements/schools/placements/build/check_your_answers.html.erb
+++ b/app/views/placements/schools/placements/build/check_your_answers.html.erb
@@ -42,6 +42,14 @@
             <% end %>
           <% end %>
 
+          <% if @school.phase == "Primary" %>
+            <% summary_list.with_row do |row| %>
+              <% row.with_key(text: t(".year_group")) %>
+              <% row.with_value(text: @placement.decorate.formatted_year_group) %>
+              <% row.with_action(text: t(".change"), href: add_year_group_placements_school_placement_build_index_path(@school, :add_year_group), visually_hidden_text: t(".add_year_group")) %>
+            <% end %>
+          <% end %>
+
           <% if @school.mentors.exists? %>
             <% summary_list.with_row do |row| %>
               <% row.with_key(text: t(".mentor")) %>

--- a/app/views/placements/schools/placements/build/check_your_answers.html.erb
+++ b/app/views/placements/schools/placements/build/check_your_answers.html.erb
@@ -45,7 +45,7 @@
           <% if @placement.year_group.present? %>
             <% summary_list.with_row do |row| %>
               <% row.with_key(text: t(".year_group")) %>
-              <% row.with_value(text: I18n.t("placements.schools.placements.year_groups.#{@placement.year_group}")) %>
+              <% row.with_value(text: t("placements.schools.placements.year_groups.#{@placement.year_group}")) %>
               <% row.with_action(text: t(".change"), href: add_year_group_placements_school_placement_build_index_path(@school, :add_year_group), visually_hidden_text: t(".add_year_group")) %>
             <% end %>
           <% end %>

--- a/app/views/placements/schools/placements/build/check_your_answers.html.erb
+++ b/app/views/placements/schools/placements/build/check_your_answers.html.erb
@@ -42,7 +42,7 @@
             <% end %>
           <% end %>
 
-          <% if @school.phase == "Primary" %>
+          <% if @placement.year_group.present? %>
             <% summary_list.with_row do |row| %>
               <% row.with_key(text: t(".year_group")) %>
               <% row.with_value(text: @placement.decorate.formatted_year_group) %>

--- a/app/views/placements/schools/placements/show.html.erb
+++ b/app/views/placements/schools/placements/show.html.erb
@@ -46,6 +46,12 @@
             <% end %>
           <% end %>
         <% end %>
+        <% if @placement.year_group.present? %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".attributes.placements.year_group")) %>
+            <% row.with_value(text: @placement.formatted_year_group) %>
+          <% end %>
+        <% end %>
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: t(".attributes.placements.mentor")) %>
           <% row.with_value do %>

--- a/app/views/placements/schools/placements/show.html.erb
+++ b/app/views/placements/schools/placements/show.html.erb
@@ -49,7 +49,7 @@
         <% if @placement.year_group.present? %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".attributes.placements.year_group")) %>
-            <% row.with_value(text: @placement.formatted_year_group) %>
+            <% row.with_value(text: t("placements.schools.placements.year_groups.#{@placement.year_group}")) %>
           <% end %>
         <% end %>
         <% summary_list.with_row do |row| %>

--- a/app/views/placements/schools/placements/show.html.erb
+++ b/app/views/placements/schools/placements/show.html.erb
@@ -27,7 +27,15 @@
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: t(".attributes.placements.subject")) %>
           <% row.with_value do %>
+              <% @placement.subject.name %>
+          <% end %>
+        <% end %>
+        <% if @placement.subject_has_child_subjects? %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".attributes.placements.additional_subjects")) %>
+            <% row.with_value do %>
               <% @placement.subject_name %>
+            <% end %>
           <% end %>
         <% end %>
         <% if @placement.subject_has_child_subjects? %>

--- a/app/views/placements/schools/placements/show.html.erb
+++ b/app/views/placements/schools/placements/show.html.erb
@@ -27,15 +27,7 @@
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: t(".attributes.placements.subject")) %>
           <% row.with_value do %>
-              <% @placement.subject.name %>
-          <% end %>
-        <% end %>
-        <% if @placement.subject_has_child_subjects? %>
-          <% summary_list.with_row do |row| %>
-            <% row.with_key(text: t(".attributes.placements.additional_subjects")) %>
-            <% row.with_value do %>
               <% @placement.subject_name %>
-            <% end %>
           <% end %>
         <% end %>
         <% if @placement.subject_has_child_subjects? %>

--- a/app/views/placements/support/schools/placements/show.html.erb
+++ b/app/views/placements/support/schools/placements/show.html.erb
@@ -31,7 +31,15 @@
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".attributes.placements.additional_subjects")) %>
             <% row.with_value do %>
+              <% @placement.subject.name %>
+          <% end %>
+        <% end %>
+        <% if @placement.subject_has_child_subjects? %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".attributes.placements.additional_subjects")) %>
+            <% row.with_value do %>
               <% @placement.title %>
+            <% end %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/views/placements/support/schools/placements/show.html.erb
+++ b/app/views/placements/support/schools/placements/show.html.erb
@@ -15,7 +15,7 @@
       </h2>
 
       <%= govuk_summary_list(actions: false) do |summary_list| %>
-        <% if !@school.primary_or_secondary_only? %>
+        <% unless @school.primary_or_secondary_only? %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".attributes.placements.school_level")) %>
             <% row.with_value(text: @placement.school_level) %>
@@ -24,22 +24,14 @@
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: t(".attributes.placements.subject")) %>
           <% row.with_value do %>
-            <% @placement.subject.name %>
+            <% @placement.subject_name %>
           <% end %>
         <% end %>
         <% if @placement.subject_has_child_subjects? %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".attributes.placements.additional_subjects")) %>
             <% row.with_value do %>
-              <% @placement.subject.name %>
-          <% end %>
-        <% end %>
-        <% if @placement.subject_has_child_subjects? %>
-          <% summary_list.with_row do |row| %>
-            <% row.with_key(text: t(".attributes.placements.additional_subjects")) %>
-            <% row.with_value do %>
-              <% @placement.title %>
-            <% end %>
+              <% @placement.additional_subject_names %>
             <% end %>
           <% end %>
         <% end %>
@@ -60,8 +52,8 @@
       <% end %>
 
       <%= govuk_link_to t(".remove_placement"),
-            remove_placements_support_school_placement_path(@school, @placement),
-            class: "app-link app-link--destructive" %>
+                        remove_placements_support_school_placement_path(@school, @placement),
+                        class: "app-link app-link--destructive" %>
 
     </div>
   </div>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -162,6 +162,7 @@ shared:
     - created_at
     - updated_at
     - provider_id
+    - year_group
   :school_contacts:
     - id
     - name

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -14,6 +14,8 @@ en:
               invalid: Select an additional subject
             provider_id:
               invalid: Select a provider
+            year_group:
+              invalid: Select a year group
   placements:
     schools:
       placements:
@@ -25,6 +27,14 @@ en:
             phase: Phase
             primary: Primary
             secondary: Secondary
+            continue: Continue
+            cancel: Cancel
+          add_year_group:
+            title: Year group - Add placement
+            title_with_error: "Error: Year group - Add placement"
+            add_placement: Add placement
+            year_group: Year group
+            primary: Primary
             continue: Continue
             cancel: Cancel
           add_subject:
@@ -63,6 +73,8 @@ en:
             additional_subjects: Additional subjects
             add_additional_subjects: Add additional subjects
             mentor: Mentor
+            year_group: Year group
+            add_year_group: Add year group
             add_mentors: Add mentors
             change: Change
             info_text: When a placement is published, it will be visible to accredited providers and lead partners.
@@ -99,6 +111,19 @@ en:
           spring: Spring
           summer: Summer
         not_yet_known: Not yet known
+        year_groups:
+          year_1: Year 1
+          year_1_description: 5 to 6 years
+          year_2: Year 2
+          year_2_description: 6 to 7 years
+          year_3: Year 3
+          year_3_description: 7 to 8 years
+          year_4: Year 4
+          year_4_description: 8 to 9 years
+          year_5: Year 5
+          year_5_description: 9 to 10 years
+          year_6: Year 6
+          year_6_description: 10 to 11 years
         available: Available
         unavailable: Unavailable
         index:
@@ -119,6 +144,7 @@ en:
               school_level: School level
               subject: Subject
               additional_subjects: Additional subjects
+              year_group: Year group
               mentor: Mentor
               status: Status
               provider: Provider

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -110,6 +110,7 @@ scope module: :placements,
           resources :build do
             collection do
               get :add_phase
+              get :add_year_group
               get :add_subject
               get :add_additional_subjects
               get :add_mentors

--- a/db/migrate/20240528153905_add_year_group_to_placement.rb
+++ b/db/migrate/20240528153905_add_year_group_to_placement.rb
@@ -1,0 +1,7 @@
+class AddYearGroupToPlacement < ActiveRecord::Migration[7.1]
+  create_enum :placement_year_group, %w[year_1 year_2 year_3 year_4 year_5 year_6]
+
+  def change
+    add_column :placements, :year_group, :enum, enum_type: :placement_year_group
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,6 +20,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_30_141427) do
   create_enum "claim_status", ["internal_draft", "draft", "submitted"]
   create_enum "mentor_training_type", ["refresher", "initial"]
   create_enum "placement_status", ["draft", "published"]
+  create_enum "placement_year_group", ["year_1", "year_2", "year_3", "year_4", "year_5", "year_6"]
   create_enum "provider_type", ["scitt", "lead_school", "university"]
   create_enum "service", ["claims", "placements"]
   create_enum "subject_area", ["primary", "secondary"]
@@ -245,6 +246,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_30_141427) do
     t.datetime "updated_at", null: false
     t.uuid "provider_id"
     t.uuid "subject_id"
+    t.enum "year_group", enum_type: "placement_year_group"
     t.index ["provider_id"], name: "index_placements_on_provider_id"
     t.index ["school_id"], name: "index_placements_on_school_id"
     t.index ["subject_id"], name: "index_placements_on_subject_id"

--- a/spec/decorators/placement_decorator_spec.rb
+++ b/spec/decorators/placement_decorator_spec.rb
@@ -64,14 +64,6 @@ RSpec.describe PlacementDecorator do
         expect(placement.decorate.title).to eq("French, German, and Spanish")
       end
     end
-
-    context "when the placement has no subject" do
-      it "returns Not yet known" do
-        placement = build(:placement, subject: nil)
-
-        expect(placement.decorate.subject_name).to eq("Not yet known")
-      end
-    end
   end
 
   describe "#school_level" do

--- a/spec/decorators/placement_decorator_spec.rb
+++ b/spec/decorators/placement_decorator_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe PlacementDecorator do
 
   describe "#title" do
     context "when the placement has a subject without children" do
-      it "returns a list of subject names" do
+      it "returns a the subject name" do
         placement = create(:placement, subject: build(:subject, name: "Maths"))
 
         expect(placement.decorate.title).to eq("Maths")
@@ -62,6 +62,14 @@ RSpec.describe PlacementDecorator do
         ])
 
         expect(placement.decorate.title).to eq("French, German, and Spanish")
+      end
+    end
+
+    context "when the placement has no subject" do
+      it "returns Not yet known" do
+        placement = build(:placement, subject: nil)
+
+        expect(placement.decorate.subject_name).to eq("Not yet known")
       end
     end
   end

--- a/spec/factories/placements.rb
+++ b/spec/factories/placements.rb
@@ -3,6 +3,7 @@
 # Table name: placements
 #
 #  id          :uuid             not null, primary key
+#  year_group  :enum
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  provider_id :uuid

--- a/spec/models/placement_spec.rb
+++ b/spec/models/placement_spec.rb
@@ -3,6 +3,7 @@
 # Table name: placements
 #
 #  id          :uuid             not null, primary key
+#  year_group  :enum
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  provider_id :uuid

--- a/spec/models/placements/schools/placements/build/placement_spec.rb
+++ b/spec/models/placements/schools/placements/build/placement_spec.rb
@@ -3,6 +3,7 @@
 # Table name: placements
 #
 #  id          :uuid             not null, primary key
+#  year_group  :enum
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  provider_id :uuid

--- a/spec/models/placements/schools/placements/build/placement_spec.rb
+++ b/spec/models/placements/schools/placements/build/placement_spec.rb
@@ -26,6 +26,10 @@ require "rails_helper"
 RSpec.describe Placements::Schools::Placements::Build::Placement, type: :model do
   let!(:school) { create(:placements_school) }
 
+  describe "delegations" do
+    it { is_expected.to delegate_method(:has_child_subjects?).to(:subject).with_prefix(true).allow_nil }
+  end
+
   describe "#valid_phase?" do
     it "returns false if phase is blank" do
       placement = described_class.new(phase: nil)

--- a/spec/system/placements/schools/placements/add_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/add_a_placement_spec.rb
@@ -40,6 +40,9 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
           then_i_see_the_add_a_placement_subject_page(school.phase)
           when_i_choose_a_subject(subject_1.name)
           and_i_click_on("Continue")
+          then_i_see_the_add_year_group_page("Year 1")
+          when_i_choose_a_year_group("Year 1")
+          and_i_click_on("Continue")
           then_i_see_the_add_a_placement_mentor_page
           when_i_check_a_mentor(mentor_1.full_name)
           and_i_click_on("Continue")
@@ -54,6 +57,9 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
           when_i_visit_the_placements_page
           and_i_click_on("Add placement")
           when_i_choose_a_subject(subject_1.name)
+          and_i_click_on("Continue")
+          then_i_see_the_add_year_group_page("Year 1")
+          when_i_choose_a_year_group("Year 1")
           and_i_click_on("Continue")
           then_i_see_the_add_a_placement_mentor_page
           when_i_check_a_mentor("Not yet known")
@@ -74,6 +80,9 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
           and_i_click_on("Add placement")
           when_i_choose_a_subject(subject_1.name)
           and_i_click_on("Continue")
+          then_i_see_the_add_year_group_page("Year 1")
+          when_i_choose_a_year_group("Year 1")
+          and_i_click_on("Continue")
           then_i_see_the_check_your_answers_page(school.phase, nil)
         end
       end
@@ -93,6 +102,10 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
           and_i_click_on("Cancel")
           then_i_see_the_placements_page
 
+          when_i_visit_the_add_year_group_page
+          and_i_click_on("Cancel")
+          then_i_see_the_placements_page
+
           when_i_visit_the_add_mentor_page
           and_i_click_on("Cancel")
           then_i_see_the_placements_page
@@ -102,35 +115,7 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
           then_i_see_the_placements_page
         end
 
-        scenario "I can navigate to the previous page using the back button" do
-          when_i_visit_the_placements_page
-          and_i_click_on("Add placement")
-          when_i_choose_a_subject(subject_1.name)
-          and_i_click_on("Continue")
-          when_i_check_a_mentor(mentor_1.full_name)
-          and_i_click_on("Back")
-          then_i_see_the_add_a_placement_subject_page(school.phase)
-          and_i_click_on("Back")
-          then_i_see_the_placements_page
-        end
-
         context "when I've checked my answers and I click on change" do
-          scenario "I can navigate back to the check my answers page with the back button" do
-            when_i_visit_the_placements_page
-            and_i_click_on("Add placement")
-            when_i_choose_a_subject(subject_1.name)
-            and_i_click_on("Continue")
-            when_i_check_a_mentor(mentor_1.full_name)
-            and_i_click_on("Continue")
-            then_i_see_the_check_your_answers_page(school.phase, mentor_1)
-            when_i_change_my_subject
-            and_i_click_on("Back")
-            then_i_see_the_check_your_answers_page(school.phase, mentor_1)
-            when_i_change_my_mentor
-            and_i_click_on("Back")
-            then_i_see_the_check_your_answers_page(school.phase, mentor_1)
-          end
-
           scenario "my selected options are rendered when navigating using the back button" do
             when_i_visit_the_placements_page
             and_i_click_on("Add placement")
@@ -138,6 +123,13 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
             and_i_click_on("Continue")
             when_i_click_on("Back")
             then_my_chosen_subject_is_selected(subject_1.name)
+
+            when_i_visit_the_add_year_group_page
+            when_i_choose_a_year_group("Year 1")
+            and_i_click_on("Continue")
+            when_i_click_on("Back")
+            then_my_chosen_year_group_is_selected("Year 1")
+
             when_i_visit_the_add_mentor_page
             when_i_check_a_mentor(mentor_1.full_name)
             and_i_click_on("Continue")
@@ -154,8 +146,13 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
 
             when_i_choose_a_subject(subject_1.name)
             and_i_click_on("Continue")
+            then_i_see_the_add_year_group_page("Year 1")
+            and_i_click_on("Continue")
+            and_i_see_the_error_message("Select a year group")
+            when_i_choose_a_year_group("Year 1")
             and_i_click_on("Continue")
             then_i_see_the_add_a_placement_mentor_page
+            when_i_click_on("Continue")
             and_i_see_the_error_message("Select a mentor or not yet known")
           end
         end
@@ -230,7 +227,7 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
           and_i_see_the_error_message("Select an additional subject")
         end
 
-        scenario "If I change the subject, I do not see teh additional subject page" do
+        scenario "If I change the subject, I do not see the additional subject page" do
           school.update!(phase: "Secondary")
           when_i_visit_the_placements_page
           and_i_click_on("Add placement")
@@ -263,8 +260,9 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
           and_i_click_on("Continue")
           then_i_see_the_add_a_placement_subject_page("Primary")
           when_i_choose_a_subject(subject_1.name)
-          then_i_see_the_add_a_placement_subject_page("Primary")
-          when_i_choose_a_subject(subject_1.name)
+          and_i_click_on("Continue")
+          then_i_see_the_add_year_group_page("Year 1")
+          when_i_choose_a_year_group("Year 1")
           and_i_click_on("Continue")
           then_i_see_the_add_a_placement_mentor_page
           when_i_check_a_mentor(mentor_1.full_name)
@@ -466,10 +464,16 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
     visit add_mentors_placements_school_placement_build_index_path(school, :add_mentor)
   end
 
+  def when_i_visit_the_add_year_group_page
+    visit add_year_group_placements_school_placement_build_index_path(school, :add_year_group)
+  end
+
   def when_i_visit_the_check_your_answers_page
     when_i_visit_the_placements_page
     and_i_click_on("Add placement")
     when_i_choose_a_subject("Primary subject")
+    and_i_click_on("Continue")
+    when_i_choose_a_year_group("Year 1")
     and_i_click_on("Continue")
     when_i_check_a_mentor(mentor_1.full_name)
     and_i_click_on("Continue")
@@ -510,12 +514,22 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
     expect(page).to have_content("Add placement")
   end
 
+  def then_i_see_the_add_year_group_page(year_group)
+    expect(page).to have_content("Add placement")
+    expect(page).to have_content("Year group")
+    expect(page).to have_content(year_group)
+  end
+
   def when_i_choose_a_phase(phase)
     page.choose phase
   end
 
   def when_i_choose_a_subject(subject_name)
     page.choose subject_name
+  end
+
+  def when_i_choose_a_year_group(year_group)
+    page.choose year_group
   end
 
   def when_i_check_a_subject(subject_name)
@@ -531,6 +545,10 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
 
   def and_my_chosen_subject_is_selected(subject_name)
     expect(page).to have_checked_field(subject_name)
+  end
+
+  def and_my_chosen_year_group_is_selected(year_group)
+    expect(page).to have_checked_field(year_group)
   end
 
   def when_i_check_a_mentor(mentor_name)
@@ -613,4 +631,5 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
   alias_method :and_i_check_the_subject, :when_i_check_a_subject
   alias_method :then_my_chosen_subject_is_selected, :and_my_chosen_subject_is_selected
   alias_method :then_my_chosen_mentor_is_checked, :and_my_chosen_mentor_is_checked
+  alias_method :then_my_chosen_year_group_is_selected, :and_my_chosen_year_group_is_selected
 end


### PR DESCRIPTION
## Context

Adds the year group selection for primary schools so that they can specify which age range the placement is for.

## Changes proposed in this pull request

- [x] Adds the `year_group` column to `placements` table
- [x] Adds the `placement_year_group` enumerable
- [x] Updates the placement decorator to display year group
- [x] Adds the year group to the add a placement journey    

## Guidance to review

Log in as Anne
Add a placement
Select your subject
Select your year group
Select your mentor
Review your answers and check that the year group is correct
Change the year group
Continue back to the Check your answers page
Confirm the year group has been updated

## Link to Trello card

Add a 'year group' step to the 'add placement' journey

## Screenshots

![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/b15751a5-b4d8-4da9-8f38-8289052a2457)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/5c65f4ad-085c-403b-8918-49cdfc718521)