### PR TITLE
Persist date of birth on validation error

### DIFF
--- a/app/forms/placements/mentor_form.rb
+++ b/app/forms/placements/mentor_form.rb
@@ -18,7 +18,7 @@ class Placements::MentorForm < ApplicationForm
   validate :validate_mentor
   validate :validate_date_of_birth
   validates :date_of_birth, presence: true
-  validates :date_of_birth, comparison: { less_than: Time.zone.today }
+  validates :date_of_birth, comparison: { less_than: Time.zone.today }, if: -> { date_of_birth.is_a?(Date) }
 
   def persist
     ActiveRecord::Base.transaction do

--- a/app/views/placements/schools/mentors/new.html.erb
+++ b/app/views/placements/schools/mentors/new.html.erb
@@ -33,6 +33,7 @@
 
         <%= f.govuk_date_field(
               :date_of_birth,
+              date_of_birth: true,
               maxlength_enabled: true,
               legend: { text: Mentor.human_attribute_name(:date_of_birth), size: "s" },
               hint: { text: t(".date_of_birth_hint"), size: "s" },

--- a/spec/forms/placements/mentor_form_spec.rb
+++ b/spec/forms/placements/mentor_form_spec.rb
@@ -78,6 +78,7 @@ describe Placements::MentorForm, type: :model do
   describe "persist" do
     context "when the mentor doesn't exist" do
       let(:trn) { "2345678" }
+
       before { stub_teaching_record_response(date_of_birth:, trn: "1234567") }
 
       it "creates a new mentor and membership" do
@@ -124,7 +125,7 @@ describe Placements::MentorForm, type: :model do
     end
   end
 
-  def stub_teaching_record_response(date_of_birth: "1991-01-22", trn:)
+  def stub_teaching_record_response(trn:, date_of_birth: "1991-01-22")
     allow(TeachingRecord::GetTeacher).to receive(:call).with(trn:, date_of_birth:).and_return(
       { "trn" => "1234567",
         "firstName" => "Judith",

--- a/spec/forms/placements/mentor_form_spec.rb
+++ b/spec/forms/placements/mentor_form_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe Placements::MentorForm, type: :model do
-  before { stub_teaching_record_response(date_of_birth:) }
+  before { stub_teaching_record_response(date_of_birth:, trn:) }
 
   let!(:school) { create(:school) }
   let!(:mentor) { create(:placements_mentor, trn:) }
@@ -41,7 +41,7 @@ describe Placements::MentorForm, type: :model do
     end
 
     context "when date_of_birth is in future" do
-      before { stub_teaching_record_response(date_of_birth: "#{year}-01-22") }
+      before { stub_teaching_record_response(date_of_birth: "#{year}-01-22", trn:) }
 
       let(:year) { Time.zone.today.year + 1 }
 
@@ -78,15 +78,7 @@ describe Placements::MentorForm, type: :model do
   describe "persist" do
     context "when the mentor doesn't exist" do
       let(:trn) { "2345678" }
-
-      before do
-        allow(TeachingRecord::GetTeacher).to receive(:call).with(trn: "1234567", date_of_birth:).and_return(
-          { "trn" => "1234567",
-            "firstName" => "Judith",
-            "lastName" => "Chicken",
-            "dateOfBirth" => "1991-01-22" },
-        )
-      end
+      before { stub_teaching_record_response(date_of_birth:, trn: "1234567") }
 
       it "creates a new mentor and membership" do
         form = described_class.new(
@@ -132,7 +124,7 @@ describe Placements::MentorForm, type: :model do
     end
   end
 
-  def stub_teaching_record_response(date_of_birth: "1991-01-22")
+  def stub_teaching_record_response(date_of_birth: "1991-01-22", trn:)
     allow(TeachingRecord::GetTeacher).to receive(:call).with(trn:, date_of_birth:).and_return(
       { "trn" => "1234567",
         "firstName" => "Judith",

--- a/spec/forms/placements/mentor_form_spec.rb
+++ b/spec/forms/placements/mentor_form_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe Placements::MentorForm, type: :model do
-  before { stub_teaching_record_response }
+  before { stub_teaching_record_response(date_of_birth:) }
 
   let!(:school) { create(:school) }
   let!(:mentor) { create(:placements_mentor, trn:) }

--- a/spec/system/placements/schools/mentors/user_adds_mentor_spec.rb
+++ b/spec/system/placements/schools/mentors/user_adds_mentor_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe "Placements school user adds mentors to schools", type: :system, 
   end
 
   scenario "I do not enter a date of birth" do
-    allow(TeachingRecord::GetTeacher).to receive(:call)
-     .with(trn: "1212121", date_of_birth: Struct.new(:day, :month, :year).new(nil, nil, nil).to_s)
-     .and_return teaching_record_valid_response(placements_mentor)
+    stub_valid_teaching_record_response(trn: "1212121",
+                                        date_of_birth: Struct.new(:day, :month, :year).new(nil, nil, nil).to_s,
+                                        mentor: placements_mentor)
 
     given_i_navigate_to_schools_mentors_list
     and_i_click_on("Add mentor")
@@ -65,9 +65,9 @@ RSpec.describe "Placements school user adds mentors to schools", type: :system, 
   end
 
   scenario "I enter a trn of mentor who already exists for this school" do
-    allow(TeachingRecord::GetTeacher).to receive(:call)
-     .with(trn: placements_mentor.trn, date_of_birth: Struct.new(:day, :month, :year).new(nil, nil, nil).to_s)
-     .and_return teaching_record_valid_response(placements_mentor)
+    stub_valid_teaching_record_response(trn: placements_mentor.trn,
+                                        date_of_birth: Struct.new(:day, :month, :year).new(nil, nil, nil).to_s,
+                                        mentor: placements_mentor)
 
     given_a_placements_mentor_exists(school, placements_mentor)
     given_i_navigate_to_schools_mentors_list
@@ -79,9 +79,9 @@ RSpec.describe "Placements school user adds mentors to schools", type: :system, 
 
   context "when the mentor already exists in the claims service" do
     before do
-      allow(TeachingRecord::GetTeacher).to receive(:call)
-                                             .with(trn: claims_mentor.trn, date_of_birth: "1990-01-01")
-                                             .and_return teaching_record_valid_response(claims_mentor)
+      stub_valid_teaching_record_response(trn: claims_mentor.trn,
+                                          date_of_birth: "1990-01-01",
+                                          mentor: claims_mentor)
     end
 
     scenario "I enter the trn of an existing claims mentor" do
@@ -107,9 +107,9 @@ RSpec.describe "Placements school user adds mentors to schools", type: :system, 
 
   context "when the mentor already exists in the placements service" do
     before do
-      allow(TeachingRecord::GetTeacher).to receive(:call)
-                                             .with(trn: placements_mentor.trn, date_of_birth: "1990-01-01")
-                                             .and_return teaching_record_valid_response(placements_mentor)
+      stub_valid_teaching_record_response(trn: placements_mentor.trn,
+                                          date_of_birth: "1990-01-01",
+                                          mentor: placements_mentor)
     end
 
     scenario "I enter the trn of an existing placements mentor from another school" do
@@ -150,9 +150,9 @@ RSpec.describe "Placements school user adds mentors to schools", type: :system, 
 
   describe "when trn is valid-looking and mentor is found on Teaching Record Service" do
     before do
-      allow(TeachingRecord::GetTeacher).to receive(:call)
-                                             .with(trn: new_mentor.trn, date_of_birth: "1990-01-01")
-                                             .and_return teaching_record_valid_response(new_mentor)
+      stub_valid_teaching_record_response(trn: new_mentor.trn,
+                                          date_of_birth: "1990-01-01",
+                                          mentor: new_mentor)
     end
 
     scenario "I enter a valid-looking trn that does exist on the Teaching Record Service" do
@@ -292,6 +292,12 @@ RSpec.describe "Placements school user adds mentors to schools", type: :system, 
       "They can find a lost TRN, or apply for a new one by following the instructions in the ",
     )
     expect(page).to have_link("TRN guidance (opens in new tab)", href: "https://www.gov.uk/guidance/teacher-reference-number-trn")
+  end
+
+  def stub_valid_teaching_record_response(trn:, date_of_birth:, mentor:)
+    allow(TeachingRecord::GetTeacher).to receive(:call)
+      .with(trn:, date_of_birth:)
+      .and_return teaching_record_valid_response(mentor)
   end
 
   alias_method :and_i_click_on, :when_i_click_on

--- a/spec/system/placements/schools/mentors/user_adds_mentor_spec.rb
+++ b/spec/system/placements/schools/mentors/user_adds_mentor_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe "Placements school user adds mentors to schools", type: :system, 
   end
 
   scenario "I do not enter a date of birth" do
+    allow(TeachingRecord::GetTeacher).to receive(:call)
+     .with(trn: "1212121", date_of_birth: Struct.new(:day, :month, :year).new(nil, nil, nil).to_s)
+     .and_return teaching_record_valid_response(placements_mentor)
+
     given_i_navigate_to_schools_mentors_list
     and_i_click_on("Add mentor")
     when_i_enter_trn(1_212_121)
@@ -61,6 +65,10 @@ RSpec.describe "Placements school user adds mentors to schools", type: :system, 
   end
 
   scenario "I enter a trn of mentor who already exists for this school" do
+    allow(TeachingRecord::GetTeacher).to receive(:call)
+     .with(trn: placements_mentor.trn, date_of_birth: Struct.new(:day, :month, :year).new(nil, nil, nil).to_s)
+     .and_return teaching_record_valid_response(placements_mentor)
+
     given_a_placements_mentor_exists(school, placements_mentor)
     given_i_navigate_to_schools_mentors_list
     and_i_click_on("Add mentor")

--- a/spec/system/placements/support/schools/mentors/support_user_adds_a_mentor_spec.rb
+++ b/spec/system/placements/support/schools/mentors/support_user_adds_a_mentor_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe "Placements support user adds mentors to schools", type: :system,
   end
 
   scenario "I do not enter a date of birth" do
+    allow(TeachingRecord::GetTeacher).to receive(:call)
+     .with(trn: "1212121", date_of_birth: Struct.new(:day, :month, :year).new(nil, nil, nil).to_s)
+     .and_return teaching_record_valid_response(claims_mentor)
+
     given_i_navigate_to_schools_mentors_list(school)
     and_i_click_on("Add mentor")
     when_i_enter_trn(1_212_121)
@@ -61,6 +65,10 @@ RSpec.describe "Placements support user adds mentors to schools", type: :system,
   end
 
   scenario "I enter a trn of mentor who already exists for this school" do
+    allow(TeachingRecord::GetTeacher).to receive(:call)
+      .with(trn: placements_mentor.trn, date_of_birth: Struct.new(:day, :month, :year).new(nil, nil, nil).to_s)
+      .and_return teaching_record_valid_response(claims_mentor)
+
     given_a_placements_mentor_exists(school, placements_mentor)
     given_i_navigate_to_schools_mentors_list(school)
     and_i_click_on("Add mentor")

--- a/spec/system/placements/support/schools/mentors/support_user_adds_a_mentor_spec.rb
+++ b/spec/system/placements/support/schools/mentors/support_user_adds_a_mentor_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe "Placements support user adds mentors to schools", type: :system,
   end
 
   scenario "I do not enter a date of birth" do
-    allow(TeachingRecord::GetTeacher).to receive(:call)
-     .with(trn: "1212121", date_of_birth: Struct.new(:day, :month, :year).new(nil, nil, nil).to_s)
-     .and_return teaching_record_valid_response(claims_mentor)
+    stub_valid_teaching_record_response(trn: "1212121",
+                                        date_of_birth: Struct.new(:day, :month, :year).new(nil, nil, nil).to_s,
+                                        mentor: claims_mentor)
 
     given_i_navigate_to_schools_mentors_list(school)
     and_i_click_on("Add mentor")
@@ -65,9 +65,9 @@ RSpec.describe "Placements support user adds mentors to schools", type: :system,
   end
 
   scenario "I enter a trn of mentor who already exists for this school" do
-    allow(TeachingRecord::GetTeacher).to receive(:call)
-      .with(trn: placements_mentor.trn, date_of_birth: Struct.new(:day, :month, :year).new(nil, nil, nil).to_s)
-      .and_return teaching_record_valid_response(claims_mentor)
+    stub_valid_teaching_record_response(trn: placements_mentor.trn,
+                                        date_of_birth: Struct.new(:day, :month, :year).new(nil, nil, nil).to_s,
+                                        mentor: claims_mentor)
 
     given_a_placements_mentor_exists(school, placements_mentor)
     given_i_navigate_to_schools_mentors_list(school)
@@ -79,9 +79,9 @@ RSpec.describe "Placements support user adds mentors to schools", type: :system,
 
   context "when the mentor already exists in the claims service" do
     before do
-      allow(TeachingRecord::GetTeacher).to receive(:call)
-                                             .with(trn: claims_mentor.trn, date_of_birth: "1990-01-01")
-                                             .and_return teaching_record_valid_response(claims_mentor)
+      stub_valid_teaching_record_response(trn: claims_mentor.trn,
+                                          date_of_birth: "1990-01-01",
+                                          mentor: claims_mentor)
     end
 
     scenario "I enter the trn of an existing claims mentor" do
@@ -107,9 +107,9 @@ RSpec.describe "Placements support user adds mentors to schools", type: :system,
 
   context "when the mentor already exists in the placements service" do
     before do
-      allow(TeachingRecord::GetTeacher).to receive(:call)
-                                             .with(trn: placements_mentor.trn, date_of_birth: "1990-01-01")
-                                             .and_return teaching_record_valid_response(placements_mentor)
+      stub_valid_teaching_record_response(trn: placements_mentor.trn,
+                                          date_of_birth: "1990-01-01",
+                                          mentor: placements_mentor)
     end
 
     scenario "I enter the trn of an existing placements mentor from another school" do
@@ -150,9 +150,9 @@ RSpec.describe "Placements support user adds mentors to schools", type: :system,
 
   describe "when trn is valid-looking and mentor is found on Teaching Record Service" do
     before do
-      allow(TeachingRecord::GetTeacher).to receive(:call)
-                                             .with(trn: new_mentor.trn, date_of_birth: "1990-01-01")
-                                             .and_return teaching_record_valid_response(new_mentor)
+      stub_valid_teaching_record_response(trn: new_mentor.trn,
+                                          date_of_birth: "1990-01-01",
+                                          mentor: new_mentor)
     end
 
     scenario "I enter a valid-looking trn that does exist on the Teaching Record Service" do
@@ -290,6 +290,12 @@ RSpec.describe "Placements support user adds mentors to schools", type: :system,
       "They can find a lost TRN, or apply for a new one by following the instructions in the ",
     )
     expect(page).to have_link("TRN guidance (opens in new tab)", href: "https://www.gov.uk/guidance/teacher-reference-number-trn")
+  end
+
+  def stub_valid_teaching_record_response(trn:, date_of_birth:, mentor:)
+    allow(TeachingRecord::GetTeacher).to receive(:call)
+                                           .with(trn:, date_of_birth:)
+                                           .and_return teaching_record_valid_response(mentor)
   end
 
   alias_method :and_i_click_on, :when_i_click_on


### PR DESCRIPTION
## Context

When entering an invalid TRN or Date of Birth whilst adding a mentor, the date of birth does not persist.

## Changes proposed in this pull request

- [x] Use a struct to populate the date of birth when an invalid date is present.

## Guidance to review

- Log in as Anne
- Add a mentor
- Enter a number into one of the three date of birth fields
- Click continue
- See a validation error and your entry has persisted

## Link to Trello card

[Add mentor → preserve partially entered DOB fields](https://trello.com/c/c7hMIOEu/486-add-mentor-%E2%86%92-preserve-partially-entered-dob-fields)

## Screenshots

![image](https://github.com/DFE-Digital/itt-mentor-services/assets/16797406/fa837aa8-a346-4511-8aa9-fc458c597a7d)

