### PR TITLE
Add policy scopes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,6 +50,10 @@ RSpec/SpecFilePathSuffix:
 RSpec/VerifiedDoubleReference:
   Enabled: false
 
+Rails/LexicallyScopedActionFilter:
+  Exclude:
+    - app/controllers/placements/application_controller.rb
+
 RSpec/NoExpectationExample:
   Exclude:
     - spec/support/shared_examples/system/**/*.rb

--- a/app/controllers/placements/application_controller.rb
+++ b/app/controllers/placements/application_controller.rb
@@ -11,7 +11,6 @@ class Placements::ApplicationController < ApplicationController
       return user unless current_org
 
       user.current_organisation = current_org.is_a?(School) ? current_org.becomes(Placements::School) : current_org.becomes(Placements::Provider)
-      user
     end
   end
 

--- a/app/controllers/placements/application_controller.rb
+++ b/app/controllers/placements/application_controller.rb
@@ -5,12 +5,16 @@ class Placements::ApplicationController < ApplicationController
 
   def current_user
     @current_user ||= sign_in_user&.user&.tap do |user|
-      organisation_id = session.dig("current_organisation", :id)
-      organisation_type = session.dig("current_organisation", :type)
-      current_org = user.user_memberships.find_by(organisation_id:, organisation_type:)&.organisation
-      return user unless current_org
+      organisation_id = session.dig("current_organisation", "id")
+      organisation_type = session.dig("current_organisation", "type")
+      organisation = user.user_memberships.find_by(organisation_id:, organisation_type:)&.organisation
 
-      user.current_organisation = current_org.is_a?(School) ? current_org.becomes(Placements::School) : current_org.becomes(Placements::Provider)
+      user.current_organisation = case organisation
+                                  when School
+                                    organisation.becomes(Placements::School)
+                                  when Provider
+                                    organisation.becomes(Placements::Provider)
+                                  end
     end
   end
 

--- a/app/controllers/placements/application_controller.rb
+++ b/app/controllers/placements/application_controller.rb
@@ -1,5 +1,21 @@
 class Placements::ApplicationController < ApplicationController
+  include Pundit::Authorization
+  after_action :verify_policy_scoped, only: %i[index]
   before_action :authorize_support_user!
+
+  def current_user
+    @current_user ||= sign_in_user&.user&.tap do |user|
+      if user
+        organisation_id = session.dig("current_organisation", :id)
+        organisation_type = session.dig("current_organisation", :type)
+        current_org = user.user_memberships.find_by(organisation_id:, organisation_type:)&.organisation
+        return user unless current_org
+
+        user.current_organisation = current_org.is_a?(School) ? current_org.becomes(Placements::School) : current_org.becomes(Placements::Provider)
+        user
+      end
+    end
+  end
 
   private
 

--- a/app/controllers/placements/application_controller.rb
+++ b/app/controllers/placements/application_controller.rb
@@ -1,5 +1,4 @@
 class Placements::ApplicationController < ApplicationController
-  include Pundit::Authorization
   after_action :verify_policy_scoped, only: %i[index]
   before_action :authorize_support_user!
 

--- a/app/controllers/placements/application_controller.rb
+++ b/app/controllers/placements/application_controller.rb
@@ -5,15 +5,13 @@ class Placements::ApplicationController < ApplicationController
 
   def current_user
     @current_user ||= sign_in_user&.user&.tap do |user|
-      if user
-        organisation_id = session.dig("current_organisation", :id)
-        organisation_type = session.dig("current_organisation", :type)
-        current_org = user.user_memberships.find_by(organisation_id:, organisation_type:)&.organisation
-        return user unless current_org
+      organisation_id = session.dig("current_organisation", :id)
+      organisation_type = session.dig("current_organisation", :type)
+      current_org = user.user_memberships.find_by(organisation_id:, organisation_type:)&.organisation
+      return user unless current_org
 
-        user.current_organisation = current_org.is_a?(School) ? current_org.becomes(Placements::School) : current_org.becomes(Placements::Provider)
-        user
-      end
+      user.current_organisation = current_org.is_a?(School) ? current_org.becomes(Placements::School) : current_org.becomes(Placements::Provider)
+      user
     end
   end
 

