### PR TITLE
Revert "Bump good_job from 3.29.3 to 4.0.1"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem "govuk_markdown"
 gem "redcarpet", "~> 3.6"
 
 # GoodJob backend for Active Job
-gem "good_job", "~> 4.0"
+gem "good_job", "~> 3.29"
 
 # Store user sessions in the database
 gem "activerecord-session_store"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,13 +236,13 @@ GEM
       csv (>= 3.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    good_job (4.0.1)
-      activejob (>= 6.1.0)
-      activerecord (>= 6.1.0)
-      concurrent-ruby (>= 1.3.1)
-      fugit (>= 1.11.0)
-      railties (>= 6.1.0)
-      thor (>= 1.0.0)
+    good_job (3.99.1)
+      activejob (>= 6.0.0)
+      activerecord (>= 6.0.0)
+      concurrent-ruby (>= 1.0.2)
+      fugit (>= 1.1)
+      railties (>= 6.0.0)
+      thor (>= 0.14.1)
     google-apis-bigquery_v2 (0.72.0)
       google-apis-core (>= 0.15.0, < 2.a)
     google-apis-core (0.15.0)
@@ -732,7 +732,7 @@ DEPENDENCIES
   faker
   flipflop
   geocoder
-  good_job (~> 4.0)
+  good_job (~> 3.29)
   govuk-components (~> 5.4.0)
   govuk_design_system_formbuilder (~> 5.4)
   govuk_markdown


### PR DESCRIPTION
## Context

Good Job jobs are failing due to queued jobs not being ready for v4.

Production returns `false` when `GoodJob.v4_ready?` is called.

```ruby
GoodJob.v4_ready? # => false
```

## Changes proposed in this pull request

- Revert commit ca906d6203099137b6e7c6072e3fcdb78d220ce8.

## Guidance

- https://github.com/bensheldon/good_job?tab=readme-ov-file#upgrading-v3-to-v4
