### PR TITLE
Hide claims closing date banner when claim window has closed

### DIFF
--- a/app/views/claims/pages/start.en.html.erb
+++ b/app/views/claims/pages/start.en.html.erb
@@ -1,6 +1,8 @@
 <div class="govuk-width-container">
-  <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
-    <% notification_banner.with_heading(text: "You must submit a claim by 11:59pm on Friday 19 July 2024") %>
+  <% if Date.parse("20 July 2024").future? %>
+    <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
+      <% notification_banner.with_heading(text: "You must submit a claim by 11:59pm on Friday 19 July 2024") %>
+    <% end %>
   <% end %>
 
   <div class="govuk-grid-row">

--- a/app/views/claims/schools/claims/index.html.erb
+++ b/app/views/claims/schools/claims/index.html.erb
@@ -2,8 +2,10 @@
 <% render "claims/schools/primary_navigation", school: @school, current: :claims %>
 
 <div class="govuk-width-container">
-  <%= govuk_notification_banner(title_text: t(".closing_date_disclaimer_title")) do |notification_banner| %>
-    <% notification_banner.with_heading(text: sanitize(t(".closing_date_disclaimer"))) %>
+  <% if Date.parse("20 July 2024").future? %>
+    <%= govuk_notification_banner(title_text: t(".closing_date_disclaimer_title")) do |notification_banner| %>
+      <% notification_banner.with_heading(text: sanitize(t(".closing_date_disclaimer"))) %>
+    <% end %>
   <% end %>
 
   <h1 class="govuk-heading-l"><%= t(".heading") %></h1>

--- a/app/views/claims/support/schools/claims/index.html.erb
+++ b/app/views/claims/support/schools/claims/index.html.erb
@@ -2,8 +2,10 @@
 <% render "claims/support/primary_navigation", current: :organisations %>
 
 <div class="govuk-width-container">
-  <%= govuk_notification_banner(title_text: t(".closing_date_disclaimer_title")) do |notification_banner| %>
-    <% notification_banner.with_heading(text: t(".closing_date_disclaimer")) %>
+  <% if Date.parse("20 July 2024").future? %>
+    <%= govuk_notification_banner(title_text: t(".closing_date_disclaimer_title")) do |notification_banner| %>
+      <% notification_banner.with_heading(text: t(".closing_date_disclaimer")) %>
+    <% end %>
   <% end %>
 
   <h1 class="govuk-heading-l"><%= @school.name %></h1>


### PR DESCRIPTION
## Context

We want to stop showing the claims closing date notification banner once the claims window has closed.

We will then have time to manually remove this dead code any time past July 20, 2024.

## Changes proposed in this pull request

- Only show the banner before July 20, 2024.

## Guidance to review

Try changing the `Date.parse("20 July 2024").future?` line to `Date.parse("8 July 2024").future?`. This will return `false` and therefore the banner will show until it becomes the 20th.