--- a/app/controllers/placements/organisations/users_controller.rb
+++ b/app/controllers/placements/organisations/users_controller.rb
@@ -5,7 +5,8 @@ class Placements::Organisations::UsersController < Placements::ApplicationContro
   before_action :authorize_user, only: %i[remove destroy]
 
   def index
-    @users = users.order_by_full_name
+    scope = policy_scope(users)
+    @users = scope.order_by_full_name
   end
 
   def show; end

--- a/app/controllers/placements/organisations_controller.rb
+++ b/app/controllers/placements/organisations_controller.rb
@@ -29,7 +29,7 @@ class Placements::OrganisationsController < Placements::ApplicationController
   end
 
   def set_current_organisation(organisation)
-    session["current_organisation"] = { id: organisation.id, type: organisation.class.name }
+    session["current_organisation"] = { "id" => organisation.id, "type" => organisation.class.name }
   end
 
   def landing_page_path(organisation)

--- a/app/controllers/placements/organisations_controller.rb
+++ b/app/controllers/placements/organisations_controller.rb
@@ -2,7 +2,8 @@ class Placements::OrganisationsController < Placements::ApplicationController
   before_action :auto_redirect_if_only_one, only: :index
 
   def index
-    @memberships = memberships.filter(&:placements_service).sort_by(&:name)
+    scope = policy_scope(memberships)
+    @memberships = scope.filter(&:placements_service).sort_by(&:name)
   end
 
   def show
@@ -23,16 +24,12 @@ class Placements::OrganisationsController < Placements::ApplicationController
   def load_organisation(membership)
     organisation = membership.organisation
 
-    set_current_provider(organisation)
+    set_current_organisation(organisation)
     redirect_to landing_page_path(organisation)
   end
 
-  def set_current_provider(organisation)
-    if organisation.is_a?(Provider)
-      session["placements_provider_id"] = organisation.id
-    else
-      session.delete("placements_provider_id")
-    end
+  def set_current_organisation(organisation)
+    session["current_organisation"] = { id: organisation.id, type: organisation.class.name }
   end
 
   def landing_page_path(organisation)

--- a/app/controllers/placements/placements_controller.rb
+++ b/app/controllers/placements/placements_controller.rb
@@ -7,12 +7,9 @@ class Placements::PlacementsController < Placements::ApplicationController
     @establishment_groups = compact_school_attribute_values(:group)
     @schools = schools_scope.order_by_name.select(:id, :name)
     @year_groups ||= Placement.year_groups_as_options
+    scope = policy_scope(Placements::PlacementsQuery.call(params: query_params))
 
-    @pagy, @placements = pagy(
-      Placements::PlacementsQuery.call(
-        params: query_params,
-      ),
-    )
+    @pagy, @placements = pagy(scope)
   end
 
   def show
@@ -31,9 +28,9 @@ class Placements::PlacementsController < Placements::ApplicationController
   end
 
   def set_provider
-    return redirect_to organisations_path if session["placements_provider_id"].blank?
+    return redirect_to organisations_path if current_user.current_organisation.blank?
 
-    @provider = Placements::Provider.find(session["placements_provider_id"])
+    @provider = current_user.current_organisation
   end
 
   def filter_form

--- a/app/controllers/placements/placements_controller.rb
+++ b/app/controllers/placements/placements_controller.rb
@@ -1,5 +1,5 @@
 class Placements::PlacementsController < Placements::ApplicationController
-  before_action :set_provider
+  before_action :set_current_organisation
   helper_method :filter_form, :location_coordinates
 
   def index
@@ -27,7 +27,7 @@ class Placements::PlacementsController < Placements::ApplicationController
     end
   end
 
-  def set_provider
+  def set_current_organisation
     return redirect_to organisations_path if current_user.current_organisation.blank?
 
     @provider = current_user.current_organisation

--- a/app/controllers/placements/placements_controller.rb
+++ b/app/controllers/placements/placements_controller.rb
@@ -28,8 +28,6 @@ class Placements::PlacementsController < Placements::ApplicationController
   end
 
   def set_current_organisation
-    return redirect_to organisations_path if current_user.current_organisation.blank?
-
     @provider = current_user.current_organisation
   end
 

