### PR TITLE
Update partial to read "User details" instead of "Add user"

### DIFF
--- a/app/views/placements/wizards/add_user_wizard/_user_step.html.erb
+++ b/app/views/placements/wizards/add_user_wizard/_user_step.html.erb
@@ -1,11 +1,11 @@
-<% content_for :page_title, user_step.errors.any? ? t(".title_with_error", caption:) : t(".title", caption:) %>
+<% content_for :page_title, user_step.errors.any? ? t(".title_with_error", caption: t(".caption")) : t(".title", caption: t(".caption")) %>
 
 <%= form_for(user_step, url: current_step_path, method: :put) do |f| %>
   <%= f.govuk_error_summary %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-l"><%= caption %></span>
+      <span class="govuk-caption-l"><%= t(".caption") %></span>
       <h2 class="govuk-heading-l"><%= t(".personal_details") %></h2>
 
       <div class="govuk-form-group">

--- a/config/locales/en/placements/wizards/add_user_wizard.yml
+++ b/config/locales/en/placements/wizards/add_user_wizard.yml
@@ -5,7 +5,7 @@ en:
         user_step:
           title_with_error: "Error: Personal details - %{caption}"
           title: Personal details - %{caption}
-          add_user: Add user
+          caption: User details
           continue: Continue
           personal_details: Personal details
         check_your_answers_step:


### PR DESCRIPTION
## Context

Pages should give directions so that screen readers can be more helpful for their users.

## Changes proposed in this pull request

- Change caption and title from `Add user` to `User details`

## Guidance to review

- Log in as Anne
- Add a user
- Verify the title and caption has changed

## Link to Trello card

[Change captions and H1 questions in a form flow (Users -> Add user)
](https://trello.com/c/7LJ1p2Bp/682-change-captions-and-h1-questions-in-a-form-flow-users-add-user)

## Screenshots

NB: I can't get a screenshot of it due to the hover effect cancelling but the title is updated too.

![image](https://github.com/user-attachments/assets/9469ab93-0143-4782-91b0-883059863101)
