### PR TITLE
Update mentor captions for support and schools

### DIFF
--- a/app/views/placements/support/schools/mentors/add_mentor/edit.html.erb
+++ b/app/views/placements/support/schools/mentors/add_mentor/edit.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <%= render @wizard.step, object: @wizard.step, contextual_text: t(".add_mentor", school_name: @wizard.school.name) %>
+  <%= render @wizard.step, object: @wizard.step, contextual_text: t(".contextual_text", school_name: @wizard.school.name) %>
 
   <p class="govuk-body">
     <%= govuk_link_to(t(".cancel"), placements_support_school_mentors_path(@wizard.school), no_visited_state: true) %>

--- a/app/views/placements/wizards/add_mentor_wizard/_mentor_step.html.erb
+++ b/app/views/placements/wizards/add_mentor_wizard/_mentor_step.html.erb
@@ -1,4 +1,5 @@
-<% content_for :page_title, mentor_step.errors.any? ? t(".page_title_with_error", error: mentor_step.errors.first.message, contextual_text:) : t(".page_title", contextual_text:) %>
+<% caption = current_user.support_user? ? "#{t(".caption")} #{contextual_text}" : t(".caption") %>
+<% content_for :page_title, mentor_step.errors.any? ? t(".page_title_with_error", error: mentor_step.errors.first.message, contextual_text: caption) : t(".page_title", contextual_text: caption) %>
 
 <div class="govuk-width-container">
   <%= form_with(model: mentor_step, url: current_step_path, method: :put) do |f| %>
@@ -6,7 +7,7 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <span class="govuk-caption-l"><%= t(".add_mentor_caption", contextual_text:) %></span>
+        <span class="govuk-caption-l"><%= caption %></span>
         <h2 class="govuk-heading-l"><%= t(".find_teacher") %></h2>
 
         <div class="govuk-form-group">

--- a/app/views/placements/wizards/add_mentor_wizard/_no_results_step.html.erb
+++ b/app/views/placements/wizards/add_mentor_wizard/_no_results_step.html.erb
@@ -1,7 +1,8 @@
-<% content_for :page_title, t(".page_title", trn: @wizard.steps[:mentor].trn, contextual_text:) %>
+<% caption = current_user.support_user? ? "#{t(".caption")} #{contextual_text}" : t(".caption") %>
+<% content_for :page_title, t(".page_title", trn: @wizard.steps[:mentor].trn, contextual_text: caption) %>
 <div class="govuk-width-container">
   <h1 class="govuk-heading-l">
-    <span class="govuk-caption-l"><%= t(".add_mentor_caption", contextual_text:) %></span>
+    <span class="govuk-caption-l"><%= caption %></span>
     <%= t(".no_results_found", trn: @wizard.steps[:mentor].trn) %>
   </h1>
   <p class="govuk-body">

--- a/config/locales/en/placements/support/schools/mentors.yml
+++ b/config/locales/en/placements/support/schools/mentors.yml
@@ -5,7 +5,8 @@ en:
         mentors:
           add_mentor:
             edit:
-              add_mentor: Add mentor - %{school_name}
+              contextual_text: "- %{school_name}"
+              add_mentor: Add mentor
               cancel: Cancel
           index:
             heading: Mentors

--- a/config/locales/en/placements/wizards/add_mentor_wizard.yml
+++ b/config/locales/en/placements/wizards/add_mentor_wizard.yml
@@ -6,7 +6,7 @@ en:
           page_title: Find teacher - %{contextual_text}
           page_title_with_error: "Error: %{error} - %{contextual_text}"
           add_mentor_caption: "%{contextual_text}"
-          add_mentor: Add mentor
+          caption: Mentor details
           cancel: Cancel
           continue: Continue
           trn: Teacher reference number (TRN)
@@ -19,8 +19,8 @@ en:
           help_with_the_trn: Help with the TRN
           date_of_birth_hint: For example, 31 3 1980
         check_your_answers_step:
-          page_title: Check your answers - %{contextual_text}
-          add_mentor_caption: "%{contextual_text}"
+          page_title: Check your answers - Add mentor - %{contextual_text}
+          add_mentor_caption: Add mentor %{contextual_text}
           add_mentor: Add mentor
           cancel: Cancel
           change: Change
