### PR TITLE
Removed set-azure-resource-group-tags which is not required

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,6 @@ ittms_domain:   ## runs a script to config variables for setting up dns
 set-azure-template-tag:
 	$(eval ARM_TEMPLATE_TAG=1.1.6)
 
-.PHONY: set-azure-resource-group-tags
-set-azure-resource-group-tags: ##Tags that will be added to resource group on its creation in ARM template
-	$(eval RG_TAGS=$(shell echo '{"Product" : "ITT mentor services", "Service Offering": "ITT mentor services", "Environment" : "$(ENV_TAG)"}' | jq . ))
 
 bin/terrafile: ## Install terrafile to manage terraform modules
 	curl -sL https://github.com/coretech/terrafile/releases/download/v${TERRAFILE_VERSION}/terrafile_${TERRAFILE_VERSION}_$$(uname)_x86_64.tar.gz \
@@ -124,7 +121,7 @@ deploy-arm-resources: arm-deployment ## Validate ARM resource deployment. Usage:
 
 validate-arm-resources: set-what-if arm-deployment ## Validate ARM resource deployment. Usage: make domains validate-arm-resources
 
-domain-azure-resources: set-azure-account set-azure-template-tag set-azure-resource-group-tags ## deploy container to store terraform state for all dns resources -run validate first
+domain-azure-resources: set-azure-account set-azure-template-tag  ## deploy container to store terraform state for all dns resources -run validate first
 	$(if $(AUTO_APPROVE), , $(error can only run with AUTO_APPROVE))
 	az deployment sub create -l "UK South" --template-uri "https://raw.githubusercontent.com/DFE-Digital/tra-shared-services/${ARM_TEMPLATE_TAG}/azure/resourcedeploy.json" \
 		--name "${DNS_ZONE}domains-$(shell date +%Y%m%d%H%M%S)" --parameters "resourceGroupName=${RESOURCE_NAME_PREFIX}-${DNS_ZONE}domains-rg" 'tags=${RG_TAGS}' \


### PR DESCRIPTION
## Context

 Fix tag on resource group s189p01-ittmsdomains-rg and Fix Makefile.

## Changes proposed in this pull request

Fix tag on resource group s189p01-ittmsdomains-rg changes on make file.

## Guidance to review

Verify tags on  s189p01-ittmsdomains-rg , it should have Product:ITT mentor services

## Link to Trello card 

 https://trello.com/c/FS1Th32O/1842-fix-ittms-azure-tag

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
