### PR TITLE
'Remove mentor' changed to 'delete mentor' in school user journey

### DIFF
--- a/app/controllers/placements/schools/mentors_controller.rb
+++ b/app/controllers/placements/schools/mentors_controller.rb
@@ -10,6 +10,8 @@ class Placements::Schools::MentorsController < Placements::ApplicationController
   def show; end
 
   def remove
+    @mentor = @mentor.decorate
+
     if policy(@mentor_membership).destroy?
       render "confirm_remove"
     else

--- a/app/controllers/placements/schools/mentors_controller.rb
+++ b/app/controllers/placements/schools/mentors_controller.rb
@@ -21,7 +21,7 @@ class Placements::Schools::MentorsController < Placements::ApplicationController
     authorize @mentor_membership
     @mentor_membership.destroy!
 
-    flash[:success] = t(".mentor_removed")
+    flash[:success] = t(".mentor_deleted")
     redirect_to_index_path
   end
 

--- a/app/controllers/placements/schools/mentors_controller.rb
+++ b/app/controllers/placements/schools/mentors_controller.rb
@@ -21,7 +21,7 @@ class Placements::Schools::MentorsController < Placements::ApplicationController
     authorize @mentor_membership
     @mentor_membership.destroy!
 
-    flash[:success] = t(".mentor_deleted")
+    flash[:success] = t(".mentor_removed")
     redirect_to_index_path
   end
 

--- a/app/decorators/mentor_decorator.rb
+++ b/app/decorators/mentor_decorator.rb
@@ -1,0 +1,7 @@
+class MentorDecorator < Draper::Decorator
+  delegate_all
+
+  def mentor_school_placements(school)
+    placements.where(school:).decorate
+  end
+end

--- a/app/helpers/placements/routes/placements_helper.rb
+++ b/app/helpers/placements/routes/placements_helper.rb
@@ -1,0 +1,9 @@
+module Placements::Routes::PlacementsHelper
+  def placements_school_placement_details_path(school:, placement:, support: false)
+    if support
+      placements_support_school_placement_path(school, placement)
+    else
+      placements_school_placement_path(school, placement)
+    end
+  end
+end

--- a/app/views/placements/schools/mentors/confirm_remove.html.erb
+++ b/app/views/placements/schools/mentors/confirm_remove.html.erb
@@ -12,7 +12,11 @@
         <%= t(".are_you_sure") %>
       </label>
 
-      <%= govuk_button_to t(".remove_mentor"),
+      <p class="govuk-body">
+      <%= t(".you_will_no_longer", user_name: @mentor.full_name) %>
+      </p>
+
+      <%= govuk_button_to t(".delete_mentor"),
         placements_school_mentor_path(@school, @mentor),
         warning: true,
         method: :delete %>

--- a/app/views/placements/schools/mentors/confirm_remove.html.erb
+++ b/app/views/placements/schools/mentors/confirm_remove.html.erb
@@ -13,7 +13,7 @@
       </label>
 
       <p class="govuk-body">
-      <%= t(".you_will_no_longer", user_name: @mentor.full_name) %>
+        <%= t(".you_will_no_longer", user_name: @mentor.full_name) %>
       </p>
 
       <%= govuk_button_to t(".delete_mentor"),

--- a/app/views/placements/schools/mentors/show.html.erb
+++ b/app/views/placements/schools/mentors/show.html.erb
@@ -26,7 +26,7 @@
         <% end %>
       <% end %>
 
-      <%= govuk_link_to t(".remove_mentor"),
+      <%= govuk_link_to t(".delete_mentor"),
         remove_placements_school_mentor_path(@school, @mentor),
         class: "app-link app-link--destructive" %>
     </div>

--- a/app/views/placements/support/schools/mentors/confirm_remove.html.erb
+++ b/app/views/placements/support/schools/mentors/confirm_remove.html.erb
@@ -12,7 +12,7 @@
         <%= t(".are_you_sure") %>
       </label>
 
