### PR TITLE
Placement preview

### DIFF
--- a/app/controllers/placements/schools/placements_controller.rb
+++ b/app/controllers/placements/schools/placements_controller.rb
@@ -1,7 +1,8 @@
 class Placements::Schools::PlacementsController < Placements::ApplicationController
   before_action :set_school
-  before_action :set_placement, only: %i[show remove destroy]
-  before_action :set_decorated_placement, only: %i[show remove]
+  before_action :set_placement, only: %i[show remove destroy preview]
+  before_action :set_decorated_placement, only: %i[show remove preview]
+  before_action :set_decorated_school, only: %i[show remove preview]
 
   helper_method :edit_attribute_path, :add_provider_path, :add_mentor_path
 
@@ -27,6 +28,8 @@ class Placements::Schools::PlacementsController < Placements::ApplicationControl
     redirect_to placements_school_placements_path(@school), flash: { success: t(".placement_deleted") }
   end
 
+  def preview; end
+
   private
 
   def set_placement
@@ -39,6 +42,10 @@ class Placements::Schools::PlacementsController < Placements::ApplicationControl
 
   def set_decorated_placement
     @placement = @placement.decorate
+  end
+
+  def set_decorated_school
+    @school = @school.decorate
   end
 
   def edit_attribute_path(attribute)

--- a/app/controllers/placements/schools/placements_controller.rb
+++ b/app/controllers/placements/schools/placements_controller.rb
@@ -2,7 +2,6 @@ class Placements::Schools::PlacementsController < Placements::ApplicationControl
   before_action :set_school
   before_action :set_placement, only: %i[show remove destroy preview]
   before_action :set_decorated_placement, only: %i[show remove preview]
-  before_action :set_decorated_school, only: %i[show remove preview]
 
   helper_method :edit_attribute_path, :add_provider_path, :add_mentor_path
 
@@ -42,10 +41,6 @@ class Placements::Schools::PlacementsController < Placements::ApplicationControl
 
   def set_decorated_placement
     @placement = @placement.decorate
-  end
-
-  def set_decorated_school
-    @school = @school.decorate
   end
 
   def edit_attribute_path(attribute)

--- a/app/views/placements/placements/_placement_details.html.erb
+++ b/app/views/placements/placements/_placement_details.html.erb
@@ -1,36 +1,28 @@
-<div class="govuk-width-container">
-  <% if preview %>
-    <%= render(GovukComponent::NotificationBannerComponent.new(title_text: "Important")) do %>
-      <h3 class="govuk-heading-m">This is a preview of how your placement will appear to teacher training providers.</h3>
-    <% end %>
-  <% end %>
+<h1 class="govuk-heading-l govuk-!-margin-bottom-2">
+  <span class="govuk-caption-l"><%= t(".placement", school_name: school.name) %></span>
+  <%= placement.title %>
+</h1>
+<div class="govuk-!-margin-top-0 govuk-!-margin-bottom-6">
+  <%= render Placement::StatusTagComponent.new(placement:) %>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m govuk-!-margin-top-0">
+      <%= t(".itt_placement_contact") %>
+    </h2>
+    <%= render "shared/schools/school_contact_details",
+               school:,
+               school_contact: school.school_contact,
+               changeable: false %>
 
-  <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
-    <span class="govuk-caption-l"><%= t(".placement", school_name: school.name) %></span>
-    <%= placement.title %>
-  </h1>
-  <div class="govuk-!-margin-top-0 govuk-!-margin-bottom-6">
-    <%= render Placement::StatusTagComponent.new(placement:) %>
-  </div>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m govuk-!-margin-top-0">
-        <%= t(".itt_placement_contact") %>
-      </h2>
-      <%= render "shared/schools/school_contact_details",
-                 school:,
-                 school_contact: school.school_contact,
-                 changeable: false %>
+    <h2 class="govuk-heading-m govuk-!-margin-top-0">
+      <%= t(".location") %>
+    </h2>
+    <%= render "shared/schools/location_details", school: %>
 
-      <h2 class="govuk-heading-m govuk-!-margin-top-0">
-        <%= t(".location") %>
-      </h2>
-      <%= render "shared/schools/location_details", school: %>
-
-      <h2 class="govuk-heading-m govuk-!-margin-top-0">
-        <%= t(".additional_details") %>
-      </h2>
-      <%= render "placements/placements/school_details", school:, placement: %>
-    </div>
+    <h2 class="govuk-heading-m govuk-!-margin-top-0">
+      <%= t(".additional_details") %>
+    </h2>
+    <%= render "placements/placements/school_details", school:, placement: %>
   </div>
 </div>

