### PR TITLE
Add documentation for building wizards

### DIFF
--- a/adr/00009-wizards.md
+++ b/adr/00009-wizards.md
@@ -1,0 +1,156 @@
+# 9. Wizards
+
+Date: 2024-07-10
+
+## Status
+
+Accepted
+
+## Context
+
+Digital services that follow the [GOV.UK service standard][1] tend to make heavy use of multi-step forms. This is [considered best practice][2] because it breaks down complex tasks into smaller, easier to follow steps – for example, when [publishing a school placement][3], or [claiming funding for mentor training][4].
+
+This is commonly known as the [Wizard design pattern][5].
+
+### Rails is CRUD
+
+Ruby on Rails is optimised for building CRUD applications and RESTful APIs. It has strong conventions that make it easy to create [resourceful routes][6].
+
+But this all depends on an assumption that the 'create' step of CRUD happens in one single HTTP request. In other words, it depends on the user submitting a single form which maps cleanly to creating a thing in the application.
+
+By their nature, wizards don't cleanly fit into that model. Users submit several forms, split across several pages, and the resultant object can only be created once the user has completed every step of the wizard. If you're not careful, you can easily end up fighting the framework as you try to shoehorn wizard behaviour into a CRUD controller.
+
+We've therefore found it helpful to abstract common wizard behaviour into a set of classes and conventions that make it easier to build multi-step forms in our service.
+
+### Options for building wizards in Rails
+
+One common approach for implementing multi-step forms is to build them as 'single page apps' using JavaScript, then submit everything to the 'create' endpoint as one single payload. But this is not an option for us because government digital services need to [work without JavaScript][7].
+
+For building server-side wizards, there are various opinions and patterns around. Some of these have been packaged up into Ruby gems – for example:
+
+- [Wicked](https://github.com/zombocom/wicked)
+- [DfE Wizard](https://github.com/DFE-Digital/dfe-wizard)
+- [GOV.UK Wizardry](https://github.com/DFE-Digital/govuk-wizardry) _\*(not an official GOV.UK project)_
+
+I spent some time investigating the features these gems offer, and the advantages and disadvantages of each approach.
+
+#### Wicked
+
+- 👍 Steps are defined as a linear journey
+- 👍 Steps can be conditional
+- 😕 The wizard is defined within the controller – this makes unit testing and code reuse more difficult
+- 👎 No help with persisting the wizard state between page loads
+- 👎 No help with building forms or validating user input
+
+**Summary:** Wicked primarily just provides navigation helpers for moving users through a series of steps. When it comes to rendering, validating and persisting forms, you're on your own.
+
+#### DfE Wizard
+
+- 👍 Wizards and steps are defined in a standalone class, outside of the controller – this is great for unit testing and code reuse
+- 👍 Steps can be conditional
+- 👍 Each step is a [form object][9], so Active Model validation is baked in
+- 😕 Each step decides what its next and previous steps are (a [doubly linked list][8]) – this works well for complex branching journeys, but for simpler journeys it's difficult to get a high-level overview of the end-to-end journey
+- 😕 Supports persisting the wizard state between page loads – although it seems to be based on an assumption that you'll be iteratively building and saving partial objects to the database (which isn't always desirable)
+
+**Summary:** DfE Wizard provides a nice structure for defining wizards and the steps they contain. It leans on established patterns like form objects. But it seems to be geared towards storing partial objects in the database as a means of persisting the wizard state.
+
+#### GOV.UK Wizardry
+
+- 😕 The entire wizard is defined inside the controller – this makes unit testing and code reuse more difficult
+- 😕 Pages and questions are defined _and rendered_ using specialised Wizardry classes – while it's possible to use Rails `.html.erb` views, these are only intended to be used by exception
+- 😕 The gem comes tightly coupled to its sister gems, [GOV.UK Components][10] and [GOV.UK Form Builder][11]
+- 😕 Each wizard is coupled to an Active Record model, where each question is represented as a field on the model – this makes it difficult to build wizards which create different types of objects depending on the user's input, or don't create anything at all
+- 👎 Limited documentation on how to use it
+- 👎 May not be production ready – the [project README][12] says:
+  > Note this library is at the very early stages of development. It's not properly tested and is very likely to change.
+
+**Summary:** GOV.UK Wizardry is highly opinionated and designed to meet a very specific need – to build multi-step forms made of [GOV.UK Design System][13] components, without needing to write any HTML code, that will progressively save to an Active Record object.
+
+## Decision
+
+After having investigated the available options, my key learnings are this – wizard gems are more useful the more opinionated they are, but only if those opinions meet your specific needs. The less opinionated they are (for example, the Wicked gem), the less helpful they are.
+
+### Key principles
+
+We came up with some key principles for wizards in our service:
+
+#### 1. Wizards store their state in the session
+
+We want to store the state of wizards in the current user's session. This means we avoid the potential for partially-complete Active Record objects to pollute the database, which would be likely if the wizard progressively populates and persists objects.
+
+By doing this, we avoid the need to retrospectively sweep through database tables and 'clean up' old, abandoned or incomplete records. Instead, we'll delegate that responsibility to the session, which is a temporary storage mechanism by its very nature.
+
+#### 2. Wizards won't always create a thing
+
+We foresee a need for wizards which don't end by creating a new thing in the database.
+
+Sometimes they'll need to update existing records. For example, a wizard could be used to allocate mentors to an existing placement.
+
+There could even be a need for wizards which don't write _anything_ to the database. For example, it could power a decision tree which ends by redirecting you to the correct location. Or to power an introductory onboarding flow for new users to the service.
+
+#### 3. Wizards should be reusable
+
+Digital services in DfE tend to have a built-in support console. This is an interface which support users can use to administer the service.
+
+Many of the tasks users perform – for example, adding new users to their organisation, or publishing new school placements – also need to be available to support users in the support console.
+
+By separating wizards from the controllers that implement them, we'd open up the possibility of re-using wizards in different contexts without needing to re-implement the journey or individual steps. For example, it'd be possible to build an "Add placement" wizard which both school users and support users have access to from their respective controllers.
+
+### The responsibilities of a wizard
+
+We have defined the following boundaries for controllers, wizards and steps:
+
+#### Controller
+
+Concerned with routing and navigating the user through the journey.
+
+- Initialises the wizard and give it the context it needs
+- Knows how to map steps to URL paths – for example, using a route helper with a 'step' parameter
+- Resets the wizard's state at the beginning and end of journeys
+- At the end of the journey, persists the resultant object and perform any required side-effects – for example, sending a notification email to the user
+
+#### Wizard
+
+Concerned with the overall flow of the form – defining the order of steps, persisting state, and initialising step objects.
+
+- Controller agnostic – it doesn't know about the HTTP request, routing concerns, or even which page it's being rendered on
+- Defines the journey that users take through the form – including skipping steps that aren't necessary under certain circumstances
+- Determines what the previous and next steps are for the given current step
+- Journeys are linear and defined centrally – it's therefore possible to see every step of the journey, in order, and defined in one single place
+- Stores the state of each step into the session
+- Makes steps available to each other – for example, so one step can change based on a previous step's state
+
+#### Step
+
+Concerned with individual fields and questions, and validating the user's input.
+
+- Behaves like a form object or Active Model object, with attributes and validation rules
+- Controller agnostic _and_ wizard agnostic
+- Coupled to a view partial which renders the form
+- May contain helper or decorator methods used by the view partial
+
+## Consequences
+
+Given all of the above, we have come up with a pattern for implementing wizards in our application. It loosely follows the structure of the DfE Wizard gem, where wizards and steps are standalone classes. But it stores its state in the session, and the wizard itself is responsible for the user's journey through the form.
+
+For a concrete implementation, see this pull request which establishes the pattern and implements an "Add placement" wizard:
+
+https://github.com/DFE-Digital/itt-mentor-services/pull/810
+
+### When will this become a gem?
+
+Never! 😄 This pattern suits our needs, but it comes with its own set of opinions. It's also fairly lightweight and would be easy to replicate in another Rails application if it's deemed to be a helpful pattern.
+
+[1]: https://www.gov.uk/service-manual/service-standard
+[2]: https://www.gov.uk/service-manual/design/form-structure
+[3]: https://becoming-a-teacher.design-history.education.gov.uk/manage-school-placements/adding-placements/#adding-a-placement
+[4]: https://becoming-a-teacher.design-history.education.gov.uk/claim-funding-for-mentors/submitting-claims-for-funding/#adding-a-claim
+[5]: https://www.nngroup.com/articles/wizards/
+[6]: https://guides.rubyonrails.org/routing.html#resource-routing-the-rails-default
+[7]: https://www.gov.uk/service-manual/technology/using-progressive-enhancement
+[8]: https://www.devx.com/terms/doubly-linked-list/
+[9]: https://dev.to/vladhilko/how-to-implement-form-object-pattern-in-ruby-on-rails-5gi3
+[10]: https://govuk-components.netlify.app
+[11]: https://govuk-form-builder.netlify.app
+[12]: https://github.com/DFE-Digital/govuk-wizardry/blob/3283ac9eb9d453a354cfa5e93a00572bc27e29ef/README.md
+[13]: https://design-system.service.gov.uk

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -6,3 +6,4 @@ To align on scalable best practices, we've documented various code conventions a
 - [Mailers](/docs/conventions/mailers.md)
 - [Service Objects](/docs/conventions/service_objects.md)
 - [View Components](/docs/conventions/view_components.md)
+- [Wizards](/docs/conventions/wizards.md)

--- a/docs/conventions/wizards.md
+++ b/docs/conventions/wizards.md
@@ -1,0 +1,255 @@
+[All Conventions](/docs/conventions.md) / Wizards
+
+# Wizards
+
+> Use wizards to build multi-step forms that help users complete complex tasks
+
+## File Structure
+
+This directory tree represents a wizard and its steps:
+
+```
+app/
+└── wizards/
+    └── placements/
+        ├── add_placement_wizard.rb
+        └── add_placement_wizard/
+            ├── check_your_answers_step.rb
+            ├── mentors_step.rb
+            └── subject_step.rb
+```
+
+## How to build a wizard
+
+This is a simplified example to demonstrate the various parts that come together to make a wizard.
+
+### 1. Create a wizard class
+
+```ruby
+# app/wizards/placements/add_placement_wizard.rb
+module Placements
+  class AddPlacementWizard < BaseWizard
+    def define_steps
+      # Define the wizard steps here
+      add_step(SubjectStep)
+      add_step(MentorsStep)
+      add_step(CheckYourAnswersStep)
+    end
+  end
+end
+```
+
+### 2. Create step classes
+
+Think of step objects as a hybrid between form objects and decorators:
+
+- **Form objects** – to hold attributes and validate their values
+- **Decorators** – just like a ViewComponent's HTML markup comes coupled with a Ruby class, or how helpers and decorators are used by the view layer
+
+```ruby
+# app/wizards/placements/add_placement_wizard/subject_step.rb
+class Placements::AddPlacementWizard::SubjectStep < Placements::BaseStep
+  attribute :subject_id
+  validates :subject_id, presence: true
+
+  def subject_name
+    Subject.find(subject_id).name
+  end
+
+  def subjects_for_selection
+    Subject.all
+  end
+end
+```
+
+```ruby
+# app/wizards/placements/add_placement_wizard/mentors_step.rb
+class Placements::AddPlacementWizard::MentorsStep < Placements::BaseStep
+  attribute :mentor_ids
+  validates :mentor_ids, presence: true
+
+  def mentors_for_selection
+    Placements::Mentor.all
+  end
+end
+```
+
+```ruby
+# app/wizards/placements/add_placement_wizard/check_your_answers_step.rb
+class Placements::AddPlacementWizard::CheckYourAnswersStep < Placements::BaseStep
+  # This step has no attributes of its own
+end
+```
+
+### 3. Create view partials for each step
+
+Each step comes coupled with a view partial.
+
+```erb
+# views/placements/wizards/add_placement_wizard/_subject_step.html.erb
+<%= form_for(subject_step, url: current_step_path, method: :put) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_collection_radio_buttons(
+    :subject_id,
+    subject_step.subjects_for_selection,
+    :id, :name,
+    legend: { text: "Subject" }
+  ) %>
+
+  <%= f.govuk_submit "Continue" %>
+<% end %>
+```
+
+```erb
+# views/placements/wizards/add_placement_wizard/_mentors_step.html.erb
+<%= form_for(mentors_step, url: current_step_path, method: :put) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_collection_check_boxes(
+    :mentor_ids,
+    mentors_step.mentors_for_selection,
+    :id, :name,
+    legend: { text: "Mentors" }
+  ) %>
+
+  <%= f.govuk_submit "Continue" %>
+<% end %>
+```
+
+```erb
+# views/placements/wizards/add_placement_wizard/_check_your_answers_step.html.erb
+<%= form_for(check_your_answers_step, url: current_step_path, method: :put) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= govuk_summary_list do |summary_list| %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key(text: "Subject") %>
+      <% row.with_value(text: @wizard.steps[:subject].subject_name) %>
+      <% row.with_action(text: "Change", href: step_path(:subject), visually_hidden_text: "subject") %>
+    <% end %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key(text: "Mentors") %>
+      <% row.with_value(text: @wizard.steps[:mentors].mentor_ids) %>
+      <% row.with_action(text: "Change", href: step_path(:mentors), visually_hidden_text: "mentors") %>
+    <% end %>
+  <% end %>
+
+  <%= f.govuk_submit "Add placement" %>
+<% end %>
+```
+
+### 4. Create a controller
+
+The controller that will implement the wizard. You'll most likely need the following actions:
+
+- `new` – to begin a fresh journey through the wizard
+- `edit` – render a step
+- `update` – validate form submission and update the wizard state
+
+It's possible to re-use the same wizard across multiple controllers. This is handy, for example, when implementing the same flow for regular users and support users in the support console.
+
+```ruby
+class AddPlacementController < ApplicationController
+  before_action :set_wizard
+
+  helper_method :step_path, :current_step_path, :back_link_path
+
+  def new
+    @wizard.reset_state
+    redirect_to step_path(@wizard.first_step)
+  end
+
+  def edit; end
+
+  def update
+    if !@wizard.save_step
+      # There were validation errors – show them to the user
+      render "edit"
+    elsif @wizard.next_step.present?
+      # The step was valid – redirect to the next step
+      redirect_to step_path(@wizard.next_step)
+    else
+      # All steps completed – create the placement & reset the wizard's state.
+      # e.g. @wizard.create_placement
+      @wizard.reset_state
+      redirect_to some_path, flash: { success: "Placement created" }
+    end
+  end
+
+  private
+
+  def set_wizard
+    current_step = params[:step]&.to_sym
+    @wizard = Placements::AddPlacementWizard.new(params:, session:, current_step:)
+  end
+
+  def step_path(step)
+    add_placement_placements_school_placements_path(step:)
+  end
+
+  def current_step_path
+    step_path(@wizard.current_step)
+  end
+
+  def back_link_path
+    if @wizard.previous_step.present?
+      step_path(@wizard.previous_step)
+    else
+      some_path
+    end
+  end
+end
+```
+
+### 5. Create a view for the controller
+
+Wizard steps [respond to `#to_partial_path`](https://api.rubyonrails.org/classes/ActionView/PartialRenderer.html#class-ActionView::PartialRenderer-label-Rendering+objects+that+respond+to+to_partial_path) so are rendered using their associated view partials.
+
+```erb
+# views/add_placement/edit.html.erb
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: back_link_path) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= render @wizard.step, object: @wizard.step %>
+</div>
+```
+
+### 6. Add routes for the controller
+
+```diff
+resources :placements, only: %i[index show destroy] do
+  member { get :remove }
+
++  collection do
++    get "new", to: "add_placement#new", as: :new_add_placement
++    get "new/:step", to: "add_placement#edit", as: :add_placement
++    put "new/:step", to: "add_placement#update"
++  end
+end
+```
+
+This results in URL paths like:
+
+- Placements controller
+  - `GET /placements` – see all placements
+  - `GET /placements/:id` – show a placement's details
+  - `GET /placements/:id/remove` – remove a placement
+- "Add placement" controller
+  - `GET /placements/new` – begin the "Add placement" journey
+  - `GET /placements/new/:step` – edit a step of the wizard
+  - `PUT /placements/new/:step` – update step and redirect to the next step
+
+## Further reading
+
+For an in-depth description of our approach to wizards, see [ADR 9. Wizards](/adr/00009-wizards.md).
+
+For a more complete example, see the _actual_ ["Add placement" wizard](/app/wizards/placements/add_placement_wizard.rb).
+
+To understand the behaviour and interface of wizards, see:
+
+- **Wizard spec:** [spec/wizards/placements/base_wizard_spec.rb](/spec/wizards/placements/base_wizard_spec.rb)
+- **Step spec:** [spec/wizards/placements/base_step_spec.rb](/spec/wizards/placements/base_step_spec.rb)
+- **Mock wizard:** [spec/wizards/placements/burger_order_wizard_mock.rb](/spec/wizards/placements/burger_order_wizard_mock.rb) (used by the above specs)


### PR DESCRIPTION
## Context

We've adopted a wizard pattern for building multi-step forms in the School Placements service.

This adds documentation of how we build them, and an ADR to document how we ended up establishing this pattern.

## Changes proposed in this pull request

Adds the following documents:

- [adr/00009-wizards.md](https://github.com/DFE-Digital/itt-mentor-services/blob/wizard-documentation/adr/00009-wizards.md) ✨
- [docs/conventions/wizards.md](https://github.com/DFE-Digital/itt-mentor-services/blob/wizard-documentation/docs/conventions/wizards.md) ✨

## Link to Trello card

https://trello.com/c/ZfCxhaLn/541-document-our-use-of-the-wizard-pattern