### PR TITLE
Part 1 add first and last name to school contact

### DIFF
--- a/app/controllers/placements/schools/school_contacts_controller.rb
+++ b/app/controllers/placements/schools/school_contacts_controller.rb
@@ -16,7 +16,8 @@ class Placements::Schools::SchoolContactsController < ApplicationController
       @back_link = @change_link = new_placements_school_school_contact_path(
         school_id: @school.id,
         placements_school_contact: {
-          name: @school_contact.name,
+          first_name: @school_contact.first_name,
+          last_name: @school_contact.last_name,
           email_address: @school_contact.email_address,
         },
       )
@@ -54,7 +55,7 @@ class Placements::Schools::SchoolContactsController < ApplicationController
 
   def school_contact_params
     params.require(:placements_school_contact)
-      .permit(:name, :email_address)
+      .permit(:first_name, :last_name, :email_address)
       .merge(school: @school)
   end
 end

--- a/app/models/placements/school_contact.rb
+++ b/app/models/placements/school_contact.rb
@@ -4,6 +4,8 @@
 #
 #  id            :uuid             not null, primary key
 #  email_address :string           not null
+#  first_name    :string
+#  last_name     :string
 #  name          :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
@@ -21,8 +23,9 @@ class Placements::SchoolContact < ApplicationRecord
   belongs_to :school
   before_destroy :prevent_destroy
 
-  normalizes :name, with: ->(value) { value.strip }
+  normalizes :name, with: ->(value) { value.strip } # TODO: Remove when column removed
   normalizes :email_address, with: ->(value) { value.strip.downcase }
+  normalizes :first_name, :last_name, with: ->(value) { value.strip }
 
   validates :email_address, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
 

--- a/app/views/placements/schools/school_contacts/_form.html.erb
+++ b/app/views/placements/schools/school_contacts/_form.html.erb
@@ -10,7 +10,11 @@
       <p class="govuk-body"><%= t(".description") %></p>
 
       <div class="govuk-form-group">
-        <%= f.govuk_text_field :name, class: "govuk-input--width-20", label: { text: t(".attributes.school_contacts.full_name"), size: "s" } %>
+        <%= f.govuk_text_field :first_name, class: "govuk-input--width-20", label: { text: t(".attributes.school_contacts.first_name"), size: "s" } %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= f.govuk_text_field :last_name, class: "govuk-input--width-20", label: { text: t(".attributes.school_contacts.last_name"), size: "s" } %>
       </div>
 
       <div class="govuk-form-group">

--- a/app/views/placements/schools/school_contacts/check.html.erb
+++ b/app/views/placements/schools/school_contacts/check.html.erb
@@ -13,7 +13,8 @@
         url: placements_school_school_contacts_path,
         method: :post,
       ) do |f| %>
-        <%= f.hidden_field :name, value: @school_contact.name %>
+        <%= f.hidden_field :first_name, value: @school_contact.first_name %>
+        <%= f.hidden_field :last_name, value: @school_contact.last_name %>
         <%= f.hidden_field :email_address, value: @school_contact.email_address %>
 
         <label class="govuk-label govuk-label--l">
@@ -23,8 +24,17 @@
 
         <%= govuk_summary_list do |summary_list| %>
           <% summary_list.with_row do |row| %>
