### PR TITLE
Remove unused routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,11 +32,6 @@ Rails.application.routes.draw do
   namespace :api do
     resources :school_suggestions, only: [:index]
     resources :provider_suggestions, only: [:index]
-
-    namespace :placements do
-      resources :school_suggestions, only: [:index]
-      resources :provider_suggestions, only: [:index]
-    end
   end
 
   draw :placements

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -71,8 +71,6 @@ scope module: :placements,
             put "edit/:step", to: "placements/edit_placement#update"
           end
 
-          collection { get :check }
-
           collection do
             get "new", to: "placements/add_placement#new", as: :new_add_placement
             get "new/:step", to: "placements/add_placement#edit", as: :add_placement


### PR DESCRIPTION
## Context

- Remove unused routes.
- Based on running `bin/rails routes --unused` the following placements routes need to be removed:

```
Prefix Verb  URI Pattern                                            Controller#Action
         api_placements_school_suggestions GET   /api/placements/school_suggestions(.:format)           api/placements/school_suggestions#index
       api_placements_provider_suggestions GET   /api/placements/provider_suggestions(.:format)         api/placements/provider_suggestions#index
check_placements_support_school_placements GET   /support/schools/:school_id/placements/check(.:format) placements/support/schools/placements#check
```

## Link to Trello card

https://trello.com/c/CBtCmcHU/656-remove-unused-placements-routes