--- a/app/controllers/placements/providers/partner_schools_controller.rb
+++ b/app/controllers/placements/providers/partner_schools_controller.rb
@@ -1,6 +1,7 @@
 class Placements::Providers::PartnerSchoolsController < Placements::PartnershipsController
   def index
-    @pagy, @partner_schools = pagy(@provider.partner_schools.order_by_name)
+    scope = policy_scope(@provider.partner_schools)
+    @pagy, @partner_schools = pagy(scope.order_by_name)
   end
 
   def destroy

--- a/app/controllers/placements/schools/mentors_controller.rb
+++ b/app/controllers/placements/schools/mentors_controller.rb
@@ -4,7 +4,8 @@ class Placements::Schools::MentorsController < Placements::ApplicationController
   before_action :set_mentor_membership, only: %i[remove destroy]
 
   def index
-    @pagy, @mentors = pagy(@school.mentors.order_by_full_name)
+    scope = policy_scope(@school.mentors)
+    @pagy, @mentors = pagy(scope.order_by_full_name)
   end
 
   def show; end

--- a/app/controllers/placements/schools/partner_providers_controller.rb
+++ b/app/controllers/placements/schools/partner_providers_controller.rb
@@ -1,6 +1,7 @@
 class Placements::Schools::PartnerProvidersController < Placements::PartnershipsController
   def index
-    @pagy, @partner_providers = pagy(@school.partner_providers.order_by_name)
+    scope = policy_scope(@school.partner_providers)
+    @pagy, @partner_providers = pagy(scope.order_by_name)
   end
 
   def destroy

--- a/app/controllers/placements/schools/placements_controller.rb
+++ b/app/controllers/placements/schools/placements_controller.rb
@@ -6,7 +6,8 @@ class Placements::Schools::PlacementsController < Placements::ApplicationControl
   helper_method :edit_attribute_path, :add_provider_path, :add_mentor_path
 
   def index
-    @pagy, placements = pagy(@school.placements.includes(:subject, :mentors, :additional_subjects, :provider).order("subjects.name"))
+    scope = policy_scope(@school.placements)
+    @pagy, placements = pagy(scope.includes(:subject, :mentors, :additional_subjects, :provider).order("subjects.name"))
     @placements = placements.decorate
   end
 

--- a/app/controllers/placements/support/mailers_controller.rb
+++ b/app/controllers/placements/support/mailers_controller.rb
@@ -1,4 +1,6 @@
 class Placements::Support::MailersController < Placements::ApplicationController
+  skip_after_action :verify_policy_scoped
+
   def index
     @previews = ActionMailer::Preview.all.filter { |preview| preview.preview_name.start_with?("placements/") }
   end

--- a/app/controllers/placements/support/organisations_controller.rb
+++ b/app/controllers/placements/support/organisations_controller.rb
@@ -1,4 +1,6 @@
 class Placements::Support::OrganisationsController < Placements::ApplicationController
+  skip_after_action :verify_policy_scoped
+
   def index
     @pagy, @organisations = pagy(organisations)
     @filters = filters_param

--- a/app/controllers/placements/support/settings_controller.rb
+++ b/app/controllers/placements/support/settings_controller.rb
@@ -1,2 +1,3 @@
 class Placements::Support::SettingsController < Placements::ApplicationController
+  skip_after_action :verify_policy_scoped
 end

--- a/app/controllers/placements/support/support_users_controller.rb
+++ b/app/controllers/placements/support/support_users_controller.rb
@@ -3,7 +3,8 @@ class Placements::Support::SupportUsersController < Placements::ApplicationContr
   before_action :authorize_support_user, only: %i[remove destroy]
 
   def index
-    @support_users = Placements::SupportUser.order_by_full_name
+    scope = policy_scope(Placements::SupportUser)
+    @support_users = scope.order_by_full_name
   end
 
   def show; end

--- a/app/models/placements/support_user.rb
+++ b/app/models/placements/support_user.rb
@@ -20,4 +20,6 @@
 #
 class Placements::SupportUser < User
   include ActsAsSupportUser
+
+  attribute :current_organisation
 end

--- a/app/models/placements/user.rb
+++ b/app/models/placements/user.rb
@@ -28,6 +28,8 @@ class Placements::User < User
            source: :organisation,
            source_type: "Provider"
 
