### PR TITLE
Fix support claims spec warning

### DIFF
--- a/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
     when_i_click("Continue")
     then_i_check_my_answers(claim, provider2, [mentor1, mentor2], [20, 12])
     when_i_click("Save claim")
-    then_i_am_redirected_to_index_page(claim)
+    then_i_am_redirected_to_index_page
   end
 
   scenario "Colin changes the mentors on claim on check page" do
@@ -55,7 +55,7 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
       [12],
     )
     when_i_click("Save claim")
-    then_i_am_redirected_to_index_page(claim)
+    then_i_am_redirected_to_index_page
   end
 
   scenario "Colin clicks change mentors the check page and is redirected back to check page" do
@@ -258,11 +258,9 @@ RSpec.describe "Change claim on check page", type: :system, service: :claims do
     end
   end
 
-  def then_i_am_redirected_to_index_page(claim)
+  def then_i_am_redirected_to_index_page
     within(".govuk-notification-banner--success") do
       expect(page).to have_content "Claim added"
     end
-
-    expect(page).to have_content(claim.reload.reference)
   end
 end


### PR DESCRIPTION
## Context

The claims/support/schools/claims/change_claim_on_check_page spec was checking against nil values, this is not really good practice.

This PR fixes this by removing the specs doing this as they don't really add value. The intention was to not create new claims when editing a claim as a support user but this is done in the support [edit_draft_claim_spec](https://github.com/DFE-Digital/itt-mentor-services/blob/1f2ca6611e926ab533913e679d1a8cf80c06e4fa/spec/system/claims/support/schools/claims/edit_draft_claim_spec.rb#L168-L171)

## Changes proposed in this pull request

claims/support/schools/claims/change_claim_on_check_page

## Guidance to review

Review code

## Screenshots

Before:
![Screenshot from 2024-06-04 11-51-00](https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/65234a9e-1269-45bc-a3d5-b775102a37cb)



After: 
![Screenshot from 2024-06-04 11-49-59](https://github.com/DFE-Digital/itt-mentor-services/assets/11318084/f78aefb7-ae32-4ab7-a712-cd301084b91d)

