### PR TITLE
confirm remove and cannot remove paragraphs updated

### DIFF
--- a/app/views/placements/schools/placements/confirm_remove.html.erb
+++ b/app/views/placements/schools/placements/confirm_remove.html.erb
@@ -12,6 +12,8 @@
         <%= t(".are_you_sure") %>
       </label>
 
+      <%= simple_format(t(".it_is_your_responsibility")) %>
+
       <%= govuk_button_to t(".delete_placement"),
         placements_school_placement_path(@school, @placement),
         warning: true,

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -95,13 +95,11 @@ en:
           page_title: "Are you sure you want to delete this placement? - %{subject_names}"
           are_you_sure: Are you sure you want to delete this placement?
           cancel: Cancel
+          it_is_your_responsibility: It is your responsibility to make sure that anyone relevant to organising this placement is aware it is being deleted.
           delete_placement: Delete placement
         can_not_remove:
           page_title: "You cannot delete this placement - %{subject_names}"
           title: You cannot delete this placement
-          description: |
-            This %{subject_names} placement cannot be deleted because it is assigned to a provider.
-
-            You must remove %{provider_name} from the placement before you can delete it.
+          description: '%{provider_name} must be removed from the placement before you can delete it.'
         destroy:
           placement_deleted: Placement deleted


### PR DESCRIPTION
## Context

- Same design context as [#927](https://github.com/DFE-Digital/itt-mentor-services/pull/927)

## Changes proposed in this pull request

**"Remove placement" confirmation page**

- Add paragraph text above the warning component: “It is your responsibility to make sure that anyone relevant to organising this placement is aware it is being deleted.”

**"Cannot remove" placement page:**

- Update paragraph text to: “%{provider_name} must be removed from the placement before you can delete it.

## Guidance to review

- Review school user journey to delete a placement with a provider.
- Review school user journey to delete a placement without a provider.
- Run `bundle exec rspec spec/system/placements/schools/placements`

## Link to Trello card

https://trello.com/c/Idp76WWF/665-improve-school-user-placement-journey-content