+  attribute :current_organisation
+
   def service
     :placements
   end

--- a/app/policies/placement_policy.rb
+++ b/app/policies/placement_policy.rb
@@ -1,4 +1,16 @@
 class PlacementPolicy < ApplicationPolicy
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      if user.current_organisation.is_a?(Placements::School)
+        scope.where(school: user.current_organisation)
+      elsif user.current_organisation.is_a?(Placements::Provider) || user.support_user?
+        scope
+      else
+        scope.none
+      end
+    end
+  end
+
   def new?
     record.school.school_contact.present?
   end

--- a/app/policies/placements/mentor_policy.rb
+++ b/app/policies/placements/mentor_policy.rb
@@ -1,0 +1,9 @@
+class Placements::MentorPolicy < ApplicationPolicy
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      return scope if user.support_user?
+
+      scope.joins(:mentor_memberships).where(mentor_memberships: { school: user.current_organisation })
+    end
+  end
+end

--- a/app/policies/placements/support_user_policy.rb
+++ b/app/policies/placements/support_user_policy.rb
@@ -1,4 +1,14 @@
 class Placements::SupportUserPolicy < ApplicationPolicy
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      if user.support_user?
+        scope
+      else
+        scope.none
+      end
+    end
+  end
+
   def destroy?
     user != record
   end

--- a/app/policies/placements/user_policy.rb
+++ b/app/policies/placements/user_policy.rb
@@ -1,0 +1,11 @@
+class Placements::UserPolicy < ApplicationPolicy
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      if user.support_user?
+        scope
+      else
+        scope.joins(:user_memberships).where(user_memberships: { organisation: user.current_organisation })
+      end
+    end
+  end
+end

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -3,7 +3,7 @@ class ProviderPolicy < ApplicationPolicy
     def resolve
       return scope if user.support_user?
 
-      scope.where(id: user.current_organisation.partner_providers.ids)
+      scope.where(id: user.current_organisation.partner_providers.select(:id))
     end
   end
 end

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -1,0 +1,9 @@
+class ProviderPolicy < ApplicationPolicy
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      return scope if user.support_user?
+
+      scope.where(id: user.current_organisation.partner_providers.ids)
+    end
+  end
+end

--- a/app/policies/school_policy.rb
+++ b/app/policies/school_policy.rb
@@ -4,9 +4,9 @@ class SchoolPolicy < ApplicationPolicy
       return scope if user.support_user?
 
       if user.current_organisation.is_a?(Placements::School)
-        scope.where(id: user.current_organisation.partner_providers.ids)
+        scope.where(id: user.current_organisation.partner_providers.select(:id))
       else
-        scope.where(id: user.current_organisation.partner_schools.ids)
+        scope.where(id: user.current_organisation.partner_schools.select(:id))
       end
     end
   end

--- a/app/policies/school_policy.rb
+++ b/app/policies/school_policy.rb
@@ -1,0 +1,13 @@
+class SchoolPolicy < ApplicationPolicy
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      return scope if user.support_user?
+
+      if user.current_organisation.is_a?(Placements::School)
+        scope.where(id: user.current_organisation.partner_providers.ids)
+      else
+        scope.where(id: user.current_organisation.partner_schools.ids)
+      end
+    end
+  end
+end

--- a/app/policies/user_membership_policy.rb
+++ b/app/policies/user_membership_policy.rb
@@ -1,0 +1,7 @@
+class UserMembershipPolicy < ApplicationPolicy
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      scope.where(user_id: user.id)
+    end
+  end
+end

--- a/app/views/placements/organisations/users/_list.html.erb
+++ b/app/views/placements/organisations/users/_list.html.erb
@@ -16,5 +16,5 @@
     <% end %>
   <% end %>
 <% else %>
-  <p><%= t("no_users", organisation_name: organisation.name) %></p>
+  <p><%= t(".no_users", organisation_name: organisation.name) %></p>
 <% end %>

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -102,6 +102,7 @@ shared:
     - first_name
     - last_name
     - email
+    - current_organisation
   :mentors:
     - first_name
     - last_name

--- a/config/locales/en/placements/organisations/users/users_list.yml
+++ b/config/locales/en/placements/organisations/users/users_list.yml
@@ -4,3 +4,4 @@ en:
       users:
         list:
           name: Name
