### PR TITLE
Change captions and H1 content to questions on add placement flow

### DIFF
--- a/app/views/placements/schools/placements/add_placement/edit.html.erb
+++ b/app/views/placements/schools/placements/add_placement/edit.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-width-container">
 
-  <%= render @wizard.step, object: @wizard.step, contextual_text: t(".add_placement") %>
+  <%= render @wizard.step, object: @wizard.step, contextual_text: t(".placement_details") %>
 
   <p class="govuk-body">
     <%= govuk_link_to(t(".cancel"), placements_school_placements_path(@school), no_visited_state: true) %>

--- a/app/views/placements/wizards/add_placement_wizard/_additional_subjects_step.html.erb
+++ b/app/views/placements/wizards/add_placement_wizard/_additional_subjects_step.html.erb
@@ -1,4 +1,9 @@
-<% content_for :page_title, additional_subjects_step.errors.any? ? t(".title_with_error", contextual_text:) : t(".title", contextual_text:) %>
+<% if additional_subjects_step.errors.any? %>
+  <% page_title = t(".title_with_error", contextual_text:, subject: additional_subjects_step.addition_subject_category) %>
+<% else %>
+  <% page_title = t(".title", contextual_text:, subject: additional_subjects_step.addition_subject_category) %>
+<% end %>
+<% content_for :page_title, page_title %>
 
 <%= form_for(additional_subjects_step, url: current_step_path, method: :put) do |f| %>
   <%= f.govuk_error_summary %>
@@ -11,7 +16,11 @@
         :additional_subject_ids,
         additional_subjects_step.additional_subjects_for_selection,
         :id, :name,
-        legend: { size: "l", text: additional_subjects_step.parent_subject_name }
+        legend: {
+          size: "l",
+          text: t(".select_a_subject", subject: additional_subjects_step.addition_subject_category),
+        },
+        hint: { text: t(".hint") }
       ) %>
 
       <%= f.govuk_submit t(".continue") %>

--- a/app/views/placements/wizards/add_placement_wizard/_mentors_step.html.erb
+++ b/app/views/placements/wizards/add_placement_wizard/_mentors_step.html.erb
@@ -10,7 +10,7 @@
         <%= f.govuk_check_boxes_fieldset :mentor_ids,
           legend: { size: "l",
                     text: t(".select_a_mentor") },
-          hint: { text: @placement.present? ? t(".hint.published") : t(".hint.unpublished") } do %>
+          hint: { text: @placement.present? ? t(".hint.published") : t(".hint.unpublished_html") } do %>
           <% mentors_step.mentors_for_selection.each_with_index do |mentor, index| %>
             <%= f.govuk_check_box :mentor_ids, mentor.id, label: { text: mentor.full_name }, link_errors: index.zero? %>
           <% end %>

--- a/app/views/placements/wizards/add_placement_wizard/_mentors_step.html.erb
+++ b/app/views/placements/wizards/add_placement_wizard/_mentors_step.html.erb
@@ -7,7 +7,10 @@
       <div class="govuk-grid-column-two-thirds">
         <span class="govuk-caption-l"><%= contextual_text %></span>
 
-        <%= f.govuk_check_boxes_fieldset :mentor_ids, legend: { size: "l", text: t(".mentor") } do %>
+        <%= f.govuk_check_boxes_fieldset :mentor_ids,
+          legend: { size: "l",
+                    text: t(".select_a_mentor") },
+          hint: { text: @placement.present? ? t(".hint.published") : t(".hint.unpublished") } do %>
           <% mentors_step.mentors_for_selection.each_with_index do |mentor, index| %>
             <%= f.govuk_check_box :mentor_ids, mentor.id, label: { text: mentor.full_name }, link_errors: index.zero? %>
           <% end %>

--- a/app/views/placements/wizards/add_placement_wizard/_phase_step.html.erb
+++ b/app/views/placements/wizards/add_placement_wizard/_phase_step.html.erb
@@ -11,7 +11,7 @@
         :phase,
         phase_step.phases_for_selection,
         :name, :name,
