### PR TITLE
Fix test failures when GOOGLE_MAPS_API_KEY is set

### DIFF
--- a/spec/lib/google/routes_api_spec.rb
+++ b/spec/lib/google/routes_api_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Google::RoutesApi do
           "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
           "Content-Type" => "application/json;odata.metadata=minimal",
           "User-Agent" => "Ruby",
-          "X-Goog-Api-Key" => "",
+          "X-Goog-Api-Key" => ENV.fetch("GOOGLE_MAPS_API_KEY", "").to_s,
           "X-Goog-Fieldmask" => "localizedValues,destinationIndex",
         },
       )


### PR DESCRIPTION
## Context

The WebMock stubs for calls to the Google Routes API expected that the environment variable `GOOGLE_MAPS_API_KEY` was not set.

However it's entirely possible for this environment variable to be set on a developer's machine. And the test suite should still pass whether it's set or not.

## Changes proposed in this pull request

Effectively ignore the value of the environment variable, by including it in both the implementation and the test stub. The test should now pass regardless of the variable's value or presence.

## Guidance to review

Do the tests still pass?
