### PR TITLE
Redirect providers to placements

### DIFF
--- a/app/controllers/placements/organisations_controller.rb
+++ b/app/controllers/placements/organisations_controller.rb
@@ -36,10 +36,9 @@ class Placements::OrganisationsController < Placements::ApplicationController
   end
 
   def landing_page_path(organisation)
-    case organisation
-    when School
+    if organisation.is_a?(School)
       placements_school_placements_path(organisation)
-    when Provider
+    else # Provider
       placements_placements_path
     end
   end

--- a/app/controllers/placements/organisations_controller.rb
+++ b/app/controllers/placements/organisations_controller.rb
@@ -40,8 +40,7 @@ class Placements::OrganisationsController < Placements::ApplicationController
     when School
       placements_school_placements_path(organisation)
     when Provider
-      # placements_placements_path
-      placements_provider_path(organisation)
+      placements_placements_path
     end
   end
 end

--- a/app/controllers/placements/providers/partner_schools_controller.rb
+++ b/app/controllers/placements/providers/partner_schools_controller.rb
@@ -79,7 +79,6 @@ class Placements::Providers::PartnerSchoolsController < Placements::ApplicationC
   private
 
   def set_provider
-    session[:placements_provider_id] = params[:provider_id]
     @provider = current_user.providers.find(params.fetch(:provider_id))
   end
 

--- a/app/controllers/placements/providers/users_controller.rb
+++ b/app/controllers/placements/providers/users_controller.rb
@@ -1,6 +1,4 @@
 class Placements::Providers::UsersController < Placements::Organisations::UsersController
-  before_action :set_provider
-
   private
 
   def set_organisation
@@ -9,9 +7,5 @@ class Placements::Providers::UsersController < Placements::Organisations::UsersC
 
   def redirect_to_index
     redirect_to placements_provider_users_path(@organisation)
-  end
-
-  def set_provider
-    session[:placements_provider_id] = @organisation.id
   end
 end

--- a/app/helpers/placements/routes/organisations_helper.rb
+++ b/app/helpers/placements/routes/organisations_helper.rb
@@ -32,18 +32,6 @@ module Placements::Routes::OrganisationsHelper
     end
   end
 
-  def placements_organisation_path(organisation)
-    case organisation
-    when School
-      placements_school_placements_path(organisation)
-    when Provider
-      session[:placements_provider_id] = organisation.id
-      placements_provider_path(organisation)
-    else
-      raise NotImplementedError
-    end
-  end
-
   def placements_support_users_path(organisation)
     case organisation
     when School

--- a/app/views/placements/organisations/index.html.erb
+++ b/app/views/placements/organisations/index.html.erb
@@ -6,7 +6,7 @@
       <% if @memberships.any? %>
         <ul class="govuk-list">
           <% @memberships.each do |membership| %>
-            <li><%= govuk_link_to(membership.name, placements_organisation_path(membership.organisation)) %></li>
+            <li><%= govuk_link_to(membership.name, placements_organisation_path(membership)) %></li>
           <% end %>
         </ul>
       <% else %>

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -88,7 +88,7 @@ scope module: :placements,
     end
   end
 
-  resources :organisations, only: [:index]
+  resources :organisations, only: %i[index show]
   resources :schools, only: %i[show] do
     scope module: :schools do
       resources :users, only: %i[index new create show destroy] do

--- a/spec/helpers/placements/routes/organisations_helper_spec.rb
+++ b/spec/helpers/placements/routes/organisations_helper_spec.rb
@@ -73,29 +73,6 @@ RSpec.describe Placements::Routes::OrganisationsHelper do
     end
   end
 
-  describe "#placements_organisation_path" do
-    context "when organisation is a school" do
-      it "returns the school placements path" do
-        organisation = create(:school)
-        expect(placements_organisation_path(organisation)).to eq(placements_school_placements_path(organisation))
-      end
-    end
-
-    context "when organisation is a provider" do
-      it "returns the provider path" do
-        organisation = create(:provider)
-        expect(placements_organisation_path(organisation)).to eq(placements_provider_path(organisation))
-      end
-    end
-
-    context "when organisation is not a school or provider" do
-      it "raises NotImplementedError" do
-        organisation = create(:claim)
-        expect { placements_organisation_path(organisation) }.to raise_error(NotImplementedError)
-      end
-    end
-  end
-
   describe "#placements_support_users_path" do
     context "when organisation is a school" do
       it "returns the support school users path" do

