### PR TITLE
Store sessions in the database

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,9 @@ gem "redcarpet", "~> 3.6"
 # GoodJob backend for Active Job
 gem "good_job", "~> 3.29"
 
+# Store user sessions in the database
+gem "activerecord-session_store"
+
 gem "govuk-components", "~> 5.4.0"
 gem "govuk_design_system_formbuilder", "~> 5.4"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,13 @@ GEM
       timeout (>= 0.4.0)
     activerecord-nulldb-adapter (1.0.1)
       activerecord (>= 5.2.0, < 7.2)
+    activerecord-session_store (2.1.0)
+      actionpack (>= 6.1)
+      activerecord (>= 6.1)
+      cgi (>= 0.3.6)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 2.0.8, < 4)
+      railties (>= 6.1)
     activestorage (7.1.3.4)
       actionpack (= 7.1.3.4)
       activejob (= 7.1.3.4)
@@ -150,6 +157,7 @@ GEM
     capybara-screenshot (1.0.26)
       capybara (>= 1.0, < 4)
       launchy
+    cgi (0.4.1)
     childprocess (5.0.0)
     choice (0.2.0)
     climate_control (1.2.0)
@@ -698,6 +706,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-nulldb-adapter
+  activerecord-session_store
   amazing_print
   annotate
   audited

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,7 +46,7 @@ class ApplicationController < ActionController::Base
   def authenticate_user!
     return if current_user
 
-    session[:requested_path] = request.fullpath
+    session["requested_path"] = request.fullpath
 
     redirect_to sign_in_path
   end

--- a/app/controllers/placements/organisations_controller.rb
+++ b/app/controllers/placements/organisations_controller.rb
@@ -29,9 +29,9 @@ class Placements::OrganisationsController < Placements::ApplicationController
 
   def set_current_provider(organisation)
     if organisation.is_a?(Provider)
-      session[:placements_provider_id] = organisation.id
+      session["placements_provider_id"] = organisation.id
     else
-      session.delete(:placements_provider_id)
+      session.delete("placements_provider_id")
     end
   end
 

--- a/app/controllers/placements/placements_controller.rb
+++ b/app/controllers/placements/placements_controller.rb
@@ -31,7 +31,7 @@ class Placements::PlacementsController < Placements::ApplicationController
   end
 
   def set_provider
-    @provider = Placements::Provider.find(session[:placements_provider_id])
+    @provider = Placements::Provider.find(session["placements_provider_id"])
   end
 
   def filter_form

--- a/app/jobs/trim_expired_sessions_job.rb
+++ b/app/jobs/trim_expired_sessions_job.rb
@@ -1,0 +1,28 @@
+##
+# Trim old sessions from the database
+#
+# This is a re-implementation of the Rake task provided by the
+# activerecord-session_store gem [1] – but with two differences:
+#
+#   - It's an Active Job rather than a Rake task. That way we can schedule it
+#     to run alongside all the other scheduled jobs, as defined in
+#     config/scheduled_jobs.yml
+#
+#   - The lifetime of a session is determined by the user's authenticated state.
+#     If the user's authentication has timed out, so should the rest of their
+#     session. So we have consciously coupled this with the authentication
+#     model DfESignInUser and its SESSION_TIMEOUT constant.
+#
+# [1]: https://github.com/rails/activerecord-session_store/blob/734c38f85f169ae26bf6f1af40bf7e1a9e4d34bc/lib/tasks/database.rake#L14-L20
+
+class TrimExpiredSessionsJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    cutoff_period = DfESignInUser::SESSION_TIMEOUT.ago
+
+    ActiveRecord::SessionStore::Session
+      .where("updated_at < ?", cutoff_period)
+      .delete_all
+  end
+end

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -1,4 +1,7 @@
 class DfESignInUser
+  # Sessions timeout after this period of inactivity
+  SESSION_TIMEOUT = 2.hours
+
   attr_reader :email, :dfe_sign_in_uid, :id_token, :provider, :service, :first_name, :last_name
 
   def initialize(email:, dfe_sign_in_uid:, first_name:, last_name:, service:, id_token: nil, provider: nil)