--- a/app/views/placements/placements/_placement_details.html.erb
+++ b/app/views/placements/placements/_placement_details.html.erb
@@ -1,0 +1,36 @@
+<div class="govuk-width-container">
+  <% if preview %>
+    <%= render(GovukComponent::NotificationBannerComponent.new(title_text: "Important")) do %>
+      <h3 class="govuk-heading-m">This is a preview of how your placement will appear to teacher training providers.</h3>
+    <% end %>
+  <% end %>
+
+  <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
+    <span class="govuk-caption-l"><%= t(".placement", school_name: school.name) %></span>
+    <%= placement.title %>
+  </h1>
+  <div class="govuk-!-margin-top-0 govuk-!-margin-bottom-6">
+    <%= render Placement::StatusTagComponent.new(placement:) %>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-m govuk-!-margin-top-0">
+        <%= t(".itt_placement_contact") %>
+      </h2>
+      <%= render "shared/schools/school_contact_details",
+                 school:,
+                 school_contact: school.school_contact,
+                 changeable: false %>
+
+      <h2 class="govuk-heading-m govuk-!-margin-top-0">
+        <%= t(".location") %>
+      </h2>
+      <%= render "shared/schools/location_details", school: %>
+
+      <h2 class="govuk-heading-m govuk-!-margin-top-0">
+        <%= t(".additional_details") %>
+      </h2>
+      <%= render "placements/placements/school_details", school:, placement: %>
+    </div>
+  </div>
+</div>

--- a/app/views/placements/placements/show.html.erb
+++ b/app/views/placements/placements/show.html.erb
@@ -5,33 +5,4 @@
   <%= govuk_back_link(href: :back) %>
 <% end %>
 
-<div class="govuk-width-container">
-  <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
-    <span class="govuk-caption-l"><%= t(".placement", school_name: @school.name) %></span>
-    <%= @placement.title %>
-  </h1>
-  <div class="govuk-!-margin-top-0 govuk-!-margin-bottom-6">
-      <%= render Placement::StatusTagComponent.new(placement: @placement) %>
-  </div>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m govuk-!-margin-top-0">
-        <%= t(".itt_placement_contact") %>
-      </h2>
-      <%= render "shared/schools/school_contact_details",
-        school: @school,
-        school_contact: @school.school_contact,
-        changeable: false %>
-
-      <h2 class="govuk-heading-m govuk-!-margin-top-0">
-        <%= t(".location") %>
-      </h2>
-      <%= render "shared/schools/location_details", school: @school %>
-
-      <h2 class="govuk-heading-m govuk-!-margin-top-0">
-        <%= t(".additional_details") %>
-      </h2>
-      <%= render "school_details", school: @school, placement: @placement %>
-    </div>
-  </div>
-</div>
+<%= render "placement_details", school: @school, placement: @placement, preview: false %>

--- a/app/views/placements/placements/show.html.erb
+++ b/app/views/placements/placements/show.html.erb
@@ -5,4 +5,6 @@
   <%= govuk_back_link(href: :back) %>
 <% end %>
 
-<%= render "placement_details", school: @school, placement: @placement, preview: false %>
+<div class="govuk-width-container">
+  <%= render "placement_details", school: @school, placement: @placement %>
+</div>

--- a/app/views/placements/schools/placements/preview.html.erb
+++ b/app/views/placements/schools/placements/preview.html.erb
@@ -6,4 +6,4 @@
   <%= govuk_back_link(href: :back) %>
 <% end %>
 
-<%= render "placements/placements/placement_details", school: @school, placement: @placement, preview: true %>
+<%= render "placements/placements/placement_details",  school: @placement.school, placement: @placement, preview: true %>

--- a/app/views/placements/schools/placements/preview.html.erb
+++ b/app/views/placements/schools/placements/preview.html.erb
@@ -1,0 +1,9 @@
+<%= content_for :page_title, sanitize(@placement.title) %>
+
+<%= render "placements/schools/primary_navigation", school: @school, current_navigation: :placements %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: :back) %>
+<% end %>
+
+<%= render "placements/placements/placement_details", school: @school, placement: @placement, preview: true %>

--- a/app/views/placements/schools/placements/preview.html.erb
+++ b/app/views/placements/schools/placements/preview.html.erb
@@ -6,4 +6,10 @@
   <%= govuk_back_link(href: :back) %>
 <% end %>
 
-<%= render "placements/placements/placement_details",  school: @placement.school, placement: @placement, preview: true %>
+<div class="govuk-width-container">
+  <%= render(GovukComponent::NotificationBannerComponent.new(title_text: t(".important"))) do %>
+    <h3 class="govuk-heading-m"><%= t(".this_is_a_preview") %></h3>
+  <% end %>
+
+  <%= render "placements/placements/placement_details", school: @placement.school, placement: @placement %>
+</div>

