### PR TITLE
Users with support accounts should login in as support users over other user accounts

### DIFF
--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -55,7 +55,7 @@ class DfESignInUser
   end
 
   def user
-    @user ||= user_by_uid || user_by_email
+    @user ||= support_user || non_support_user
   end
 
   def self.end_session!(session)
@@ -64,17 +64,13 @@ class DfESignInUser
 
   private
 
-  def user_by_uid
-    return if dfe_sign_in_uid.blank?
-
+  def support_user
     support_user_klass.find_by(dfe_sign_in_uid:) ||
-      user_klass.find_by(dfe_sign_in_uid:)
+      support_user_klass.find_by(email:)
   end
 
-  def user_by_email
-    return if email.blank?
-
-    support_user_klass.find_by(email:) ||
+  def non_support_user
+    user_klass.find_by(dfe_sign_in_uid:) ||
       user_klass.find_by(email:)
   end
 

--- a/spec/system/placements/sign_in_as_a_placements_user_spec.rb
+++ b/spec/system/placements/sign_in_as_a_placements_user_spec.rb
@@ -66,6 +66,18 @@ RSpec.describe "Sign In as a Placements User", type: :system, service: :placemen
     end
   end
 
+  context "when the user has both a support and non-support account" do
+    scenario "I sign in as user colin and accesses the support user page" do
+      given_there_is_an_existing_user_for("Colin")
+      given_there_is_an_existing_support_user_for("Colin")
+      and_there_are_placement_organisations
+
+      when_i_visit_the_sign_in_path
+      when_i_click_sign_in
+      then_i_see_a_list_of_organisations
+    end
+  end
+
   private
 
   def given_there_is_an_existing_user_for(user_name)


### PR DESCRIPTION
## Context

- Users with SupportUser accounts, should be logged in as Support Users over their other accounts.

## Changes proposed in this pull request

- Change `app/models/dfe_sign_in_user.rb` to log the user in as their SupportUser, over their other accounts.

## Guidance to review

⚠️ Can't be tested in Review, as it uses Personas instead of DfE ⚠️ 
- Create two accounts using the same email address (One Placements::SupportUser, One Placements::User)
- Sign in via DfE Sign In
- The user should see the Support User interface

## Link to Trello card

https://trello.com/c/GF1dL3p7/458-when-someone-has-both-a-user-and-a-support-user-account-prefer-their-support-account
