### PR TITLE
Rename "Users" to "Support users" in the support console

### DIFF
--- a/config/locales/en/placements/support/primary_navigation.yml
+++ b/config/locales/en/placements/support/primary_navigation.yml
@@ -2,5 +2,5 @@ en:
   placements:
     support:
       primary_navigation:
-        users: Users
+        users: Support users
         organisations: Organisations

--- a/config/locales/en/placements/support/support_users.yml
+++ b/config/locales/en/placements/support/support_users.yml
@@ -3,13 +3,13 @@ en:
     support:
       support_users:
         index:
-          page_title: Users
-          add_user: Add user
-          heading: Users
+          page_title: Support users
+          add_user: Add support user
+          heading: Support users
         new:
-          page_title: Personal details - Add user
-          page_title_with_errors: "Error: Personal details - Add user"
-          caption: Add user
+          page_title: Personal details - Add support user
+          page_title_with_errors: "Error: Personal details - Add support user"
+          caption: Add support user
           title: Personal details
           submit: Continue
           cancel: Cancel
@@ -17,24 +17,24 @@ en:
             email:
               hint: Email must be a valid Department for Education address, like name@education.gov.uk
         check:
-          page_title: Check your answers - Add user
-          caption: Add user
+          page_title: Check your answers - Add support user
+          caption: Add support user
           title: Check your answers
-          submit: Add user
+          submit: Add support user
           cancel: Cancel
           change: Change
-          warning: The user will be sent an email to tell them you’ve added them to Manage school placements.
+          warning: The support user will be sent an email to tell them you’ve added them to Manage school placements.
         create:
-          success: User added
+          success: Support user added
         show:
           change: Change
-          remove_user: Remove user
+          remove_user: Remove support user
         remove:
-          page_title: Are you sure you want to remove this user? - %{user_name}
-          title: Are you sure you want to remove this user?
-          warning: The user will be sent an email to tell them you removed them from Manage school placements.
-          submit: Remove user
+          page_title: Are you sure you want to remove this support user? - %{user_name}
+          title: Are you sure you want to remove this support user?
+          warning: The support user will be sent an email to tell them you removed them from Manage school placements.
+          submit: Remove support user
           cancel: Cancel
         destroy:
-          success: User removed
-          failure: There was a problem removing the user
+          success: Support user removed
+          failure: There was a problem removing the support user

--- a/spec/system/placements/support/organisations/support_filtering_and_searching_for_organisation_spec.rb
+++ b/spec/system/placements/support/organisations/support_filtering_and_searching_for_organisation_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe "Support user filters and searches for organisations", type: :sys
   def then_i_see_support_navigation_with_organisation_selected
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Organisations", current: "page"
-      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Support users", current: "false"
     end
   end
 

--- a/spec/system/placements/support/organisations/support_user_selects_an_organisation_type_to_add_spec.rb
+++ b/spec/system/placements/support/organisations/support_user_selects_an_organisation_type_to_add_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "Placements / Support / Organisations / Support User Selects An O
   def then_i_see_support_navigation_with_organisation_selected
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Organisations", current: "page"
-      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Support users", current: "false"
     end
   end
 

--- a/spec/system/placements/support/providers/partner_schools/support_user_adds_a_partner_school_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/support_user_adds_a_partner_school_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
   def then_i_see_support_navigation_with_organisation_selected
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Organisations", current: "page"
-      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Support users", current: "false"
     end
   end
 

--- a/spec/system/placements/support/providers/partner_schools/support_user_adds_a_partner_school_without_javascript_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/support_user_adds_a_partner_school_without_javascript_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
   def then_i_see_support_navigation_with_organisation_selected
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Organisations", current: "page"
-      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Support users", current: "false"
     end
   end
 

--- a/spec/system/placements/support/providers/partner_schools/support_user_remove_a_partner_school_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/support_user_remove_a_partner_school_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
   def then_i_see_support_navigation_with_organisation_selected
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Organisations", current: "page"
-      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Support users", current: "false"
     end
   end
 

