### PR TITLE
Add content to the sign-in page

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -11,9 +11,14 @@
         <%= govuk_button_to t(".sign_in_with_dsi"), omniauth_sign_in_path("dfe") %>
       <% end %>
 
-      <p class="govuk-body">
-        <%= sanitize t(".disclaimer", service_name:, support_email: mail_to(t("#{current_service}.support_email"))) %>
-      </p>
+      <% if current_service == :placements %>
+        <h2 class="govuk-heading-m">How to get an account</h2>
+        <p class="govuk-body">This is a pilot service for schools and teacher training providers in Leeds.</p>
+        <p class="govuk-body">Ask a colleague in your organisation to add you if you do not have an account.</p>
+        <p class="govuk-body">If your organisation has not been set up to use this service, email <%= mail_to(t("#{current_service}.support_email")) %>.</p>
+      <% else %>
+        <p class="govuk-body"><%= sanitize t(".disclaimer", service_name:, support_email: mail_to(t("#{current_service}.support_email"))) %></p>
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Requested as part of the 'Manage school placements' launch day.

## Link to Trello card

https://trello.com/c/aHTwXv9H/497-start-page-content-for-users-who-have-not-yet-been-onboarded

## Screenshots

### Manage school placements

![placements localhost_3000_sign-in](https://github.com/DFE-Digital/itt-mentor-services/assets/7735945/d2dd8b02-a55d-4c09-ab71-f22f4db86efc)

### Funding mentors

![claims localhost_3000_sign-in](https://github.com/DFE-Digital/itt-mentor-services/assets/7735945/8535002e-8509-4e13-9950-755dc8e8a2fc)