### PR TITLE
Support request specs in the `sign_in_as` helper

### DIFF
--- a/spec/requests/placements/providers/users_spec.rb
+++ b/spec/requests/placements/providers/users_spec.rb
@@ -5,9 +5,7 @@ RSpec.describe "Provider users", service: :placements, type: :request do
   let(:current_user) { create(:placements_user, providers: [provider]) }
 
   before do
-    user_exists_in_dfe_sign_in(user: current_user)
-    get "/auth/dfe/callback"
-    follow_redirect!
+    sign_in_as current_user
   end
 
   describe "DELETE" do

--- a/spec/requests/placements/schools/placements/placements_spec.rb
+++ b/spec/requests/placements/schools/placements/placements_spec.rb
@@ -6,11 +6,7 @@ RSpec.describe "Placements", service: :placements, type: :request do
 
     before do
       user = create(:placements_user, schools: [school])
-      user_exists_in_dfe_sign_in(user:)
-
-      get "/auth/dfe/callback"
-
-      follow_redirect!
+      sign_in_as user
     end
 
     context "when editing mentors" do

--- a/spec/requests/placements/schools/users_spec.rb
+++ b/spec/requests/placements/schools/users_spec.rb
@@ -5,9 +5,7 @@ RSpec.describe "School users", service: :placements, type: :request do
   let(:current_user) { create(:placements_user, schools: [school]) }
 
   before do
-    user_exists_in_dfe_sign_in(user: current_user)
-    get "/auth/dfe/callback"
-    follow_redirect!
+    sign_in_as current_user
   end
 
   describe "DELETE" do

--- a/spec/requests/placements/support/support_users_spec.rb
+++ b/spec/requests/placements/support/support_users_spec.rb
@@ -5,9 +5,7 @@ RSpec.describe "Support users", service: :placements, type: :request do
   let(:support_users) { Placements::SupportUser.all }
 
   before do
-    user_exists_in_dfe_sign_in(user: current_user)
-    get "/auth/dfe/callback"
-    follow_redirect!
+    sign_in_as current_user
   end
 
   describe "DELETE" do

--- a/spec/requests/placements/support/user_authorisation_spec.rb
+++ b/spec/requests/placements/support/user_authorisation_spec.rb
@@ -55,10 +55,4 @@ RSpec.describe "Support console / user authorization", service: :placements, typ
       end
     end
   end
-
-  def sign_in_as(user)
-    user_exists_in_dfe_sign_in(user:)
-    get "/auth/dfe/callback"
-    follow_redirect!
-  end
 end

--- a/spec/support/dfe_sign_in_user_helper.rb
+++ b/spec/support/dfe_sign_in_user_helper.rb
@@ -1,8 +1,15 @@
 module DfESignInUserHelper
   def sign_in_as(user)
     user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
+
+    case RSpec.current_example.metadata[:type]
+    when :system
+      visit sign_in_path
+      click_on "Sign in using DfE Sign In"
+    when :request
+      get "/auth/dfe/callback"
+      follow_redirect!
+    end
   end
   alias_method :given_i_sign_in_as, :sign_in_as
 


### PR DESCRIPTION
I've updated the `sign_in_as` test helper method so it can be used for both system specs and request specs.

Since they're both operating under different contexts, authentication needs to be mocked differently depending on the type of test.
