### PR TITLE
Partner placements

### DIFF
--- a/app/controllers/placements/providers/partner_schools/placements_controller.rb
+++ b/app/controllers/placements/providers/partner_schools/placements_controller.rb
@@ -3,14 +3,13 @@ class Placements::Providers::PartnerSchools::PlacementsController < ApplicationC
   before_action :set_partner_school, only: %i[index show]
 
   def index
-    placements_assigned_to_provider = @partner_school.placements.where(provider_id: @provider.id)
-    other_placements = @partner_school.placements.where.not(id: placements_assigned_to_provider.ids)
-    @placements_assigned_to_provider = placements_assigned_to_provider.decorate
-    @other_placements = other_placements.decorate
+    @placements_assigned_to_provider = placements_scope.where(provider: @provider).decorate
+    @other_placements = placements_scope.where.not(provider: @provider)
+      .or(placements_scope.where(provider: nil)).decorate
   end
 
   def show
-    @placement = @partner_school.placements.find(params.require(:id)).decorate
+    @placement = placements_scope.find(params.require(:id)).decorate
     @partner_school = @placement.school
   end
 
@@ -23,5 +22,9 @@ class Placements::Providers::PartnerSchools::PlacementsController < ApplicationC
   def set_provider
     provider_id = params.fetch(:provider_id)
     @provider = current_user.providers.find(provider_id)
+  end
+
+  def placements_scope
+    @partner_school.placements
   end
 end

--- a/app/controllers/placements/providers/partner_schools/placements_controller.rb
+++ b/app/controllers/placements/providers/partner_schools/placements_controller.rb
@@ -1,6 +1,7 @@
 class Placements::Providers::PartnerSchools::PlacementsController < ApplicationController
   before_action :set_provider, only: %i[index show]
   before_action :set_partner_school, only: %i[index show]
+
   def index
     placements_assigned_to_provider = @partner_school.placements.where(provider_id: @provider.id)
     other_placements = @partner_school.placements.where.not(id: placements_assigned_to_provider.ids)
@@ -10,7 +11,7 @@ class Placements::Providers::PartnerSchools::PlacementsController < ApplicationC
 
   def show
     @placement = @partner_school.placements.find(params.require(:id)).decorate
-    @partner_school = @partner_school.decorate
+    @partner_school = @placement.school
   end
 
   private

--- a/app/controllers/placements/providers/partner_schools/placements_controller.rb
+++ b/app/controllers/placements/providers/partner_schools/placements_controller.rb
@@ -1,0 +1,26 @@
+class Placements::Providers::PartnerSchools::PlacementsController < ApplicationController
+  before_action :set_provider, only: %i[index show]
+  before_action :set_partner_school, only: %i[index show]
+  def index
+    placements_assigned_to_provider = @partner_school.placements.where(provider_id: @provider.id)
+    other_placements = @partner_school.placements.where.not(id: placements_assigned_to_provider.ids)
+    @placements_assigned_to_provider = placements_assigned_to_provider.decorate
+    @other_placements = other_placements.decorate
+  end
+
+  def show
+    @placement = @partner_school.placements.find(params.require(:id)).decorate
+    @partner_school = @partner_school.decorate
+  end
+
+  private
+
+  def set_partner_school
+    @partner_school = @provider.partner_schools.find(params.require(:partner_school_id)).becomes(Placements::School)
+  end
+
+  def set_provider
+    provider_id = params.fetch(:provider_id)
+    @provider = current_user.providers.find(provider_id)
+  end
+end

--- a/app/views/placements/providers/partner_schools/_sub_navigation.html.erb
+++ b/app/views/placements/providers/partner_schools/_sub_navigation.html.erb
@@ -1,0 +1,4 @@
+<%= render SecondaryNavigationComponent.new do |component| %>
+  <% component.with_navigation_item "School details", placements_provider_partner_school_path(provider, school) %>
+  <% component.with_navigation_item "Placements", placements_provider_partner_school_placements_path(provider, school) %>
+<% end %>

--- a/app/views/placements/providers/partner_schools/_sub_navigation.html.erb
+++ b/app/views/placements/providers/partner_schools/_sub_navigation.html.erb
@@ -1,4 +1,4 @@
 <%= render SecondaryNavigationComponent.new do |component| %>