+          no_users: No users found

--- a/spec/models/placements/support_user_spec.rb
+++ b/spec/models/placements/support_user_spec.rb
@@ -21,6 +21,11 @@
 require "rails_helper"
 
 RSpec.describe Placements::SupportUser do
+  describe "attributes" do
+    it { is_expected.to have_attributes(current_organisation: nil) }
+  end
+
+
   context "with validations" do
     subject { build(:placements_support_user) }
 

--- a/spec/models/placements/support_user_spec.rb
+++ b/spec/models/placements/support_user_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe Placements::SupportUser do
     it { is_expected.to have_attributes(current_organisation: nil) }
   end
 
-
   context "with validations" do
     subject { build(:placements_support_user) }
 

--- a/spec/models/placements/user_spec.rb
+++ b/spec/models/placements/user_spec.rb
@@ -38,6 +38,10 @@ RSpec.describe Placements::User do
     end
   end
 
+  describe "attributes" do
+    it { is_expected.to have_attributes(current_organisation: nil) }
+  end
+
   describe "default scope" do
     let(:email) { "same_email@email.co.uk" }
     let!(:user_with_placements_service) { create(:placements_user, email:) }

--- a/spec/policies/placement_policy_spec.rb
+++ b/spec/policies/placement_policy_spec.rb
@@ -62,11 +62,11 @@ RSpec.describe PlacementPolicy do
 
     context "when the user is a school user" do
       let(:user) { create(:placements_user, schools: [school]) }
-      let(:school) { create(:placements_school) }
+      let(:school) { build(:placements_school) }
 
       before do
         user.current_organisation = school
-        school.placements << create(:placement)
+        create(:placement, school:)
       end
 
       it "returns the school's placements" do

--- a/spec/policies/placement_policy_spec.rb
+++ b/spec/policies/placement_policy_spec.rb
@@ -44,4 +44,55 @@ RSpec.describe PlacementPolicy do
       end
     end
   end
+
+  describe "scope" do
+    let(:scope) { Placement.all }
+
+    before do
+      create_list(:placement, 3)
+    end
+
+    context "when the user is a support user" do
+      let(:user) { create(:placements_support_user) }
+
+      it "returns all placements" do
+        expect(placement_policy::Scope.new(user, scope).resolve).to eq(scope)
+      end
+    end
+
+    context "when the user is a school user" do
+      let(:user) { create(:placements_user, schools: [school]) }
+      let(:school) { create(:placements_school) }
+
+      before do
+        user.current_organisation = school
+        school.placements << create(:placement)
+      end
+
+      it "returns the school's placements" do
+        expect(placement_policy::Scope.new(user, scope).resolve).to eq(school.placements)
+      end
+    end
+
+    context "when the user is a provider user" do
+      let(:user) { create(:placements_user, providers: [provider]) }
+      let(:provider) { create(:placements_provider) }
+
+      before do
+        user.current_organisation = provider
+      end
+
+      it "returns the provider's placements" do
+        expect(placement_policy::Scope.new(user, scope).resolve).to eq(scope)
+      end
+    end
+
+    context "when the user is none of the above" do
+      let(:user) { create(:placements_user) }
+
+      it "returns no placements" do
+        expect(placement_policy::Scope.new(user, scope).resolve).to eq(scope.none)
+      end
+    end
+  end
 end

--- a/spec/policies/placement_policy_spec.rb
+++ b/spec/policies/placement_policy_spec.rb
@@ -61,16 +61,18 @@ RSpec.describe PlacementPolicy do
     end
 
     context "when the user is a school user" do
-      let(:user) { create(:placements_user, schools: [school]) }
       let(:school) { build(:placements_school) }
+      let(:user) { create(:placements_user, schools: [school]) }
+      let!(:placement_1) { create(:placement, school:) }
+      let(:placement_2) { create(:placement) }
 
       before do
         user.current_organisation = school
-        create(:placement, school:)
+        placement_2
       end
 
       it "returns the school's placements" do
-        expect(placement_policy::Scope.new(user, scope).resolve).to eq(school.placements)
+        expect(placement_policy::Scope.new(user, scope).resolve).to eq([placement_1])
       end
     end
 