--- a/spec/system/placements/support/providers/partner_schools/view_a_partner_school_as_support_user_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/view_a_partner_school_as_support_user_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Placements / Support/ Providers / Partner schools / View a partn
   def then_i_see_support_navigation_with_organisation_selected
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Organisations", current: "page"
-      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Support users", current: "false"
     end
   end
 

--- a/spec/system/placements/support/providers/partner_schools/view_partner_school_list_as_support_user_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/view_partner_school_list_as_support_user_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Placements / Support / Providers / Partner schools / View a part
   def then_i_see_support_navigation_with_organisation_selected
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Organisations", current: "page"
-      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Support users", current: "false"
     end
   end
 

--- a/spec/system/placements/support/providers/support_user_adds_a_provider_spec.rb
+++ b/spec/system/placements/support/providers/support_user_adds_a_provider_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Placements / Support / Providers / Support User adds a Provider"
   def then_i_see_support_navigation_with_organisation_selected
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Organisations", current: "page"
-      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Support users", current: "false"
     end
   end
 

--- a/spec/system/placements/support/providers/support_user_adds_a_provider_without_javascript_spec.rb
+++ b/spec/system/placements/support/providers/support_user_adds_a_provider_without_javascript_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe "Support User adds a Provider without JavaScript", type: :system,
   def then_i_see_support_navigation_with_organisation_selected
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Organisations", current: "page"
-      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Support users", current: "false"
     end
   end
 

--- a/spec/system/placements/support/schools/mentors/support_user_adds_a_mentor_spec.rb
+++ b/spec/system/placements/support/schools/mentors/support_user_adds_a_mentor_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe "Placements support user adds mentors to schools", type: :system,
   def expect_organisations_to_be_selected_in_primary_navigation
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Organisations", current: "page"
-      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Support users", current: "false"
     end
   end
 

--- a/spec/system/placements/support/schools/mentors/support_user_removes_a_mentor_spec.rb
+++ b/spec/system/placements/support/schools/mentors/support_user_removes_a_mentor_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "Placements / Support / Schools / Mentor / Support User removes a
   def organisations_is_selected_in_primary_nav
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Organisations", current: "page"
-      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Support users", current: "false"
     end
   end
 

--- a/spec/system/placements/support/schools/partner_providers/support_user_adds_a_partner_provider_spec.rb
+++ b/spec/system/placements/support/schools/partner_providers/support_user_adds_a_partner_provider_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe "Placements / Support / Schools / Partner providers / Support use
   def then_i_see_support_navigation_with_organisation_selected
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Organisations", current: "page"
-      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Support users", current: "false"
     end
   end
 

--- a/spec/system/placements/support/schools/partner_providers/support_user_adds_a_partner_provider_without_javascript_spec.rb
+++ b/spec/system/placements/support/schools/partner_providers/support_user_adds_a_partner_provider_without_javascript_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe "Placements / Support / Schools / Partner providers / Support use
   def then_i_see_support_navigation_with_organisation_selected
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Organisations", current: "page"
-      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Support users", current: "false"
     end
   end
 

--- a/spec/system/placements/support/schools/partner_providers/support_user_removes_a_partner_provider_spec.rb
+++ b/spec/system/placements/support/schools/partner_providers/support_user_removes_a_partner_provider_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe "Placements / Support / Schools / Partner providers / Support use
   def then_i_see_support_navigation_with_organisation_selected
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Organisations", current: "page"
-      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Support users", current: "false"
     end
   end
 

--- a/spec/system/placements/support/schools/partner_providers/view_a_partner_provider_as_support_user_spec.rb
+++ b/spec/system/placements/support/schools/partner_providers/view_a_partner_provider_as_support_user_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Placements / Support / Schools / Partner providers / View a part
   def then_i_see_support_navigation_with_organisation_selected
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Organisations", current: "page"
-      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Support users", current: "false"
     end
   end
 

