### PR TITLE
Populate claim windows on claims

### DIFF
--- a/app/controllers/claims/schools/claims_controller.rb
+++ b/app/controllers/claims/schools/claims_controller.rb
@@ -80,7 +80,7 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
   end
 
   def default_params
-    { school: @school, current_user: }
+    { school: @school, current_user:, claim_window: Claims::ClaimWindow.current }
   end
 
   def claim_provider_form

--- a/app/controllers/claims/support/schools/claims_controller.rb
+++ b/app/controllers/claims/support/schools/claims_controller.rb
@@ -87,7 +87,7 @@ class Claims::Support::Schools::ClaimsController < Claims::Support::ApplicationC
   end
 
   def default_params
-    { school: @school, current_user: }
+    { school: @school, current_user:, claim_window: Claims::ClaimWindow.current }
   end
 
   def claim_id

--- a/app/forms/claims/claim/provider_form.rb
+++ b/app/forms/claims/claim/provider_form.rb
@@ -1,5 +1,5 @@
 class Claims::Claim::ProviderForm < ApplicationForm
-  attr_accessor :id, :provider_id, :school, :current_user
+  attr_accessor :id, :provider_id, :school, :current_user, :claim_window
 
   validates :provider_id, presence: true
 
@@ -17,6 +17,7 @@ class Claims::Claim::ProviderForm < ApplicationForm
       claim.mentor_trainings.update_all(provider_id:)
       claim.status = :internal_draft if claim.status.nil?
       claim.created_by ||= current_user
+      claim.claim_window = claim_window
       claim.save!
     end
   end

--- a/app/models/claims/claim.rb
+++ b/app/models/claims/claim.rb
@@ -40,7 +40,7 @@ class Claims::Claim < ApplicationRecord
 
   belongs_to :school
   belongs_to :provider
-  belongs_to :claim_window, optional: true
+  belongs_to :claim_window
   belongs_to :created_by, polymorphic: true
   belongs_to :submitted_by, polymorphic: true, optional: true
   belongs_to :previous_revision, class_name: "Claims::Claim", optional: true

--- a/app/policies/claims/claim_policy.rb
+++ b/app/policies/claims/claim_policy.rb
@@ -4,7 +4,7 @@ class Claims::ClaimPolicy < Claims::ApplicationPolicy
   end
 
   def edit?
-    current_claim_window? && !record.submitted?
+    claim_claim_window_current? && !record.submitted?
   end
 
   def update?
@@ -48,5 +48,9 @@ class Claims::ClaimPolicy < Claims::ApplicationPolicy
 
   def current_claim_window?
     Claims::ClaimWindow.current.present?
+  end
+
+  def claim_claim_window_current?
+    record.claim_window.current?
   end
 end

--- a/app/policies/claims/claim_policy.rb
+++ b/app/policies/claims/claim_policy.rb
@@ -1,10 +1,10 @@
 class Claims::ClaimPolicy < Claims::ApplicationPolicy
   def create?
-    Claims::ClaimWindow.current.present?
+    current_claim_window?
   end
 
   def edit?
-    create? && !record.submitted?
+    current_claim_window? && !record.submitted?
   end
 
   def update?
@@ -16,7 +16,7 @@ class Claims::ClaimPolicy < Claims::ApplicationPolicy
   end
 
   def submit?
-    create? && !user.support_user? && !record.submitted?
+    current_claim_window? && !user.support_user? && !record.submitted?
   end
 
   def rejected?
@@ -33,7 +33,7 @@ class Claims::ClaimPolicy < Claims::ApplicationPolicy
 
   # TODO: Remove record.draft? and not create drafts for existing drafts
   def draft?
-    user.support_user? && (record.internal_draft? || record.draft?)
+    current_claim_window? && user.support_user? && (record.internal_draft? || record.draft?)
   end
 
   def check?
@@ -42,5 +42,11 @@ class Claims::ClaimPolicy < Claims::ApplicationPolicy
 
   def download_csv?
     user.support_user?
+  end
+
+  private
+
+  def current_claim_window?
+    Claims::ClaimWindow.current.present?
   end
 end

--- a/db/data/20240722123910_add_claim_window_to_claims.rb
+++ b/db/data/20240722123910_add_claim_window_to_claims.rb
@@ -1,0 +1,12 @@
+class AddClaimWindowToClaims < ActiveRecord::Migration[7.1]
+  def up
+    date = Date.parse("2 May 2024")
+    claim_window = Claims::ClaimWindow.find_by_date(date)
+
+    Claims::Claim.update_all(claim_window_id: claim_window.id) if claim_window
+  end
+
+  def down
+    Claims::Claim.update_all(claim_window_id: nil)
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20240719081853)
+DataMigrate::Data.define(version: 20240722123910)

--- a/spec/factories/academic_years.rb
+++ b/spec/factories/academic_years.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :academic_year do
+    trait :current do
+      starts_on { Date.parse("1 September #{Date.current.year - 1}") }
+      ends_on { Date.parse("31 August #{Date.current.year}") }
+      name { "#{starts_on.year} to #{ends_on.year}" }
+
+      to_create { |instance| instance.save!(validate: false) }
+    end
+  end
+end

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -39,6 +39,7 @@ FactoryBot.define do
     association :provider
     association :created_by, factory: :claims_user
     association :submitted_by, factory: :claims_user