-      <%= govuk_button_to t(".remove_mentor"),
+      <%= govuk_button_to t(".delete_mentor"),
         placements_support_school_mentor_path(@school, @mentor),
         warning: true,
         method: :delete %>

--- a/app/views/shared/schools/mentors/_can_not_remove.html.erb
+++ b/app/views/shared/schools/mentors/_can_not_remove.html.erb
@@ -8,7 +8,7 @@
 
   <%= simple_format(t(".description", mentor_name: mentor.full_name)) %>
 
-  <ul class="govuk-list">
+  <ul class="govuk-list govuk-list--bullet">
     <% mentor.placements.where(school:).find_each do |placement| %>
       <li><%= govuk_link_to(placement.decorate.title, placements_school_placement_path(school, placement), target: "_blank") %></li>
     <% end %>

--- a/app/views/shared/schools/mentors/_can_not_remove.html.erb
+++ b/app/views/shared/schools/mentors/_can_not_remove.html.erb
@@ -10,6 +10,6 @@
 
   <ul class="govuk-list govuk-list--bullet">
     <% mentor.placements.where(school:).find_each do |placement| %>
-      <li><%= govuk_link_to(placement.decorate.title, placements_school_placement_path(school, placement), target: "_blank") %></li>
+      <li><%= govuk_link_to(placement.decorate.title, placements_school_placement_path(school, placement), target: "_blank", no_visited_state: true) %></li>
     <% end %>
   </ul>

--- a/app/views/shared/schools/mentors/_can_not_remove.html.erb
+++ b/app/views/shared/schools/mentors/_can_not_remove.html.erb
@@ -9,7 +9,13 @@
   <%= simple_format(t(".description", mentor_name: mentor.full_name)) %>
 
   <ul class="govuk-list govuk-list--bullet">
-    <% mentor.placements.where(school:).find_each do |placement| %>
-      <li><%= govuk_link_to(placement.decorate.title, placements_school_placement_path(school, placement), target: "_blank", no_visited_state: true) %></li>
+    <% mentor.placements.where(school:).decorate.each do |placement| %>
+      <li>
+        <%= govuk_link_to(placement.title,
+          placements_school_placement_path(school, placement),
+          target: "_blank",
+          new_tab: true,
+          no_visited_state: true) %>
+      </li>
     <% end %>
   </ul>

--- a/app/views/shared/schools/mentors/_can_not_remove.html.erb
+++ b/app/views/shared/schools/mentors/_can_not_remove.html.erb
@@ -11,8 +11,14 @@
   <ul class="govuk-list govuk-list--bullet">
     <% mentor.placements.where(school:).decorate.each do |placement| %>
       <li>
+        <% if support %>
+          <% placement_link = placements_support_school_placement_path(school, placement) %>
+        <% else %>
+          <% placement_link = placements_school_placement_path(school, placement) %>
+        <% end %>
+
         <%= govuk_link_to(placement.title,
-          placements_school_placement_path(school, placement),
+          placement_link,
           target: "_blank",
           new_tab: true,
           no_visited_state: true) %>

--- a/app/views/shared/schools/mentors/_can_not_remove.html.erb
+++ b/app/views/shared/schools/mentors/_can_not_remove.html.erb
@@ -9,7 +9,7 @@
   <%= simple_format(t(".description", mentor_name: mentor.full_name)) %>
 
   <ul class="govuk-list">
-    <% mentor.placements.where(school:).each do |placement| %>
+    <% mentor.placements.where(school:).find_each do |placement| %>
       <li><%= govuk_link_to(placement.decorate.title, placements_school_placement_path(school, placement), target: "_blank") %></li>
     <% end %>
   </ul>

--- a/app/views/shared/schools/mentors/_can_not_remove.html.erb
+++ b/app/views/shared/schools/mentors/_can_not_remove.html.erb
@@ -6,6 +6,10 @@
   <%= t(".title") %>
 </label>
 
-<p class="govuk-body">
   <%= simple_format(t(".description", mentor_name: mentor.full_name)) %>
