### PR TITLE
Placements to show filter

### DIFF
--- a/app/controllers/placements/placements_controller.rb
+++ b/app/controllers/placements/placements_controller.rb
@@ -57,7 +57,7 @@ class Placements::PlacementsController < ApplicationController
 
   def filter_params
     params.fetch(:filters, {}).permit(
-      :only_available_placements,
+      :placements_to_show,
       :only_partner_schools,
       school_ids: [],
       subject_ids: [],

--- a/app/forms/placements/placements/filter_form.rb
+++ b/app/forms/placements/placements/filter_form.rb
@@ -4,8 +4,8 @@ class Placements::Placements::FilterForm < ApplicationForm
   attribute :school_ids, default: []
   attribute :subject_ids, default: []
   attribute :year_groups, default: []
+  attribute :placements_to_show, default: "available_placements"
   attribute :only_partner_schools, :boolean, default: false
-  attribute :only_available_placements, :boolean, default: false
 
   def initialize(params = {})
     params.each_value { |v| v.compact_blank! if v.is_a?(Array) }
@@ -14,15 +14,15 @@ class Placements::Placements::FilterForm < ApplicationForm
   end
 
   def filters_selected?
-    attributes.values.compact.flatten.any?
+    attributes.except("placements_to_show").values.compact.flatten.any?
   end
 
   def clear_filters_path(search_location: nil)
-    placements_placements_path(search_location:)
+    placements_placements_path(search_location:, filters: { placements_to_show: })
   end
 
   def index_path_without_filter(filter:, value: nil, search_location: nil)
-    without_filter = if BOOLEAN_ATTRIBUTES.include?(filter)
+    without_filter = if SINGULAR_ATTRIBUTES.include?(filter)
                        compacted_attributes.reject { |key, _| key == filter }
                      else
                        compacted_attributes.merge(filter => compacted_attributes[filter].reject { |filter_value| filter_value == value })
@@ -39,7 +39,7 @@ class Placements::Placements::FilterForm < ApplicationForm
       subject_ids:,
       year_groups:,
       only_partner_schools:,
-      only_available_placements:,
+      placements_to_show:,
     }
   end
 
@@ -53,7 +53,7 @@ class Placements::Placements::FilterForm < ApplicationForm
 
   private
 
-  BOOLEAN_ATTRIBUTES = %w[only_available_placements only_partner_schools].freeze
+  SINGULAR_ATTRIBUTES = %w[only_partner_schools placements_to_show].freeze
 
   def compacted_attributes
     @compacted_attributes ||= attributes.compact_blank

--- a/app/queries/placements/placements_query.rb
+++ b/app/queries/placements/placements_query.rb
@@ -7,7 +7,7 @@ class Placements::PlacementsQuery < ApplicationQuery
     scope = school_condition(scope)
     scope = partner_school_condition(scope)
     scope = subject_condition(scope)
-    scope = placements_to_show(scope)
+    scope = placements_to_show_condition(scope)
     scope = year_group_condition(scope)
     order_condition(scope)
   end
@@ -34,7 +34,7 @@ class Placements::PlacementsQuery < ApplicationQuery
     scope.where(school_id: provider.partner_schools.select(:id))
   end
 
-  def placements_to_show(scope)
+  def placements_to_show_condition(scope)
     case filter_params[:placements_to_show]
     when "available_placements"
       scope.where(provider_id: nil)

--- a/app/queries/placements/placements_query.rb
+++ b/app/queries/placements/placements_query.rb
@@ -7,7 +7,7 @@ class Placements::PlacementsQuery < ApplicationQuery
     scope = school_condition(scope)
     scope = partner_school_condition(scope)
     scope = subject_condition(scope)
-    scope = only_available_placements_condition(scope)
+    scope = placements_to_show(scope)
     scope = year_group_condition(scope)
     order_condition(scope)
   end
@@ -34,10 +34,15 @@ class Placements::PlacementsQuery < ApplicationQuery
     scope.where(school_id: provider.partner_schools.select(:id))
   end
 
