### PR TITLE
Convert provider messaging to long form

### DIFF
--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -45,7 +45,7 @@ en:
           attributes:
             id:
               already_added: "%{provider_name} has already been added. Try another provider"
-              blank: Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode
+              blank: Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode
               option_blank: Select a provider
         school_onboarding_form:
           attributes:
@@ -61,5 +61,5 @@ en:
               option_blank: Select a school
             provider_id:
               already_added: "%{provider_name} has already been added. Try another provider"
-              blank: Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode
+              blank: Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode
               option_blank: Select a provider

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -45,7 +45,7 @@ en:
           attributes:
             id:
               already_added: "%{provider_name} has already been added. Try another provider"
-              blank: Enter a provider name, UKPRN, URN or postcode
+              blank: Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode
               option_blank: Select a provider
         school_onboarding_form:
           attributes:
@@ -61,5 +61,5 @@ en:
               option_blank: Select a school
             provider_id:
               already_added: "%{provider_name} has already been added. Try another provider"
-              blank: Enter a provider name, UKPRN, URN or postcode
+              blank: Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode
               option_blank: Select a provider

--- a/config/locales/en/placements/schools/partner_providers.yml
+++ b/config/locales/en/placements/schools/partner_providers.yml
@@ -13,10 +13,10 @@ en:
               ukprn: UK provider reference number (UKPRN)
         new:
           change_organisation: Change organisation
-          page_title: Enter a provider name, UKPRN, URN or postcode - Add partner provider
-          page_title_with_error: "Errors:  Enter a provider name, UKPRN, URN or postcode - Add partner provider"
+          page_title: Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode - Add partner provider
+          page_title_with_error: "Errors: Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode - Add partner provider"
           caption: Add partner provider
-          title: Enter a provider name, UKPRN, URN or postcode
+          title: Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode
           continue: Continue
           cancel: Cancel
         check:

--- a/config/locales/en/placements/schools/partner_providers.yml
+++ b/config/locales/en/placements/schools/partner_providers.yml
@@ -13,10 +13,10 @@ en:
               ukprn: UK provider reference number (UKPRN)
         new:
           change_organisation: Change organisation
-          page_title: Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode - Add partner provider
-          page_title_with_error: "Errors: Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode - Add partner provider"
+          page_title: Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode - Add partner provider
+          page_title_with_error: "Errors: Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode - Add partner provider"
           caption: Add partner provider
-          title: Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode
+          title: Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode
           continue: Continue
           cancel: Cancel
         check:

--- a/config/locales/en/placements/support/providers.yml
+++ b/config/locales/en/placements/support/providers.yml
@@ -10,8 +10,8 @@ en:
           caption: Add organisation
           cancel: Cancel
           continue: Continue
-          title_with_error: "Error: Enter a provider name, UKPRN, URN or postcode"
-          title: Enter a provider name, UKPRN, URN or postcode
+          title_with_error: "Error: Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode."
+          title: Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode.
         check:
           add_organisation: Add organisation
           address: Address

--- a/config/locales/en/placements/support/providers.yml
+++ b/config/locales/en/placements/support/providers.yml
@@ -10,8 +10,8 @@ en:
           caption: Add organisation
           cancel: Cancel
           continue: Continue
-          title_with_error: "Error: Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode."
-          title: Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode.
+          title_with_error: "Error: Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode."
+          title: Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode.
         check:
           add_organisation: Add organisation
           address: Address

--- a/config/locales/en/placements/support/schools/partner_providers.yml
+++ b/config/locales/en/placements/support/schools/partner_providers.yml
@@ -25,10 +25,10 @@ en:
           destroy:
             partner_provider_removed: Partner provider removed
           new:
-            page_title: "Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode - Add partner provider - %{school_name}"
-            page_title_with_error: "Errors: Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode - Add partner provider - %{school_name}"
+            page_title: "Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode - Add partner provider - %{school_name}"
+            page_title_with_error: "Errors: Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode - Add partner provider - %{school_name}"
             caption: Add partner provider - %{school_name}