-</p>
+
+  <ul class="govuk-list">
+    <% mentor.placements.where(school:).each do |placement| %>
+      <li><%= govuk_link_to(placement.decorate.title, placements_school_placement_path(school, placement), target: "_blank") %></li>
+    <% end %>
+  </ul>

--- a/app/views/shared/schools/mentors/_can_not_remove.html.erb
+++ b/app/views/shared/schools/mentors/_can_not_remove.html.erb
@@ -9,16 +9,10 @@
   <%= simple_format(t(".description", mentor_name: mentor.full_name)) %>
 
   <ul class="govuk-list govuk-list--bullet">
-    <% mentor.placements.where(school:).decorate.each do |placement| %>
+    <% mentor.mentor_school_placements(school).each do |placement| %>
       <li>
-        <% if support %>
-          <% placement_link = placements_support_school_placement_path(school, placement) %>
-        <% else %>
-          <% placement_link = placements_school_placement_path(school, placement) %>
-        <% end %>
-
         <%= govuk_link_to(placement.title,
-          placement_link,
+          placements_school_placement_details_path(school:, placement:, support:),
           target: "_blank",
           new_tab: true,
           no_visited_state: true) %>

--- a/config/locales/en/placements/schools/mentors.yml
+++ b/config/locales/en/placements/schools/mentors.yml
@@ -25,11 +25,7 @@ en:
         can_not_remove:
           page_title: You cannot delete this mentor - %{user_name}
         destroy:
-          mentor_removed: Mentor removed
-          caption: "Mentors - %{school_name}"
-          attributes:
-            mentors:
-              trn: Teacher reference number (TRN)
+          mentor_deleted: Mentor deleted
         new:
           page_title: Find teacher - Add mentor
           page_title_with_error: "Error: Find teacher - Add mentor"

--- a/config/locales/en/placements/schools/mentors.yml
+++ b/config/locales/en/placements/schools/mentors.yml
@@ -12,19 +12,20 @@ en:
           add_mentor: Add mentor
           page_title: Mentors
         show:
-          remove_mentor: Remove mentor
+          delete_mentor: Delete mentor
           attributes:
             mentors:
               trn: Teacher reference number (TRN)
         confirm_remove:
-          page_title: Are you sure you want to remove this mentor? - %{user_name}
-          are_you_sure: Are you sure you want to remove this mentor?
-          remove_mentor: Remove mentor
+          page_title: Are you sure you want to delete this mentor? - %{user_name}
+          are_you_sure: Are you sure you want to delete this mentor?
+          delete_mentor: Delete mentor
+          you_will_no_longer: You will no longer be able to assign %{user_name} to placements.
           cancel: Cancel
         can_not_remove:
-          page_title: You can not remove this mentor - %{user_name}
+          page_title: You cannot delete this mentor - %{user_name}
         destroy:
-          mentor_removed: Mentor removed
+          mentor_deleted: Mentor deleted
           caption: "Mentors - %{school_name}"
           attributes:
             mentors:

--- a/config/locales/en/placements/schools/mentors.yml
+++ b/config/locales/en/placements/schools/mentors.yml
@@ -25,7 +25,7 @@ en:
         can_not_remove:
           page_title: You cannot delete this mentor - %{user_name}
         destroy:
-          mentor_deleted: Mentor deleted
+          mentor_removed: Mentor removed
           caption: "Mentors - %{school_name}"
           attributes:
             mentors:

--- a/config/locales/en/placements/support/schools/mentors.yml
+++ b/config/locales/en/placements/support/schools/mentors.yml
@@ -32,4 +32,4 @@ en:
             cancel: Cancel
             remove_mentor: Remove mentor
           destroy:
-            mentor_removed: Mentor removed
+            mentor_deleted: Mentor deleted

