### PR TITLE
Update summary lists throught the application

### DIFF
--- a/app/views/claims/pages/index.html.erb
+++ b/app/views/claims/pages/index.html.erb
@@ -8,6 +8,7 @@
       </p>
 
       <%= govuk_summary_list(
+        actions: false,
         rows: [
           { key: { text: "Service" }, value: { text: "Claims" } },
           { key: { text: "Signed in as" }, value: { text: current_user&.first_name } },

--- a/app/views/claims/schools/_additional_details.html.erb
+++ b/app/views/claims/schools/_additional_details.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_summary_list(html_attributes: { id: "additional-details" }) do |summary_list| %>
+<%= govuk_summary_list(html_attributes: { id: "additional-details" }, actions: false) do |summary_list| %>
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: t("claims.schools.show.group")) %>
     <% row.with_value(**summary_row_value(value: @school.group)) %>

--- a/app/views/claims/schools/_contact_details.html.erb
+++ b/app/views/claims/schools/_contact_details.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_summary_list(html_attributes: { id: "contact-details" }) do |summary_list| %>
+<%= govuk_summary_list(html_attributes: { id: "contact-details" }, actions: false) do |summary_list| %>
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: t("claims.schools.show.email_address")) %>
     <% if @school.email_address.present? %>

--- a/app/views/claims/schools/_ofsted_details.html.erb
+++ b/app/views/claims/schools/_ofsted_details.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_summary_list(html_attributes: { id: "ofsted-details" }) do |summary_list| %>
+<%= govuk_summary_list(html_attributes: { id: "ofsted-details" }, actions: false) do |summary_list| %>
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: t("claims.schools.show.rating")) %>
     <% row.with_value(**summary_row_value(value: @school.rating, empty_text: t("claims.schools.show.unknown"))) %>

--- a/app/views/claims/schools/_send_details.html.erb
+++ b/app/views/claims/schools/_send_details.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_summary_list(html_attributes: { id: "send-details" }) do |summary_list| %>
+<%= govuk_summary_list(html_attributes: { id: "send-details" }, actions: false) do |summary_list| %>
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: t("claims.schools.show.special_classes")) %>
     <% row.with_value(**summary_row_value(value: @school.special_classes)) %>

--- a/app/views/claims/schools/claims/check.html.erb
+++ b/app/views/claims/schools/claims/check.html.erb
@@ -13,7 +13,7 @@
         <%= @claim.draft? ? t(".declaration") : t(".page_title") %>
       </label>
 
-      <%= govuk_summary_list do |summary_list| %>
+      <%= govuk_summary_list(actions: !@claim.draft?) do |summary_list| %>
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: Claims::Claim.human_attribute_name(:school)) %>
           <% row.with_value(text: @school.name) %>
@@ -54,7 +54,7 @@
 
       <h2 class="govuk-heading-m"><%= t(".hours_of_training") %></h2>
 
-      <%= govuk_summary_list do |summary_list| %>
+      <%= govuk_summary_list(actions: !@claim.draft?) do |summary_list| %>
         <% @claim.mentor_trainings.order_by_mentor_full_name.each do |mentor_training| %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: mentor_training.mentor.full_name) %>
@@ -76,7 +76,7 @@
       <% end %>
 
       <h2 class="govuk-heading-m"><%= t(".grant_funding") %></h2>
-        <%= govuk_summary_list do |summary_list| %>
+        <%= govuk_summary_list(actions: false) do |summary_list| %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".total_hours")) %>
             <% row.with_value(text: pluralize(@claim.mentor_trainings.sum(:hours_completed), t(".hour"))) %>

--- a/app/views/claims/schools/claims/show.html.erb
+++ b/app/views/claims/schools/claims/show.html.erb
@@ -22,7 +22,7 @@
         <p class="govuk-body"><%= t(".submitted_by", name: @claim.submitted_by.full_name, date: l(@claim.submitted_on, format: :long)) %></p>
       <% end %>
 
-      <%= govuk_summary_list do |summary_list| %>
+      <%= govuk_summary_list(actions: @claim.draft?) do |summary_list| %>
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: Claims::Claim.human_attribute_name(:school)) %>
           <% row.with_value(text: @school.name) %>
@@ -69,7 +69,7 @@
       <% end %>
 
       <h2 class="govuk-heading-m"><%= t(".hours_of_training") %></h2>
-        <%= govuk_summary_list do |summary_list| %>
+        <%= govuk_summary_list(actions: @claim.draft?) do |summary_list| %>
          <%= @claim.mentor_trainings.order_by_mentor_full_name.each do |mentor_training| %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: mentor_training.mentor.full_name) %>
@@ -91,7 +91,7 @@
       <% end %>
 
       <h2 class="govuk-heading-m"><%= t(".grant_funding") %></h2>
