### PR TITLE
Improve readability of "change" links and refactor the "Add placement" spec

### DIFF
--- a/app/views/placements/schools/placements/build/check_your_answers.html.erb
+++ b/app/views/placements/schools/placements/build/check_your_answers.html.erb
@@ -24,21 +24,21 @@
             <% row.with_key { t(".phase") } %>
             <% row.with_value(text: @phase) %>
             <% unless @school.primary_or_secondary_only? %>
-              <% row.with_action(text: t(".change"), href: add_phase_placements_school_placement_build_index_path(@school, :add_phase), visually_hidden_text: t(".add_phase")) %>
+              <% row.with_action(text: t(".change"), href: add_phase_placements_school_placement_build_index_path(@school, :add_phase), visually_hidden_text: t(".phase")) %>
             <% end %>
           <% end %>
 
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".subject")) %>
             <% row.with_value(text: @placement.subject_name) %>
-            <% row.with_action(text: t(".change"), href: add_subject_placements_school_placement_build_index_path(@school, :add_subject), visually_hidden_text: t(".add_subject")) %>
+            <% row.with_action(text: t(".change"), href: add_subject_placements_school_placement_build_index_path(@school, :add_subject), visually_hidden_text: t(".subject")) %>
           <% end %>
 
           <% if @placement.subject_has_child_subjects? %>
             <% summary_list.with_row do |row| %>
               <% row.with_key(text: t(".additional_subjects")) %>
               <% row.with_value(text: @placement.additional_subject_names) %>
-              <% row.with_action(text: t(".change"), href: add_additional_subjects_placements_school_placement_build_index_path(@school, :add_additional_subjects), visually_hidden_text: t(".add_additional_subjects")) %>
+              <% row.with_action(text: t(".change"), href: add_additional_subjects_placements_school_placement_build_index_path(@school, :add_additional_subjects), visually_hidden_text: t(".additional_subjects")) %>
             <% end %>
           <% end %>
 
@@ -46,7 +46,7 @@
             <% summary_list.with_row do |row| %>
               <% row.with_key(text: t(".year_group")) %>
               <% row.with_value(text: t("placements.schools.placements.year_groups.#{@placement.year_group}")) %>
-              <% row.with_action(text: t(".change"), href: add_year_group_placements_school_placement_build_index_path(@school, :add_year_group), visually_hidden_text: t(".add_year_group")) %>
+              <% row.with_action(text: t(".change"), href: add_year_group_placements_school_placement_build_index_path(@school, :add_year_group), visually_hidden_text: t(".year_group")) %>
             <% end %>
           <% end %>
 
@@ -54,7 +54,7 @@
             <% summary_list.with_row do |row| %>
               <% row.with_key(text: t(".mentor")) %>
               <% row.with_value(text: @selected_mentor_text) %>
-              <% row.with_action(text: t(".change"), href: add_mentors_placements_school_placement_build_index_path(@school, :add_mentors), visually_hidden_text: t(".add_mentors")) %>
+              <% row.with_action(text: t(".change"), href: add_mentors_placements_school_placement_build_index_path(@school, :add_mentors), visually_hidden_text: t(".mentor")) %>
             <% end %>
           <% end %>
         <% end %>

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -73,15 +73,10 @@ en:
             title: Check your answers
             add_placement: Add placement
             phase: Phase
-            add_phase: Add phase
             subject: Subject
-            add_subject: Add subject
             additional_subjects: Additional subjects
-            add_additional_subjects: Add additional subjects
             mentor: Mentor
             year_group: Year group
-            add_year_group: Add year group
-            add_mentors: Add mentors
             change: Change
             info_text: When a placement is published, it will be visible to teacher training providers.
             publish_placement: Publish placement
@@ -172,7 +167,7 @@ en:
         destroy:
           placement_deleted: Placement deleted
         update:
-          success: 
+          success:
             edit_mentors: Mentor updated
             edit_provider: Provider updated
             edit_year_group: Year group updated

--- a/spec/system/placements/schools/placements/add_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/add_a_placement_spec.rb
@@ -96,24 +96,41 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
         end
 
         scenario "I can navigate back to the index page with cancel" do
-          when_i_visit_the_add_phase_page
-          and_i_click_on("Cancel")
+          when_i_visit_the_placements_page
+          and_i_click_on("Add placement")
+          then_i_see_the_add_a_placement_subject_page(school.phase)
+          when_i_choose_a_subject(subject_1.name)
+          and_i_click_on("Continue")
+          then_i_see_the_add_year_group_page("Year 1")
+          when_i_choose_a_year_group("Year 1")
+          and_i_click_on("Continue")
+          then_i_see_the_add_a_placement_mentor_page
+          when_i_check_a_mentor(mentor_1.full_name)
+          and_i_click_on("Continue")
+          then_i_see_the_check_your_answers_page(school.phase, mentor_1)
+
+          check_your_answers_page = page.current_path
+
+          # 'Cancel' link on the 'Check your answers' page
+          when_i_click_on "Cancel"
           then_i_see_the_placements_page
 
