### PR TITLE
Jc/add status to support placements index

### DIFF
--- a/app/views/placements/placements/_table.html.erb
+++ b/app/views/placements/placements/_table.html.erb
@@ -13,7 +13,7 @@
         <% if support %>
           <% row.with_cell(text: govuk_link_to(
             placement.title,
-            placements_support_school_placement_path(@school, placement),
+            placements_support_school_placement_path(school, placement),
           )) %>
         <% else %>
           <% row.with_cell(text: govuk_link_to(

--- a/app/views/placements/placements/_table.html.erb
+++ b/app/views/placements/placements/_table.html.erb
@@ -14,11 +14,13 @@
           <% row.with_cell(text: govuk_link_to(
             placement.title,
             placements_support_school_placement_path(school, placement),
+            no_visited_state: true,
           )) %>
         <% else %>
           <% row.with_cell(text: govuk_link_to(
             placement.title,
             placements_school_placement_path(school, placement),
+            no_visited_state: true,
           )) %>
         <% end %>
         <% row.with_cell(text: placement.mentor_names) %>

--- a/app/views/placements/placements/_table.html.erb
+++ b/app/views/placements/placements/_table.html.erb
@@ -1,0 +1,31 @@
+<%# locals: (school:, placements: [], support: false) -%>
+<%= app_table do |table| %>
+  <% table.with_head do |head| %>
+    <% head.with_row do |row| %>
+      <% row.with_cell(header: true, text: t(".subject")) %>
+      <% row.with_cell(header: true, text: t(".mentor")) %>
+      <% row.with_cell(header: true, text: t(".status")) %>
+    <% end %>
+  <% end %>
+  <% table.with_body do |body| %>
+    <% placements.each do |placement| %>
+      <% body.with_row do |row| %>
+        <% if support %>
+          <% row.with_cell(text: govuk_link_to(
+            placement.title,
+            placements_support_school_placement_path(@school, placement),
+          )) %>
+        <% else %>
+          <% row.with_cell(text: govuk_link_to(
+            placement.title,
+            placements_school_placement_path(school, placement),
+          )) %>
+        <% end %>
+        <% row.with_cell(text: placement.mentor_names) %>
+        <% row.with_cell do %>
+          <%= render Placement::StatusTagComponent.new(placement:) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/placements/schools/placements/index.html.erb
+++ b/app/views/placements/schools/placements/index.html.erb
@@ -8,29 +8,7 @@
         <%= govuk_button_to(t(".add_placement"), new_placements_school_placement_build_path(@school, placement_id: "new_placement"), method: :get) %>
 
         <% if @placements.any? %>
-          <%= app_table do |table| %>
-            <% table.with_head do |head| %>
-              <% head.with_row do |row| %>
-                <% row.with_cell(header: true, text: t(".subject")) %>
-                <% row.with_cell(header: true, text: t(".mentor")) %>
-                <% row.with_cell(header: true, text: t(".status")) %>
-              <% end %>
-            <% end %>
-            <% table.with_body do |body| %>
-              <% @placements.each do |placement| %>
-                <% body.with_row do |row| %>
-                  <% row.with_cell(text: govuk_link_to(
-                    placement.title,
-                    placements_school_placement_path(@school, placement),
-                  )) %>
-                  <% row.with_cell(text: placement.mentor_names) %>
-                  <% row.with_cell do %>
-                    <%= render Placement::StatusTagComponent.new(placement:) %>
-                  <% end %>
-                <% end %>
-              <% end %>
-            <% end %>
-          <% end %>
+          <%= render "placements/placements/table", school: @school, placements: @placements %>
           <%= render PaginationComponent.new(pagy: @pagy) %>
         <% else %>
           <p>

--- a/app/views/placements/support/schools/placements/index.html.erb
+++ b/app/views/placements/support/schools/placements/index.html.erb
@@ -9,25 +9,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l"><%= t(".placements") %></h1>
       <% if @placements.any? %>
-        <%= app_table do |table| %>
-          <% table.with_head do |head| %>
-            <% head.with_row do |row| %>
-              <% row.with_cell(header: true, text: t(".subject")) %>
-              <% row.with_cell(header: true, text: t(".mentor")) %>
-            <% end %>
-          <% end %>
-          <% table.with_body do |body| %>
-            <% @placements.each do |placement| %>
-              <% body.with_row do |row| %>
-                <% row.with_cell(text: govuk_link_to(
-                  placement.title,
-                  placements_support_school_placement_path(@school, placement),
-                )) %>
-                <% row.with_cell(text: placement.mentor_names) %>
-              <% end %>
-            <% end %>
-          <% end %>
-        <% end %>
+        <%= render "placements/placements/table", school: @school, placements: @placements, support: true %>
         <%= render PaginationComponent.new(pagy: @pagy) %>
       <% else %>
         <p>

--- a/config/locales/en/placements/placements.yml
+++ b/config/locales/en/placements/placements.yml
@@ -1,6 +1,11 @@
 en:
   placements:
     placements:
+      table:
+        subject: Subject
+        mentor: Mentor
+        status: Status
+        not_entered: Not entered
       index:
         placements_found:
           zero: No placements found

--- a/config/locales/en/placements/placements.yml
+++ b/config/locales/en/placements/placements.yml
@@ -5,7 +5,6 @@ en:
         subject: Subject
         mentor: Mentor
         status: Status
-        not_entered: Not entered
       index:
         placements_found:
           zero: No placements found

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -135,10 +135,6 @@ en:
         index:
           page_title: Placements
           placements: Placements
-          subject: Subject
-          mentor: Mentor
-          status: Status
-          not_entered: Not entered
           add_placement: Add placement
           you_must_add_itt_placement_contact: |
             You must add the %{link_to} email before adding a placement

--- a/config/locales/en/placements/support/schools/placements.yml
+++ b/config/locales/en/placements/support/schools/placements.yml
@@ -6,10 +6,6 @@ en:
           index:
             page_title: Placements
             placements: Placements
-            subject: Subject
-            mentor: Mentor
-            status: Status
-            not_entered: Not entered
             add_placement: Add placement
           remove:
             page_title: "Are you sure you want to remove this placement? - %{subject_names}"


### PR DESCRIPTION
## Context

- Use shared partial for placements index view (visible by support and school users)

## Changes proposed in this pull request

- Introduce shared partial for placements index view (visible by support and school users)

## Guidance to review

- Sign in as Anne (School User)
- Navigate to Placements, using the navbar
- Placements table should show Subject, Mentor, Status

- Sign in as Colin (Support User)
- Select a school
- Navigate to Placements, using the navbar
- Placements table should show Subject, Mentor, Status

## Link to Trello card

https://trello.com/c/GLBWIaja/448-add-status-column-to-placements-table-in-the-support-console

## Screenshots
_School User_
![screencapture-placements-localhost-3000-schools-00000563-7933-4495-a84e-7a35228d4c1b-placements-2024-06-04-17_07_13](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/76213f4d-029c-4f3b-8940-caf6d7eb9321)

_Support User_
![screencapture-placements-localhost-3000-support-schools-00000563-7933-4495-a84e-7a35228d4c1b-placements-2024-06-04-17_08_27](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/d2ebe26b-79f0-4847-ad37-a78825b985ee)