-            <% row.with_key(text: t(".attributes.school_contacts.name")) %>
-            <% row.with_value(text: @school_contact.name) %>
+            <% row.with_key(text: t(".attributes.school_contacts.first_name")) %>
+            <% row.with_value(text: @school_contact.first_name) %>
+            <% row.with_action(text: t(".change"),
+                               href: @change_link,
+                               html_attributes: {
+                                 class: "govuk-link--no-visited-state",
+                               }) %>
+          <% end %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".attributes.school_contacts.last_name")) %>
+            <% row.with_value(text: @school_contact.last_name) %>
             <% row.with_action(text: t(".change"),
                                href: @change_link,
                                html_attributes: {

--- a/app/views/shared/schools/_school_contact_details.html.erb
+++ b/app/views/shared/schools/_school_contact_details.html.erb
@@ -2,8 +2,19 @@
 <% if school_contact.present? %>
   <%= govuk_summary_list(html_attributes: { id: "school-contact-details" }) do |summary_list| %>
     <% summary_list.with_row do |row| %>
-      <% row.with_key(text: t(".full_name")) %>
-      <% row.with_value(**summary_row_value(value: school_contact.name)) %>
+      <% row.with_key(text: t(".first_name")) %>
+      <% row.with_value(**summary_row_value(value: school_contact.first_name)) %>
+      <% if changeable %>
+        <% row.with_action(text: t(".change"),
+                           href: edit_placements_school_school_contact_path(school, school_contact),
+                           html_attributes: {
+                                    class: "govuk-link--no-visited-state",
+                                  }) %>
+      <% end %>
+    <% end %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key(text: t(".last_name")) %>
+      <% row.with_value(**summary_row_value(value: school_contact.last_name)) %>
       <% if changeable %>
         <% row.with_action(text: t(".change"),
                            href: edit_placements_school_school_contact_path(school, school_contact),

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -164,6 +164,8 @@ shared:
     - school_id
     - created_at
     - updated_at
+    - first_name
+    - last_name
   :placement_additional_subjects:
     - id
     - subject_id

--- a/config/locales/en/placements/schools/school_contacts.yml
+++ b/config/locales/en/placements/schools/school_contacts.yml
@@ -15,7 +15,8 @@ en:
           change: Change
           attributes:
             school_contacts:
-              name: Name
+              first_name: First name
+              last_name: Last name
               email_address: Email address
         create:
           school_contact_added: Placement contact added
@@ -41,6 +42,7 @@ en:
           cancel: Cancel
           attributes:
             school_contacts:
-              full_name: Full name
               email: Email address
+              first_name: First name
+              last_name: Last name
           

--- a/config/locales/en/shared/schools/school_contact_details.yml
+++ b/config/locales/en/shared/schools/school_contact_details.yml
@@ -2,6 +2,7 @@ en:
   shared:
     schools:
       school_contact_details:
-        full_name: Full name
+        first_name: First name
+        last_name: Last name
         email: Email address
         change: Change

--- a/db/data/20240607144521_split_school_contact_name_into_first_and_last_name.rb
+++ b/db/data/20240607144521_split_school_contact_name_into_first_and_last_name.rb
@@ -1,0 +1,16 @@
+class SplitSchoolContactNameIntoFirstAndLastName < ActiveRecord::Migration[7.1]
+  def up
+    return unless Placements::SchoolContact.column_names.include?("name")
+
+    Placements::SchoolContact.where(first_name: nil, last_name: nil).find_each do |school_contact|
+      first_name, *last_names = school_contact.name.split
+      school_contact.update!(first_name:, last_name: last_names.join(" "))
+    end
+  end
+
+  def down
+    return unless Placements::SchoolContact.column_names.include?("name")
+
+    Placements::SchoolContact.update_all(first_name: nil, last_name: nil)
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20240523162025)
+DataMigrate::Data.define(version: 20240607144521)

--- a/db/migrate/20240607135849_add_first_name_and_last_name_to_school_contact.rb
+++ b/db/migrate/20240607135849_add_first_name_and_last_name_to_school_contact.rb
@@ -1,0 +1,10 @@
+class AddFirstNameAndLastNameToSchoolContact < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      change_table :school_contacts, bulk: true do |t|
+        t.string :first_name
+        t.string :last_name
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_07_105222) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_07_135849) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -286,6 +286,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_07_105222) do
     t.uuid "school_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "first_name"
+    t.string "last_name"
     t.index ["school_id"], name: "index_school_contacts_on_school_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -84,7 +84,8 @@ Placements::School.find_each do |school|
   if school.school_contact.blank?
     Placements::SchoolContact.create!(
       school:,
-      name: "ITT School Contact",
+      first_name: "School",
+      last_name: "Contact",
       email_address: "itt_contact@example.com",
     )
   end

--- a/spec/factories/placements/school_contacts.rb
+++ b/spec/factories/placements/school_contacts.rb
@@ -4,6 +4,8 @@
 #
 #  id            :uuid             not null, primary key
 #  email_address :string           not null
+#  first_name    :string
+#  last_name     :string
 #  name          :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
@@ -22,6 +24,8 @@ FactoryBot.define do
     association :school, factory: :placements_school
 
     name { "Placement Coordinator" }
+    first_name { "Placement" }
+    last_name { "Coordinator" }
     email_address { "placement_coordinator@example.school" }
   end
 end

--- a/spec/models/placements/school_contact_spec.rb
+++ b/spec/models/placements/school_contact_spec.rb
@@ -4,6 +4,8 @@
 #
 #  id            :uuid             not null, primary key
 #  email_address :string           not null