-        <%= govuk_summary_list do |summary_list| %>
+        <%= govuk_summary_list(actions: false) do |summary_list| %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".total_hours")) %>
             <% row.with_value(text: pluralize(@claim.mentor_trainings.sum(:hours_completed), t(".hour"))) %>

--- a/app/views/claims/schools/mentors/show.html.erb
+++ b/app/views/claims/schools/mentors/show.html.erb
@@ -10,7 +10,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-l"><%= @mentor.full_name %></h2>
 
-      <%= govuk_summary_list do |summary_list| %>
+      <%= govuk_summary_list(actions: false) do |summary_list| %>
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: Mentor.human_attribute_name(:first_name)) %>
           <% row.with_value(text: @mentor.first_name) %>

--- a/app/views/claims/schools/users/check.html.erb
+++ b/app/views/claims/schools/users/check.html.erb
@@ -22,7 +22,7 @@
           <%= t(".title") %>
         </label>
 
-        <%= govuk_summary_list do |summary_list| %>
+        <%= govuk_summary_list(actions: false) do |summary_list| %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: User.human_attribute_name("first_name")) %>
             <% row.with_value(text: @user_form.first_name) %>

--- a/app/views/claims/schools/users/show.html.erb
+++ b/app/views/claims/schools/users/show.html.erb
@@ -10,7 +10,7 @@
       <span class="govuk-caption-l"><%= @school.name %></span>
       <h2 class="govuk-heading-l"><%= @user.full_name %></h2>
 
-      <%= govuk_summary_list do |summary_list| %>
+      <%= govuk_summary_list(actions: false) do |summary_list| %>
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: User.human_attribute_name(:first_name)) %>
           <% row.with_value(text: @user.first_name) %>

--- a/app/views/claims/support/claims/_details.html.erb
+++ b/app/views/claims/support/claims/_details.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_summary_list do |summary_list| %>
+<%= govuk_summary_list(actions: policy(claim).edit?) do |summary_list| %>
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: Claims::Claim.human_attribute_name(:school)) %>
     <% row.with_value(text: govuk_link_to(claim.school.name, claims_support_school_path(claim.school))) %>
@@ -43,7 +43,7 @@
 <% end %>
 
 <h2 class="govuk-heading-m"><%= t(".hours_of_training") %></h2>
-  <%= govuk_summary_list do |summary_list| %>
+  <%= govuk_summary_list(actions: policy(claim).edit?) do |summary_list| %>
    <%= claim.mentor_trainings.order_by_mentor_full_name.each do |mentor_training| %>
     <% summary_list.with_row do |row| %>
       <% row.with_key(text: mentor_training.mentor.full_name) %>
@@ -64,7 +64,7 @@
 <% end %>
 
 <h2 class="govuk-heading-m"><%= t(".grant_funding") %></h2>
-<%= govuk_summary_list do |summary_list| %>
+<%= govuk_summary_list(actions: false) do |summary_list| %>
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: t(".total_hours")) %>
     <% row.with_value(text: pluralize(claim.mentor_trainings.sum(:hours_completed), t(".hour"))) %>

--- a/app/views/claims/support/schools/_contact_details.html.erb
+++ b/app/views/claims/support/schools/_contact_details.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_summary_list(html_attributes: { id: "contact-details" }) do |summary_list| %>
+<%= govuk_summary_list(html_attributes: { id: "contact-details" }, actions: false) do |summary_list| %>
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: t("placements.support.schools.show.email_address")) %>
     <% if @school.email_address.present? %>

--- a/app/views/claims/support/schools/check.html.erb
+++ b/app/views/claims/support/schools/check.html.erb
@@ -40,7 +40,7 @@
           <%= t(".contact_details") %>
         </h2>
 
-        <%= govuk_summary_list do |summary_list| %>
+        <%= govuk_summary_list(actions: false) do |summary_list| %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".telephone")) %>
             <% row.with_value(text: @school.telephone) %>

--- a/app/views/claims/support/schools/claims/check.html.erb
+++ b/app/views/claims/support/schools/claims/check.html.erb
@@ -65,7 +65,7 @@
       <% end %>
 
       <h2 class="govuk-heading-m"><%= t(".grant_funding") %></h2>
-        <%= govuk_summary_list do |summary_list| %>
+        <%= govuk_summary_list(actions: false) do |summary_list| %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".total_hours")) %>
             <% row.with_value(text: pluralize(@claim.mentor_trainings.sum(:hours_completed), t(".hour"))) %>

--- a/app/views/claims/support/schools/mentors/show.html.erb
+++ b/app/views/claims/support/schools/mentors/show.html.erb
@@ -12,7 +12,7 @@
       <span class="govuk-caption-l"><%= t(".caption", school_name: @school.name) %></span>
       <h2 class="govuk-heading-l"><%= @mentor.full_name %></h2>
 