@@ -34,7 +34,7 @@ en:
           privacy_notice: privacy notice
         no_results_step:
           page_title: No results found for ‘%{trn}’ - %{contextual_text}
-          add_mentor_caption: "%{contextual_text}"
+          caption: Mentor not found
           add_mentor: Add mentor
           change_your_search: Change your search
           help_text: Check that you typed in the teacher reference number (TRN) correctly.

--- a/spec/support/shared_examples/system/placements/add_a_placement_wizard.rb
+++ b/spec/support/shared_examples/system/placements/add_a_placement_wizard.rb
@@ -551,7 +551,7 @@ RSpec.shared_examples "an add a placement wizard" do
   end
 
   def then_i_see_the_new_mentor_page
-    expect(page).to have_content("Add mentor")
+    expect(page).to have_content("Mentor details")
     expect(page).to have_content("Find teacher")
   end
 

--- a/spec/system/placements/schools/mentors/user_adds_mentor_spec.rb
+++ b/spec/system/placements/schools/mentors/user_adds_mentor_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe "Placements school user adds mentors to schools", service: :place
   end
 
   def then_i_see_the_error(message, field_index = 0)
-    expect(page).to have_title "Error: #{message} - Add mentor"
+    expect(page).to have_title "Error: #{message}"
     within(".govuk-error-summary") do
       expect(page).to have_content message
     end
@@ -266,7 +266,7 @@ RSpec.describe "Placements school user adds mentors to schools", service: :place
 
   def then_i_see_no_results_page(_school_name, trn)
     expect(page).to have_title "No results found for ‘#{trn}’"
-    expect(page).to have_content "Add mentor"
+    expect(page).to have_content "Mentor not found"
     expect(page).to have_content "No results found for ‘#{trn}’"
   end
 

--- a/spec/system/placements/support/schools/mentors/support_user_adds_a_mentor_spec.rb
+++ b/spec/system/placements/support/schools/mentors/support_user_adds_a_mentor_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe "Placements support user adds mentors to schools", service: :plac
   end
 
   def then_i_see_the_error(message, school_name, title = message, field_index = 0)
-    expect(page).to have_title "Error: #{title} - Add mentor - #{school_name}"
+    expect(page).to have_title "Error: #{title} - Mentor details - #{school_name}"
     within(".govuk-error-summary") do
       expect(page).to have_content message
     end
@@ -269,7 +269,7 @@ RSpec.describe "Placements support user adds mentors to schools", service: :plac
 
   def then_i_see_no_results_page(_school_name, trn)
     expect(page).to have_title "No results found for ‘#{trn}’"
-    expect(page).to have_content "Add mentor - #{school.name}"
+    expect(page).to have_content "Mentor not found - #{school.name}"
     expect(page).to have_content "No results found for ‘#{trn}’"
   end
 


### PR DESCRIPTION
## Context

Pages should give directions so that screen readers can be more helpful for their users.

## Changes proposed in this pull request

- Updated Add mentor caption and page title
- Updated No mentor found caption and page title

## Guidance to review

Schools

- Log in as Anne
- Add a mentor
- Veify page title and caption have changed
- Enter 1234565, 11, 1, 1111
- Verify the no results found page title and caption have changed

Support

- Log in as Colin
- Select a school
- Add a mentor
- Veify page title and caption have changed
- Enter 1234565, 11, 1, 1111
- Verify the no results found page title and caption have changed

## Link to Trello card

[Change captions and H1 questions in a form flow (Add mentor)
](https://trello.com/c/bXvkSRLt/679-change-captions-and-h1-questions-in-a-form-flow-add-mentor)

## Screenshots

### Schools
![image](https://github.com/user-attachments/assets/2814fd28-c367-40ef-9ce7-d0c0087c6a72)
![image](https://github.com/user-attachments/assets/12a03e5f-35a3-4ac1-aa8c-77279d7d83b1)

### Support
![image](https://github.com/user-attachments/assets/6b0d56c1-d800-41a4-b73b-841bfcaae9f1)
![image](https://github.com/user-attachments/assets/2b44a613-63e3-4887-a8bb-566751d644b8)
