### PR TITLE
Select academic year when creating a claim window

### DIFF
--- a/app/controllers/claims/support/claim_windows_controller.rb
+++ b/app/controllers/claims/support/claim_windows_controller.rb
@@ -2,50 +2,36 @@ class Claims::Support::ClaimWindowsController < Claims::Support::ApplicationCont
   before_action :set_claim_window, only: %i[show edit edit_check update remove destroy]
   before_action :authorize_claim_window
 
+  helper_method :claim_window_form
+
   def index
     @claim_windows = Claims::ClaimWindow.order(starts_on: :desc)
   end
 
-  def new
-    @claim_window = if params[:claims_claim_window]
-                      Claims::ClaimWindow.new(claim_window_params)
-                    else
-                      Claims::ClaimWindow.new
-                    end
-  end
+  def new; end
 
   def new_check
-    @claim_window = Claims::ClaimWindow::Build.call(claim_window_params:)
-
-    render :new unless @claim_window.valid?
+    render :new unless claim_window_form.valid?
   end
 
   def create
-    @claim_window = Claims::ClaimWindow::Build.call(claim_window_params:)
-    @claim_window.save!
+    claim_window_form.save!
 
-    redirect_to claims_support_claim_windows_path, flash: { success: "Claim window created" }
+    redirect_to claims_support_claim_windows_path, flash: { success: t(".success") }
   end
 
   def show; end
 
-  def edit
-    if params[:claims_claim_window]
-      @claim_window.assign_attributes(claim_window_params)
-    end
-  end
+  def edit; end
 
   def edit_check
-    @claim_window = Claims::ClaimWindow::Build.call(claim_window: @claim_window, claim_window_params:)
-
-    render :edit unless @claim_window.valid?
+    render :edit unless claim_window_form.valid?
   end
 
   def update
-    @claim_window = Claims::ClaimWindow::Build.call(claim_window: @claim_window, claim_window_params:)
-    @claim_window.save!
+    claim_window_form.save!
 
-    redirect_to claims_support_claim_window_path(@claim_window), flash: { success: "Claim window updated" }
+    redirect_to claims_support_claim_window_path(@claim_window), flash: { success: t(".success") }
   end
 
   def remove; end
@@ -53,13 +39,13 @@ class Claims::Support::ClaimWindowsController < Claims::Support::ApplicationCont
   def destroy
     @claim_window.discard!
 
-    redirect_to claims_support_claim_windows_path, flash: { success: "Claim window removed" }
+    redirect_to claims_support_claim_windows_path, flash: { success: t(".success") }
   end
 
   private
 
-  def claim_window_params
-    params.require(:claims_claim_window).permit(:starts_on, :ends_on)
+  def claim_window_form_params
+    params.fetch(:claims_claim_window_form, {}).permit(:starts_on, :ends_on, :academic_year_id)
   end
 
   def set_claim_window
@@ -68,5 +54,9 @@ class Claims::Support::ClaimWindowsController < Claims::Support::ApplicationCont
 
   def authorize_claim_window
     authorize @claim_window || Claims::ClaimWindow
+  end
+
+  def claim_window_form
+    @claim_window_form ||= Claims::ClaimWindowForm.new(id: params[:id], **claim_window_form_params)
   end
 end

--- a/app/forms/application_form.rb
+++ b/app/forms/application_form.rb
@@ -1,7 +1,9 @@
 class ApplicationForm
   include ActiveModel::Model
+  include ActiveModel::Attributes
   include ActionView::Helpers::TranslationHelper
   include Rails.application.routes.url_helpers
+  include DateAttributes
 
   def initialize(attributes = {})
     @virtual_path = "forms/#{self.class.name.underscore}"