-  <% component.with_navigation_item "School details", placements_provider_partner_school_path(provider, school) %>
-  <% component.with_navigation_item "Placements", placements_provider_partner_school_placements_path(provider, school) %>
+  <% component.with_navigation_item t(".school_details"), placements_provider_partner_school_path(provider, school) %>
+  <% component.with_navigation_item t(".placements"), placements_provider_partner_school_placements_path(provider, school) %>
 <% end %>

--- a/app/views/placements/providers/partner_schools/placements/index.html.erb
+++ b/app/views/placements/providers/partner_schools/placements/index.html.erb
@@ -26,7 +26,7 @@
       <% table.with_body do |body| %>
         <% @placements_assigned_to_provider.each do |placement| %>
           <% body.with_row do |row| %>
-            <% row.with_cell(text: govuk_link_to(placement.title, placements_provider_partner_school_placement_path(@provider, @partner_school, placement))) %>
+            <% row.with_cell(text: govuk_link_to(placement.title, placements_provider_partner_school_placement_path(@provider, @partner_school, placement)), no_visited_state: true) %>
             <% row.with_cell(text: placement.mentor_names) %>
           <% end %>
         <% end %>
@@ -46,7 +46,7 @@
       <% table.with_body do |body| %>
         <% @other_placements.each do |placement| %>
           <% body.with_row do |row| %>
-            <% row.with_cell(text: govuk_link_to(placement.title, placements_provider_partner_school_placement_path(@provider, @partner_school, placement))) %>
+            <% row.with_cell(text: govuk_link_to(placement.title, placements_provider_partner_school_placement_path(@provider, @partner_school, placement)), no_visited_state: true) %>
             <% row.with_cell do %>
               <%= render Placement::StatusTagComponent.new(placement:) %>
             <% end %>

--- a/app/views/placements/providers/partner_schools/placements/index.html.erb
+++ b/app/views/placements/providers/partner_schools/placements/index.html.erb
@@ -1,0 +1,58 @@
+<% content_for :page_title, "Placements" %>
+<%= render "placements/providers/primary_navigation", provider: @provider, current_navigation: :partner_schools %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: placements_provider_partner_schools_path) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h1 class="govuk-heading-l"><%= @partner_school.name %></h1>
+    </div>
+
+    <%= render "placements/providers/partner_schools/sub_navigation", school: @partner_school, provider: @provider, current_navigation: :school_details %>
+
+    <%= govuk_table(html_attributes: { id: "placements-assigned-to-you" }) do |table| %>
+      <% table.with_caption(size: "m", text: "Placements assigned to you") %>
+
+      <% table.with_head do |head| %>
+        <% head.with_row do |row| %>
+          <% row.with_cell(text: t(".subject")) %>
+          <% row.with_cell(text: "Mentors") %>
+        <% end %>
+      <% end %>
+
+      <% table.with_body do |body| %>
+        <% @placements_assigned_to_provider.each do |placement| %>
+          <% body.with_row do |row| %>
+            <% row.with_cell(text: govuk_link_to(placement.title, placements_provider_partner_school_placement_path(@provider, @partner_school, placement))) %>
+            <% row.with_cell(text: placement.mentor_names) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <%= govuk_table(html_attributes: { id: "other-placements" }) do |table| %>
+      <% table.with_caption(size: "m", text: "Other placements") %>
+
+      <% table.with_head do |head| %>
+        <% head.with_row do |row| %>
+          <% row.with_cell(text: "Subject") %>
+          <% row.with_cell(text: "Status") %>
+        <% end %>
+      <% end %>
+
+      <% table.with_body do |body| %>
+        <% @other_placements.each do |placement| %>
+          <% body.with_row do |row| %>
+            <% row.with_cell(text: govuk_link_to(placement.title, placements_provider_partner_school_placement_path(@provider, @partner_school, placement))) %>
+            <% row.with_cell do %>
+              <%= render Placement::StatusTagComponent.new(placement:) %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/placements/providers/partner_schools/placements/index.html.erb
+++ b/app/views/placements/providers/partner_schools/placements/index.html.erb
@@ -26,7 +26,7 @@
       <% table.with_body do |body| %>
         <% @placements_assigned_to_provider.each do |placement| %>
           <% body.with_row do |row| %>