-            title: Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode.
+            title: Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode.
             cancel: Cancel
           check:
             continue: Continue

--- a/config/locales/en/placements/support/schools/partner_providers.yml
+++ b/config/locales/en/placements/support/schools/partner_providers.yml
@@ -25,10 +25,10 @@ en:
           destroy:
             partner_provider_removed: Partner provider removed
           new:
-            page_title: "Enter a provider name, UKPRN, URN or postcode - Add partner provider - %{school_name}"
-            page_title_with_error: "Errors: Enter a provider name, UKPRN, URN or postcode - Add partner provider - %{school_name}"
+            page_title: "Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode - Add partner provider - %{school_name}"
+            page_title_with_error: "Errors: Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode - Add partner provider - %{school_name}"
             caption: Add partner provider - %{school_name}
-            title: Enter a provider name, UKPRN, URN or postcode
+            title: Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode.
             cancel: Cancel
           check:
             continue: Continue

--- a/spec/components/autocomplete_select_form_component_spec.rb
+++ b/spec/components/autocomplete_select_form_component_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe AutocompleteSelectFormComponent, type: :component do
       {
         field_name: :id,
         value: nil,
-        label: "Enter a provider name, UKPRN, URN or postcode",
+        label: "Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode.",
         caption: "Add organisation",
         previous_search: nil,
       }
@@ -126,7 +126,7 @@ RSpec.describe AutocompleteSelectFormComponent, type: :component do
         "[data-autocomplete-path-value='/api/provider_suggestions']" \
         "[data-autocomplete-return-attributes-value='[\"code\"]']",
       )
-      expect(page.find(".govuk-label")).to have_content("Enter a provider name, UKPRN, URN or postcode")
+      expect(page.find(".govuk-label")).to have_content("Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode.")
       expect(page.find(".govuk-caption-l")).to have_content("Add organisation")
       expect(page).to have_field("provider-id-field")
       page.find("div[data-input-name='provider[name]']")

--- a/spec/components/autocomplete_select_form_component_spec.rb
+++ b/spec/components/autocomplete_select_form_component_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe AutocompleteSelectFormComponent, type: :component do
       {
         field_name: :id,
         value: nil,
-        label: "Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode.",
+        label: "Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode.",
         caption: "Add organisation",
         previous_search: nil,
       }
@@ -126,7 +126,7 @@ RSpec.describe AutocompleteSelectFormComponent, type: :component do
         "[data-autocomplete-path-value='/api/provider_suggestions']" \
         "[data-autocomplete-return-attributes-value='[\"code\"]']",
       )
-      expect(page.find(".govuk-label")).to have_content("Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode.")
+      expect(page.find(".govuk-label")).to have_content("Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode.")
       expect(page.find(".govuk-caption-l")).to have_content("Add organisation")
       expect(page).to have_field("provider-id-field")
       page.find("div[data-input-name='provider[name]']")

--- a/spec/components/previews/autocomplete_select_form_component_preview.rb
+++ b/spec/components/previews/autocomplete_select_form_component_preview.rb
@@ -36,7 +36,7 @@ class AutocompleteSelectFormComponentPreview < ApplicationComponentPreview
       input: {
         field_name: :id,
         value: nil,
-        label: "Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode.",
+        label: "Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode.",
         caption: "Add organisation",
         previous_search: nil,
       },

--- a/spec/components/previews/autocomplete_select_form_component_preview.rb
+++ b/spec/components/previews/autocomplete_select_form_component_preview.rb
@@ -36,7 +36,7 @@ class AutocompleteSelectFormComponentPreview < ApplicationComponentPreview
       input: {
         field_name: :id,
         value: nil,
-        label: "Enter a provider name, UKPRN, URN or postcode",
+        label: "Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode.",
         caption: "Add organisation",
         previous_search: nil,
       },