--- a/app/forms/claims/claim_window_form.rb
+++ b/app/forms/claims/claim_window_form.rb
@@ -1,0 +1,60 @@
+class Claims::ClaimWindowForm < ApplicationForm
+  attr_accessor :id
+
+  date_attribute :starts_on
+  date_attribute :ends_on
+
+  attribute :academic_year_id
+
+  validates :starts_on, date_presence: true
+  validates :ends_on, date_presence: true
+  validates :ends_on, comparison: { greater_than_or_equal_to: :starts_on }, if: -> { starts_on_is_date? && ends_on_is_date? }
+  validates :academic_year_id, presence: true
+
+  validate :does_not_start_within_another_claim_window, if: :starts_on_is_date?
+  validate :does_not_end_within_another_claim_window, if: :ends_on_is_date?
+
+  def initialize(attributes = {})
+    super
+
+    if id
+      self.starts_on ||= claim_window.starts_on
+      self.ends_on ||= claim_window.ends_on
+      self.academic_year_id ||= claim_window.academic_year_id
+    end
+  end
+
+  def persist
+    claim_window.update!(starts_on:, ends_on:, academic_year_id:)
+  end
+
+  def new_back_path
+    new_claims_support_claim_window_path(claims_claim_window_form: slice(:starts_on, :ends_on, :academic_year_id))
+  end
+
+  def edit_back_path
+    edit_claims_support_claim_window_path(id, claims_claim_window_form: slice(:starts_on, :ends_on, :academic_year_id))
+  end
+
+  def academic_year_name
+    AcademicYear.find_by(id: academic_year_id)&.name
+  end
+
+  private
+
+  def claim_window
+    @claim_window ||= id ? Claims::ClaimWindow.find(id) : Claims::ClaimWindow.new
+  end
+
+  def does_not_start_within_another_claim_window
+    return unless Claims::ClaimWindow.where.not(id:).where("starts_on <= :starts_on AND ends_on >= :starts_on", starts_on:).exists?
+
+    errors.add(:starts_on, :overlap)
+  end
+
+  def does_not_end_within_another_claim_window
+    return unless Claims::ClaimWindow.where.not(id:).where("starts_on <= :ends_on AND ends_on >= :ends_on", ends_on:).exists?
+
+    errors.add(:ends_on, :overlap)
+  end
+end

--- a/app/forms/concerns/date_attributes.rb
+++ b/app/forms/concerns/date_attributes.rb
@@ -1,0 +1,45 @@
+module DateAttributes
+  extend ActiveSupport::Concern
+
+  IncompleteDate = Struct.new(:year, :month, :day)
+
+  class_methods do
+    private
+
+    def date_attribute(attribute_name)
+      attr_accessor :"#{attribute_name}_year", :"#{attribute_name}_month", :"#{attribute_name}_day"
+
+      alias_method :"#{attribute_name}(1i)", :"#{attribute_name}_year"
+      alias_method :"#{attribute_name}(2i)", :"#{attribute_name}_month"
+      alias_method :"#{attribute_name}(3i)", :"#{attribute_name}_day"
+
+      alias_method :"#{attribute_name}(1i)=", :"#{attribute_name}_year="
+      alias_method :"#{attribute_name}(2i)=", :"#{attribute_name}_month="
+      alias_method :"#{attribute_name}(3i)=", :"#{attribute_name}_day="
+
+      define_method "#{attribute_name}=" do |value|
+        attribute_value = ActiveModel::Type::Date.new.cast(value)
+
+        raise ArgumentError, "Invalid date format" unless attribute_value.is_a?(Date) || attribute_value.nil?
+
+        send("#{attribute_name}_year=", attribute_value&.year)
+        send("#{attribute_name}_month=", attribute_value&.month)
+        send("#{attribute_name}_day=", attribute_value&.day)
+      end
+
+      define_method attribute_name do
+        year, month, day = %w[year month day].map { |date_part| send("#{attribute_name}_#{date_part}") }
+
+        if year.present? && month.present? && day.present?
+          Date.new(year.to_i, month.to_i, day.to_i)
+        else
+          IncompleteDate.new(year, month, day)
+        end
+      end
+
+      define_method "#{attribute_name}_is_date?" do
+        send(attribute_name).is_a?(Date)
+      end
+    end
+  end
+end

--- a/app/models/claims/claim_window.rb
+++ b/app/models/claims/claim_window.rb
@@ -29,7 +29,6 @@ class Claims::ClaimWindow < ApplicationRecord
   validates :starts_on, presence: true
   validates :ends_on, presence: true, comparison: { greater_than_or_equal_to: :starts_on }
 
-  validate :is_not_longer_than_an_academic_year
   validate :does_not_start_within_another_claim_window
   validate :does_not_end_within_another_claim_window
 
@@ -54,14 +53,6 @@ class Claims::ClaimWindow < ApplicationRecord
   end
 
   private
