### PR TITLE
Close div tags

### DIFF
--- a/app/views/claims/schools/claims/_form.html.erb
+++ b/app/views/claims/schools/claims/_form.html.erb
@@ -18,5 +18,6 @@
       <p class="govuk-body">
         <%= govuk_link_to(t("cancel"), claims_school_claims_path(school), no_visited_state: true) %>
       </p>
+    </div>
   </div>
 <% end %>

--- a/app/views/claims/schools/claims/check.html.erb
+++ b/app/views/claims/schools/claims/check.html.erb
@@ -112,6 +112,6 @@
       <p class="govuk-body">
         <%= govuk_link_to t("cancel"), claims_school_claims_path(@school), no_visited_state: true %>
       </p>
-    <div>
-  <div>
+    </div>
+  </div>
 </div>

--- a/app/views/claims/schools/claims/mentor_trainings/edit.html.erb
+++ b/app/views/claims/schools/claims/mentor_trainings/edit.html.erb
@@ -53,6 +53,7 @@
         <p class="govuk-body">
           <%= govuk_link_to(t("cancel"), claims_school_claims_path(@school), no_visited_state: true) %>
         </p>
+      </div>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
## Context

My IDE kindly informed me that we had some unclosed HTML tags.

## Changes proposed in this pull request

- Close a few divs that were unclosed.

## Guidance to review

- Add a claim, there should be no discernable changes.

## Link to Trello card

[Close divs](https://trello.com/c/TW1WvVMG/684-close-divs)

## Screenshots

![image](https://github.com/user-attachments/assets/fb989ad8-4fef-4c6b-a6d4-c5eaa974e8f8)
![image](https://github.com/user-attachments/assets/c6b41080-4a42-46ae-b4a4-435a35fe7a9d)
![image](https://github.com/user-attachments/assets/2f4e6d61-60b0-48b8-b765-af1e30e68e3b)