--- a/spec/policies/placements/mentor_policy_spec.rb
+++ b/spec/policies/placements/mentor_policy_spec.rb
@@ -17,14 +17,16 @@ describe Placements::MentorPolicy do
     context "when the user is a school user" do
       let(:school) { build(:placements_school) }
       let(:user) { create(:placements_user, schools: [school]) }
+      let!(:mentor_1) { create(:placements_mentor, schools: [school]) }
+      let(:mentor_2) { create(:placements_mentor) }
 
       before do
         user.current_organisation = school
-        create(:placements_mentor, schools: [school])
+        mentor_2
       end
 
       it "returns the school's mentors" do
-        expect(described_class::Scope.new(user, scope).resolve).to eq(school.mentors)
+        expect(described_class::Scope.new(user, scope).resolve).to eq([mentor_1])
       end
     end
 

--- a/spec/policies/placements/mentor_policy_spec.rb
+++ b/spec/policies/placements/mentor_policy_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+describe Placements::MentorPolicy do
+  describe "scope" do
+    let(:scope) { Placements::Mentor.all }
+
+    before { create_list(:placements_mentor, 3) }
+
+    context "when the user is a support user" do
+      let(:user) { create(:placements_support_user) }
+
+      it "returns all mentors" do
+        expect(described_class::Scope.new(user, scope).resolve).to eq(scope)
+      end
+    end
+
+    context "when the user is a school user" do
+      let(:user) { create(:placements_user, schools: [school]) }
+      let(:school) { create(:placements_school) }
+
+      before do
+        user.current_organisation = school
+        school.mentors << create(:placements_mentor)
+      end
+
+      it "returns the school's mentors" do
+        expect(described_class::Scope.new(user, scope).resolve).to eq(school.mentors)
+      end
+    end
+
+    context "when the user is none of the above" do
+      let(:user) { create(:placements_user) }
+
+      it "returns no mentors" do
+        expect(described_class::Scope.new(user, scope).resolve).to be_empty
+      end
+    end
+  end
+end

--- a/spec/policies/placements/mentor_policy_spec.rb
+++ b/spec/policies/placements/mentor_policy_spec.rb
@@ -15,12 +15,12 @@ describe Placements::MentorPolicy do
     end
 
     context "when the user is a school user" do
+      let(:school) { build(:placements_school) }
       let(:user) { create(:placements_user, schools: [school]) }
-      let(:school) { create(:placements_school) }
 
       before do
         user.current_organisation = school
-        school.mentors << create(:placements_mentor)
+        create(:placements_mentor, schools: [school])
       end
 
       it "returns the school's mentors" do

--- a/spec/policies/placements/support_user_policy_spec.rb
+++ b/spec/policies/placements/support_user_policy_spec.rb
@@ -15,4 +15,25 @@ describe Placements::SupportUserPolicy do
       expect(support_user_policy).to permit(support_user_1, support_user_2)
     end
   end
+
+  describe "scope" do
+    let(:support_user) { create(:placements_support_user) }
+    let(:scope) { Placements::SupportUser.all }
+
+    before { support_user }
+
+    context "when the user is a support user" do
+      it "returns all support users" do
+        expect(support_user_policy::Scope.new(support_user_1, scope).resolve).to eq(scope)
+      end
+    end
+
+    context "when the user is not a support user" do
+      let(:user) { create(:placements_user) }
+
+      it "returns no support users" do
+        expect(support_user_policy::Scope.new(user, scope).resolve).to eq(scope.none)
+      end
+    end
+  end
 end

--- a/spec/policies/placements/user_policy_spec.rb
+++ b/spec/policies/placements/user_policy_spec.rb
@@ -19,16 +19,17 @@ RSpec.describe Placements::UserPolicy do
     end
 
     context "when the user is a school user" do
-      let(:user) { create(:placements_user, schools: [school]) }
       let(:school) { build(:placements_school) }
+      let!(:user_1) { create(:placements_user, schools: [school]) }
+      let(:user_2) { create(:placements_user) }
 
       before do
-        user.current_organisation = school
-        create(:user_membership, organisation: school)
+        user_1.current_organisation = school
+        user_2
       end
 
       it "returns the school's users" do
-        expect(user_policy::Scope.new(user, scope).resolve).to eq(school.users)
+        expect(user_policy::Scope.new(user_1, scope).resolve).to eq([user_1])
       end
     end
 

