### PR TITLE
Prevent all users from making new claims when there is no claim windo…

### DIFF
--- a/app/models/claims/claim_window.rb
+++ b/app/models/claims/claim_window.rb
@@ -43,6 +43,14 @@ class Claims::ClaimWindow < ApplicationRecord
     (starts_on..ends_on).cover?(Date.current)
   end
 
+  def self.find_by_date(date)
+    find_by(starts_on: ..date, ends_on: date..)
+  end
+
+  def self.current
+    find_by_date(Date.current)
+  end
+
   private
 
   def is_not_longer_than_an_academic_year

--- a/app/policies/claims/claim_policy.rb
+++ b/app/policies/claims/claim_policy.rb
@@ -1,6 +1,10 @@
 class Claims::ClaimPolicy < Claims::ApplicationPolicy
+  def create?
+    Claims::ClaimWindow.current.present?
+  end
+
   def edit?
-    !record.submitted?
+    create? && !record.submitted?
   end
 
   def update?
@@ -12,7 +16,7 @@ class Claims::ClaimPolicy < Claims::ApplicationPolicy
   end
 
   def submit?
-    !user.support_user? && !record.submitted?
+    create? && !user.support_user? && !record.submitted?
   end
 
   def rejected?

--- a/app/views/claims/schools/claims/index.html.erb
+++ b/app/views/claims/schools/claims/index.html.erb
@@ -4,20 +4,28 @@
 <div class="govuk-width-container">
   <% if Date.parse("20 July 2024").future? %>
     <%= govuk_notification_banner(title_text: t(".closing_date_disclaimer_title")) do |notification_banner| %>
-      <% notification_banner.with_heading(text: sanitize(t(".closing_date_disclaimer"))) %>
+      <% notification_banner.with_heading(text: sanitize(t(".closing_date_disclaimer", time: "11:59pm on Friday 19 July 2024"))) %>
     <% end %>
   <% end %>
 
   <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 
-  <% if @school.mentors.any? %>
-    <div class="govuk-inset-text">
-      <p class="govuk-body"><%= t(".guidance") %></p>
-      <p class="govuk-body"><%= sanitize t(".closing_date_disclaimer") %></p>
-    </div>
-    <%= govuk_link_to t(".add_claim"), new_claims_school_claim_path, class: "govuk-button" %>
+  <% if policy(Claims::Claim).create? %>
+    <% if @school.mentors.any? %>
+      <%= govuk_inset_text do %>
+        <p class="govuk-body"><%= t(".guidance") %></p>
+        <p class="govuk-body"><%= sanitize t(".closing_date_disclaimer", time: "11:59pm on #{l(Claims::ClaimWindow.current.ends_on, format: :long)}") %></p>
+      <% end %>
+
+      <%= govuk_link_to t(".add_claim"), new_claims_school_claim_path, class: "govuk-button" %>
+    <% else %>
+      <%= govuk_inset_text text: t(".add_mentor_guidance_html", link_to: govuk_link_to(t(".add_a_mentor"), claims_school_mentors_path(@school))) %>
+    <% end %>
   <% else %>
-    <p class="govuk-inset-text"><%= t(".add_mentor_guidance_html", link_to: govuk_link_to(t(".add_a_mentor"), claims_school_mentors_path(@school))) %></p>
+    <%= govuk_inset_text do %>
+      <p class="govuk-body"><%= t(".window_closed") %></p>
+      <p class="govuk-body"><%= sanitize t(".window_closed_guidance", link_to: govuk_link_to(t(".window_closed_guidance_link_text"), claims_school_mentors_path(@school))) %></p>
+    <% end %>
   <% end %>
 
   <% if @claims.any? %>
@@ -58,5 +66,9 @@
     <p>
       <%= t("no_records_for", records: "claims", for: @school.name) %>
     </p>
+  <% end %>
+
+  <% unless policy(Claims::Claim).create? %>
+    <p class="govuk-body"><%= sanitize t(".window_closed_support", link_to: govuk_mail_to(t("claims.support_email"))) %></p>
   <% end %>
 </div>

