### PR TITLE
Refactor academic year model to consolidate hardcoded magic dates

### DIFF
--- a/app/models/academic_year.rb
+++ b/app/models/academic_year.rb
@@ -13,4 +13,28 @@ class AcademicYear < ApplicationRecord
   validates :name, presence: true
   validates :starts_on, presence: true
   validates :ends_on, presence: true, comparison: { greater_than_or_equal_to: :starts_on }
+
+  START_DATE = {
+    day: 1,
+    month: 9, # September
+  }.freeze
+
+  END_DATE = {
+    day: 31,
+    month: 8, # August
+  }.freeze
+
+  def self.for_date(date)
+    existing_academic_year = find_by(starts_on: ..date, ends_on: date..)
+    return existing_academic_year if existing_academic_year.present?
+
+    start_year = date.month < START_DATE[:month] ? date.year - 1 : date.year
+    starts_on = Date.new(start_year, START_DATE[:month], START_DATE[:day])
+    ends_on = Date.new(start_year + 1, END_DATE[:month], END_DATE[:day])
+    create!(
+      starts_on:,
+      ends_on:,
+      name: "#{start_year} to #{start_year + 1}",
+    )
+  end
 end

--- a/app/services/claims/claim_window/build.rb
+++ b/app/services/claims/claim_window/build.rb
@@ -20,11 +20,6 @@ class Claims::ClaimWindow::Build
   def find_academic_year
     return unless claim_window.starts_on
 
-    year = claim_window.starts_on.month > 1 ? claim_window.starts_on.year - 1 : claim_window.starts_on.year - 2
-
-    AcademicYear.create_with(
-      starts_on: Date.new(year, 9, 1),
-      ends_on: Date.new(year + 1, 8, 31),
-    ).find_or_create_by!(name: "#{year} to #{year + 1}")
+    AcademicYear.for_date(claim_window.starts_on)
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -79,36 +79,26 @@ end
 PublishTeacherTraining::Subject::Import.call
 
 # Create academic years
-year = Date.current.year
-month = Date.current.month
+current_date = Date.current
 
-current_academic_year = if month < 9
-                          year - 1
-                        else
-                          year
-                        end
+# Create academic years here
+current_academic_year = AcademicYear.for_date(current_date)
+previous_academic_year = AcademicYear.for_date(current_date - 1.year)
+next_academic_year = AcademicYear.for_date(current_date + 1.year)
 
-previous_academic_year = current_academic_year - 1
-next_academic_year = current_academic_year + 1
-
-[previous_academic_year, current_academic_year, next_academic_year].each do |start_year|
-  end_year = start_year + 1
-  academic_year = AcademicYear.find_or_create_by!(
-    starts_on: Date.parse("1 September #{start_year}"),
-    ends_on: Date.parse("31 August #{end_year}"),
-    name: "#{start_year} to #{end_year}",
-  )
-  next unless start_year == current_academic_year
+# Loop through to create a claim windows only for the current year
+[previous_academic_year, current_academic_year, next_academic_year].each do |academic_year|
+  next unless academic_year == current_academic_year
 
   Claims::ClaimWindow.find_or_create_by!(
-    starts_on: Date.parse("2 May #{end_year}"),
-    ends_on: Date.parse("19 July #{end_year}"),
+    starts_on: Date.parse("2 May #{academic_year.ends_on.year}"),
+    ends_on: Date.parse("19 July #{academic_year.ends_on.year}"),
     academic_year:,
   )
 
   Claims::ClaimWindow.find_or_create_by!(
-    starts_on: Date.parse("29 July #{end_year}"),
-    ends_on: Date.parse("9 August #{end_year}"),
+    starts_on: Date.parse("29 July #{academic_year.ends_on.year}"),
+    ends_on: Date.parse("9 August #{academic_year.ends_on.year}"),
     academic_year:,
   )
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -78,30 +78,26 @@ end
 # Create subjects
 PublishTeacherTraining::Subject::Import.call
 
-# Create academic years
+# Create current academic year
 current_date = Date.current
-
-# Create academic years here
 current_academic_year = AcademicYear.for_date(current_date)
-previous_academic_year = AcademicYear.for_date(current_date - 1.year)
-next_academic_year = AcademicYear.for_date(current_date + 1.year)
 
-# Loop through to create a claim windows only for the current year
-[previous_academic_year, current_academic_year, next_academic_year].each do |academic_year|
-  next unless academic_year == current_academic_year
+# Create a previous and subsequent academic years
+AcademicYear.for_date(current_date - 1.year)
+AcademicYear.for_date(current_date + 1.year)
 
-  Claims::ClaimWindow.find_or_create_by!(
-    starts_on: Date.parse("2 May #{academic_year.ends_on.year}"),
-    ends_on: Date.parse("19 July #{academic_year.ends_on.year}"),
-    academic_year:,
-  )
+# Create claim windows for current academic year
+Claims::ClaimWindow.find_or_create_by!(
+  starts_on: Date.parse("2 May #{current_academic_year.ends_on.year}"),
+  ends_on: Date.parse("19 July #{current_academic_year.ends_on.year}"),
+  academic_year: current_academic_year,
+)
 
-  Claims::ClaimWindow.find_or_create_by!(
-    starts_on: Date.parse("29 July #{academic_year.ends_on.year}"),
-    ends_on: Date.parse("9 August #{academic_year.ends_on.year}"),
-    academic_year:,
-  )
-end
+Claims::ClaimWindow.find_or_create_by!(
+  starts_on: Date.parse("29 July #{current_academic_year.ends_on.year}"),
+  ends_on: Date.parse("9 August #{current_academic_year.ends_on.year}"),
+  academic_year: current_academic_year,
+)
 
 # Create placements
 Placements::School.find_each do |school|