--- a/spec/forms/placements/partnership_form_spec.rb
+++ b/spec/forms/placements/partnership_form_spec.rb
@@ -57,7 +57,7 @@ describe Placements::PartnershipForm, type: :model do
           )
 
           expect(form.valid?).to eq(false)
-          expect(form.errors.messages[:provider_id]).to include("Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode")
+          expect(form.errors.messages[:provider_id]).to include("Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode")
         end
       end
 
@@ -84,7 +84,7 @@ describe Placements::PartnershipForm, type: :model do
         )
 
         expect(form.valid?).to eq(false)
-        expect(form.errors.messages[:provider_id]).to include("Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode")
+        expect(form.errors.messages[:provider_id]).to include("Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode")
       end
     end
 

--- a/spec/forms/placements/partnership_form_spec.rb
+++ b/spec/forms/placements/partnership_form_spec.rb
@@ -57,7 +57,7 @@ describe Placements::PartnershipForm, type: :model do
           )
 
           expect(form.valid?).to eq(false)
-          expect(form.errors.messages[:provider_id]).to include("Enter a provider name, UKPRN, URN or postcode")
+          expect(form.errors.messages[:provider_id]).to include("Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode")
         end
       end
 
@@ -84,7 +84,7 @@ describe Placements::PartnershipForm, type: :model do
         )
 
         expect(form.valid?).to eq(false)
-        expect(form.errors.messages[:provider_id]).to include("Enter a provider name, UKPRN, URN or postcode")
+        expect(form.errors.messages[:provider_id]).to include("Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode")
       end
     end
 

--- a/spec/forms/provider_onboarding_form_spec.rb
+++ b/spec/forms/provider_onboarding_form_spec.rb
@@ -7,7 +7,7 @@ describe ProviderOnboardingForm, type: :model do
         form = described_class.new(id: nil)
         expect(form.valid?).to eq(false)
         expect(form.valid?).to eq(false)
-        expect(form.errors.messages[:id]).to include("Enter a provider name, UKPRN, URN or postcode")
+        expect(form.errors.messages[:id]).to include("Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode")
       end
     end
 
@@ -15,7 +15,7 @@ describe ProviderOnboardingForm, type: :model do
       it "returns invalid" do
         form = described_class.new(id: "1231")
         expect(form.valid?).to eq(false)
-        expect(form.errors.messages[:id]).to include("Enter a provider name, UKPRN, URN or postcode")
+        expect(form.errors.messages[:id]).to include("Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode")
       end
     end
 

--- a/spec/forms/provider_onboarding_form_spec.rb
+++ b/spec/forms/provider_onboarding_form_spec.rb
@@ -7,7 +7,7 @@ describe ProviderOnboardingForm, type: :model do
         form = described_class.new(id: nil)
         expect(form.valid?).to eq(false)
         expect(form.valid?).to eq(false)
-        expect(form.errors.messages[:id]).to include("Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode")
+        expect(form.errors.messages[:id]).to include("Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode")
       end
     end
 
@@ -15,7 +15,7 @@ describe ProviderOnboardingForm, type: :model do
       it "returns invalid" do
         form = described_class.new(id: "1231")
         expect(form.valid?).to eq(false)
-        expect(form.errors.messages[:id]).to include("Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode")
+        expect(form.errors.messages[:id]).to include("Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode")
       end
     end
 

--- a/spec/system/placements/schools/partner_providers/add_a_partner_provider_spec.rb
+++ b/spec/system/placements/schools/partner_providers/add_a_partner_provider_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Placements / Schools / Partner providers / Add a partner provide
   scenario "User submits the search form without selecting a provider", js: true, retry: 3 do
     when_i_visit_the_add_partner_provider_page
     and_i_click_on("Continue")
-    then_i_see_an_error("Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode")
+    then_i_see_an_error("Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode")
   end
 
   scenario "User reconsiders selecting a provider", js: true, retry: 3 do

