### PR TITLE
Update TRN guidance and error message

### DIFF
--- a/app/views/placements/schools/mentors/new.html.erb
+++ b/app/views/placements/schools/mentors/new.html.erb
@@ -15,7 +15,7 @@
         <h2 class="govuk-heading-l"><%= t(".find_teacher") %></h2>
 
         <div class="govuk-form-group">
-          <%= f.govuk_text_field :trn, width: "two-thirds", label: { text: t(".trn"), size: "s" } %>
+          <%= f.govuk_text_field :trn, width: "two-thirds", label: { text: t(".trn"), size: "s" }, hint: { text: t(".trn_hint") } %>
         </div>
 
         <%= govuk_details(

--- a/app/views/placements/support/schools/mentors/new.html.erb
+++ b/app/views/placements/support/schools/mentors/new.html.erb
@@ -15,7 +15,7 @@
         <h2 class="govuk-heading-l"><%= t(".find_teacher") %></h2>
 
         <div class="govuk-form-group">
-          <%= f.govuk_text_field :trn, width: "two-thirds", label: { text: t(".trn"), size: "s" } %>
+          <%= f.govuk_text_field :trn, width: "two-thirds", label: { text: t(".trn"), size: "s" }, hint: { text: t(".trn_hint") } %>
         </div>
 
         <%= govuk_details(

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -17,7 +17,7 @@ en:
           attributes:
             trn:
               blank: Enter a teacher reference number (TRN)
-              invalid: Enter a valid teacher reference number (TRN)
+              invalid: Enter a 7 digit teacher reference number (TRN)
         claims/claim:
           attributes:
             provider_id:

--- a/config/locales/en/placements/schools/mentors.yml
+++ b/config/locales/en/placements/schools/mentors.yml
@@ -32,12 +32,12 @@ en:
           cancel: Cancel
           continue: Continue
           trn: Teacher reference number (TRN)
+          trn_hint: A TRN is a 7 digit number that uniquely identifies people in the education sector in England.
           find_teacher: Find teacher
           trn_guidance: TRN guidance
           what_is_a_trn: |
-              A TRN is a 7 digit number that uniquely identifies people in the education sector in England. 
-              If you do not know a teacher’s TRN, you can ask them for it. 
-              They can find a lost TRN, or apply for a new one by following the instructions in the %{link}.
+            If you do not know a teacher’s TRN, you can ask them for it. 
+            They can find a lost TRN, or apply for a new one by following the instructions in the %{link}.
           help_with_the_trn: Help with the TRN
           date_of_birth_hint: For example, 31 3 1980
         check:

--- a/config/locales/en/placements/support/schools/mentors.yml
+++ b/config/locales/en/placements/support/schools/mentors.yml
@@ -22,10 +22,10 @@ en:
             cancel: Cancel
             continue: Continue
             trn: Teacher reference number (TRN)
+            trn_hint: A TRN is a 7 digit number that uniquely identifies people in the education sector in England.
             find_teacher: Find teacher
             trn_guidance: TRN guidance
             what_is_a_trn: |
-              A TRN is a 7 digit number that uniquely identifies people in the education sector in England. 
               If you do not know a teacher’s TRN, you can ask them for it. 
               They can find a lost TRN, or apply for a new one by following the instructions in the %{link}.
             help_with_the_trn: Help with the TRN

--- a/spec/models/mentor_spec.rb
+++ b/spec/models/mentor_spec.rb
@@ -38,15 +38,15 @@ RSpec.describe Mentor, type: :model do
     it "allows only TRNs that are seven numeric characters long" do
       mentor_with_alpha_trn = build(:mentor, trn: "a12345b")
       expect(mentor_with_alpha_trn.valid?).to eq false
-      expect(mentor_with_alpha_trn.errors.messages[:trn]).to include "Enter a valid teacher reference number (TRN)"
+      expect(mentor_with_alpha_trn.errors.messages[:trn]).to include "Enter a 7 digit teacher reference number (TRN)"
 
       mentor_with_too_few_chars = build(:mentor, trn: "123")
       expect(mentor_with_too_few_chars.valid?).to eq false
-      expect(mentor_with_too_few_chars.errors.messages[:trn]).to include "Enter a valid teacher reference number (TRN)"
+      expect(mentor_with_too_few_chars.errors.messages[:trn]).to include "Enter a 7 digit teacher reference number (TRN)"
 
       mentor_with_too_many_chars = build(:mentor, trn: "123456789")
       expect(mentor_with_too_many_chars.valid?).to eq false
-      expect(mentor_with_too_many_chars.errors.messages[:trn]).to include "Enter a valid teacher reference number (TRN)"
+      expect(mentor_with_too_many_chars.errors.messages[:trn]).to include "Enter a 7 digit teacher reference number (TRN)"
     end
   end
 

--- a/spec/services/claims/mentor_builder_spec.rb
+++ b/spec/services/claims/mentor_builder_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Claims::MentorBuilder do
     it "returns mentor object with error on trn" do
       mentor = described_class.call(trn:)
       expect(mentor.class).to eq(Claims::Mentor)
-      expect(mentor.errors[:trn]).to include "Enter a valid teacher reference number (TRN)"
+      expect(mentor.errors[:trn]).to include "Enter a 7 digit teacher reference number (TRN)"
     end
   end
 

--- a/spec/services/mentor_builder_spec.rb
+++ b/spec/services/mentor_builder_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe MentorBuilder do
     it "returns mentor object with error on trn" do
       mentor = described_class.call(trn:)
       expect(mentor.class).to eq(Placements::Mentor)
-      expect(mentor.errors[:trn]).to include "Enter a valid teacher reference number (TRN)"
+      expect(mentor.errors[:trn]).to include "Enter a 7 digit teacher reference number (TRN)"
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -95,7 +95,7 @@ RSpec.configure do |config|
   #   # Allows RSpec to persist some state between runs in order to support
   #   # the `--only-failures` and `--next-failure` CLI options. We recommend
   #   # you configure your source control system to ignore this file.
-  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  config.example_status_persistence_file_path = "tmp/rspec-examples.txt"
   #
   #   # Limits the available syntax to the non-monkey patched syntax that is
   #   # recommended. For more details, see:

--- a/spec/system/claims/schools/mentors/add_a_mentor_spec.rb
+++ b/spec/system/claims/schools/mentors/add_a_mentor_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Claims school user adds mentors to schools", type: :system, serv
     and_i_click_on("Add mentor")
     when_i_enter_trn("12a")
     and_i_click_on("Continue")
-    then_i_see_errors(["Enter a valid teacher reference number (TRN)"])
+    then_i_see_errors(["Enter a 7 digit teacher reference number (TRN)"])
   end
 
   scenario "I enter a trn of mentor who already exists for this school" do

--- a/spec/system/claims/support/schools/mentors/support_user_adds_a_mentor_spec.rb
+++ b/spec/system/claims/support/schools/mentors/support_user_adds_a_mentor_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Claims support user adds mentors to schools", type: :system, ser
     and_i_click_on("Add mentor")
     when_i_enter_trn("12a")
     and_i_click_on("Continue")
-    then_i_see_errors(["Enter a valid teacher reference number (TRN)"])
+    then_i_see_errors(["Enter a 7 digit teacher reference number (TRN)"])
   end
 
   scenario "I enter a trn of mentor who already exists for this school" do

--- a/spec/system/placements/schools/mentors/user_adds_mentor_spec.rb
+++ b/spec/system/placements/schools/mentors/user_adds_mentor_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Placements school user adds mentors to schools", type: :system, 
     and_i_click_on("Add mentor")
     when_i_enter_trn("12a")
     and_i_click_on("Continue")
-    then_i_see_the_error("Enter a valid teacher reference number (TRN)")
+    then_i_see_the_error("Enter a 7 digit teacher reference number (TRN)")
   end
 
   scenario "I enter a trn of mentor who already exists for this school" do
@@ -287,7 +287,6 @@ RSpec.describe "Placements school user adds mentors to schools", type: :system, 
 
   def then_i_see_link_to_trn_guidance
     expect(page).to have_content(
-      "A TRN is a 7 digit number that uniquely identifies people in the education sector in England. " \
       "If you do not know a teacher’s TRN, you can ask them for it. " \
       "They can find a lost TRN, or apply for a new one by following the instructions in the ",
     )

--- a/spec/system/placements/support/schools/mentors/support_user_adds_a_mentor_spec.rb
+++ b/spec/system/placements/support/schools/mentors/support_user_adds_a_mentor_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Placements support user adds mentors to schools", type: :system,
     and_i_click_on("Add mentor")
     when_i_enter_trn("12a")
     and_i_click_on("Continue")
-    then_i_see_the_error("Enter a valid teacher reference number (TRN)", school.name)
+    then_i_see_the_error("Enter a 7 digit teacher reference number (TRN)", school.name)
   end
 
   scenario "I enter a trn of mentor who already exists for this school" do
@@ -285,7 +285,6 @@ RSpec.describe "Placements support user adds mentors to schools", type: :system,
 
   def then_i_see_link_to_trn_guidance
     expect(page).to have_content(
-      "A TRN is a 7 digit number that uniquely identifies people in the education sector in England. " \
       "If you do not know a teacher’s TRN, you can ask them for it. " \
       "They can find a lost TRN, or apply for a new one by following the instructions in the ",
     )


### PR DESCRIPTION
## Context

Content changes:

- Add hint text to the TRN field in the 'add mentor' journey
- Remove content from the 'Help with the TRN' details component – since it now appears as hint text instead
- Clarify the error message shown when the TRN is entered in an invalid format.

I've applied these changes to both the school user and support user 'add mentor' journeys.

## Changes proposed in this pull request

In addition to the content changes, I've also configured RSpec with a `example_status_persistence_file_path` so we can now use the `--only-failures` option. This should make it quicker to re-run the test suite with a quick feedback loop when fixing failures from across the app.

Read more about how to use `--only-failures` in the RSpec docs:
https://rspec.info/features/3-13/rspec-core/command-line/only-failures/

## Link to Trello card

https://trello.com/c/vf1v2l1K/438-improvements-to-the-error-summary-on-the-find-a-teacher-page

## Screenshots

| Before | After |
| --- | --- |
| ![Before](https://github.com/DFE-Digital/itt-mentor-services/assets/7735945/06df3f1f-5439-4df6-88ec-ca438f8fb87c) | ![After](https://github.com/DFE-Digital/itt-mentor-services/assets/7735945/dee9b23b-7167-4b96-9033-42e270b4bcfb) |
