### PR TITLE
Fix a flaky system spec in Claims

### DIFF
--- a/spec/system/claims/support/schools/view_a_school_spec.rb
+++ b/spec/system/claims/support/schools/view_a_school_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.describe "View a school", type: :system do
   let!(:support_user) { create(:claims_support_user, :colin) }
-  let!(:school) { create(:school, :claims) }
-  let!(:school_not_accepted_grant_conditions) { create(:school, :claims, claims_grant_conditions_accepted_at: nil, claims_grant_conditions_accepted_by_id: nil) }
+  let!(:school) { create(:school, :claims, name: "Hilltop Primary School") }
+  let!(:school_not_accepted_grant_conditions) { create(:school, :claims, name: "Sir Thomas Wharton Academy", claims_grant_conditions_accepted_at: nil, claims_grant_conditions_accepted_by_id: nil) }
 
   scenario "View a school's details as a support user" do
     given_i_sign_in_as(support_user)


### PR DESCRIPTION
## Context

This spec would regularly flake because the school names clashed.

We should not rely on Faker to provide unique values. If tests are dependent on unique values then we should specify the names directly.

## Changes proposed in this pull request

Give the schools names so they're always unique.