### PR TITLE
Change add placement flash message

### DIFF
--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -88,7 +88,7 @@ en:
             cancel: Cancel
             not_yet_known: Not yet known
           update:
-            success: Placement added
+            success: Placement published
         edit_provider:
           title_with_error: "Error: Provider - Manage a placement"
           title: Provider - Manage a placement

--- a/spec/system/placements/schools/placements/add_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/add_a_placement_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
           when_i_click_on("Publish placement")
           then_i_see_the_placements_page
           and_i_see_my_placement(school.phase)
+          and_i_see_success_message("Placement published")
         end
 
         scenario "when I select not known for the mentor" do
@@ -71,6 +72,7 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
           and_i_click_on("Publish placement")
           then_i_see_the_placements_page
           and_i_see_my_placement(school.phase)
+          and_i_see_success_message("Placement published")
         end
       end
 
@@ -195,6 +197,7 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
         when_i_click_on("Publish placement")
         then_i_see_the_placements_page
         and_i_see_my_placement(school.phase)
+        and_i_see_success_message("Placement published")
       end
 
       context "when I select a subject with child subjects" do
@@ -218,6 +221,7 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
           when_i_click_on("Publish placement")
           then_i_see_the_placements_page
           and_i_see_my_placement(school.phase)
+          and_i_see_success_message("Placement published")
         end
 
         scenario "I see a validation message if I do not select an additional subject" do
@@ -277,6 +281,7 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
           when_i_click_on("Publish placement")
           then_i_see_the_placements_page
           and_i_see_my_placement("Primary")
+          and_i_see_success_message("Placement published")
         end
       end
 
@@ -299,6 +304,7 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
           and_i_click_on("Publish placement")
           then_i_see_the_placements_page
           and_i_see_my_placement("Secondary")
+          and_i_see_success_message("Placement published")
         end
       end
 
@@ -629,6 +635,12 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
 
   def and_i_do_not_see_the_button_to(button_text)
     expect(page).not_to have_button(button_text)
+  end
+
+  def and_i_see_success_message(message)
+    within(".govuk-notification-banner") do
+      expect(page).to have_content message
+    end
   end
 
   alias_method :and_i_click_on, :when_i_click_on


### PR DESCRIPTION
## Context

- Change flash message when adding a placements to "Placement published"

## Guidance to review

- Sign in as Anne
- Create a placement
- Check the flash message reads "Placement published"

## Link to Trello card

https://trello.com/c/ti0JnrPh/518-change-the-add-placement-success-flash-message

## Screenshots

![screencapture-placements-localhost-3000-schools-00004607-b87d-42e6-86f3-ac514dfd9d2b-placements-2024-06-25-11_10_55](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/a4095c1d-74ef-419b-8c94-f03bf1f3f21f)
