### PR TITLE
Fix to placment filter search js

### DIFF
--- a/app/javascript/controllers/placements_filter_search_controller.js
+++ b/app/javascript/controllers/placements_filter_search_controller.js
@@ -67,7 +67,6 @@ export default class extends Controller {
         item.style.display = "";
       } else {
         item.style.display = "none";
-        inputField.checked = false;
       }
     });
   }


### PR DESCRIPTION
## Context

- Fix to placements filter search JS, so when searching a filter it doesn't remove pre-selected checkboxes

## Changes proposed in this pull request

- Remove line 70, to stop toggleItems unchecking checkboxes.

## Guidance to review

- Sign in as Patricia.
- Navigate to "Placements" in Navbar.
- Select a checkbox in either the schools or subjects filters.
- Type into the search bar of that filter.
- Clear the search filter.
- The selected filter should still be checked.

## Link to Trello card

https://trello.com/c/EDAUUu7h/446-search-filter-component-fix-a-bug-where-the-inline-search-unchecks-previously-checked-options

## Screenshots

https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/0b535878-71e7-46d2-82b9-9183948da45d



