### PR TITLE
Add closing date disclaimer banners

### DIFF
--- a/app/views/claims/pages/start.en.html.erb
+++ b/app/views/claims/pages/start.en.html.erb
@@ -1,4 +1,8 @@
 <div class="govuk-width-container">
+  <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
+    <% notification_banner.with_heading(text: "You must submit a claim by 11:59pm on Friday 19 July 2024") %>
+  <% end %>
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Claim funding for mentor training</h1>
@@ -12,7 +16,7 @@
       </p>
 
       <p class="govuk-body">
-        Final closing date for claims: <b>19 July 2024 by 11:59pm<b />
+        You must submit a claim by <strong>11:59pm on Friday 19 July 2024<strong />
       </p>
 
       <p class="govuk-body">

--- a/app/views/claims/schools/claims/index.html.erb
+++ b/app/views/claims/schools/claims/index.html.erb
@@ -2,12 +2,16 @@
 <% render "claims/schools/primary_navigation", school: @school, current: :claims %>
 
 <div class="govuk-width-container">
+  <%= govuk_notification_banner(title_text: t(".closing_date_disclaimer_title")) do |notification_banner| %>
+    <% notification_banner.with_heading(text: sanitize(t(".closing_date_disclaimer"))) %>
+  <% end %>
+
   <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 
   <% if @school.mentors.any? %>
     <div class="govuk-inset-text">
       <p class="govuk-body"><%= t(".guidance") %></p>
-      <p class="govuk-body"><%= t(".final_date") %></p>
+      <p class="govuk-body"><%= sanitize t(".closing_date_disclaimer") %></p>
     </div>
     <%= govuk_link_to t(".add_claim"), new_claims_school_claim_path, class: "govuk-button" %>
   <% else %>

--- a/app/views/claims/support/schools/claims/index.html.erb
+++ b/app/views/claims/support/schools/claims/index.html.erb
@@ -2,9 +2,13 @@
 <% render "claims/support/primary_navigation", current: :organisations %>
 
 <div class="govuk-width-container">
+  <%= govuk_notification_banner(title_text: t(".closing_date_disclaimer_title")) do |notification_banner| %>
+    <% notification_banner.with_heading(text: t(".closing_date_disclaimer")) %>
+  <% end %>
+
   <h1 class="govuk-heading-l"><%= @school.name %></h1>
   <%= render "claims/support/schools/secondary_navigation", school: @school %>
-  <h1 class="govuk-heading-m"><%= t(".heading") %></h1>
+  <h2 class="govuk-heading-m"><%= t(".heading") %></h2>
 
   <% if @school.mentors.any? %>
     <p class="govuk-inset-text"><%= t(".guidance") %></p>

--- a/config/locales/en/claims/schools/claims.yml
+++ b/config/locales/en/claims/schools/claims.yml
@@ -48,8 +48,9 @@ en:
           heading: Claims
           add_claim: Add claim
           guidance: Claims can only be made for the school year September 2023 to July 2024.
-          final_date: The final date to submit a claim is 19 July 2024.
-          add_mentor_guidance_html: Before you can start a claim you will need to %{link_to}.</p>
+          closing_date_disclaimer_title: Important
+          closing_date_disclaimer: You must submit a claim by <strong>11:59pm on Friday 19 July 2024</strong>.
+          add_mentor_guidance_html: Before you can start a claim you will need to %{link_to}.
           add_a_mentor: add a mentor
         update:
           claim_updated: Claim updated

--- a/config/locales/en/claims/support/schools/claims.yml
+++ b/config/locales/en/claims/support/schools/claims.yml
@@ -28,6 +28,8 @@ en:
             claim_id: ID
             add_claim: Add claim
             guidance: You can only claim for the academic year September 2023 to July 2024.
+            closing_date_disclaimer_title: Important
+            closing_date_disclaimer: You must submit a claim by 11:59pm on Friday 19 July 2024
             add_mentor_guidance_html: You need to %{link_to} before creating a claim.</p>
             add_a_mentor: add a mentor
           show:

--- a/spec/system/claims/start_page_spec.rb
+++ b/spec/system/claims/start_page_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Start Page", service: :claims, type: :system do
     end
 
     expect(page).to have_content("Use this service to claim for mentors who supported, or intended to support, trainee teachers from September 2023 to July 2024.")
-    expect(page).to have_content("Final closing date for claims: 19 July 2024 by 11:59pm")
+    expect(page).to have_content("You must submit a claim by 11:59pm on Friday 19 July 2024")
     expect(page).to have_content("You must wait until May 2025 to claim for training that took place from April 2024 for the school year starting September 2025.")
     expect(page).to have_content(
       "Before you start\n"\


### PR DESCRIPTION
## Context

We want to highlight the closing date of submitting claims as we near the closing date.

## Changes proposed in this pull request

- Add closing data disclaimer banner to start page and school's claims pages (Users and Support Users).
- Correct closing date time formatting.

## Guidance to review

- Banner should only appear on `/`, `/schools/:school_id/claims`, and `/support/schools/:school_id/claims` pages.

## Screenshots

![CleanShot 2024-07-08 at 10 03 11](https://github.com/DFE-Digital/itt-mentor-services/assets/4231530/d890f4eb-0a64-49f4-9578-bad39d7b3bfb)
