### PR TITLE
Add support settings

### DIFF
--- a/app/controllers/claims/support/mailers_controller.rb
+++ b/app/controllers/claims/support/mailers_controller.rb
@@ -1,0 +1,7 @@
+class Claims::Support::MailersController < Claims::Support::ApplicationController
+  before_action :skip_authorization
+
+  def index
+    @previews = ActionMailer::Preview.all.filter { |preview| preview.preview_name.start_with?("claims/") }
+  end
+end

--- a/app/controllers/claims/support/settings_controller.rb
+++ b/app/controllers/claims/support/settings_controller.rb
@@ -1,0 +1,3 @@
+class Claims::Support::SettingsController < Claims::Support::ApplicationController
+  before_action :skip_authorization
+end

--- a/app/controllers/placements/support/mailers_controller.rb
+++ b/app/controllers/placements/support/mailers_controller.rb
@@ -1,0 +1,5 @@
+class Placements::Support::MailersController < Placements::ApplicationController
+  def index
+    @previews = ActionMailer::Preview.all.filter { |preview| preview.preview_name.start_with?("placements/") }
+  end
+end

--- a/app/controllers/placements/support/settings_controller.rb
+++ b/app/controllers/placements/support/settings_controller.rb
@@ -1,0 +1,2 @@
+class Placements::Support::SettingsController < Placements::ApplicationController
+end

--- a/app/views/claims/support/_primary_navigation.html.erb
+++ b/app/views/claims/support/_primary_navigation.html.erb
@@ -3,6 +3,7 @@
     <% component.with_navigation_item t(".organisations"), claims_support_schools_path, current: local_assigns[:current] == :organisations %>
     <% component.with_navigation_item t(".claims"), claims_support_claims_path, current: local_assigns[:current] == :claims %>
     <% component.with_navigation_item t(".support_users"), claims_support_support_users_path, current: local_assigns[:current] == :users %>
+    <% component.with_navigation_item t(".settings"), claims_support_settings_path, current: local_assigns[:current] == :settings %>
   <% end %>
 
   <% content_for(:no_phase_banner_border, true) %>

--- a/app/views/claims/support/mailers/index.html.erb
+++ b/app/views/claims/support/mailers/index.html.erb
@@ -1,0 +1,15 @@
+<% render "claims/support/primary_navigation", current: :settings %>
+
+<div class="govuk-width-container">
+  <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+
+  <% @previews.each do |mailer| %>
+    <h2 class="govuk-heading-m"><%= mailer.preview_name.delete_prefix("claims/").titleize %></h2>
+
+    <% email_links = mailer.emails.map do |email| %>
+      <% govuk_link_to(email, url_for(controller: "/rails/mailers", action: :preview, path: "#{mailer.preview_name}/#{email}"), no_visited_state: true, new_tab: true) %>
+    <% end %>
+
+    <%= govuk_list email_links, type: :bullet %>
+  <% end %>
+</div>

--- a/app/views/claims/support/settings/index.html.erb
+++ b/app/views/claims/support/settings/index.html.erb
@@ -4,10 +4,11 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">Settings</h1>
+      <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 
       <%= govuk_list [
-        govuk_link_to("Background Jobs", "/good_job", no_visited_state: true, new_tab: true),
+        govuk_link_to(t(".background_jobs"), "/good_job", no_visited_state: true, new_tab: true),
+        govuk_link_to(t(".emails"), claims_support_mailers_path, no_visited_state: true),
       ], spaced: true %>
     </div>
   </div>

--- a/app/views/claims/support/settings/index.html.erb
+++ b/app/views/claims/support/settings/index.html.erb
@@ -5,6 +5,10 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Settings</h1>
+
+      <%= govuk_list [
+        govuk_link_to("Background Jobs", "/good_job", no_visited_state: true, new_tab: true),
+      ], spaced: true %>
     </div>
   </div>
 </div>

