### PR TITLE
Fix issue when no DOB included in mentor search

### DIFF
--- a/app/services/mentor_builder.rb
+++ b/app/services/mentor_builder.rb
@@ -12,7 +12,7 @@ class MentorBuilder
   def call
     mentor = Mentor.find_or_initialize_by(trn:).becomes(mentor_class)
     return mentor if mentor.invalid_attributes?(:trn)
-    return mentor if date_of_birth.nil?
+    return mentor if date_of_birth.nil? || !date_of_birth.is_a?(Date)
 
     mentor.assign_attributes(
       first_name: teacher["firstName"],

--- a/spec/support/shared_examples/mentor_builder.rb
+++ b/spec/support/shared_examples/mentor_builder.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples "a mentor builder" do
     let(:date_of_birth) { "1991-01-22" }
 
     it "returns mentor object with error on trn" do
-      mentor = described_class.call(trn:, date_of_birth:)
+      mentor = described_class.call(trn:, date_of_birth: Date.parse(date_of_birth))
       expect(mentor.class).to eq(mentor_class)
       expect(mentor.errors[:trn]).to include "Enter a 7 digit teacher reference number (TRN)"
     end
@@ -19,7 +19,7 @@ RSpec.shared_examples "a mentor builder" do
     let(:date_of_birth) { "1991-01-22" }
 
     it "returns mentor object with error on trn" do
-      mentor = described_class.call(trn:, date_of_birth:)
+      mentor = described_class.call(trn:, date_of_birth: Date.parse(date_of_birth))
       expect(mentor.class).to eq(mentor_class)
       expect(mentor.errors[:trn]).to include "Enter a teacher reference number (TRN)"
     end
@@ -29,7 +29,7 @@ RSpec.shared_examples "a mentor builder" do
     let(:date_of_birth) { "1991-01-22" }
 
     it "returns an error with missing keyword: trn" do
-      expect { described_class.call(date_of_birth:) }.to raise_error(ArgumentError, "missing keyword: :trn")
+      expect { described_class.call(date_of_birth: Date.parse(date_of_birth)) }.to raise_error(ArgumentError, "missing keyword: :trn")
     end
   end
 
@@ -43,7 +43,7 @@ RSpec.shared_examples "a mentor builder" do
     end
 
     it "returns existing mentor" do
-      mentor = described_class.call(trn:, date_of_birth:)
+      mentor = described_class.call(trn:, date_of_birth: Date.parse(date_of_birth))
       expect(mentor).to eq existing_mentor
     end
   end
@@ -57,7 +57,7 @@ RSpec.shared_examples "a mentor builder" do
     end
 
     it "returns initialized placements mentor record without errors" do
-      mentor = described_class.call(trn:, date_of_birth:)
+      mentor = described_class.call(trn:, date_of_birth: Date.parse(date_of_birth))
       expect(mentor.class).to eq(mentor_class)
       expect(mentor.trn).to eq trn
       expect(mentor.first_name).to eq teacher_object["firstName"]
@@ -78,7 +78,7 @@ RSpec.shared_examples "a mentor builder" do
     end
 
     it "returns initialized placements mentor record with first and last name" do
-      mentor = described_class.call(trn:, first_name:, last_name:, date_of_birth:)
+      mentor = described_class.call(trn:, first_name:, last_name:, date_of_birth: Date.parse(date_of_birth))
       expect(mentor.class).to eq(mentor_class)
       expect(mentor.trn).to eq trn
       expect(mentor.first_name).to eq first_name

--- a/spec/system/placements/schools/mentors/user_adds_mentor_spec.rb
+++ b/spec/system/placements/schools/mentors/user_adds_mentor_spec.rb
@@ -44,10 +44,6 @@ RSpec.describe "Placements school user adds mentors to schools", service: :place
   end
 
   scenario "I do not enter a date of birth" do
-    stub_valid_teaching_record_response(trn: "1212121",
-                                        date_of_birth: Struct.new(:day, :month, :year).new(nil, nil, nil).to_s,
-                                        mentor: placements_mentor)
-
     given_i_navigate_to_schools_mentors_list
     and_i_click_on("Add mentor")
     when_i_enter_trn(1_212_121)


### PR DESCRIPTION
## Context

- Fix issue when users don't include a Date of Birth when finding a Mentor.

## Changes proposed in this pull request

- Return `mentor` when `date_of_birth` is not a `Date`. Preventing call to TeachingRecord API

## Guidance to review

- Sign in as Anne (School User)
- Navigate to "Mentors" using the NavBar
- Click "Add mentor"
- Input a TRN (e.g 1234567)
- DO NOT input a Date of birth
- Click "Continue"
- Page should show "Enter a date of birth" error. (The page itself should not error)

## Link to Trello card

https://trello.com/c/qy0lfp2s/551-fix-error-when-submitting-the-mentor-form-with-an-empty-dob

## Screenshots

![screencapture-placements-localhost-3000-schools-00004607-b87d-42e6-86f3-ac514dfd9d2b-mentors-check-2024-07-11-16_40_24](https://github.com/DFE-Digital/itt-mentor-services/assets/17162488/508c6f54-cfed-4c25-a045-ceed33b9ded6)
