### PR TITLE
Add sessions table to the DfE Analytics blocklist

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -168,9 +168,3 @@ shared:
     - placement_id
     - created_at
     - updated_at
-  :sessions:
-    - id
-    - session_id
-    - data
-    - created_at
-    - updated_at

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -97,3 +97,9 @@ shared:
   :providers:
     - email_address
     - telephone
+  :sessions:
+    - id
+    - session_id
+    - data
+    - created_at
+    - updated_at


### PR DESCRIPTION
The database table to hold sessions should have been added to the DfE Analytics blocklist in #781. This is a follow-up commit to add it.

This will stop user sessions being sent in to BigQuery.
