### PR TITLE
Upgrade stg postgres db to B_Standard_B2s

### DIFF
--- a/terraform/application/config/staging.tfvars.json
+++ b/terraform/application/config/staging.tfvars.json
@@ -6,5 +6,6 @@
         "website_url": [ "https://staging.claim-funding-for-mentor-training.education.gov.uk/healthcheck/all","https://staging.manage-school-placements.education.gov.uk/healthcheck/all" ],
         "contact_groups": [311842]
     },
-    "enable_postgres_backup_storage": true
+    "enable_postgres_backup_storage": true,
+    "postgres_flexible_server_sku": "B_Standard_B2s"
   }


### PR DESCRIPTION
## Context

stg postgres is triggering cpu alerts, and looks to be underpowered.

![image](https://github.com/DFE-Digital/itt-mentor-services/assets/94844345/33948e45-8673-4170-8371-e0a89fd3b0d2)

## Changes proposed in this pull request

Upgrade db from B_Standard_B1ms to B_Standard_B2s

## Guidance to review

make staging terraform-plan

```
# module.postgres.azurerm_postgresql_flexible_server.main[0] will be updated in-place
  ~ resource "azurerm_postgresql_flexible_server" "main" {
        name                          = "s189t01-ittms-stg-pg"
      ~ sku_name                      = "B_Standard_B1ms" -> "B_Standard_B2s"
```

## Link to Trello card

https://trello.com/c/ZiMrcySC/1882-stg-posgtres-db-cpu-alerts 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
