### PR TITLE
Add a migration step to the deployment

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -50,19 +50,6 @@ jobs:
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
           pull-request-number: ${{ github.event.number }}
 
-      - uses: azure/login@v2
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-      - name: Seed Review App
-        shell: bash
-        if: github.event.number != ''
-        run: |
-          make ci review get-cluster-credentials
-          kubectl exec -n bat-qa deployment/itt-mentor-services-${{ github.event.number }} -- sh -c "export GIAS_CSV_BASE_URL=https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public  && export PUBLISH_BASE_URL=https://qa.api.publish-teacher-training-courses.service.gov.uk// && cd /app && /usr/local/bin/rake db:seed"
-        env:
-          PR_NUMBER: ${{ github.event.number }}
-
       - name: Post comment to Pull Request ${{ github.event.number }}
         if: ${{ github.event_name == 'pull_request' }}
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,11 +9,11 @@ on:
         type: choice
         default: review
         options:
-        - qa
-        - review
-        - staging
-        - sandbox
-        - dv
+          - qa
+          - review
+          - staging
+          - sandbox
+          - dv
       sha:
         description: Commit sha to be deployed
         required: true
@@ -54,15 +54,6 @@ jobs:
           docker-image: ${{ github.event.inputs.sha }}
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
           pull-request-number: ${{ github.event.inputs.pr_number }}
-
-      - name: Seed Review App
-        shell: bash
-        if: github.event.inputs.pr_number!= '' && ${{ github.event.inputs.environment == 'review' }}
-        run: |
-          make ci review get-cluster-credentials
-          kubectl exec -n bat-qa deployment/itt-mentor-services-${{ github.event.inputs.pr_number }} -- sh -c "export GIAS_CSV_BASE_URL=https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public  && export PUBLISH_BASE_URL=https://qa.api.publish-teacher-training-courses.service.gov.uk// && cd /app && /usr/local/bin/rake db:seed"
-        env:
-          PR_NUMBER: ${{ github.event.inputs.pr_number }}
 
       - name: Post comment to Pull Request ${{ github.event.inputs.pr_number }}
         if: ${{ github.event.inputs.environment == 'review' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,5 +76,4 @@ RUN apk add --no-cache proj-util
 COPY --from=builder /app /app
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 
-CMD bundle exec rails db:migrate:with_data && \
-    bundle exec rails server -b 0.0.0.0
+CMD bundle exec rails server -b 0.0.0.0

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -53,6 +53,30 @@ resource "kubernetes_job" "migrations" {
               name = module.application_configuration.kubernetes_secret_name
             }
           }
+
+          resources {
+            requests = {
+              cpu    = module.cluster_data.configuration_map.cpu_min
+              memory = "1Gi"
+            }
+            limits = {
+              cpu    = 1
+              memory = "1Gi"
+            }
+          }
+
+          security_context {
+            allow_privilege_escalation = false
+
+            seccomp_profile {
+              type = "RuntimeDefault"
+            }
+
+            capabilities {
+              drop = ["ALL"]
+              add  = ["NET_BIND_SERVICE"]
+            }
+          }
         }
 
         restart_policy = "Never"

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -34,7 +34,14 @@ resource "kubernetes_job" "migrations" {
 
   spec {
     template {
-      metadata {}
+      metadata {
+        labels = { app = "${var.service_name}-${var.environment}-migrations" }
+        annotations = {
+          "logit.io/send"        = "true"
+          "fluentbit.io/exclude" = "true"
+        }
+      }
+
       spec {
         container {
           name    = "migrate"


### PR DESCRIPTION
## Context

We've been experiencing issues with review apps due to the way database migrations are run by the deployment pipeline.

Migrations currently run inline within the web app container. The web app is started with the command `rails db:migrate && rails server`, which is a straightforward but slightly hacky way to run migrations before starting the server. It works on the assumption that your web app is the only service which depends on the database schema being up to date.

However in our case, we have a separate service called [Good Job](https://github.com/bensheldon/good_job) which runs alongside the web app to process background jobs. This service also has a dependency on the same Postgres database that our web app uses. Therefore it's important that our deployment pipeline runs migrations _before_ attempting to start the web app and Good Job worker, since they both depend on schema migrations having been successfully run.

For more details about the problem, refer to [the Trello card](https://trello.com/c/LcIqY4Fo/630-update-terraform-configuration-to-run-migrations-before-starting-the-app-and-worker) and [this Slack thread](https://ukgovernmentdfe.slack.com/archives/C011EM7HU85/p1722270014308649).

## Changes proposed in this pull request

This pull request makes the following changes:

### 1. Run migrations before starting the web app and Good Job worker

This is done through the introduction of a new Kubernetes Job resource in the Terraform template.

When deployed, Terraform will wait for the migration job to complete before spinning up the web app and worker. This works because I've configured the migration job with `wait_for_completion = true`, and made the web app & worker modules dependent on it with `depends_on = [kubernetes_job.migrations]`.

### 2. Use `rails db:prepare` to speed up review app initialisation

Rather than using `rails db:migrate`, I've switched to using `rails db:prepare`.

This means that new review apps should spin up quicker because the database schema will be loaded from `schema.rb` rather than generated by running every migration sequentially.

It also means that we no longer need to explicitly seed the database in review apps. That's taken care of by `rails db:prepare` too.

For more details about what the command does, see the [Rails migrations guide](https://guides.rubyonrails.org/active_record_migrations.html#preparing-the-database).

### 3. Remove `rails db:migrate` from `Dockerfile`

The default image command no longer needs to include `rails db:migrate` because migrations are now handled separately at deploy time.

## Guidance to review

See the review app for this PR.

## Link to Trello card

https://trello.com/c/LcIqY4Fo/630-update-terraform-configuration-to-run-migrations-before-starting-the-app-and-worker