+#  first_name    :string
+#  last_name     :string
 #  name          :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
@@ -25,8 +27,10 @@ RSpec.describe Placements::SchoolContact, type: :model do
   end
 
   describe "normalisations" do
-    it { is_expected.to normalize(:name).from("  Name  ").to("Name") }
+    it { is_expected.to normalize(:name).from("  Name  ").to("Name") } # TODO: Remove when column removed
     it { is_expected.to normalize(:email_address).from("EmAiL@eXaMPlE.cOm ").to("email@example.com") }
+    it { is_expected.to normalize(:first_name).from("  First name  ").to("First name") }
+    it { is_expected.to normalize(:last_name).from("  Last name  ").to("Last name") }
   end
 
   describe "validations" do

--- a/spec/system/placements/placements/view_a_placement_spec.rb
+++ b/spec/system/placements/placements/view_a_placement_spec.rb
@@ -112,7 +112,8 @@ RSpec.describe "Placements / Placements / View a placement",
 
   def and_i_see_the_itt_placement_contact_details_for_the_school
     expect(page).to have_content("Placement contact")
-    expect(page).to have_content(school.school_contact.name)
+    expect(page).to have_content(school.school_contact.first_name)
+    expect(page).to have_content(school.school_contact.last_name)
     expect(page).to have_content(school.school_contact.email_address)
   end
 

--- a/spec/system/placements/schools/school_contacts/add_a_school_contact_spec.rb
+++ b/spec/system/placements/schools/school_contacts/add_a_school_contact_spec.rb
@@ -13,18 +13,21 @@ RSpec.describe "Placements / Schools / School Contacts / Add a school contact",
     then_i_see_no_school_contact_details
     when_i_click_on("Add placement contact")
     and_i_fill_out_the_school_contact_form(
-      name: "Placement Coordinator",
+      first_name: "Placement",
+      last_name: "Coordinator",
       email_address: "placement_coordinator@example.school",
     )
     and_i_click_on("Continue")
     then_i_see_the_check_your_answers_page(
-      name: "Placement Coordinator",
+      first_name: "Placement",
+      last_name: "Coordinator",
       email_address: "placement_coordinator@example.school",
     )
     when_i_click_on("Add placement contact")
     then_i_return_to_my_organisation_details_page
     and_i_see_the_school_contact_details(
-      name: "Placement Coordinator",
+      first_name: "Placement",
+      last_name: "Coordinator",
       email_address: "placement_coordinator@example.school",
     )
     and_i_see_success_message
@@ -34,12 +37,14 @@ RSpec.describe "Placements / Schools / School Contacts / Add a school contact",
     given_i_have_completed_the_school_contact_form
     when_i_click_on("Back")
     then_i_see_the_inputs_pre_filled_with(
-      name: "Placement Coordinator",
+      first_name: "Placement",
+      last_name: "Coordinator",
       email_address: "placement_coordinator@example.school",
     )
     when_i_click_on("Continue")
     then_i_see_the_check_your_answers_page(
-      name: "Placement Coordinator",
+      first_name: "Placement",
+      last_name: "Coordinator",
       email_address: "placement_coordinator@example.school",
     )
   end
@@ -49,7 +54,8 @@ RSpec.describe "Placements / Schools / School Contacts / Add a school contact",
     then_i_see_no_school_contact_details
     when_i_click_on("Add placement contact")
     and_i_fill_out_the_school_contact_form(
-      name: "Placement Coordinator",
+      first_name: "Placemen",
+      last_name: "Coordinator",
       email_address: "invalid_email",
     )
     and_i_click_on("Continue")
@@ -94,15 +100,17 @@ RSpec.describe "Placements / Schools / School Contacts / Add a school contact",
     expect(page).to have_content("Add placement contact")
   end
 
-  def when_i_fill_out_the_school_contact_form(name:, email_address:)
-    fill_in "Full name", with: name
+  def when_i_fill_out_the_school_contact_form(first_name:, last_name:, email_address:)
+    fill_in "First name", with: first_name
+    fill_in "Last name", with: last_name
     fill_in "Email", with: email_address
   end
   alias_method :and_i_fill_out_the_school_contact_form,
                :when_i_fill_out_the_school_contact_form
 
-  def then_i_see_the_check_your_answers_page(name:, email_address:)
-    expect(page).to have_content(name)
+  def then_i_see_the_check_your_answers_page(first_name:, last_name:, email_address:)
+    expect(page).to have_content(first_name)
+    expect(page).to have_content(last_name)
     expect(page).to have_content(email_address)
   end
 