--- a/spec/policies/placements/user_policy_spec.rb
+++ b/spec/policies/placements/user_policy_spec.rb
@@ -20,11 +20,11 @@ RSpec.describe Placements::UserPolicy do
 
     context "when the user is a school user" do
       let(:user) { create(:placements_user, schools: [school]) }
-      let(:school) { create(:placements_school) }
+      let(:school) { build(:placements_school) }
 
       before do
         user.current_organisation = school
-        school.user_memberships << create(:user_membership)
+        create(:user_membership, organisation: school)
       end
 
       it "returns the school's users" do

--- a/spec/policies/placements/user_policy_spec.rb
+++ b/spec/policies/placements/user_policy_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe Placements::UserPolicy do
+  subject(:user_policy) { described_class }
+
+  describe "scope" do
+    let(:scope) { Placements::User.all }
+
+    before do
+      create_list(:placements_user, 3)
+    end
+
+    context "when the user is a support user" do
+      let(:user) { create(:placements_support_user) }
+
+      it "returns all users" do
+        expect(user_policy::Scope.new(user, scope).resolve).to eq(scope)
+      end
+    end
+
+    context "when the user is a school user" do
+      let(:user) { create(:placements_user, schools: [school]) }
+      let(:school) { create(:placements_school) }
+
+      before do
+        user.current_organisation = school
+        school.user_memberships << create(:user_membership)
+      end
+
+      it "returns the school's users" do
+        expect(user_policy::Scope.new(user, scope).resolve).to eq(school.users)
+      end
+    end
+
+    context "when the user is none of the above" do
+      let(:user) { create(:placements_user) }
+
+      it "returns the user's organisations" do
+        expect(user_policy::Scope.new(user, scope).resolve).to be_empty
+      end
+    end
+  end
+end

--- a/spec/policies/provider_policy_spec.rb
+++ b/spec/policies/provider_policy_spec.rb
@@ -4,8 +4,10 @@ RSpec.describe ProviderPolicy do
   subject(:provider_policy) { described_class }
 
   describe "scope" do
-    let!(:placements_provider) { create(:placements_provider) }
+    let(:placements_provider) { create(:placements_provider) }
     let(:scope) { Provider.all }
+
+    before { placements_provider }
 
     context "when the user is a support user" do
       let(:user) { create(:placements_support_user) }

--- a/spec/policies/provider_policy_spec.rb
+++ b/spec/policies/provider_policy_spec.rb
@@ -16,16 +16,19 @@ RSpec.describe ProviderPolicy do
     end
 
     context "when the user is a school user" do
+      let(:school) { build(:placements_school) }
       let(:user) { create(:placements_user, schools: [school]) }
-      let(:school) { create(:placements_school) }
+      let!(:provider_1) { create(:placements_provider, partner_schools: [school]) }
+      let(:provider_2) { create(:placements_provider) }
 
       before do
         user.current_organisation = school
-        school.partner_providers << placements_provider
+        provider_2
       end
 
       it "returns the school's partner providers" do
-        expect(provider_policy::Scope.new(user, scope).resolve).to eq(school.partner_providers)
+        # Scope returns Providers, but partner schools association is only on Placements::Provider
+        expect(provider_policy::Scope.new(user, scope).resolve).to eq([provider_1.becomes(Provider)])
       end
     end
   end

--- a/spec/policies/provider_policy_spec.rb
+++ b/spec/policies/provider_policy_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe ProviderPolicy do
+  subject(:provider_policy) { described_class }
+
+  describe "scope" do
+    let!(:placements_provider) { create(:placements_provider) }
+    let(:scope) { Provider.all }
+
+    context "when the user is a support user" do
+      let(:user) { create(:placements_support_user) }
+
+      it "returns all providers" do
+        expect(provider_policy::Scope.new(user, scope).resolve).to eq(scope)
+      end
+    end
+
+    context "when the user is a school user" do
+      let(:user) { create(:placements_user, schools: [school]) }
+      let(:school) { create(:placements_school) }
+
+      before do
+        user.current_organisation = school
+        school.partner_providers << placements_provider
+      end
+
+      it "returns the school's partner providers" do
+        expect(provider_policy::Scope.new(user, scope).resolve).to eq(school.partner_providers)
+      end
+    end
+  end
+end