--- a/spec/system/placements/support/schools/partner_providers/view_partner_school_list_as_support_user_spec.rb
+++ b/spec/system/placements/support/schools/partner_providers/view_partner_school_list_as_support_user_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Placements / Support / Schools / Partner providers / View partne
   def then_i_see_support_navigation_with_organisation_selected
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Organisations", current: "page"
-      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Support users", current: "false"
     end
   end
 

--- a/spec/system/placements/support/schools/placements/support_user_removes_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/support_user_removes_a_placement_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "Placements / Support / Schools / Placement / Support User remove
   def organisations_is_selected_in_primary_nav
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Organisations", current: "page"
-      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Support users", current: "false"
     end
   end
 

--- a/spec/system/placements/support/support_users/support_user_adds_a_support_user_spec.rb
+++ b/spec/system/placements/support/support_users/support_user_adds_a_support_user_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Placements / Support Users / Support user adds a support user",
     and_i_click_on_add_a_support_user
     and_i_fill_in_the_support_user_form(email_address: "john.doe@example.com")
     then_i_see_an_error("Enter a Department for Education email address in the correct format, like name@education.gov.uk")
-    and_the_page_title_is("Error: Personal details - Add user - Manage school placements")
+    and_the_page_title_is("Error: Personal details - Add support user - Manage school placements")
   end
 
   scenario "Attempt to add a support user with an email that already exists in the system" do
@@ -38,7 +38,7 @@ RSpec.describe "Placements / Support Users / Support user adds a support user",
     and_i_click_on_add_a_support_user
     and_i_fill_in_the_support_user_form(email_address: "john.doe@education.gov.uk")
     then_i_see_an_error("Email address already in use")
-    and_the_page_title_is("Error: Personal details - Add user - Manage school placements")
+    and_the_page_title_is("Error: Personal details - Add support user - Manage school placements")
   end
 
   scenario "Make changes while adding a support user" do
@@ -68,12 +68,12 @@ RSpec.describe "Placements / Support Users / Support user adds a support user",
 
   def and_i_visit_the_support_users_page
     within(".app-primary-navigation nav") do
-      click_on "Users"
+      click_on "Support users"
     end
   end
 
   def and_i_click_on_add_a_support_user
-    click_on "Add user"
+    click_on "Add support user"
   end
 
   def when_i_fill_in_the_support_user_form(email_address:)
@@ -94,12 +94,12 @@ RSpec.describe "Placements / Support Users / Support user adds a support user",
   end
 
   def when_i_click_on_add_user
-    click_on "Add user"
+    click_on "Add support user"
   end
   alias_method :and_i_click_on_add_user, :when_i_click_on_add_user
 
   def then_i_see_the_support_user_has_been_added(email_address:)
-    expect(page).to have_content "User added"
+    expect(page).to have_content "Support user added"
     expect(page).to have_content email_address
   end
 

--- a/spec/system/placements/support/support_users/support_user_re_adds_a_discarded_support_user_spec.rb
+++ b/spec/system/placements/support/support_users/support_user_re_adds_a_discarded_support_user_spec.rb
@@ -93,12 +93,12 @@ RSpec.describe "Placements / Support Users / Support user re-adds a discarded su
 
   def and_i_visit_the_support_users_page
     within(".app-primary-navigation nav") do
-      click_on "Users"
+      click_on "Support users"
     end
   end
 
   def and_i_click_on_add_a_support_user
-    click_on "Add user"
+    click_on "Add support user"
   end
 
   def and_i_fill_in_the_support_user_form(email_address:, first_name:, last_name:)
@@ -120,11 +120,11 @@ RSpec.describe "Placements / Support Users / Support user re-adds a discarded su
   end
 
   def when_i_click_on_add_user
-    click_on "Add user"
+    click_on "Add support user"
   end
 
   def i_see_the_support_user_has_been_added(email_address:)