-
-  def is_not_longer_than_an_academic_year
-    return if starts_on.blank? || ends_on.blank?
-
-    if (ends_on - starts_on).to_i > 365
-      errors.add(:base, :longer_than_academic_year)
-    end
-  end
 
   def does_not_start_within_another_claim_window
     return unless Claims::ClaimWindow.where.not(id:).where("starts_on <= :starts_on AND ends_on >= :starts_on", starts_on:).exists?

--- a/app/validators/date_presence_validator.rb
+++ b/app/validators/date_presence_validator.rb
@@ -1,0 +1,5 @@
+class DatePresenceValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    record.errors.add(attribute, :blank) unless value.is_a?(Date)
+  end
+end

--- a/app/views/claims/support/claim_windows/edit.html.erb
+++ b/app/views/claims/support/claim_windows/edit.html.erb
@@ -6,10 +6,8 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <%= form_with(model: @claim_window, url: edit_check_claims_support_claim_window_path(@claim_window), method: :get) do |f| %>
+  <%= form_with(model: claim_window_form, url: edit_check_claims_support_claim_window_path(@claim_window), method: :get) do |f| %>
     <%= f.govuk_error_summary %>
-
-    <%= f.hidden_field :id, value: f.object.id %>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
@@ -26,6 +24,15 @@
           <%= f.govuk_date_field :ends_on,
                                   class: "govuk-input--width-20",
                                   legend: { text: Claims::ClaimWindow.human_attribute_name(:ends_on), size: "s" } %>
+        </div>
+
+        <div class="govuk-form-group">
+          <%= f.govuk_collection_radio_buttons :academic_year_id,
+                                               AcademicYear.order(starts_on: :desc),
+                                               :id,
+                                               :name,
+                                               class: "govuk-input--width-20",
+                                               legend: { text: Claims::ClaimWindow.human_attribute_name(:academic_year), size: "s" } %>
         </div>
 
         <%= f.govuk_submit t(".submit") %>

--- a/app/views/claims/support/claim_windows/edit_check.html.erb
+++ b/app/views/claims/support/claim_windows/edit_check.html.erb
@@ -2,13 +2,14 @@
 <% render "claims/support/primary_navigation", current: :settings %>
 
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: edit_claims_support_claim_window_path(@claim_window, claims_claim_window: @claim_window.slice(:starts_on, :ends_on))) %>
+  <%= govuk_back_link(href: claim_window_form.edit_back_path) %>
 <% end %>
 
 <div class="govuk-width-container">
-  <%= form_with(model: @claim_window, url: claims_support_claim_window_path(@claim_window), method: :patch) do |f| %>
+  <%= form_with(model: claim_window_form, url: claims_support_claim_window_path(@claim_window), method: :patch) do |f| %>
     <%= f.hidden_field :starts_on, value: f.object.starts_on %>
     <%= f.hidden_field :ends_on, value: f.object.ends_on %>
+    <%= f.hidden_field :academic_year_id, value: f.object.academic_year_id %>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
@@ -18,10 +19,10 @@
         <%= govuk_summary_list do |summary_list| %>
           <% summary_list.with_row do |row| %>
             <% row.with_key text: Claims::ClaimWindow.human_attribute_name(:starts_on) %>
-            <% row.with_value text: l(@claim_window.starts_on, format: :long) %>
+            <% row.with_value text: l(claim_window_form.starts_on, format: :long) %>
             <% row.with_action(
               text: t("change"),
-              href: edit_claims_support_claim_window_path(@claim_window, claims_claim_window: @claim_window.slice(:starts_on, :ends_on)),
+              href: claim_window_form.edit_back_path,
               visually_hidden_text: Claims::ClaimWindow.human_attribute_name(:starts_on),
               classes: ["govuk-link--no-visited-state"],
             ) %>
@@ -29,10 +30,10 @@
 
           <% summary_list.with_row do |row| %>
             <% row.with_key text: Claims::ClaimWindow.human_attribute_name(:ends_on) %>
-            <% row.with_value text: l(@claim_window.ends_on, format: :long) %>
+            <% row.with_value text: l(claim_window_form.ends_on, format: :long) %>
             <% row.with_action(
               text: t("change"),
-              href: edit_claims_support_claim_window_path(@claim_window, claims_claim_window: @claim_window.slice(:starts_on, :ends_on)),
+              href: claim_window_form.edit_back_path,
               visually_hidden_text: Claims::ClaimWindow.human_attribute_name(:ends_on),
               classes: ["govuk-link--no-visited-state"],
             ) %>
