### PR TITLE
Fix placement count and add spec for when location isn't found

### DIFF
--- a/app/views/placements/placements/index.html.erb
+++ b/app/views/placements/placements/index.html.erb
@@ -6,7 +6,7 @@
     <%= t(".placements") %>
   </h1>
   <h2 class="govuk-heading-m">
-    <%= t(".placements_found", count: @placements.count) %>
+    <%= t(".placements_found", count: @pagy.count) %>
   </h2>
   <div>
     <button class="govuk-button govuk-button--secondary show-filter-button" type="button" data-action="click->filter#open">

--- a/spec/system/placements/placements/searching_for_a_placement_spec.rb
+++ b/spec/system/placements/placements/searching_for_a_placement_spec.rb
@@ -100,6 +100,17 @@ RSpec.describe "Placements / Placements / Searching for a placements list",
     end
   end
 
+  context "when searching for a location that doesn't exist" do
+    before { stub_unknown_geocoder_search }
+
+    scenario "User sees a message that no placements were found" do
+      when_i_visit_the_placements_index_page
+      and_i_fill_in_location_search_with("Chicken")
+      and_i_click_on("Search")
+      expect(page).to have_content("There are no results for the selected filter.")
+    end
+  end
+
   private
 
   def given_i_sign_in_as_patricia
@@ -177,6 +188,14 @@ RSpec.describe "Placements / Placements / Searching for a placements list",
     geocoder_result = instance_double("geocoder_result")
     allow(geocoder_results).to receive(:first).and_return(geocoder_result)
     allow(geocoder_result).to receive(:coordinates).and_return([51.23622, -0.570409])
+    allow(Geocoder).to receive(:search).and_return(geocoder_results)
+  end
+
+  def stub_unknown_geocoder_search
+    geocoder_results = instance_double("geocoder_results")
+    geocoder_result = instance_double("geocoder_result")
+    allow(geocoder_results).to receive(:first).and_return(geocoder_result)
+    allow(geocoder_result).to receive(:coordinates).and_return([55.378051, -3.435973])
     allow(Geocoder).to receive(:search).and_return(geocoder_results)
   end
 end


### PR DESCRIPTION
## Context

- Placement count for results was based on the current page, rather than all results
- Entering a search location with no results threw at 500 error as a result of the placements being counted

## Changes proposed in this pull request

- [x] `@placements` changed to `@pagy`
- [x] Added a spec to prevent this issue slipping through again

## Guidance to review

- Log in as Patricia
- Navigate to the placements tab
- Check that the placement count a reflects the total count rather than the page count (25)
- Search for a location that doesn't exist, e.g. "Chicken"
- Verify the application hasn't given you an error page

## Link to Trello card

[Fix pagination count on the placements search page](https://trello.com/c/d7U71t48/460-fix-pagination-count-on-the-placements-search-page)