### PR TITLE
Remove establishment group search filter

### DIFF
--- a/app/forms/placements/placements/filter_form.rb
+++ b/app/forms/placements/placements/filter_form.rb
@@ -3,7 +3,6 @@ class Placements::Placements::FilterForm < ApplicationForm
 
   attribute :school_ids, default: []
   attribute :subject_ids, default: []
-  attribute :establishment_groups, default: []
   attribute :only_partner_schools, :boolean, default: false
   attribute :only_available_placements, :boolean, default: false
 
@@ -37,7 +36,6 @@ class Placements::Placements::FilterForm < ApplicationForm
     {
       school_ids:,
       subject_ids:,
-      establishment_groups:,
       only_partner_schools:,
       only_available_placements:,
     }

--- a/app/javascript/controllers/placements_filter_search_controller.js
+++ b/app/javascript/controllers/placements_filter_search_controller.js
@@ -9,8 +9,6 @@ export default class extends Controller {
     "schoolList",
     "subjectInput",
     "subjectList",
-    "establishmentGroupInput",
-    "establishmentGroupList",
   ];
 
   connect() {
@@ -24,10 +22,6 @@ export default class extends Controller {
 
     if (this.subjectInputTarget.value !== "") {
       this.searchSubject();
-    }
-
-    if (this.establishmentGroupInputTarget.value !== "") {
-      this.searchEstablishmentGroup();
     }
   }
 
@@ -50,13 +44,6 @@ export default class extends Controller {
     const searchValue = this.subjectInputTarget.value.toLowerCase();
 
     this.toggleItems(subjectItems, searchValue);
-  }
-
-  searchEstablishmentGroup() {
-    const establishmentGroupItems = this.establishmentGroupListTarget.children;
-    const searchValue = this.establishmentGroupInputTarget.value.toLowerCase();
-
-    this.toggleItems(establishmentGroupItems, searchValue);
   }
 
   toggleItems(items, searchValue) {

--- a/app/queries/placements/placements_query.rb
+++ b/app/queries/placements/placements_query.rb
@@ -7,7 +7,6 @@ class Placements::PlacementsQuery < ApplicationQuery
     scope = school_condition(scope)
     scope = partner_school_condition(scope)
     scope = subject_condition(scope)
-    scope = establishment_group_condition(scope)
     scope = only_available_placements_condition(scope)
     order_condition(scope)
   end
@@ -24,12 +23,6 @@ class Placements::PlacementsQuery < ApplicationQuery
     return scope if filter_params[:subject_ids].blank?
 
     scope.where(subject_id: filter_params[:subject_ids])
-  end
-
-  def establishment_group_condition(scope)
-    return scope if filter_params[:establishment_groups].blank?
-
-    scope.where(schools: { group: filter_params[:establishment_groups] })
   end
 
   def partner_school_condition(scope)

--- a/app/views/placements/placements/_filter.html.erb
+++ b/app/views/placements/placements/_filter.html.erb
@@ -97,26 +97,6 @@
               <% end %>
             </ul>
           <% end %>
-
-          <% if filter_form.establishment_groups.present? %>
-            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".establishment_group") %></h3>
-            <ul class="app-filter-tags">
-              <% filter_form.establishment_groups.each do |establishment_group| %>
-                <li>
-                  <%= govuk_link_to(
-                    establishment_group,
-                    filter_form.index_path_without_filter(
-                      filter: "establishment_groups",
-                      value: establishment_group,
-                      search_location:,
-                    ),
-                    class: "app-filter__tag",
-                    no_visited_state: true,
-                  ) %>
-                </li>
-              <% end %>
-            </ul>
-          <% end %>
         </div>
       <% end %>
 
@@ -210,31 +190,6 @@
                 <%= form.govuk_check_box :subject_ids,
                   subject.id,
                   label: { text: subject.name } %>
-              <% end %>
-            <% end %>
-          </div>
-
-          <div class="app-filter__option">
-            <%= form.govuk_text_field(
-              :search_establishment_groups,
-              type: :search,
-              data: {
-                placements_filter_search_target: "establishmentGroupInput",
-                action: "input->placements-filter-search#searchEstablishmentGroup",
-              },
-              label: { text: t(".establishment_group"), size: "s" },
-            ) %>
-
-            <%= form.govuk_check_boxes_fieldset(
-              :establishment_groups,
-              legend: { hidden: true },
-              data: { placements_filter_search_target: "establishmentGroupList" },
-              small: true,
-            ) do %>
-              <% @establishment_groups.each do |establishment_groups| %>
-                <%= form.govuk_check_box :establishment_groups,
-                  establishment_groups,
-                  label: { text: establishment_groups } %>
               <% end %>
             <% end %>
           </div>

--- a/spec/forms/placements/placements/filter_form_spec.rb
+++ b/spec/forms/placements/placements/filter_form_spec.rb
@@ -32,14 +32,6 @@ describe Placements::Placements::FilterForm, type: :model do
       end
     end
 
-    context "when given establishment group params" do
-      let(:params) { { establishment_groups: %w[Colleges] } }
-
-      it "returns true" do
-        expect(filter_form).to eq(true)
-      end
-    end
-
     context "when given partner school params" do
       let(:params) { { only_partner_schools: true } }
 
@@ -141,34 +133,14 @@ describe Placements::Placements::FilterForm, type: :model do
         )
       end
     end