--- a/spec/models/academic_year_spec.rb
+++ b/spec/models/academic_year_spec.rb
@@ -12,18 +12,54 @@
 require "rails_helper"
 
 RSpec.describe AcademicYear, type: :model do
-  subject(:academic_year) do
-    build(:academic_year,
-          name: "2023 to 2024",
-          starts_on: Date.current,
-          ends_on: Date.current + 1.day)
-  end
+  describe "with validations" do
+    subject(:academic_year) do
+      build(:academic_year,
+            name: "2023 to 2024",
+            starts_on: Date.current,
+            ends_on: Date.current + 1.day)
+    end
 
-  context "with validations" do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:starts_on) }
     it { is_expected.to validate_presence_of(:ends_on) }
-
     it { is_expected.to validate_comparison_of(:ends_on).is_greater_than_or_equal_to(:starts_on) }
+  end
+
+  describe ".for_date" do
+    let!(:existing_academic_year) do
+      create(:academic_year,
+             name: "2024 to 2025",
+             starts_on: Date.new(2024, 9, 1),
+             ends_on: Date.new(2025, 8, 31))
+    end
+
+    context "when date is within an existing academic year" do
+      it "returns the existing academic year" do
+        date = Date.new(2024, 11, 7)
+        expect(described_class.for_date(date)).to eq(existing_academic_year)
+      end
+    end
+
+    context "when date is not within an existing academic year" do
+      it "creates a new academic year" do
+        date = Date.new(2026, 10, 5)
+        expect { described_class.for_date(date) }.to change(described_class, :count).by(1)
+        new_academic_year = described_class.for_date(date)
+        expect(new_academic_year.starts_on).to eq(Date.new(2026, 9, 1))
+        expect(new_academic_year.ends_on).to eq(Date.new(2027, 8, 31))
+        expect(new_academic_year.name).to eq("2026 to 2027")
+      end
+    end
+
+    context "when start month is before September and academic year does not exist" do
+      it "creates a new academic year starting the previous year" do
+        date = Date.new(2026, 3, 14)
+        new_academic_year = described_class.for_date(date)
+        expect(new_academic_year.starts_on).to eq(Date.new(2025, 9, 1))
+        expect(new_academic_year.ends_on).to eq(Date.new(2026, 8, 31))
+        expect(new_academic_year.name).to eq("2025 to 2026")
+      end
+    end
   end
 end

--- a/spec/models/academic_year_spec.rb
+++ b/spec/models/academic_year_spec.rb
@@ -30,34 +30,34 @@ RSpec.describe AcademicYear, type: :model do
     let!(:existing_academic_year) do
       create(:academic_year,
              name: "2024 to 2025",
-             starts_on: Date.new(2024, 9, 1),
-             ends_on: Date.new(2025, 8, 31))
+             starts_on: Date.parse("1 September 2024"),
+             ends_on: Date.parse("31 August 2025"))
     end
 
     context "when date is within an existing academic year" do
       it "returns the existing academic year" do
-        date = Date.new(2024, 11, 7)
+        date = Date.parse("7 November 2024")
         expect(described_class.for_date(date)).to eq(existing_academic_year)
       end
     end
 
     context "when date is not within an existing academic year" do
       it "creates a new academic year" do
-        date = Date.new(2026, 10, 5)
+        date = Date.parse("5 October 2026")
         expect { described_class.for_date(date) }.to change(described_class, :count).by(1)
         new_academic_year = described_class.for_date(date)
-        expect(new_academic_year.starts_on).to eq(Date.new(2026, 9, 1))
-        expect(new_academic_year.ends_on).to eq(Date.new(2027, 8, 31))
+        expect(new_academic_year.starts_on).to eq(Date.parse("1 September 2026"))
+        expect(new_academic_year.ends_on).to eq(Date.parse("31 August 2027"))
         expect(new_academic_year.name).to eq("2026 to 2027")
       end
     end
 
     context "when start month is before September and academic year does not exist" do
       it "creates a new academic year starting the previous year" do
-        date = Date.new(2026, 3, 14)
+        date = Date.parse("14 March 2026")
         new_academic_year = described_class.for_date(date)
-        expect(new_academic_year.starts_on).to eq(Date.new(2025, 9, 1))
-        expect(new_academic_year.ends_on).to eq(Date.new(2026, 8, 31))
+        expect(new_academic_year.starts_on).to eq(Date.parse("1 September 2025"))
+        expect(new_academic_year.ends_on).to eq(Date.parse("31 August 2026"))
         expect(new_academic_year.name).to eq("2025 to 2026")
       end
     end


### PR DESCRIPTION
## Context

- .for_date method added to academic year model to take an arbitrary date and find or generate a year with appropriate start and end dates. 
- Centralises the logic for academic year name, starts_on, and ends_on.

## Changes proposed in this pull request

- Addition of .for_date method to academic year model. 
- Refactor of seeds.rb and claim/claim_window/build.rb to replace hardcoded dates.

## Guidance to review

- Review AcademicYear model.
- Review refactor of code in seeds.rb and claim_window/build.rb.
- Run `bundle exec rspec spec/models/academic_year_spec.rb`.

## Link to Trello card

https://trello.com/c/qLLh08g6/635-refactor-the-academic-year-model-to-consolidate-hardcoded-magic-dates