-            <% row.with_cell(text: govuk_link_to(placement.title, placements_provider_partner_school_placement_path(@provider, @partner_school, placement)), no_visited_state: true) %>
+            <% row.with_cell(text: govuk_link_to(placement.title, placements_provider_partner_school_placement_path(@provider, @partner_school, placement), no_visited_state: true)) %>
             <% row.with_cell(text: placement.mentor_names) %>
           <% end %>
         <% end %>
@@ -46,7 +46,7 @@
       <% table.with_body do |body| %>
         <% @other_placements.each do |placement| %>
           <% body.with_row do |row| %>
-            <% row.with_cell(text: govuk_link_to(placement.title, placements_provider_partner_school_placement_path(@provider, @partner_school, placement)), no_visited_state: true) %>
+            <% row.with_cell(text: govuk_link_to(placement.title, placements_provider_partner_school_placement_path(@provider, @partner_school, placement), no_visited_state: true)) %>
             <% row.with_cell do %>
               <%= render Placement::StatusTagComponent.new(placement:) %>
             <% end %>

--- a/app/views/placements/providers/partner_schools/placements/index.html.erb
+++ b/app/views/placements/providers/partner_schools/placements/index.html.erb
@@ -9,50 +9,51 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-l"><%= @partner_school.name %></h1>
+      <%= render "placements/providers/partner_schools/sub_navigation", school: @partner_school, provider: @provider, current_navigation: :school_details %>
     </div>
 
-    <%= render "placements/providers/partner_schools/sub_navigation", school: @partner_school, provider: @provider, current_navigation: :school_details %>
+    <div class="govuk-grid-column-two-thirds">
+      <%= govuk_table(html_attributes: { id: "placements-assigned-to-you" }) do |table| %>
+        <% table.with_caption(size: "m", text: t(".placements_assigned_to_you")) %>
 
-    <%= govuk_table(html_attributes: { id: "placements-assigned-to-you" }) do |table| %>
-      <% table.with_caption(size: "m", text: t(".placements_assigned_to_you")) %>
-
-      <% table.with_head do |head| %>
-        <% head.with_row do |row| %>
-          <% row.with_cell(text: t(".subject"), width: "govuk-!-width-one-half") %>
-          <% row.with_cell(text: t(".mentors")) %>
-        <% end %>
-      <% end %>
-
-      <% table.with_body do |body| %>
-        <% @placements_assigned_to_provider.each do |placement| %>
-          <% body.with_row do |row| %>
-            <% row.with_cell(text: govuk_link_to(placement.title, placements_provider_partner_school_placement_path(@provider, @partner_school, placement), no_visited_state: true)) %>
-            <% row.with_cell(text: placement.mentor_names) %>
+        <% table.with_head do |head| %>
+          <% head.with_row do |row| %>
+            <% row.with_cell(text: t(".subject"), width: "govuk-!-width-one-half") %>
+            <% row.with_cell(text: t(".mentors")) %>
           <% end %>
         <% end %>
-      <% end %>
-    <% end %>
 
-    <%= govuk_table(html_attributes: { id: "other-placements" }) do |table| %>
-      <% table.with_caption(size: "m", text: t(".other_placements")) %>
-
-      <% table.with_head do |head| %>
-        <% head.with_row do |row| %>
-          <% row.with_cell(text: t(".subject"), width: "govuk-!-width-one-half") %>
-          <% row.with_cell(text: t(".status")) %>
-        <% end %>
-      <% end %>
-
-      <% table.with_body do |body| %>
-        <% @other_placements.each do |placement| %>
-          <% body.with_row do |row| %>
-            <% row.with_cell(text: govuk_link_to(placement.title, placements_provider_partner_school_placement_path(@provider, @partner_school, placement), no_visited_state: true)) %>
-            <% row.with_cell do %>
-              <%= render Placement::StatusTagComponent.new(placement:) %>
+        <% table.with_body do |body| %>
+          <% @placements_assigned_to_provider.each do |placement| %>
+            <% body.with_row do |row| %>
+              <% row.with_cell(text: govuk_link_to(placement.title, placements_provider_partner_school_placement_path(@provider, @partner_school, placement), no_visited_state: true)) %>
+              <% row.with_cell(text: placement.mentor_names) %>
             <% end %>
           <% end %>
         <% end %>
       <% end %>
