### PR TITLE
Always use strings for session keys

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,7 +40,7 @@ class ApplicationController < ActionController::Base
   def requested_path
     return if [sign_in_path, sign_out_path, nil].include?(session["requested_path"])
 
-    session[:requested_path]
+    session["requested_path"]
   end
 
   def after_sign_out_path


### PR DESCRIPTION
Addresses comment: https://github.com/DFE-Digital/itt-mentor-services/pull/807/files#r1658957291

As per commit 3f37281c7560bdb031b5baf5db73353dd7c3292a
