### PR TITLE
Support console – include organisation name in page captions

### DIFF
--- a/app/views/placements/support/providers/partner_schools/remove.html.erb
+++ b/app/views/placements/support/providers/partner_schools/remove.html.erb
@@ -10,7 +10,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <label class="govuk-label govuk-label--l">
-        <span class="govuk-caption-l"><%= @partner_school.name %></span>
+        <span class="govuk-caption-l"><%= "#{@partner_school.name} - #{@provider.name}" %></span>
         <%= t(".are_you_sure") %>
       </label>
       <%= render GovukComponent::WarningTextComponent.new(

--- a/app/views/placements/support/schools/partner_providers/remove.html.erb
+++ b/app/views/placements/support/schools/partner_providers/remove.html.erb
@@ -10,7 +10,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <label class="govuk-label govuk-label--l">
-        <span class="govuk-caption-l"><%= @partner_provider.name %></span>
+        <span class="govuk-caption-l"><%= "#{@partner_provider.name} - #{@school.name}" %></span>
         <%= t(".are_you_sure") %>
       </label>
       <%= render GovukComponent::WarningTextComponent.new(

--- a/app/views/placements/support/schools/placements/remove.html.erb
+++ b/app/views/placements/support/schools/placements/remove.html.erb
@@ -10,7 +10,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <label class="govuk-label govuk-label--l">
-        <span class="govuk-caption-l"><%= @placement.title %></span>
+        <span class="govuk-caption-l"><%= "#{@placement.title} - #{@school.name}" %></span>
         <%= t(".are_you_sure") %>
       </label>
 


### PR DESCRIPTION
## Context

Content has been reviewed across the app for inconsistencies, this brings the app back in line with designs.

## Changes proposed in this pull request

- [x] Updates the `remove.html.erb` views to include the organisation name.

## Guidance to review

- Sign in as Colin
- Remove a placement, check the text
- Remove a partner provider, check the text
- Remove a partner school, check the text

## Link to Trello card

[Support console – include organisation name in page captions](https://trello.com/c/LI149XK9)

## Screenshots

![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/3aa534ba-5b89-4d94-9237-d29487da7619)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/7d5c01da-0e5b-4e00-b57c-e6d701f67633)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/efa5025e-b0dc-43b8-a67a-b6543bdf3034)