@@ -40,11 +41,17 @@
 
           <% summary_list.with_row do |row| %>
             <% row.with_key text: Claims::ClaimWindow.human_attribute_name(:academic_year) %>
-            <% row.with_value text: @claim_window.academic_year_name %>
+            <% row.with_value text: claim_window_form.academic_year_name %>
+            <% row.with_action(
+              text: t("change"),
+              href: claim_window_form.edit_back_path,
+              visually_hidden_text: Claims::ClaimWindow.human_attribute_name(:academic_year),
+              classes: ["govuk-link--no-visited-state"],
+            ) %>
           <% end %>
         <% end %>
 
-        <% if @claim_window.ends_on.past? %>
+        <% if claim_window_form.ends_on.past? %>
           <%= govuk_warning_text text: t(".warning") %>
         <% end %>
 

--- a/app/views/claims/support/claim_windows/new.html.erb
+++ b/app/views/claims/support/claim_windows/new.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <%= form_with(model: @claim_window, url: new_check_claims_support_claim_windows_path, method: :get) do |f| %>
+  <%= form_with(model: claim_window_form, url: new_check_claims_support_claim_windows_path, method: :get) do |f| %>
     <%= f.govuk_error_summary %>
 
     <div class="govuk-grid-row">
@@ -24,6 +24,15 @@
           <%= f.govuk_date_field :ends_on,
                                   class: "govuk-input--width-20",
                                   legend: { text: Claims::ClaimWindow.human_attribute_name(:ends_on), size: "s" } %>
+        </div>
+
+        <div class="govuk-form-group">
+          <%= f.govuk_collection_radio_buttons :academic_year_id,
+                                               AcademicYear.order(starts_on: :desc),
+                                               :id,
+                                               :name,
+                                               class: "govuk-input--width-20",
+                                               legend: { text: Claims::ClaimWindow.human_attribute_name(:academic_year), size: "s" } %>
         </div>
 
         <%= f.govuk_submit t(".submit") %>

--- a/app/views/claims/support/claim_windows/new_check.html.erb
+++ b/app/views/claims/support/claim_windows/new_check.html.erb
@@ -2,13 +2,14 @@
 <% render "claims/support/primary_navigation", current: :settings %>
 
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: new_claims_support_claim_window_path(claims_claim_window: @claim_window.slice(:starts_on, :ends_on))) %>
+  <%= govuk_back_link(href: claim_window_form.new_back_path) %>
 <% end %>
 
 <div class="govuk-width-container">
-  <%= form_with(model: @claim_window, url: claims_support_claim_windows_path, method: :post) do |f| %>
+  <%= form_with(model: claim_window_form, url: claims_support_claim_windows_path, method: :post) do |f| %>
     <%= f.hidden_field :starts_on, value: f.object.starts_on %>
     <%= f.hidden_field :ends_on, value: f.object.ends_on %>
+    <%= f.hidden_field :academic_year_id, value: f.object.academic_year_id %>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
@@ -18,10 +19,10 @@
         <%= govuk_summary_list do |summary_list| %>
           <% summary_list.with_row do |row| %>
             <% row.with_key text: Claims::ClaimWindow.human_attribute_name(:starts_on) %>
-            <% row.with_value text: l(@claim_window.starts_on, format: :long) %>
+            <% row.with_value text: l(claim_window_form.starts_on, format: :long) %>
             <% row.with_action(
               text: t("change"),
-              href: new_claims_support_claim_window_path(claims_claim_window: @claim_window.slice(:starts_on, :ends_on)),
+              href: claim_window_form.new_back_path,
               visually_hidden_text: Claims::ClaimWindow.human_attribute_name(:starts_on),
               classes: ["govuk-link--no-visited-state"],
             ) %>
@@ -29,10 +30,10 @@
 
           <% summary_list.with_row do |row| %>
             <% row.with_key text: Claims::ClaimWindow.human_attribute_name(:ends_on) %>