--- a/app/views/placements/schools/placements/show.html.erb
+++ b/app/views/placements/schools/placements/show.html.erb
@@ -15,6 +15,16 @@
 
       <%= render "placements/schools/placements/details", school: @school, placement: @placement %>
 
+      <%= govuk_inset_text do %>
+        <%= embedded_link_text(
+              t(".preview_placement", href: govuk_link_to(
+                t(".preview_link"),
+                preview_placement_placements_school_placement_path(@school, @placement),
+                no_visited_state: true,
+              )),
+            ) %>
+      <% end %>
+
       <%= govuk_link_to t(".delete_placement"),
                         remove_placements_school_placement_path(@school, @placement),
                         class: "app-link app-link--destructive" %>

--- a/app/views/placements/wizards/add_placement_wizard/_check_your_answers_step.html.erb
+++ b/app/views/placements/wizards/add_placement_wizard/_check_your_answers_step.html.erb
@@ -71,7 +71,10 @@
 
       <%= govuk_inset_text(text: t(".info_text")) %>
 
-      <%= f.govuk_submit t(".publish_placement") %>
+      <div class="govuk-button-group">
+        <%= f.govuk_submit t(".publish_placement") %>
+        <%= govuk_link_to t(".preview_placement"), step_path(:preview_placement) %>
+      </div>
     </div>
   </div>
 <% end %>

--- a/app/views/placements/wizards/add_placement_wizard/_preview_placement_step.html.erb
+++ b/app/views/placements/wizards/add_placement_wizard/_preview_placement_step.html.erb
@@ -10,6 +10,9 @@
 
     <%= render "placements/placements/placement_details", school: @wizard.school.decorate, placement: preview_placement_step.placement.decorate %>
 
-    <%= f.govuk_submit t(".publish_placement") %>
+    <div class="govuk-button-group">
+      <%= f.govuk_submit t(".publish_placement") %>
+      <%= govuk_button_link_to t(".edit_placement"), step_path(:check_your_answers), secondary: true %>
+    </div>
   <% end %>
 </div>

--- a/app/views/placements/wizards/add_placement_wizard/_preview_placement_step.html.erb
+++ b/app/views/placements/wizards/add_placement_wizard/_preview_placement_step.html.erb
@@ -1,3 +1,9 @@
 <%= content_for :page_title, sanitize(t(".page_title", contextual_text:)) %>
 
-<%= render "placements/placements/placement_details", school: @wizard.school.decorate, placement: preview_placement_step.placement.decorate, preview: true %>
+<div class="govuk-width-container">
+  <%= render(GovukComponent::NotificationBannerComponent.new(title_text: t(".important"))) do %>
+    <h3 class="govuk-heading-m"><%= t(".this_is_a_preview") %></h3>
+  <% end %>
+
+  <%= render "placements/placements/placement_details", school: @wizard.school.decorate, placement: preview_placement_step.placement.decorate %>
+</div>

--- a/app/views/placements/wizards/add_placement_wizard/_preview_placement_step.html.erb
+++ b/app/views/placements/wizards/add_placement_wizard/_preview_placement_step.html.erb
@@ -5,5 +5,11 @@
     <h3 class="govuk-heading-m"><%= t(".this_is_a_preview") %></h3>
   <% end %>
 
-  <%= render "placements/placements/placement_details", school: @wizard.school.decorate, placement: preview_placement_step.placement.decorate %>
+  <%= form_for(preview_placement_step, url: current_step_path, method: :put) do |f| %>
+    <%= f.govuk_error_summary %>
+
+    <%= render "placements/placements/placement_details", school: @wizard.school.decorate, placement: preview_placement_step.placement.decorate %>
+
+    <%= f.govuk_submit t(".publish_placement") %>
+  <% end %>
 </div>

--- a/app/views/placements/wizards/add_placement_wizard/_preview_placement_step.html.erb
+++ b/app/views/placements/wizards/add_placement_wizard/_preview_placement_step.html.erb
@@ -1,0 +1,3 @@
+<%= content_for :page_title, sanitize(t(".page_title", contextual_text:)) %>
+
+<%= render "placements/placements/placement_details", school: @wizard.school.decorate, placement: preview_placement_step.placement.decorate, preview: true %>

--- a/app/wizards/placements/add_placement_wizard.rb
+++ b/app/wizards/placements/add_placement_wizard.rb
@@ -25,6 +25,13 @@ module Placements
     def create_placement
       raise "Invalid wizard state" unless valid?
 
+      placement = build_placement
+
+      placement.save!
+      placement
+    end
+
+    def build_placement
       placement = school.placements.build
       placement.subject = steps[:subject].subject
 
@@ -39,8 +46,6 @@ module Placements
       if steps[:mentors].present?
         placement.mentors = steps[:mentors].mentors
       end
