### PR TITLE
Update placements check your answers text

### DIFF
--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -83,7 +83,9 @@ en:
             add_year_group: Add year group
             add_mentors: Add mentors
             change: Change
-            info_text: When a placement is published, it will be visible to teacher training providers.
+            info_text: |
+              When a placement is published, it will be visible to teacher training providers. 
+              You can edit your placement after it is published.
             publish_placement: Publish placement
             cancel: Cancel
             not_yet_known: Not yet known


### PR DESCRIPTION
## Context

- Update the inset text on the Check your answers page

## Guidance to review

- Sign in as Anne
- Create a new placement, but stop on the Check your answers page
- The inset text should read:
  - When a placement is published, it will be visible to teacher training providers. You can edit your placement after it is published.

## Link to Trello card

https://trello.com/c/Gq2hSY8E/519-update-the-inset-text-on-add-placement-%E2%86%92-check-your-answers

## Screenshots

![screencapture-placements-localhost-3000-schools-00004607-b87d-42e6-86f3-ac514dfd9d2b-placements-new-placement-build-check-your-answers-2024-06-25-11_47_20](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/2663375a-4961-4301-ba46-53e82e80b447)