@@ -31,7 +34,7 @@ class DfESignInUser
     # `last_active_at` set. In that case, force them to sign in again.
     return unless dfe_sign_in_session["last_active_at"]
 
-    return if dfe_sign_in_session.fetch("last_active_at") < 2.hours.ago
+    return if dfe_sign_in_session.fetch("last_active_at") < SESSION_TIMEOUT.ago
 
     dfe_sign_in_session["last_active_at"] = Time.current
 

--- a/app/views/placements/schools/placements/build/add_mentors.html.erb
+++ b/app/views/placements/schools/placements/build/add_mentors.html.erb
@@ -20,7 +20,7 @@
             <%= f.govuk_check_box :mentor_ids, mentor.id, label: { text: mentor.full_name }, checked: @current_step.mentor_ids.include?(mentor.id) %>
           <% end %>
           <%= f.govuk_check_box_divider %>
-          <%= f.govuk_check_box :mentor_ids, :not_known, label: { text: t(".not_known") }, checked: @current_step.mentor_ids.include?(:not_known), exclusive: true %>
+          <%= f.govuk_check_box :mentor_ids, "not_known", label: { text: t(".not_known") }, checked: @current_step.mentor_ids.include?("not_known"), exclusive: true %>
         <% end %>
 
         <%= govuk_details(

--- a/app/wizards/placements/add_placement/steps/mentors.rb
+++ b/app/wizards/placements/add_placement/steps/mentors.rb
@@ -22,7 +22,7 @@ class Placements::AddPlacement::Steps::Mentors
 
   private
 
-  NOT_KNOWN = [:not_known].freeze
+  NOT_KNOWN = %w[not_known].freeze
 
   def normalised_mentor_ids(mentor_ids)
     if mentor_ids.blank?

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -168,3 +168,9 @@ shared:
     - placement_id
     - created_at
     - updated_at
+  :sessions:
+    - id
+    - session_id
+    - data
+    - created_at
+    - updated_at

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,5 +45,8 @@ module IttMentorServices
     config.active_record.yaml_column_permitted_classes = [Symbol, Date, Time, ActiveSupport::TimeWithZone, ActiveSupport::TimeZone]
 
     config.skylight.probes << "active_job"
+
+    # Store user sessions in the database
+    config.session_store :active_record_store
   end
 end

--- a/config/scheduled_jobs.yml
+++ b/config/scheduled_jobs.yml
@@ -32,7 +32,12 @@ remove_internal_draft_claims:
   description: "Remove all internal_draft claims"
 
 send_entity_table_checks_to_bigquery:
-  cron: "30 0 * * *"  # Every day at 00:30.
+  cron: "30 0 * * *" # Every day at 00:30.
   class: "DfE::Analytics::EntityTableCheckJob"
   queue: dfe_analytics
   description: "Syncs the entity table in BigQuery with the database"
+
+trim_expired_sessions:
+  cron: "15 * * * *" # Every hour at quarter past
+  class: "TrimExpiredSessionsJob"
+  description: Trim old sessions from the database

--- a/db/migrate/20240617152221_add_sessions_table.rb
+++ b/db/migrate/20240617152221_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration[7.1]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, null: false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, unique: true
+    add_index :sessions, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_11_151728) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_17_152221) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -348,6 +348,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_11_151728) do
     t.index ["trust_id"], name: "index_schools_on_trust_id"
     t.index ["urn"], name: "index_schools_on_urn", unique: true
     t.index ["urn"], name: "index_schools_on_urn_trigram", opclass: :gin_trgm_ops, using: :gin
+  end
+
+  create_table "sessions", force: :cascade do |t|
+    t.string "session_id", null: false
+    t.text "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
+    t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
   create_table "subjects", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/jobs/trim_expired_sessions_job_spec.rb