-
-      placement.save!
 
       placement
     end

--- a/app/wizards/placements/add_placement_wizard.rb
+++ b/app/wizards/placements/add_placement_wizard.rb
@@ -15,6 +15,7 @@ module Placements
       add_step(YearGroupStep) if placement_phase == School::PRIMARY_PHASE
       add_step(MentorsStep) if school.mentors.present?
       add_step(CheckYourAnswersStep)
+      add_step(PreviewPlacementStep) if current_step == :preview_placement
     end
 
     def placement_phase

--- a/app/wizards/placements/add_placement_wizard/preview_placement_step.rb
+++ b/app/wizards/placements/add_placement_wizard/preview_placement_step.rb
@@ -1,0 +1,23 @@
+class Placements::AddPlacementWizard::PreviewPlacementStep < Placements::BaseStep
+  delegate :school, to: :wizard
+  delegate :steps, to: :wizard
+
+  def placement
+    placement = school.placements.build
+    placement.subject = steps[:subject].subject
+
+    if steps[:additional_subjects].present?
+      placement.additional_subjects = steps[:additional_subjects].additional_subjects
+    end
+
+    if steps[:year_group].present?
+      placement.year_group = steps[:year_group].year_group
+    end
+
+    if steps[:mentors].present?
+      placement.mentors = steps[:mentors].mentors
+    end
+
+    placement
+  end
+end

--- a/app/wizards/placements/add_placement_wizard/preview_placement_step.rb
+++ b/app/wizards/placements/add_placement_wizard/preview_placement_step.rb
@@ -1,5 +1,7 @@
 class Placements::AddPlacementWizard::PreviewPlacementStep < Placements::BaseStep
   delegate :build_placement, to: :wizard
 
-  alias_method :placement, :build_placement
+  def placement
+    @placement ||= build_placement
+  end
 end

--- a/app/wizards/placements/add_placement_wizard/preview_placement_step.rb
+++ b/app/wizards/placements/add_placement_wizard/preview_placement_step.rb
@@ -1,23 +1,5 @@
 class Placements::AddPlacementWizard::PreviewPlacementStep < Placements::BaseStep
-  delegate :school, to: :wizard
-  delegate :steps, to: :wizard
+  delegate :build_placement, to: :wizard
 
-  def placement
-    placement = school.placements.build
-    placement.subject = steps[:subject].subject
-
-    if steps[:additional_subjects].present?
-      placement.additional_subjects = steps[:additional_subjects].additional_subjects
-    end
-
-    if steps[:year_group].present?
-      placement.year_group = steps[:year_group].year_group
-    end
-
-    if steps[:mentors].present?
-      placement.mentors = steps[:mentors].mentors
-    end
-
-    placement
-  end
+  alias_method :placement, :build_placement
 end

--- a/config/locales/en/placements/placements.yml
+++ b/config/locales/en/placements/placements.yml
@@ -26,13 +26,15 @@ en:
           assigned_to_me: Assigned to me
           all_placements: All placements
         year_group: Primary year group
-      show:
-        page_title: "%{subject_name} - Placements - %{school_name}"
-        placement: "Placement - %{school_name}"
+      placement_details:
         contact_details: Contact details
         itt_placement_contact: Placement contact
         location: Location
         additional_details: Additional details
+        placement: "Placement - %{school_name}"
+      show:
+        page_title: "%{subject_name} - Placements - %{school_name}"
+        placement: "Placement - %{school_name}"
       school_details:
         establishment_group: Establishment group
         school_phase: School phase

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -67,6 +67,9 @@ en:
           delete_placement: Delete placement
           preview_placement: You can %{href} as it appears to providers.
           preview_link: preview this placement
+        preview:
+          important: Important
+          this_is_a_preview: This is a preview of how your placement will appear to teacher training providers.
         details:
           select_a_mentor: Select a mentor
           add_a_mentor: Add a mentor

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -65,6 +65,8 @@ en:
           add_itt_placement_contact: add a placement contact
         show:
           delete_placement: Delete placement
+          preview_placement: You can %{href} as it appears to providers.
+          preview_link: preview this placement
         details:
           select_a_mentor: Select a mentor
           add_a_mentor: Add a mentor

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -69,7 +69,7 @@ en:
           preview_link: preview this placement
         preview:
           important: Important
-          this_is_a_preview: This is a preview of how your placement will appear to teacher training providers.
+          this_is_a_preview: This is a preview of how your placement appears to teacher training providers.
         details:
           select_a_mentor: Select a mentor
           add_a_mentor: Add a mentor

--- a/config/locales/en/placements/wizards/add_placement_wizard.yml
+++ b/config/locales/en/placements/wizards/add_placement_wizard.yml
@@ -54,5 +54,6 @@ en:
           important: Important
           this_is_a_preview: This is a preview of how your placement will appear to teacher training providers.
           publish_placement: Publish placement
