### PR TITLE
Rollout workload identity federation to all envs

### DIFF
--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -72,4 +72,9 @@ DfE::Analytics.configure do |config|
   # in the format of '22-01-2024 19:30..22-01-2024 20:30' (UTC).
   #
   # config.bigquery_maintenance_window = ENV['BIGQUERY_MAINTENANCE_WINDOW']
+
+  # Whether to use azure workload identity federation for authentication
+  # instead of the BigQuery API JSON Key. Note that this also will also
+  # use a new version of the BigQuery streaming APIs.
+  config.azure_federated_auth = true
 end

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -60,4 +60,5 @@ module "worker_application" {
   replicas                   = var.worker_replicas
   docker_image               = var.docker_image
   enable_logit               = true
+  enable_gcp_wif             = true
 }

--- a/terraform/application/config/review_app_env.yml
+++ b/terraform/application/config/review_app_env.yml
@@ -10,3 +10,8 @@ TEACHING_RECORD_API_MINOR_VERSION: 20240416
 
 # User authentication
 SIGN_IN_METHOD: persona
+
+# DfE Analytics gem
+BIGQUERY_TABLE_NAME: events
+BIGQUERY_PROJECT_ID: rugged-abacus-218110
+BIGQUERY_DATASET: itt_mentor_events_qa


### PR DESCRIPTION
## Context

This is part of a wider BigQuery Assurance piece to to harden the security around BigQuery.

It allows the use of OAuth mechanism for authentication to BigQuery rather than relying on plain text JSON API Keys.

## Changes proposed in this pull request

Enable Azure workload identity federation within DfE Analytics.

Set GOOGLE_CLOUD_CREDENTIALS secret in the key vault for each environment. 

## Guidance to review

See [Dfe Analytics GEM](https://github.com/DFE-Digital/dfe-analytics) for further details.

This change involves the following steps
- Set GOOGLE_CLOUD_CREDENTIALS by downloading from GCP. This should be done for each environment.
- Enable WIF in the Azure Infrastructure
- Enable WIF in the App. We can remove references to the the JSON API Key at the same time
- Enable WIF in the Review App and test sending of data to BIgQuery. This can be disabled after testing
- Release to production

## Link to Trello card

The Data Insights ticket is [here](https://trello.com/c/IDG7vXFy).

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated or [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