-        legend: { size: "l", text: t(".phase") }
+        legend: { size: "l", text: t(".select_a_phase") }
       ) %>
 
       <%= f.govuk_submit t(".continue") %>

--- a/app/views/placements/wizards/add_placement_wizard/_subject_step.html.erb
+++ b/app/views/placements/wizards/add_placement_wizard/_subject_step.html.erb
@@ -11,7 +11,7 @@
         :subject_id,
         subject_step.subjects_for_selection,
         :id, :name,
-        legend: { size: "l", text: t(".subject") }
+        legend: { size: "l", text: t(".select_a_subject") }
       ) %>
 
       <%= f.govuk_submit t(".continue") %>

--- a/app/views/placements/wizards/add_placement_wizard/_year_group_step.html.erb
+++ b/app/views/placements/wizards/add_placement_wizard/_year_group_step.html.erb
@@ -11,7 +11,7 @@
         :year_group,
         year_group_step.year_groups_for_selection,
         :value, :name, :description,
-        legend: { size: "l", text: t(".year_group") }
+        legend: { size: "l", text: t(".select_a_year_group") }
       ) %>
 
       <%= f.govuk_submit t(".continue") %>

--- a/app/views/placements/wizards/edit_placement_wizard/_provider_step.html.erb
+++ b/app/views/placements/wizards/edit_placement_wizard/_provider_step.html.erb
@@ -7,7 +7,7 @@
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l"><%= contextual_text %></span>
 
-      <%= f.govuk_radio_buttons_fieldset :provider_id, legend: { size: "l", text: t(".provider") } do %>
+      <%= f.govuk_radio_buttons_fieldset :provider_id, legend: { size: "l", text: t(".select_a_provider") } do %>
         <% provider_step.providers_for_selection.each do |provider| %>
           <%= f.govuk_radio_button :provider_id, provider.id, label: { text: provider.name },
                                                               checked: provider_step.provider_id == provider.id %>

--- a/app/wizards/placements/add_placement_wizard/additional_subjects_step.rb
+++ b/app/wizards/placements/add_placement_wizard/additional_subjects_step.rb
@@ -6,6 +6,11 @@ class Placements::AddPlacementWizard::AdditionalSubjectsStep < Placements::BaseS
 
   delegate :name, to: :parent_subject, prefix: true
 
+  def addition_subject_category
+    # For Modern languages this returns "modern language"
+    parent_subject_name.singularize.downcase
+  end
+
   def additional_subject_ids=(value)
     super Array(value).compact_blank
   end

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -33,12 +33,12 @@ en:
         add_placement:
           edit:
             cancel: Cancel
-            add_placement: Add placement
+            placement_details: Placement details
         edit_placement:
           update:
             success: "%{step_attribute} updated"
           edit:
-            edit_placement: Manage a placement
+            edit_placement: Placement details
             cancel: Cancel
           success: Placement updated
         terms:

--- a/config/locales/en/placements/support/schools/placements.yml
+++ b/config/locales/en/placements/support/schools/placements.yml
@@ -6,12 +6,12 @@ en:
           add_placement:
             edit:
               cancel: Cancel
-              add_placement: Add placement - %{organisation_name}
+              add_placement: Placement details - %{organisation_name}
           edit_placement:
             update:
               success: "%{step_attribute} updated"
             edit:
-              edit_placement: Manage a placement - %{organisation_name}
+              edit_placement: Placement details - %{organisation_name}
               cancel: Cancel
             success: Placement updated
           index:

--- a/config/locales/en/placements/wizards/add_placement_wizard.yml
+++ b/config/locales/en/placements/wizards/add_placement_wizard.yml
@@ -36,7 +36,6 @@ en:
             unpublished_html: |
               Some placements may have more than one mentor. 
               For example, if a mentor works part time.<br>
-              <br>
               You can change who the mentor is after you have published the placement.
             published: |
               Some placements may have more than one mentor. 

--- a/config/locales/en/placements/wizards/add_placement_wizard.yml
+++ b/config/locales/en/placements/wizards/add_placement_wizard.yml
@@ -36,7 +36,7 @@ en:
             unpublished_html: |
               Some placements may have more than one mentor. 
               For example, if a mentor works part time.<br>
