### PR TITLE
Fix issue with DFE sign in

### DIFF
--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -65,13 +65,17 @@ class DfESignInUser
   private
 
   def support_user
-    support_user_klass.find_by(dfe_sign_in_uid:) ||
-      support_user_klass.find_by(email:)
+    @support_user ||= support_user_klass.find_by(dfe_sign_in_uid:) if dfe_sign_in_uid.present?
+    return @support_user if @support_user.present?
+
+    @support_user = support_user_klass.find_by(email:)
   end
 
   def non_support_user
-    user_klass.find_by(dfe_sign_in_uid:) ||
-      user_klass.find_by(email:)
+    @non_support_user ||= user_klass.find_by(dfe_sign_in_uid:) if dfe_sign_in_uid.present?
+    return @non_support_user if @non_support_user.present?
+
+    @non_support_user = user_klass.find_by(email:)
   end
 
   def support_user_klass

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -65,17 +65,19 @@ class DfESignInUser
   private
 
   def support_user
-    @support_user ||= support_user_klass.find_by(dfe_sign_in_uid:) if dfe_sign_in_uid.present?
-    return @support_user if @support_user.present?
-
-    @support_user = support_user_klass.find_by(email:)
+    @support_user ||= user_by_id(support_user_klass) ||
+      support_user_klass.find_by(email:)
   end
 
   def non_support_user
-    @non_support_user ||= user_klass.find_by(dfe_sign_in_uid:) if dfe_sign_in_uid.present?
-    return @non_support_user if @non_support_user.present?
+    @non_support_user ||= user_by_id(user_klass) ||
+      user_klass.find_by(email:)
+  end
 
-    @non_support_user = user_klass.find_by(email:)
+  def user_by_id(klass)
+    return if dfe_sign_in_uid.blank?
+
+    klass.find_by(dfe_sign_in_uid:)
   end
 
   def support_user_klass

--- a/spec/system/placements/sign_in_as_a_placements_user_spec.rb
+++ b/spec/system/placements/sign_in_as_a_placements_user_spec.rb
@@ -78,15 +78,43 @@ RSpec.describe "Sign In as a Placements User", type: :system, service: :placemen
     end
   end
 
+  context "when the user does not have a DfE ID" do
+    context "when the user is not a support user" do
+      scenario "I sign in as user Anne, using my email address" do
+        given_there_is_an_existing_user_for("Anne", with_dfe_sign_id: false)
+        when_i_visit_the_sign_in_path
+        when_i_click_sign_in
+        then_i_dont_get_redirected_to_support_organisations
+        and_i_visit_my_account_page
+        then_i_see_user_details_for_anne
+      end
+    end
+
+    context "when the user is a support user" do
+      scenario "I sign in as support user Colin, using my email address" do
+        given_there_is_an_existing_support_user_for("Colin", with_dfe_sign_id: false)
+        and_there_are_placement_organisations
+        when_i_visit_the_sign_in_path
+        when_i_click_sign_in
+        then_i_see_a_list_of_organisations
+
+        and_i_visit_my_account_page
+        then_i_see_user_details_for_colin
+      end
+    end
+  end
+
   private
 
-  def given_there_is_an_existing_user_for(user_name)
+  def given_there_is_an_existing_user_for(user_name, with_dfe_sign_id: true)
     user = create(:placements_user, user_name.downcase.to_sym)
+    user.update!(dfe_sign_in_uid: nil) unless with_dfe_sign_id
     user_exists_in_dfe_sign_in(user:)
   end
 
-  def given_there_is_an_existing_support_user_for(user_name)
+  def given_there_is_an_existing_support_user_for(user_name, with_dfe_sign_id: true)
     user = create(:placements_support_user, user_name.downcase.to_sym)
+    user.update!(dfe_sign_in_uid: nil) unless with_dfe_sign_id
     user_exists_in_dfe_sign_in(user:)
   end
 


### PR DESCRIPTION
## Context

Fix issue with DfE Sign In for QA, when no `dfe_sign_in_uid` is given in params

## Changes proposed in this pull request

- Check if `dfe_sign_in_uid` is present when using DfE sign in

## Guidance to review

- Sign in as the different Personas

## Link to Trello card

https://trello.com/c/fY3TaaSQ/477-fix-a-bug-in-qa-where-non-support-users-got-signed-in-as-support