-          when_i_visit_the_add_subject_page
-          and_i_click_on("Cancel")
+          # 'Cancel' link on the 'Subject' page
+          given_i_visit check_your_answers_page
+          when_i_click_on "Change Subject"
+          and_i_click_on "Cancel"
           then_i_see_the_placements_page
 
-          when_i_visit_the_add_year_group_page
-          and_i_click_on("Cancel")
+          # 'Cancel' link on the 'Year group' page
+          given_i_visit check_your_answers_page
+          when_i_click_on "Change Year group"
+          and_i_click_on "Cancel"
           then_i_see_the_placements_page
 
-          when_i_visit_the_add_mentor_page
-          and_i_click_on("Cancel")
-          then_i_see_the_placements_page
-
-          when_i_visit_the_check_your_answers_page
-          and_i_click_on("Cancel")
+          # 'Cancel' link on the 'Mentor' page
+          given_i_visit check_your_answers_page
+          when_i_click_on "Change Mentor"
+          and_i_click_on "Cancel"
           then_i_see_the_placements_page
         end
 
@@ -161,16 +178,6 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
             then_i_see_the_add_a_placement_mentor_page
             when_i_click_on("Continue")
             and_i_see_the_error_message("Select a mentor or not yet known")
-          end
-        end
-
-        context "when I tamper with the form URL", js: true do
-          scenario "I see an error message" do
-            when_i_visit_the_placements_page
-            and_i_click_on("Add placement")
-            then_i_tamper_with_the_form_url
-            and_i_click_on("Continue")
-            then_i_see_an_error_page
           end
         end
       end
@@ -337,6 +344,10 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
           then_i_see_the_add_a_placement_subject_page("Primary")
           when_i_choose_a_subject(subject_1.name)
           when_i_click_on("Continue")
+          # TODO: a bug fix is needed - we should ask for the year group here
+          # then_i_see_the_add_year_group_page("Year 1")
+          # when_i_choose_a_year_group("Year 1")
+          # and_i_click_on("Continue")
           then_i_see_the_add_a_placement_mentor_page
           and_i_click_on("Continue")
           then_i_see_the_check_your_answers_page("Primary", mentor_1)
@@ -479,15 +490,8 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
     visit add_year_group_placements_school_placement_build_index_path(school, :add_year_group)
   end
 
-  def when_i_visit_the_check_your_answers_page
-    when_i_visit_the_placements_page
-    and_i_click_on("Add placement")
-    when_i_choose_a_subject("Primary subject")
-    and_i_click_on("Continue")
-    when_i_choose_a_year_group("Year 1")
-    and_i_click_on("Continue")
-    when_i_check_a_mentor(mentor_1.full_name)
-    and_i_click_on("Continue")
+  def given_i_visit(path)
+    visit path
   end
 
   def given_i_sign_in_as_anne
@@ -585,36 +589,28 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
     expect(page).to have_content(message)
   end
 
-  def then_i_tamper_with_the_form_url
-    page.execute_script("document.querySelector('form').action = '/schools/#{school.id}/placements/new_placement/build/invalid_id'")
-  end
-
   def then_see_that_not_known_is_selected
     expect(page).to have_checked_field("Not yet known")
   end
 
   def and_i_cannot_change_the_phase
-    expect(page).not_to have_link("Change", href: add_phase_placements_school_placement_build_index_path(school, :add_phase))
+    expect(page).not_to have_link("Change Phase")
   end
 
   def and_i_can_change_the_phase
-    expect(page).to have_link("Change", href: add_phase_placements_school_placement_build_index_path(school, :add_phase))
+    expect(page).to have_link("Change Phase")
   end
 
   def when_i_change_my_phase
-    click_link "Change", href: add_phase_placements_school_placement_build_index_path(school, :add_phase)
+    click_link "Change Phase"
   end
 
   def when_i_change_my_subject
-    click_link "Change", href: add_subject_placements_school_placement_build_index_path(school, :add_subject)
+    click_link "Change Subject"
   end
 
   def when_i_change_my_mentor
-    click_link "Change", href: add_mentors_placements_school_placement_build_index_path(school, :add_mentors)
-  end
-
-  def then_i_see_an_error_page
-    expect(page).to have_content("Sorry, there’s a problem with the service")
+    click_link "Change Mentor"
   end
 
   def and_my_selection_has_changed_to(selection)


### PR DESCRIPTION
## Context

I'm implementing these changes ahead of an anticipated refactor of the 'Add placement' multi-step form. The changes in this PR reduce the coupling between the spec and the current implementation, making it more compatible with upcoming implementation changes.

## Guidance to review

See individual commits and their commit messages for details.

There are no visual changes.

## Link to Trello card

This is a preparatory refactor for: https://trello.com/c/FiYvPVpK/516-refactor-add-placement-controller-into-a-wizard