-
+              <br>
               You can change who the mentor is after you have published the placement.
             published: |
               Some placements may have more than one mentor. 

--- a/config/locales/en/placements/wizards/add_placement_wizard.yml
+++ b/config/locales/en/placements/wizards/add_placement_wizard.yml
@@ -33,9 +33,9 @@ en:
           title_with_error: "Error: Select a mentor - %{contextual_text}"
           select_a_mentor: Select a mentor
           hint:
-            unpublished: |
+            unpublished_html: |
               Some placements may have more than one mentor. 
-              For example, if a mentor works part time.
+              For example, if a mentor works part time.<br>
 
               You can change who the mentor is after you have published the placement.
             published: |

--- a/config/locales/en/placements/wizards/add_placement_wizard.yml
+++ b/config/locales/en/placements/wizards/add_placement_wizard.yml
@@ -35,12 +35,12 @@ en:
           hint:
             unpublished: |
               Some placements may have more than one mentor. 
-              For example if a mentor works part time.
+              For example, if a mentor works part time.
 
               You can change who the mentor is after you have published the placement.
             published: |
               Some placements may have more than one mentor. 
-              For example if a mentor works part time.
+              For example, if a mentor works part time.
           continue: Continue
           mentors: Mentors
           not_known: Not yet known

--- a/config/locales/en/placements/wizards/add_placement_wizard.yml
+++ b/config/locales/en/placements/wizards/add_placement_wizard.yml
@@ -36,6 +36,7 @@ en:
             unpublished_html: |
               Some placements may have more than one mentor. 
               For example, if a mentor works part time.<br>
+              <br>
               You can change who the mentor is after you have published the placement.
             published: |
               Some placements may have more than one mentor. 

--- a/config/locales/en/placements/wizards/add_placement_wizard.yml
+++ b/config/locales/en/placements/wizards/add_placement_wizard.yml
@@ -5,37 +5,48 @@ en:
         edit:
           cancel: Cancel
         phase_step:
-          title: Phase - %{contextual_text}
-          title_with_error: "Error: Phase - %{contextual_text}"
-          phase: Phase
+          title: Select a phase - %{contextual_text}
+          title_with_error: "Error: Select a phase - %{contextual_text}"
+          select_a_phase: Select a phase
           primary: Primary
           secondary: Secondary
           continue: Continue
         subject_step:
-          title: Subject - %{contextual_text}
-          title_with_error: "Error: Subject - %{contextual_text}"
-          subject: Subject
+          title: Select a subject - %{contextual_text}
+          title_with_error: "Error: Select a subject - %{contextual_text}"
+          select_a_subject: Select a subject
           continue: Continue
         additional_subjects_step:
-          title: Additional subject - %{contextual_text}
-          title_with_error: "Error: Additional subject - %{contextual_text}"
+          title: Select a %{subject} - %{contextual_text}
+          title_with_error: "Error: Select a %{subject} - %{contextual_text}"
+          select_a_subject: Select a %{subject}
+          hint: Select all that apply
           continue: Continue
         year_group_step:
-          title: Year group - %{contextual_text}
-          title_with_error: "Error: Year group - %{contextual_text}"
-          year_group: Year group
+          title: Select a year group - %{contextual_text}
+          title_with_error: "Error: Select a year group - %{contextual_text}"
+          select_a_year_group: Select a year group
           primary: Primary
           continue: Continue
         mentors_step:
-          title: Mentor - %{contextual_text}
-          title_with_error: "Error: Mentor - %{contextual_text}"
-          mentor: Mentor
+          title: Select a mentor - %{contextual_text}
+          title_with_error: "Error: Select a mentor - %{contextual_text}"
+          select_a_mentor: Select a mentor
+          hint:
+            unpublished: |
+              Some placements may have more than one mentor. 
+              For example if a mentor works part time.
+
+              You can change who the mentor is after you have published the placement.
+            published: |
+              Some placements may have more than one mentor. 
+              For example if a mentor works part time.
           continue: Continue
           mentors: Mentors
           not_known: Not yet known
           mentor_not_listed: My mentor is not listed
