### PR TITLE
Split email heading content per service

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -7,6 +7,7 @@ class UserMailer < ApplicationMailer
                    user_name: user.first_name,
                    organisation_name: organisation.name,
                    service_name:,
+                   heading: t(".#{service}.heading"),
                    support_email:,
                    sign_in_url:,
                  )

--- a/config/locales/en/user_mailer.yml
+++ b/config/locales/en/user_mailer.yml
@@ -7,7 +7,7 @@ en:
 
         You have been invited to join the %{service_name} service for %{organisation_name}.
 
-        # Sign in to submit claims
+        # %{heading}
 
         If you have a DfE Sign-in account, you can use it to sign in:
 
@@ -24,6 +24,10 @@ en:
         Regards
 
         %{service_name} team
+      claims:
+        heading: Sign in to submit claims
+      placements:
+        heading: Sign in to view placements
 
     user_membership_destroyed_notification:
       subject: You have been removed from %{service_name}

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe UserMailer, type: :mailer do
 
             You have been invited to join the Manage school placements service for #{organisation.name}.
 
-            # Sign in to submit claims
+            # Sign in to view placements
 
             If you have a DfE Sign-in account, you can use it to sign in:
 
@@ -123,7 +123,7 @@ RSpec.describe UserMailer, type: :mailer do
 
             You have been invited to join the Manage school placements service for #{organisation.name}.
 
-            # Sign in to submit claims
+            # Sign in to view placements
 
             If you have a DfE Sign-in account, you can use it to sign in:
 


### PR DESCRIPTION
## Context

The Placements service requires different email content.

## Changes proposed in this pull request

- Split content based on service.

## Guidance to review

This unblocks placements.

Moving forward, the likelihood of our emails being equal seems low. I suggest we split out into `Claims::___Mailer` and `Placements::___Mailer` classes. Not for this PR.
