### PR TITLE
Content Changes to Provider User Journey - Remove Partner School (Remove -> Delete)

### DIFF
--- a/app/controllers/placements/providers/partner_schools_controller.rb
+++ b/app/controllers/placements/providers/partner_schools_controller.rb
@@ -6,7 +6,7 @@ class Placements::Providers::PartnerSchoolsController < Placements::Partnerships
   def destroy
     super
 
-    flash[:success] = t(".partner_school_removed")
+    flash[:success] = t(".partner_school_deleted")
   end
 
   private

--- a/app/views/placements/providers/partner_schools/remove.html.erb
+++ b/app/views/placements/providers/partner_schools/remove.html.erb
@@ -11,13 +11,16 @@
         <span class="govuk-caption-l"><%= @partner_school.name %></span>
         <%= t(".are_you_sure") %>
       </label>
+
+     <%= simple_format(t(".school_will_no_longer")) %>
+
       <%= render GovukComponent::WarningTextComponent.new(
         text: t(".school_will_be_sent_an_email",
           provider_name: @provider.name,
           school_name: @partner_school.name),
       ) %>
 
-      <%= govuk_button_to t(".remove_partner_school"), placements_provider_partner_school_path(@provider, @partner_school), warning: true, method: :delete %>
+      <%= govuk_button_to t(".delete_partner_school"), placements_provider_partner_school_path(@provider, @partner_school), warning: true, method: :delete %>
 
       <p class="govuk-body">
         <%= govuk_link_to(t(".cancel"), placements_provider_partner_school_path(@provider, @partner_school), no_visited_state: true) %>

--- a/app/views/placements/providers/partner_schools/show.html.erb
+++ b/app/views/placements/providers/partner_schools/show.html.erb
@@ -26,7 +26,7 @@
   </div>
 
   <% if policy(@partnership).remove? %>