--- a/app/views/claims/support/settings/index.html.erb
+++ b/app/views/claims/support/settings/index.html.erb
@@ -1,0 +1,10 @@
+<%# content_for :page_title, t(".heading", records: @pagy.count) %>
+<% render "claims/support/primary_navigation", current: :settings %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Settings</h1>
+    </div>
+  </div>
+</div>

--- a/app/views/placements/support/_primary_navigation.html.erb
+++ b/app/views/placements/support/_primary_navigation.html.erb
@@ -6,5 +6,6 @@
                                       support_organisations_path,
                                       current: current_navigation == :organisations %>
     <% component.with_navigation_item t(".users"), support_support_users_path, current: current_navigation == :users %>
+    <% component.with_navigation_item t(".settings"), placements_support_settings_path, current: current_navigation == :settings %>
   <% end %>
 <% end %>

--- a/app/views/placements/support/mailers/index.html.erb
+++ b/app/views/placements/support/mailers/index.html.erb
@@ -1,0 +1,15 @@
+<% render "placements/support/primary_navigation", current_navigation: :settings %>
+
+<div class="govuk-width-container">
+  <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+
+  <% @previews.each do |mailer| %>
+    <h2 class="govuk-heading-m"><%= mailer.preview_name.delete_prefix("placements/").titleize %></h2>
+
+    <% email_links = mailer.emails.map do |email| %>
+      <% govuk_link_to(email, url_for(controller: "/rails/mailers", action: :preview, path: "#{mailer.preview_name}/#{email}"), no_visited_state: true, new_tab: true) %>
+    <% end %>
+
+    <%= govuk_list email_links, type: :bullet %>
+  <% end %>
+</div>

--- a/app/views/placements/support/settings/index.html.erb
+++ b/app/views/placements/support/settings/index.html.erb
@@ -1,0 +1,15 @@
+<%# content_for :page_title, t(".heading", records: @pagy.count) %>
+<%= render "placements/support/primary_navigation", current_navigation: :settings %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+
+      <%= govuk_list [
+        govuk_link_to(t(".background_jobs"), "/good_job", no_visited_state: true, new_tab: true),
+        govuk_link_to(t(".emails"), placements_support_mailers_path, no_visited_state: true),
+      ], spaced: true %>
+    </div>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,9 @@ module IttMentorServices
       "node_modules/govuk-frontend/dist/govuk/assets",
     )
 
+    config.action_mailer.show_previews = true
+    config.action_mailer.preview_paths << Rails.root.join("spec/mailers/previews").to_s
+
     config.view_component.preview_paths << Rails.root.join("spec/components/previews").to_s
     config.view_component.default_preview_layout = "component_preview"
 

--- a/config/locales/en/claims/support/mailers.yml
+++ b/config/locales/en/claims/support/mailers.yml
@@ -1,0 +1,6 @@
+en:
+  claims:
+    support:
+      mailers:
+        index:
+          heading: Emails

--- a/config/locales/en/claims/support/primary_navigation.yml
+++ b/config/locales/en/claims/support/primary_navigation.yml
@@ -5,3 +5,4 @@ en:
         claims: Claims
         organisations: Organisations
         support_users: Support users
+        settings: Settings

--- a/config/locales/en/claims/support/settings.yml
+++ b/config/locales/en/claims/support/settings.yml
@@ -1,0 +1,8 @@
+en:
+  claims:
+    support:
+      settings:
+        index:
+          heading: Settings
+          background_jobs: Background Jobs
+          emails: Emails

--- a/config/locales/en/placements/support/mailers.yml
+++ b/config/locales/en/placements/support/mailers.yml
@@ -1,0 +1,6 @@
+en:
+  placements:
+    support:
+      mailers:
+        index:
+          heading: Emails

--- a/config/locales/en/placements/support/primary_navigation.yml
+++ b/config/locales/en/placements/support/primary_navigation.yml
@@ -4,3 +4,4 @@ en:
       primary_navigation:
         users: Support users
         organisations: Organisations
