### PR TITLE
Add test coverage for user deletion

### DIFF
--- a/app/controllers/placements/support/support_users_controller.rb
+++ b/app/controllers/placements/support/support_users_controller.rb
@@ -25,8 +25,6 @@ class Placements::Support::SupportUsersController < Placements::Support::Applica
   def remove; end
 
   def destroy
-    authorize @support_user
-
     SupportUser::Remove.call(support_user: @support_user)
     redirect_to placements_support_support_users_path, flash: { success: t(".success") }
   end

--- a/spec/requests/placements/providers/users_spec.rb
+++ b/spec/requests/placements/providers/users_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe "Provider users", type: :request, service: :placements do
+  let(:provider) { build(:placements_provider) }
+  let(:current_user) { create(:placements_user, providers: [provider]) }
+
+  before do
+    user_exists_in_dfe_sign_in(user: current_user)
+    get "/auth/dfe/callback"
+    follow_redirect!
+  end
+
+  describe "DELETE" do
+    let(:provider) { create(:placements_provider) }
+
+    context "when deleting a user in the same provider as the current user" do
+      let(:user) { create(:placements_user, providers: [provider]) }
+
+      it "deletes the user" do
+        expect(provider.users).to include(user)
+        delete placements_provider_user_path(provider, user)
+        expect(flash[:success]).to eq "User removed"
+        expect(provider.users).not_to include(user)
+      end
+    end
+
+    context "when the current user tries to delete themselves" do
+      it "shows an error message" do
+        delete placements_provider_user_path(provider, current_user)
+        expect(flash[:alert]).to eq "You cannot perform this action"
+        expect(provider.users).to include(current_user)
+      end
+    end
+
+    context "when deleting a user in a different provider" do
+      let(:another_provider) { build(:placements_provider) }
+      let(:user) { create(:placements_user, providers: [another_provider]) }
+
+      it "shows an error message" do
+        expect {
+          delete placements_provider_user_path(another_provider, user)
+        }.to raise_exception(ActiveRecord::RecordNotFound)
+        expect(another_provider.users).to include(user)
+      end
+    end
+  end
+end

--- a/spec/requests/placements/schools/users_spec.rb
+++ b/spec/requests/placements/schools/users_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe "School users", type: :request, service: :placements do
+  let(:school) { build(:placements_school) }
+  let(:current_user) { create(:placements_user, schools: [school]) }
+
+  before do
+    user_exists_in_dfe_sign_in(user: current_user)
+    get "/auth/dfe/callback"
+    follow_redirect!
+  end
+
+  describe "DELETE" do
+    let(:school) { create(:placements_school) }
+
+    context "when deleting a user in the same school as the current user" do
+      let(:user) { create(:placements_user, schools: [school]) }
+
+      it "deletes the user" do
+        expect(school.users).to include(user)
+        delete placements_school_user_path(school, user)
+        expect(flash[:success]).to eq "User removed"
+        expect(school.users).not_to include(user)
+      end
+    end
+
+    context "when the current user tries to delete themselves" do
+      it "shows an error message" do
+        delete placements_school_user_path(school, current_user)
+        expect(flash[:alert]).to eq "You cannot perform this action"
+        expect(school.users).to include(current_user)
+      end
+    end
+
+    context "when deleting a user in a different school" do
+      let(:another_school) { build(:placements_school) }
+      let(:user) { create(:placements_user, schools: [another_school]) }
+
+      it "shows an error message" do
+        expect {
+          delete placements_school_user_path(another_school, user)
+        }.to raise_exception(ActiveRecord::RecordNotFound)
+        expect(another_school.users).to include(user)
+      end
+    end
+  end
+end

--- a/spec/requests/placements/support/support_users_spec.rb
+++ b/spec/requests/placements/support/support_users_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe "Support users", type: :request, service: :placements do
+  let(:current_user) { create(:placements_support_user) }
+  let(:support_users) { Placements::SupportUser.all }
+
+  before do
+    user_exists_in_dfe_sign_in(user: current_user)
+    get "/auth/dfe/callback"
+    follow_redirect!
+  end
+
+  describe "DELETE" do
+    context "when deleting a support user" do
+      let(:user) { create(:placements_support_user) }
+
+      it "deletes the user" do
+        expect(support_users).to include(user)
+        delete placements_support_support_user_path(user)
+        expect(flash[:success]).to eq "Support user removed"
+        expect(support_users).not_to include(user)
+      end
+    end
+
+    context "when the current user tries to delete themselves" do
+      it "shows an error message" do
+        delete placements_support_support_user_path(current_user)
+        expect(flash[:alert]).to eq "You cannot perform this action"
+        expect(support_users).to include(current_user)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

I noticed we weren't covering the "support user cannot delete themselves" scenario, and so it was possible to remove the authorization code and the tests would still pass.

## Changes proposed in this pull request

I've added request specs to prove that users must be authorized when deleting other users. It also proves that users cannot delete themselves.

I also noticed that we were running `authorize @support_user` twice on the `Placements::Support::SupportUsersController#destroy` action, so I've tidied that up.

## Guidance to review

Do the tests pass?

## Link to Trello card

Discovered while working on: https://trello.com/c/URtV1kGv/403-make-find-placements-the-default-page-for-providers
