### PR TITLE
Add 'year group' to the School → Placement details page

### DIFF
--- a/app/controllers/placements/schools/placements/build_controller.rb
+++ b/app/controllers/placements/schools/placements/build_controller.rb
@@ -228,9 +228,7 @@ class Placements::Schools::Placements::BuildController < ApplicationController
   end
 
   def year_groups_for_select
-    @year_groups_for_select ||= Placement.year_groups.map do |_, value|
-      OpenStruct.new value:, name: t("placements.schools.placements.year_groups.#{value}"), description: t("placements.schools.placements.year_groups.#{value}_description")
-    end
+    @year_groups_for_select ||= Placement.year_groups_as_options
   end
 
   def additional_subject_ids

--- a/app/controllers/placements/schools/placements_controller.rb
+++ b/app/controllers/placements/schools/placements_controller.rb
@@ -35,7 +35,6 @@ class Placements::Schools::PlacementsController < ApplicationController
       @providers = @school.partner_providers.all if params[:edit_path] == "edit_provider"
       year_groups_for_select if params[:edit_path] == "edit_year_group"
 
-
       render params[:edit_path]
     end
   end
@@ -102,8 +101,6 @@ class Placements::Schools::PlacementsController < ApplicationController
   end
 
   def year_groups_for_select
-    @year_groups_for_select ||= Placement.year_groups.map do |_, value|
-      OpenStruct.new value:, name: t("placements.schools.placements.year_groups.#{value}"), description: t("placements.schools.placements.year_groups.#{value}_description")
-    end
+    @year_groups_for_select ||= Placement.year_groups_as_options
   end
 end

--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -62,4 +62,11 @@ class Placement < ApplicationRecord
     end
     order(condition)
   end
+
+  def self.year_groups_as_options
+    year_groups.map do |_, value|
+      OpenStruct.new value:, name: I18n.t("placements.schools.placements.year_groups.#{value}"),
+                     description: I18n.t("placements.schools.placements.year_groups.#{value}_description")
+    end
+  end
 end

--- a/app/views/placements/schools/placements/edit_year_group.html.erb
+++ b/app/views/placements/schools/placements/edit_year_group.html.erb
@@ -1,0 +1,28 @@
+<% content_for :page_title, @placement.errors.any? ? t(".title_with_error") : t(".title") %>
+<%= render "placements/schools/primary_navigation", school: @school, current_navigation: :placements %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: :back) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= form_for(@placement, url: placements_school_placement_path(@school, @placement, edit_path: :edit_year_group), method: :put) do |f| %>
+    <%= f.govuk_error_summary %>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <span class="govuk-caption-l">
+          <%= t(".manage_placement") %>
+        </span>
+
+        <%= f.govuk_collection_radio_buttons :year_group, @year_groups_for_select, :value, :name, :description, legend: { size: "l", text: t(".year_group") } %>
+
+        <%= f.govuk_submit t(".continue") %>
+      </div>
+    </div>
+  <% end %>
+
+  <p class="govuk-body">
+    <%= govuk_link_to(t(".cancel"), placements_school_placement_path(@school, @placement), no_visited_state: true) %>
+  </p>
+</div>

--- a/app/views/placements/schools/placements/show.html.erb
+++ b/app/views/placements/schools/placements/show.html.erb
@@ -42,6 +42,11 @@
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".attributes.placements.year_group")) %>
             <% row.with_value(text: t("placements.schools.placements.year_groups.#{@placement.year_group}")) %>
+            <% row.with_action(
+                 text: t(".change"),
+                 href: edit_year_group_placements_school_placement_path(@school, @placement),
+                 visually_hidden_text: t(".attributes.placements.year_group"),
+               ) %>
           <% end %>
         <% end %>
         <% summary_list.with_row do |row| %>

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -22,6 +22,8 @@ en:
               invalid: Select a mentor or not yet known
             provider_id:
               invalid: Select a provider or not yet known
+            year_group:
+              invalid: Select a year group
   placements:
     schools:
       placements:
@@ -112,6 +114,13 @@ en:
           mentor_not_listed: My mentor is not listed
           you_need_to_add_a_mentor: "You will first need to %{link}."
           add_a_mentor: add a mentor
+        edit_year_group:
+          title: Year group - Manage a placement
+          title_with_error: "Error: Year group - Manage a placement"
+          manage_placement: Manage a placement
+          year_group: Year group
+          continue: Continue
+          cancel: Cancel
         terms:
           autumn: Autumn
           spring: Spring
@@ -154,6 +163,7 @@ en:
               mentor: Mentor
               status: Status
               provider: Provider
+              year_group: Year group
           select_a_mentor: Select a mentor
           add_a_mentor: Add a mentor
           assign_a_provider: Assign a provider

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -105,6 +105,7 @@ scope module: :placements,
         member { get :remove }
         get :edit_provider, on: :member
         get :edit_mentors, on: :member
+        get :edit_year_group, on: :member
 
         scope module: :placements do
           resources :build do

--- a/spec/models/placement_spec.rb
+++ b/spec/models/placement_spec.rb
@@ -95,4 +95,21 @@ RSpec.describe Placement, type: :model do
       )
     end
   end
