### PR TITLE
Add academic years and claims windows to seed file

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -78,6 +78,41 @@ end
 # Create subjects
 PublishTeacherTraining::Subject::Import.call
 
+# Create academic years
+year = Date.current.year
+month = Date.current.month
+
+current_academic_year = if month < 9
+                          year - 1
+                        else
+                          year
+                        end
+
+previous_academic_year = current_academic_year - 1
+next_academic_year = current_academic_year + 1
+
+[previous_academic_year, current_academic_year, next_academic_year].each do |start_year|
+  end_year = start_year + 1
+  academic_year = AcademicYear.find_or_create_by!(
+    starts_on: Date.parse("1 September #{start_year}"),
+    ends_on: Date.parse("31 August #{end_year}"),
+    name: "#{start_year} to #{end_year}",
+  )
+  next unless start_year == current_academic_year
+
+  Claims::ClaimWindow.find_or_create_by!(
+    starts_on: Date.parse("2 May #{end_year}"),
+    ends_on: Date.parse("19 July #{end_year}"),
+    academic_year:,
+  )
+
+  Claims::ClaimWindow.find_or_create_by!(
+    starts_on: Date.parse("29 July #{end_year}"),
+    ends_on: Date.parse("9 August #{end_year}"),
+    academic_year:,
+  )
+end
+
 # Create placements
 Placements::School.find_each do |school|
   # A school must have a school contact before creating placements


### PR DESCRIPTION
## Context

- Added academic years to seed file.
- Added claims windows to seed file.

## Changes proposed in this pull request

seeds.rb added academic years and added claims windows.

## Guidance to review

- Run in terminal "bundle exec rake db:drop db:create db:setup".
- You should see an academic year record for previous, current, and next academic year.
- You should see two claims windows for the current academic year.

## Link to Trello card

https://trello.com/c/mS6wI3Ib/239-add-academic-years-and-claim-windows-to-seeds-file
