### PR TITLE
Update incorrect url path for new placement slack notification

### DIFF
--- a/app/slack_notifiers/placements/placement_slack_notifier.rb
+++ b/app/slack_notifiers/placements/placement_slack_notifier.rb
@@ -7,7 +7,7 @@ class Placements::PlacementSlackNotifier < Placements::ApplicationSlackNotifier
           type: "section",
           text: {
             type: "mrkdwn",
-            text: ":new: *Placement added:* <#{placements_support_school_placements_url(school, placement)}|#{placement.title}> at #{school.name}",
+            text: ":new: *Placement added:* <#{placements_support_school_placement_url(school, placement)}|#{placement.title}> at #{school.name}",
           },
         },
       ],


### PR DESCRIPTION
## Context

The Slack notifier links are incorrect and do not redirect us to the placement when opening the link.

## Changes proposed in this pull request

- [x] Fix the URL so that it is pointing to the right location

## Guidance to review

- Trigger a slack notification via the console
- Check that the link opens the placement when logged in as Colin

## Link to Trello card

[Fix broken link in Slack notifications for new placements](https://trello.com/c/0WgwLppQ/575-fix-broken-link-in-slack-notifications-for-new-placements)
