### PR TITLE
Add status filter for support claims index page

### DIFF
--- a/app/controllers/claims/support/claims_controller.rb
+++ b/app/controllers/claims/support/claims_controller.rb
@@ -43,6 +43,7 @@ class Claims::Support::ClaimsController < Claims::Support::ApplicationController
       :submitted_before,
       provider_ids: [],
       school_ids: [],
+      statuses: [],
     )
   end
 

--- a/app/forms/claims/support/claims/filter_form.rb
+++ b/app/forms/claims/support/claims/filter_form.rb
@@ -12,6 +12,7 @@ class Claims::Support::Claims::FilterForm < ApplicationForm
   attribute "submitted_before(3i)"
   attribute :school_ids, default: []
   attribute :provider_ids, default: []
+  attribute :statuses, default: []
 
   def initialize(params = {})
     params[:school_ids].compact_blank! if params[:school_ids].present?
@@ -24,7 +25,8 @@ class Claims::Support::Claims::FilterForm < ApplicationForm
     school_ids.present? ||
       provider_ids.present? ||
       submitted_after.present? ||
-      submitted_before.present?
+      submitted_before.present? ||
+      statuses.present?
   end
 
   def index_path_without_filter(filter:, value: nil)
@@ -80,6 +82,7 @@ class Claims::Support::Claims::FilterForm < ApplicationForm
       provider_ids:,
       submitted_after:,
       submitted_before:,
+      statuses:,
     }
   end
 

--- a/app/helpers/claims/claim_helper.rb
+++ b/app/helpers/claims/claim_helper.rb
@@ -1,0 +1,7 @@
+module Claims::ClaimHelper
+  def claim_statuses_for_selection
+    Claims::Claim.statuses.values.reject { |status|
+      Claims::Claim::DRAFT_STATUSES.map(&:to_s).include?(status)
+    }.sort
+  end
+end

--- a/app/models/claims/claim.rb
+++ b/app/models/claims/claim.rb
@@ -59,9 +59,11 @@ class Claims::Claim < ApplicationRecord
   )
 
   ACTIVE_STATUSES = %i[draft submitted].freeze
+  DRAFT_STATUSES = %i[internal_draft draft].freeze
 
   scope :active, -> { where(status: ACTIVE_STATUSES) }
   scope :order_created_at_desc, -> { order(created_at: :desc) }
+  scope :not_draft_status, -> { where.not(status: DRAFT_STATUSES) }
 
   enum :status,
        { internal_draft: "internal_draft", draft: "draft", submitted: "submitted" },

--- a/app/queries/claims/claims_query.rb
+++ b/app/queries/claims/claims_query.rb
@@ -1,11 +1,12 @@
 class Claims::ClaimsQuery < ApplicationQuery
   def call
-    scope = Claims::Claim.submitted
+    scope = Claims::Claim.not_draft_status
     scope = search_condition(scope)
     scope = school_condition(scope)
     scope = provider_condition(scope)
     scope = submitted_after(scope)
     scope = submitted_before(scope)
+    scope = status_condition(scope)
 
     scope.order_created_at_desc
   end
@@ -40,5 +41,11 @@ class Claims::ClaimsQuery < ApplicationQuery
     return scope if params[:submitted_before].nil?
 
     scope.where(submitted_at: ..params[:submitted_before])
+  end
+
+  def status_condition(scope)
+    return scope if params[:statuses].blank?
+
+    scope.where(status: params[:statuses])
   end
 end

--- a/app/views/claims/support/claims/_filter.html.erb
+++ b/app/views/claims/support/claims/_filter.html.erb
@@ -24,6 +24,22 @@
             </div>
           </div>
 
