### PR TITLE
Add settings page to reset claims data

### DIFF
--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -3,6 +3,7 @@
 @import "content_header";
 @import "header";
 @import "heading";
+@import "inline_code";
 @import "link";
 @import "organisation_list_item";
 @import "phase_banner";
@@ -10,3 +11,4 @@
 @import "secondary_navigation";
 @import "search_results";
 @import "typography";
+@import "tag";

--- a/app/assets/stylesheets/components/_inline_code.scss
+++ b/app/assets/stylesheets/components/_inline_code.scss
@@ -1,0 +1,7 @@
+code.inline-code {
+  color: govuk-shade(govuk-colour("dark-grey"), 50%);
+  background-color: govuk-tint(govuk-colour("dark-grey"), 85%);
+  padding: govuk-spacing(1) / 3 * 2 govuk-spacing(1);
+  font-family: monospace;
+  font-size: 1rem;
+}

--- a/app/assets/stylesheets/components/_tag.scss
+++ b/app/assets/stylesheets/components/_tag.scss
@@ -1,0 +1,5 @@
+.govuk-tag {
+  &.govuk-tag--middle {
+    vertical-align: middle;
+  }
+}

--- a/app/controllers/claims/support/databases_controller.rb
+++ b/app/controllers/claims/support/databases_controller.rb
@@ -1,0 +1,9 @@
+class Claims::Support::DatabasesController < Claims::Support::ApplicationController
+  before_action :skip_authorization
+
+  def destroy
+    Claims::ResetDatabase.call
+
+    redirect_to claims_support_settings_path, flash: { success: t(".success") }
+  end
+end

--- a/app/services/claims/reset_database.rb
+++ b/app/services/claims/reset_database.rb
@@ -1,0 +1,17 @@
+class Claims::ResetDatabase
+  include ServicePattern
+
+  def call
+    return if HostingEnvironment.env.production?
+
+    ActiveRecord::Base.transaction do
+      Claims::Claim.destroy_all
+      Claims::MentorMembership.destroy_all
+
+      Claims::School.update_all(
+        claims_grant_conditions_accepted_at: nil,
+        claims_grant_conditions_accepted_by_id: nil,
+      )
+    end
+  end
+end

--- a/app/views/claims/support/databases/reset.en.html.erb
+++ b/app/views/claims/support/databases/reset.en.html.erb
@@ -1,0 +1,32 @@
+<% content_for :page_title, "Reset database" %>
+<% render "claims/support/primary_navigation", current: :settings %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: claims_support_settings_path) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <span class="govuk-caption-l">Reset database</span>
+  <h1 class="govuk-heading-l">Are you sure you want to reset the <%= govuk_tag text: hosting_environment_phase(current_service), colour: hosting_environment_color, classes: "govuk-tag--middle" %> database?</h1>
+
+  <p class="govuk-body">This action will truncate the following tables:</p>
+
+  <%= govuk_list type: :bullet do %>
+    <%= tag.li tag.code("claims", class: "inline-code") %>
+    <%= tag.li tag.code("mentor_memberships WHERE mentor_memberships.type = 'Claims::MentorMembership'", class: "inline-code") %>
+  <% end %>
+
+  <p class="govuk-body">It will also perform the following data updates:</p>
+
+  <%= govuk_list type: :bullet, spaced: true do %>
+    <%= tag.li do %>
+      <div>Reset all grant conditions acceptances for all schools</div>
+      <div><code class="inline-code">schools.claims_grant_conditions_accepted_at = null</code></div>
+      <div><code class="inline-code">schools.claims_grant_conditions_accepted_by_id = null</code></div>
+    <% end %>
+  <% end %>
+
+  <%= govuk_button_to "Reset database", claims_support_database_path, warning: true, method: :delete, class: "govuk-button--warning" %>
+
+  <%= govuk_link_to "Cancel", claims_support_settings_path, no_visited_state: true %>
+</div>