--- a/config/locales/en/placements/support/schools/mentors.yml
+++ b/config/locales/en/placements/support/schools/mentors.yml
@@ -23,7 +23,7 @@ en:
             page_title: Are you sure you want to remove this mentor? - %{user_name} - %{school_name}
             are_you_sure: Are you sure you want to remove this mentor?
             cancel: Cancel
-            remove_mentor: Remove mentor
+            delete_mentor: Remove mentor
           can_not_remove:
             page_title: You can not remove this mentor - %{user_name} - %{school_name}
           remove:

--- a/config/locales/en/shared/schools/mentors.yml
+++ b/config/locales/en/shared/schools/mentors.yml
@@ -3,8 +3,8 @@ en:
     schools:
       mentors:
         can_not_remove:
-          title: You can not remove this mentor
+          title: You cannot delete this mentor
           description: |
-            %{mentor_name} cannot be removed from your organisation because they are assigned to placements.
+            %{mentor_name} must be removed from current placements before you can delete them.
 
-            To remove %{mentor_name} as a mentor you must remove them from any current placements.
+            They are currently assigned to: 

--- a/spec/decorators/mentor_decorator_spec.rb
+++ b/spec/decorators/mentor_decorator_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe MentorDecorator do
+  describe ".mentor_school_placements" do
+    let(:school) { create(:placements_school) }
+    let(:mentor) { create(:placements_mentor, schools: [school]) }
+    let!(:placement) { create(:placement, mentors: [mentor], school:) }
+
+    before do
+      _random_placement = create(:placement)
+    end
+
+    it "returns the placements associated to the mentor and school" do
+      decorated_mentor = mentor.decorate
+      decorated_placement = placement.decorate
+      result = decorated_mentor.mentor_school_placements(school)
+
+      expect(result).to contain_exactly(decorated_placement)
+    end
+  end
+end

--- a/spec/helpers/placements/routes/placements_helper_spec.rb
+++ b/spec/helpers/placements/routes/placements_helper_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe Placements::Routes::PlacementsHelper do
+  describe ".placements_school_placement_details_path" do
+    let(:school) { create(:placements_school) }
+    let!(:placement) { create(:placement, school:) }
+
+    context "when the path is for a support view" do
+      it "returns a path to view the placement as a support user" do
+        expect(
+          placements_school_placement_details_path(school:, placement:, support: true),
+        ).to eq(
+          placements_support_school_placement_path(school, placement),
+        )
+      end
+    end
+
+    context "when the path is not for a support view" do
+      it "returns a path to view the placement as a school user" do
+        expect(
+          placements_school_placement_details_path(school:, placement:, support: false),
+        ).to eq(
+          placements_school_placement_path(school, placement),
+        )
+      end
+    end
+  end
+end

--- a/spec/system/placements/schools/mentors/remove_a_mentor_spec.rb
+++ b/spec/system/placements/schools/mentors/remove_a_mentor_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Placements / Schools / Mentors / Remove a mentor", service: :pla
     scenario "User cannot remove the mentor from the school" do
       when_i_visit_the_show_page_for(school, mentor_1)
       and_i_click_on("Delete mentor")
-      then_i_see_i_cannot_remove_the_mentor("John Doe")
+      then_i_see_i_cannot_remove_the_mentor(mentor_1)
     end
   end
 
@@ -122,8 +122,12 @@ RSpec.describe "Placements / Schools / Mentors / Remove a mentor", service: :pla
     expect(page).to have_content(mentor_name)
   end
 
-  def then_i_see_i_cannot_remove_the_mentor(mentor_name)
-    expect(page).to have_content(mentor_name)
+  def then_i_see_i_cannot_remove_the_mentor(mentor)
+    expect(page).to have_content(mentor.full_name)
     expect(page).to have_content("You cannot delete this mentor")
+
+    mentor.placements.where(school:).find_each do |placement|
+      expect(page).to have_link(placement.decorate.title, href: placements_school_placement_path(school, placement))
+    end
   end
 end