--- a/spec/system/placements/schools/partner_providers/add_a_partner_provider_spec.rb
+++ b/spec/system/placements/schools/partner_providers/add_a_partner_provider_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Placements / Schools / Partner providers / Add a partner provide
   scenario "User submits the search form without selecting a provider", js: true, retry: 3 do
     when_i_visit_the_add_partner_provider_page
     and_i_click_on("Continue")
-    then_i_see_an_error("Enter a provider name, UKPRN, URN or postcode")
+    then_i_see_an_error("Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode")
   end
 
   scenario "User reconsiders selecting a provider", js: true, retry: 3 do

--- a/spec/system/placements/schools/partner_providers/add_a_partner_provider_without_javascript_spec.rb
+++ b/spec/system/placements/schools/partner_providers/add_a_partner_provider_without_javascript_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Placements / Schools / Partner providers / Add a partner provide
   scenario "User submits the search form without selecting a provider" do
     when_i_visit_the_add_partner_provider_page
     and_i_click_on("Continue")
-    then_i_see_an_error("Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode")
+    then_i_see_an_error("Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode")
   end
 
   scenario "User submits the options form without selecting a provider" do

--- a/spec/system/placements/schools/partner_providers/add_a_partner_provider_without_javascript_spec.rb
+++ b/spec/system/placements/schools/partner_providers/add_a_partner_provider_without_javascript_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Placements / Schools / Partner providers / Add a partner provide
   scenario "User submits the search form without selecting a provider" do
     when_i_visit_the_add_partner_provider_page
     and_i_click_on("Continue")
-    then_i_see_an_error("Enter a provider name, UKPRN, URN or postcode")
+    then_i_see_an_error("Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode")
   end
 
   scenario "User submits the options form without selecting a provider" do

--- a/spec/system/placements/support/organisations/support_user_selects_an_organisation_type_to_add_spec.rb
+++ b/spec/system/placements/support/organisations/support_user_selects_an_organisation_type_to_add_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Placements / Support / Organisations / Support User Selects An O
   scenario "Colin selects to add an ITT provider" do
     when_i_select_the_radio_option("ITT provider")
     and_i_click_continue
-    then_i_see_the_title("Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode")
+    then_i_see_the_title("Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode")
   end
 
   scenario "Colin selects to add a school" do

--- a/spec/system/placements/support/organisations/support_user_selects_an_organisation_type_to_add_spec.rb
+++ b/spec/system/placements/support/organisations/support_user_selects_an_organisation_type_to_add_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Placements / Support / Organisations / Support User Selects An O
   scenario "Colin selects to add an ITT provider" do
     when_i_select_the_radio_option("ITT provider")
     and_i_click_continue
-    then_i_see_the_title("Enter a provider name, UKPRN, URN or postcode")
+    then_i_see_the_title("Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode")
   end
 
   scenario "Colin selects to add a school" do

--- a/spec/system/placements/support/providers/support_user_adds_a_provider_spec.rb
+++ b/spec/system/placements/support/providers/support_user_adds_a_provider_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Placements / Support / Providers / Support User adds a Provider"
     when_i_visit_the_add_provider_page
     then_i_see_support_navigation_with_organisation_selected
     and_i_click_continue
-    then_i_see_an_error("Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode")
+    then_i_see_an_error("Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode")
   end
 
   scenario "Colin reconsiders onboarding a provider", js: true, retry: 3 do

--- a/spec/system/placements/support/providers/support_user_adds_a_provider_spec.rb
+++ b/spec/system/placements/support/providers/support_user_adds_a_provider_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Placements / Support / Providers / Support User adds a Provider"
     when_i_visit_the_add_provider_page
     then_i_see_support_navigation_with_organisation_selected
     and_i_click_continue
-    then_i_see_an_error("Enter a provider name, UKPRN, URN or postcode")
+    then_i_see_an_error("Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode")
   end
 
   scenario "Colin reconsiders onboarding a provider", js: true, retry: 3 do

