### PR TITLE
Use pluralisation for placement search results subheading

### DIFF
--- a/app/views/placements/placements/index.html.erb
+++ b/app/views/placements/placements/index.html.erb
@@ -6,11 +6,7 @@
     <%= t(".placements") %>
   </h1>
   <h2 class="govuk-heading-m">
-    <% if @placements.any? %>
-      <%= t(".placements_found", placements_count: @placements.count) %>
-    <% else %>
-      <%= t(".no_placements_found") %>
-    <% end %>
+    <%= t(".placements_found", count: @placements.count) %>
   </h2>
   <div>
     <button class="govuk-button govuk-button--secondary show-filter-button" type="button" data-action="click->filter#open">

--- a/config/locales/en/placements/providers/placements.yml
+++ b/config/locales/en/placements/providers/placements.yml
@@ -2,8 +2,10 @@ en:
   placements:
     placements:
       index:
-        placements_found: "%{placements_count} placements found"
-        no_placements_found: No school placements found
+        placements_found:
+          zero: No placements found
+          one: 1 placement found
+          other: "%{count} placements found"
         placements: Placements
         no_results_for_filters: There are no results for the selected filter.
         enter_a_location: Enter a location


### PR DESCRIPTION
## Context

Grammatical correctness.

## Changes proposed in this pull request

- [x] Replaces the existing translations for placements found with a pluralisation

## Guidance to review

- Log in as Patricia
- Click on Placements
- See that the text changes based on how many results you have after filtering

## Link to Trello card

[Use pluralisation for placement search results subheading](https://trello.com/c/r4ebHq8P)

## Screenshots

![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/742cb99e-2762-4e2d-aea2-949648a97763)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/999bec98-0157-47ac-a0c3-008624adaf8b)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/3bc13e57-8818-48e2-b95b-7a95a28bbc20)