### PR TITLE
Redirect users after sign in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,11 +28,19 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path
-    if current_user.support_user?
+    if requested_path.present?
+      requested_path
+    elsif current_user.support_user?
       support_root_path
     else
       organisations_path
     end
+  end
+
+  def requested_path
+    return if [sign_in_path, sign_out_path, nil].include?(session["requested_path"])
+
+    session[:requested_path]
   end
 
   def after_sign_out_path

--- a/app/controllers/placements/placements_controller.rb
+++ b/app/controllers/placements/placements_controller.rb
@@ -31,6 +31,8 @@ class Placements::PlacementsController < Placements::ApplicationController
   end
 
   def set_provider
+    return redirect_to organisations_path if session["placements_provider_id"].blank?
+
     @provider = Placements::Provider.find(session["placements_provider_id"])
   end
 

--- a/spec/system/placements/sign_in_as_a_placements_user_spec.rb
+++ b/spec/system/placements/sign_in_as_a_placements_user_spec.rb
@@ -118,7 +118,6 @@ RSpec.describe "Sign In as a Placements User", type: :system, service: :placemen
         let!(:organisation) { create(:school, :placements, name: "Deep Link Placement School") }
         let(:provider_organisation) { create(:provider, :placements, name: "Provider") }
 
-
         scenario "when I sign in as Anne I am redirected to my requested page" do
           given_there_is_an_existing_user_for("Anne", with_dfe_sign_id: false)
           and_anne_is_part_of_an_organisation(organisation)

--- a/spec/system/placements/sign_in_as_a_placements_user_spec.rb
+++ b/spec/system/placements/sign_in_as_a_placements_user_spec.rb
@@ -116,6 +116,8 @@ RSpec.describe "Sign In as a Placements User", type: :system, service: :placemen
 
       context "when I am not a support user" do
         let!(:organisation) { create(:school, :placements, name: "Deep Link Placement School") }
+        let(:provider_organisation) { create(:provider, :placements, name: "Provider") }
+
 
         scenario "when I sign in as Anne I am redirected to my requested page" do
           given_there_is_an_existing_user_for("Anne", with_dfe_sign_id: false)
@@ -124,6 +126,16 @@ RSpec.describe "Sign In as a Placements User", type: :system, service: :placemen
           then_i_am_redirected_to_the_sign_in_page
           when_i_click_sign_in
           then_i_am_redirected_to_the_school_users_page(organisation)
+        end
+
+        scenario "when I sign in as Anne and I have multiple organisations" do
+          given_there_is_an_existing_user_for("Anne", with_dfe_sign_id: false)
+          and_anne_is_part_of_an_organisation(organisation)
+          and_anne_is_part_of_an_organisation(provider_organisation)
+          when_i_visit_the_placements_path
+          then_i_am_redirected_to_the_sign_in_page
+          when_i_click_sign_in
+          then_i_am_redirected_to_the_organisations_page
         end
       end
     end
@@ -244,7 +256,15 @@ RSpec.describe "Sign In as a Placements User", type: :system, service: :placemen
     visit placements_school_users_path(organisation)
   end
 
+  def when_i_visit_the_placements_path
+    visit placements_placements_path
+  end
+
   def then_i_am_redirected_to_the_school_users_page(organisation)
     expect(page).to have_current_path(placements_school_users_path(organisation))
+  end
+
+  def then_i_am_redirected_to_the_organisations_page
+    expect(page).to have_current_path(placements_organisations_path)
   end
 end

--- a/spec/system/placements/sign_in_as_a_placements_user_spec.rb
+++ b/spec/system/placements/sign_in_as_a_placements_user_spec.rb
@@ -102,6 +102,31 @@ RSpec.describe "Sign In as a Placements User", type: :system, service: :placemen
         then_i_see_user_details_for_colin
       end
     end
+
+    context "when I use a deep link without being logged in" do
+      context "when I am a support user" do
+        scenario "when I sign in as Colin I am redirected to my requested page" do
+          given_there_is_an_existing_support_user_for("Colin", with_dfe_sign_id: false)
+          when_i_visit_the_support_users_path
+          then_i_am_redirected_to_the_sign_in_page
+          when_i_click_sign_in
+          then_i_am_redirected_to_the_support_users_page
+        end
+      end
+
+      context "when I am not a support user" do
+        let!(:organisation) { create(:school, :placements, name: "Deep Link Placement School") }
+
+        scenario "when I sign in as Anne I am redirected to my requested page" do
+          given_there_is_an_existing_user_for("Anne", with_dfe_sign_id: false)
+          and_anne_is_part_of_an_organisation(organisation)
+          when_i_visit_the_school_users_path(organisation)
+          then_i_am_redirected_to_the_sign_in_page
+          when_i_click_sign_in
+          then_i_am_redirected_to_the_school_users_page(organisation)
+        end
+      end
+    end
   end
 
   private
@@ -197,5 +222,29 @@ RSpec.describe "Sign In as a Placements User", type: :system, service: :placemen
 
   def then_i_am_redirect_to_internal_server_error
     expect(page).to have_content("Sorry, there’s a problem with the service")
+  end
+
+  def when_i_visit_the_support_users_path
+    visit placements_support_support_users_path
+  end
+
+  def then_i_am_redirected_to_the_sign_in_page
+    expect(page).to have_current_path(sign_in_path)
+  end
+
+  def then_i_am_redirected_to_the_support_users_page
+    expect(page).to have_current_path(placements_support_support_users_path)
+  end
+
+  def and_anne_is_part_of_an_organisation(organisation)
+    organisation.users << User.find_by(email: "anne_wilson@example.org")
+  end
+
+  def when_i_visit_the_school_users_path(organisation)
+    visit placements_school_users_path(organisation)
+  end
+
+  def then_i_am_redirected_to_the_school_users_page(organisation)
+    expect(page).to have_current_path(placements_school_users_path(organisation))
   end
 end


### PR DESCRIPTION
## Context

When using a deep link into the application the user would always been redirected to the root path after sign in, we want to send them to their requested page instead.

## Changes proposed in this pull request

- [x] Make use of the requested path session value to send the user to the correct place
- [x] Redirect the user to the organisatons controller if a provider cannot be found.

## Guidance to review

- Log in as any user
- Navigate to a page in the application
- Copy the URL
- Log out
- Paste the URL
- Log in
- You should be on the same URL you requested

## Link to Trello card

[After signing in, redirect users back to the page they originally requested](https://trello.com/c/CA5fcgyX/513-after-signing-in-redirect-users-back-to-the-page-they-originally-requested)