+
+  describe ".year_groups_as_options" do
+    it "returns an array of OpenStruct objects with the year group value, name and description" do
+      options = described_class.year_groups_as_options
+
+      expect(options).to eq(
+        [
+          OpenStruct.new(value: "year_1", name: "Year 1", description: "5 to 6 years"),
+          OpenStruct.new(value: "year_2", name: "Year 2", description: "6 to 7 years"),
+          OpenStruct.new(value: "year_3", name: "Year 3", description: "7 to 8 years"),
+          OpenStruct.new(value: "year_4", name: "Year 4", description: "8 to 9 years"),
+          OpenStruct.new(value: "year_5", name: "Year 5", description: "9 to 10 years"),
+          OpenStruct.new(value: "year_6", name: "Year 6", description: "10 to 11 years"),
+        ],
+      )
+    end
+  end
 end

--- a/spec/requests/placements/schools/placements/placements_spec.rb
+++ b/spec/requests/placements/schools/placements/placements_spec.rb
@@ -38,5 +38,18 @@ RSpec.describe "Placements", type: :request, service: :placements do
         expect(response.body).to include("Select a provider")
       end
     end
+
+    context "when editing a year group" do
+      it "returns an error message when the year_group is invalid" do
+        placement = create(:placement, school:)
+
+        patch placements_school_placement_path(school, placement), params: {
+          placement: { year_group: nil },
+          edit_path: "edit_year_group",
+        }
+
+        expect(response.body).to include("Select a year group")
+      end
+    end
   end
 end

--- a/spec/system/placements/schools/placements/edit_a_year_group_spec.rb
+++ b/spec/system/placements/schools/placements/edit_a_year_group_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Placements / Schools / Placements / View a placement",
+RSpec.describe "Placements / Schools / Placements / Edit a year group",
                type: :system, service: :placements do
   let!(:school) { create(:placements_school, name: "School 1", phase: "Primary") }
   let!(:placement) { create(:placement, school:, year_group: :year_1) }

--- a/spec/system/placements/schools/placements/edit_a_year_group_spec.rb
+++ b/spec/system/placements/schools/placements/edit_a_year_group_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.describe "Placements / Schools / Placements / View a placement",
+               type: :system, service: :placements do
+  let!(:school) { create(:placements_school, name: "School 1", phase: "Primary") }
+  let!(:placement) { create(:placement, school:, year_group: :year_1) }
+
+  before { given_i_sign_in_as_anne }
+
+  context "when I edit the year group" do
+    scenario "User edits the year group" do
+      when_i_visit_the_placement_show_page
+      then_i_should_see_the_year_group_in_the_placement_details(
+        year_group_name: "Year 1",
+      )
+      when_i_click_link(
+        text: "Change",
+        href: edit_year_group_placements_school_placement_path(school, placement),
+      )
+      then_i_should_see_the_edit_year_group_page
+      when_i_select "Year 4"
+      and_i_click_on("Continue")
+      then_i_should_see_the_year_group_in_the_placement_details(
+        year_group_name: "Year 4",
+      )
+    end
+  end
+
+  private
+
+  def and_there_is_an_existing_user_for(user_name)
+    user = create(:placements_user, user_name.downcase.to_sym)
+    user_exists_in_dfe_sign_in(user:)
+    create(:user_membership, user:, organisation: school)
+  end
+
+  def and_i_visit_the_sign_in_path
+    visit sign_in_path
+  end
+
+  def and_i_click_sign_in
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def when_i_visit_the_placement_show_page
+    visit placements_school_placement_path(school, placement)
+  end
+
+  def given_i_sign_in_as_anne
+    and_there_is_an_existing_user_for("Anne")
+    and_i_visit_the_sign_in_path
+    and_i_click_sign_in
+  end
+
+  def then_i_should_see_the_edit_year_group_page
+    expect(page).to have_content("Manage a placement")
+    expect(page).to have_content("Year group")
+  end
+
+  def when_i_select(text)
+    choose text
+  end
+
+  def and_i_click_on(text)
+    click_on text
+  end
+
+  def when_i_click_link(text:, href:)
+    click_link text, href:
+  end
+
+  def then_i_should_see_the_year_group_in_the_placement_details(year_group_name:, change_link: "Change")
+    within(".govuk-summary-list") do
+      expect(page).to have_content(year_group_name)
+      expect(page).to have_content(change_link)
+    end
+  end
+end


### PR DESCRIPTION
## Context

For placements in a primary subject, the user should additionally specify the year group of the placement.

## Changes proposed in this pull request

- [x] Adds new route for editing a year group
- [x] Adds new view for editing year group
- [x] Adds translations
- [x] Adds request spec to test invalid params

## Guidance to review

- Log in as Anne
- Create a primary placement
- View the placement after creation
- Click on change next to the year group
- Select a new year group
- Click on continue
- Verify the year group has changed

## Link to Trello card

[Add 'year group' to the School → Placement details page](https://trello.com/c/7UuaXb9A)

## Screenshots

![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/a2655b9b-af2e-47d6-98ba-e039851acdef)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/f356ccd5-f4ce-49d8-93af-48306777f1dd)

