### PR TITLE
Prevent support from deleting assigned placements

### DIFF
--- a/app/controllers/placements/schools/placements_controller.rb
+++ b/app/controllers/placements/schools/placements_controller.rb
@@ -24,7 +24,7 @@ class Placements::Schools::PlacementsController < Placements::ApplicationControl
     authorize @placement
 
     @placement.destroy!
-    redirect_to placements_school_placements_path(@school), flash: { success: t(".placement_deleted") }
+    redirect_to index_path, flash: { success: t(".placement_deleted") }
   end
 
   private
@@ -51,5 +51,9 @@ class Placements::Schools::PlacementsController < Placements::ApplicationControl
 
   def add_mentor_path
     placements_school_mentors_path
+  end
+
+  def index_path
+    placements_school_placements_path(@school)
   end
 end

--- a/app/controllers/placements/support/schools/placements_controller.rb
+++ b/app/controllers/placements/support/schools/placements_controller.rb
@@ -1,31 +1,8 @@
-class Placements::Support::Schools::PlacementsController < Placements::ApplicationController
-  before_action :set_school
-  before_action :set_placement, except: %i[index]
-
-  helper_method :edit_attribute_path, :add_provider_path, :add_mentor_path
-
-  def index
-    @pagy, placements = pagy(@school.placements.includes(:subject, :mentors).order("subjects.name"))
-    @placements = placements.decorate
-  end
-
-  def show; end
-
-  def remove; end
-
-  def destroy
-    @placement.destroy!
-    redirect_to placements_support_school_placements_path(@school), flash: { success: t(".placement_removed") }
-  end
-
+class Placements::Support::Schools::PlacementsController < Placements::Schools::PlacementsController
   private
 
   def set_school
     @school = Placements::School.find(params.fetch(:school_id))
-  end
-
-  def set_placement
-    @placement = @school.placements.find(params.fetch(:id)).decorate
   end
 
   def edit_attribute_path(attribute)
@@ -38,5 +15,9 @@ class Placements::Support::Schools::PlacementsController < Placements::Applicati
 
   def add_mentor_path
     placements_support_school_mentors_path
+  end
+
+  def index_path
+    placements_support_school_placements_path(@school)
   end
 end

--- a/app/views/placements/support/schools/placements/can_not_remove.html.erb
+++ b/app/views/placements/support/schools/placements/can_not_remove.html.erb
@@ -1,0 +1,26 @@
+<%= content_for :page_title, sanitize(t(".page_title", subject_names: @placement.title, school_name: @school.name)) %>
+
+<%= render "placements/support/primary_navigation", current_navigation: :organisations %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: placements_support_school_placement_path(@school, @placement)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <label class="govuk-label govuk-label--l">
+          <span class="govuk-caption-l">
+            <%= t(".placement_title", subject_names: @placement.title, school_name: @school.name) %>
+          </span>
+          <%= t("placements.schools.placements.can_not_remove.title") %>
+        </label>
+
+        <p class="govuk-body">
+          <%= simple_format(t("placements.schools.placements.can_not_remove.description",
+            subject_names: @placement.title,
+            provider_name: @placement.provider.name)) %>
+        </p>
+    </div>
+  </div>
+</div>

--- a/app/views/placements/support/schools/placements/confirm_remove.html.erb
+++ b/app/views/placements/support/schools/placements/confirm_remove.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, sanitize(t(".page_title", subject_names: @placement.title)) %>
+<%= content_for :page_title, sanitize(t(".page_title", subject_names: @placement.title, school_name: @school.name)) %>
 
 <%= render "placements/support/primary_navigation", current_navigation: :organisations %>
 
@@ -14,7 +14,7 @@
         <%= t(".are_you_sure") %>
       </label>
 
-      <%= govuk_button_to t(".remove_placement"),
+      <%= govuk_button_to t(".delete_placement"),
         placements_support_school_placement_path(@school, @placement),
         warning: true,
         method: :delete %>

--- a/app/views/placements/support/schools/placements/show.html.erb
+++ b/app/views/placements/support/schools/placements/show.html.erb
@@ -16,7 +16,7 @@
 
       <%= render "placements/schools/placements/details", school: @school, placement: @placement, support: true %>
 
-      <%= govuk_link_to t(".remove_placement"),
+      <%= govuk_link_to t(".delete_placement"),
                         remove_placements_support_school_placement_path(@school, @placement),
                         class: "app-link app-link--destructive" %>
 

--- a/config/locales/en/placements/support/schools/placements.yml
+++ b/config/locales/en/placements/support/schools/placements.yml
@@ -18,11 +18,14 @@ en:
             page_title: Placements
             placements: Placements
             add_placement: Add placement
-          remove:
-            page_title: "Are you sure you want to remove this placement? - %{subject_names}"
-            are_you_sure: Are you sure you want to remove this placement?
+          confirm_remove:
+            page_title: "Are you sure you want to delete this placement? - %{subject_names} - %{school_name}"
+            are_you_sure: Are you sure you want to delete this placement?
             cancel: Cancel