@@ -111,9 +119,10 @@ RSpec.describe "Placements / Schools / School Contacts / Add a school contact",
     expect_organisation_details_to_be_selected_in_primary_navigation
   end
 
-  def and_i_see_the_school_contact_details(name:, email_address:)
+  def and_i_see_the_school_contact_details(first_name:, last_name:, email_address:)
     within("#school-contact-details") do
-      expect(page).to have_content(name)
+      expect(page).to have_content(first_name)
+      expect(page).to have_content(last_name)
       expect(page).to have_content(email_address)
     end
   end
@@ -125,7 +134,8 @@ RSpec.describe "Placements / Schools / School Contacts / Add a school contact",
   def given_i_have_completed_the_school_contact_form
     params = {
       "placements_school_contact" => {
-        name: "Placement Coordinator",
+        first_name: "Placement",
+        last_name: "Coordinator",
         email_address: "placement_coordinator@example.school",
       },
       school_id: school.id,
@@ -133,8 +143,9 @@ RSpec.describe "Placements / Schools / School Contacts / Add a school contact",
     visit check_placements_school_school_contacts_path(params)
   end
 
-  def then_i_see_the_inputs_pre_filled_with(name:, email_address:)
-    expect(page.find("#placements-school-contact-name-field").value).to eq(name)
+  def then_i_see_the_inputs_pre_filled_with(first_name:, last_name:, email_address:)
+    expect(page.find("#placements-school-contact-first-name-field").value).to eq(first_name)
+    expect(page.find("#placements-school-contact-last-name-field").value).to eq(last_name)
     expect(page.find("#placements-school-contact-email-address-field").value).to eq(email_address)
   end
 

--- a/spec/system/placements/schools/school_contacts/edit_a_school_contact_spec.rb
+++ b/spec/system/placements/schools/school_contacts/edit_a_school_contact_spec.rb
@@ -13,22 +13,26 @@ RSpec.describe "Placements / Schools / School Contacts / Edit a school contact",
   scenario "User edits the name of the school contact for their organisation" do
     when_i_view_my_organisation_details_page
     then_i_see_the_school_contact_details(
-      name: "Placement Coordinator",
+      first_name: "Placement",
+      last_name: "Coordinator",
       email_address: "placement_coordinator@example.school",
     )
     when_i_click_on_change(attribute: :name)
     then_i_see_the_inputs_pre_filled_with(
-      name: "Placement Coordinator",
+      first_name: "Placement",
+      last_name: "Coordinator",
       email_address: "placement_coordinator@example.school",
     )
     when_i_fill_out_the_school_contact_form(
-      name: "Placement Organiser",
+      first_name: "Placement",
+      last_name: "Organiser",
       email_address: "placement_organiser@example.school",
     )
     and_i_click_on("Continue")
     then_i_return_to_my_organisation_details_page
     and_i_see_the_school_contact_details(
-      name: "Placement Organiser",
+      first_name: "Placement",
+      last_name: "Organiser",
       email_address: "placement_organiser@example.school",
     )
     and_i_see_success_message
@@ -37,22 +41,26 @@ RSpec.describe "Placements / Schools / School Contacts / Edit a school contact",
   scenario "User edits the email address of the school contact for their organisation" do
     when_i_view_my_organisation_details_page
     then_i_see_the_school_contact_details(
-      name: "Placement Coordinator",
+      first_name: "Placement",
+      last_name: "Coordinator",
       email_address: "placement_coordinator@example.school",
     )
     when_i_click_on_change(attribute: :email_address)
     then_i_see_the_inputs_pre_filled_with(
-      name: "Placement Coordinator",
+      first_name: "Placement",
+      last_name: "Coordinator",
       email_address: "placement_coordinator@example.school",
     )
     when_i_fill_out_the_school_contact_form(
-      name: "Placement Organiser",
+      first_name: "Placement",
+      last_name: "Organiser",
       email_address: "placement_organiser@example.school",
     )
     and_i_click_on("Continue")
     then_i_return_to_my_organisation_details_page
     and_i_see_the_school_contact_details(
-      name: "Placement Organiser",
+      first_name: "Placement",
+      last_name: "Organiser",
       email_address: "placement_organiser@example.school",
     )
     and_i_see_success_message
@@ -61,12 +69,14 @@ RSpec.describe "Placements / Schools / School Contacts / Edit a school contact",
   scenario "User attempts to edit a school contact with an invalid email address" do
     when_i_view_my_organisation_details_page
     then_i_see_the_school_contact_details(
-      name: "Placement Coordinator",
+      first_name: "Placement",
+      last_name: "Coordinator",
       email_address: "placement_coordinator@example.school",
     )
     when_i_click_on_change(attribute: :email_address)
     and_i_fill_out_the_school_contact_form(
-      name: "Placement Organiser",
+      first_name: "Placement",
+      last_name: "Organiser",
       email_address: "placement organiser",
     )
     and_i_click_on("Continue")
@@ -114,22 +124,25 @@ RSpec.describe "Placements / Schools / School Contacts / Edit a school contact",
     end
   end
 
-  def then_i_see_the_school_contact_details(name:, email_address:)
+  def then_i_see_the_school_contact_details(first_name:, last_name:, email_address:)
     within("#school-contact-details") do
-      expect(page).to have_content(name)
+      expect(page).to have_content(first_name)
+      expect(page).to have_content(last_name)
       expect(page).to have_content(email_address)
     end
   end
   alias_method :and_i_see_the_school_contact_details,
                :then_i_see_the_school_contact_details
 
-  def then_i_see_the_inputs_pre_filled_with(name:, email_address:)
-    expect(page.find("#placements-school-contact-name-field").value).to eq(name)
+  def then_i_see_the_inputs_pre_filled_with(first_name:, last_name:, email_address:)
+    expect(page.find("#placements-school-contact-first-name-field").value).to eq(first_name)
+    expect(page.find("#placements-school-contact-last-name-field").value).to eq(last_name)
     expect(page.find("#placements-school-contact-email-address-field").value).to eq(email_address)
   end
 
-  def when_i_fill_out_the_school_contact_form(name:, email_address:)
-    fill_in "Full name", with: name
+  def when_i_fill_out_the_school_contact_form(first_name:, last_name:, email_address:)
+    fill_in "First name", with: first_name
+    fill_in "Last name", with: last_name
     fill_in "Email", with: email_address
   end
   alias_method :and_i_fill_out_the_school_contact_form,
@@ -140,9 +153,10 @@ RSpec.describe "Placements / Schools / School Contacts / Edit a school contact",
     expect_organisation_details_to_be_selected_in_primary_navigation
   end
 
-  def and_i_see_the_school_contact_details(name:, email_address:)
+  def and_i_see_the_school_contact_details(first_name:, last_name:, email_address:)
     within("#school-contact-details") do
-      expect(page).to have_content(name)
+      expect(page).to have_content(first_name)
+      expect(page).to have_content(last_name)
       expect(page).to have_content(email_address)
     end
   end


### PR DESCRIPTION
## Context

- Swap "Full name" `(:name)` for "First name" and "Last name" on School Contact 

## Changes proposed in this pull request

(Aligning with [strong migrations](https://github.com/ankane/strong_migrations?tab=readme-ov-file#renaming-a-column) the `name` will be removed in another PR)
- Add `first_name` column to 'school_contacts'
- Add `last_name` column to 'school_contacts'
- Swap "Full name" with "First name" and "Last name" inputs on SchoolContact forms
- Swap "Full name" with "First name" and "Last name" in school contact details partial

## Guidance to review

- Sign in as Anne (School User)
- Navigate to "Organisation detail"
- The School Contact details shown should be `first_name`, `last_name` and `email`
- Click any of the "Change" links
- The form should have inputs for ONLY `first_name`, `last_name` and `email`
- Change the inputs for `first_name`, `last_name` and `email`
- Click "Continue"
- Check that the attributes `first_name`, `last_name` and `email` have changed

## Link to Trello card

https://trello.com/c/sM0NMNzX/472-split-full-name-into-first-name-and-last-name-on-placement-contacts

## Screenshots
![screencapture-placements-localhost-3000-schools-00006306-367f-4447-962b-247a2aa79ceb-school-contacts-4efb3945-163d-4549-a47f-b5d904646bce-edit-2024-06-10-11_54_57](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/0ac00f30-6912-41c2-a03b-9598959748b5)

![screencapture-placements-localhost-3000-schools-00006306-367f-4447-962b-247a2aa79ceb-2024-06-10-11_55_23](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/0f8d8f91-3b25-429d-982a-48ce2249140a)

