### PR TITLE
School user delete partner provider journey made more consistent (remove -> delete)

### DIFF
--- a/app/controllers/placements/schools/partner_providers_controller.rb
+++ b/app/controllers/placements/schools/partner_providers_controller.rb
@@ -6,7 +6,7 @@ class Placements::Schools::PartnerProvidersController < Placements::Partnerships
   def destroy
     super
 
-    flash[:success] = t(".partner_provider_removed")
+    flash[:success] = t(".partner_provider_deleted")
   end
 
   private

--- a/app/decorators/provider_decorator.rb
+++ b/app/decorators/provider_decorator.rb
@@ -4,6 +4,10 @@ class ProviderDecorator < OrganisationDecorator
     parts.join(", ")
   end
 
+  def partner_provider_placements(school)
+    @partner_provider_placements ||= becomes(Placements::Provider).placements.where(school:).decorate
+  end
+
   private
 
   def address_parts

--- a/app/decorators/provider_decorator.rb
+++ b/app/decorators/provider_decorator.rb
@@ -4,8 +4,8 @@ class ProviderDecorator < OrganisationDecorator
     parts.join(", ")
   end
 
-  def partner_provider_placements(school)
-    @partner_provider_placements ||= becomes(Placements::Provider).placements.where(school:).decorate
+  def partner_school_placements(school)
+    @partner_school_placements ||= becomes(Placements::Provider).placements.where(school:).decorate
   end
 
   private

--- a/app/views/placements/schools/partner_providers/remove.html.erb
+++ b/app/views/placements/schools/partner_providers/remove.html.erb
@@ -9,15 +9,24 @@
     <div class="govuk-grid-column-two-thirds">
       <label class="govuk-label govuk-label--l">
         <span class="govuk-caption-l"><%= @partner_provider.name %></span>
-        <%= t(".are_you_sure") %>
+        <%= t(".are_you_sure", provider_name: @partner_provider.name) %>
       </label>
+
+      <%= simple_format(t(".you_will_no_longer")) %>
+
+      <ul class="govuk-list">
+        <% @partner_provider.becomes(Placements::Provider).placements.where(school: @school).find_each do |placement| %>
+          <li><%= govuk_link_to(placement.decorate.title, placements_school_placement_path(@school, placement), target: "_blank") %></li>
+        <% end %>
+      </ul>
+
       <%= render GovukComponent::WarningTextComponent.new(
         text: t(".provider_will_be_sent_an_email",
           school_name: @school.name,
           provider_name: @partner_provider.name),
       ) %>
 
-      <%= govuk_button_to t(".remove_partner_provider"), placements_school_partner_provider_path(@school, @partner_provider), warning: true, method: :delete %>
+      <%= govuk_button_to t(".delete_partner_provider"), placements_school_partner_provider_path(@school, @partner_provider), warning: true, method: :delete %>
 
       <p class="govuk-body">
         <%= govuk_link_to(t(".cancel"), placements_school_partner_provider_path(@school, @partner_provider), no_visited_state: true) %>

--- a/app/views/placements/schools/partner_providers/remove.html.erb
+++ b/app/views/placements/schools/partner_providers/remove.html.erb
@@ -14,11 +14,17 @@
 
       <%= simple_format(t(".you_will_no_longer")) %>
 
-      <% if @partner_provider.partner_provider_placements(@school).any? %>
-        <p class="govuk-body">Placements with this provider are:</p>
+      <% if @partner_provider.partner_school_placements(@school).any? %>
+        <p class="govuk-body"><%= t(".placements_with_provider") %></p>
         <ul class="govuk-list govuk-list--bullet">
-          <% @partner_provider.partner_provider_placements(@school).each do |placement| %>
-            <li><%= govuk_link_to(placement.title, placements_school_placement_path(@school, placement), target: "_blank", no_visited_state: true) %></li>
+          <% @partner_provider.partner_school_placements(@school).each do |placement| %>
+            <li>
+              <%= govuk_link_to(placement.title,
+              placements_school_placement_path(@school, placement),
+              target: "_blank",
+              new_tab: true,
+              no_visited_state: true) %>
+            </li>
           <% end %>
         </ul>
       <% end %>