-  def only_available_placements_condition(scope)
-    return scope if filter_params[:only_available_placements].blank?
-
-    scope.where(provider_id: nil)
+  def placements_to_show(scope)
+    case filter_params[:placements_to_show]
+    when "available_placements"
+      scope.where(provider_id: nil)
+    when "assigned_to_me"
+      scope.where(provider_id: params[:current_provider].id)
+    else
+      scope
+    end
   end
 
   def year_group_condition(scope)

--- a/app/views/placements/placements/_filter.html.erb
+++ b/app/views/placements/placements/_filter.html.erb
@@ -44,20 +44,6 @@
             </ul>
           <% end %>
 
-          <% if filter_form.only_available_placements.present? %>
-            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".availability") %></h3>
-            <ul class="app-filter-tags">
-              <li>
-                <%= govuk_link_to(
-                      t(".availability"),
-                      filter_form.index_path_without_filter(filter: "only_available_placements", value: true),
-                      class: "app-filter__tag",
-                      no_visited_state: true,
-                    ) %>
-              </li>
-            </ul>
-          <% end %>
-
           <% if filter_form.school_ids.present? %>
             <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".school") %></h3>
             <ul class="app-filter-tags">
@@ -131,6 +117,31 @@
           <%= form.hidden_field :search_location, value: search_location %>
 
           <div class="app-filter__option">
+            <%= form.govuk_radio_buttons_fieldset(
+              :placements_to_show,
+              legend: { text: t(".placements_to_show_title"), size: "s" },
+              small: true,
+              multiple: false,
+            ) do %>
+              <%= form.govuk_radio_button :placements_to_show,
+                :available_placements,
+                label: { text: t(".placements_to_show.available_placements") },
+                checked: filter_form.placements_to_show == "available_placements",
+                multiple: false %>
+              <%= form.govuk_radio_button :placements_to_show,
+                :assigned_to_me,
+                label: { text: t(".placements_to_show.assigned_to_me") },
+                checked: filter_form.placements_to_show == "assigned_to_me",
+                multiple: false %>
+              <%= form.govuk_radio_button :placements_to_show,
+                :all_placements,
+                label: { text: t(".placements_to_show.all_placements") },
+                checked: filter_form.placements_to_show == "all_placements",
+                multiple: false %>
+            <% end %>
+          </div>
+
+          <div class="app-filter__option">
             <%= form.govuk_check_boxes_fieldset(
               :only_partner_schools,
               legend: { text: t(".partner_schools"), size: "s" },
@@ -144,22 +155,6 @@
                                        multiple: false,
                                        checked: filter_form.only_partner_schools == true %>
 
-            <% end %>
-          </div>
-
-          <div class="app-filter__option">
-            <%= form.govuk_check_boxes_fieldset(
-              :only_available_placements,
-              legend: { text: t(".availability"), size: "s" },
-              small: true,
-              multiple: false,
-            ) do %>
-
-              <%= form.govuk_check_box :only_available_placements,
-                                       true,
-                                       label: { text: t(".available_text") },
-                                       checked: filter_form.only_available_placements.present?,
-                                       multiple: false %>
             <% end %>
           </div>
 

--- a/config/locales/en/placements/placements.yml
+++ b/config/locales/en/placements/placements.yml
@@ -21,11 +21,14 @@ en:
         subject: Subject
         school_phase: School phase
         establishment_group: Establishment group
-        availability: Placements available
-        available_text: Only show placements open to accepting trainees
         gender: Gender
         religious_character: Religious character
         ofsted_rating: Ofsted rating
+        placements_to_show_title: Placements to show
+        placements_to_show:
+          available_placements: Available placements
+          assigned_to_me: Assigned to me
+          all_placements: All placements
         year_group: Primary year group
       show:
         page_title: "%{subject_name} - Placements - %{school_name}"

--- a/spec/forms/placements/placements/filter_form_spec.rb
+++ b/spec/forms/placements/placements/filter_form_spec.rb
@@ -8,14 +8,6 @@ describe Placements::Placements::FilterForm, type: :model do
   describe "#filters_selected?" do
     subject(:filter_form) { described_class.new(params).filters_selected? }
 
-    context "when given only available placements params" do
-      let(:params) { { only_available_placements: true } }
-
-      it "returns true" do
-        expect(filter_form).to eq(true)
-      end
-    end
-
     context "when given school id params" do
       let(:params) { { school_ids: %w[school_id] } }
 
@@ -62,30 +54,13 @@ describe Placements::Placements::FilterForm, type: :model do
 
     it "returns the placements index page path" do
       expect(filter_form.clear_filters_path).to eq(
-        placements_placements_path,
+        placements_placements_path(filters: { placements_to_show: "available_placements" }),
       )
     end
   end
 
   describe "index_path_without_filter" do
     subject(:filter_form) { described_class.new(params) }
-
-    context "when removing available params" do
-      let(:params) do
-        { only_available_placements: true }
-      end
-
-      it "returns the placements index page path without the given available param" do
-        expect(
-          filter_form.index_path_without_filter(
-            filter: "only_available_placements",
-            value: true,
-          ),
-        ).to eq(
-          placements_placements_path,
-        )
-      end
-    end
 
     context "when removing school id params" do
       let(:params) do
@@ -100,6 +75,7 @@ describe Placements::Placements::FilterForm, type: :model do
           ),
         ).to eq(
           placements_placements_path(filters: {
+            placements_to_show: "available_placements",
             school_ids: %w[school_id_2],
           }),
         )
