### PR TITLE
Improve context of placement success messages

### DIFF
--- a/app/controllers/placements/schools/placements_controller.rb
+++ b/app/controllers/placements/schools/placements_controller.rb
@@ -29,7 +29,7 @@ class Placements::Schools::PlacementsController < ApplicationController
     if valid_attributes?
       @placement.update!(placement_params)
 
-      redirect_to placements_school_placement_path(@school, @placement), flash: { success: t(".success") }
+      redirect_to placements_school_placement_path(@school, @placement), flash: { success: t(".success.#{params[:edit_path]}") }
     else
       @mentors = @school.mentors.all if params[:edit_path] == "edit_mentors"
       @providers = @school.partner_providers.all if params[:edit_path] == "edit_provider"

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -178,4 +178,7 @@ en:
         destroy:
           placement_deleted: Placement deleted
         update:
-          success: Placement updated
+          success: 
+            edit_mentors: Mentor updated
+            edit_provider: Provider updated
+            edit_year_group: Year group updated

--- a/spec/system/placements/schools/placements/edit_a_provider_spec.rb
+++ b/spec/system/placements/schools/placements/edit_a_provider_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
         then_i_should_see_the_provider_name_in_the_placement_details(
           provider_name: "Provider 2",
         )
+        and_i_see_success_message("Provider updated")
       end
 
       scenario "User does not select a provider" do
@@ -100,6 +101,7 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
         then_i_should_see_the_provider_name_in_the_placement_details(
           provider_name: "Provider 2",
         )
+        and_i_see_success_message("Provider updated")
       end
 
       scenario "User does not select a provider" do
@@ -119,6 +121,7 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
           text: "Assign a provider",
           href: edit_provider_placements_school_placement_path(school, placement),
         )
+        and_i_see_success_message("Provider updated")
       end
     end
   end
@@ -197,5 +200,11 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
 
   def then_i_see_link(text:, href:)
     expect(page).to have_link(text, href:)
+  end
+
+  def and_i_see_success_message(message)
+    within(".govuk-notification-banner") do
+      expect(page).to have_content message
+    end
   end
 end

--- a/spec/system/placements/schools/placements/edit_a_year_group_spec.rb
+++ b/spec/system/placements/schools/placements/edit_a_year_group_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe "Placements / Schools / Placements / Edit a year group",
       then_i_should_see_the_year_group_in_the_placement_details(
         year_group_name: "Year 4",
       )
+      and_i_see_success_message("Year group updated")
     end
   end
 
@@ -73,6 +74,12 @@ RSpec.describe "Placements / Schools / Placements / Edit a year group",
     within(".govuk-summary-list") do
       expect(page).to have_content(year_group_name)
       expect(page).to have_content(change_link)
+    end
+  end
+
+  def and_i_see_success_message(message)
+    within(".govuk-notification-banner") do
+      expect(page).to have_content message
     end
   end
 end

--- a/spec/system/placements/schools/placements/edit_mentors_spec.rb
+++ b/spec/system/placements/schools/placements/edit_mentors_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe "Placements / Schools / Placements / Edit mentors",
         when_i_select_mentor_2
         and_i_click_on("Continue")
         then_i_should_see_the_mentor_name_in_the_placement_details(mentor_name: mentor_2.full_name)
+        and_i_see_success_message("Mentor updated")
       end
 
       scenario "User does not select a mentor" do
@@ -104,6 +105,7 @@ RSpec.describe "Placements / Schools / Placements / Edit mentors",
         then_i_should_see_the_mentor_name_in_the_placement_details(
           mentor_name: mentor_2.full_name,
         )
+        and_i_see_success_message("Mentor updated")
       end
 
       scenario "User does not select a mentor" do
@@ -168,6 +170,7 @@ RSpec.describe "Placements / Schools / Placements / Edit mentors",
         when_i_select_not_yet_known
         and_i_click_on("Continue")
         then_i_should_see_the_mentor_is_not_yet_known_in_the_placement_details
+        and_i_see_success_message("Mentor updated")
       end
     end
   end
@@ -260,6 +263,12 @@ RSpec.describe "Placements / Schools / Placements / Edit mentors",
 
   def when_i_uncheck(text)
     uncheck(text)
+  end
+
+  def and_i_see_success_message(message)
+    within(".govuk-notification-banner") do
+      expect(page).to have_content message
+    end
   end
 
   alias_method :and_i_click_on, :when_i_click_on


### PR DESCRIPTION
## Context

- Improve the context of success messages when updating a placement.
  - Mentor -> Mentor updated
  - Provider -> Provider updated
  - Year group -> Year group updated

## Changes proposed in this pull request

- Add locales for the different types of updates
- Change controller to fetch the flash message specific to the update

## Guidance to review

- Sign in as Anne (School user) or Mary (Multi-org user)
- Navigate to "Placements" using the Navbar
- Click an existing Placement (Primary Placement preferred to test all the changes)
- Update the Mentor/s and see what success message appears
- Update the Year group and see what success message appears
- Assign/Update the Provider and see what success message appears

## Link to Trello card

https://trello.com/c/xQuGJZs4/440-content-update-success-notification-banner

## Screenshots
_Change Provider_
![screencapture-placements-localhost-3000-schools-fffc336b-33a9-471f-b8bd-23a8b7001c96-placements-535a9ba9-9f7c-4017-b400-3b116316f6e2-2024-06-10-15_18_47](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/9d8c38c7-5806-4c89-b479-84cbce742db5)

_Change Year Group_
![screencapture-placements-localhost-3000-schools-fffc336b-33a9-471f-b8bd-23a8b7001c96-placements-535a9ba9-9f7c-4017-b400-3b116316f6e2-2024-06-10-15_19_33](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/90bf7261-1213-4493-91ff-51662ac9549d)

_Change Mentor_
![screencapture-placements-localhost-3000-schools-fffc336b-33a9-471f-b8bd-23a8b7001c96-placements-535a9ba9-9f7c-4017-b400-3b116316f6e2-2024-06-10-15_20_05](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/b776a368-38e4-4ff0-a540-9df3f25d5c33)