+++ b/spec/jobs/trim_expired_sessions_job_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe TrimExpiredSessionsJob, type: :job do
+  def create_session(attributes)
+    ActiveRecord::SessionStore::Session.create!(
+      session_id: SecureRandom.uuid,
+      data: "Some very important session data",
+      **attributes,
+    )
+  end
+
+  # Freeze time to avoid drift during the test – so we can be sure
+  # "exactly 2 hours old" does not become "more than 2 hours old"
+  before { Timecop.freeze }
+  after { Timecop.return }
+
+  it "deletes sessions which haven't been active in more than 2 hours" do
+    two_weeks_old = create_session(updated_at: 2.weeks.ago)
+    two_days_old = create_session(updated_at: 2.days.ago)
+    three_hours_old = create_session(updated_at: 3.hours.ago)
+    two_hours_old = create_session(updated_at: 2.hours.ago)
+    one_hour_old = create_session(updated_at: 1.hour.ago)
+    twenty_minutes_old = create_session(updated_at: 20.minutes.ago)
+
+    described_class.perform_now
+
+    expect_deleted = [two_weeks_old, two_days_old, three_hours_old]
+    expect_remaining = [two_hours_old, one_hour_old, twenty_minutes_old]
+
+    expect(ActiveRecord::SessionStore::Session.where(id: expect_deleted.map(&:id))).to be_empty
+    expect(ActiveRecord::SessionStore::Session.all).to match_array(expect_remaining)
+  end
+end

--- a/spec/wizards/placements/add_placement/steps/mentors_spec.rb
+++ b/spec/wizards/placements/add_placement/steps/mentors_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Placements::AddPlacement::Steps::Mentors, type: :model do
 
         step.mentor_ids = ["not_known", mentor.id]
 
-        expect(step.mentor_ids).to eq([:not_known])
+        expect(step.mentor_ids).to eq(%w[not_known])
       end
     end
 
@@ -70,7 +70,7 @@ RSpec.describe Placements::AddPlacement::Steps::Mentors, type: :model do
   describe "#wizard_attributes" do
     it "removes not_known" do
       school = create(:placements_school)
-      step = described_class.new(school:, mentor_ids: [:not_known])
+      step = described_class.new(school:, mentor_ids: %w[not_known])
 
       expect(step.wizard_attributes).to eq({ mentor_ids: [] })
     end


### PR DESCRIPTION
> [!IMPORTANT]  
> **Care should be taken when deploying this change. To reduce the risk of disrupting live user sessions, it should be deployed out of hours.**
>
> Users will be signed out because their existing sessions will be discarded. However the app is currently low-traffic enough that an out of hours deployment seems like a reasonable mitigation.

## Context

Currently we use the cookie session store. This is the default session store which comes out of the box with Rails. The cookie store mostly works fine and is a good default, but there is one major drawback: storage space is limited to ~4 KB.

From experience, it's surprisingly easy to use up that space. Features such as multi-step forms (a.k.a. wizards) will often depend on using the session as temporary storage – and since such forms accept user input, the amount of session storage required will consequently be unpredictable and vary wildly.

If you over-fill session cookies, the application will raise `CookieOverflow` errors. As abundantly tasty as these errors sound, they don't make for a good user experience. Users will randomly start seeing the "something went wrong" page, and the server will give `500 Internal Server Error` responses.

Thankfully [Rails provides other session stores](https://guides.rubyonrails.org/action_controller_overview.html#session) which don't have a hard limit on storage.

## Changes proposed in this pull request

I've set up the Active Record session storage adapter. This means user sessions will be stored in the database, and we'll be able to read & write to sessions without worrying about the ~4 KB storage limit.

As [recommended in the documentation](https://github.com/rails/activerecord-session_store), I have also set up a scheduled job which will prune the database of old & expired sessions. However rather than using the `db:sessions:trim` Rake task, it ended up being simpler to re-implement the trim functionality as an Active Job so it can be scheduled via Good Job.

## Guidance to review

- This PR should not result in any user-facing changes.
- Does everything work the same as it did before?

## Link to Trello card

https://trello.com/c/AVwbE2ax/504-use-a-database-backed-session-store