-
-    context "when removing establishment group params" do
-      let(:params) do
-        { establishment_groups: ["Academies", "Independent schools"] }
-      end
-
-      it "returns the placements index page path without the given establishment group param" do
-        expect(
-          filter_form.index_path_without_filter(
-            filter: "establishment_groups",
-            value: "Independent schools",
-          ),
-        ).to eq(
-          placements_placements_path(filters: {
-            establishment_groups: %w[Academies],
-          }),
-        )
-      end
-    end
   end
 
   describe "#query_params" do
-    it "returns { only_partner_schools: false, school_ids: [], subject_ids: [], establishment_groups: [] }" do
+    it "returns { only_partner_schools: false, school_ids: [], subject_ids: [] }" do
       expect(described_class.new.query_params).to eq(
         {
           school_ids: [],
           only_partner_schools: false,
-          establishment_groups: [],
           subject_ids: [],
           only_available_placements: false,
         },

--- a/spec/system/placements/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/placements/view_placements_list_spec.rb
@@ -94,16 +94,6 @@ RSpec.describe "Placements / Placements / View placements list",
       and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
     end
 
-    scenario "User can filter placements by establishment group" do
-      when_i_visit_the_placements_index_page
-      then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
-      and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
-      when_i_check_filter_option("establishment-groups", "free-schools")
-      and_i_click_on("Apply filters")
-      then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
-      and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
-    end
-
     context "when a filter is pre-selected in the URL params" do
       scenario "User can remove the available filter" do
         when_i_visit_the_placements_index_page({ filters: { only_available_placements: true } })
@@ -150,17 +140,6 @@ RSpec.describe "Placements / Placements / View placements list",
         and_i_can_not_see_any_selected_filters
       end
 
-      scenario "User can remove a establishment group filter" do
-        when_i_visit_the_placements_index_page({ filters: { establishment_groups: ["Free Schools"] } })
-        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
-        and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
-        and_i_can_see_a_preset_filter("Establishment group", "Free Schools")
-        when_i_click_to_remove_filter("Establishment group", "Free Schools")
-        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
-        and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
-        and_i_can_not_see_any_selected_filters
-      end
-
       scenario "User can clear all filters" do
         given_a_partnership_exists_between(provider, primary_school)
         when_i_visit_the_placements_index_page(
@@ -170,7 +149,6 @@ RSpec.describe "Placements / Placements / View placements list",
               only_partner_schools: true,
               school_ids: [primary_school.id],
               subject_ids: [subject_1.id],
-              establishment_groups: ["Free Schools"],
             },
           },
         )
@@ -180,7 +158,6 @@ RSpec.describe "Placements / Placements / View placements list",
         and_i_can_see_a_preset_filter("Partner schools", "Partner schools")
         and_i_can_see_a_preset_filter("School", "Primary School")
         and_i_can_see_a_preset_filter("Subject", "Primary with mathematics")
-        and_i_can_see_a_preset_filter("Establishment group", "Free Schools")
         when_i_click_on("Clear filters")
         then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
         and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")


### PR DESCRIPTION
## Context

- Remove Establishment group from search filter

## Guidance to review

- Sign in as Patricia
- Navigate to "Placements" in Navbar
- Establishment group should no longer appear in the filters

## Link to Trello card

https://trello.com/c/3vV6Jzc1/432-remove-the-establishment-group-search-filter

## Screenshots
![screencapture-placements-localhost-3000-placements-2024-06-04-13_56_11](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/c8f3d0d4-a5df-473d-854f-0bf60295c315)