-            <% row.with_value text: l(@claim_window.ends_on, format: :long) %>
+            <% row.with_value text: l(claim_window_form.ends_on, format: :long) %>
             <% row.with_action(
               text: t("change"),
-              href: new_claims_support_claim_window_path(claims_claim_window: @claim_window.slice(:starts_on, :ends_on)),
+              href: claim_window_form.new_back_path,
               visually_hidden_text: Claims::ClaimWindow.human_attribute_name(:ends_on),
               classes: ["govuk-link--no-visited-state"],
             ) %>
@@ -40,7 +41,13 @@
 
           <% summary_list.with_row do |row| %>
             <% row.with_key text: Claims::ClaimWindow.human_attribute_name(:academic_year) %>
-            <% row.with_value text: @claim_window.academic_year_name %>
+            <% row.with_value text: claim_window_form.academic_year_name %>
+            <% row.with_action(
+              text: t("change"),
+              href: claim_window_form.new_back_path,
+              visually_hidden_text: Claims::ClaimWindow.human_attribute_name(:academic_year),
+              classes: ["govuk-link--no-visited-state"],
+            ) %>
           <% end %>
         <% end %>
 

--- a/app/views/claims/support/claim_windows/show.html.erb
+++ b/app/views/claims/support/claim_windows/show.html.erb
@@ -41,6 +41,14 @@
         <% summary_list.with_row do |row| %>
           <% row.with_key text: Claims::ClaimWindow.human_attribute_name(:academic_year) %>
           <% row.with_value text: @claim_window.academic_year_name %>
+          <% if policy(@claim_window).edit? %>
+            <% row.with_action(
+              text: t("change"),
+              href: edit_claims_support_claim_window_path(@claim_window),
+              visually_hidden_text: Claims::ClaimWindow.human_attribute_name(:academic_year),
+              classes: ["govuk-link--no-visited-state"],
+            ) %>
+          <% end %>
         <% end %>
       <% end %>
 

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -76,10 +76,10 @@ en:
               blank: Enter a date of birth
               less_than: Date of birth must be in the past
         placements/edit_placement_wizard/provider_step:
-            attributes:
-              provider_id:
-                blank: Select a provider or not yet known
-                inclusion: Select a provider or not yet known
+          attributes:
+            provider_id:
+              blank: Select a provider or not yet known
+              inclusion: Select a provider or not yet known
         placements/add_support_user_wizard/support_user_step:
           attributes:
             first_name:
@@ -106,6 +106,19 @@ en:
           attributes:
             mentor_ids:
               blank: Select a mentor
+        claims/claim_window_form:
+          attributes:
+            base:
+              longer_than_academic_year: Claim window must be shorter than an academic year
+            academic_year_id:
+              blank: Select an academic year
+            starts_on:
+              blank: Enter a window opening date
+              overlap: Select a date that is not within an existing claim window
+            ends_on:
+              blank: Enter a window closing date
+              overlap: Select a date that is not within an existing claim window
+              greater_than_or_equal_to: Enter a window closing date that is after the opening date
         placements/mentor_form:
           attributes:
             trn:

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -33,10 +33,8 @@ en:
               enter_mentor_name: Enter a mentor's name
         claims/claim_window:
           attributes:
-            base:
-              longer_than_academic_year: Claim window must be shorter than an academic year
             academic_year:
-              required: Window opening date is required to set the academic year for this window
+              required: Select an academic year
             starts_on:
               blank: Enter a window opening date
               overlap: Select a date that is not within an existing claim window

--- a/config/locales/en/claims/support/claim_windows.yml
+++ b/config/locales/en/claims/support/claim_windows.yml
@@ -22,6 +22,8 @@ en:
           page_heading: Check your answers
           submit: Save claim window
           cancel: Cancel
+        create:
+          success: Claim window added
         edit:
           page_caption: Change claim window
           page_title: Changing %{window}
@@ -34,9 +36,13 @@ en:
           warning: Setting the current claim window to a date in the past will close the window and prevent users from making any claims.
           submit: Save claim window
           cancel: Cancel
+        update:
+          success: Claim window updated
         remove:
           page_title: Are you sure you want to remove this claim window?
           submit: Remove claim window
           cancel: Cancel
           description: This will soft-delete the claim window.
           warning: This is the current claim window. Soft-deleting the current claim window means users cannot make any claims.
+        destroy:
+          success: Claim window removed