-    <% end %>
+
+      <%= govuk_table(html_attributes: { id: "other-placements" }) do |table| %>
+        <% table.with_caption(size: "m", text: t(".other_placements")) %>
+
+        <% table.with_head do |head| %>
+          <% head.with_row do |row| %>
+            <% row.with_cell(text: t(".subject"), width: "govuk-!-width-one-half") %>
+            <% row.with_cell(text: t(".status")) %>
+          <% end %>
+        <% end %>
+
+        <% table.with_body do |body| %>
+          <% @other_placements.each do |placement| %>
+            <% body.with_row do |row| %>
+              <% row.with_cell(text: govuk_link_to(placement.title, placements_provider_partner_school_placement_path(@provider, @partner_school, placement), no_visited_state: true)) %>
+              <% row.with_cell do %>
+                <%= render Placement::StatusTagComponent.new(placement:) %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/placements/providers/partner_schools/placements/index.html.erb
+++ b/app/views/placements/providers/partner_schools/placements/index.html.erb
@@ -18,7 +18,7 @@
 
       <% table.with_head do |head| %>
         <% head.with_row do |row| %>
-          <% row.with_cell(text: t(".subject")) %>
+          <% row.with_cell(text: t(".subject"), width: "govuk-!-width-one-half") %>
           <% row.with_cell(text: t(".mentors")) %>
         <% end %>
       <% end %>
@@ -38,7 +38,7 @@
 
       <% table.with_head do |head| %>
         <% head.with_row do |row| %>
-          <% row.with_cell(text: t(".subject")) %>
+          <% row.with_cell(text: t(".subject"), width: "govuk-!-width-one-half") %>
           <% row.with_cell(text: t(".status")) %>
         <% end %>
       <% end %>

--- a/app/views/placements/providers/partner_schools/placements/index.html.erb
+++ b/app/views/placements/providers/partner_schools/placements/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Placements" %>
+<% content_for :page_title, t(".title") %>
 <%= render "placements/providers/primary_navigation", provider: @provider, current_navigation: :partner_schools %>
 
 <%= content_for(:before_content) do %>
@@ -14,12 +14,12 @@
     <%= render "placements/providers/partner_schools/sub_navigation", school: @partner_school, provider: @provider, current_navigation: :school_details %>
 
     <%= govuk_table(html_attributes: { id: "placements-assigned-to-you" }) do |table| %>
-      <% table.with_caption(size: "m", text: "Placements assigned to you") %>
+      <% table.with_caption(size: "m", text: t(".placements_assigned_to_you")) %>
 
       <% table.with_head do |head| %>
         <% head.with_row do |row| %>
           <% row.with_cell(text: t(".subject")) %>
-          <% row.with_cell(text: "Mentors") %>
+          <% row.with_cell(text: t(".mentors")) %>
         <% end %>
       <% end %>
 
@@ -34,12 +34,12 @@
     <% end %>
 
     <%= govuk_table(html_attributes: { id: "other-placements" }) do |table| %>
-      <% table.with_caption(size: "m", text: "Other placements") %>
+      <% table.with_caption(size: "m", text: t(".other_placements")) %>
 
       <% table.with_head do |head| %>
         <% head.with_row do |row| %>
-          <% row.with_cell(text: "Subject") %>
-          <% row.with_cell(text: "Status") %>
+          <% row.with_cell(text: t(".subject")) %>
+          <% row.with_cell(text: t(".status")) %>
         <% end %>
       <% end %>
 

--- a/app/views/placements/providers/partner_schools/placements/show.html.erb
+++ b/app/views/placements/providers/partner_schools/placements/show.html.erb
@@ -1,0 +1,11 @@
+<%= content_for :page_title, sanitize(@placement.title) %>
+
+<%= render "placements/providers/primary_navigation", provider: @provider, current_navigation: :partner_schools %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: :back) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= render "placements/placements/placement_details", school: @placement.school, placement: @placement %>
+</div>

--- a/app/views/placements/providers/partner_schools/show.html.erb
+++ b/app/views/placements/providers/partner_schools/show.html.erb
@@ -9,9 +9,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-l"><%= @partner_school.name %></h1>
+      <%= render "placements/providers/partner_schools/sub_navigation", school: @partner_school, provider: @provider, current_navigation: :school_details %>
     </div>
 
-    <%= render "placements/providers/partner_schools/sub_navigation", school: @partner_school, provider: @provider, current_navigation: :school_details %>
 
     <div class="govuk-grid-column-two-thirds">
       <%= render "shared/organisations/organisation_details", organisation: @partner_school %>