+          edit_placement: Edit placement
         update:
           success: Placement published

--- a/config/locales/en/placements/wizards/add_placement_wizard.yml
+++ b/config/locales/en/placements/wizards/add_placement_wizard.yml
@@ -53,5 +53,6 @@ en:
           page_title: Preview placement - %{contextual_text}
           important: Important
           this_is_a_preview: This is a preview of how your placement will appear to teacher training providers.
+          publish_placement: Publish placement
         update:
           success: Placement published

--- a/config/locales/en/placements/wizards/add_placement_wizard.yml
+++ b/config/locales/en/placements/wizards/add_placement_wizard.yml
@@ -51,5 +51,7 @@ en:
           not_yet_known: Not yet known
         preview_placement_step:
           page_title: Preview placement - %{contextual_text}
+          important: Important
+          this_is_a_preview: This is a preview of how your placement will appear to teacher training providers.
         update:
           success: Placement published

--- a/config/locales/en/placements/wizards/add_placement_wizard.yml
+++ b/config/locales/en/placements/wizards/add_placement_wizard.yml
@@ -47,6 +47,9 @@ en:
           change: Change
           info_text: When a placement is published, it will be visible to teacher training providers.
           publish_placement: Publish placement
+          preview_placement: Preview placement
           not_yet_known: Not yet known
+        preview_placement_step:
+          page_title: Preview placement - %{contextual_text}
         update:
           success: Placement published

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -146,6 +146,7 @@ scope module: :placements,
           get "edit", to: "placements/edit_placement#new", as: :new_edit_placement
           get "edit/:step", to: "placements/edit_placement#edit", as: :edit_placement
           put "edit/:step", to: "placements/edit_placement#update"
+          get "preview", to: "placements#preview", as: :preview_placement
         end
 
         collection do

--- a/spec/support/shared_examples/system/placements/add_a_placement_wizard.rb
+++ b/spec/support/shared_examples/system/placements/add_a_placement_wizard.rb
@@ -176,6 +176,72 @@ RSpec.shared_examples "an add a placement wizard" do
             and_i_see_the_error_message("Select a mentor or not yet known")
           end
         end
+
+        context "when I preview my placement" do
+          it "I can see the placement details" do
+            when_i_visit_the_placements_page
+            and_i_click_on("Add placement")
+            when_i_choose_a_subject(subject_1.name)
+            and_i_click_on("Continue")
+            when_i_choose_a_year_group("Year 1")
+            and_i_click_on("Continue")
+            when_i_check_a_mentor(mentor_1.full_name)
+            and_i_click_on("Continue")
+            then_i_see_the_check_your_answers_page(school.phase, mentor_1)
+            when_i_click_on("Preview placement")
+            then_i_see_the_preview_page(phase: school.phase, subject: subject_1)
+          end
+
+          it "I can go back to the check your answers page" do
+            when_i_visit_the_placements_page
+            and_i_click_on("Add placement")
+            when_i_choose_a_subject(subject_1.name)
+            and_i_click_on("Continue")
+            when_i_choose_a_year_group("Year 1")
+            and_i_click_on("Continue")
+            when_i_check_a_mentor(mentor_1.full_name)
+            and_i_click_on("Continue")
+            then_i_see_the_check_your_answers_page(school.phase, mentor_1)
+            when_i_click_on("Preview placement")
+            then_i_see_the_preview_page(phase: school.phase, subject: subject_1)
+            and_i_click_on("Back")
+            then_i_see_the_check_your_answers_page(school.phase, mentor_1)
+          end
+
+          it "I can go back and edit my placement" do
+            when_i_visit_the_placements_page
+            and_i_click_on("Add placement")
+            when_i_choose_a_subject(subject_1.name)
+            and_i_click_on("Continue")
+            when_i_choose_a_year_group("Year 1")
+            and_i_click_on("Continue")
+            when_i_check_a_mentor(mentor_1.full_name)
+            and_i_click_on("Continue")
+            then_i_see_the_check_your_answers_page(school.phase, mentor_1)
+            when_i_click_on("Preview placement")
+            then_i_see_the_preview_page(phase: school.phase, subject: subject_1)
+            and_i_click_on("Edit placement")
+            then_i_see_the_check_your_answers_page(school.phase, mentor_1)
+          end
+
+          it "I can publish my placement" do
+            when_i_visit_the_placements_page
+            and_i_click_on("Add placement")
+            when_i_choose_a_subject(subject_1.name)
+            and_i_click_on("Continue")
+            when_i_choose_a_year_group("Year 1")
+            and_i_click_on("Continue")
+            when_i_check_a_mentor(mentor_1.full_name)
+            and_i_click_on("Continue")
+            then_i_see_the_check_your_answers_page(school.phase, mentor_1)
+            when_i_click_on("Preview placement")
+            then_i_see_the_preview_page(phase: school.phase, subject: subject_1)
+            and_i_click_on("Publish placement")
+            then_i_see_the_placements_page
+            and_i_see_my_placement(school.phase)
+            and_i_see_success_message("Placement published")
+          end
+        end
       end
     end
 