--- a/spec/system/placements/support/providers/support_user_adds_a_provider_without_javascript_spec.rb
+++ b/spec/system/placements/support/providers/support_user_adds_a_provider_without_javascript_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Support User adds a Provider without JavaScript", type: :system,
     when_i_visit_the_add_provider_page
     then_i_see_support_navigation_with_organisation_selected
     and_i_click_continue
-    then_i_see_an_error("Enter a provider name, UKPRN, URN or postcode")
+    then_i_see_an_error("Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode")
   end
 
   scenario "Colin submits the options form without selecting a provider" do

--- a/spec/system/placements/support/providers/support_user_adds_a_provider_without_javascript_spec.rb
+++ b/spec/system/placements/support/providers/support_user_adds_a_provider_without_javascript_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Support User adds a Provider without JavaScript", type: :system,
     when_i_visit_the_add_provider_page
     then_i_see_support_navigation_with_organisation_selected
     and_i_click_continue
-    then_i_see_an_error("Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode")
+    then_i_see_an_error("Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode")
   end
 
   scenario "Colin submits the options form without selecting a provider" do

--- a/spec/system/placements/support/schools/partner_providers/support_user_adds_a_partner_provider_spec.rb
+++ b/spec/system/placements/support/schools/partner_providers/support_user_adds_a_partner_provider_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Placements / Support / Schools / Partner providers / Support use
   scenario "Support user submits the search form without selecting a provider", js: true, retry: 3 do
     when_i_visit_the_add_partner_provider_page
     and_i_click_on("Continue")
-    then_i_see_an_error("Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode")
+    then_i_see_an_error("Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode")
   end
 
   scenario "Support user reconsiders selecting a provider", js: true, retry: 3 do

--- a/spec/system/placements/support/schools/partner_providers/support_user_adds_a_partner_provider_spec.rb
+++ b/spec/system/placements/support/schools/partner_providers/support_user_adds_a_partner_provider_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Placements / Support / Schools / Partner providers / Support use
   scenario "Support user submits the search form without selecting a provider", js: true, retry: 3 do
     when_i_visit_the_add_partner_provider_page
     and_i_click_on("Continue")
-    then_i_see_an_error("Enter a provider name, UKPRN, URN or postcode")
+    then_i_see_an_error("Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode")
   end
 
   scenario "Support user reconsiders selecting a provider", js: true, retry: 3 do

--- a/spec/system/placements/support/schools/partner_providers/support_user_adds_a_partner_provider_without_javascript_spec.rb
+++ b/spec/system/placements/support/schools/partner_providers/support_user_adds_a_partner_provider_without_javascript_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Placements / Support / Schools / Partner providers / Support use
   scenario "Support user submits the search form without selecting a provider" do
     when_i_visit_the_add_partner_provider_page_for(school)
     and_i_click_on("Continue")
-    then_i_see_an_error("Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode")
+    then_i_see_an_error("Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode")
   end
 
   scenario "Support user submits the options form without selecting a provider" do

--- a/spec/system/placements/support/schools/partner_providers/support_user_adds_a_partner_provider_without_javascript_spec.rb
+++ b/spec/system/placements/support/schools/partner_providers/support_user_adds_a_partner_provider_without_javascript_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Placements / Support / Schools / Partner providers / Support use
   scenario "Support user submits the search form without selecting a provider" do
     when_i_visit_the_add_partner_provider_page_for(school)
     and_i_click_on("Continue")
-    then_i_see_an_error("Enter a provider name, UKPRN, URN or postcode")
+    then_i_see_an_error("Enter a provider name, United Kingdom Provider Number (UKPRN), Unique Reference Number (URN) or postcode")
   end
 
   scenario "Support user submits the options form without selecting a provider" do


### PR DESCRIPTION
## Context

Acronyms within the service should be written out in full

## Changes proposed in this pull request

- [x] Convert specified instances of UKPRN and URN to long form.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[Write out acronyms in full](https://trello.com/c/0zCQZ26z/442-write-out-acronyms-in-full)