--- a/app/views/placements/providers/partner_schools/show.html.erb
+++ b/app/views/placements/providers/partner_schools/show.html.erb
@@ -12,7 +12,6 @@
       <%= render "placements/providers/partner_schools/sub_navigation", school: @partner_school, provider: @provider, current_navigation: :school_details %>
     </div>
 
-
     <div class="govuk-grid-column-two-thirds">
       <%= render "shared/organisations/organisation_details", organisation: @partner_school %>
       <h2 class="govuk-heading-m govuk-!-margin-top-9"><%= t(".additional_details") %></h2>

--- a/app/views/placements/providers/partner_schools/show.html.erb
+++ b/app/views/placements/providers/partner_schools/show.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title, t(".page_title") %>
 <%= render "placements/providers/primary_navigation", provider: @provider, current_navigation: :partner_schools %>
+
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: placements_provider_partner_schools_path) %>
 <% end %>
@@ -9,6 +10,9 @@
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-l"><%= @partner_school.name %></h1>
     </div>
+
+    <%= render "placements/providers/partner_schools/sub_navigation", school: @partner_school, provider: @provider, current_navigation: :school_details %>
+
     <div class="govuk-grid-column-two-thirds">
       <%= render "shared/organisations/organisation_details", organisation: @partner_school %>
       <h2 class="govuk-heading-m govuk-!-margin-top-9"><%= t(".additional_details") %></h2>

--- a/app/views/placements/wizards/add_placement_wizard/_check_your_answers_step.html.erb
+++ b/app/views/placements/wizards/add_placement_wizard/_check_your_answers_step.html.erb
@@ -73,7 +73,7 @@
 
       <div class="govuk-button-group">
         <%= f.govuk_submit t(".publish_placement") %>
-        <%= govuk_link_to t(".preview_placement"), step_path(:preview_placement) %>
+        <%= govuk_link_to t(".preview_placement"), step_path(:preview_placement), no_visited_state: true %>
       </div>
     </div>
   </div>

--- a/config/locales/en/placements/providers/partner_schools.yml
+++ b/config/locales/en/placements/providers/partner_schools.yml
@@ -44,8 +44,12 @@ en:
 
             ofsted_rating: Ofsted rating
             percentage_free_school_meals: Percentage free school meals
-
           index:
+            title: Placements
+            placements_assigned_to_you: Placements assigned to you
             subject: Subject
             mentors: Mentors
+            other_placements: Other placements
+            status: Status
+
           show:

--- a/config/locales/en/placements/providers/partner_schools.yml
+++ b/config/locales/en/placements/providers/partner_schools.yml
@@ -28,5 +28,24 @@ en:
           school_will_be_sent_an_email: We will send an email to %{school_name}. This will let them know you have removed them as a partner school for %{provider_name}.
         destroy: 
           partner_school_removed: Partner school removed
+        placements:
+          details:
+            placement_contact: Placement contact
+            placement_contact_email: Email
+            placement_contact_name: Name
+            address: Address
+            school_details: School details
+            establishment_group: Establishment group
+            phase: Phase
+            gender: Gender
+            age_range: Age range
+            religious_character: Religious character
+            urban_or_rural: Urban or rural
 
+            ofsted_rating: Ofsted rating
+            percentage_free_school_meals: Percentage free school meals
 
+          index:
+            subject: Subject
+            mentors: Mentors
+          show:

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -19,6 +19,11 @@ en:
             year_group:
               invalid: Select a year group
   placements:
+    providers:
+      partner_schools:
+        sub_navigation:
+          school_details: School details
+          placements: Placements
     schools:
       placements:
         table:

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -201,6 +201,10 @@ scope module: :placements,
           get "new/:step", to: "partner_schools/add_partner_school#edit", as: :add_partner_school
           put "new/:step", to: "partner_schools/add_partner_school#update"
         end
+
+        scope module: :partner_schools do
+          resources :placements, only: %i[index show]
+        end
       end
     end
   end

