### PR TITLE
Clean up old jobs after 4 days

### DIFF
--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -18,4 +18,9 @@ Rails.application.configure do
   # Disabled in development and test so scheduled jobs don't run automatically
   config.good_job.enable_cron = Rails.env.production?
   config.good_job.cron = scheduled_jobs || {}
+
+  # Clean up completed jobs after 3 days
+  # A few days affords us time to investigate/debug jobs after they've run,
+  # but is short enough that we don't fill up the database unnecessarily.
+  config.good_job.cleanup_preserved_jobs_before_seconds_ago = 3.days
 end

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -19,8 +19,8 @@ Rails.application.configure do
   config.good_job.enable_cron = Rails.env.production?
   config.good_job.cron = scheduled_jobs || {}
 
-  # Clean up completed jobs after 3 days
+  # Clean up completed jobs after 4 days
   # A few days affords us time to investigate/debug jobs after they've run,
   # but is short enough that we don't fill up the database unnecessarily.
-  config.good_job.cleanup_preserved_jobs_before_seconds_ago = 3.days
+  config.good_job.cleanup_preserved_jobs_before_seconds_ago = 4.days
 end


### PR DESCRIPTION
I've configured Good Job to clean up old jobs ~~3 days~~ 4 days after they've executed.

By default, Good Job preserves jobs for 14 days. However since we use Active Job so heavily (thanks to the DfE Analytics gem), it seems sensible to drop this to avoid unnecessarily filling up the database.

I figured ~~3 days~~ 4 days is a sensible amount of time to keep jobs around for. That way, we can still investigate or debug jobs for a few days (including on Mondays after the weekend) before they drop off the radar.