-      <%= govuk_summary_list do |summary_list| %>
+      <%= govuk_summary_list(actions: false) do |summary_list| %>
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: Mentor.human_attribute_name(:first_name)) %>
           <% row.with_value(text: @mentor.first_name) %>

--- a/app/views/claims/support/schools/users/show.html.erb
+++ b/app/views/claims/support/schools/users/show.html.erb
@@ -9,7 +9,7 @@
       <span class="govuk-caption-l"><%= @school.name %></span>
       <h2 class="govuk-heading-l"><%= @user.full_name %></h2>
 
-      <%= govuk_summary_list do |summary_list| %>
+      <%= govuk_summary_list(actions: false) do |summary_list| %>
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: User.human_attribute_name(:first_name)) %>
           <% row.with_value(text: @user.first_name) %>

--- a/app/views/claims/support/support_users/show.html.erb
+++ b/app/views/claims/support/support_users/show.html.erb
@@ -10,7 +10,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l"><%= @support_user.full_name %></h1>
 
-      <%= govuk_summary_list do |summary_list| %>
+      <%= govuk_summary_list(actions: false) do |summary_list| %>
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: User.human_attribute_name(:first_name)) %>
           <% row.with_value(text: @support_user.first_name) %>

--- a/app/views/placements/organisations/users/_details.html.erb
+++ b/app/views/placements/organisations/users/_details.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_summary_list do |summary_list| %>
+<%= govuk_summary_list(actions: false) do |summary_list| %>
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: User.human_attribute_name(:first_name)) %>
     <% row.with_value(text: @user.first_name) %>

--- a/app/views/placements/pages/index.html.erb
+++ b/app/views/placements/pages/index.html.erb
@@ -8,6 +8,7 @@
       </p>
 
       <%= govuk_summary_list(
+        actions: false,
         rows: [
           { key: { text: "Service" }, value: { text: "Placements" } },
           { key: { text: "Signed in as" }, value: { text: current_user&.first_name } },

--- a/app/views/placements/placements/_school_details.html.erb
+++ b/app/views/placements/placements/_school_details.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (school:, placement:) -%>
-<%= govuk_summary_list do |summary_list| %>
+<%= govuk_summary_list(actions: false) do |summary_list| %>
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: t(".establishment_group")) %>
     <% row.with_value(text: school.group) %>

--- a/app/views/placements/schools/mentors/show.html.erb
+++ b/app/views/placements/schools/mentors/show.html.erb
@@ -11,7 +11,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-l"><%= @mentor.full_name %></h2>
 
-      <%= govuk_summary_list do |summary_list| %>
+      <%= govuk_summary_list(actions: false) do |summary_list| %>
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: Mentor.human_attribute_name("first_name")) %>
           <% row.with_value(text: @mentor.first_name) %>

--- a/app/views/placements/support/organisations/users/_details.html.erb
+++ b/app/views/placements/support/organisations/users/_details.html.erb
@@ -5,7 +5,7 @@
       <span class="govuk-caption-l"><%= organisation.name %></span>
       <h2 class="govuk-heading-l"><%= user.full_name %></h2>
 
-      <%= govuk_summary_list do |summary_list| %>
+      <%= govuk_summary_list(actions: false) do |summary_list| %>
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: t(".attributes.users.first_name")) %>
           <% row.with_value(text: user.first_name) %>

--- a/app/views/placements/support/schools/mentors/show.html.erb
+++ b/app/views/placements/support/schools/mentors/show.html.erb
@@ -12,7 +12,7 @@
       <span class="govuk-caption-l"><%= t(".caption", school_name: @school.name) %></span>
       <h2 class="govuk-heading-l"><%= @mentor.full_name %></h2>
 
-      <%= govuk_summary_list do |summary_list| %>
+      <%= govuk_summary_list(actions: false) do |summary_list| %>
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: Mentor.human_attribute_name("first_name")) %>
           <% row.with_value(text: @mentor.first_name) %>

--- a/app/views/placements/support/schools/placements/show.html.erb
+++ b/app/views/placements/support/schools/placements/show.html.erb
@@ -14,7 +14,7 @@
         <%= @placement.subject_names %>
       </h2>
 
-      <%= govuk_summary_list do |summary_list| %>
+      <%= govuk_summary_list(actions: false) do |summary_list| %>
         <% if !@school.primary_or_secondary_only? %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".attributes.placements.school_level")) %>

--- a/app/views/placements/support/support_users/show.html.erb
+++ b/app/views/placements/support/support_users/show.html.erb
@@ -11,7 +11,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l"><%= @support_user.full_name %></h1>
 
