### PR TITLE
Update "no results" message for placements search

### DIFF
--- a/app/views/placements/placements/index.html.erb
+++ b/app/views/placements/placements/index.html.erb
@@ -36,7 +36,7 @@
         <%= render PaginationComponent.new(pagy: @pagy) %>
       <% else %>
         <p>
-          <%= t(".no_results_for_filters") %>
+          <%= t(".no_results") %>
         </p>
       <% end %>
     </div>

--- a/config/locales/en/placements/placements.yml
+++ b/config/locales/en/placements/placements.yml
@@ -7,7 +7,7 @@ en:
           one: 1 placement found
           other: "%{count} placements found"
         placements: Placements
-        no_results_for_filters: There are no results for the selected filter.
+        no_results: There are no placements that match your selection. Try searching again, or removing one or more filters.
         enter_a_location: Enter a location
         location_search_example: For example, Sunderland or SR2
       filter:

--- a/spec/system/placements/placements/searching_for_a_placement_spec.rb
+++ b/spec/system/placements/placements/searching_for_a_placement_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe "Placements / Placements / Searching for a placements list",
       when_i_visit_the_placements_index_page
       and_i_fill_in_location_search_with("Chicken")
       and_i_click_on("Search")
-      expect(page).to have_content("There are no results for the selected filter.")
+      then_i_see_the_empty_state
     end
   end
 
@@ -172,6 +172,10 @@ RSpec.describe "Placements / Placements / Searching for a placements list",
     end
   end
   alias_method :and_i_can_see_a_preset_filter, :then_i_can_see_a_preset_filter
+
+  def then_i_see_the_empty_state
+    expect(page).to have_content I18n.t("placements.placements.index.no_results")
+  end
 
   # Stub requests
 

--- a/spec/system/placements/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/placements/view_placements_list_spec.rb
@@ -319,7 +319,7 @@ RSpec.describe "Placements / Placements / View placements list",
   end
 
   def then_i_see_the_empty_state
-    expect(page).to have_content("There are no results for the selected filter.")
+    expect(page).to have_content I18n.t("placements.placements.index.no_results")
   end
 
   def then_i_can_see_a_placement_for_school_and_subject(school_name, subject_name)


### PR DESCRIPTION
## Changes proposed in this pull request

Update the content shown when no placements are found.

## Link to Trello card

https://trello.com/c/KOoB10aO/373-10-confirm-content-for-no-placements

## Screenshots

| Before | After |
| --- | --- |
| ![Before](https://github.com/DFE-Digital/itt-mentor-services/assets/7735945/194ad441-b9e9-49e3-934a-c30f2c23c9f6) | ![After](https://github.com/DFE-Digital/itt-mentor-services/assets/7735945/5b3581d9-3a90-442f-91c7-efb15a950a6c) |
