### PR TITLE
Remove whitespaces from TRN input field

### DIFF
--- a/app/forms/mentor_form.rb
+++ b/app/forms/mentor_form.rb
@@ -59,6 +59,10 @@ class MentorForm < ApplicationForm
     end
   end
 
+  def trn
+    super&.remove("\s")
+  end
+
   private
 
   def validate_membership

--- a/spec/support/shared_examples/mentor_form.rb
+++ b/spec/support/shared_examples/mentor_form.rb
@@ -125,6 +125,14 @@ RSpec.shared_examples "a mentor form" do
     end
   end
 
+  describe "#trn" do
+    it "returns the inputted trn without whitespaces" do
+      form = described_class.new(trn: " 123 456 7 ")
+
+      expect(form.trn).to eq("1234567")
+    end
+  end
+
   def stub_teaching_record_response(trn:, date_of_birth: "1991-01-22")
     allow(TeachingRecord::GetTeacher).to receive(:call).with(trn:, date_of_birth:).and_return(
       { "trn" => "1234567",


### PR DESCRIPTION
## Context

During UR, we witnessed a user using Speech-to-Text software. During the session, the user entered a TRN using their voice. The inputted text contained a "space" mid-way through the 7 digits.

To avoid this issue moving forward, we've decided to strip out all whitespaces.

## Changes proposed in this pull request

- Normalise `#trn` attribute reader of the `MentorForm`, this ensures no whitespace is present when accessing the attribute.

## Guidance to review

- Try to add a Mentor with the following TRN/DoB:
  - TRN: " 12 34 56 8"
  - DoB: 12/11/1986