-      <%= govuk_summary_list do |summary_list| %>
+      <%= govuk_summary_list(actions: false) do |summary_list| %>
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: User.human_attribute_name(:first_name)) %>
           <% row.with_value(text: @support_user.first_name) %>

--- a/app/views/shared/organisations/_contact_details.html.erb
+++ b/app/views/shared/organisations/_contact_details.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_summary_list(html_attributes: { id: "contact-details" }) do |summary_list| %>
+<%= govuk_summary_list(html_attributes: { id: "contact-details" }, actions: false) do |summary_list| %>
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: t(".email_address")) %>
     <% if organisation.email_address.present? %>

--- a/app/views/shared/organisations/_grant_conditions.html.erb
+++ b/app/views/shared/organisations/_grant_conditions.html.erb
@@ -1,5 +1,5 @@
 <% if organisation.claims_grant_conditions_accepted_at %>
-  <%= govuk_summary_list(html_attributes: { id: "grant-conditions" }) do |summary_list| %>
+  <%= govuk_summary_list(html_attributes: { id: "grant-conditions" }, actions: false) do |summary_list| %>
     <% summary_list.with_row do |row| %>
       <% row.with_key(text: t(".agreed_by")) %>
       <% row.with_value(**summary_row_value(value: organisation.claims_grant_conditions_accepted_by&.full_name)) %>

--- a/app/views/shared/organisations/_grant_funding.html.erb
+++ b/app/views/shared/organisations/_grant_funding.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_summary_list(html_attributes: { id: "grant-funding" }) do |summary_list| %>
+<%= govuk_summary_list(html_attributes: { id: "grant-funding" }, actions: false) do |summary_list| %>
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: t(".region")) %>
     <% row.with_value(**summary_row_value(value: "#{organisation.region.name} (#{organisation.town})")) %>

--- a/app/views/shared/organisations/_organisation_details.html.erb
+++ b/app/views/shared/organisations/_organisation_details.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_summary_list(html_attributes: { id: "organisation-details" }) do |summary_list| %>
+<%= govuk_summary_list(html_attributes: { id: "organisation-details" }, actions: false) do |summary_list| %>
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: t(".organisation_name")) %>
     <% row.with_value(**summary_row_value(value: organisation.name)) %>

--- a/app/views/shared/schools/_additional_details.html.erb
+++ b/app/views/shared/schools/_additional_details.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_summary_list(html_attributes: { id: "additional-details" }) do |summary_list| %>
+<%= govuk_summary_list(html_attributes: { id: "additional-details" }, actions: false) do |summary_list| %>
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: t(".establishment_group")) %>
     <% row.with_value(**summary_row_value(value: school.group)) %>

--- a/app/views/shared/schools/_location_details.html.erb
+++ b/app/views/shared/schools/_location_details.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (school:) -%>
-<%= govuk_summary_list(html_attributes: { id: "location-details" }) do |summary_list| %>
+<%= govuk_summary_list(html_attributes: { id: "location-details" }, actions: false) do |summary_list| %>
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: t(".address")) %>
     <% row.with_value(**summary_row_value(value: school.formatted_address)) %>

--- a/app/views/shared/schools/_ofsted_details.html.erb
+++ b/app/views/shared/schools/_ofsted_details.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_summary_list(html_attributes: { id: "ofsted-details" }) do |summary_list| %>
+<%= govuk_summary_list(html_attributes: { id: "ofsted-details" }, actions: false) do |summary_list| %>
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: t(".rating")) %>
     <% row.with_value(**summary_row_value(value: school.rating, empty_text: t(".unknown"))) %>

--- a/app/views/shared/schools/_send_details.html.erb
+++ b/app/views/shared/schools/_send_details.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_summary_list(html_attributes: { id: "send-details" }) do |summary_list| %>
+<%= govuk_summary_list(html_attributes: { id: "send-details" }, actions: false) do |summary_list| %>
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: t(".special_classes")) %>
     <% row.with_value(**summary_row_value(value: school.special_classes)) %>


### PR DESCRIPTION
## Context

When `actions` is not specified on a `govuk_summary_list` component it reserves a space for them even if they're not used. This change means that when actions are not present the component will use the full width available for the data.

## Changes proposed in this pull request

- [x] Canvasses the entire apps usage of `govuk_summary_list` and adds `actions: false` or sets `actions` conditionally based on wheter or not actions are used.

## Guidance to review

Check out the changes and have a quick run through of pages that use summary lists to confirm that they are still working as expected. Any instances of text being squashed when actons were not present should be resolved.

## Link to Trello card

[Make summary lists display full-width when they have no actions](https://trello.com/c/JFl42Qnf)

## Screenshots

|Before|After|
|------|------|
| ![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/aba6be00-ba6b-4bfe-8e34-a073813f37b2) | ![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/5f243d65-f822-46f6-9e01-4c513d9f534d) |

After:


