### PR TITLE
Prepare the database for Good Job v4

### DIFF
--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -33,6 +33,7 @@ shared:
     - created_at
     - updated_at
     - state
+    - lock_type
   :good_job_executions:
     - id
     - created_at
@@ -45,6 +46,9 @@ shared:
     - finished_at
     - error
     - error_event
+    - error_backtrace
+    - process_id
+    - duration
   :good_job_batches:
     - id
     - created_at
@@ -82,6 +86,8 @@ shared:
     - job_class
     - error_event
     - labels
+    - locked_by_id
+    - locked_at
   :school_contacts:
     - name
     - email_address

--- a/db/migrate/20240711104406_create_good_job_settings.rb
+++ b/db/migrate/20240711104406_create_good_job_settings.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateGoodJobSettings < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.table_exists?(:good_job_settings)
+      end
+    end
+
+    create_table :good_job_settings, id: :uuid do |t|
+      t.timestamps
+      t.text :key
+      t.jsonb :value
+      t.index :key, unique: true
+    end
+  end
+end

--- a/db/migrate/20240711104406_create_good_job_settings.rb
+++ b/db/migrate/20240711104406_create_good_job_settings.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateGoodJobSettings < ActiveRecord::Migration[7.1]
   def change
     reversible do |dir|

--- a/db/migrate/20240711104407_create_index_good_jobs_jobs_on_priority_created_at_when_unfinished.rb
+++ b/db/migrate/20240711104407_create_index_good_jobs_jobs_on_priority_created_at_when_unfinished.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateIndexGoodJobsJobsOnPriorityCreatedAtWhenUnfinished < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.index_name_exists?(:good_jobs, :index_good_jobs_jobs_on_priority_created_at_when_unfinished)
+      end
+    end
+
+    add_index :good_jobs, [:priority, :created_at], order: { priority: "DESC NULLS LAST", created_at: :asc },
+      where: "finished_at IS NULL", name: :index_good_jobs_jobs_on_priority_created_at_when_unfinished,
+      algorithm: :concurrently
+  end
+end

--- a/db/migrate/20240711104407_create_index_good_jobs_jobs_on_priority_created_at_when_unfinished.rb
+++ b/db/migrate/20240711104407_create_index_good_jobs_jobs_on_priority_created_at_when_unfinished.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateIndexGoodJobsJobsOnPriorityCreatedAtWhenUnfinished < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 
@@ -12,8 +10,10 @@ class CreateIndexGoodJobsJobsOnPriorityCreatedAtWhenUnfinished < ActiveRecord::M
       end
     end
 
-    add_index :good_jobs, [:priority, :created_at], order: { priority: "DESC NULLS LAST", created_at: :asc },
-      where: "finished_at IS NULL", name: :index_good_jobs_jobs_on_priority_created_at_when_unfinished,
-      algorithm: :concurrently
+    add_index :good_jobs, %i[priority created_at],
+              order: { priority: "DESC NULLS LAST", created_at: :asc },
+              where: "finished_at IS NULL",
+              name: :index_good_jobs_jobs_on_priority_created_at_when_unfinished,
+              algorithm: :concurrently
   end
 end

--- a/db/migrate/20240711104408_create_good_job_batches.rb
+++ b/db/migrate/20240711104408_create_good_job_batches.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class CreateGoodJobBatches < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.table_exists?(:good_job_batches)
+      end
+    end
+
+    create_table :good_job_batches, id: :uuid do |t|
+      t.timestamps
+      t.text :description
+      t.jsonb :serialized_properties
+      t.text :on_finish
+      t.text :on_success
+      t.text :on_discard
+      t.text :callback_queue_name
+      t.integer :callback_priority
+      t.datetime :enqueued_at
+      t.datetime :discarded_at
+      t.datetime :finished_at
+    end
+
+    change_table :good_jobs do |t|
+      t.uuid :batch_id
+      t.uuid :batch_callback_id
+
+      t.index :batch_id, where: "batch_id IS NOT NULL"
+      t.index :batch_callback_id, where: "batch_callback_id IS NOT NULL"
+    end
+  end
+end

--- a/db/migrate/20240711104408_create_good_job_batches.rb
+++ b/db/migrate/20240711104408_create_good_job_batches.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateGoodJobBatches < ActiveRecord::Migration[7.1]
   def change
     reversible do |dir|

--- a/db/migrate/20240711104409_create_good_job_executions.rb
+++ b/db/migrate/20240711104409_create_good_job_executions.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class CreateGoodJobExecutions < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.table_exists?(:good_job_executions)
+      end
+    end
+
+    create_table :good_job_executions, id: :uuid do |t|
+      t.timestamps
+
+      t.uuid :active_job_id, null: false
+      t.text :job_class
+      t.text :queue_name
+      t.jsonb :serialized_params
+      t.datetime :scheduled_at
+      t.datetime :finished_at
+      t.text :error
+
+      t.index [:active_job_id, :created_at], name: :index_good_job_executions_on_active_job_id_and_created_at
+    end
+
+    change_table :good_jobs do |t|
+      t.boolean :is_discrete
+      t.integer :executions_count
+      t.text :job_class
+    end
+  end
+end

--- a/db/migrate/20240711104409_create_good_job_executions.rb
+++ b/db/migrate/20240711104409_create_good_job_executions.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateGoodJobExecutions < ActiveRecord::Migration[7.1]
   def change
     reversible do |dir|
@@ -21,10 +19,10 @@ class CreateGoodJobExecutions < ActiveRecord::Migration[7.1]
       t.datetime :finished_at
       t.text :error
 
-      t.index [:active_job_id, :created_at], name: :index_good_job_executions_on_active_job_id_and_created_at
+      t.index %i[active_job_id created_at], name: :index_good_job_executions_on_active_job_id_and_created_at
     end
 
-    change_table :good_jobs do |t|
+    change_table :good_jobs, bulk: true do |t|
       t.boolean :is_discrete
       t.integer :executions_count
       t.text :job_class

--- a/db/migrate/20240711104410_create_good_jobs_error_event.rb
+++ b/db/migrate/20240711104410_create_good_jobs_error_event.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateGoodJobsErrorEvent < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_jobs, :error_event)
+      end
+    end
+
+    add_column :good_jobs, :error_event, :integer, limit: 2
+    add_column :good_job_executions, :error_event, :integer, limit: 2
+  end
+end

--- a/db/migrate/20240711104410_create_good_jobs_error_event.rb
+++ b/db/migrate/20240711104410_create_good_jobs_error_event.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateGoodJobsErrorEvent < ActiveRecord::Migration[7.1]
   def change
     reversible do |dir|

--- a/db/migrate/20240711104411_recreate_good_job_cron_indexes_with_conditional.rb
+++ b/db/migrate/20240711104411_recreate_good_job_cron_indexes_with_conditional.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class RecreateGoodJobCronIndexesWithConditional < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at_cond)
+          add_index :good_jobs, [:cron_key, :created_at], where: "(cron_key IS NOT NULL)",
+                    name: :index_good_jobs_on_cron_key_and_created_at_cond, algorithm: :concurrently
+        end
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_cron_at_cond)
+          add_index :good_jobs, [:cron_key, :cron_at], where: "(cron_key IS NOT NULL)", unique: true,
+                    name: :index_good_jobs_on_cron_key_and_cron_at_cond, algorithm: :concurrently
+        end
+
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at)
+          remove_index :good_jobs, name: :index_good_jobs_on_cron_key_and_created_at
+        end
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_cron_at)
+          remove_index :good_jobs, name: :index_good_jobs_on_cron_key_and_cron_at
+        end
+      end
+
+      dir.down do
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at)
+          add_index :good_jobs, [:cron_key, :created_at],
+                    name: :index_good_jobs_on_cron_key_and_created_at, algorithm: :concurrently
+        end
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_cron_at)
+          add_index :good_jobs, [:cron_key, :cron_at], unique: true,
+                    name: :index_good_jobs_on_cron_key_and_cron_at, algorithm: :concurrently
+        end
+
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at_cond)
+          remove_index :good_jobs, name: :index_good_jobs_on_cron_key_and_created_at_cond
+        end
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_cron_at_cond)
+          remove_index :good_jobs, name: :index_good_jobs_on_cron_key_and_cron_at_cond
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20240711104411_recreate_good_job_cron_indexes_with_conditional.rb
+++ b/db/migrate/20240711104411_recreate_good_job_cron_indexes_with_conditional.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RecreateGoodJobCronIndexesWithConditional < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 
@@ -7,12 +5,17 @@ class RecreateGoodJobCronIndexesWithConditional < ActiveRecord::Migration[7.1]
     reversible do |dir|
       dir.up do
         unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at_cond)
-          add_index :good_jobs, [:cron_key, :created_at], where: "(cron_key IS NOT NULL)",
-                    name: :index_good_jobs_on_cron_key_and_created_at_cond, algorithm: :concurrently
+          add_index :good_jobs, %i[cron_key created_at],
+                    where: "(cron_key IS NOT NULL)",
+                    name: :index_good_jobs_on_cron_key_and_created_at_cond,
+                    algorithm: :concurrently
         end
         unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_cron_at_cond)
-          add_index :good_jobs, [:cron_key, :cron_at], where: "(cron_key IS NOT NULL)", unique: true,
-                    name: :index_good_jobs_on_cron_key_and_cron_at_cond, algorithm: :concurrently
+          add_index :good_jobs, %i[cron_key cron_at],
+                    where: "(cron_key IS NOT NULL)",
+                    unique: true,
+                    name: :index_good_jobs_on_cron_key_and_cron_at_cond,
+                    algorithm: :concurrently
         end
 
         if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at)
@@ -25,12 +28,15 @@ class RecreateGoodJobCronIndexesWithConditional < ActiveRecord::Migration[7.1]
 
       dir.down do
         unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at)
-          add_index :good_jobs, [:cron_key, :created_at],
-                    name: :index_good_jobs_on_cron_key_and_created_at, algorithm: :concurrently
+          add_index :good_jobs, %i[cron_key created_at],
+                    name: :index_good_jobs_on_cron_key_and_created_at,
+                    algorithm: :concurrently
         end
         unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_cron_at)
-          add_index :good_jobs, [:cron_key, :cron_at], unique: true,
-                    name: :index_good_jobs_on_cron_key_and_cron_at, algorithm: :concurrently
+          add_index :good_jobs, %i[cron_key cron_at],
+                    unique: true,
+                    name: :index_good_jobs_on_cron_key_and_cron_at,
+                    algorithm: :concurrently
         end
 
         if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at_cond)

--- a/db/migrate/20240711104412_create_good_job_labels.rb
+++ b/db/migrate/20240711104412_create_good_job_labels.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateGoodJobLabels < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_jobs, :labels)
+      end
+    end
+
+    add_column :good_jobs, :labels, :text, array: true
+  end
+end

--- a/db/migrate/20240711104412_create_good_job_labels.rb
+++ b/db/migrate/20240711104412_create_good_job_labels.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateGoodJobLabels < ActiveRecord::Migration[7.1]
   def change
     reversible do |dir|

--- a/db/migrate/20240711104413_create_good_job_labels_index.rb
+++ b/db/migrate/20240711104413_create_good_job_labels_index.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CreateGoodJobLabelsIndex < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_labels)
+          add_index :good_jobs, :labels, using: :gin, where: "(labels IS NOT NULL)",
+            name: :index_good_jobs_on_labels, algorithm: :concurrently
+        end
+      end
+
+      dir.down do
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_labels)
+          remove_index :good_jobs, name: :index_good_jobs_on_labels
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20240711104413_create_good_job_labels_index.rb
+++ b/db/migrate/20240711104413_create_good_job_labels_index.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateGoodJobLabelsIndex < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 
@@ -7,8 +5,11 @@ class CreateGoodJobLabelsIndex < ActiveRecord::Migration[7.1]
     reversible do |dir|
       dir.up do
         unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_labels)
-          add_index :good_jobs, :labels, using: :gin, where: "(labels IS NOT NULL)",
-            name: :index_good_jobs_on_labels, algorithm: :concurrently
+          add_index :good_jobs, :labels,
+                    using: :gin,
+                    where: "(labels IS NOT NULL)",
+                    name: :index_good_jobs_on_labels,
+                    algorithm: :concurrently
         end
       end
 

--- a/db/migrate/20240711104414_remove_good_job_active_id_index.rb
+++ b/db/migrate/20240711104414_remove_good_job_active_id_index.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class RemoveGoodJobActiveIdIndex < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_active_job_id)
+          remove_index :good_jobs, name: :index_good_jobs_on_active_job_id
+        end
+      end
+
+      dir.down do
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_active_job_id)
+          add_index :good_jobs, :active_job_id, name: :index_good_jobs_on_active_job_id
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20240711104414_remove_good_job_active_id_index.rb
+++ b/db/migrate/20240711104414_remove_good_job_active_id_index.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RemoveGoodJobActiveIdIndex < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 

--- a/db/migrate/20240711104415_create_index_good_job_jobs_for_candidate_lookup.rb
+++ b/db/migrate/20240711104415_create_index_good_job_jobs_for_candidate_lookup.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateIndexGoodJobJobsForCandidateLookup < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.index_name_exists?(:good_jobs, :index_good_job_jobs_for_candidate_lookup)
+      end
+    end
+
+    add_index :good_jobs, [:priority, :created_at], order: { priority: "ASC NULLS LAST", created_at: :asc },
+      where: "finished_at IS NULL", name: :index_good_job_jobs_for_candidate_lookup,
+      algorithm: :concurrently
+  end
+end

--- a/db/migrate/20240711104415_create_index_good_job_jobs_for_candidate_lookup.rb
+++ b/db/migrate/20240711104415_create_index_good_job_jobs_for_candidate_lookup.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateIndexGoodJobJobsForCandidateLookup < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 
@@ -12,8 +10,10 @@ class CreateIndexGoodJobJobsForCandidateLookup < ActiveRecord::Migration[7.1]
       end
     end
 
-    add_index :good_jobs, [:priority, :created_at], order: { priority: "ASC NULLS LAST", created_at: :asc },
-      where: "finished_at IS NULL", name: :index_good_job_jobs_for_candidate_lookup,
-      algorithm: :concurrently
+    add_index :good_jobs, %i[priority created_at],
+              order: { priority: "ASC NULLS LAST", created_at: :asc },
+              where: "finished_at IS NULL",
+              name: :index_good_job_jobs_for_candidate_lookup,
+              algorithm: :concurrently
   end
 end

--- a/db/migrate/20240711104416_create_good_job_execution_error_backtrace.rb
+++ b/db/migrate/20240711104416_create_good_job_execution_error_backtrace.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateGoodJobExecutionErrorBacktrace < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_job_executions, :error_backtrace)
+      end
+    end
+
+    add_column :good_job_executions, :error_backtrace, :text, array: true
+  end
+end

--- a/db/migrate/20240711104416_create_good_job_execution_error_backtrace.rb
+++ b/db/migrate/20240711104416_create_good_job_execution_error_backtrace.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateGoodJobExecutionErrorBacktrace < ActiveRecord::Migration[7.1]
   def change
     reversible do |dir|

--- a/db/migrate/20240711104417_create_good_job_process_lock_ids.rb
+++ b/db/migrate/20240711104417_create_good_job_process_lock_ids.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateGoodJobProcessLockIds < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_jobs, :locked_by_id)
+      end
+    end
+
+    add_column :good_jobs, :locked_by_id, :uuid
+    add_column :good_jobs, :locked_at, :datetime
+    add_column :good_job_executions, :process_id, :uuid
+    add_column :good_job_processes, :lock_type, :integer, limit: 2
+  end
+end

--- a/db/migrate/20240711104417_create_good_job_process_lock_ids.rb
+++ b/db/migrate/20240711104417_create_good_job_process_lock_ids.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateGoodJobProcessLockIds < ActiveRecord::Migration[7.1]
   def change
     reversible do |dir|
@@ -10,8 +8,11 @@ class CreateGoodJobProcessLockIds < ActiveRecord::Migration[7.1]
       end
     end
 
-    add_column :good_jobs, :locked_by_id, :uuid
-    add_column :good_jobs, :locked_at, :datetime
+    change_table :good_jobs, bulk: true do |t|
+      t.uuid :locked_by_id
+      t.datetime :locked_at
+    end
+
     add_column :good_job_executions, :process_id, :uuid
     add_column :good_job_processes, :lock_type, :integer, limit: 2
   end

--- a/db/migrate/20240711104417_create_good_job_process_lock_ids.rb
+++ b/db/migrate/20240711104417_create_good_job_process_lock_ids.rb
@@ -8,9 +8,11 @@ class CreateGoodJobProcessLockIds < ActiveRecord::Migration[7.1]
       end
     end
 
-    change_table :good_jobs, bulk: true do |t|
-      t.uuid :locked_by_id
-      t.datetime :locked_at
+    safety_assured do
+      change_table :good_jobs, bulk: true do |t|
+        t.uuid :locked_by_id
+        t.datetime :locked_at
+      end
     end
 
     add_column :good_job_executions, :process_id, :uuid

--- a/db/migrate/20240711104418_create_good_job_process_lock_indexes.rb
+++ b/db/migrate/20240711104418_create_good_job_process_lock_indexes.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class CreateGoodJobProcessLockIndexes < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked)
+          add_index :good_jobs, [:priority, :scheduled_at],
+                    order: { priority: "ASC NULLS LAST", scheduled_at: :asc },
+                    where: "finished_at IS NULL AND locked_by_id IS NULL",
+                    name: :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked,
+                    algorithm: :concurrently
+        end
+
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_locked_by_id)
+          add_index :good_jobs, :locked_by_id,
+                    where: "locked_by_id IS NOT NULL",
+                    name: :index_good_jobs_on_locked_by_id,
+                    algorithm: :concurrently
+        end
+
+        unless connection.index_name_exists?(:good_job_executions, :index_good_job_executions_on_process_id_and_created_at)
+          add_index :good_job_executions, [:process_id, :created_at],
+                    name: :index_good_job_executions_on_process_id_and_created_at,
+                    algorithm: :concurrently
+        end
+      end
+
+      dir.down do
+        remove_index(:good_jobs, name: :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked) if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked)
+        remove_index(:good_jobs, name: :index_good_jobs_on_locked_by_id) if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_locked_by_id)
+        remove_index(:good_job_executions, name: :index_good_job_executions_on_process_id_and_created_at) if connection.index_name_exists?(:good_job_executions, :index_good_job_executions_on_process_id_and_created_at)
+      end
+    end
+  end
+end

--- a/db/migrate/20240711104418_create_good_job_process_lock_indexes.rb
+++ b/db/migrate/20240711104418_create_good_job_process_lock_indexes.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateGoodJobProcessLockIndexes < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 
@@ -7,7 +5,7 @@ class CreateGoodJobProcessLockIndexes < ActiveRecord::Migration[7.1]
     reversible do |dir|
       dir.up do
         unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked)
-          add_index :good_jobs, [:priority, :scheduled_at],
+          add_index :good_jobs, %i[priority scheduled_at],
                     order: { priority: "ASC NULLS LAST", scheduled_at: :asc },
                     where: "finished_at IS NULL AND locked_by_id IS NULL",
                     name: :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked,
@@ -22,7 +20,7 @@ class CreateGoodJobProcessLockIndexes < ActiveRecord::Migration[7.1]
         end
 
         unless connection.index_name_exists?(:good_job_executions, :index_good_job_executions_on_process_id_and_created_at)
-          add_index :good_job_executions, [:process_id, :created_at],
+          add_index :good_job_executions, %i[process_id created_at],
                     name: :index_good_job_executions_on_process_id_and_created_at,
                     algorithm: :concurrently
         end

