### PR TITLE
Optimise school and provider autocompletes

### DIFF
--- a/app/controllers/api/provider_suggestions_controller.rb
+++ b/app/controllers/api/provider_suggestions_controller.rb
@@ -1,6 +1,8 @@
 class Api::ProviderSuggestionsController < ApplicationController
   def index
     render json: Provider.search_name_urn_ukprn_postcode(query_params)
+                         .select(:id, :name, :code)
+                         .limit(50)
   end
 
   private

--- a/app/controllers/api/school_suggestions_controller.rb
+++ b/app/controllers/api/school_suggestions_controller.rb
@@ -1,6 +1,8 @@
 class Api::SchoolSuggestionsController < ApplicationController
   def index
     render json: School.search_name_urn_postcode(query_params)
+                       .select(:id, :name, :town, :postcode)
+                       .limit(50)
   end
 
   private

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -21,7 +21,7 @@ export default class extends Controller {
       name: this.inputTarget.dataset.inputName,
       defaultValue: this.serverInputTarget.value,
       minLength,
-      source: debounce(request(this.pathValue), 900),
+      source: debounce(request(this.pathValue), 200),
       templates: {
         inputValue: this.inputValueTemplate.bind(this),
         suggestion: this.resultTemplate.bind(this),

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -1,61 +1,66 @@
-import { Controller } from "@hotwired/stimulus"
-import accessibleAutocomplete from 'accessible-autocomplete'
+import { Controller } from "@hotwired/stimulus";
+import accessibleAutocomplete from "accessible-autocomplete";
 import debounce from "lodash.debounce";
 import { request } from "../utils/request_helper";
 
 // Connects to data-controller="autocomplete"
 export default class extends Controller {
-  static targets = [ "serverInput", "input" ]
+  static targets = ["serverInput", "input"];
   static values = {
     path: String,
     returnAttributes: Array,
-  }
+  };
 
   connect() {
     const minLength = 2;
 
-   accessibleAutocomplete({
-     element: this.inputTarget,
-     id: this.serverInputTarget.id,
-     showNoOptionsFound: true,
-     name: this.inputTarget.dataset.inputName,
-     defaultValue: this.serverInputTarget.value,
-     minLength,
-     source: debounce(request(this.pathValue), 900),
-     templates: {
-       inputValue: this.inputValueTemplate.bind(this),
-       suggestion: this.resultTemplate.bind(this),
-     },
-     onConfirm: this.onConfirm.bind(this),
-     confirmOnBlur: false,
-     autoselect: true,
-   });
+    accessibleAutocomplete({
+      element: this.inputTarget,
+      id: this.serverInputTarget.id,
+      showNoOptionsFound: true,
+      name: this.inputTarget.dataset.inputName,
+      defaultValue: this.serverInputTarget.value,
+      minLength,
+      source: debounce(request(this.pathValue), 900),
+      templates: {
+        inputValue: this.inputValueTemplate.bind(this),
+        suggestion: this.resultTemplate.bind(this),
+      },
+      onConfirm: this.onConfirm.bind(this),
+      confirmOnBlur: false,
+      autoselect: true,
+    });
 
     // Hijack the original input to submit the selected value.
     this.serverInputTarget.id = `old-${this.serverInputTarget.id}`;
     this.serverInputTarget.type = "hidden";
-    this.serverInputTarget.value = this.serverInputTarget.dataset.previousSearch || '';
+    this.serverInputTarget.value =
+      this.serverInputTarget.dataset.previousSearch || "";
   }
 
   clearUndefinedSuggestions() {
-    const autocompleteElement = this.element.getElementsByClassName("autocomplete__wrapper")[0];
+    const autocompleteElement = this.element.getElementsByClassName(
+      "autocomplete__wrapper"
+    )[0];
     if (autocompleteElement) {
-      const autocompleteOptions = autocompleteElement.getElementsByClassName("autocomplete__option");
+      const autocompleteOptions = autocompleteElement.getElementsByClassName(
+        "autocomplete__option"
+      );
       for (const option of autocompleteOptions) {
-        if ( option.innerHTML === ""){
+        if (option.innerHTML === "") {
           option.remove();
         }
       }
     }
   }
 
-  private
+  private;
 
   inputValueTemplate(result) {
     if (result && typeof result === "object") {
       return result.name;
     } else {
-      return ""
+      return "";
     }
   }
 
@@ -68,7 +73,7 @@ export default class extends Controller {
 
       return `${result.name} (${attributes})`;
     } else {
-      return ""
+      return "";
     }
   }
 

--- a/spec/system/placements/providers/partner_schools/view_partner_schools_list_spec.rb
+++ b/spec/system/placements/providers/partner_schools/view_partner_schools_list_spec.rb
@@ -3,10 +3,10 @@ require "rails_helper"
 RSpec.describe "Placements / Providers / Partner schools / View a list of partner schools",
                type: :system,
                service: :placements do
-  let!(:provider) { create(:placements_provider) }
-  let!(:another_provider) { create(:placements_provider) }
-  let!(:school) { create(:placements_school, urn: "1234") }
-  let!(:another_school) { create(:placements_school, urn: "5678") }
+  let!(:provider) { create(:placements_provider, name: "Springfield Community College") }
+  let!(:another_provider) { create(:placements_provider, name: "Burns University") }
+  let!(:school) { create(:placements_school, name: "Springfield Elementary School", urn: "1234") }
+  let!(:another_school) { create(:placements_school, name: "Shelbyville Elementary School", urn: "5678") }
 
   scenario "User views provider partner schools page where provider has no partner schools" do
     given_i_sign_in_as_patricia

--- a/spec/system/placements/schools/partner_providers/view_partner_providers_list_spec.rb
+++ b/spec/system/placements/schools/partner_providers/view_partner_providers_list_spec.rb
@@ -3,10 +3,10 @@ require "rails_helper"
 RSpec.describe "Placements / Schools / Partner providers / View a list of partner providers",
                type: :system,
                service: :placements do
-  let!(:school) { create(:placements_school) }
-  let!(:another_school) { create(:placements_school) }
-  let!(:provider) { create(:placements_provider, ukprn: "1234") }
-  let!(:another_provider) { create(:placements_provider, ukprn: "5678") }
+  let!(:school) { create(:placements_school, name: "Springfield Elementary School") }
+  let!(:another_school) { create(:placements_school, name: "Shelbyville Elementary School") }
+  let!(:provider) { create(:placements_provider, name: "Springfield Community College", ukprn: "1234") }
+  let!(:another_provider) { create(:placements_provider, name: "Burns University", ukprn: "5678") }
 
   scenario "User views school partner providers page where school has no partner providers" do
     given_i_sign_in_as_anne

--- a/spec/system/placements/support/providers/partner_schools/view_partner_school_list_as_support_user_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/view_partner_school_list_as_support_user_spec.rb
@@ -3,10 +3,10 @@ require "rails_helper"
 RSpec.describe "Placements / Support / Providers / Partner schools / View a partner school as support user",
                type: :system,
                service: :placements do
-  let!(:provider) { create(:placements_provider) }
-  let!(:another_provider) { create(:placements_provider) }
-  let!(:school) { create(:placements_school, urn: "1234") }
-  let!(:another_school) { create(:placements_school, urn: "5678") }
+  let!(:provider) { create(:placements_provider, name: "Springfield Community College") }
+  let!(:another_provider) { create(:placements_provider, name: "Burns University") }
+  let!(:school) { create(:placements_school, name: "Springfield Elementary School", urn: "1234") }
+  let!(:another_school) { create(:placements_school, name: "Shelbyville Elementary School", urn: "5678") }
 
   before do
     given_i_am_signed_in_as_a_support_user

--- a/spec/system/placements/support/schools/partner_providers/view_partner_school_list_as_support_user_spec.rb
+++ b/spec/system/placements/support/schools/partner_providers/view_partner_school_list_as_support_user_spec.rb
@@ -3,10 +3,10 @@ require "rails_helper"
 RSpec.describe "Placements / Support / Schools / Partner providers / View partner provider list as support user",
                type: :system,
                service: :placements do
-  let!(:school) { create(:placements_school) }
-  let!(:another_school) { create(:placements_school) }
-  let!(:provider) { create(:placements_provider, ukprn: "1234") }
-  let!(:another_provider) { create(:placements_provider, ukprn: "5678") }
+  let!(:school) { create(:placements_school, name: "Springfield Elementary School") }
+  let!(:another_school) { create(:placements_school, name: "Shelbyville Elementary School") }
+  let!(:provider) { create(:placements_provider, name: "Springfield Community College", ukprn: "1234") }
+  let!(:another_provider) { create(:placements_provider, name: "Burns University", ukprn: "5678") }
 
   before do
     given_i_am_signed_in_as_a_support_user


### PR DESCRIPTION
## Context

During our bug party, we noticed the autocomplete suggestions were very unresponsive when provided by an Ajax endpoint.

This PR optimises the way suggestions are requested by the client, and the response that the server returns. Together with PR #735, this should greatly improve the performance and perceived responsiveness of the autocomplete component.

## Changes proposed in this pull request

1. [Reduce the debounce timeout on autocompletes](https://github.com/DFE-Digital/itt-mentor-services/commit/35000d03ea0a338cfaa09bcffa965bd42636a695)
2. [Optimise the size of autocomplete responses](https://github.com/DFE-Digital/itt-mentor-services/commit/9db546bc486abc84425460ca930eb791317abb8f)

I also [fixed a flaky test](https://github.com/DFE-Digital/itt-mentor-services/commit/543033dd296898adf9d876eba207ffa7c4218597) which seemed to play up while I was working on this PR. And my code editor (VS Code) insisted on reformatting the JavaScript file, so I put that into [a separate commit](https://github.com/DFE-Digital/itt-mentor-services/commit/a6addba6839d3bcc7be73db6b31cd9c9ba51c2b0) too.

## Guidance to review

No visual changes have been made. The autocomplete still looks and behaves as it did before – it should just be a bit quicker now.

## Link to Trello card

https://trello.com/c/3nBLBvb7/476-tweak-the-autocomplete-so-suggestions-feel-more-responsive