+          <% if filter_form.statuses.present? %>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t("claims.support.claims.index.status") %></h3>
+            <ul class="app-filter-tags">
+              <% filter_form.statuses.each do |status| %>
+                <li>
+                 <%= govuk_link_to(
+                   status.titleize,
+                   filter_form.index_path_without_filter(filter: "statuses", value: status),
+                   class: "app-filter__tag",
+                   no_visited_state: true,
+                 ) %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+
           <% if filter_form.school_ids.present? %>
             <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t("claims.support.claims.index.school") %></h3>
             <ul class="app-filter-tags">
@@ -40,43 +56,43 @@
             </ul>
           <% end %>
 
-           <% if filter_form.provider_ids.present? %>
-             <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t("claims.support.claims.index.accredited_provider") %></h3>
-             <ul class="app-filter-tags">
-               <% filter_form.providers.each do |provider| %>
-                 <li>
-                  <%= govuk_link_to(
-                    provider.name,
-                    filter_form.index_path_without_filter(filter: "provider_ids", value: provider.id),
-                    class: "app-filter__tag",
-                    no_visited_state: true,
-                  ) %>
-                 </li>
-               <% end %>
-             </ul>
-           <% end %>
+          <% if filter_form.provider_ids.present? %>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t("claims.support.claims.index.accredited_provider") %></h3>
+            <ul class="app-filter-tags">
+              <% filter_form.providers.each do |provider| %>
+                <li>
+                <%= govuk_link_to(
+                  provider.name,
+                  filter_form.index_path_without_filter(filter: "provider_ids", value: provider.id),
+                  class: "app-filter__tag",
+                  no_visited_state: true,
+                ) %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
 
-           <% if filter_form.submitted_after.present? %>
-             <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t("claims.support.claims.index.submitted_after") %></h3>
-              <%= govuk_link_to(
-                safe_l(filter_form.submitted_after, format: :short),
-                filter_form.index_path_without_submitted_dates("submitted_after"),
-                class: "app-filter__tag",
-                no_visited_state: true,
-              ) %>
-           <% end %>
+          <% if filter_form.submitted_after.present? %>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t("claims.support.claims.index.submitted_after") %></h3>
+            <%= govuk_link_to(
+              safe_l(filter_form.submitted_after, format: :short),
+              filter_form.index_path_without_submitted_dates("submitted_after"),
+              class: "app-filter__tag",
+              no_visited_state: true,
+            ) %>
+          <% end %>
 