-          you_need_to_add_a_mentor: "You will need to %{link} first."
-          add_a_mentor: add a mentor
+          you_need_to_add_a_mentor: "You must %{link} before they can be assigned to a specific placement."
+          add_a_mentor: add mentors to your school's profile
         check_your_answers_step:
           page_title: Check your answers - %{contextual_text}
           title: Check your answers

--- a/config/locales/en/placements/wizards/edit_placement_wizard.yml
+++ b/config/locales/en/placements/wizards/edit_placement_wizard.yml
@@ -9,5 +9,5 @@ en:
           not_known: Not yet known
           continue: Continue
           help_with_providers: My provider is not listed
-          you_need_to_add_a_provider: You mush %{link} before they can be assigned to a specific placement.
+          you_need_to_add_a_provider: You must %{link} before they can be assigned to a specific placement.
           add_a_provider: add providers to your school's provider

--- a/config/locales/en/placements/wizards/edit_placement_wizard.yml
+++ b/config/locales/en/placements/wizards/edit_placement_wizard.yml
@@ -10,4 +10,4 @@ en:
           continue: Continue
           help_with_providers: My provider is not listed
           you_need_to_add_a_provider: You must %{link} before they can be assigned to a specific placement.
-          add_a_provider: add providers to your school's provider
+          add_a_provider: add providers to your school's profile

--- a/config/locales/en/placements/wizards/edit_placement_wizard.yml
+++ b/config/locales/en/placements/wizards/edit_placement_wizard.yml
@@ -3,12 +3,11 @@ en:
     wizards:
       edit_placement_wizard:
         provider_step:
-          title_with_error: "Error: Provider - %{contextual_text}"
-          title: Provider - %{contextual_text}
-          caption: Manage a placement
-          provider: Provider
+          title_with_error: "Error: Select a provider - %{contextual_text}"
+          title: Select a provider - %{contextual_text}
+          select_a_provider: Select a provider
           not_known: Not yet known
           continue: Continue
           help_with_providers: My provider is not listed
-          you_need_to_add_a_provider: You will need to %{link} first.
-          add_a_provider: add a provider
+          you_need_to_add_a_provider: You mush %{link} before they can be assigned to a specific placement.
+          add_a_provider: add providers to your school's provider

--- a/spec/support/shared_examples/system/placements/add_a_placement_wizard.rb
+++ b/spec/support/shared_examples/system/placements/add_a_placement_wizard.rb
@@ -66,7 +66,7 @@ RSpec.shared_examples "an add a placement wizard" do
           and_i_click_on("Continue")
           then_i_see_the_add_a_placement_mentor_page
           when_i_expand_the_summary_text
-          and_i_click_on("add a mentor")
+          and_i_click_on("add mentors to your school's profile")
           then_i_see_the_new_mentor_page
         end
       end
@@ -522,22 +522,22 @@ RSpec.shared_examples "an add a placement wizard" do
   end
 
   def then_i_see_the_add_a_placement_add_phase_page
-    expect(page).to have_content("Add placement")
-    expect(page).to have_content("Phase")
+    expect(page).to have_content("Placement details")
+    expect(page).to have_content("Select a phase")
     expect(page).to have_content("Primary")
     expect(page).to have_content("Secondary")
   end
 
   def then_i_see_the_add_a_placement_subject_page(phase)
     opposite_phase = phase == "Primary" ? "Secondary" : "Primary"
-    expect(page).to have_content("Add placement")
-    expect(page).to have_content("Subject")
+    expect(page).to have_content("Placement details")
+    expect(page).to have_content("Select a subject")
     expect(page).to have_content("#{phase} subject")
     expect(page).not_to have_content("#{opposite_phase} subject")
   end
 
   def then_i_see_the_add_additional_subjects_page(subject)
-    expect(page).to have_content("Add placement")
+    expect(page).to have_content("Placement details")
     expect(page).to have_content(subject.name)
 
     subject.child_subjects.each do |child_subject|
@@ -560,8 +560,8 @@ RSpec.shared_examples "an add a placement wizard" do
   end
 
   def then_i_see_the_add_year_group_page(year_group)
