### PR TITLE
Validate DOB is in the past

### DIFF
--- a/app/forms/placements/mentor_form.rb
+++ b/app/forms/placements/mentor_form.rb
@@ -14,6 +14,7 @@ class Placements::MentorForm < ApplicationForm
   validate :validate_membership
   validate :validate_mentor
   validates :date_of_birth, presence: true
+  validates :date_of_birth, comparison: { less_than: Time.zone.today }
 
   def persist
     ActiveRecord::Base.transaction do

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -27,6 +27,7 @@ en:
               taken: The mentor has already been added
             date_of_birth:
               blank: Enter a date of birth
+              less_than: Date of birth must be in the past
         claims/mentor_form:
           attributes:
             trn:

--- a/spec/forms/placements/mentor_form_spec.rb
+++ b/spec/forms/placements/mentor_form_spec.rb
@@ -37,6 +37,24 @@ describe Placements::MentorForm, type: :model do
         expect(form.errors.messages[:date_of_birth]).to include("Enter a date of birth")
       end
     end
+
+    context "when date_of_birth is in future" do
+      before { stub_teaching_record_response(date_of_birth: "#{year}-01-22") }
+
+      let(:year) { Time.zone.today.year + 1 }
+
+      it "returns invalid", :aggregate_failures do
+        form = described_class.new(
+          "date_of_birth(3i)" => "22",
+          "date_of_birth(2i)" => "1",
+          "date_of_birth(1i)" => year.to_s,
+          "trn" => trn,
+          "school" => school,
+        )
+        expect(form.valid?).to eq(false)
+        expect(form.errors.messages[:date_of_birth]).to include("Date of birth must be in the past")
+      end
+    end
   end
 
   describe "#mentor" do
@@ -99,12 +117,12 @@ describe Placements::MentorForm, type: :model do
     end
   end
 
-  def stub_teaching_record_response
+  def stub_teaching_record_response(date_of_birth: "1991-01-22")
     allow(TeachingRecord::GetTeacher).to receive(:call).with(trn:, date_of_birth:).and_return(
       { "trn" => "1234567",
         "firstName" => "Judith",
         "lastName" => "Chicken",
-        "dateOfBirth" => "1991-01-22" },
+        "dateOfBirth" => date_of_birth },
     )
   end
 end


### PR DESCRIPTION
## Context

- Add validation for MentorForm, so that the Date of Birth is in the past.

## Guidance to review

- Sign in as Anne (School user)
- Navigate to "Mentors" using the Navbar
- Click "Add mentor"
- Enter a Date of Birth in the future (e.g 23/05/2044)

## Link to Trello card

https://trello.com/c/3kcGzw2M/485-add-mentor-%E2%86%92-validate-dob-so-it-cannot-be-in-the-future

## Screenshots

![screencapture-placements-localhost-3000-schools-0006eeb8-fbb6-4f7e-8828-3c2c84f48289-mentors-check-2024-06-11-14_10_19](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/99a33698-edfc-4278-a30a-8dc9fadfb383)