-           <% if filter_form.submitted_before.present? %>
-             <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t("claims.support.claims.index.submitted_before") %></h3>
-              <%= govuk_link_to(
-                safe_l(filter_form.submitted_before, format: :short),
-                filter_form.index_path_without_submitted_dates("submitted_before"),
-                class: "app-filter__tag",
-                no_visited_state: true,
-              ) %>
-           <% end %>
-         </div>
-       <% end %>
+          <% if filter_form.submitted_before.present? %>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t("claims.support.claims.index.submitted_before") %></h3>
+            <%= govuk_link_to(
+              safe_l(filter_form.submitted_before, format: :short),
+              filter_form.index_path_without_submitted_dates("submitted_before"),
+              class: "app-filter__tag",
+              no_visited_state: true,
+            ) %>
+          <% end %>
+        </div>
+      <% end %>
 
       <div class="app-filter__options">
         <%= form_with(
@@ -87,6 +103,22 @@
           <%= form.govuk_submit t("apply_filters") %>
 
           <%= form.hidden_field :search, value: filter_form.search %>
+
+          <div class="app-filter__option">
+            <%= form.govuk_check_boxes_fieldset(
+              :school_ids,
+              legend: {
+                text: t("claims.support.claims.index.status"),
+                size: "s",
+              },
+              small: true,
+            ) do %>
+
+              <% claim_statuses_for_selection.each do |status| %>
+                <%= form.govuk_check_box :statuses, status, label: { text: status.titleize } %>
+               <% end %>
+             <% end %>
+          </div>
 
           <div class="app-filter__option" data-controller="filter-search">
             <%= form.govuk_check_boxes_fieldset(
@@ -124,8 +156,8 @@
               :submitted_after,
               date_of_birth: true,
               maxlength_enabled: true,
-              legend: { text: t("claims.support.claims.index.submitted_after") },
-              hint: { text: t("claims.support.claims.index.submitted_after_hint") },
+              legend: { text: t("claims.support.claims.index.submitted_after"), size: "s" },
+              hint: { text: t("claims.support.claims.index.submitted_after_hint"), size: "s" },
             ) %>
           </div>
 
@@ -133,8 +165,8 @@
             <%= form.govuk_date_field(
               :submitted_before,
               maxlength_enabled: true,
-              legend: { text: t("claims.support.claims.index.submitted_before") },
-              hint: { text: t("claims.support.claims.index.submitted_before_hint") },
+              legend: { text: t("claims.support.claims.index.submitted_before"), size: "s" },
+              hint: { text: t("claims.support.claims.index.submitted_before_hint"), size: "s" },
             ) %>
           </div>
         <% end %>

--- a/config/locales/en/claims/support/claims.yml
+++ b/config/locales/en/claims/support/claims.yml
@@ -17,6 +17,7 @@ en:
           provider: Accredited provider
           submit: Search
           clear: Clear search
+          status: Status
         show:
           page_caption: Claim - %{reference}
           page_title: Claim - %{school_name}

--- a/spec/forms/claims/support/claims/filter_form_spec.rb
+++ b/spec/forms/claims/support/claims/filter_form_spec.rb
@@ -3,6 +3,25 @@ require "rails_helper"
 describe Claims::Support::Claims::FilterForm, type: :model do
   include Rails.application.routes.url_helpers
 
+  describe "attributes" do
+    it do
+      expect(described_class.new).to have_attributes(
+        search: nil,
+        search_school: nil,
+        search_provider: nil,
+        "submitted_after(1i)" => nil,
+        "submitted_after(2i)" => nil,
+        "submitted_after(3i)" => nil,
+        "submitted_before(1i)" => nil,
+        "submitted_before(2i)" => nil,
+        "submitted_before(3i)" => nil,
+        school_ids: [],
+        provider_ids: [],
+        statuses: [],
+      )
+    end
+  end
+
   describe "#filters_selected?" do
     it "returns true if school_ids present" do
       params = { school_ids: %w[school_id] }
@@ -35,6 +54,16 @@ describe Claims::Support::Claims::FilterForm, type: :model do
         "submitted_before(2i)" => "1",
         "submitted_before(3i)" => "2",
       }
+      form = described_class.new(params)
+
+      expect(form.filters_selected?).to be(true)
+    end
+
+    it "returns true if statuses are present" do
+      params = {
+        "statuses" => %w[submitted],
+      }
+
       form = described_class.new(params)
 
       expect(form.filters_selected?).to be(true)
@@ -194,6 +223,7 @@ describe Claims::Support::Claims::FilterForm, type: :model do
         "submitted_before(3i)" => "2",
         school_ids: %w[school_id],
         provider_ids: %w[provider_id],
+        statuses: %w[submitted],
       }
 
       call = described_class.new(params).query_params
@@ -206,6 +236,7 @@ describe Claims::Support::Claims::FilterForm, type: :model do
         search_school: "school_name",
         submitted_after: Date.new(2024, 1, 2),
         submitted_before: Date.new(2023, 1, 2),
+        statuses: %w[submitted],
       )
     end
   end

--- a/spec/helpers/claims/claim_helper_spec.rb
+++ b/spec/helpers/claims/claim_helper_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe Claims::ClaimHelper do
+  describe "#claim_statuses_for_selection" do
+    it "returns an array of claims statuses, except draft statuses" do
+      expect(claim_statuses_for_selection).to contain_exactly("submitted")
+    end
+  end
+end

