### PR TITLE
Add privacy notice

### DIFF
--- a/app/helpers/footer_helper.rb
+++ b/app/helpers/footer_helper.rb
@@ -23,7 +23,7 @@ module FooterHelper
       { text: t(".guidance"), href: "#" },
       { text: t(".accessibility"), href: placements_accessibility_path },
       { text: t(".cookies"), href: placements_cookies_path },
-      { text: t(".privacy_policy"), href: "#" },
+      { text: t(".privacy_policy"), href: placements_privacy_path },
       { text: t(".terms_and_conditions"), href: "#" },
     ]
   end

--- a/app/views/placements/pages/cookies.md
+++ b/app/views/placements/pages/cookies.md
@@ -12,6 +12,6 @@ Essential cookies keep your information secure while you use Manage school place
 | -------- | -------- | -------- |
 | _itt_mentor_services_session | Session cookie to identify the user of the service and their place on multi-step form journeys. | When the user's browser is closed. |
 
-Read more about how we process personal data in our [privacy notice](/privacy_notice).
+Read more about how we process personal data in our [privacy notice](/privacy).
 
 Last updated 10 May 2024

--- a/app/views/placements/pages/privacy.md
+++ b/app/views/placements/pages/privacy.md
@@ -1,0 +1,7 @@
+# Manage school placements privacy notice
+
+Read the [Privacy information: education providers’ workforce, including teachers](https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers).
+
+[Section 8.4](https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers#using-your-data-to-maintain-a-list-of-teachers) tells you what we do with you and your mentor’s data when you make contact with us or use this service.
+
+[Section 4.1](https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers#using-your-datato-contact-you-for-feed) tells you how we use your data to contact you for feedback.

--- a/app/views/placements/pages/privacy.md
+++ b/app/views/placements/pages/privacy.md
@@ -4,4 +4,4 @@ Read the [Privacy information: education providers’ workforce, including teach
 
 [Section 8.4](https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers#using-your-data-to-maintain-a-list-of-teachers) tells you what we do with you and your mentor’s data when you make contact with us or use this service.
 
-[Section 4.1](https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers#using-your-datato-contact-you-for-feed) tells you how we use your data to contact you for feedback.
+[Section 4.1](https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers#using-your-datato-contact-you-for-feedback) tells you how we use your data to contact you for feedback.

--- a/app/views/placements/schools/mentors/check.html.erb
+++ b/app/views/placements/schools/mentors/check.html.erb
@@ -49,12 +49,11 @@
         <% end %>
 
         <p class="govuk-inset-text">
-          <!-- TODO: Replace hardcoded URL with path when available -->
           <%= embedded_link_text(
             t(".confirm_mentor_informed",
               mentor_name: @mentor_form.mentor.full_name,
               link: govuk_link_to(
-                t(".privacy_notice"), "/privacy", no_visited_state: true
+                t(".privacy_notice"), placements_privacy_path, no_visited_state: true
               )),
           ) %>
         </p>

--- a/app/views/placements/support/schools/mentors/check.html.erb
+++ b/app/views/placements/support/schools/mentors/check.html.erb
@@ -49,12 +49,11 @@
         <% end %>
 
         <p class="govuk-inset-text">
-          <!-- TODO: Replace hardcoded URL with path when available -->
           <%= embedded_link_text(
             t(".confirm_mentor_informed",
               mentor_name: @mentor_form.mentor.full_name,
               link: govuk_link_to(
-                t(".privacy_notice"), "/privacy", no_visited_state: true
+                t(".privacy_notice"), placements_privacy_path, no_visited_state: true
               )),
           ) %>
         </p>

--- a/config/locales/en/placements/pages.yml
+++ b/config/locales/en/placements/pages.yml
@@ -14,3 +14,5 @@ en:
           page_title: Cookies on Manage school placements
         accessibility:
           page_title: Accessibility statement for Manage school placements
+        privacy:
+            page_title: Privacy notice for Manage school placements

--- a/spec/helpers/footer_helper_spec.rb
+++ b/spec/helpers/footer_helper_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe FooterHelper do
             { href: "#", text: "Guidance" },
             { href: "/accessibility", text: "Accessibility" },
             { href: "/cookies", text: "Cookies" },
-            { href: "#", text: "Privacy notice" },
+            { href: "/privacy", text: "Privacy notice" },
             { href: "#", text: "Terms and conditions" },
           ],
         )


### PR DESCRIPTION
## Context

We do not have a privacy notice

## Changes proposed in this pull request

- [x] Add a privacy notice

## Guidance to review

- Log in as Anne
- Check the privacy notice link in the footer
- Navigate to Mentors
- Add a mentor
- Continue through to Check your answers
- Check the privacy notice link on the check your answers page
- Log out
- Log in as Colin
- Select an organisation
- Navigate to Mentors
- Add a mentor
- Continue through to Check your answers
- Check the privacy notice link on the check your answers page

## Link to Trello card

[Add the privacy policy page](https://trello.com/c/PPR4AtAk/455-add-the-privacy-policy-page)

## Screenshots

![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/d47fe2f0-01da-4849-b534-b6d8e9daca16)