-    expect(page).to have_content "User added"
+    expect(page).to have_content "Support user added"
     expect(page).to have_content email_address
   end
 

--- a/spec/system/placements/support/support_users/support_user_removes_a_support_user_spec.rb
+++ b/spec/system/placements/support/support_users/support_user_removes_a_support_user_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Placements / Support Users / Support users removes a support use
 
   def and_i_visit_the_support_users_page
     within(".app-primary-navigation nav") do
-      click_on "Users"
+      click_on "Support users"
     end
   end
 
@@ -50,18 +50,18 @@ RSpec.describe "Placements / Support Users / Support users removes a support use
   end
 
   def when_i_click_on_remove
-    click_on "Remove user"
+    click_on "Remove support user"
   end
   alias_method :and_i_click_on_remove, :when_i_click_on_remove
 
   def then_i_see_the_support_user_removal_confirmation(support_user)
     expect(page).to have_content support_user.full_name
-    expect(page).to have_content "Are you sure you want to remove this user?"
+    expect(page).to have_content "Are you sure you want to remove this support user?"
   end
 
   def then_i_see_the_support_user_has_been_removed(support_user)
     expect(page).not_to have_content support_user.full_name
-    expect(page).to have_content "User removed"
+    expect(page).to have_content "Support user removed"
   end
 
   def then_an_email_is_sent(email)

--- a/spec/system/placements/support/support_users/support_user_views_a_support_user_spec.rb
+++ b/spec/system/placements/support/support_users/support_user_views_a_support_user_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Placements / Support Users / Support user views a support user",
 
   def and_i_visit_the_support_users_page
     within(".app-primary-navigation nav") do
-      click_on "Users"
+      click_on "Support users"
     end
   end
 

--- a/spec/system/placements/support/support_users/support_user_views_support_users_spec.rb
+++ b/spec/system/placements/support/support_users/support_user_views_support_users_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Placements / Support Users / Support user views support users",
 
   def and_i_visit_the_support_users_page
     within(".app-primary-navigation nav") do
-      click_on "Users"
+      click_on "Support users"
     end
   end
 

--- a/spec/system/placements/support/users/support_user_invites_a_new_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_invites_a_new_user_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
   def then_i_see_the_navigation_bars_with_organisations_and_users_selected(organisation)
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Organisations", current: "page"
-      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Support users", current: "false"
     end
 
     within(".app-secondary-navigation") do
@@ -257,7 +257,7 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
   def then_i_see_support_navigation_with_organisation_selected
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Organisations", current: "page"
-      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Support users", current: "false"
     end
   end
 end

--- a/spec/system/placements/support/users/support_user_removes_a_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_removes_a_user_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe "Placements support user removes a user from an organisation", ty
   def organisations_is_selected_in_primary_nav
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Organisations", current: "page"
-      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Support users", current: "false"
     end
   end
 


### PR DESCRIPTION
## Context

Having "Users" twice in the navigation was causing confusion and it was decided that we'd update the primary navigation "Users" to "Support users"

## Changes proposed in this pull request

- [x] Updates the support users translations file
- [x] Fixes a lot of tests as a result of this change 😅 

## Guidance to review

- Log in as Colin
- Verify that there is a Support users link
- Navigate to Support users
- Verify that the button now says "Add support user"
- Go through the add journey to make sure everything is consistent

## Link to Trello card

[Rename "Users" to "Support users" in the support console](https://trello.com/c/kacBdWq8)

## Screenshots

![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/4b12f9ea-31e0-4be2-b4de-777d2427af42)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/3e07885e-26a7-4cb4-ae22-964c611c750b)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/6bc10e15-43aa-4563-816c-a8614eb2c669)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/cbd01a5d-fe9e-4ef6-b25d-31078e325f29)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/df567c96-0296-4b2c-be29-57b4a8c718a5)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/0d44c743-dd85-4e26-88b1-31d1683a0c48)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/3995a153-2460-46fa-861d-351a4301957f)

