### PR TITLE
Remove guidance from the placements footer

### DIFF
--- a/app/helpers/footer_helper.rb
+++ b/app/helpers/footer_helper.rb
@@ -20,7 +20,6 @@ module FooterHelper
 
   def placements_footer_meta_items
     [
-      { text: t(".guidance"), href: "#" },
       { text: t(".accessibility"), href: placements_accessibility_path },
       { text: t(".cookies"), href: placements_cookies_path },
       { text: t(".privacy_policy"), href: "#" },

--- a/spec/helpers/footer_helper_spec.rb
+++ b/spec/helpers/footer_helper_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe FooterHelper do
         allow(HostingEnvironment).to receive(:current_service).and_return(:placements)
         expect(helper.footer_meta_items).to eq(
           [
-            { href: "#", text: "Guidance" },
             { href: "/accessibility", text: "Accessibility" },
             { href: "/cookies", text: "Cookies" },
             { href: "#", text: "Privacy notice" },


### PR DESCRIPTION
## Context

The guidance footer item is not needed for the placements service

## Changes proposed in this pull request

- [x] Remove guidance footer

## Guidance to review

- Log in as anyone
- Confirm the guidance footer item is gone

## Link to Trello card

[Remove the 'Guidance' footer link](https://trello.com/c/ZuEG8sK0/483-remove-the-guidance-footer-link)

## Screenshots

![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/c8854558-dcca-4d12-a498-7f74ccf36e93)
