### PR TITLE
Fix issue with clear search removing selected  filters

### DIFF
--- a/app/views/placements/placements/index.html.erb
+++ b/app/views/placements/placements/index.html.erb
@@ -25,7 +25,7 @@
         label: { hidden: true },
         caption: { text: t(".location_search_example") },
         name: :search_location,
-        clear_search_url: placements_placements_path,
+        clear_search_url: placements_placements_path(filters: filter_form.attributes),
         filters: filter_form.attributes,
         value: @search_location,
       } %>

--- a/spec/system/placements/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/placements/view_placements_list_spec.rb
@@ -246,6 +246,18 @@ RSpec.describe "Placements / Placements / View placements list",
           and_i_can_see_search_location_is_set_as("London")
           and_i_see_placements_for(school_name: "Primary School", list_item: 0, distance: 0.0)
         end
+
+        scenario "User can clear the location search, and the filters persist" do
+          when_i_visit_the_placements_index_page(
+            { search_location: "London", filters: { school_ids: [primary_school.id] } },
+          )
+          and_i_can_see_search_location_is_set_as("London")
+          and_i_can_see_a_preset_filter("School", "Primary School")
+          when_i_click_on("Clear search")
+          then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+          and_i_can_see_a_preset_filter("School", "Primary School")
+          and_i_can_see_search_location_is_set_as("")
+        end
       end
     end
 


### PR DESCRIPTION
## Context

- Fix issue where clicking "Clear search" (on the placements page) does not make the filters persist.

## Changes proposed in this pull request

- Add filter arguments to the Search Form partial.

## Guidance to review

- Sign in as Patricia (Provider user)
- Navigate to "Placements" in the Navbar
- Select some filters
- Click "Apply filters"
- Enter a location into the "Enter a location" search input (such as "London")
- Click "Search"
- Filters and Search location should persist
- Click "Clear search"
- The filters should still persist.

## Link to Trello card

https://trello.com/c/CutFfUgX/465-confirm-interaction-for-clear-filters-vs-clear-search-links-and-implement

## Screenshots

https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/d44ef2d2-48a4-4399-a8ea-0602f631a613


