### PR TITLE
Swap mentor form validation

### DIFF
--- a/app/forms/placements/mentor_form.rb
+++ b/app/forms/placements/mentor_form.rb
@@ -12,8 +12,8 @@ class Placements::MentorForm < ApplicationForm
   FORM_PARAMS = [:trn, "date_of_birth(1i)", "date_of_birth(2i)", "date_of_birth(3i)"].freeze
 
   validate :validate_membership
-  validates :date_of_birth, presence: true
   validate :validate_mentor
+  validates :date_of_birth, presence: true
 
   def persist
     ActiveRecord::Base.transaction do


### PR DESCRIPTION
## Context

- Move validation in MentorForm, so it appears in the order: TRN, DOB

## Guidance to review

- Sign in as Anne (School user)
- Navigate to "Mentors" using the Navbar
- Click "Add mentor"
- Click "Continue"
- Check the validation appears in to order of inputs.

## Link to Trello card

https://trello.com/c/WKiF870U/484-add-mentor-%E2%86%92-change-the-order-of-validation-messages-shown-in-the-error-summary

## Screenshots

![screencapture-placements-localhost-3000-schools-0006eeb8-fbb6-4f7e-8828-3c2c84f48289-mentors-check-2024-06-11-13_14_03](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/23d451a6-d5b0-47d8-9169-27ceb6871bd2)

