### PR TITLE
Jc/show year group in primary placements title

### DIFF
--- a/app/decorators/placement_decorator.rb
+++ b/app/decorators/placement_decorator.rb
@@ -13,11 +13,14 @@ class PlacementDecorator < Draper::Decorator
   end
 
   def title
-    if additional_subjects.present?
-      additional_subject_names.to_sentence
-    else
-      subject_name
-    end
+    placement_title = if additional_subjects.present?
+                        additional_subject_names.to_sentence
+                      else
+                        subject_name
+                      end
+    return placement_title if year_group.blank?
+
+    "#{placement_title} (#{I18n.t("placements.schools.placements.year_groups.#{year_group}")})"
   end
 
   def school_level

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -91,13 +91,13 @@ Placements::School.find_each do |school|
 
   next if school.placements.any?
 
-  year_group = nil
-  subject = if school.phase == "Primary"
-              year_group =  Placement.year_groups.to_a.sample.first
-              Subject.primary.first
-            else
-              Subject.secondary.first
-            end
+  if school.phase == "Primary"
+    year_group =  Placement.year_groups.to_a.sample.first
+    subject = Subject.primary.first
+  else
+    year_group = nil
+    subject = Subject.secondary.first
+  end
   placement = Placement.create!(school:, subject:, year_group:)
 
   PlacementMentorJoin.create!(placement:, mentor: Placements::Mentor.first)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -91,8 +91,15 @@ Placements::School.find_each do |school|
 
   next if school.placements.any?
 
-  subject = school.phase == "Primary" ? Subject.primary.first : Subject.secondary.first
-  placement = Placement.create!(school:, subject:)
+  year_group = nil
+  subject = if school.phase == "Primary"
+              year_group =  Placement.year_groups.to_a.sample.first
+              Subject.primary.first
+            else
+              Subject.secondary.first
+            end
+  placement = Placement.create!(school:, subject:, year_group:)
 
+  PlacementSubjectJoin.create!(placement:, subject:)
   PlacementMentorJoin.create!(placement:, mentor: Placements::Mentor.first)
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -100,6 +100,5 @@ Placements::School.find_each do |school|
             end
   placement = Placement.create!(school:, subject:, year_group:)
 
-  PlacementSubjectJoin.create!(placement:, subject:)
   PlacementMentorJoin.create!(placement:, mentor: Placements::Mentor.first)
 end

--- a/spec/decorators/placement_decorator_spec.rb
+++ b/spec/decorators/placement_decorator_spec.rb
@@ -64,6 +64,14 @@ RSpec.describe PlacementDecorator do
         expect(placement.decorate.title).to eq("French, German, and Spanish")
       end
     end
+
+    context "when the placement has a year group" do
+      it "returns a subject name, followed by the year group in brackets" do
+        placement = create(:placement, subject: build(:subject, name: "Maths"), year_group: :year_1)
+
+        expect(placement.decorate.title).to eq("Maths (Year 1)")
+      end
+    end
   end
 
   describe "#school_level" do


### PR DESCRIPTION
## Context

Change `PlacementDecorator` `title` method to account for showing a year group within the title.

## Guidance to review

As Anne (School User)
- View placements list/index page
  - Check `Year Group` appears in brackets on any Primary Placements
  ![screencapture-placements-localhost-3000-schools-0001dfc5-d0b3-4b5b-a882-79ea267e6eac-placements-2024-06-03-16_55_28](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/7aef491b-da11-40a0-8e06-88c372077047)

- View placement show page (of a Primary Placement)
  - Check `Year Group` appears in the brackets of the Placement details
  ![screencapture-placements-localhost-3000-schools-0001dfc5-d0b3-4b5b-a882-79ea267e6eac-placements-de1c1247-68e3-4202-b42d-6678b509fa31-2024-06-03-16_56_53](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/fe92b80e-9ccb-4f45-beea-bd04e4716c50)

- Go to Delete a (primary )placement 
  - Check `Year Group` appears in the brackets of the Placement's title
  ![screencapture-placements-localhost-3000-schools-0001dfc5-d0b3-4b5b-a882-79ea267e6eac-placements-de1c1247-68e3-4202-b42d-6678b509fa31-remove-2024-06-03-16_58_55](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/40633b55-39d0-4812-99ea-a830e98de1cf)

--------

As Patricia (Provider User)
- View placements list/index page
  - Check `Year Group` appears in brackets on any Primary Placements 
  ![screencapture-placements-localhost-3000-placements-2024-06-03-17_00_17](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/af41345c-617a-4eae-b46f-086407c1f3ac)

- View placement show page (of a Primary Placement)
  - Check `Year Group` appears in the brackets of the Placement details
  ![screencapture-placements-localhost-3000-placements-4989c0ac-278f-41be-9fa5-9d375beee007-2024-06-03-17_01_20](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/93d61e05-c6cb-45c5-9705-f9d75afb91ba)

----------

As Colin (Support User)
- View placements list/index page
  - Check `Year Group` appears in brackets on any Primary Placements
  ![screencapture-placements-localhost-3000-support-schools-fffbf9b4-cca6-4b12-b40d-96def9c5ef76-placements-2024-06-03-17_02_46](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/81a5c864-af58-4209-a166-6dace33ee54d)

- View placement show page (of a Primary Placement)
  - Check `Year Group` appears in the brackets of the Placement details
  ![screencapture-placements-localhost-3000-support-schools-fffbf9b4-cca6-4b12-b40d-96def9c5ef76-placements-4989c0ac-278f-41be-9fa5-9d375beee007-2024-06-03-17_03_26](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/c0963105-5c8e-4db2-b504-010a011f77bb)

- Go to Delete a (primary )placement 
  - Check `Year Group` appears in the brackets of the Placement's title
  ![screencapture-placements-localhost-3000-support-schools-fffbf9b4-cca6-4b12-b40d-96def9c5ef76-placements-4989c0ac-278f-41be-9fa5-9d375beee007-remove-2024-06-03-17_04_02](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/5642aa32-e16f-4373-a61a-7330053275b2)

## Link to Trello card

https://trello.com/c/MfP6GOim/426-show-year-group-in-the-title-of-primary-placements