@@ -118,7 +94,7 @@ describe Placements::Placements::FilterForm, type: :model do
             value: false,
           ),
         ).to eq(
-          placements_placements_path(filters: {}),
+          placements_placements_path(filters: { placements_to_show: "available_placements" }),
         )
       end
     end
@@ -136,6 +112,7 @@ describe Placements::Placements::FilterForm, type: :model do
           ),
         ).to eq(
           placements_placements_path(filters: {
+            placements_to_show: "available_placements",
             subject_ids: %w[subject_id_2],
           }),
         )
@@ -163,9 +140,10 @@ describe Placements::Placements::FilterForm, type: :model do
   end
 
   describe "#query_params" do
-    it "returns { only_partner_schools: false, school_ids: [], subject_ids: [] }" do
+    it "returns the expected result" do
       expect(described_class.new.query_params).to eq(
         {
+          placements_to_show: "available_placements",
           school_ids: [],
           only_partner_schools: false,
           subject_ids: [],

--- a/spec/forms/placements/placements/filter_form_spec.rb
+++ b/spec/forms/placements/placements/filter_form_spec.rb
@@ -132,6 +132,7 @@ describe Placements::Placements::FilterForm, type: :model do
           ),
         ).to eq(
           placements_placements_path(filters: {
+            placements_to_show: "available_placements",
             year_groups: %w[year_group_2],
           }),
         )
@@ -148,7 +149,6 @@ describe Placements::Placements::FilterForm, type: :model do
           only_partner_schools: false,
           subject_ids: [],
           year_groups: [],
-          only_available_placements: false,
         },
       )
     end


### PR DESCRIPTION
## Context

Designs have been updated to support a radio button selection of filters instead of just available placements

## Changes proposed in this pull request

- [x] Removed references to available placements
- [x] Added the new Placements to show filter
- [x] Updated the filter form logic to exclude this filter from the selected filters list
- [x] Updated the placement query to support this filter
- [x] Updated the filter form specs to work with these changes

## Guidance to review

- Log in as Patricia
- Make a note of the organisation
- Log out
- Log in as Anne
- Create a placement, assign it to the same organisation that Patricia is in
- Create a second placement assigned to a different organisation
- Log out
- Log in as Patricia
- Navigate to Placements
- Verify that Available placements is selected by default, all placements should be available
- Change the filter to Assigned to me, there should be 1 unavailable placement
- Change the Placements to show filter to all placements, there should be 2 unavailable placements

## Link to Trello card

[Implement the 'Placements to show' search filter](https://trello.com/c/pwv8cvSD)

## Screenshots

![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/45e55cf1-fbe9-4944-b695-d51a539b5ad7)