### PR TITLE
Fix change link on partnership check your answers

### DIFF
--- a/app/views/placements/wizards/add_partnership_wizard/_check_your_answers_step.html.erb
+++ b/app/views/placements/wizards/add_partnership_wizard/_check_your_answers_step.html.erb
@@ -10,7 +10,7 @@
         <%= t(".title") %>
       </label>
 
-      <%= render "shared/organisations/organisation_details", organisation: @wizard.partner_organisation, change_link: step_path(:organisation) %>
+      <%= render "shared/organisations/organisation_details", organisation: @wizard.partner_organisation, change_link: step_path(:partnership) %>
       <% if @wizard.partner_organisation.is_a?(School) %>
         <h2 class="govuk-heading-m govuk-!-margin-top-9"><%= t(".additional_details") %></h2>
         <%= render "shared/schools/additional_details", school: @wizard.partner_organisation %>

--- a/spec/system/placements/providers/partner_schools/add_a_partner_school_spec.rb
+++ b/spec/system/placements/providers/partner_schools/add_a_partner_school_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Placements / Providers / Partner schools / Add a partner school"
     then_i_see_an_error("Enter a school name, unique reference number (URN) or postcode")
   end
 
-  scenario "User reconsiders selecting a school", :js, retry: 3 do
+  scenario "User reconsiders selecting a school using back link", :js, retry: 3 do
     when_i_view_the_partner_schools_page
     and_i_click_on("Add partner school")
     and_i_enter_a_school_named("School 1")
@@ -57,6 +57,20 @@ RSpec.describe "Placements / Providers / Partner schools / Add a partner school"
     and_i_click_on("Continue")
     then_i_see_the_check_details_page_for_school("School 1")
     when_i_click_on("Back")
+    then_i_see_the_search_input_pre_filled_with("School 1")
+    and_i_click_on("Continue")
+    then_i_see_the_check_details_page_for_school("School 1")
+  end
+
+  scenario "User reconsiders selecting a school using change link", :js, retry: 3 do
+    when_i_view_the_partner_schools_page
+    and_i_click_on("Add partner school")
+    and_i_enter_a_school_named("School 1")
+    then_i_see_a_dropdown_item_for("School 1")
+    when_i_click_the_dropdown_item_for("School 1")
+    and_i_click_on("Continue")
+    then_i_see_the_check_details_page_for_school("School 1")
+    when_i_click_on("Change")
     then_i_see_the_search_input_pre_filled_with("School 1")
     and_i_click_on("Continue")
     then_i_see_the_check_details_page_for_school("School 1")

--- a/spec/system/placements/schools/partner_providers/add_a_partner_provider_spec.rb
+++ b/spec/system/placements/schools/partner_providers/add_a_partner_provider_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Placements / Schools / Partner providers / Add a partner provide
     then_i_see_an_error("Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode")
   end
 
-  scenario "User reconsiders selecting a provider", :js, retry: 3 do
+  scenario "User reconsiders selecting a provider using back link", :js, retry: 3 do
     when_i_view_the_partner_providers_page
     and_i_click_on("Add partner provider")
     and_i_enter_a_provider_named("Provider 1")
@@ -57,6 +57,20 @@ RSpec.describe "Placements / Schools / Partner providers / Add a partner provide
     and_i_click_on("Continue")
     then_i_see_the_check_details_page_for_provider("Provider 1")
     when_i_click_on("Back")
+    then_i_see_the_search_input_pre_filled_with("Provider 1")
+    and_i_click_on("Continue")
+    then_i_see_the_check_details_page_for_provider("Provider 1")
+  end
+
+  scenario "User reconsiders selecting a provider using change link", :js, retry: 3 do
+    when_i_view_the_partner_providers_page
+    and_i_click_on("Add partner provider")
+    and_i_enter_a_provider_named("Provider 1")
+    then_i_see_a_dropdown_item_for("Provider 1")
+    when_i_click_the_dropdown_item_for("Provider 1")
+    and_i_click_on("Continue")
+    then_i_see_the_check_details_page_for_provider("Provider 1")
+    when_i_click_on("Change")
     then_i_see_the_search_input_pre_filled_with("Provider 1")
     and_i_click_on("Continue")
     then_i_see_the_check_details_page_for_provider("Provider 1")


### PR DESCRIPTION
## Context

- Fix issue with incorrect step used in change link in partnerships

## Guidance to review

- Sign in as Anne
- Follow the process to create a partner provider UNTIL the check your answers page
- Click "Change"
- You should be redirected back to the Provider selection page.

## Screenshots

https://github.com/user-attachments/assets/3df5f9b7-accd-4abb-ae9d-4f639a11cbbc