--- a/spec/policies/school_policy_spec.rb
+++ b/spec/policies/school_policy_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe SchoolPolicy do
+  subject(:school_policy) { described_class }
+
+  describe "scope" do
+    let(:scope) { School.all }
+
+    context "when the user is a support user" do
+      let(:user) { create(:placements_support_user) }
+
+      it "returns all schools" do
+        expect(school_policy::Scope.new(user, scope).resolve).to eq(scope)
+      end
+    end
+
+    context "when the user is a school user" do
+      let(:user) { create(:placements_user, schools: [school]) }
+      let(:school) { create(:placements_school) }
+
+      before do
+        user.current_organisation = school
+      end
+
+      it "returns the school's partner providers" do
+        expect(school_policy::Scope.new(user, scope).resolve).to eq(school.partner_providers)
+      end
+    end
+
+    context "when the user is a provider user" do
+      let(:user) { create(:placements_user, providers: [provider]) }
+      let(:provider) { create(:placements_provider) }
+
+      before do
+        user.current_organisation = provider
+      end
+
+      it "returns the provider's partner schools" do
+        expect(school_policy::Scope.new(user, scope).resolve).to eq(provider.partner_schools)
+      end
+    end
+  end
+end

--- a/spec/policies/user_membership_policy_spec.rb
+++ b/spec/policies/user_membership_policy_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe UserMembershipPolicy do
 
     context "when the user is a school user" do
       let(:user) { create(:placements_user, schools: [school]) }
-      let(:school) { create(:placements_school) }
+      let(:school) { build(:placements_school) }
 
       before do
         user.current_organisation = school
-        school.user_memberships << create(:user_membership)
+        create(:user_membership, organisation: school)
       end
 
       it "returns the school's user memberships" do

--- a/spec/policies/user_membership_policy_spec.rb
+++ b/spec/policies/user_membership_policy_spec.rb
@@ -11,16 +11,18 @@ RSpec.describe UserMembershipPolicy do
     end
 
     context "when the user is a school user" do
-      let(:user) { create(:placements_user, schools: [school]) }
       let(:school) { build(:placements_school) }
+      let(:user) { create(:placements_user, user_memberships: [user_membership_1]) }
+      let(:user_membership_1) { build(:user_membership, organisation: school) }
+      let(:user_membership_2) { create(:user_membership) }
 
       before do
         user.current_organisation = school
-        create(:user_membership, organisation: school)
+        user_membership_2
       end
 
       it "returns the school's user memberships" do
-        expect(user_membership_policy::Scope.new(user, scope).resolve).to eq(user.user_memberships)
+        expect(user_membership_policy::Scope.new(user, scope).resolve).to eq([user_membership_1])
       end
     end
   end

--- a/spec/policies/user_membership_policy_spec.rb
+++ b/spec/policies/user_membership_policy_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe UserMembershipPolicy do
+  subject(:user_membership_policy) { described_class }
+
+  describe "scope" do
+    let(:scope) { UserMembership.all }
+
+    before do
+      create_list(:user_membership, 3)
+    end
+
+    context "when the user is a school user" do
+      let(:user) { create(:placements_user, schools: [school]) }
+      let(:school) { create(:placements_school) }
+
+      before do
+        user.current_organisation = school
+        school.user_memberships << create(:user_membership)
+      end
+
+      it "returns the school's user memberships" do
+        expect(user_membership_policy::Scope.new(user, scope).resolve).to eq(user.user_memberships)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

As our service expands it is important that we are scoping our data correctly based on who is accessing the application. This is a first pass to add some basic policy scopes to ensure the correct data is visible to the correct users.

## Changes proposed in this pull request

- Adds an after callback to check for the presence of a policy scope for all placements index pages
- Adds multiple new policy scopes to enable this behaviour
- Updates index actions to make use of the new policy scopes
- Adds a missed translation which caused an error 😲 

## Guidance to review

Heavy smoke testing of _everything_ placements related. The tests should give some confidence, but test everything... manually... twice.

## Link to Trello card

[Add pundit policy scopes](https://trello.com/c/oOOUTNaY/660-add-pundit-policy-scopes)
