### PR TITLE
Replace itt across service

### DIFF
--- a/app/views/placements/pages/landing-page.md
+++ b/app/views/placements/pages/landing-page.md
@@ -1,13 +1,13 @@
 This service is for:
 
 - schools offering placements for trainee teachers
-- initial teacher training (ITT) providers in England
+- teacher training providers in England
 
 ### If you are a school, use this service to: ###
 
-- publish placement opportunities for placement teachers so that ITT providers can contact you
+- publish placement opportunities for trainee teachers so that teacher training providers can contact you
 - add and assign mentors to placements to track capacity
 
-### If you are an ITT provider, use this service to: ###
+### If you are a teacher training provider, use this service to: ###
 
-- find schools who are offering placements for your trainees
+- find schools that are offering placements for trainee teachers

--- a/app/views/placements/schools/placements/index.html.erb
+++ b/app/views/placements/schools/placements/index.html.erb
@@ -21,7 +21,7 @@
             t(
               ".you_must_add_itt_placement_contact",
               link_to: govuk_link_to(
-                t(".itt_placement_contact"),
+                t(".add_itt_placement_contact"),
                 new_placements_school_school_contact_path,
                 no_visited_state: true,
               ),

--- a/config/locales/en/forms/organisation_onboarding_form.yml
+++ b/config/locales/en/forms/organisation_onboarding_form.yml
@@ -1,5 +1,5 @@
 en:
   forms:
     organisation_onboarding_form:
-      itt_provider: ITT provider
+      itt_provider: Teacher training provider
       school: School

--- a/config/locales/en/placements/placements.yml
+++ b/config/locales/en/placements/placements.yml
@@ -30,7 +30,7 @@ en:
         page_title: "%{subject_name} - Placements - %{school_name}"
         placement: "Placement - %{school_name}"
         contact_details: Contact details
-        itt_placement_contact: ITT placement contact
+        itt_placement_contact: Placement contact
         location: Location
         additional_details: Additional details
       school_details:

--- a/config/locales/en/placements/schools.yml
+++ b/config/locales/en/placements/schools.yml
@@ -7,7 +7,6 @@ en:
         additional_details: Additional details
         ofsted: Ofsted
         send: Special educational needs and disabilities (SEND)
-        school_contact_details: School contact details
         itt_placement_contact: Placement contact
         add_itt_placement_contact: Add placement contact
         school_details: School 

--- a/config/locales/en/placements/schools.yml
+++ b/config/locales/en/placements/schools.yml
@@ -8,7 +8,7 @@ en:
         ofsted: Ofsted
         send: Special educational needs and disabilities (SEND)
         school_contact_details: School contact details
-        itt_placement_contact: ITT placement contact
-        add_itt_placement_contact: Add ITT placement contact
+        itt_placement_contact: Placement contact
+        add_itt_placement_contact: Add placement contact
         school_details: School 
         location: Location

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -150,8 +150,8 @@ en:
           placements: Placements
           add_placement: Add placement
           you_must_add_itt_placement_contact: |
-            You must add the %{link_to} email before adding a placement
-          itt_placement_contact: ITT placement contact
+            Before you add a placement, you must add a %{link_to} so that the teacher training providers can contact you.
+          itt_placement_contact: placement contact
         show:
           delete_placement: Delete placement
         details:

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -89,7 +89,7 @@ en:
             add_year_group: Add year group
             add_mentors: Add mentors
             change: Change
-            info_text: When a placement is published, it will be visible to accredited providers and lead partners.
+            info_text: When a placement is published, it will be visible to teacher training providers.
             publish_placement: Publish placement
             cancel: Cancel
             not_yet_known: Not yet known

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -150,8 +150,8 @@ en:
           placements: Placements
           add_placement: Add placement
           you_must_add_itt_placement_contact: |
-            Before you add a placement, you must add a %{link_to} so that the teacher training providers can contact you.
-          itt_placement_contact: placement contact
+            Before you add a placement, you must %{link_to} so that the teacher training providers can contact you.
+          add_itt_placement_contact: add a placement contact
         show:
           delete_placement: Delete placement
         details:

--- a/config/locales/en/placements/schools/school_contacts.yml
+++ b/config/locales/en/placements/schools/school_contacts.yml
@@ -3,14 +3,14 @@ en:
     schools:
       school_contacts:
         new:
-          page_title: Add the ITT placement contact
-          page_title_with_error: Error - Add the ITT placement contact
+          page_title: Add the placement contact
+          page_title_with_error: Error - Add the placement contact
           continue: Continue
           cancel: Cancel
         check:
           page_title: Check your answers
           check_your_answers: Check your answers
-          add_the_itt_placement_contact: Add the ITT placement contact
+          add_the_itt_placement_contact: Add the placement contact
           cancel: Cancel
           change: Change
           attributes:
@@ -18,21 +18,21 @@ en:
               name: Name
               email_address: Email address
         create:
-          school_contact_added: School contact added
+          school_contact_added: Placement contact added
         edit:
-          page_title: School contact
-          page_title_with_error: Error - School contact
+          page_title: Placement contact
+          page_title_with_error: Error - Placement contact
           continue: Continue
           cancel: Cancel
         update:
-          school_contact_updated: School contact updated
+          school_contact_updated: Placement contact updated
         remove:
-          page_title: Are you sure you want to remove this school contact? - %{school_contact_name}
-          are_you_sure: Are you sure you want to remove this school contact?
+          page_title: Are you sure you want to remove this placement contact? - %{school_contact_name}
+          are_you_sure: Are you sure you want to remove this placement contact?
           cancel: Cancel
-          remove_school_contact: Remove school contact
+          remove_school_contact: Remove placement contact
         destroy:
-          school_contact_removed: School contact removed
+          school_contact_removed: Placement contact removed
         form:
           caption: Organisation details
           title: Add the ITT placement contact

--- a/config/locales/en/placements/schools/school_contacts.yml
+++ b/config/locales/en/placements/schools/school_contacts.yml
@@ -3,14 +3,14 @@ en:
     schools:
       school_contacts:
         new:
-          page_title: Add the placement contact
-          page_title_with_error: Error - Add the placement contact
+          page_title: Add placement contact
+          page_title_with_error: Error - Add placement contact
           continue: Continue
           cancel: Cancel
         check:
           page_title: Check your answers
           check_your_answers: Check your answers
-          add_the_itt_placement_contact: Add the placement contact
+          add_the_itt_placement_contact: Add placement contact
           cancel: Cancel
           change: Change
           attributes:
@@ -35,7 +35,7 @@ en:
           school_contact_removed: Placement contact removed
         form:
           caption: Organisation details
-          title: Add the placement contact
+          title: Add placement contact
           description: Add an email address for the main contact for school placements. This can also be a shared inbox.
           continue: Continue
           cancel: Cancel

--- a/config/locales/en/placements/schools/school_contacts.yml
+++ b/config/locales/en/placements/schools/school_contacts.yml
@@ -35,12 +35,12 @@ en:
           school_contact_removed: Placement contact removed
         form:
           caption: Organisation details
-          title: Add the ITT placement contact
-          description: Add an email for the main contact for school placements. This can also be a shared inbox.
+          title: Add the placement contact
+          description: Add an email address for the main contact for school placements. This can also be a shared inbox.
           continue: Continue
           cancel: Cancel
           attributes:
             school_contacts:
               full_name: Full name
-              email: Email
+              email: Email address
           

--- a/config/locales/en/placements/support/organisations.yml
+++ b/config/locales/en/placements/support/organisations.yml
@@ -4,7 +4,7 @@ en:
       organisations:
         new:
           caption: Add organisation
-          itt_provider: ITT provider
+          itt_provider: Teacher training provider
           school: School
           title: Organisation type
           title_with_error: "Error: Organisation type"

--- a/config/locales/en/shared/schools/school_contact_details.yml
+++ b/config/locales/en/shared/schools/school_contact_details.yml
@@ -3,5 +3,5 @@ en:
     schools:
       school_contact_details:
         full_name: Full name
-        email: Email
+        email: Email address
         change: Change

--- a/config/locales/en/shared/schools/school_details.yml
+++ b/config/locales/en/shared/schools/school_details.yml
@@ -3,7 +3,7 @@ en:
     schools:
       school_details:
         gias: Get Information about Schools (GIAS)
-        gias_details: "These details will be displayed to ITT providers. 
+        gias_details: "These details will be displayed to teacher training providers.
           If any details are incorrect, go to the %{link_to} service to update them."
         organisation_name: Organisation name
         ukprn: UK provider reference number (UKPRN)

--- a/spec/forms/organisation_onboarding_form_spec.rb
+++ b/spec/forms/organisation_onboarding_form_spec.rb
@@ -13,7 +13,7 @@ describe OrganisationOnboardingForm, type: :model do
         [
           OpenStruct.new(
             id: described_class::ITT_PROVIDER,
-            name: "ITT provider",
+            name: "Teacher training provider",
           ),
           OpenStruct.new(
             id: described_class::SCHOOL,

--- a/spec/system/placements/placements/view_a_placement_spec.rb
+++ b/spec/system/placements/placements/view_a_placement_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe "Placements / Placements / View a placement",
   end
 
   def and_i_see_the_itt_placement_contact_details_for_the_school
-    expect(page).to have_content("ITT placement contact")
+    expect(page).to have_content("Placement contact")
     expect(page).to have_content(school.school_contact.name)
     expect(page).to have_content(school.school_contact.email_address)
   end

--- a/spec/system/placements/schools/placements/add_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/add_a_placement_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
     it "does not allow the user to add a placement" do
       when_i_visit_the_placements_page
       then_i_see_content(
-        "You must add the ITT placement contact email before adding a placement",
+        "Before you add a placement, you must add a placement contact so that the teacher training providers can contact you.",
       )
       and_i_do_not_see_the_button_to("Add placement")
     end

--- a/spec/system/placements/schools/school_contacts/add_a_school_contact_spec.rb
+++ b/spec/system/placements/schools/school_contacts/add_a_school_contact_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Placements / Schools / School Contacts / Add a school contact",
   scenario "User adds a school contact to their organisation" do
     when_i_view_my_organisation_details_page
     then_i_see_no_school_contact_details
-    when_i_click_on("Add ITT placement contact")
+    when_i_click_on("Add placement contact")
     and_i_fill_out_the_school_contact_form(
       name: "Placement Coordinator",
       email_address: "placement_coordinator@example.school",
@@ -21,7 +21,7 @@ RSpec.describe "Placements / Schools / School Contacts / Add a school contact",
       name: "Placement Coordinator",
       email_address: "placement_coordinator@example.school",
     )
-    when_i_click_on("Add the ITT placement contact")
+    when_i_click_on("Add the placement contact")
     then_i_return_to_my_organisation_details_page
     and_i_see_the_school_contact_details(
       name: "Placement Coordinator",
@@ -47,7 +47,7 @@ RSpec.describe "Placements / Schools / School Contacts / Add a school contact",
   scenario "User attempts to add a school contact with an invalid email address" do
     when_i_view_my_organisation_details_page
     then_i_see_no_school_contact_details
-    when_i_click_on("Add ITT placement contact")
+    when_i_click_on("Add placement contact")
     and_i_fill_out_the_school_contact_form(
       name: "Placement Coordinator",
       email_address: "invalid_email",
@@ -90,8 +90,8 @@ RSpec.describe "Placements / Schools / School Contacts / Add a school contact",
   alias_method :and_i_click_on, :when_i_click_on
 
   def then_i_see_no_school_contact_details
-    expect(page).to have_content("ITT placement contact")
-    expect(page).to have_content("Add ITT placement contact")
+    expect(page).to have_content("Placement contact")
+    expect(page).to have_content("Add placement contact")
   end
 
   def when_i_fill_out_the_school_contact_form(name:, email_address:)
@@ -119,7 +119,7 @@ RSpec.describe "Placements / Schools / School Contacts / Add a school contact",
   end
 
   def and_i_see_success_message
-    expect(page).to have_content("School contact added")
+    expect(page).to have_content("Placement contact added")
   end
 
   def given_i_have_completed_the_school_contact_form

--- a/spec/system/placements/schools/school_contacts/add_a_school_contact_spec.rb
+++ b/spec/system/placements/schools/school_contacts/add_a_school_contact_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Placements / Schools / School Contacts / Add a school contact",
       name: "Placement Coordinator",
       email_address: "placement_coordinator@example.school",
     )
-    when_i_click_on("Add the placement contact")
+    when_i_click_on("Add placement contact")
     then_i_return_to_my_organisation_details_page
     and_i_see_the_school_contact_details(
       name: "Placement Coordinator",

--- a/spec/system/placements/schools/school_contacts/edit_a_school_contact_spec.rb
+++ b/spec/system/placements/schools/school_contacts/edit_a_school_contact_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe "Placements / Schools / School Contacts / Edit a school contact",
   end
 
   def and_i_see_success_message
-    expect(page).to have_content("School contact updated")
+    expect(page).to have_content("Placement contact updated")
   end
 
   def then_i_see_an_error(error_message)

--- a/spec/system/placements/support/organisations/support_user_selects_an_organisation_type_to_add_spec.rb
+++ b/spec/system/placements/support/organisations/support_user_selects_an_organisation_type_to_add_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Placements / Support / Organisations / Support User Selects An O
   end
 
   scenario "Colin selects to add an ITT provider" do
-    when_i_select_the_radio_option("ITT provider")
+    when_i_select_the_radio_option("Teacher training provider")
     and_i_click_continue
     then_i_see_the_title("Enter a provider name, UKPRN, URN or postcode")
   end


### PR DESCRIPTION
## Context

After a content sweep it was decided that acronyms should be removed.

## Changes proposed in this pull request

- [x] Update references of "ITT" to "Teacher training"
- [x] Update "ITT Contact"/"School Contact" to "Placement contact"
- [x] Change placement contact "Email" to "Email address"
- [x] Update any broken specs

## Guidance to review

- Check changes against content designs

## Link to Trello card

[Replace use of ITT acronym in service](http://placements.localhost:3000/schools/000b2c51-9c1c-41b2-bd40-8f79f8ae8be1/placements)

## Screenshots

![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/50d55012-8b20-49f8-99a4-79a7de2eef96)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/92c5e969-43c8-433e-a8b8-02ce9b14224a)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/c75ef9a0-82c9-4b2d-80bf-0718d1625088)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/49ed64d2-85df-4e30-bda5-b58bde04384a)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/8062f21c-9ae6-46c9-8ac8-4cb926775b51)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/39d058fa-ac9c-4f3d-bed2-77c01e647767)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/b24a79de-5869-40b4-ac77-34f86215c949)
![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/0d7afb1b-a2a7-457b-932e-97d3bdb1de7d)