### PR TITLE
Fix additonal subject names after filter

### DIFF
--- a/app/decorators/placement_decorator.rb
+++ b/app/decorators/placement_decorator.rb
@@ -32,6 +32,7 @@ class PlacementDecorator < Draper::Decorator
   end
 
   def additional_subject_names
+    reload unless new_record?
     additional_subjects.map(&:name).sort.to_sentence
   end
 end

--- a/spec/system/placements/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/placements/view_placements_list_spec.rb
@@ -109,7 +109,11 @@ RSpec.describe "Placements / Placements / View placements list",
     context "when placements have additional subjects" do
       let!(:parent_subject) { build(:subject, name: "Modern Foreign Languages") }
       let!(:additional_subject) { create(:subject, name: "French", parent_subject:) }
-      let(:additional_subject_placement) { create(:placement, subject: parent_subject, school: secondary_school, additional_subjects: [additional_subject]) }
+      let!(:additional_subject_2) { create(:subject, name: "Spanish", parent_subject:) }
+      let(:additional_subject_placement) do
+        create(:placement, subject: parent_subject, school: secondary_school,
+                           additional_subjects: [additional_subject, additional_subject_2])
+      end
 
       before { additional_subject_placement }
 
@@ -117,10 +121,10 @@ RSpec.describe "Placements / Placements / View placements list",
         when_i_visit_the_placements_index_page
         then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
         and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
-        and_i_can_see_a_placement_for_school_and_subject("Secondary School", "French")
+        and_i_can_see_a_placement_for_school_and_subject("Secondary School", "French and Spanish")
         when_i_check_filter_option("subject-ids", additional_subject.id)
         and_i_click_on("Apply filters")
-        then_i_can_see_a_placement_for_school_and_subject("Secondary School", "French")
+        then_i_can_see_a_placement_for_school_and_subject("Secondary School", "French and Spanish")
         and_i_can_not_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
         and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
       end


### PR DESCRIPTION
## Context

When we filter down the placements we also clip out their additional subjects. The simplest way to resolve this issue is to reload the record when we need the additional subject names. We do not want to reload the record when dealing with the add a placement flow as the record is not saved at this point and no filters can be applied.

## Changes proposed in this pull request

- [x] Add conditional reload when calculating the additional subject names
- [x] Update spec to cover this scenario and prevent this happening again.

## Guidance to review

- Log in as Patricia
- Navigate to placements
- Filter on one of the MFLs, e.g. "French"
- Verify that the full title of the placement is displayed.

## Link to Trello card

[Placement title changes on MFL placements when filtering by language subjects](https://trello.com/c/FnhiFmsk/466-placement-title-changes-on-mfl-placements-when-filtering-by-language-subjects)

## Screenshots

![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/aa386775-a75b-4dc6-89a8-eb83c8c66abd)