### PR TITLE
Update claims start page

### DIFF
--- a/app/views/claims/pages/start.en.html.erb
+++ b/app/views/claims/pages/start.en.html.erb
@@ -1,10 +1,4 @@
 <div class="govuk-width-container">
-  <% if Date.parse("20 July 2024").future? %>
-    <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
-      <% notification_banner.with_heading(text: "You must submit a claim by 11:59pm on Friday 19 July 2024") %>
-    <% end %>
-  <% end %>
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Claim funding for mentor training</h1>
@@ -18,7 +12,7 @@
       </p>
 
       <p class="govuk-body">
-        You must submit a claim by <strong>11:59pm on Friday 19 July 2024<strong />
+        Final closing date for claims: <strong>11:59pm on Friday 19 July 2024<strong />
       </p>
 
       <p class="govuk-body">

--- a/app/views/claims/schools/claims/index.html.erb
+++ b/app/views/claims/schools/claims/index.html.erb
@@ -2,12 +2,6 @@
 <% render "claims/schools/primary_navigation", school: @school, current: :claims %>
 
 <div class="govuk-width-container">
-  <% if Date.parse("20 July 2024").future? %>
-    <%= govuk_notification_banner(title_text: t(".closing_date_disclaimer_title")) do |notification_banner| %>
-      <% notification_banner.with_heading(text: sanitize(t(".closing_date_disclaimer", time: "11:59pm on Friday 19 July 2024"))) %>
-    <% end %>
-  <% end %>
-
   <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 
   <% if policy(Claims::Claim).create? %>

--- a/app/views/claims/support/schools/claims/index.html.erb
+++ b/app/views/claims/support/schools/claims/index.html.erb
@@ -2,12 +2,6 @@
 <% render "claims/support/primary_navigation", current: :organisations %>
 
 <div class="govuk-width-container">
-  <% if Date.parse("20 July 2024").future? %>
-    <%= govuk_notification_banner(title_text: t(".closing_date_disclaimer_title")) do |notification_banner| %>
-      <% notification_banner.with_heading(text: t(".closing_date_disclaimer")) %>
-    <% end %>
-  <% end %>
-
   <h1 class="govuk-heading-l"><%= @school.name %></h1>
   <%= render "claims/support/schools/secondary_navigation", school: @school %>
   <h2 class="govuk-heading-m"><%= t(".heading") %></h2>

--- a/spec/system/claims/start_page_spec.rb
+++ b/spec/system/claims/start_page_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Start Page", service: :claims, type: :system do
     end
 
     expect(page).to have_content("Use this service to claim for mentors who supported, or intended to support, trainee teachers from September 2023 to July 2024.")
-    expect(page).to have_content("You must submit a claim by 11:59pm on Friday 19 July 2024")
+    expect(page).to have_content("Final closing date for claims: 11:59pm on Friday 19 July 2024")
     expect(page).to have_content("You must wait until May 2025 to claim for training that took place from April 2024 for the school year starting September 2025.")
     expect(page).to have_content(
       "Before you start\n"\


### PR DESCRIPTION
## Context

The window has now closed. We want to remove the notification banner and update the start page content slightly.

## Changes proposed in this pull request

- Remove notification banners about window closing dates.
- Update start page content.