@@ -598,6 +664,12 @@ RSpec.shared_examples "an add a placement wizard" do
 
   def when_i_uncheck(text)
     uncheck(text)
+  end
+
+  def then_i_see_the_preview_page(phase:, subject:)
+    expect(page).to have_content("This is a preview of how your placement will appear to teacher training providers.")
+    expect(page).to have_content(phase)
+    expect(page).to have_content(subject.name)
   end
 
   alias_method :and_i_click_on, :when_i_click_on

--- a/spec/system/placements/schools/placements/view_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/view_a_placement_spec.rb
@@ -299,6 +299,6 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
   end
 
   def then_i_see_the_placement_preview_page
-    expect(page).to have_content("This is a preview of how your placement will appear to teacher training providers.")
+    expect(page).to have_content("This is a preview of how your placement appears to teacher training providers.")
   end
 end

--- a/spec/system/placements/schools/placements/view_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/view_a_placement_spec.rb
@@ -146,6 +146,14 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
     end
   end
 
+  context "when I preview the placement" do
+    scenario "I can see the placement details" do
+      when_i_visit_the_placement_show_page
+      when_i_visit_the_placement_preview_page
+      then_i_see_the_placement_preview_page
+    end
+  end
+
   private
 
   def and_there_is_an_existing_user_for(user_name)
@@ -278,5 +286,13 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
 
   def then_i_see_link(text:, href:)
     expect(page).to have_link(text, href:)
+  end
+
+  def when_i_visit_the_placement_preview_page
+    click_link "preview this placement"
+  end
+
+  def then_i_see_the_placement_preview_page
+    expect(page).to have_content("This is a preview of how your placement will appear to teacher training providers.")
   end
 end

--- a/spec/system/placements/schools/placements/view_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/view_a_placement_spec.rb
@@ -148,8 +148,8 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
 
   context "when I preview the placement" do
     scenario "I can see the placement details" do
-      when_i_visit_the_placement_show_page
-      when_i_visit_the_placement_preview_page
+      given_i_visit_the_placement_show_page
+      and_i_click_link("preview this placement")
       then_i_see_the_placement_preview_page
     end
   end
@@ -173,6 +173,8 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
   def when_i_visit_the_placement_show_page
     visit placements_school_placement_path(school, placement)
   end
+
+  alias_method :given_i_visit_the_placement_show_page, :when_i_visit_the_placement_show_page
 
   def given_i_sign_in_as_anne
     and_there_is_an_existing_user_for("Anne")
@@ -290,6 +292,10 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
 
   def when_i_visit_the_placement_preview_page
     click_link "preview this placement"
+  end
+
+  def and_i_click_link(link_text)
+    click_link link_text
   end
 
   def then_i_see_the_placement_preview_page

--- a/spec/wizards/placements/add_placement_wizard/preview_placement_step_spec.rb
+++ b/spec/wizards/placements/add_placement_wizard/preview_placement_step_spec.rb
@@ -11,9 +11,12 @@ RSpec.describe Placements::AddPlacementWizard::PreviewPlacementStep, type: :mode
     it { is_expected.to delegate_method(:build_placement).to(:wizard) }
   end
 
-  describe "aliases" do
-    it "aliases #build_placement to #placement" do
-      expect(step.method(:build_placement)).to eq step.method(:placement)
+  describe "#placement" do
+    it "returns the placement built by the wizard" do
+      placement = instance_double(Placement)
+      allow(mock_wizard).to receive(:build_placement).and_return(placement)
+
+      expect(step.placement).to eq(placement)
     end
   end
 end

--- a/spec/wizards/placements/add_placement_wizard/preview_placement_step_spec.rb
+++ b/spec/wizards/placements/add_placement_wizard/preview_placement_step_spec.rb
@@ -3,59 +3,17 @@ require "rails_helper"
 RSpec.describe Placements::AddPlacementWizard::PreviewPlacementStep, type: :model do
   subject(:step) { described_class.new(wizard: mock_wizard, attributes: nil) }
 
-  let(:mock_subject_step) { instance_double(Placements::AddPlacementWizard::SubjectStep, subject: placement_subject) }
-  let(:mock_additional_subjects_step) { nil }
-  let(:mock_year_group_step) { nil }
-  let(:mock_mentors_step) { nil }
-
   let(:mock_wizard) do