--- a/spec/system/placements/schools/mentors/remove_a_mentor_spec.rb
+++ b/spec/system/placements/schools/mentors/remove_a_mentor_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe "Placements / Schools / Mentors / Remove a mentor", service: :pla
     scenario "User cannot remove the mentor from the school" do
       when_i_visit_the_show_page_for(school, mentor_1)
       and_i_click_on("Delete mentor")
-      then_i_see_i_cannot_remove_the_mentor(mentor_1)
+      then_i_see_i_cannot_remove_the_mentor("John Doe")
+      and_i_see_a_list_of_placements_assigned_to_mentor(mentor_1)
     end
   end
 
@@ -112,7 +113,7 @@ RSpec.describe "Placements / Schools / Mentors / Remove a mentor", service: :pla
     mentors_is_selected_in_primary_nav
     expect(mentor.mentor_memberships.find_by(school:)).to be_nil
     within(".govuk-notification-banner__content") do
-      expect(page).to have_content "Mentor removed"
+      expect(page).to have_content "Mentor deleted"
     end
 
     expect(page).not_to have_content mentor.full_name
@@ -122,10 +123,12 @@ RSpec.describe "Placements / Schools / Mentors / Remove a mentor", service: :pla
     expect(page).to have_content(mentor_name)
   end
 
-  def then_i_see_i_cannot_remove_the_mentor(mentor)
-    expect(page).to have_content(mentor.full_name)
+  def then_i_see_i_cannot_remove_the_mentor(mentor_name)
+    expect(page).to have_content(mentor_name)
     expect(page).to have_content("You cannot delete this mentor")
+  end
 
+  def and_i_see_a_list_of_placements_assigned_to_mentor(mentor)
     mentor.placements.where(school:).find_each do |placement|
       expect(page).to have_link(placement.decorate.title, href: placements_school_placement_path(school, placement))
     end

--- a/spec/system/placements/schools/mentors/remove_a_mentor_spec.rb
+++ b/spec/system/placements/schools/mentors/remove_a_mentor_spec.rb
@@ -19,15 +19,15 @@ RSpec.describe "Placements / Schools / Mentors / Remove a mentor", service: :pla
   end
 
   context "when the mentor has no placements" do
-    scenario "User removes a mentor from a school" do
+    scenario "User deletes a mentor from a school" do
       when_i_visit_the_show_page_for(school, mentor_1)
-      and_i_click_on("Remove mentor")
+      and_i_click_on("Delete mentor")
       then_i_am_asked_to_confirm(school, mentor_1)
       when_i_click_on("Cancel")
       then_i_return_to_mentor_page(school, mentor_1)
-      when_i_click_on("Remove mentor")
+      when_i_click_on("Delete mentor")
       then_i_am_asked_to_confirm(school, mentor_1)
-      when_i_click_on("Remove mentor")
+      when_i_click_on("Delete mentor")
       then_the_mentor_is_removed_from_the_school(school, mentor_1)
       and_a_school_mentor_remains_called("Agatha Christie")
     end
@@ -36,9 +36,9 @@ RSpec.describe "Placements / Schools / Mentors / Remove a mentor", service: :pla
   context "when the mentor has placements" do
     before { create(:placement, mentors: [mentor_1], school:) }
 
-    scenario "User can not remove the mentor from the school" do
+    scenario "User cannot remove the mentor from the school" do
       when_i_visit_the_show_page_for(school, mentor_1)
-      and_i_click_on("Remove mentor")
+      and_i_click_on("Delete mentor")
       then_i_see_i_cannot_remove_the_mentor("John Doe")
     end
   end
@@ -87,10 +87,10 @@ RSpec.describe "Placements / Schools / Mentors / Remove a mentor", service: :pla
   def then_i_am_asked_to_confirm(_school, mentor)
     mentors_is_selected_in_primary_nav
     expect(page).to have_title(
-      "Are you sure you want to remove this mentor? - #{mentor.full_name} - Manage school placements",
+      "Are you sure you want to delete this mentor? - #{mentor.full_name} - Manage school placements",
     )
     expect(page).to have_content mentor.full_name
