### PR TITLE
Add back links to support settings mailer pages

### DIFF
--- a/app/views/claims/support/mailers/index.html.erb
+++ b/app/views/claims/support/mailers/index.html.erb
@@ -1,5 +1,9 @@
 <% render "claims/support/primary_navigation", current: :settings %>
 
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: claims_support_settings_path) %>
+<% end %>
+
 <div class="govuk-width-container">
   <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 

--- a/app/views/placements/support/mailers/index.html.erb
+++ b/app/views/placements/support/mailers/index.html.erb
@@ -1,5 +1,9 @@
 <% render "placements/support/primary_navigation", current_navigation: :settings %>
 
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: placements_support_settings_path) %>
+<% end %>
+
 <div class="govuk-width-container">
   <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 


### PR DESCRIPTION
## Context

Back links were missing from the mailer pages.

## Changes proposed in this pull request

- Add back links to the mailer pages.

## Guidance to review

- Mailer page back links should be correct.