### PR TITLE
Add preview emails for partnerships

### DIFF
--- a/spec/mailers/previews/placements/user_mailer_preview.rb
+++ b/spec/mailers/previews/placements/user_mailer_preview.rb
@@ -6,4 +6,12 @@ class Placements::UserMailerPreview < ActionMailer::Preview
   def user_membership_destroyed_notification
     UserMailer.with(service: :placements).user_membership_destroyed_notification(Placements::User.first, Placements::School.first)
   end
+
+  def partnership_created_notification
+    UserMailer.with(service: :placements).partnership_created_notification(Placements::User.first, Placements::School.first, Placements::Provider.first)
+  end
+
+  def partnership_destroyed_notification
+    UserMailer.with(service: :placements).partnership_destroyed_notification(Placements::User.first, Placements::School.first, Placements::Provider.first)
+  end
 end


### PR DESCRIPTION
## Context

- Add Partnership Creation Notification preview
- Add Partnership Destroyed Notification preview

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

- Sign in as Colin (Support user)
- Navigate to "Settings" in Navbar
- You should see:
  - partnership_created_notification (opens in new tab)
  - partnership_destroyed_notification (opens in new tab)
- Click each of the above to preview each email.

## Link to Trello card

https://trello.com/c/1TykvLa6/562-add-email-previews-for-partnership-notifications

## Screenshots

![screencapture-placements-localhost-3000-support-mailers-2024-07-12-14_49_04](https://github.com/user-attachments/assets/23d4a331-eccd-4b62-a85d-5bd24b053b6a)