--- a/db/migrate/20240711104419_create_good_job_execution_duration.rb
+++ b/db/migrate/20240711104419_create_good_job_execution_duration.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateGoodJobExecutionDuration < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_job_executions, :duration)
+      end
+    end
+
+    add_column :good_job_executions, :duration, :interval
+  end
+end

--- a/db/migrate/20240711104419_create_good_job_execution_duration.rb
+++ b/db/migrate/20240711104419_create_good_job_execution_duration.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateGoodJobExecutionDuration < ActiveRecord::Migration[7.1]
   def change
     reversible do |dir|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_17_152221) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_11_104419) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -105,13 +105,18 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_17_152221) do
     t.datetime "finished_at"
     t.text "error"
     t.integer "error_event", limit: 2
+    t.text "error_backtrace", array: true
+    t.uuid "process_id"
+    t.interval "duration"
     t.index ["active_job_id", "created_at"], name: "index_good_job_executions_on_active_job_id_and_created_at"
+    t.index ["process_id", "created_at"], name: "index_good_job_executions_on_process_id_and_created_at"
   end
 
   create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "state"
+    t.integer "lock_type", limit: 2
   end
 
   create_table "good_job_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -144,6 +149,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_17_152221) do
     t.text "job_class"
     t.integer "error_event", limit: 2
     t.text "labels", array: true
+    t.uuid "locked_by_id"
+    t.datetime "locked_at"
     t.index ["active_job_id", "created_at"], name: "index_good_jobs_on_active_job_id_and_created_at"
     t.index ["batch_callback_id"], name: "index_good_jobs_on_batch_callback_id", where: "(batch_callback_id IS NOT NULL)"
     t.index ["batch_id"], name: "index_good_jobs_on_batch_id", where: "(batch_id IS NOT NULL)"
@@ -152,8 +159,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_17_152221) do
     t.index ["cron_key", "cron_at"], name: "index_good_jobs_on_cron_key_and_cron_at_cond", unique: true, where: "(cron_key IS NOT NULL)"
     t.index ["finished_at"], name: "index_good_jobs_jobs_on_finished_at", where: "((retried_good_job_id IS NULL) AND (finished_at IS NOT NULL))"
     t.index ["labels"], name: "index_good_jobs_on_labels", where: "(labels IS NOT NULL)", using: :gin
+    t.index ["locked_by_id"], name: "index_good_jobs_on_locked_by_id", where: "(locked_by_id IS NOT NULL)"
     t.index ["priority", "created_at"], name: "index_good_job_jobs_for_candidate_lookup", where: "(finished_at IS NULL)"
     t.index ["priority", "created_at"], name: "index_good_jobs_jobs_on_priority_created_at_when_unfinished", order: { priority: "DESC NULLS LAST" }, where: "(finished_at IS NULL)"
+    t.index ["priority", "scheduled_at"], name: "index_good_jobs_on_priority_scheduled_at_unfinished_unlocked", where: "((finished_at IS NULL) AND (locked_by_id IS NULL))"
     t.index ["queue_name", "scheduled_at"], name: "index_good_jobs_on_queue_name_and_scheduled_at", where: "(finished_at IS NULL)"
     t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
   end


### PR DESCRIPTION
## Context

We need to perform some database migrations to prepare for the upgrade from Good Job v3 to v4. This will allow us to re-apply the upgrade in #828, which was reverted by #838.

> [!NOTE]  
> **This PR does not upgrade Good Job to v4.** It prepares the database for v4, but these changes are still compatible with v3.99.1 which is currently in use.

## Changes proposed in this pull request

I've followed the instructions in [the upgrade guide][1]. The database migrations were automatically generated by the gem.

I've also updated the DfE Analytics blocklist to exclude the newly added fields.

## Guidance to review

Run the migrations in this pull request, then open a Rails console and run:

```
GoodJob.v4_ready?
```

It should return `true`.

## Link to Trello card

https://trello.com/c/vneRTcpO/554-review-and-merge-dependabot-prs

[1]: https://github.com/bensheldon/good_job?tab=readme-ov-file#upgrading-v3-to-v4