### PR TITLE
Add a search filter for 'year group'

### DIFF
--- a/app/controllers/placements/placements_controller.rb
+++ b/app/controllers/placements/placements_controller.rb
@@ -6,9 +6,7 @@ class Placements::PlacementsController < ApplicationController
     @subjects = Subject.order_by_name.select(:id, :name)
     @establishment_groups = compact_school_attribute_values(:group)
     @schools = schools_scope.order_by_name.select(:id, :name)
-    @year_groups ||= Placement.year_groups.map do |_, value|
-      OpenStruct.new value:, name: t("placements.schools.placements.year_groups.#{value}"), description: t("placements.schools.placements.year_groups.#{value}_description")
-    end
+    @year_groups ||= Placement.year_groups_as_options
 
     @pagy, @placements = pagy(
       Placements::PlacementsQuery.call(

--- a/app/controllers/placements/placements_controller.rb
+++ b/app/controllers/placements/placements_controller.rb
@@ -6,6 +6,9 @@ class Placements::PlacementsController < ApplicationController
     @subjects = Subject.order_by_name.select(:id, :name)
     @establishment_groups = compact_school_attribute_values(:group)
     @schools = schools_scope.order_by_name.select(:id, :name)
+    @year_groups ||= Placement.year_groups.map do |_, value|
+      OpenStruct.new value:, name: t("placements.schools.placements.year_groups.#{value}"), description: t("placements.schools.placements.year_groups.#{value}_description")
+    end
 
     @pagy, @placements = pagy(
       Placements::PlacementsQuery.call(
@@ -61,6 +64,7 @@ class Placements::PlacementsController < ApplicationController
       school_ids: [],
       subject_ids: [],
       establishment_groups: [],
+      year_groups: [],
     )
   end
 

--- a/app/forms/placements/placements/filter_form.rb
+++ b/app/forms/placements/placements/filter_form.rb
@@ -3,6 +3,7 @@ class Placements::Placements::FilterForm < ApplicationForm
 
   attribute :school_ids, default: []
   attribute :subject_ids, default: []
+  attribute :year_groups, default: []
   attribute :only_partner_schools, :boolean, default: false
   attribute :only_available_placements, :boolean, default: false
 
@@ -36,6 +37,7 @@ class Placements::Placements::FilterForm < ApplicationForm
     {
       school_ids:,
       subject_ids:,
+      year_groups:,
       only_partner_schools:,
       only_available_placements:,
     }

--- a/app/queries/placements/placements_query.rb
+++ b/app/queries/placements/placements_query.rb
@@ -8,6 +8,7 @@ class Placements::PlacementsQuery < ApplicationQuery
     scope = partner_school_condition(scope)
     scope = subject_condition(scope)
     scope = only_available_placements_condition(scope)
+    scope = year_group_condition(scope)
     order_condition(scope)
   end
 
@@ -37,6 +38,12 @@ class Placements::PlacementsQuery < ApplicationQuery
     return scope if filter_params[:only_available_placements].blank?
 
     scope.where(provider_id: nil)
+  end
+
+  def year_group_condition(scope)
+    return scope if filter_params[:year_groups].blank?
+
+    scope.where(year_group: filter_params[:year_groups])
   end
 
   def filter_params

--- a/app/views/placements/placements/_filter.html.erb
+++ b/app/views/placements/placements/_filter.html.erb
@@ -97,6 +97,25 @@
               <% end %>
             </ul>
           <% end %>
+
+          <% if filter_form.year_groups.present? %>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".year_group") %></h3>
+            <ul class="app-filter-tags">
+              <% filter_form.year_groups.each do |year_group| %>
+                <li>
+                  <%= govuk_link_to(
+                        t("placements.schools.placements.year_groups.#{year_group}"),
+                        filter_form.index_path_without_filter(
+                          filter: "year_groups",
+                          value: year_group,
+                        ),
+                        class: "app-filter__tag",
+                        no_visited_state: true,
+                      ) %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
         </div>
       <% end %>
 
@@ -190,6 +209,20 @@
                 <%= form.govuk_check_box :subject_ids,
                   subject.id,
                   label: { text: subject.name } %>
+              <% end %>
+            <% end %>
+          </div>
+
+          <div class="app-filter__option">
+            <%= form.govuk_check_boxes_fieldset(
+              :year_groups,
+              legend: { text: t(".year_group"), size: "s" },
+              small: true,
+            ) do %>
+              <% @year_groups.each do |year_group| %>
+                <%= form.govuk_check_box :year_groups,
+                                         year_group.value,
+                                         label: { text: year_group.name } %>
               <% end %>
             <% end %>
           </div>

--- a/config/locales/en/placements/placements.yml
+++ b/config/locales/en/placements/placements.yml
@@ -26,6 +26,7 @@ en:
         gender: Gender
         religious_character: Religious character
         ofsted_rating: Ofsted rating
+        year_group: Primary year group
       show:
         page_title: "%{subject_name} - Placements - %{school_name}"
         placement: "Placement - %{school_name}"

--- a/spec/forms/placements/placements/filter_form_spec.rb
+++ b/spec/forms/placements/placements/filter_form_spec.rb
@@ -32,6 +32,14 @@ describe Placements::Placements::FilterForm, type: :model do
       end
     end
 
+    context "when given year group params" do
+      let(:params) { { year_groups: %w[year_group] } }
+
+      it "returns true" do
+        expect(filter_form).to eq(true)
+      end
+    end
+
     context "when given partner school params" do
       let(:params) { { only_partner_schools: true } }
 
@@ -133,6 +141,25 @@ describe Placements::Placements::FilterForm, type: :model do
         )
       end
     end
+
+    context "when removing year group params" do
+      let(:params) do
+        { year_groups: %w[year_group_1 year_group_2] }
+      end
+
+      it "returns the placements index page path without the given year group param" do
+        expect(
+          filter_form.index_path_without_filter(
+            filter: "year_groups",
+            value: "year_group_1",
+          ),
+        ).to eq(
+          placements_placements_path(filters: {
+            year_groups: %w[year_group_2],
+          }),
+        )
+      end
+    end
   end
 
   describe "#query_params" do
@@ -142,6 +169,7 @@ describe Placements::Placements::FilterForm, type: :model do
           school_ids: [],
           only_partner_schools: false,
           subject_ids: [],
+          year_groups: [],
           only_available_placements: false,
         },
       )