-    instance_double(Placements::AddPlacementWizard).tap do |wizard|
-      allow(wizard).to receive_messages(school:, steps: {
-        subject: mock_subject_step,
-        additional_subjects: mock_additional_subjects_step,
-        year_group: mock_year_group_step,
-        mentors: mock_mentors_step,
-      })
-    end
+    instance_double(Placements::AddPlacementWizard)
   end
-
-  let(:school) { create(:placements_school, phase:) }
-  let(:phase) { "Primary" }
-  let(:placement_subject) { create(:subject) }
-  let(:additional_subjects) { [] }
-  let(:year_group) { nil }
-  let(:mentors) { [] }
 
   describe "delegations" do
-    it { is_expected.to delegate_method(:school).to(:wizard) }
-    it { is_expected.to delegate_method(:steps).to(:wizard) }
+    it { is_expected.to delegate_method(:build_placement).to(:wizard) }
   end
 
-  describe "#placement" do
-    subject { step.placement }
-
-    it { is_expected.to be_a(Placement) }
-    it { is_expected.to have_attributes(subject: placement_subject) }
-
-    context "when additional subjects are present" do
-      let(:mock_additional_subjects_step) { instance_double(Placements::AddPlacementWizard::AdditionalSubjectsStep, additional_subjects:) }
-      let(:additional_subjects) { create_list(:subject, 2, parent_subject: placement_subject) }
-
-      it { is_expected.to have_attributes(additional_subjects:) }
-    end
-
-    context "when year group is present" do
-      let(:mock_year_group_step) { instance_double(Placements::AddPlacementWizard::YearGroupStep, year_group:) }
-      let(:year_group) { "Year 1" }
-
-      it { is_expected.to have_attributes(year_group:) }
-    end
-
-    context "when mentors are present" do
-      let(:mock_mentors_step) { instance_double(Placements::AddPlacementWizard::MentorsStep, mentors:) }
-      let(:mentors) { create_list(:placements_mentor, 2) }
-
-      it { is_expected.to have_attributes(mentors:) }
+  describe "aliases" do
+    it "aliases #build_placement to #placement" do
+      expect(step.method(:build_placement)).to eq step.method(:placement)
     end
   end
 end

--- a/spec/wizards/placements/add_placement_wizard/preview_placement_step_spec.rb
+++ b/spec/wizards/placements/add_placement_wizard/preview_placement_step_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe Placements::AddPlacementWizard::PreviewPlacementStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes: nil) }
+
+  let(:mock_subject_step) { instance_double(Placements::AddPlacementWizard::SubjectStep, subject: placement_subject) }
+  let(:mock_additional_subjects_step) { instance_double(Placements::AddPlacementWizard::AdditionalSubjectsStep, additional_subjects:) }
+  let(:mock_year_group_step) { instance_double(Placements::AddPlacementWizard::YearGroupStep, year_group:) }
+  let(:mock_mentors_step) { instance_double(Placements::AddPlacementWizard::MentorsStep, mentors:) }
+
+  let(:mock_wizard) do
+    instance_double(Placements::AddPlacementWizard).tap do |wizard|
+      allow(wizard).to receive_messages(school:, steps: {
+        subject: mock_subject_step,
+        additional_subjects: mock_additional_subjects_step,
+        year_group: mock_year_group_step,
+        mentors: mock_mentors_step,
+      })
+    end
+  end
+
+  let(:school) { create(:placements_school, phase:) }
+  let(:phase) { "Primary" }
+  let(:placement_subject) { create(:subject) }
+  let(:additional_subjects) { create_list(:subject, 2, parent_subject: placement_subject) }
+  let(:year_group) { "Year 1" }
+  let(:mentors) { create_list(:placements_mentor, 2) }
+
+  describe "delegations" do
+    it { is_expected.to delegate_method(:school).to(:wizard) }
+    it { is_expected.to delegate_method(:steps).to(:wizard) }
+  end
+
+  describe "#placement" do
+    subject { step.placement }
+
+    it { is_expected.to be_a(Placement) }
+    it { is_expected.to have_attributes(subject: placement_subject) }
+
+    context "when additional subjects are present" do
+      it { is_expected.to have_attributes(additional_subjects:) }
+    end
+
+    context "when year group is present" do
+      it { is_expected.to have_attributes(year_group:) }
+    end
+
+    context "when mentors are present" do
+      it { is_expected.to have_attributes(mentors:) }
+    end
+  end
+end

