### PR TITLE
Fix error link in add placement mentor step

### DIFF
--- a/app/views/placements/wizards/add_placement_wizard/_mentors_step.html.erb
+++ b/app/views/placements/wizards/add_placement_wizard/_mentors_step.html.erb
@@ -8,8 +8,8 @@
         <span class="govuk-caption-l"><%= t(".add_placement") %></span>
 
         <%= f.govuk_check_boxes_fieldset :mentor_ids, legend: { size: "l", text: t(".mentor") } do %>
-          <% mentors_step.mentors_for_selection.each do |mentor| %>
-            <%= f.govuk_check_box :mentor_ids, mentor.id, label: { text: mentor.full_name } %>
+          <% mentors_step.mentors_for_selection.each_with_index do |mentor, index| %>
+            <%= f.govuk_check_box :mentor_ids, mentor.id, label: { text: mentor.full_name }, link_errors: index.zero? %>
           <% end %>
           <%= f.govuk_check_box_divider %>
           <%= f.govuk_check_box :mentor_ids, "not_known", label: { text: t(".not_known") }, exclusive: true %>


### PR DESCRIPTION
## Context

- Fix broken error link on Add placement -> Mentor step

## Changes proposed in this pull request

- When using a `govuk_check_boxes_fieldset` the first `govuk_check_box` must have attribute `link_errors: true`
https://www.rubydoc.info/gems/govuk_design_system_formbuilder/GOVUKDesignSystemFormBuilder/Builder#govuk_check_boxes_fieldset-instance_method

## Guidance to review

- Sign in as Anne (School user)
- Follow the process of adding a Placement
  - When you reach the mentor step, DO NOT SELECT A MENTOR OR 'Not yet know'
- When the error message appears at the top of the page, click this link.
  - This should focus you on the checkboxes for selecting a mentor.

## Link to Trello card

https://trello.com/c/xAVoTsgb/545-fix-broken-link-in-error-summary-on-the-add-placement-%E2%86%92-mentors-step-page

## Screenshots

https://github.com/user-attachments/assets/02f92104-6677-4890-a135-fe9efc308cf2