--- a/app/views/claims/support/settings/index.html.erb
+++ b/app/views/claims/support/settings/index.html.erb
@@ -10,6 +10,7 @@
         govuk_link_to(t(".background_jobs"), "/good_job", no_visited_state: true, new_tab: true),
         govuk_link_to(t(".claim_windows"), claims_support_claim_windows_path, no_visited_state: true),
         govuk_link_to(t(".emails"), claims_support_mailers_path, no_visited_state: true),
+        (govuk_link_to(t(".reset_database"), reset_claims_support_database_path, no_visited_state: true) unless HostingEnvironment.env.production?),
       ], spaced: true %>
     </div>
   </div>

--- a/config/locales/en/claims/support/databases.yml
+++ b/config/locales/en/claims/support/databases.yml
@@ -1,0 +1,6 @@
+en:
+  claims:
+    support:
+      databases:
+        destroy:
+          success: Database has been reset

--- a/config/locales/en/claims/support/settings.yml
+++ b/config/locales/en/claims/support/settings.yml
@@ -7,3 +7,4 @@ en:
           background_jobs: Background jobs
           claim_windows: Claim windows
           emails: Emails
+          reset_database: Reset database

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -54,6 +54,12 @@ scope module: :claims, as: :claims, constraints: {
   namespace :support do
     root to: redirect("/support/schools")
 
+    unless HostingEnvironment.env.production?
+      resource :database, only: %i[destroy] do
+        get :reset
+      end
+    end
+
     resources :claims, only: %i[index show] do
       get :download_csv, on: :collection
     end

--- a/spec/services/claims/reset_database_spec.rb
+++ b/spec/services/claims/reset_database_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe Claims::ResetDatabase do
+  describe "#call" do
+    let(:school) { create(:claims_school, claims_grant_conditions_accepted_at: Time.current) }
+
+    before do
+      create(:claim, school:)
+      create(:claims_mentor_membership, school:)
+    end
+
+    it "removes all claims and mentor memberships and resets all grant conditions acceptances for all schools" do
+      expect { described_class.call }.to change(Claims::Claim, :count).by(-1)
+        .and change(Claims::MentorMembership, :count).by(-1)
+        .and change { school.reload.claims_grant_conditions_accepted_at }.to(nil)
+    end
+
+    it "does nothing in Production" do
+      allow(HostingEnvironment).to receive(:env).and_return(ActiveSupport::EnvironmentInquirer.new("production"))
+
+      expect { described_class.call }.to not_change(Claims::Claim, :count)
+        .and not_change(Claims::MentorMembership, :count)
+        .and(not_change { school.reload.claims_grant_conditions_accepted_at })
+    end
+  end
+end

--- a/spec/system/claims/support/reset_database_spec.rb
+++ b/spec/system/claims/support/reset_database_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "Reset claims database", service: :claims, type: :system do
+  let(:support_user) { create(:claims_support_user) }
+
+  before do
+    user_exists_in_dfe_sign_in(user: support_user)
+    given_i_sign_in
+  end
+
+  scenario "Support user resets claims database for testing purposes" do
+    when_i_visit_the_reset_database_page
+    then_i_see "Are you sure you want to reset the Test database?"
+
+    when_i_click_on "Reset database"
+    then_i_see "Database has been reset"
+  end
+
+  private
+
+  def given_i_sign_in
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def when_i_visit_the_reset_database_page
+    click_on "Settings"
+    click_on "Reset database"
+  end
+
+  alias_method :when_i_click_on, :click_on
+
+  def then_i_see(content)
+    expect(page).to have_content(content)
+  end
+end


### PR DESCRIPTION
## Context

We regularly need to reset the claims database to perform UR and testing.

## Changes proposed in this pull request

- Add a settings page that appears only in non-production environments to reset the Claims database.

## Guidance to review

- Sign in as Anne
- Create a claim
- Sign out and in as Colin (Support User)
- Navigate to the Settings page
- Click on "Reset Database"
- Confirm
- All claims should now have been deleted