-    expect(page).to have_content("Add placement")
-    expect(page).to have_content("Year group")
+    expect(page).to have_content("Placement details")
+    expect(page).to have_content("Select a year group")
     expect(page).to have_content(year_group)
   end
 
@@ -582,8 +582,8 @@ RSpec.shared_examples "an add a placement wizard" do
   end
 
   def then_i_see_the_add_a_placement_mentor_page
-    expect(page).to have_content("Add placement")
-    expect(page).to have_content("Mentor")
+    expect(page).to have_content("Placement details")
+    expect(page).to have_content("Select a mentor")
     expect(page).to have_content(mentor_1.full_name)
     expect(page).to have_content(mentor_2.full_name)
   end

--- a/spec/support/shared_examples/system/placements/edit_a_placement_wizard.rb
+++ b/spec/support/shared_examples/system/placements/edit_a_placement_wizard.rb
@@ -367,8 +367,8 @@ RSpec.shared_examples "an edit placement wizard", :js do
   end
 
   def then_i_should_see_the_edit_mentors_page
-    expect(page).to have_content("Manage a placement")
-    expect(page).to have_content("Mentor")
+    expect(page).to have_content("Placement details")
+    expect(page).to have_content("Select a mentor")
   end
 
   def when_i_select_mentor_2
@@ -398,7 +398,7 @@ RSpec.shared_examples "an edit placement wizard", :js do
   end
 
   def then_i_should_see_the_edit_provider_page
-    expect(page).to have_content("Manage a placement")
+    expect(page).to have_content("Placement details")
     expect(page).to have_content("Provider")
   end
 
@@ -429,8 +429,8 @@ RSpec.shared_examples "an edit placement wizard", :js do
   end
 
   def then_i_should_see_the_edit_year_group_page
-    expect(page).to have_content("Manage a placement")
-    expect(page).to have_content("Year group")
+    expect(page).to have_content("Placement details")
+    expect(page).to have_content("Select a year group")
   end
 
   def when_i_select_year(year)

--- a/spec/support/shared_examples/system/placements/edit_a_placement_wizard.rb
+++ b/spec/support/shared_examples/system/placements/edit_a_placement_wizard.rb
@@ -399,7 +399,7 @@ RSpec.shared_examples "an edit placement wizard", :js do
 
   def then_i_should_see_the_edit_provider_page
     expect(page).to have_content("Placement details")
-    expect(page).to have_content("Provider")
+    expect(page).to have_content("Select a provider")
   end
 
   def when_i_select_provider(provider)


### PR DESCRIPTION
## Context

- Content changes to the Add/Edit placement flow.

## Changes proposed in this pull request

- H1, caption and hint text changes in accordance with [Lucid](https://lucid.app/lucidspark/262e5d35-0c1f-4f90-aa60-c3b00a9a53ef/edit?invitationId=inv_fe53fead-7afb-41fa-b89f-6c57958d9867&page=0_0#)

## Guidance to review

- Sign in as Anne (School User)
- Follow the process to add a placement. (Ensure all H1, captions and hint text appear as shown in Lucid examples)
- Follow the process to edit a placement (Change Mentor, Year Group and Provider). (Ensure all H1, captions and hint text appear as shown in Lucid examples)

------------

- Sign in as Colin (Support User)
- Follow the process to add a placement. (Ensure all H1, captions and hint text appear as shown in Lucid examples)
- Follow the process to edit a placement (Change Mentor, Year Group and Provider). (Ensure all H1, captions and hint text appear as shown in Lucid examples)

## Link to Trello card

https://trello.com/c/TRQxzzzx/678-change-captions-and-h1-questions-in-a-form-flow-add-a-placement

## Screenshots

_Add a placement_

https://github.com/user-attachments/assets/812427c2-fd24-4c7e-b86e-61ea80b5f0f9

_Edit a placement_

https://github.com/user-attachments/assets/98723ece-e206-49dc-af89-755b935ff650

_Add a Provider to Placement_

https://github.com/user-attachments/assets/c4244552-131b-4e04-b993-6014e7929805





