### PR TITLE
Add normalize to mentor and school_contact

### DIFF
--- a/app/models/mentor.rb
+++ b/app/models/mentor.rb
@@ -20,6 +20,8 @@ class Mentor < ApplicationRecord
   has_many :placement_mentor_joins, dependent: :restrict_with_error
   has_many :placements, through: :placement_mentor_joins
 
+  normalizes :trn, with: ->(value) { value.strip }
+
   validates :first_name, :last_name, presence: true
   validates :trn, presence: true, uniqueness: true, format: /\A\d{7}\z/
 

--- a/app/models/placements/school_contact.rb
+++ b/app/models/placements/school_contact.rb
@@ -21,6 +21,9 @@ class Placements::SchoolContact < ApplicationRecord
   belongs_to :school
   before_destroy :prevent_destroy
 
+  normalizes :name, with: ->(value) { value.strip }
+  normalizes :email_address, with: ->(value) { value.strip.downcase }
+
   validates :email_address, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
 
   def prevent_destroy

--- a/app/services/teaching_record/rest_client.rb
+++ b/app/services/teaching_record/rest_client.rb
@@ -13,7 +13,7 @@ module TeachingRecord
     class HttpError < StandardError; end
 
     def self.get(path)
-      response = Request.get("/v3/#{path}")
+      response = Request.get("/v3/#{path.delete(" ")}")
 
       if response.ok?
         JSON.parse(response.body || "{}")

--- a/spec/models/mentor_spec.rb
+++ b/spec/models/mentor_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe Mentor, type: :model do
     it { is_expected.to have_many(:placements).through(:placement_mentor_joins) }
   end
 
+  describe "normalisations" do
+    it { is_expected.to normalize(:trn).from(" 1234567 ").to("1234567") }
+  end
+
   context "with validations" do
     subject { build(:mentor) }
 

--- a/spec/models/placements/school_contact_spec.rb
+++ b/spec/models/placements/school_contact_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe Placements::SchoolContact, type: :model do
     it { is_expected.to belong_to(:school) }
   end
 
+  describe "normalisations" do
+    it { is_expected.to normalize(:name).from("  Name  ").to("Name") }
+    it { is_expected.to normalize(:email_address).from("EmAiL@eXaMPlE.cOm ").to("email@example.com") }
+  end
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:email_address) }
     it { is_expected.to allow_value("name@education.gov.uk").for(:email_address) }


### PR DESCRIPTION
## Context

Whitespace fails validation rules when we could be removing it before it becomes an issue.

## Changes proposed in this pull request

- [x] Normalise `Mentor` TRN
- [x] Normalise `Placements::SchoolContact` name and email address
- [x] delete whitespace from teacher API path
- [x] Add specs

## Guidance to review

- Add a mentor
- Add space to TRN
- Verify that TRN is still valid
- Add ITT placement contact
- Add whitespice to both fields
- Verify that it is still valid

## Link to Trello card

[Strip whitespace from user input before validation](https://trello.com/c/i5E3VJ9j/463-strip-whitespace-from-user-input-before-validation)