--- a/spec/system/placements/providers/partner_schools/placements/view_a_placement_for_partner_school_spec.rb
+++ b/spec/system/placements/providers/partner_schools/placements/view_a_placement_for_partner_school_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe "Placements / Providers / Partner schools / Placements / View a placement for partner school",
+               service: :placements, type: :system do
+  let!(:provider) { create(:placements_provider) }
+  let!(:school) { create(:placements_school, phase: :primary, rating: "Good") }
+  let(:placements_partnership) { create(:placements_partnership, school:, provider:) }
+  let!(:assigned_placement) { create(:placement, school:, provider:) }
+
+  before do
+    placements_partnership
+    given_i_sign_in_as_patricia
+  end
+
+  scenario "User views a placement for a partner school" do
+    when_i_view_the_partner_school_placements_page
+    and_i_click_on_a_placement(assigned_placement)
+    then_i_see_the_placement_details_page
+  end
+
+  private
+
+  def given_i_sign_in_as_patricia
+    user = create(:placements_user, :patricia)
+    create(:user_membership, user:, organisation: provider)
+    user_exists_in_dfe_sign_in(user:)
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def when_i_view_the_partner_school_placements_page
+    visit placements_provider_partner_school_placements_path(provider, school)
+  end
+
+  def and_i_click_on_a_placement(placement)
+    click_on placement.decorate.title
+  end
+
+  def when_i_click_on_the_placements_sub_nav
+    within ".app-secondary-navigation" do
+      click_on "Placements"
+    end
+  end
+
+  def then_i_see_the_placement_details_page
+    expect(page).to have_content(assigned_placement.decorate.title)
+    expect(page).to have_content(school.rating)
+    expect(page).to have_content(school.phase)
+  end
+end

--- a/spec/system/placements/providers/partner_schools/placements/view_placements_for_partner_school_spec.rb
+++ b/spec/system/placements/providers/partner_schools/placements/view_placements_for_partner_school_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe "Placements / Providers / Partner schools / Placements / View placements for partner school",
+               service: :placements, type: :system do
+  let!(:provider) { create(:placements_provider) }
+  let!(:school) { create(:placements_school) }
+  let(:placements_partnership) { create(:placements_partnership, school:, provider:) }
+  let!(:assigned_placement) { create(:placement, school:, provider:) }
+  let!(:unassigned_placement) { create(:placement, school:) }
+
+  before do
+    placements_partnership
+    given_i_sign_in_as_patricia
+  end
+
+  scenario "User views placements for a partner school" do
+    when_i_view_the_partner_school_show_page
+    then_i_see_the_placements_tab
+    when_i_click_on_the_placements_sub_nav
+    then_i_see_the_placements_page
+  end
+
+  private
+
+  def given_i_sign_in_as_patricia
+    user = create(:placements_user, :patricia)
+    create(:user_membership, user:, organisation: provider)
+    user_exists_in_dfe_sign_in(user:)
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  alias_method :and_i_sign_in_as_patricia, :given_i_sign_in_as_patricia
+
+  def when_i_view_the_partner_school_show_page
+    visit placements_provider_partner_school_path(provider, school)
+  end
+
+  def then_i_see_the_placements_tab
+    expect(page).to have_text("Placements")
+  end
+
+  def when_i_click_on_the_placements_sub_nav
+    within ".app-secondary-navigation" do
+      click_on "Placements"
+    end
+  end
+
+  def then_i_see_the_placements_page
+    within "#placements-assigned-to-you" do
+      expect(page).to have_content(assigned_placement.decorate.title)
+      expect(page).to have_content("Not yet known")
+    end
+
+    within "#other-placements" do
+      expect(page).to have_content(unassigned_placement.decorate.title)
+      expect(page).to have_content("Available")
+    end
+  end
+end


### PR DESCRIPTION
## Context

Adds a placements index and show page when viewing a partner school as provider

## Changes proposed in this pull request

- [x] Adds placements show page for partner provider
- [x] Adds placement index page for partner provider
- [x] Adds sub navigation for partner provider

## Guidance to review

- Log in as Patricia
- Navigate to partner schools
- Click on placements in the new sub nav
- Click on a placement

## Link to Trello card

[Add a 'Placements' section to partner schools](https://trello.com/c/MqulMHHA/618-add-a-placements-section-to-partner-schools)

## Screenshots

![image](https://github.com/user-attachments/assets/946265e8-1eb0-4f81-9bd4-79ce581dce87)
![image](https://github.com/user-attachments/assets/7b984bff-d536-46ef-8de9-445b2591b798)
![image](https://github.com/user-attachments/assets/4058b7e5-e5d5-416c-b4bc-fb71c396358e)