+        settings: Settings

--- a/config/locales/en/placements/support/settings.yml
+++ b/config/locales/en/placements/support/settings.yml
@@ -1,0 +1,8 @@
+en:
+  placements:
+    support:
+      settings:
+        index:
+          heading: Settings
+          background_jobs: Background Jobs
+          emails: Emails

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -108,5 +108,7 @@ scope module: :claims, as: :claims, constraints: {
     end
 
     get :settings, to: "settings#index"
+
+    resources :mailers, only: :index
   end
 end

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -106,5 +106,7 @@ scope module: :claims, as: :claims, constraints: {
         end
       end
     end
+
+    get :settings, to: "settings#index"
   end
 end

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -19,6 +19,10 @@ scope module: :placements,
   namespace :support do
     root to: redirect("/support/organisations")
 
+    get :settings, to: "settings#index"
+
+    resources :mailers, only: :index
+
     resources :support_users do
       collection { get :check }
       member { get :remove }

--- a/spec/mailers/previews/claims/support_user_mailer_preview.rb
+++ b/spec/mailers/previews/claims/support_user_mailer_preview.rb
@@ -1,0 +1,9 @@
+class Claims::SupportUserMailerPreview < ActionMailer::Preview
+  def support_user_invitation
+    SupportUserMailer.with(service: :claims).support_user_invitation(Claims::SupportUser.first)
+  end
+
+  def support_user_removal_notification
+    SupportUserMailer.with(service: :claims).support_user_removal_notification(Claims::SupportUser.first)
+  end
+end

--- a/spec/mailers/previews/claims/user_mailer_preview.rb
+++ b/spec/mailers/previews/claims/user_mailer_preview.rb
@@ -1,0 +1,17 @@
+class Claims::UserMailerPreview < ActionMailer::Preview
+  def user_membership_created_notification
+    UserMailer.with(service: :claims).user_membership_created_notification(Claims::User.first, Claims::School.first)
+  end
+
+  def user_membership_destroyed_notification
+    UserMailer.with(service: :claims).user_membership_destroyed_notification(Claims::User.first, Claims::School.first)
+  end
+
+  def claim_submitted_notification
+    UserMailer.with(service: :claims).claim_submitted_notification(Claims::User.first, Claims::Claim.submitted.first)
+  end
+
+  def claim_created_support_notification
+    UserMailer.with(service: :claims).claim_created_support_notification(Claims::Claim.draft.first, Claims::User.first)
+  end
+end

--- a/spec/mailers/previews/placements/support_user_mailer_preview.rb
+++ b/spec/mailers/previews/placements/support_user_mailer_preview.rb
@@ -1,0 +1,9 @@
+class Placements::SupportUserMailerPreview < ActionMailer::Preview
+  def support_user_invitation
+    SupportUserMailer.with(service: :placements).support_user_invitation(Placements::SupportUser.first)
+  end
+
+  def support_user_removal_notification
+    SupportUserMailer.with(service: :placements).support_user_removal_notification(Placements::SupportUser.first)
+  end
+end

--- a/spec/mailers/previews/placements/user_mailer_preview.rb
+++ b/spec/mailers/previews/placements/user_mailer_preview.rb
@@ -1,0 +1,9 @@
+class Placements::UserMailerPreview < ActionMailer::Preview
+  def user_membership_created_notification
+    UserMailer.with(service: :placements).user_membership_created_notification(Placements::User.first, Placements::School.first)
+  end
+
+  def user_membership_destroyed_notification
+    UserMailer.with(service: :placements).user_membership_destroyed_notification(Placements::User.first, Placements::School.first)
+  end
+end

--- a/spec/system/claims/support/view_emails_spec.rb
+++ b/spec/system/claims/support/view_emails_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe "View Emails", service: :claims, type: :system do
+  let(:support_user) { create(:claims_support_user) }
+
+  before do
+    user_exists_in_dfe_sign_in(user: support_user)
+    given_i_sign_in
+  end
+
+  scenario "User visits the emails page" do
+    when_i_visit_the_emails_page
+    then_i_can_see_the_list_of_claims_email_templates
+  end
+
+  private
+
+  def given_i_sign_in
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def when_i_visit_the_emails_page
+    click_on "Settings"
+    click_on "Emails"
+  end
+
+  def then_i_can_see_the_list_of_claims_email_templates
+    expect(page).to have_content("Support User Mailer")
+    expect(page).to have_link("support_user_invitation (opens in new tab)", href: "/rails/mailers/claims/support_user_mailer/support_user_invitation")
+    expect(page).to have_link("support_user_removal_notification (opens in new tab)", href: "/rails/mailers/claims/support_user_mailer/support_user_removal_notification")
+
+    expect(page).to have_content("User Mailer")
+    expect(page).to have_link("claim_created_support_notification (opens in new tab)", href: "/rails/mailers/claims/user_mailer/claim_created_support_notification")
+    expect(page).to have_link("claim_submitted_notification (opens in new tab)", href: "/rails/mailers/claims/user_mailer/claim_submitted_notification")
+    expect(page).to have_link("user_membership_created_notification (opens in new tab)", href: "/rails/mailers/claims/user_mailer/user_membership_created_notification")
+    expect(page).to have_link("user_membership_destroyed_notification (opens in new tab)", href: "/rails/mailers/claims/user_mailer/user_membership_destroyed_notification")
+  end
+end

--- a/spec/system/placements/support/view_emails_spec.rb
+++ b/spec/system/placements/support/view_emails_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe "View Emails", service: :placements, type: :system do
+  let(:support_user) { create(:placements_support_user) }
+
+  before do
+    user_exists_in_dfe_sign_in(user: support_user)
+    given_i_sign_in
+  end
+
+  scenario "User visits the emails page" do
+    when_i_visit_the_emails_page
+    then_i_can_see_the_list_of_placements_email_templates
+  end
+
+  private
+
+  def given_i_sign_in
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def when_i_visit_the_emails_page
+    click_on "Settings"
+    click_on "Emails"
+  end
+
+  def then_i_can_see_the_list_of_placements_email_templates
+    expect(page).to have_content("Support User Mailer")
+    expect(page).to have_link("support_user_invitation (opens in new tab)", href: "/rails/mailers/placements/support_user_mailer/support_user_invitation")
+    expect(page).to have_link("support_user_removal_notification (opens in new tab)", href: "/rails/mailers/placements/support_user_mailer/support_user_removal_notification")
+
+    expect(page).to have_content("User Mailer")
+    expect(page).to have_link("user_membership_created_notification (opens in new tab)", href: "/rails/mailers/placements/user_mailer/user_membership_created_notification")
+    expect(page).to have_link("user_membership_destroyed_notification (opens in new tab)", href: "/rails/mailers/placements/user_mailer/user_membership_destroyed_notification")
+  end
+end


### PR DESCRIPTION
## Context

We want to be able to visualise what emails we have.

## Changes proposed in this pull request

- Add a Settings page to Claims support console.
- Add a link to Background Jobs.
- Add a page for listing out emails.

## Guidance to review

Does @DFE-Digital/school-placements want this too? I can add it in.

I have opted to **NOT** using the default `/rails/mailers` path for listing out the emails, for 2 reasons:

1. I want the experience to align with the look at feel of the rest of the Support console.
2. I want to filter emails by service.

## Link to Trello card

https://trello.com/c/5qfMu8ZG/544-look-into-getting-email-previews-live

## Screenshots

| Page | Screenshot |
| ---- | ---------- |
| Settings | ![image](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/3af31b51-8a9e-47a2-a333-a76936db0a0e) |
| Emails list | ![image](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/141a70cb-b72f-4af3-a661-7a65a112a3ea) |
| Rails mailer preview | ![image](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/bddd84c3-bfb0-495f-b500-c7b8997444d1) |