### PR TITLE
Added service-specific localhost urls to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ To run the application locally:
 
 1. Run `yarn` to install dependencies for the web app to run
 2. Run `bin/setup` to setup the database
-3. Run `bin/dev` to launch the app on <http://localhost:3000>
+3. Run `bin/dev` to launch the app on <http://placements.localhost:3000> or <http://claims.localhost:3000>
 
 ### Seed Data
 


### PR DESCRIPTION
## Context

Added service-specific localhost urls to readme.

## Changes proposed in this pull request

- Updated <http://localhost:3000> url in readme to <http://placements.localhost:3000> or <http://claims.localhost:3000>. 

## Guidance to review

- Test urls correctly access the localhost for each service.

## Link to Trello card

https://trello.com/c/ONGEvkbU/632-update-the-readme-file-with-dans-improvements
