### PR TITLE
School and Provider user journey for deleting another user made more consistent (remove -> delete)

### DIFF
--- a/app/controllers/placements/organisations/users_controller.rb
+++ b/app/controllers/placements/organisations/users_controller.rb
@@ -15,7 +15,7 @@ class Placements::Organisations::UsersController < Placements::ApplicationContro
   def destroy
     User::Remove.call(user: @user, organisation: @organisation)
     redirect_to_index
-    flash[:success] = t(".user_removed")
+    flash[:success] = t(".user_deleted")
   end
 
   private

--- a/app/views/placements/providers/users/remove.html.erb
+++ b/app/views/placements/providers/users/remove.html.erb
@@ -15,7 +15,7 @@
         text: t(".user_will_be_sent_an_email", organisation_name: @organisation.name),
       ) %>
 
-      <%= govuk_button_to t(".remove_user"), placements_provider_user_path(@organisation, @user), warning: true, method: :delete %>
+      <%= govuk_button_to t(".delete_user"), placements_provider_user_path(@organisation, @user), warning: true, method: :delete %>
 
       <p class="govuk-body">
         <%= govuk_link_to(t(".cancel"), placements_provider_user_path(@organisation, @user), no_visited_state: true) %>

--- a/app/views/placements/providers/users/remove.html.erb
+++ b/app/views/placements/providers/users/remove.html.erb
@@ -11,6 +11,9 @@
         <span class="govuk-caption-l"><%= @user.full_name.to_s %></span>
         <%= t(".are_you_sure") %>
       </label>
+
+      <%= simple_format(t(".user_will_no_longer", user_name: @user.full_name)) %>
+
       <%= render GovukComponent::WarningTextComponent.new(
         text: t(".user_will_be_sent_an_email", organisation_name: @organisation.name),
       ) %>

--- a/app/views/placements/providers/users/show.html.erb
+++ b/app/views/placements/providers/users/show.html.erb
@@ -10,7 +10,7 @@
     <div class="govuk-grid-column-two-thirds">
       <%= render "placements/organisations/users/details", user: @user %>
       <% if policy([:placements, @user_membership]).destroy? %>
