### PR TITLE
Update school search boxes to add comma's and remove null values

### DIFF
--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -61,21 +61,12 @@ export default class extends Controller {
 
   resultTemplate(result) {
     if (result && typeof result === "object") {
-      const returnString = `${result.name}`;
-      const attributesValue = this.returnAttributesValue
-      let attributesString = '';
+      const attributes = this.returnAttributesValue
+        .map((attribute) => result[attribute])
+        .filter((attribute) => !!attribute)
+        .join(", ");
 
-      for (let i = 0; i < attributesValue.length; i++) {
-        const attribute = attributesValue[i];
-         if (result[attribute] !== null && result[attribute] !== undefined) {
-           attributesString += `${result[attribute]}`;
-           if (i < attributesValue.length - 1) {
-             attributesString += ", ";
-           }
-         }
-      }
-
-      return returnString.concat(` (${attributesString.trim()})`)
+      return `${result.name} (${attributes})`;
     } else {
       return ""
     }

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -61,11 +61,20 @@ export default class extends Controller {
 
   resultTemplate(result) {
     if (result && typeof result === "object") {
-      var returnString = `${result.name}`
-      var attributesString = ''
-      this.returnAttributesValue.forEach(function(attribute) {
-        attributesString = attributesString.concat(`${result[attribute]} `)
-      });
+      const returnString = `${result.name}`;
+      const attributesValue = this.returnAttributesValue
+      let attributesString = '';
+
+
+      for (let i = 0; i < attributesValue.length; i++) {
+        let attribute = attributesValue[i];
+         if (result[attribute] !== null && result[attribute] !== undefined) {
+           attributesString += `${result[attribute]}`;
+           if (i < attributesValue.length - 1) {
+             attributesString += ", ";
+           }
+         }
+      }
 
       return returnString.concat(` (${attributesString.trim()})`)
     } else {

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -66,7 +66,7 @@ export default class extends Controller {
       let attributesString = '';
 
       for (let i = 0; i < attributesValue.length; i++) {
-        let attribute = attributesValue[i];
+        const attribute = attributesValue[i];
          if (result[attribute] !== null && result[attribute] !== undefined) {
            attributesString += `${result[attribute]}`;
            if (i < attributesValue.length - 1) {

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -65,7 +65,6 @@ export default class extends Controller {
       const attributesValue = this.returnAttributesValue
       let attributesString = '';
 
-
       for (let i = 0; i < attributesValue.length; i++) {
         let attribute = attributesValue[i];
          if (result[attribute] !== null && result[attribute] !== undefined) {


### PR DESCRIPTION
## Context

Currently the school selection concatenates data togther into a space separated string. For readability we have decided that it should be a comma separated string. Additionally `null` values were slipping through into the results, these have been removed.

## Changes proposed in this pull request

- [x] Adds some JS to comma concatenate additional data and stop `null` values displaying

## Guidance to review

Log in as Colin
Add an organisation
Search for "York Ste"
See that the data is comma separated and that no `null` values are present

## Link to Trello card

[Add a comma & hide "null" values](https://trello.com/c/Wt2OCdhk)

## Screenshots

![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/f8d41a84-83ab-47c1-a20b-db6c9013e715)