--- a/app/views/placements/schools/partner_providers/remove.html.erb
+++ b/app/views/placements/schools/partner_providers/remove.html.erb
@@ -14,13 +14,13 @@
 
       <%= simple_format(t(".you_will_no_longer")) %>
 
-      <% if @partner_provider.becomes(Placements::Provider).placements.where(school: @school).exists? %>
-      <p class="govuk-body">Placements with this provider are:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <% @partner_provider.becomes(Placements::Provider).placements.where(school: @school).find_each do |placement| %>
-          <li><%= govuk_link_to(placement.decorate.title, placements_school_placement_path(@school, placement), target: "_blank") %></li>
-        <% end %>
-      </ul>
+      <% if @partner_provider.partner_provider_placements(@school).any? %>
+        <p class="govuk-body">Placements with this provider are:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <% @partner_provider.partner_provider_placements(@school).each do |placement| %>
+            <li><%= govuk_link_to(placement.title, placements_school_placement_path(@school, placement), target: "_blank", no_visited_state: true) %></li>
+          <% end %>
+        </ul>
       <% end %>
 
       <%= render GovukComponent::WarningTextComponent.new(

--- a/app/views/placements/schools/partner_providers/remove.html.erb
+++ b/app/views/placements/schools/partner_providers/remove.html.erb
@@ -13,12 +13,15 @@
       </label>
 
       <%= simple_format(t(".you_will_no_longer")) %>
-
+      
+      <% if @partner_provider.becomes(Placements::Provider).placements.where(school: @school).exists? %>
+      <p class="govuk-body">Placements with this provider are:</p>
       <ul class="govuk-list govuk-list--bullet">
         <% @partner_provider.becomes(Placements::Provider).placements.where(school: @school).find_each do |placement| %>
           <li><%= govuk_link_to(placement.decorate.title, placements_school_placement_path(@school, placement), target: "_blank") %></li>
         <% end %>
       </ul>
+      <% end %>
 
       <%= render GovukComponent::WarningTextComponent.new(
         text: t(".provider_will_be_sent_an_email",

--- a/app/views/placements/schools/partner_providers/remove.html.erb
+++ b/app/views/placements/schools/partner_providers/remove.html.erb
@@ -14,7 +14,7 @@
 
       <%= simple_format(t(".you_will_no_longer")) %>
 
-      <ul class="govuk-list--bullet'">
+      <ul class="govuk-list govuk-list--bullet">
         <% @partner_provider.becomes(Placements::Provider).placements.where(school: @school).find_each do |placement| %>
           <li><%= govuk_link_to(placement.decorate.title, placements_school_placement_path(@school, placement), target: "_blank") %></li>
         <% end %>

--- a/app/views/placements/schools/partner_providers/remove.html.erb
+++ b/app/views/placements/schools/partner_providers/remove.html.erb
@@ -14,7 +14,7 @@
 
       <%= simple_format(t(".you_will_no_longer")) %>
 
-      <ul class="govuk-list">
+      <ul class="govuk-list--bullet'">
         <% @partner_provider.becomes(Placements::Provider).placements.where(school: @school).find_each do |placement| %>
           <li><%= govuk_link_to(placement.decorate.title, placements_school_placement_path(@school, placement), target: "_blank") %></li>
         <% end %>

--- a/app/views/placements/schools/partner_providers/remove.html.erb
+++ b/app/views/placements/schools/partner_providers/remove.html.erb
@@ -13,7 +13,7 @@
       </label>
 
       <%= simple_format(t(".you_will_no_longer")) %>
-      
+
       <% if @partner_provider.becomes(Placements::Provider).placements.where(school: @school).exists? %>
       <p class="govuk-body">Placements with this provider are:</p>
       <ul class="govuk-list govuk-list--bullet">

--- a/app/views/placements/schools/partner_providers/show.html.erb
+++ b/app/views/placements/schools/partner_providers/show.html.erb
@@ -18,7 +18,7 @@
   </div>
 
   <% if policy(@partnership).remove? %>
-    <%= link_to(t(".remove_partner_provider"),
+    <%= link_to(t(".delete_partner_provider"),
       remove_placements_school_partner_provider_path(@school, @partner_provider),
       class: "app-link app-link--destructive") %>
   <% end %>

--- a/config/locales/en/placements/schools/partner_providers.yml
+++ b/config/locales/en/placements/schools/partner_providers.yml
@@ -24,5 +24,5 @@ en:
           you_will_no_longer: You will no longer be able to assign this provider to placements. They will remain assigned to current placements unless you remove them.               
           provider_will_be_sent_an_email: We will send an email to %{provider_name} to let them know they are no longer a partner provider. It is your responsibility to confirm with them whether they should still fulfil existing assigned placements.
         destroy:
-          partner_provider_removed: Partner provider removed
+          partner_provider_deleted: Partner provider deleted
 

--- a/config/locales/en/placements/schools/partner_providers.yml
+++ b/config/locales/en/placements/schools/partner_providers.yml
@@ -15,13 +15,18 @@ en:
           page_title: Partner schools
           change_organisation: Change organisation
           contact_details: Contact details
-          remove_partner_provider: Remove partner provider
+          delete_partner_provider: Delete partner provider
         remove:
-          page_title: Are you sure you want to remove this partner provider? - %{provider_name}
+          page_title: Are you sure you want to delete this partner provider? - %{provider_name}
           cancel: Cancel
-          remove_partner_provider: Remove partner provider
-          are_you_sure: Are you sure you want to remove this partner provider?
-          provider_will_be_sent_an_email: We will send an email to %{provider_name}. This will let them know you have removed them as a partner provider for %{school_name}.
+          delete_partner_provider: Delete partner provider
+          are_you_sure: Are you sure you no longer want %{provider_name} as one of your partner providers?
+          you_will_no_longer: | 
+              You will no longer be able to assign this provider to placements. They will remain assigned to current placements unless you remove them. 
+              
+              Placements with this provider are:
+              
+          provider_will_be_sent_an_email: We will send an email to %{provider_name} to let them know they are no longer a partner provider. It is your responsibility to confirm with them whether they should still fulfil existing assigned placements.
         destroy:
           partner_provider_removed: Partner provider removed
 

--- a/config/locales/en/placements/schools/partner_providers.yml
+++ b/config/locales/en/placements/schools/partner_providers.yml
@@ -23,6 +23,7 @@ en:
           are_you_sure: Are you sure you no longer want %{provider_name} as one of your partner providers?
           you_will_no_longer: You will no longer be able to assign this provider to placements. They will remain assigned to current placements unless you remove them.               
           provider_will_be_sent_an_email: We will send an email to %{provider_name} to let them know they are no longer a partner provider. It is your responsibility to confirm with them whether they should still fulfil existing assigned placements.
+          placements_with_provider: "Placements with this provider are:"
         destroy:
           partner_provider_deleted: Partner provider deleted
 

--- a/config/locales/en/placements/schools/partner_providers.yml
+++ b/config/locales/en/placements/schools/partner_providers.yml
@@ -21,11 +21,7 @@ en:
           cancel: Cancel
           delete_partner_provider: Delete partner provider
           are_you_sure: Are you sure you no longer want %{provider_name} as one of your partner providers?
-          you_will_no_longer: | 
-              You will no longer be able to assign this provider to placements. They will remain assigned to current placements unless you remove them. 
-              
-              Placements with this provider are:
-              
+          you_will_no_longer: You will no longer be able to assign this provider to placements. They will remain assigned to current placements unless you remove them.               
           provider_will_be_sent_an_email: We will send an email to %{provider_name} to let them know they are no longer a partner provider. It is your responsibility to confirm with them whether they should still fulfil existing assigned placements.
         destroy:
           partner_provider_removed: Partner provider removed

--- a/config/locales/en/placements/support/schools/partner_providers.yml
+++ b/config/locales/en/placements/support/schools/partner_providers.yml
@@ -23,4 +23,4 @@ en:
             are_you_sure: Are you sure you want to remove this partner provider?
             provider_will_be_sent_an_email: We will send an email to %{provider_name}. This will let them know you have removed them as a partner provider for %{school_name}.
           destroy:
-            partner_provider_removed: Partner provider removed
+            partner_provider_deleted: Partner provider deleted

--- a/spec/decorators/provider_decorator_spec.rb
+++ b/spec/decorators/provider_decorator_spec.rb
@@ -7,12 +7,16 @@ RSpec.describe ProviderDecorator do
     let(:school) { create(:placements_school) }
     let!(:placement) { create(:placement, provider:, subject: a_subject, school:) }
 
+    before do
+      _random_placement = create(:placement)
+    end
+
     it "returns placements belonging to a partner school" do
       decorated_provider = provider.decorate
       result = decorated_provider.partner_school_placements(school)
       decorated_placement = placement.decorate
 
-      expect(result).to include(decorated_placement)
+      expect(result).to contain_exactly(decorated_placement)
     end
   end
 

--- a/spec/decorators/provider_decorator_spec.rb
+++ b/spec/decorators/provider_decorator_spec.rb
@@ -5,8 +5,13 @@ RSpec.describe ProviderDecorator do
     it "returns placements belonging to a partner provider" do
       provider = create(:provider)
       subject = create(:subject)
-      school = Placements::School.create(name: "Springfield Elementary")
-      placement = Placement.create(provider:, school:, subject:)
+      region = Region.create!(name: "Springfield")
+      school = Placements::School.create!(
+        name: "Springfield Elementary",
+        urn: "1234567890",
+        region:,
+      )
+      placement = Placement.create!(provider:, school:, subject:)
 
       decorated_provider = provider.decorate
       result = decorated_provider.partner_provider_placements(school)

--- a/spec/decorators/provider_decorator_spec.rb
+++ b/spec/decorators/provider_decorator_spec.rb
@@ -1,20 +1,15 @@
 require "rails_helper"
 
 RSpec.describe ProviderDecorator do
-  describe "#partner_provider_placements" do
-    it "returns placements belonging to a partner provider" do
-      provider = create(:provider)
-      subject = create(:subject)
-      region = Region.create!(name: "Springfield")
-      school = Placements::School.create!(
-        name: "Springfield Elementary",
-        urn: "1234567890",
-        region:,
-      )
-      placement = Placement.create!(provider:, school:, subject:)
+  describe "#partner_school_placements" do
+    let(:provider) { create(:provider) }
+    let(:a_subject) { create(:subject) }
+    let(:school) { create(:placements_school) }
+    let!(:placement) { create(:placement, provider:, subject: a_subject, school:) }
 
+    it "returns placements belonging to a partner school" do
       decorated_provider = provider.decorate
-      result = decorated_provider.partner_provider_placements(school)
+      result = decorated_provider.partner_school_placements(school)
       decorated_placement = placement.decorate
 
       expect(result).to include(decorated_placement)

--- a/spec/decorators/provider_decorator_spec.rb
+++ b/spec/decorators/provider_decorator_spec.rb
@@ -1,6 +1,21 @@
 require "rails_helper"
 
 RSpec.describe ProviderDecorator do
+  describe "#partner_provider_placements" do
+    it "returns placements belonging to a partner provider" do
+      provider = create(:provider)
+      subject = create(:subject)
+      school = Placements::School.create(name: "Springfield Elementary")
+      placement = Placement.create(provider:, school:, subject:)
+
+      decorated_provider = provider.decorate
+      result = decorated_provider.partner_provider_placements(school)
+      decorated_placement = placement.decorate
+
+      expect(result).to include(decorated_placement)
+    end
+  end
+
   describe "#formatted_address" do
     it "returns a formatted address" do
       provider = create(:provider,

--- a/spec/system/placements/schools/partner_providers/remove_a_partner_provider_spec.rb
+++ b/spec/system/placements/schools/partner_providers/remove_a_partner_provider_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "Placements / Schools / Partner providers / Remove a partner prov
 
     expect(school.partner_providers.find_by(id: provider.id)).to be_nil
     within(".govuk-notification-banner__content") do
-      expect(page).to have_content "Partner provider removed"
+      expect(page).to have_content "Partner provider deleted"
     end
 
     expect(page).not_to have_content provider.name

--- a/spec/system/placements/schools/partner_providers/remove_a_partner_provider_spec.rb
+++ b/spec/system/placements/schools/partner_providers/remove_a_partner_provider_spec.rb
@@ -25,13 +25,13 @@ RSpec.describe "Placements / Schools / Partner providers / Remove a partner prov
   scenario "User removes a partner provider" do
     given_i_sign_in_as_anne
     when_i_view_the_partner_provider_show_page
-    and_i_click_on("Remove partner provider")
+    and_i_click_on("Delete partner provider")
     then_i_am_asked_to_confirm_partner_provider(provider)
     when_i_click_on("Cancel")
     then_i_return_to_partner_provider_page(provider)
-    when_i_click_on("Remove partner provider")
+    when_i_click_on("Delete partner provider")
     then_i_am_asked_to_confirm_partner_provider(provider)
-    when_i_click_on("Remove partner provider")
+    when_i_click_on("Delete partner provider")
     then_the_partner_provider_is_removed(provider)
     and_a_partner_provider_remains_called("Another provider")
     and_a_notification_email_is_sent_to(provider_user)
@@ -41,13 +41,13 @@ RSpec.describe "Placements / Schools / Partner providers / Remove a partner prov
     given_the_provider_is_not_onboarded_on_placements_service(provider)
     given_i_sign_in_as_anne
     when_i_view_the_partner_provider_show_page
-    and_i_click_on("Remove partner provider")
+    and_i_click_on("Delete partner provider")
     then_i_am_asked_to_confirm_partner_provider(provider)
     when_i_click_on("Cancel")
     then_i_return_to_partner_provider_page(provider)
-    when_i_click_on("Remove partner provider")
+    when_i_click_on("Delete partner provider")
     then_i_am_asked_to_confirm_partner_provider(provider)
-    when_i_click_on("Remove partner provider")
+    when_i_click_on("Delete partner provider")
     then_the_partner_provider_is_removed(provider)
     and_a_partner_provider_remains_called("Another provider")
     and_a_notification_email_is_not_sent_to(provider_user)
@@ -78,10 +78,10 @@ RSpec.describe "Placements / Schools / Partner providers / Remove a partner prov
     expect_partner_providers_to_be_selected_in_primary_navigation
 
     expect(page).to have_title(
-      "Are you sure you want to remove this partner provider? - #{provider.name} - Manage school placements",
+      "Are you sure you want to delete this partner provider? - #{provider.name} - Manage school placements",
     )
     expect(page).to have_content provider.name
-    expect(page).to have_content "Are you sure you want to remove this partner provider?"
+    expect(page).to have_content "Are you sure you no longer want #{provider.name} as one of your partner providers?"
   end
 
   def then_i_return_to_partner_provider_page(provider)

--- a/spec/system/placements/support/schools/partner_providers/support_user_removes_a_partner_provider_spec.rb
+++ b/spec/system/placements/support/schools/partner_providers/support_user_removes_a_partner_provider_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe "Placements / Support / Schools / Partner providers / Support use
 
     expect(school.partner_providers.find_by(id: provider.id)).to be_nil
     within(".govuk-notification-banner__content") do
-      expect(page).to have_content "Partner provider removed"
+      expect(page).to have_content "Partner provider deleted"
     end
 
     expect(page).not_to have_content provider.name


### PR DESCRIPTION
## Context

Inconsistent terminology causes confusion for users - if different words have the same action it adds cognitive load.

## Changes proposed in this pull request

**Partner provider show page**
- Update “Remove partner provider” to “Delete partner provider”

**"Remove partner" provider confirmation page:**
- Update “Are you sure you want to remove this partner provider?” to “Are you sure you no longer want %{provider_name} as one of your partner providers?”
- Add paragraph text above the warning component: “You will no longer be able to assign this provider to placements. They will remain assigned to current placements unless you remove them. "Placements with this provider are:"  followed by a bulleted list of their currently assigned placements which are hyperlinked to the placements and open in a new tab when clicked.
- Update the warning component text:”We will send an email to %{provider_name} to let them know they are no longer a partner provider.It is your responsibility to confirm with them whether they should still fulfil existing assigned placements.”
- Update button text from “Remove partner provider” to “Delete partner provider”

## Guidance to review

- Review journey to delete a partner provider.
- Run `bundle exec rspec spec/system/placements/schools/partner_providers/remove_a_partner_provider_spec.rb`

## Link to Trello card

https://trello.com/c/8qMWBMMe/664-improve-school-user-partner-provider-journey-content

## Screenshots

<img width="676" alt="Screenshot 2024-08-15 at 10 47 12" src="https://github.com/user-attachments/assets/b660d551-73e3-4b00-88f5-09dfd9ded1f4">