### PR TITLE
Fix broken change link

### DIFF
--- a/app/views/placements/support/schools/mentors/check.html.erb
+++ b/app/views/placements/support/schools/mentors/check.html.erb
@@ -41,7 +41,7 @@
             <% row.with_key(text: t(".date_of_birth")) %>
             <% row.with_value(text: safe_l(@mentor_form.date_of_birth, format: :short)) %>
             <% row.with_action(text: t(".change"),
-                               href: new_placements_school_mentor_path(params: @mentor_form.as_form_params),
+                               href: new_placements_support_school_mentor_path(params: @mentor_form.as_form_params),
                                html_attributes: {
                                  class: "govuk-link--no-visited-state",
                                }) %>


### PR DESCRIPTION
## Context

- Fix broken change like on Mentor check your answers page

## Guidance to review

- Sign in as Colin (Support User)
- Select a school
- Navigate to "Mentors" in navbar
- Click the "Add mentor" button
- Complete the Add mentor form
- Once on the "Check your answers" page, check the "Change" links redirect back to the previous page.

## Link to Trello card

https://trello.com/c/zbmPhroZ/447-fix-a-broken-change-link-in-the-support-console

## Screenshots

https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/0d087cb6-cd4b-4eeb-a147-0b322030b973