--- a/spec/system/placements/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/placements/view_placements_list_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Placements / Placements / View placements list",
   end
   let!(:subject_1) { create(:subject, name: "Primary with mathematics") }
   let!(:subject_2) { create(:subject, name: "Chemistry") }
-  let(:placement_1) { create(:placement, subject: subject_1, school: primary_school) }
+  let(:placement_1) { create(:placement, subject: subject_1, school: primary_school, year_group: :year_1) }
   let(:placement_2) { create(:placement, subject: subject_2, school: secondary_school, provider: build(:placements_provider)) }
 
   before do
@@ -173,6 +173,17 @@ RSpec.describe "Placements / Placements / View placements list",
         and_i_can_not_see_any_selected_filters
       end
 
+      scenario "User can remove a year group filter" do
+        when_i_visit_the_placements_index_page({ filters: { year_groups: [:year_1] } })
+        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+        and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
+        and_i_can_see_a_preset_filter("Primary year group", "Year 1")
+        when_i_click_to_remove_filter("Primary year group", "Year 1")
+        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+        and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
+        and_i_can_not_see_any_selected_filters
+      end
+
       scenario "User can clear all filters" do
         given_a_partnership_exists_between(provider, primary_school)
         when_i_visit_the_placements_index_page(
@@ -182,6 +193,7 @@ RSpec.describe "Placements / Placements / View placements list",
               only_partner_schools: true,
               school_ids: [primary_school.id],
               subject_ids: [subject_1.id],
+              year_groups: [:year_1],
             },
           },
         )
@@ -191,6 +203,7 @@ RSpec.describe "Placements / Placements / View placements list",
         and_i_can_see_a_preset_filter("Partner schools", "Partner schools")
         and_i_can_see_a_preset_filter("School", "Primary School")
         and_i_can_see_a_preset_filter("Subject", "Primary with mathematics")
+        and_i_can_see_a_preset_filter("Primary year group", "Year 1")
         when_i_click_on("Clear filters")
         then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
         and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")


### PR DESCRIPTION
## Context

So providers can find primary placements by their year group.

## Changes proposed in this pull request

- [x] Adds the Priamary year group filter
- [x] Updates the placement query to filter on year groups when provided
- [x] Updates the filter form to accept year groups
- [x] Updates existing specs to prove this works

## Guidance to review

- Log in as Anne
- Create a new primary placement
- Log out
- Log in as Patricia
- Navigate to Placements
- Filter on the year group for the placement you created as Anne
- Verify that the placement is visible after filtering the results

## Link to Trello card

[Add a search filter for 'year group'](https://trello.com/c/9uXzUI7r)

## Screenshots

![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/56224e3d-90d5-4b4f-bdd6-66bc9d0d30e6)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/9ee96305-ef64-4734-81de-157cc392f0ab)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/70615674-0c6e-45ad-a59d-8ba31f5fc571)