--- a/spec/forms/application_form_spec.rb
+++ b/spec/forms/application_form_spec.rb
@@ -54,4 +54,102 @@ RSpec.describe ApplicationForm do
       end
     end
   end
+
+  describe ".date_attribute" do
+    subject(:example_form) { ExampleForm.new }
+
+    before do
+      example_form_class = Class.new(ApplicationForm) do
+        date_attribute :date_of_birth
+      end
+
+      stub_const("ExampleForm", example_form_class)
+    end
+
+    it "adds getters and setters for the attribute suffixed with (1i), (2i), and (3i)" do
+      example_form.public_send("date_of_birth(1i)=", 2024)
+      example_form.public_send("date_of_birth(2i)=", 5)
+      example_form.public_send("date_of_birth(3i)=", 2)
+
+      expect(example_form.public_send("date_of_birth(1i)")).to eq(2024)
+      expect(example_form.public_send("date_of_birth(2i)")).to eq(5)
+      expect(example_form.public_send("date_of_birth(3i)")).to eq(2)
+    end
+
+    it "aliases the (1i), (2i), and (3i) suffixed attribute accessors to year, month, and day, respectively" do
+      example_form.public_send("date_of_birth(1i)=", 2024)
+      example_form.public_send("date_of_birth(2i)=", 5)
+      example_form.public_send("date_of_birth(3i)=", 2)
+
+      expect(example_form.date_of_birth_year).to eq(2024)
+      expect(example_form.date_of_birth_month).to eq(5)
+      expect(example_form.date_of_birth_day).to eq(2)
+
+      example_form.public_send("date_of_birth_year=", 2025)
+      example_form.public_send("date_of_birth_month=", 6)
+      example_form.public_send("date_of_birth_day=", 3)
+
+      expect(example_form.public_send("date_of_birth(1i)")).to eq(2025)
+      expect(example_form.public_send("date_of_birth(2i)")).to eq(6)
+      expect(example_form.public_send("date_of_birth(3i)")).to eq(3)
+    end
+
+    it "adds getter and setter methods to set and read all fields as Date objects" do
+      example_form.date_of_birth_year = 2024
+      example_form.date_of_birth_month = 5
+      example_form.date_of_birth_day = 2
+
+      expect(example_form.date_of_birth).to eq(Date.new(2024, 5, 2))
+
+      example_form.date_of_birth = Date.new(2025, 6, 3)
+
+      expect(example_form.date_of_birth_year).to eq(2025)
+      expect(example_form.date_of_birth_month).to eq(6)
+      expect(example_form.date_of_birth_day).to eq(3)
+    end
+
+    describe "date attribute setter" do
+      it "casts strings into dates" do
+        example_form.date_of_birth = "2024-05-02"
+
+        expect(example_form.date_of_birth).to eq(Date.new(2024, 5, 2))
+      end
+
+      it "casts dates into dates" do
+        example_form.date_of_birth = Date.new(2024, 5, 2)
+
+        expect(example_form.date_of_birth).to eq(Date.new(2024, 5, 2))
+      end
+
+      it "casts times into dates" do
+        example_form.date_of_birth = Time.new(2024, 5, 2, 12, 0, 0, 0)
+
+        expect(example_form.date_of_birth).to eq(Date.new(2024, 5, 2))
+      end
+
+      it "doesn't cast other values" do
+        expect { example_form.date_of_birth = 123 }.to raise_error(ArgumentError)
+        expect { example_form.date_of_birth = 123.4 }.to raise_error(ArgumentError)
+        expect { example_form.date_of_birth = true }.to raise_error(ArgumentError)
+        expect { example_form.date_of_birth = false }.to raise_error(ArgumentError)
+      end
+    end
+
+    describe "date attribute getter" do
+      it "composes the individual date components into a date object" do
+        example_form.date_of_birth_year = 2024
+        example_form.date_of_birth_month = 5
+        example_form.date_of_birth_day = 2
+
+        expect(example_form.date_of_birth).to eq(Date.new(2024, 5, 2))
+      end
+
+      it "returns DateAttributes::IncompleteDate object if any of the date components are missing" do
+        example_form.date_of_birth_year = 2024
+        example_form.date_of_birth_month = 5
+
+        expect(example_form.date_of_birth).to eq(DateAttributes::IncompleteDate.new(2024, 5, nil))
+      end
+    end
+  end
 end