--- a/spec/models/claims/claim_spec.rb
+++ b/spec/models/claims/claim_spec.rb
@@ -120,6 +120,21 @@ RSpec.describe Claims::Claim, type: :model do
         )
       end
     end
+
+    describe "not_draft_status" do
+      let!(:submitted_claim) { create(:claim, :submitted) }
+      let(:draft_claim) { create(:claim, :draft) }
+      let(:internal_draft_claim) { create(:claim) }
+
+      before do
+        draft_claim
+        internal_draft_claim
+      end
+
+      it "returns all claims which are not in a draft or internal draft status" do
+        expect(described_class.not_draft_status).to contain_exactly(submitted_claim)
+      end
+    end
   end
 
   describe "#submitted_on" do

--- a/spec/queries/claims/claims_query_spec.rb
+++ b/spec/queries/claims/claims_query_spec.rb
@@ -70,5 +70,18 @@ describe Claims::ClaimsQuery do
         expect(claims_query).to contain_exactly(expected_claim)
       end
     end
+
+    context "when given statuses" do
+      let(:params) { { statuses: %w[submitted] } }
+
+      it "filters the results by status" do
+        _internal_claim = create(:claim)
+        _draft_claim = create(:claim, :draft)
+        expected_claim = create(:claim, :submitted)
+        # TODO: Add unexpected claim with a different status, once additional statuses have been added.
+
+        expect(claims_query).to contain_exactly(expected_claim)
+      end
+    end
   end
 end

--- a/spec/system/claims/support/claims/view_claims_spec.rb
+++ b/spec/system/claims/support/claims/view_claims_spec.rb
@@ -21,40 +21,52 @@ RSpec.describe "View claims", :js, service: :claims, type: :system do
 
   scenario "Support user visits the claims index page" do
     when_i_visit_claim_index_page
-    then_i_see_a_list_of_submitted_claims([claim_2, claim_3, claim_4, claim_5, claim_6, claim_7])
+    then_i_see_a_list_of_claims([claim_2, claim_3, claim_4, claim_5, claim_6, claim_7])
     and_i_see_no_draft_claims
     when_i_check_school_filter(school_1)
-    then_i_see_a_list_of_submitted_claims([claim_2, claim_3, claim_4, claim_5, claim_6])
+    then_i_see_a_list_of_claims([claim_2, claim_3, claim_4, claim_5, claim_6])
     when_i_check_provider_filter(provider_1)
-    then_i_see_a_list_of_submitted_claims([claim_2, claim_3, claim_4, claim_5])
+    then_i_see_a_list_of_claims([claim_2, claim_3, claim_4, claim_5])
     when_i_set_submitted_after(5, 4, 2024)
-    then_i_see_a_list_of_submitted_claims([claim_2, claim_3, claim_4])
+    then_i_see_a_list_of_claims([claim_2, claim_3, claim_4])
     when_i_set_submitted_before(6, 4, 2024)
-    then_i_see_a_list_of_submitted_claims([claim_3, claim_4])
+    then_i_see_a_list_of_claims([claim_3, claim_4])
     when_i_search_for_claim_reference(claim_3.reference)
-    then_i_see_a_list_of_submitted_claims([claim_3])
+    then_i_see_a_list_of_claims([claim_3])
     when_i_remove_my_search
-    then_i_see_a_list_of_submitted_claims([claim_3, claim_4])
+    then_i_see_a_list_of_claims([claim_3, claim_4])
     when_i_remove_the_filter("06/04/2024")
-    then_i_see_a_list_of_submitted_claims([claim_2, claim_3, claim_4])
+    then_i_see_a_list_of_claims([claim_2, claim_3, claim_4])
     when_i_remove_the_filter("05/04/2024")
-    then_i_see_a_list_of_submitted_claims([claim_2, claim_3, claim_4, claim_5])
+    then_i_see_a_list_of_claims([claim_2, claim_3, claim_4, claim_5])
     when_i_remove_the_filter(provider_1.name)