-        <%= link_to(t(".remove_user"),
+        <%= link_to(t(".delete_user"),
                     remove_placements_provider_user_path(@organisation, @user),
                     class: "app-link app-link--destructive") %>
       <% end %>

--- a/app/views/placements/schools/users/remove.html.erb
+++ b/app/views/placements/schools/users/remove.html.erb
@@ -11,11 +11,14 @@
         <span class="govuk-caption-l"><%= @user.full_name.to_s %></span>
         <%= t(".are_you_sure") %>
       </label>
+
+      <%= simple_format(t(".user_will_no_longer", user_name: @user.full_name)) %>
+
       <%= render GovukComponent::WarningTextComponent.new(
         text: t(".user_will_be_sent_an_email", organisation_name: @organisation.name),
       ) %>
 
-      <%= govuk_button_to t(".remove_user"), placements_school_user_path(@organisation, @user), warning: true, method: :delete %>
+      <%= govuk_button_to t(".delete_user"), placements_school_user_path(@organisation, @user), warning: true, method: :delete %>
 
       <p class="govuk-body">
         <%= govuk_link_to(t(".cancel"), placements_school_user_path(@organisation, @user), no_visited_state: true) %>

--- a/app/views/placements/schools/users/show.html.erb
+++ b/app/views/placements/schools/users/show.html.erb
@@ -10,7 +10,7 @@
     <div class="govuk-grid-column-two-thirds">
       <%= render "placements/organisations/users/details", user: @user %>
       <% if policy([:placements, @user_membership]).destroy? %>
-        <%= govuk_link_to t(".remove_user"),
+        <%= govuk_link_to t(".delete_user"),
           remove_placements_school_user_path(@organisation, @user),
           class: "app-link app-link--destructive" %>
       <% end %>

--- a/config/locales/en/placements/providers/users.yml
+++ b/config/locales/en/placements/providers/users.yml
@@ -17,5 +17,6 @@ en:
           delete_user: Delete user
           cancel: Cancel
           change_organisation: Change organisation
+          user_will_no_longer: '%{user_name} will no longer be able to access placement information.'
           user_will_be_sent_an_email: The user will be sent an email to tell them you deleted them from %{organisation_name}
         you_cannot_perform_this_action: You cannot perform this action

--- a/config/locales/en/placements/providers/users.yml
+++ b/config/locales/en/placements/providers/users.yml
@@ -10,7 +10,7 @@ en:
           change_organisation: Change organisation
           delete_user: Delete user
         destroy:
-          user_removed: User removed
+          user_deleted: User deleted
         remove:
           page_title: Are you sure you want to delete this user? - %{user_name}
           are_you_sure: Are you sure you want to delete this user?
@@ -18,5 +18,4 @@ en:
           cancel: Cancel
           change_organisation: Change organisation
           user_will_no_longer: '%{user_name} will no longer be able to access placement information.'
-          user_will_be_sent_an_email: The user will be sent an email to tell them you deleted them from %{organisation_name}
-        you_cannot_perform_this_action: You cannot perform this action
+          user_will_be_sent_an_email: The user will be sent an email to tell them you deleted them from %{organisation_name}.

--- a/config/locales/en/placements/providers/users.yml
+++ b/config/locales/en/placements/providers/users.yml
@@ -8,14 +8,14 @@ en:
           change_organisation: Change organisation
         show:
           change_organisation: Change organisation
-          remove_user: Remove user
+          delete_user: Delete user
         destroy:
           user_removed: User removed
         remove:
-          page_title: Are you sure you want to remove this user? - %{user_name}
-          are_you_sure: Are you sure you want to remove this user?
-          remove_user: Remove user
+          page_title: Are you sure you want to delete this user? - %{user_name}
+          are_you_sure: Are you sure you want to delete this user?
+          delete_user: Delete user
           cancel: Cancel
           change_organisation: Change organisation
-          user_will_be_sent_an_email: The user will be sent an email to tell them you removed them from %{organisation_name}
+          user_will_be_sent_an_email: The user will be sent an email to tell them you deleted them from %{organisation_name}
         you_cannot_perform_this_action: You cannot perform this action

--- a/config/locales/en/placements/schools/users.yml
+++ b/config/locales/en/placements/schools/users.yml
@@ -10,7 +10,7 @@ en:
           change_organisation: Change organisation
           delete_user: Delete user
         destroy:
-          user_removed: User removed
+          user_deleted: User deleted
         remove:
           page_title: Are you sure you want to delete this user? - %{user_name}
           are_you_sure: Are you sure you want to delete this user?
@@ -18,5 +18,4 @@ en:
           cancel: Cancel
           change_organisation: Change organisation
           user_will_no_longer: "%{user_name} will no longer be able to view, create or manage placements at your school."
-          user_will_be_sent_an_email: The user will be sent an email to tell them you deleted them from %{organisation_name}
-        you_cannot_perform_this_action: You cannot perform this action
+          user_will_be_sent_an_email: The user will be sent an email to tell them you deleted them from %{organisation_name}.

--- a/config/locales/en/placements/schools/users.yml
+++ b/config/locales/en/placements/schools/users.yml
@@ -8,14 +8,15 @@ en:
           change_organisation: Change organisation
         show:
           change_organisation: Change organisation
-          remove_user: Remove user
+          delete_user: Delete user
         destroy:
           user_removed: User removed
         remove:
-          page_title: Are you sure you want to remove this user? - %{user_name}
-          are_you_sure: Are you sure you want to remove this user?
-          remove_user: Remove user
+          page_title: Are you sure you want to delete this user? - %{user_name}
+          are_you_sure: Are you sure you want to delete this user?
+          delete_user: Delete user
           cancel: Cancel
           change_organisation: Change organisation
-          user_will_be_sent_an_email: The user will be sent an email to tell them you removed them from %{organisation_name}
+          user_will_no_longer: "%{user_name} will no longer be able to view, create or manage placements at your school."
+          user_will_be_sent_an_email: The user will be sent an email to tell them you deleted them from %{organisation_name}
         you_cannot_perform_this_action: You cannot perform this action

--- a/config/locales/en/placements/support/providers/users.yml
+++ b/config/locales/en/placements/support/providers/users.yml
@@ -20,4 +20,4 @@ en:
           show:
             remove_user: Remove user
           destroy:
-            user_removed: User removed
+            user_deleted: User deleted

--- a/config/locales/en/placements/support/schools/users.yml
+++ b/config/locales/en/placements/support/schools/users.yml
@@ -12,7 +12,7 @@ en:
                 email: Email
             empty_state: There are no users for %{school_name}.
           destroy:
-            user_removed: User removed
+            user_deleted: User deleted
           show:
             remove_user: Remove user
           remove:

--- a/spec/requests/placements/providers/users_spec.rb
+++ b/spec/requests/placements/providers/users_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Provider users", service: :placements, type: :request do
       it "deletes the user" do
         expect(provider.users).to include(user)
         delete placements_provider_user_path(provider, user)
-        expect(flash[:success]).to eq "User removed"
+        expect(flash[:success]).to eq "User deleted"
         expect(provider.users).not_to include(user)
       end
     end

--- a/spec/requests/placements/schools/users_spec.rb
+++ b/spec/requests/placements/schools/users_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "School users", service: :placements, type: :request do
       it "deletes the user" do
         expect(school.users).to include(user)
         delete placements_school_user_path(school, user)
-        expect(flash[:success]).to eq "User removed"
+        expect(flash[:success]).to eq "User deleted"
         expect(school.users).not_to include(user)
       end
     end

--- a/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
+++ b/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe "Placements support user removes a user from an organisation", se
 
     expect(user.user_memberships.find_by(organisation:)).to be_nil
     within(".govuk-notification-banner__content") do
-      expect(page).to have_content "User removed"
+      expect(page).to have_content "User deleted"
     end
 
     expect(page).not_to have_content user.full_name

--- a/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
+++ b/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
@@ -21,13 +21,13 @@ RSpec.describe "Placements support user removes a user from an organisation", se
     scenario "user is removed from a school" do
       given_i_am_signed_in_as_mary
       and_i_visit_the_user_page(anne)
-      when_i_click_on("Remove user")
+      when_i_click_on("Delete user")
       then_i_am_asked_to_confirm(anne, school)
       when_i_click_on("Cancel")
       then_i_return_to_user_page(anne, school)
-      when_i_click_on("Remove user")
+      when_i_click_on("Delete user")
       then_i_am_asked_to_confirm(anne, school)
-      when_i_click_on("Remove user")
+      when_i_click_on("Delete user")
       then_the_the_user_is_removed_from_the_organisation(anne, school)
       and_message_is_sent_to_user(anne, school)
     end
@@ -53,13 +53,13 @@ RSpec.describe "Placements support user removes a user from an organisation", se
     scenario "user is removed from a provider" do
       given_i_am_signed_in_as_mary
       and_i_visit_the_user_page(anne)
-      when_i_click_on("Remove user")
+      when_i_click_on("Delete user")
       then_i_am_asked_to_confirm(anne, provider)
       when_i_click_on("Cancel")
       then_i_return_to_user_page(anne, provider)
-      when_i_click_on("Remove user")
+      when_i_click_on("Delete user")
       then_i_am_asked_to_confirm(anne, provider)
-      when_i_click_on("Remove user")
+      when_i_click_on("Delete user")
       then_the_the_user_is_removed_from_the_organisation(anne, provider)
       and_message_is_sent_to_user(anne, provider)
     end
@@ -130,11 +130,11 @@ RSpec.describe "Placements support user removes a user from an organisation", se
     end
 
     expect(page).to have_title(
-      "Are you sure you want to remove this user? - #{user.full_name} - Manage school placements",
+      "Are you sure you want to delete this user? - #{user.full_name} - Manage school placements",
     )
     expect(page).to have_content user.full_name.to_s
-    expect(page).to have_content "Are you sure you want to remove this user?"
-    expect(page).to have_content "The user will be sent an email to tell them you removed them from #{organisation.name}"
+    expect(page).to have_content "Are you sure you want to delete this user?"
+    expect(page).to have_content "The user will be sent an email to tell them you deleted them from #{organisation.name}"
   end
 
   def users_is_selected_in_schools_primary_nav

--- a/spec/system/placements/organisations/users/user_views_other_users_spec.rb
+++ b/spec/system/placements/organisations/users/user_views_other_users_spec.rb
@@ -88,11 +88,11 @@ RSpec.describe "Placements user views other users in their organisation", servic
   end
 
   def and_i_see_the_remove_user_link
-    expect(page).to have_link "Remove user"
+    expect(page).to have_link "Delete user"
   end
 
   def and_i_do_not_see_the_remove_user_link
-    expect(page).not_to have_link "Remove user"
+    expect(page).not_to have_link "Delete user"
   end
 
   def and_users_is_selected_in_schools_primary_nav

--- a/spec/system/placements/support/users/support_user_removes_a_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_removes_a_user_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Placements support user removes a user from an organisation", se
   def when_i_remove_user_from_school
     click_on "Remove user"
     click_on "Remove user"
-    expect(page).to have_content "User removed"
+    expect(page).to have_content "User deleted"
     expect(user.user_memberships.find_by(organisation: school)).to be_nil
   end
 
@@ -151,7 +151,7 @@ RSpec.describe "Placements support user removes a user from an organisation", se
     users_is_selected_in_secondary_nav(organisation)
     expect(user.user_memberships.find_by(organisation:)).to be_nil
     within(".govuk-notification-banner__content") do
-      expect(page).to have_content "User removed"
+      expect(page).to have_content "User deleted"
     end
 
     expect(page).not_to have_content user.full_name


### PR DESCRIPTION
## Context

- Same design context as [#927.](https://github.com/DFE-Digital/itt-mentor-services/pull/927)
- This PR encompasses two trello tickets as they share some tests.

## Changes proposed in this pull request

### School user

**User show page:**

- Update “Remove user” to “Delete user”

**Remove user confirmation page:**

- Update “Are you sure you want to remove this user?” to “Are you sure you want to delete this user?”

- Add paragraph text above the warning component:“%{user_name} will no longer be able to view, create or manage placements at your school.”

- Update the warning component text from “removed” to “deleted”.

- Update the button text from “Remove user” to “Delete user”

### Provider user

**User show page:**

- Update “Remove user” to “Delete user”

**"Remove user" confirmation page:**

- Update “Are you sure you want to remove this user?” to “Are you sure you want to delete this user?”
- Add paragraph text above the warning component:“%{user_name} will no longer be able to access placement information.”
- Update the warning component text “removed” to “deleted”
- Update button text from “Remove user” to “Delete user”

## Guidance to review

- Review school user journey to delete another user, i.e. Mary.
- Review provider user journey to delete another user.
- Run `bundle exec rspec spec/system/placements`.

## Link to Trello card

https://trello.com/c/gTlRJQx2/666-improve-school-user-user-journey-content
https://trello.com/c/stZYPyzG/669-improve-provider-user-user-content