--- a/spec/forms/claims/claim_window_form_spec.rb
+++ b/spec/forms/claims/claim_window_form_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+describe Claims::ClaimWindowForm, type: :model do
+  subject(:claim_window_form) { described_class.new(academic_year_id: academic_year.id) }
+
+  let(:academic_year) { create(:academic_year, starts_on: Date.parse("1 September 2023"), ends_on: Date.parse("31 August 2024"), name: "2023 to 2024") }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:starts_on) }
+    it { is_expected.to validate_presence_of(:ends_on) }
+    it { is_expected.to validate_presence_of(:academic_year_id) }
+
+    it "validates that end date is always after the start date" do
+      claim_window_form.starts_on = Date.parse("17 July 2023")
+      claim_window_form.ends_on = Date.parse("18 July 2023")
+
+      expect(claim_window_form).to be_valid
+
+      claim_window_form.ends_on = Date.parse("16 July 2023")
+
+      expect(claim_window_form).to be_invalid
+      expect(claim_window_form.errors[:ends_on]).to include("Enter a window closing date that is after the opening date")
+    end
+  end
+
+  describe "#academic_year_name" do
+    subject(:academic_year_name) { claim_window_form.academic_year_name }
+
+    it "returns the name of the academic year" do
+      claim_window_form.academic_year_id = academic_year.id
+
+      expect(academic_year_name).to eq("2023 to 2024")
+    end
+
+    it "returns nil if the academic year is not present" do
+      claim_window_form.academic_year_id = nil
+
+      expect(academic_year_name).to be_nil
+    end
+  end
+end

--- a/spec/models/claims/claim_window_spec.rb
+++ b/spec/models/claims/claim_window_spec.rb
@@ -46,14 +46,6 @@ RSpec.describe Claims::ClaimWindow, type: :model do
       expect(claim_window.errors[:ends_on]).to include("Enter a window closing date that is after the opening date")
     end
 
-    it "validates that the duration of a claim window does not exceed a year" do
-      claim_window.starts_on = Date.parse("17 July 2024")
-      claim_window.ends_on = Date.parse("18 July 2025")
-
-      expect(claim_window).to be_invalid
-      expect(claim_window.errors[:base]).to include("Claim window must be shorter than an academic year")
-    end
-
     context "with validating against existing claim windows" do
       before do
         create(:claim_window, starts_on: Date.parse("1 July 2024"), ends_on: Date.parse("31 July 2024"), academic_year:)

--- a/spec/system/claims/support/create_a_claim_window_spec.rb
+++ b/spec/system/claims/support/create_a_claim_window_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe "Create a claim window", freeze: "20 July 2024", service: :claims
     then_i_see_a_form_error("Enter a window opening date")
     then_i_see_a_form_error("Enter a window closing date")
 
-    when_i_fill_in_the_form(starts_on: Date.parse("21 July 2024"), ends_on: Date.parse("31 July 2024"))
+    when_i_fill_in_the_form(starts_on: Date.parse("21 July 2024"), ends_on: Date.parse("31 July 2024"), academic_year: "2023 to 2024")
     and_i_click_continue
     then_i_see_the_claim_window_details_check_page_with(start_date: "21 July 2024", end_date: "31 July 2024")
 
     when_i_click_on_change
     then_i_see_the_form_to_create_a_claim_window
 
-    when_i_fill_in_the_form(starts_on: Date.parse("22 July 2024"), ends_on: Date.parse("31 July 2024"))
+    when_i_fill_in_the_form(starts_on: Date.parse("22 July 2024"), ends_on: Date.parse("31 July 2024"), academic_year: "2023 to 2024")
     and_i_click_continue
     then_i_see_the_claim_window_details_check_page_with(start_date: "22 July 2024", end_date: "31 July 2024")
 
@@ -54,14 +54,20 @@ RSpec.describe "Create a claim window", freeze: "20 July 2024", service: :claims
     expect(page).to have_css("legend", text: "Window closes")
   end
 