--- a/spec/wizards/placements/add_placement_wizard/preview_placement_step_spec.rb
+++ b/spec/wizards/placements/add_placement_wizard/preview_placement_step_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe Placements::AddPlacementWizard::PreviewPlacementStep, type: :mode
   subject(:step) { described_class.new(wizard: mock_wizard, attributes: nil) }
 
   let(:mock_subject_step) { instance_double(Placements::AddPlacementWizard::SubjectStep, subject: placement_subject) }
-  let(:mock_additional_subjects_step) { instance_double(Placements::AddPlacementWizard::AdditionalSubjectsStep, additional_subjects:) }
-  let(:mock_year_group_step) { instance_double(Placements::AddPlacementWizard::YearGroupStep, year_group:) }
-  let(:mock_mentors_step) { instance_double(Placements::AddPlacementWizard::MentorsStep, mentors:) }
+  let(:mock_additional_subjects_step) { nil }
+  let(:mock_year_group_step) { nil }
+  let(:mock_mentors_step) { nil }
 
   let(:mock_wizard) do
     instance_double(Placements::AddPlacementWizard).tap do |wizard|
@@ -22,9 +22,9 @@ RSpec.describe Placements::AddPlacementWizard::PreviewPlacementStep, type: :mode
   let(:school) { create(:placements_school, phase:) }
   let(:phase) { "Primary" }
   let(:placement_subject) { create(:subject) }
-  let(:additional_subjects) { create_list(:subject, 2, parent_subject: placement_subject) }
-  let(:year_group) { "Year 1" }
-  let(:mentors) { create_list(:placements_mentor, 2) }
+  let(:additional_subjects) { [] }
+  let(:year_group) { nil }
+  let(:mentors) { [] }
 
   describe "delegations" do
     it { is_expected.to delegate_method(:school).to(:wizard) }
@@ -38,14 +38,23 @@ RSpec.describe Placements::AddPlacementWizard::PreviewPlacementStep, type: :mode
     it { is_expected.to have_attributes(subject: placement_subject) }
 
     context "when additional subjects are present" do
+      let(:mock_additional_subjects_step) { instance_double(Placements::AddPlacementWizard::AdditionalSubjectsStep, additional_subjects:) }
+      let(:additional_subjects) { create_list(:subject, 2, parent_subject: placement_subject) }
+
       it { is_expected.to have_attributes(additional_subjects:) }
     end
 
     context "when year group is present" do
+      let(:mock_year_group_step) { instance_double(Placements::AddPlacementWizard::YearGroupStep, year_group:) }
+      let(:year_group) { "Year 1" }
+
       it { is_expected.to have_attributes(year_group:) }
     end
 
     context "when mentors are present" do
+      let(:mock_mentors_step) { instance_double(Placements::AddPlacementWizard::MentorsStep, mentors:) }
+      let(:mentors) { create_list(:placements_mentor, 2) }
+
       it { is_expected.to have_attributes(mentors:) }
     end
   end

--- a/spec/wizards/placements/add_placement_wizard_spec.rb
+++ b/spec/wizards/placements/add_placement_wizard_spec.rb
@@ -1,7 +1,9 @@
 require "rails_helper"
 
 RSpec.describe Placements::AddPlacementWizard do
-  subject(:wizard) { described_class.new(session:, params:, school:, current_step: nil) }
+  subject(:wizard) { described_class.new(session:, params:, school:, current_step:) }
+
+  let(:current_step) { nil }
 
   # Schools
   let(:primary_school) { build(:placements_school, :primary, mentors:) }
@@ -67,6 +69,12 @@ RSpec.describe Placements::AddPlacementWizard do
       let(:state) { { "subject" => { "subject_id" => modern_foreign_languages.id } } }
 
       it { is_expected.to eq %i[subject additional_subjects mentors check_your_answers] }
+    end
+
+    context "when the preview placement step is active" do
+      let(:current_step) { :preview_placement }
+
+      it { is_expected.to eq %i[subject mentors check_your_answers preview_placement] }
     end
   end
 


### PR DESCRIPTION
## Context

School users wish to be able to see how providers can view their placements

## Changes proposed in this pull request

- Refactors the provider placement details to use a partial
- Adds a new endpoint for previewing existing placements
- Adds a new preview placement step in the add placement journey

## Guidance to review

- Log in as Anne
- View an existing placement
- Click on "preview this placement"

- Log in as Anne
- Create a new placement
- On the check your answers page, click on "preview placement"

## Link to Trello card

[Implement placement preview functionality](https://trello.com/c/FzZvWF1J/617-implement-placement-preview-functionality)

## Screenshots

![image](https://github.com/user-attachments/assets/65858423-e362-4f53-8580-dfacb466c872)
![image](https://github.com/user-attachments/assets/ecf88076-25ff-4ca4-8049-c26d1b05577b)
![image](https://github.com/user-attachments/assets/edc5bb8b-786c-4c2e-985e-12adfeddb21b)