-            remove_placement: Remove placement
+            delete_placement: Delete placement
+          can_not_remove:
+            page_title: "You cannot delete this placement - %{subject_names} - %{school_name}"
+            placement_title: "%{subject_names} - %{school_name}"
           show:
             page_title: "%{placement_name} - Placements - %{school_name}"
             caption: "Placements - %{school_name}"
@@ -33,6 +36,6 @@ en:
                 additional_subjects: Additional subjects
                 mentor: Mentor
                 status: Status
-            remove_placement: Remove placement
+            delete_placement: Delete placement
           destroy:
-            placement_removed: Placement removed
+            placement_deleted: Placement deleted

--- a/spec/system/placements/support/schools/placements/support_user_deletes_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/support_user_deletes_a_placement_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Placements / Support / Schools / Placement / Support User removes a placement",
+RSpec.describe "Placements / Support / Schools / Placement / Support User deletes a placement",
                service: :placements, type: :system do
   let(:school) { create(:placements_school, name: "School 1", phase: "Nursery") }
   let(:placement_1) do
@@ -17,19 +17,25 @@ RSpec.describe "Placements / Support / Schools / Placement / Support User remove
   before do
     placement_2
     given_i_sign_in_as_colin
+    when_i_visit_the_support_show_page_for(school, placement_1)
   end
 
-  scenario "Support User removes a placement from a school" do
-    when_i_visit_the_support_show_page_for(school, placement_1)
-    and_i_click_on("Remove placement")
-    then_i_am_asked_to_confirm(placement_1)
+  scenario "Support User deletes a placement from a school" do
+    and_i_click_on("Delete placement")
+    then_i_am_asked_to_confirm(school, placement_1)
     when_i_click_on("Cancel")
     then_i_return_to_placement_page(school, placement_1)
-    when_i_click_on("Remove placement")
-    then_i_am_asked_to_confirm(placement_1)
-    when_i_click_on("Remove placement")
-    then_the_placement_is_removed_from_the_school(school, placement_1)
+    when_i_click_on("Delete placement")
+    then_i_am_asked_to_confirm(school, placement_1)
+    when_i_click_on("Delete placement")
+    then_the_placement_is_deleted_from_the_school(school, placement_1)
     and_a_school_placement_remains_called(placement_2.decorate.title)
+  end
+
+  scenario "User can not delete a placement assigned to a provider" do
+    given_the_placement_is_assigned_to_a_provider(placement_1)
+    and_i_click_on("Delete placement")
+    then_i_see_i_can_not_delete_the_placement(placement_1)
   end
 
   private
@@ -62,12 +68,12 @@ RSpec.describe "Placements / Support / Schools / Placement / Support User remove
   end
   alias_method :and_i_click_on, :when_i_click_on
 
-  def then_i_am_asked_to_confirm(placement)
+  def then_i_am_asked_to_confirm(school, placement)
     organisations_is_selected_in_primary_nav
     expect(page).to have_title(
-      "Are you sure you want to remove this placement? - #{placement.decorate.title} - Manage school placements",
+      "Are you sure you want to delete this placement? - #{placement.decorate.title} - #{school.name} - Manage school placements",
     )
-    expect(page).to have_content "Are you sure you want to remove this placement?"
+    expect(page).to have_content "Are you sure you want to delete this placement?"
   end
 
   def organisations_is_selected_in_primary_nav
@@ -83,12 +89,12 @@ RSpec.describe "Placements / Support / Schools / Placement / Support User remove
                                       ignore_query: true
   end
 
-  def then_the_placement_is_removed_from_the_school(school, placement)
+  def then_the_placement_is_deleted_from_the_school(school, placement)
     organisations_is_selected_in_primary_nav
     placements_is_selected_in_secondary_nav
     expect(school.placements.find_by(id: placement.id)).to be_nil
     within(".govuk-notification-banner__content") do
-      expect(page).to have_content "Placement removed"
+      expect(page).to have_content "Placement deleted"
     end
 
     expect(page).not_to have_content placement.subject.name
@@ -106,5 +112,14 @@ RSpec.describe "Placements / Support / Schools / Placement / Support User remove
 
   def and_a_school_placement_remains_called(placement_name)
     expect(page).to have_content(placement_name)
+  end
+
+  def given_the_placement_is_assigned_to_a_provider(placement)
+    placement.update!(provider: create(:placements_provider))
+  end
+
+  def then_i_see_i_can_not_delete_the_placement(placement)
+    expect(page).to have_content(placement.decorate.title)
+    expect(page).to have_content("You cannot delete this placement")
   end
 end


### PR DESCRIPTION
## Context

- Align support's placement functionality with what currently exists for school users
- Prevent support users from deleting placements if they are assigned to a provider.

## Guidance to review

- Sign in as Colin (Support User)
- Select a school with placements
- Click on a placement
- (Assign a provider to the placement if one is not assigned)
- Click "Delete placement"
- You should see a page with text explaining why you can not delete this placement

## Link to Trello card

https://trello.com/c/7ZEGQQ4a/648-prevent-support-from-deleting-assigned-placements

## Screenshots

https://github.com/user-attachments/assets/0708d6ba-dd87-4b07-895b-571d20c8d7ed


