### PR TITLE
Fix ordering of providers by name on end-user side

### DIFF
--- a/app/views/claims/schools/claims/_form.html.erb
+++ b/app/views/claims/schools/claims/_form.html.erb
@@ -8,7 +8,7 @@
 
       <%= f.govuk_collection_radio_buttons(
         :provider_id,
-        Provider.private_beta_providers,
+        Provider.private_beta_providers.order_by_name,
         :id,
         :name,
         legend: { text: t(".heading"), size: "l" },


### PR DESCRIPTION
## Context

A bug slipped through and was detected in a flaky spec.

## Changes proposed in this pull request

- Order Providers by name alphabetically on the end-user's side.

## Guidance to review

- Providers are ordered correctly.