--- a/spec/system/placements/organisations/view_organisations_spec.rb
+++ b/spec/system/placements/organisations/view_organisations_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "View organisations", type: :system, service: :placements do
     when_i_click_on_change_organisation
     i_am_redirected_to_organisation_index
     when_i_click_on_provider_name
-    then_i_see_provider_page(multi_org_provider)
+    then_i_see_the_placements_search_page
     when_i_click_on_change_organisation
     i_am_redirected_to_organisation_index
   end
@@ -42,7 +42,7 @@ RSpec.describe "View organisations", type: :system, service: :placements do
     and_user_has_one_provider(user:)
     when_i_visit_sign_in_path
     when_i_click_sign_in
-    then_i_see_the_one_provider(one_provider)
+    then_i_see_the_one_provider
   end
 
   scenario "I cannot view a school unless it is a placements school" do
@@ -93,6 +93,7 @@ RSpec.describe "View organisations", type: :system, service: :placements do
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Placements", current: "page"
       expect(page).to have_link "Mentors", current: "false"
+      expect(page).to have_link "Partner providers", current: "false"
       expect(page).to have_link "Users", current: "false"
       expect(page).to have_link "Organisation details", current: "false"
     end
@@ -111,12 +112,13 @@ RSpec.describe "View organisations", type: :system, service: :placements do
     click_on "Provider 1"
   end
 
-  def then_i_see_provider_page(provider)
-    expect(page).to have_current_path placements_provider_path(provider), ignore_query: true
-    within(".govuk-main-wrapper") do
-      expect(page).to have_content provider.name
-      expect(page).to have_content "Organisation details"
-      expect(page).to have_content "Contact details"
+  def then_i_see_the_placements_search_page
+    expect(page).to have_current_path placements_placements_path, ignore_query: true
+    within(".app-primary-navigation__nav") do
+      expect(page).to have_link "Placements", current: "page"
+      expect(page).to have_link "Partner schools", current: "false"
+      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Organisation details", current: "false"
     end
   end
 
@@ -133,9 +135,9 @@ RSpec.describe "View organisations", type: :system, service: :placements do
     then_i_see_the_school_page(school)
   end
 
-  def then_i_see_the_one_provider(provider)
+  def then_i_see_the_one_provider
     expect(page).not_to have_content "Change organisation"
-    then_i_see_provider_page(provider)
+    then_i_see_the_placements_search_page
   end
 
   def when_i_visit_sign_in_path

--- a/spec/system/placements/providers/remembering_the_current_provider_spec.rb
+++ b/spec/system/placements/providers/remembering_the_current_provider_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe "Remembering the current provider", type: :system, service: :placements do
+  let(:provider_one) { build(:placements_provider, name: "The Chalkboard Champions") }
+  let(:provider_two) { build(:placements_provider, name: "Ctrl + Alt + Teach") }
+
+  scenario "A multi-org user switches between different providers" do
+    given_i_sign_in_with_access_to_multiple_providers
+
+    when_i_click_on "The Chalkboard Champions"
+    then_my_current_provider_is "The Chalkboard Champions"
+    when_i_click_on "Placements"
+    then_my_current_provider_is "The Chalkboard Champions"
+
+    when_i_click_on "Change organisation"
+    and_i_click_on "Ctrl + Alt + Teach"
+    then_my_current_provider_is "Ctrl + Alt + Teach"
+    when_i_click_on "Placements"
+    then_my_current_provider_is "Ctrl + Alt + Teach"
+  end
+
+  private
+
+  def given_i_sign_in_with_access_to_multiple_providers
+    user = create(:placements_user, providers: [provider_one, provider_two])
+    user_exists_in_dfe_sign_in(user:)
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def when_i_click_on(text)
+    click_on text
+  end
+  alias_method :and_i_click_on, :when_i_click_on
+
+  def then_my_current_provider_is(provider_name)
+    expect(page).to have_css(".content-header-title", text: provider_name)
+  end
+end


### PR DESCRIPTION
## Context

Take provider users to the placements search page when they sign in.

## Link to Trello card

https://trello.com/c/URtV1kGv/403-make-find-placements-the-default-page-for-providers