-    then_i_see_a_list_of_submitted_claims([claim_2, claim_3, claim_4, claim_5, claim_6])
+    then_i_see_a_list_of_claims([claim_2, claim_3, claim_4, claim_5, claim_6])
     when_i_remove_the_filter(school_1.name)
-    then_i_see_a_list_of_submitted_claims([claim_2, claim_3, claim_4, claim_5, claim_6, claim_7])
+    then_i_see_a_list_of_claims([claim_2, claim_3, claim_4, claim_5, claim_6, claim_7])
+  end
+
+  context "when filtering by a status" do
+    scenario "Support user filters claims in a submitted status" do
+      when_i_visit_claim_index_page
+      then_i_see_a_list_of_claims([claim_2, claim_3, claim_4, claim_5, claim_6, claim_7])
+      and_i_see_no_draft_claims
+      when_i_check_status_filter("Submitted")
+      then_i_see_a_list_of_claims([claim_2, claim_3, claim_4, claim_5, claim_6, claim_7])
+      when_i_remove_the_filter("Submitted")
+      then_i_see_a_list_of_claims([claim_2, claim_3, claim_4, claim_5, claim_6, claim_7])
+    end
   end
 
   scenario "Support user uses the js filter search" do
     when_i_visit_claim_index_page
-    then_i_see_a_list_of_submitted_claims([claim_2, claim_3, claim_4, claim_5, claim_6, claim_7])
+    then_i_see_a_list_of_claims([claim_2, claim_3, claim_4, claim_5, claim_6, claim_7])
     when_i_search_the_school_filter_with(school_2.name)
     then_i_see_only_my_filter_school_as_an_option
     when_i_check_school_filter(school_2)
-    then_i_see_a_list_of_submitted_claims([claim_7])
+    then_i_see_a_list_of_claims([claim_7])
     when_i_search_the_provider_filter_with(provider_2.name)
     when_i_check_provider_filter(provider_2)
-    then_i_see_a_list_of_submitted_claims([claim_7])
+    then_i_see_a_list_of_claims([claim_7])
   end
 
   private
@@ -68,7 +80,7 @@ RSpec.describe "View claims", :js, service: :claims, type: :system do
     click_on("Claims")
   end
 
-  def then_i_see_a_list_of_submitted_claims(claims)
+  def then_i_see_a_list_of_claims(claims)
     claims.each_with_index do |claim, index|
       within(".claim-card:nth-child(#{index + 1})") do
         expect(page).to have_content(claim.school.name)
@@ -93,6 +105,11 @@ RSpec.describe "View claims", :js, service: :claims, type: :system do
 
   def when_i_check_provider_filter(provider)
     page.find("#claims-support-claims-filter-form-provider-ids-#{provider.id}-field", visible: :all).check
+    click_on("Apply filters")
+  end
+
+  def when_i_check_status_filter(status)
+    page.find("#claims-support-claims-filter-form-statuses-#{status.downcase}-field", visible: :all).check
     click_on("Apply filters")
   end
 


### PR DESCRIPTION
## Context

- Add a status filter for the support claims index page

## Guidance to review

- Sign in as Colin (Support User)
- Click "Claims" in the Navbar
- You should see a status filter for "Submitted"
- Check the "Submitted" checkbox
- Click "Apply filters"
- You should see that the status filter has been enabled.

## Link to Trello card

https://trello.com/c/gb7fEWgX/642-add-additional-filters-to-the-support-claims-index-page

## Screenshots

![screencapture-claims-localhost-3000-support-claims-2024-08-13-12_10_03](https://github.com/user-attachments/assets/db0ebf09-c3d5-4b29-9d27-c7fd350c39d5)

![screencapture-claims-localhost-3000-support-claims-2024-08-13-12_11_05](https://github.com/user-attachments/assets/442404a5-3778-4a82-be8e-f8542033d6f0)