--- a/app/views/claims/schools/claims/show.html.erb
+++ b/app/views/claims/schools/claims/show.html.erb
@@ -18,11 +18,11 @@
 
       <% if policy(@claim).submit? %>
         <%= govuk_button_to t(".submit"), check_claims_school_claim_path(@school, @claim), method: :get %>
-      <% else %>
+      <% elsif @claim.submitted? %>
         <p class="govuk-body"><%= t(".submitted_by", name: @claim.submitted_by.full_name, date: l(@claim.submitted_on, format: :long)) %></p>
       <% end %>
 
-      <%= govuk_summary_list(actions: @claim.draft?) do |summary_list| %>
+      <%= govuk_summary_list(actions: policy(@claim).edit?) do |summary_list| %>
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: Claims::Claim.human_attribute_name(:school)) %>
           <% row.with_value(text: @school.name) %>
@@ -32,7 +32,7 @@
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: Claims::Claim.human_attribute_name(:accredited_provider)) %>
             <% row.with_value(text: @claim.provider.name) %>
-            <% if @claim.draft? %>
+            <% if policy(@claim).edit? %>
               <% row.with_action(
                 text: t("change"),
                 href: create_revision_claims_school_claim_path(@school, @claim),
@@ -57,7 +57,7 @@
               <% end %>
             </ul>
           <% end %>
-          <% if @claim.draft? %>
+          <% if policy(@claim).edit? %>
             <% row.with_action(
               text: t("change"),
               href: create_revision_claims_school_claim_mentors_path(@school, @claim),
@@ -69,12 +69,12 @@
       <% end %>
 
       <h2 class="govuk-heading-m"><%= t(".hours_of_training") %></h2>
-        <%= govuk_summary_list(actions: @claim.draft?) do |summary_list| %>
+        <%= govuk_summary_list(actions: policy(@claim).edit?) do |summary_list| %>
          <%= @claim.mentor_trainings.order_by_mentor_full_name.each do |mentor_training| %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: mentor_training.mentor.full_name) %>
             <% row.with_value(text: pluralize(mentor_training.hours_completed, t(".hour"))) %>
-            <% if @claim.draft? %>
+            <% if policy(@claim).edit? %>
               <% row.with_action(
                 text: t("change"),
                 href: create_revision_claims_school_claim_mentor_training_path(

--- a/app/views/claims/support/claims/_details.html.erb
+++ b/app/views/claims/support/claims/_details.html.erb
@@ -43,21 +43,21 @@
 <% end %>
 
 <h2 class="govuk-heading-m"><%= t(".hours_of_training") %></h2>
-  <%= govuk_summary_list(actions: policy(claim).edit?) do |summary_list| %>
-   <%= claim.mentor_trainings.order_by_mentor_full_name.each do |mentor_training| %>
-    <% summary_list.with_row do |row| %>
-      <% row.with_key(text: mentor_training.mentor.full_name) %>
-      <% row.with_value(text: pluralize(mentor_training.hours_completed, t(".hour"))) %>
-      <% if policy(claim).edit? %>
-        <% row.with_action(text: t("change"),
-                           href: create_revision_claims_support_school_claim_mentor_training_path(
-                             @school,
-                             claim,
-                             mentor_training.mentor_id,
-                           ),
-                           html_attributes: {
-                            class: "govuk-link--no-visited-state",
-                          }) %>
+<%= govuk_summary_list(actions: policy(claim).edit?) do |summary_list| %>
+  <%= claim.mentor_trainings.order_by_mentor_full_name.each do |mentor_training| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: mentor_training.mentor.full_name) %>
+    <% row.with_value(text: pluralize(mentor_training.hours_completed, t(".hour"))) %>
+    <% if policy(claim).edit? %>
+      <% row.with_action(text: t("change"),
+                         href: create_revision_claims_support_school_claim_mentor_training_path(
+                           @school,
+                           claim,
+                           mentor_training.mentor_id,
+                         ),
+                         html_attributes: {
+                         class: "govuk-link--no-visited-state",
+                        }) %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/claims/support/schools/claims/index.html.erb
+++ b/app/views/claims/support/schools/claims/index.html.erb
@@ -12,11 +12,19 @@
   <%= render "claims/support/schools/secondary_navigation", school: @school %>
   <h2 class="govuk-heading-m"><%= t(".heading") %></h2>
 
-  <% if @school.mentors.any? %>
-    <p class="govuk-inset-text"><%= t(".guidance") %></p>
-    <%= govuk_link_to t(".add_claim"), new_claims_support_school_claim_path, class: "govuk-button" %>
+  <% if policy(Claims::Claim).create? %>
+    <% if @school.mentors.any? %>
+      <%= govuk_inset_text text: t(".guidance") %>
+
+      <%= govuk_link_to t(".add_claim"), new_claims_support_school_claim_path, class: "govuk-button" %>
+    <% else %>
+      <%= govuk_inset_text text: t(".add_mentor_guidance_html", link_to: govuk_link_to(t(".add_a_mentor"), claims_support_school_mentors_path(@school))) %>
+    <% end %>
   <% else %>
-    <p class="govuk-inset-text"><%= t(".add_mentor_guidance_html", link_to: govuk_link_to(t(".add_a_mentor"), claims_support_school_mentors_path(@school))) %></p>
+    <%= govuk_inset_text do %>
+      <p class="govuk-body"><%= t(".window_closed") %></p>
+      <p class="govuk-body"><%= sanitize t(".window_closed_guidance", link_to: govuk_link_to(t(".window_closed_link_text"))) %></p>
+    <% end %>
   <% end %>
 
   <% if @claims.any? %>

--- a/config/locales/en/claims/schools/claims.yml
+++ b/config/locales/en/claims/schools/claims.yml
@@ -49,9 +49,13 @@ en:
           add_claim: Add claim
           guidance: Claims can only be made for the school year September 2023 to July 2024.
           closing_date_disclaimer_title: Important
-          closing_date_disclaimer: You must submit a claim by <strong>11:59pm on Friday 19 July 2024</strong>.
+          closing_date_disclaimer: You must submit a claim by <strong>%{time}</strong>.
           add_mentor_guidance_html: Before you can start a claim you will need to %{link_to}.
           add_a_mentor: add a mentor
+          window_closed: Claims can no longer be submitted for school year September 2023 to July 2024.
+          window_closed_guidance: "You can still %{link_to}. Final closing date for claims: <strong>11:59pm on Friday 19 July 2024</strong>."
+          window_closed_guidance_link_text: add a mentor
+          window_closed_support: Email %{link_to} if you have a query about your claims.
         update:
           claim_updated: Claim updated
         remove:

--- a/config/locales/en/claims/support/schools/claims.yml
+++ b/config/locales/en/claims/support/schools/claims.yml
@@ -32,6 +32,9 @@ en:
             closing_date_disclaimer: You must submit a claim by 11:59pm on Friday 19 July 2024
             add_mentor_guidance_html: You need to %{link_to} before creating a claim.</p>
             add_a_mentor: add a mentor
+            window_closed: Claims can no longer be submitted for school year September 2023 to July 2024.
+            window_closed_guidance: You can still %{link_to}.
+            window_closed_link_text: add a mentor
           show:
             page_title: Claim - %{reference}
             page_caption: Claims - %{school_name}

--- a/spec/policies/claims/claim_policy_spec.rb
+++ b/spec/policies/claims/claim_policy_spec.rb
@@ -9,6 +9,10 @@ describe Claims::ClaimPolicy do
   let(:draft_claim) { build(:claim, :draft) }
   let(:submitted_claim) { build(:claim, :submitted) }
 
+  before do
+    Claims::ClaimWindow::Build.call(claim_window_params: { starts_on: 2.days.ago, ends_on: 2.days.from_now }).save!(validate: false)
+  end
+
   permissions :edit? do
     context "when user has an internal draft claim" do
       it "grants access" do

--- a/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
   before do
     user_exists_in_dfe_sign_in(user: anne)
     given_i_sign_in
+    given_there_is_a_current_claim_window
     create(:mentor_training, mentor: mentor1, provider: provider1, claim:, hours_completed: 20)
     create(:mentor_training, mentor: mentor2, provider: provider1, claim:, hours_completed: 12)
   end
@@ -131,6 +132,10 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
   def given_i_sign_in
     visit sign_in_path
     click_on "Sign in using DfE Sign In"
+  end
+
+  def given_there_is_a_current_claim_window
+    Claims::ClaimWindow::Build.call(claim_window_params: { starts_on: 2.days.ago, ends_on: 2.days.from_now }).save!(validate: false)
   end
 
   def given_i_visit_claim_check_page

--- a/spec/system/claims/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/schools/claims/create_claim_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "Create claim", service: :claims, type: :system do
   let!(:niot) { create(:claims_provider, :niot) }
 
   before do
+    given_there_is_a_current_claim_window
     user_exists_in_dfe_sign_in(user: anne)
     given_i_sign_in
   end
@@ -155,6 +156,10 @@ RSpec.describe "Create claim", service: :claims, type: :system do
   def given_i_sign_in
     visit sign_in_path
     click_on "Sign in using DfE Sign In"
+  end
+
+  def given_there_is_a_current_claim_window
+    Claims::ClaimWindow::Build.call(claim_window_params: { starts_on: 2.days.ago, ends_on: 2.days.from_now }).save!(validate: false)
   end
 
   def given_my_school_has_fully_claimed_for_all_mentors_for_provider(provider)

--- a/spec/system/claims/schools/claims/submit_draft_claim_spec.rb
+++ b/spec/system/claims/schools/claims/submit_draft_claim_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe "Submit a draft claim", service: :claims, type: :system do
   scenario "Anne visits the show page of a draft claim" do
     user_exists_in_dfe_sign_in(user: anne)
     given_i_sign_in
+    given_there_is_a_current_claim_window
+
     when_i_visit_the_claim_show_page(draft_claim)
     then_i_can_then_see_the_draft_claim_details
     when_i_click_submit_button
@@ -60,6 +62,10 @@ RSpec.describe "Submit a draft claim", service: :claims, type: :system do
   def given_i_sign_in
     visit sign_in_path
     click_on "Sign in using DfE Sign In"
+  end
+
+  def given_there_is_a_current_claim_window
+    Claims::ClaimWindow::Build.call(claim_window_params: { starts_on: 2.days.ago, ends_on: 2.days.from_now }).save!(validate: false)
   end
 
   def when_i_click_submit_button

--- a/spec/system/claims/schools/claims/view_claim_spec.rb
+++ b/spec/system/claims/schools/claims/view_claim_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe "View a claim", service: :claims, type: :system do
   let!(:mentor_training) { create(:mentor_training, claim: submitted_claim, mentor:, hours_completed: 6) }
   let!(:draft_mentor_training) { create(:mentor_training, claim: draft_claim, mentor:, hours_completed: 6) }
 
+  before do
+    given_there_is_a_current_claim_window
+  end
+
   scenario "Anne visits the show page of a submitted claim" do
     user_exists_in_dfe_sign_in(user: anne)
     given_i_sign_in
@@ -111,6 +115,10 @@ RSpec.describe "View a claim", service: :claims, type: :system do
   def given_i_sign_in
     visit sign_in_path
     click_on "Sign in using DfE Sign In"
+  end
+
+  def given_there_is_a_current_claim_window
+    Claims::ClaimWindow::Build.call(claim_window_params: { starts_on: 2.days.ago, ends_on: 2.days.from_now }).save!(validate: false)
   end
 
   def then_i_cant_see_submit_button

--- a/spec/system/claims/schools/claims/view_claims_spec.rb
+++ b/spec/system/claims/schools/claims/view_claims_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe "View claims", service: :claims, type: :system do
 
   before do
     create(:claim, status: :internal_draft, school:)
+    given_there_is_a_current_claim_window
   end
 
   scenario "Anne visits the claims index page with no mentors" do
@@ -70,6 +71,10 @@ RSpec.describe "View claims", service: :claims, type: :system do
   end
 
   private
+
+  def given_there_is_a_current_claim_window
+    Claims::ClaimWindow::Build.call(claim_window_params: { starts_on: 2.days.ago, ends_on: 2.days.from_now }).save!(validate: false)
+  end
 
   def i_do_not_see_any_internal_draft_claims
     expect(page).to have_content("There are no claims for #{school.name}")

--- a/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
   before do
     user_exists_in_dfe_sign_in(user: colin)
     given_i_sign_in
+    given_there_is_a_current_claim_window
     create(:mentor_training, mentor: mentor1, provider: provider1, claim:, hours_completed: 20)
     create(:mentor_training, mentor: mentor2, provider: provider1, claim:, hours_completed: 12)
   end
@@ -134,6 +135,10 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
   def given_i_sign_in
     visit sign_in_path
     click_on "Sign in using DfE Sign In"
+  end
+
+  def given_there_is_a_current_claim_window
+    Claims::ClaimWindow::Build.call(claim_window_params: { starts_on: 2.days.ago, ends_on: 2.days.from_now }).save!(validate: false)
   end
 
   def given_i_visit_claim_support_check_page

--- a/spec/system/claims/support/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/create_claim_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Create claim", service: :claims, type: :system do
   before do
     user_exists_in_dfe_sign_in(user: colin)
     given_i_sign_in
+    given_there_is_a_current_claim_window
   end
 
   scenario "Colin creates a claim" do
@@ -158,6 +159,10 @@ RSpec.describe "Create claim", service: :claims, type: :system do
     school.mentors.find_each do |mentor|
       create(:mentor_training, :submitted, mentor:, provider:, hours_completed: 20)
     end
+  end
+
+  def given_there_is_a_current_claim_window
+    Claims::ClaimWindow::Build.call(claim_window_params: { starts_on: 2.days.ago, ends_on: 2.days.from_now }).save!(validate: false)
   end
 
   def when_i_click(button)

--- a/spec/system/claims/support/schools/claims/edit_draft_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/edit_draft_claim_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe "Edit a draft claim", service: :claims, type: :system do
 
   let!(:draft_mentor_training) { create(:mentor_training, claim: draft_claim, mentor: claims_mentor, hours_completed: 6) }
 
+  before do
+    given_there_is_a_current_claim_window
+  end
+
   scenario "A support user I can edit a draft claim" do
     user_exists_in_dfe_sign_in(user: colin)
     given_i_sign_in
@@ -86,6 +90,10 @@ RSpec.describe "Edit a draft claim", service: :claims, type: :system do
   end
 
   private
+
+  def given_there_is_a_current_claim_window
+    Claims::ClaimWindow::Build.call(claim_window_params: { starts_on: 2.days.ago, ends_on: 2.days.from_now }).save!(validate: false)
+  end
 
   def then_i_update_the_claim(mentor)
     click_on("Update claim")


### PR DESCRIPTION
## Context

As we now have configurable claim windows, we want these claim windows to take effect on preventing the creation of claims once the window is closed.

## Changes proposed in this pull request

- Update the `Claims::ClaimPolicy` to only allow the creation of claims if there is a current `Claims::ClaimWindow`.
- Update the `Claims::ClaimPolicy` to only allow editing claims if they can be created. (This logic works with the current constraints, technically, it may not be accurate. There is possibility that we allow changes to be made whilst a new claim cannot be created in the future.)
- If a user cannot make a claim, they will see a different guidance text within the inset text above.

## Guidance to review

- Try visiting the Claim Window settings and playing around with dates and windows.
- Try creating/submitting claims when a window is currently open or all are closed.

## Link to Trello card

https://trello.com/c/ULmE5aCc/571-as-a-user-i-should-not-be-able-to-submit-a-claim-outside-of-the-claim-window

## Screenshots

![CleanShot 2024-07-17 at 10 24 41](https://github.com/user-attachments/assets/362191d3-174d-4edb-8c7a-608e844a1ff6)
