### PR TITLE
Update add a placement back button

### DIFF
--- a/app/controllers/placements/schools/placements/build_controller.rb
+++ b/app/controllers/placements/schools/placements/build_controller.rb
@@ -142,7 +142,7 @@ class Placements::Schools::Placements::BuildController < ApplicationController
                   flash: { alert: t("errors.internal_server_error.page_title") } and return
     end
 
-    redirect_to public_send(next_step(params[:id]))
+    redirect_to next_step(params[:id])
   end
 
   private
@@ -206,7 +206,7 @@ class Placements::Schools::Placements::BuildController < ApplicationController
   end
 
   def next_step(step)
-    "#{steps[steps.index(step.to_sym) + 1]}_placements_school_placement_build_index_path"
+    public_send("#{steps[steps.index(step.to_sym) + 1]}_placements_school_placement_build_index_path")
   end
 
   def previous_step(step)

--- a/app/views/placements/schools/placements/build/add_additional_subjects.erb
+++ b/app/views/placements/schools/placements/build/add_additional_subjects.erb
@@ -2,7 +2,7 @@
 <%= render "placements/schools/primary_navigation", school: @school, current_navigation: :placements %>
 
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: :back) %>
+  <%= govuk_back_link(href: @previous_step) %>
 <% end %>
 
 <div class="govuk-width-container">

--- a/app/views/placements/schools/placements/build/add_mentors.html.erb
+++ b/app/views/placements/schools/placements/build/add_mentors.html.erb
@@ -2,7 +2,7 @@
 <%= render "placements/schools/primary_navigation", school: @school, current_navigation: :placements %>
 
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: :back) %>
+  <%= govuk_back_link(href: @previous_step) %>
 <% end %>
 
 <div class="govuk-width-container">

--- a/app/views/placements/schools/placements/build/add_phase.html.erb
+++ b/app/views/placements/schools/placements/build/add_phase.html.erb
@@ -2,7 +2,7 @@
 <%= render "placements/schools/primary_navigation", school: @school, current_navigation: :placements %>
 
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: :back) %>
+  <%= govuk_back_link(href: @previous_step) %>
 <% end %>
 
 <div class="govuk-width-container">

--- a/app/views/placements/schools/placements/build/add_subject.html.erb
+++ b/app/views/placements/schools/placements/build/add_subject.html.erb
@@ -2,7 +2,7 @@
 <%= render "placements/schools/primary_navigation", school: @school, current_navigation: :placements %>
 
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: :back) %>
+  <%= govuk_back_link(href: @previous_step) %>
 <% end %>
 
 <div class="govuk-width-container">

--- a/app/views/placements/schools/placements/build/add_year_group.html.erb
+++ b/app/views/placements/schools/placements/build/add_year_group.html.erb
@@ -2,7 +2,7 @@
 <%= render "placements/schools/primary_navigation", school: @school, current_navigation: :placements %>
 
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: :back) %>
+  <%= govuk_back_link(href: @previous_step) %>
 <% end %>
 
 <div class="govuk-width-container">

--- a/app/views/placements/schools/placements/build/check_your_answers.html.erb
+++ b/app/views/placements/schools/placements/build/check_your_answers.html.erb
@@ -2,7 +2,7 @@
 <%= render "placements/schools/primary_navigation", school: @school, current_navigation: :placements %>
 
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: :back) %>
+  <%= govuk_back_link(href: @previous_step) %>
 <% end %>
 
 <div class="govuk-width-container">

--- a/spec/system/placements/schools/placements/add_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/add_a_placement_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
           then_i_see_the_placements_page
         end
 
-        context "navigated back through the steps" do
+        context "when navigating back through the steps" do
           scenario "my selected options are rendered and I go to the previous step" do
             when_i_visit_the_placements_page
             and_i_click_on("Add placement")

--- a/spec/system/placements/schools/placements/add_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/add_a_placement_spec.rb
@@ -115,28 +115,33 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
           then_i_see_the_placements_page
         end
 
-        context "when I've checked my answers and I click on change" do
-          scenario "my selected options are rendered when navigating using the back button" do
+        context "navigated back through the steps" do
+          scenario "my selected options are rendered and I go to the previous step" do
             when_i_visit_the_placements_page
             and_i_click_on("Add placement")
             when_i_choose_a_subject(subject_1.name)
             and_i_click_on("Continue")
-            when_i_click_on("Back")
-            then_my_chosen_subject_is_selected(subject_1.name)
-
-            when_i_visit_the_add_year_group_page
             when_i_choose_a_year_group("Year 1")
             and_i_click_on("Continue")
+            when_i_check_a_mentor(mentor_1.full_name)
+            and_i_click_on("Continue")
+            then_i_see_the_check_your_answers_page(school.phase, mentor_1)
+
+            when_i_click_on("Back")
+            then_my_chosen_mentor_is_checked(mentor_1.full_name)
+
             when_i_click_on("Back")
             then_my_chosen_year_group_is_selected("Year 1")
 
-            when_i_visit_the_add_mentor_page
-            when_i_check_a_mentor(mentor_1.full_name)
-            and_i_click_on("Continue")
-            when_i_change_my_mentor
-            then_my_chosen_mentor_is_checked(mentor_1.full_name)
-          end
+            when_i_click_on("Back")
+            then_my_chosen_subject_is_selected(subject_1.name)
 
+            when_i_click_on("Back")
+            then_i_see_the_placements_page
+          end
+        end
+
+        context "when I've checked my answers and I click on change" do
           scenario "when I do not enter valid options" do
             when_i_visit_the_placements_page
             and_i_click_on("Add placement")


### PR DESCRIPTION
## Context

The back button was not working as expected during the bug party.

## Changes proposed in this pull request

- [x] Added logic to work the previous step

## Guidance to review

- Log in as Anne
- Add a placement
- Fill in the form until you get to check your answers
- Click on the back button until you return to the placements page

## Link to Trello card

[Confirm interaction for the 'back' link during the 'Add placement' journey – and implement it](https://trello.com/c/6ofqSDIW/464-confirm-interaction-for-the-back-link-during-the-add-placement-journey-and-implement-it)