+    association :claim_window, :current
 
     status { :internal_draft }
 

--- a/spec/factories/claims/claim_windows.rb
+++ b/spec/factories/claims/claim_windows.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :claim_window, class: "Claims::ClaimWindow" do
+    trait :current do
+      starts_on { 2.days.ago }
+      ends_on { 2.days.from_now }
+      association :academic_year, :current
+
+      to_create { |instance| instance.save!(validate: false) }
+    end
+  end
+end

--- a/spec/forms/claims/claim/provider_form_spec.rb
+++ b/spec/forms/claims/claim/provider_form_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 describe Claims::Claim::ProviderForm, type: :model do
   let(:school) { create(:claims_school) }
   let(:existing_claim) { create(:claim, school:) }
+  let(:claim_window) { create(:claim_window, :current) }
 
   describe "validations" do
     context "when provider is not set" do
@@ -38,7 +39,7 @@ describe Claims::Claim::ProviderForm, type: :model do
 
     context "when claim doesn't exist" do
       it "creates an internal draft claim with a provider" do
-        form = described_class.new(provider_id: provider.id, school:, current_user:)
+        form = described_class.new(provider_id: provider.id, school:, current_user:, claim_window:)
 
         expect { form.save! }.to change { form.claim.provider }.to provider
 
@@ -49,7 +50,7 @@ describe Claims::Claim::ProviderForm, type: :model do
 
     context "when claim does exist" do
       it "updates the claim with the new provider" do
-        form = described_class.new(id: existing_claim.id, provider_id: provider.id, school:, current_user:)
+        form = described_class.new(id: existing_claim.id, provider_id: provider.id, school:, current_user:, claim_window:)
 
         expect { form.save! }.to change { existing_claim.reload.provider }.to provider
 
@@ -60,7 +61,7 @@ describe Claims::Claim::ProviderForm, type: :model do
 
       context "when selecting the same provider" do
         it "doesn't update anything" do
-          form = described_class.new(id: existing_claim.id, provider_id: existing_claim.provider.id, school:, current_user:)
+          form = described_class.new(id: existing_claim.id, provider_id: existing_claim.provider.id, school:, current_user:, claim_window:)
 
           expect { form.save! }.to not_change { existing_claim.reload.provider }
             .and(not_change { existing_claim.reload.mentor_trainings.pluck(:provider_id) })

--- a/spec/forms/claims/support/claim/provider_form_spec.rb
+++ b/spec/forms/claims/support/claim/provider_form_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 describe Claims::Support::Claim::ProviderForm, type: :model do
   let(:school) { create(:claims_school) }
   let(:existing_claim) { create(:claim, school:) }
+  let(:claim_window) { create(:claim_window, :current) }
 
   describe "validations" do
     context "when provider is not set" do
@@ -38,7 +39,7 @@ describe Claims::Support::Claim::ProviderForm, type: :model do
 
     context "when claim doesn't exist" do
       it "creates an internal draft claim with a provider" do
-        form = described_class.new(provider_id: provider.id, school:, current_user:)
+        form = described_class.new(provider_id: provider.id, school:, current_user:, claim_window:)
 
         expect { form.save! }.to change { form.claim.provider }.to provider
 
@@ -49,7 +50,7 @@ describe Claims::Support::Claim::ProviderForm, type: :model do
 
     context "when claim does exist" do
       it "updates the claim with the new provider" do
-        form = described_class.new(id: existing_claim.id, provider_id: provider.id, school:, current_user:)
+        form = described_class.new(id: existing_claim.id, provider_id: provider.id, school:, current_user:, claim_window:)
 
         expect { form.save! }.to change { existing_claim.reload.provider }.to provider
 
@@ -60,7 +61,7 @@ describe Claims::Support::Claim::ProviderForm, type: :model do
 
       context "when selecting the same provider" do
         it "doesn't update anything" do
-          form = described_class.new(id: existing_claim.id, provider_id: existing_claim.provider.id, school:, current_user:)
+          form = described_class.new(id: existing_claim.id, provider_id: existing_claim.provider.id, school:, current_user:, claim_window:)
 
           expect { form.save! }.to not_change { existing_claim.reload.provider }
             .and(not_change { existing_claim.reload.mentor_trainings.pluck(:provider_id) })

--- a/spec/models/claims/claim_spec.rb
+++ b/spec/models/claims/claim_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe Claims::Claim, type: :model do
     it { is_expected.to belong_to(:school).class_name("Claims::School") }
     it { is_expected.to belong_to(:provider) }
     it { is_expected.to belong_to(:created_by) }
+    it { is_expected.to belong_to(:claim_window) }
     it { is_expected.to belong_to(:previous_revision).class_name("Claims::Claim").optional }
-    it { is_expected.to belong_to(:claim_window).optional }
     it { is_expected.to belong_to(:submitted_by).optional }
     it { is_expected.to have_many(:mentor_trainings).dependent(:destroy) }
     it { is_expected.to have_many(:mentors).through(:mentor_trainings) }


### PR DESCRIPTION
## Context

Now that we have a `claim_window` association on the `Claim` model, we can start associating the claim windows when a claim is created.

## Changes proposed in this pull request

- Back-populate claim windows onto all existing claims.
- When a claim is being created, assign the current claim window to the claim being created.

## Guidance to review

- Locally, try creating a Claim. It will associate the "current" claim window to the claim.