-    <%= link_to(t(".remove_partner_school"),
+    <%= link_to(t(".delete_partner_school"),
       remove_placements_provider_partner_school_path(@provider, @partner_school),
       class: "app-link app-link--destructive") %>
   <% end %>

--- a/config/locales/en/placements/providers/partner_schools.yml
+++ b/config/locales/en/placements/providers/partner_schools.yml
@@ -19,15 +19,16 @@ en:
           ofsted: Ofsted
           send: Special educational needs and disabilities (SEND)
           contact_details: Contact details
-          remove_partner_school: Remove partner school
+          delete_partner_school: Delete partner school
         remove:
-          page_title: Are you sure you want to remove this partner school? - %{school_name}
+          page_title: Are you sure you want to delete this partner school? - %{school_name}
           cancel: Cancel
-          remove_partner_school: Remove partner school
-          are_you_sure: Are you sure you want to remove this partner school?
-          school_will_be_sent_an_email: We will send an email to %{school_name}. This will let them know you have removed them as a partner school for %{provider_name}.
+          delete_partner_school: Delete partner school
+          are_you_sure: Are you sure you want to delete this partner school?
+          school_will_no_longer: The school will no longer be able to assign you to their placements. You can still view placements at this school.
+          school_will_be_sent_an_email: We will send an email to %{school_name}. This will let them know you have deleted them as a partner school for %{provider_name}.
         destroy: 
-          partner_school_removed: Partner school removed
+          partner_school_deleted: Partner school deleted
         placements:
           details:
             placement_contact: Placement contact

--- a/config/locales/en/placements/support/providers/partner_schools.yml
+++ b/config/locales/en/placements/support/providers/partner_schools.yml
@@ -26,4 +26,4 @@ en:
             are_you_sure: Are you sure you want to remove this partner school?
             school_will_be_sent_an_email: We will send an email to %{school_name}. This will let them know you have removed them as a partner school for %{provider_name}.
           destroy:
-            partner_school_removed: Partner school removed
+            partner_school_deleted: Partner school deleted

--- a/spec/system/placements/providers/partner_schools/remove_a_partner_school_spec.rb
+++ b/spec/system/placements/providers/partner_schools/remove_a_partner_school_spec.rb
@@ -25,13 +25,13 @@ RSpec.describe "Placements / Providers / Partner schools / Remove a partner scho
   scenario "User removes a partner school" do
     given_i_sign_in_as_patricia
     when_i_view_the_partner_school_show_page
-    and_i_click_on("Remove partner school")
+    and_i_click_on("Delete partner school")
     then_i_am_asked_to_confirm_partner_school(school)
     when_i_click_on("Cancel")
     then_i_return_to_partner_school_page(school)
-    when_i_click_on("Remove partner school")
+    when_i_click_on("Delete partner school")
     then_i_am_asked_to_confirm_partner_school(school)
-    when_i_click_on("Remove partner school")
+    when_i_click_on("Delete partner school")
     then_the_partner_school_is_removed(school)
     and_a_partner_provider_remains_called("Another school")
     and_a_notification_email_is_sent_to(school_user)
@@ -41,13 +41,13 @@ RSpec.describe "Placements / Providers / Partner schools / Remove a partner scho
     given_the_school_is_not_onboarded_on_placements_service(school)
     given_i_sign_in_as_patricia
     when_i_view_the_partner_school_show_page
-    and_i_click_on("Remove partner school")
+    and_i_click_on("Delete partner school")
     then_i_am_asked_to_confirm_partner_school(school)
     when_i_click_on("Cancel")
     then_i_return_to_partner_school_page(school)
-    when_i_click_on("Remove partner school")
+    when_i_click_on("Delete partner school")
     then_i_am_asked_to_confirm_partner_school(school)
-    when_i_click_on("Remove partner school")
+    when_i_click_on("Delete partner school")
     then_the_partner_school_is_removed(school)
     and_a_partner_provider_remains_called("Another school")
     and_a_notification_email_is_not_sent_to(school_user)
@@ -78,10 +78,10 @@ RSpec.describe "Placements / Providers / Partner schools / Remove a partner scho
     expect_partner_schools_to_be_selected_in_primary_navigation
 
     expect(page).to have_title(
-      "Are you sure you want to remove this partner school? - #{school.name} - Manage school placements",
+      "Are you sure you want to delete this partner school? - #{school.name} - Manage school placements",
     )
     expect(page).to have_content school.name
-    expect(page).to have_content "Are you sure you want to remove this partner school?"
+    expect(page).to have_content "Are you sure you want to delete this partner school?"
   end
 
   def then_i_return_to_partner_school_page(school)
@@ -95,7 +95,7 @@ RSpec.describe "Placements / Providers / Partner schools / Remove a partner scho
 
     expect(provider.partner_schools.find_by(id: school.id)).to be_nil
     within(".govuk-notification-banner__content") do
-      expect(page).to have_content "Partner school removed"
+      expect(page).to have_content "Partner school deleted"
     end
 
     expect(page).not_to have_content school.name

--- a/spec/system/placements/support/providers/partner_schools/support_user_remove_a_partner_school_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/support_user_remove_a_partner_school_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
 
     expect(provider.partner_schools.find_by(id: school.id)).to be_nil
     within(".govuk-notification-banner__content") do
-      expect(page).to have_content "Partner school removed"
+      expect(page).to have_content "Partner school deleted"
     end
 
     expect(page).not_to have_content school.name


### PR DESCRIPTION
## Context

- Same design context as [#927](https://github.com/DFE-Digital/itt-mentor-services/pull/927).

## Changes proposed in this pull request

**Partner school show page:**

- Update “Remove partner school” to “Delete partner school”

**Remove partner school confirmation page:**

- Update “Are you sure you want to remove this partner school?” to “Are you sure you want to delete this partner school?”
- Add paragraph text above the warning component:“The school will no longer be able to assign you to their placements.You can still view placements at this school.”
- Update the warning component text “removed” to “deleted”
- Update button text from “Remove partner school” to “Delete partner school”

**Destroy action in partner school controller**
- Updated success messaged to reflect removed -> deleted.

## Guidance to review

Sign in as Patricia (Provider User)
Click on Partner Schools
Add a Partner School 
Return to the Partner Schools Index 
Click into the newly created school 
Scroll to the bottom and click 'Delete partner school'
Review the confirmation page (new paragraph and language should consistently use 'delete' in place of 'remove')
Click 'Delete partner school'
You should see the flash message "Partner school deleted

## Link to Trello card

https://trello.com/c/7KlHuqGW/668-improve-provider-user-partner-school-journey-content

## Screen recording

https://github.com/user-attachments/assets/8b518808-a374-4f3d-861b-ea4de69fc19f