-  def when_i_fill_in_the_form(starts_on:, ends_on:)
-    fill_in "claims_claim_window[starts_on(3i)]", with: starts_on.day
-    fill_in "claims_claim_window[starts_on(2i)]", with: starts_on.month
-    fill_in "claims_claim_window[starts_on(1i)]", with: starts_on.year
+  def when_i_fill_in_the_form(starts_on:, ends_on:, academic_year:)
+    within_fieldset "Window opens" do
+      fill_in "Day", with: starts_on.day
+      fill_in "Month", with: starts_on.month
+      fill_in "Year", with: starts_on.year
+    end
 
-    fill_in "claims_claim_window[ends_on(3i)]", with: ends_on.day
-    fill_in "claims_claim_window[ends_on(2i)]", with: ends_on.month
-    fill_in "claims_claim_window[ends_on(1i)]", with: ends_on.year
+    within_fieldset "Window closes" do
+      fill_in "Day", with: ends_on.day
+      fill_in "Month", with: ends_on.month
+      fill_in "Year", with: ends_on.year
+    end
+
+    choose academic_year
   end
 
   def and_i_click_continue
@@ -84,7 +90,7 @@ RSpec.describe "Create a claim window", freeze: "20 July 2024", service: :claims
   end
 
   def then_i_see_the_claim_window_created_successfully_with(start_date:, end_date:)
-    expect(page).to have_content("Claim window created")
+    expect(page).to have_content("Claim window added")
     expect(page).to have_content("#{start_date} to #{end_date}")
   end
 

--- a/spec/system/claims/support/update_a_claim_window_spec.rb
+++ b/spec/system/claims/support/update_a_claim_window_spec.rb
@@ -76,13 +76,17 @@ RSpec.describe "Update a claim window", freeze: "17 July 2024", service: :claims
   end
 
   def when_i_fill_in_the_form(starts_on:, ends_on:)
-    fill_in "claims_claim_window[starts_on(3i)]", with: starts_on.day
-    fill_in "claims_claim_window[starts_on(2i)]", with: starts_on.month
-    fill_in "claims_claim_window[starts_on(1i)]", with: starts_on.year
+    within_fieldset "Window opens" do
+      fill_in "Day", with: starts_on.day
+      fill_in "Month", with: starts_on.month
+      fill_in "Year", with: starts_on.year
+    end
 
-    fill_in "claims_claim_window[ends_on(3i)]", with: ends_on.day
-    fill_in "claims_claim_window[ends_on(2i)]", with: ends_on.month
-    fill_in "claims_claim_window[ends_on(1i)]", with: ends_on.year
+    within_fieldset "Window closes" do
+      fill_in "Day", with: ends_on.day
+      fill_in "Month", with: ends_on.month
+      fill_in "Year", with: ends_on.year
+    end
   end
 
   def and_i_click_continue


### PR DESCRIPTION
## Context

Follows up on the committed task here: https://github.com/DFE-Digital/itt-mentor-services/pull/854#pullrequestreview-2186352476

We want to avoid automatically associating academic years to claim windows, as it reduces flexibility but also adds additional logic to the service.

## Changes proposed in this pull request

- Require user selecting the academic year for a claim window.
- Add `Claims::ClaimWindowForm` form object to handle `Claims::ClaimWindow` validations.
  - As the `belongs_to :academic_year` adds a `required` validation, a lot of error-movement is required to show the `:academic_year` error on the `:academic_year_id` field, which is present on the claim window form.
  - Moving the claim window form data object from a model to a form object allows us to validate the form submission in isolation.
- Allow over year-long windows at the Model level. Prevent over year-long windows at the FormObject level.
- Add a `DateAttributes` concern for FormObjects to clean up the logic. This is adopted in the new `Claims::ClaimWindowForm` form object, but not elsewhere.

## Guidance to review

- Sign in a a support user.
- Visit the settings tab.
- Visit the "Claim windows" link.
- Try adding and editing (only active or upcoming) claim windows.

## Link to Trello card

https://trello.com/c/9OcRpTbF/639-claim-windows-should-select-an-academic-year-and-not-automatically-associate-together

## Screenshots

| Page | Screenshot |
| ---- | ---------- |
| New  | ![CleanShot 2024-08-13 at 15 52 00](https://github.com/user-attachments/assets/dfb5f26f-c7c4-4233-945a-dbecd2a0732f) |
| Edit | ![CleanShot 2024-08-13 at 15 51 10](https://github.com/user-attachments/assets/df7c3b09-8aff-402d-a246-23edc7f8b24e) |