-    expect(page).to have_content "Are you sure you want to remove this mentor?"
+    expect(page).to have_content "Are you sure you want to delete this mentor?"
   end
 
   def mentors_is_selected_in_primary_nav
@@ -112,7 +112,7 @@ RSpec.describe "Placements / Schools / Mentors / Remove a mentor", service: :pla
     mentors_is_selected_in_primary_nav
     expect(mentor.mentor_memberships.find_by(school:)).to be_nil
     within(".govuk-notification-banner__content") do
-      expect(page).to have_content "Mentor removed"
+      expect(page).to have_content "Mentor deleted"
     end
 
     expect(page).not_to have_content mentor.full_name
@@ -124,6 +124,6 @@ RSpec.describe "Placements / Schools / Mentors / Remove a mentor", service: :pla
 
   def then_i_see_i_cannot_remove_the_mentor(mentor_name)
     expect(page).to have_content(mentor_name)
-    expect(page).to have_content("You can not remove this mentor")
+    expect(page).to have_content("You cannot delete this mentor")
   end
 end

--- a/spec/system/placements/schools/mentors/remove_a_mentor_spec.rb
+++ b/spec/system/placements/schools/mentors/remove_a_mentor_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe "Placements / Schools / Mentors / Remove a mentor", service: :pla
     mentors_is_selected_in_primary_nav
     expect(mentor.mentor_memberships.find_by(school:)).to be_nil
     within(".govuk-notification-banner__content") do
-      expect(page).to have_content "Mentor deleted"
+      expect(page).to have_content "Mentor removed"
     end
 
     expect(page).not_to have_content mentor.full_name

--- a/spec/system/placements/support/schools/mentors/support_user_removes_a_mentor_spec.rb
+++ b/spec/system/placements/support/schools/mentors/support_user_removes_a_mentor_spec.rb
@@ -129,6 +129,6 @@ RSpec.describe "Placements / Support / Schools / Mentor / Support User removes a
 
   def then_i_see_i_cannot_remove_the_mentor(mentor_name)
     expect(page).to have_content(mentor_name)
-    expect(page).to have_content("You can not remove this mentor")
+    expect(page).to have_content("You cannot delete this mentor")
   end
 end

--- a/spec/system/placements/support/schools/mentors/support_user_removes_a_mentor_spec.rb
+++ b/spec/system/placements/support/schools/mentors/support_user_removes_a_mentor_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe "Placements / Support / Schools / Mentor / Support User removes a
     mentors_is_selected_in_secondary_nav
     expect(mentor.mentor_memberships.find_by(school:)).to be_nil
     within(".govuk-notification-banner__content") do
-      expect(page).to have_content "Mentor removed"
+      expect(page).to have_content "Mentor deleted"
     end
 
     expect(page).not_to have_content mentor.full_name


### PR DESCRIPTION
## Context

Inconsistent terminology causes confusion for users - if different words have the same action it adds cognitive load.

## Changes proposed in this pull request

**Mentor show page:**
- Update “Remove mentor” to “Delete mentor”

**"Remove mentor" confirmation page:**
- Update “Are you sure you wish to remove this mentor?” to “Are you sure you want to delete this mentor?”
- Add paragraph: “You will no longer be able to assign %{mentor_name} to placements.”
- Update button text from “Remove mentor” to “Delete mentor”

**"You cannot remove this mentor" page:**
- Update “You can not remove this mentor” to “You cannot delete this mentor”
- Replace paragraph text with :“%{mentor_name} must be removed from current placements before you can delete them.They are currently assigned to: ” followed by a bulleted list of their currently assigned placements. 

## Guidance to review

- Review journey to delete a mentor to whom no placements are assigned (e.g. John Doe).
- Review journey to delete a mentor to whom placements are assigned (e.g. Pomona Doe).
- Run `bundle exec rspec spec/system/placements/schools/mentors`

## Link to Trello card

https://trello.com/c/sNxSwjcB/663-improve-school-user-mentor-journey-content