### PR TITLE
Content changes for Support User delete partner school

### DIFF
--- a/app/decorators/school_decorator.rb
+++ b/app/decorators/school_decorator.rb
@@ -23,6 +23,13 @@ class SchoolDecorator < OrganisationDecorator
     "#{percentage_free_school_meals}%" if percentage_free_school_meals.present?
   end
 
+  def partner_provider_placements(provider)
+    @partner_provider_placements ||= becomes(Placements::School)
+      .placements
+      .where(provider:)
+      .decorate
+  end
+
   private
 
   def address_parts

--- a/app/views/placements/providers/partner_schools/_delete.html.erb
+++ b/app/views/placements/providers/partner_schools/_delete.html.erb
@@ -1,0 +1,18 @@
+<%# caption:, provider:, partner_school:, delete_link: %>
+<label class="govuk-label govuk-label--l">
+  <span class="govuk-caption-l"><%= partner_school.name %></span>
+  <%= t(".are_you_sure") %>
+</label>
+
+<%= simple_format(t(".school_will_no_longer")) %>
+
+<%= render GovukComponent::WarningTextComponent.new(
+  text: t(".school_will_be_sent_an_email",
+    provider_name: provider.name,
+    school_name: partner_school.name),
+) %>
+
+<%= govuk_button_to t(".delete_partner_school"),
+  delete_link,
+  warning: true,
+  method: :delete %>

--- a/app/views/placements/providers/partner_schools/_delete.html.erb
+++ b/app/views/placements/providers/partner_schools/_delete.html.erb
@@ -6,6 +6,19 @@
 
 <%= simple_format(t(".school_will_no_longer")) %>
 
+<%= simple_format(t(".school_will_remain_assigned")) %>
+
+<% if @partner_school.partner_provider_placements(provider).any? %>
+  <p class="govuk-body"><%= t(".you_are_currently_assigned_to") %></p>
+  <ul class="govuk-list govuk-list--bullet">
+    <% @partner_school.partner_provider_placements(provider).each do |placement| %>
+      <li>
+        <%= govuk_link_to(placement.title, placements_placement_path(placement), target: "_blank", new_tab: true, no_visited_state: true) %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
+
 <%= render GovukComponent::WarningTextComponent.new(
   text: t(".school_will_be_sent_an_email",
     provider_name: provider.name,

--- a/app/views/placements/providers/partner_schools/_delete.html.erb
+++ b/app/views/placements/providers/partner_schools/_delete.html.erb
@@ -1,6 +1,6 @@
 <%# caption:, provider:, partner_school:, delete_link: %>
 <label class="govuk-label govuk-label--l">
-  <span class="govuk-caption-l"><%= partner_school.name %></span>
+  <span class="govuk-caption-l"><%= caption %></span>
   <%= t(".are_you_sure") %>
 </label>
 

--- a/app/views/placements/providers/partner_schools/remove.html.erb
+++ b/app/views/placements/providers/partner_schools/remove.html.erb
@@ -7,20 +7,11 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <label class="govuk-label govuk-label--l">
-        <span class="govuk-caption-l"><%= @partner_school.name %></span>
-        <%= t(".are_you_sure") %>
-      </label>
-
-     <%= simple_format(t(".school_will_no_longer")) %>
-
-      <%= render GovukComponent::WarningTextComponent.new(
-        text: t(".school_will_be_sent_an_email",
-          provider_name: @provider.name,
-          school_name: @partner_school.name),
-      ) %>
-
-      <%= govuk_button_to t(".delete_partner_school"), placements_provider_partner_school_path(@provider, @partner_school), warning: true, method: :delete %>
+      <%= render "delete",
+        caption: @partner_school.name,
+        provider: @provider,
+        partner_school: @partner_school,
+        delete_link: placements_provider_partner_school_path(@provider, @partner_school) %>
 
       <p class="govuk-body">
         <%= govuk_link_to(t(".cancel"), placements_provider_partner_school_path(@provider, @partner_school), no_visited_state: true) %>

--- a/app/views/placements/support/providers/partner_schools/remove.html.erb
+++ b/app/views/placements/support/providers/partner_schools/remove.html.erb
@@ -9,17 +9,11 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <label class="govuk-label govuk-label--l">
-        <span class="govuk-caption-l"><%= "#{@partner_school.name} - #{@provider.name}" %></span>
-        <%= t(".are_you_sure") %>
-      </label>
-      <%= render GovukComponent::WarningTextComponent.new(
-        text: t(".school_will_be_sent_an_email",
-          provider_name: @provider.name,
-          school_name: @partner_school.name),
-      ) %>
-
-      <%= govuk_button_to t(".remove_partner_school"), placements_support_provider_partner_school_path(@provider, @partner_school), warning: true, method: :delete %>
+      <%= render "placements/providers/partner_schools/delete",
+        caption: "#{@partner_school.name} - #{@provider.name}",
+        provider: @provider,
+        partner_school: @partner_school,
+        delete_link: placements_support_provider_partner_school_path(@provider, @partner_school) %>
 
       <p class="govuk-body">
         <%= govuk_link_to(t(".cancel"), placements_support_provider_partner_school_path(@provider, @partner_school), no_visited_state: true) %>

--- a/app/views/placements/support/providers/partner_schools/show.html.erb
+++ b/app/views/placements/support/providers/partner_schools/show.html.erb
@@ -25,7 +25,7 @@
   </div>
 
   <% if policy(@partnership).remove? %>
-    <%= link_to(t(".remove_partner_provider"),
+    <%= link_to(t(".delete_partner_provider"),
       remove_placements_support_provider_partner_school_path(@provider, @partner_school),
       class: "app-link app-link--destructive") %>
   <% end %>

--- a/config/locales/en/placements/providers/partner_schools.yml
+++ b/config/locales/en/placements/providers/partner_schools.yml
@@ -27,6 +27,8 @@ en:
           delete_partner_school: Delete partner school
           are_you_sure: Are you sure you want to delete this partner school?
           school_will_no_longer: The school will no longer be able to assign you to their placements. You can still view placements at this school.
+          school_will_remain_assigned: You will remain assigned to current placements unless the school removes you.
+          you_are_currently_assigned_to: "You are currently assigned to:"
           school_will_be_sent_an_email: We will send an email to %{school_name}. This will let them know you have deleted them as a partner school for %{provider_name}.
         destroy: 
           partner_school_deleted: Partner school deleted

--- a/config/locales/en/placements/providers/partner_schools.yml
+++ b/config/locales/en/placements/providers/partner_schools.yml
@@ -23,6 +23,7 @@ en:
         remove:
           page_title: Are you sure you want to delete this partner school? - %{school_name}
           cancel: Cancel
+        delete:
           delete_partner_school: Delete partner school
           are_you_sure: Are you sure you want to delete this partner school?
           school_will_no_longer: The school will no longer be able to assign you to their placements. You can still view placements at this school.

--- a/config/locales/en/placements/support/providers/partner_schools.yml
+++ b/config/locales/en/placements/support/providers/partner_schools.yml
@@ -18,12 +18,9 @@ en:
             ofsted: Ofsted
             send: Special educational needs and disabilities (SEND)
             contact_details: Contact details
-            remove_partner_provider: Remove partner school
+            delete_partner_provider: Delete partner school
           remove:
-            page_title: "Are you sure you want to remove this partner school? - %{school_name} - %{provider_name}"
+            page_title: "Are you sure you want to delete this partner school? - %{school_name} - %{provider_name}"
             cancel: Cancel
-            remove_partner_school: Remove partner school
-            are_you_sure: Are you sure you want to remove this partner school?
-            school_will_be_sent_an_email: We will send an email to %{school_name}. This will let them know you have removed them as a partner school for %{provider_name}.
           destroy:
             partner_school_deleted: Partner school deleted

--- a/spec/system/placements/providers/partner_schools/remove_a_partner_school_spec.rb
+++ b/spec/system/placements/providers/partner_schools/remove_a_partner_school_spec.rb
@@ -37,6 +37,39 @@ RSpec.describe "Placements / Providers / Partner schools / Remove a partner scho
     and_a_notification_email_is_sent_to(school_user)
   end
 
+  context "when the provider has placements associated with the partnership" do
+    let(:english) { create(:subject, name: "English") }
+    let(:maths) { create(:subject, name: "Mathematics") }
+    let(:science) { create(:subject, name: "Science") }
+
+    let(:placements_school) { school.becomes(Placements::School) }
+    let(:english_placement) { create(:placement, school: placements_school, provider:, subject: english) }
+    let(:maths_placement) { create(:placement, school: placements_school, provider:, subject: maths) }
+    let(:science_placement) { create(:placement, school: placements_school, provider:, subject: science) }
+
+    before do
+      english_placement
+      maths_placement
+      science_placement
+    end
+
+    scenario "User removes a partner school, and see the placements listed" do
+      given_i_sign_in_as_patricia
+      when_i_view_the_partner_school_show_page
+      and_i_click_on("Delete partner school")
+      then_i_am_asked_to_confirm_partner_school(school)
+      and_i_see_a_list_of_associated_placements_with_partner_school_and_provider
+      when_i_click_on("Cancel")
+      then_i_return_to_partner_school_page(school)
+      when_i_click_on("Delete partner school")
+      then_i_am_asked_to_confirm_partner_school(school)
+      when_i_click_on("Delete partner school")
+      then_the_partner_school_is_removed(school)
+      and_a_partner_provider_remains_called("Another school")
+      and_a_notification_email_is_sent_to(school_user)
+    end
+  end
+
   scenario "User removes a partner school, which is not onboarded on the placements service" do
     given_the_school_is_not_onboarded_on_placements_service(school)
     given_i_sign_in_as_patricia
@@ -137,5 +170,11 @@ RSpec.describe "Placements / Providers / Partner schools / Remove a partner scho
 
   def given_the_school_is_not_onboarded_on_placements_service(school)
     school.update!(placements_service: false)
+  end
+
+  def and_i_see_a_list_of_associated_placements_with_partner_school_and_provider
+    expect(page).to have_link("English (opens in new tab)")
+    expect(page).to have_link("Mathematics (opens in new tab)")
+    expect(page).to have_link("Science (opens in new tab)")
   end
 end

--- a/spec/system/placements/support/providers/partner_schools/support_user_deletes_a_partner_school_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/support_user_deletes_a_partner_school_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Placements / Support / Providers / Partner schools / Support user removes a partner school",
+RSpec.describe "Placements / Support / Providers / Partner schools / Support user deletes a partner school",
                service: :placements, type: :system do
   include ActiveJob::TestHelper
 
@@ -23,31 +23,31 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
     given_i_am_signed_in_as_a_support_user
   end
 
-  scenario "Support user removes a partner school" do
+  scenario "Support user deletes a partner school" do
     when_i_visit_the_partner_schools_page_for(provider:, school:)
-    and_i_click_on("Remove partner school")
+    and_i_click_on("Delete partner school")
     then_i_am_asked_to_confirm_partner_school(school)
     when_i_click_on("Cancel")
     then_i_return_to_partner_school_page(school)
-    when_i_click_on("Remove partner school")
+    when_i_click_on("Delete partner school")
     then_i_am_asked_to_confirm_partner_school(school)
-    when_i_click_on("Remove partner school")
-    then_the_partner_school_is_removed(school)
+    when_i_click_on("Delete partner school")
+    then_the_partner_school_is_deleted(school)
     and_a_partner_provider_remains_called("Another school")
     and_a_notification_email_is_sent_to(school_user)
   end
 
-  scenario "Support user removes a partner school, which is not onboarded on the placements service" do
+  scenario "Support user deletes a partner school, which is not onboarded on the placements service" do
     given_the_school_is_not_onboarded_on_placements_service(school)
     when_i_visit_the_partner_schools_page_for(provider:, school:)
-    and_i_click_on("Remove partner school")
+    and_i_click_on("Delete partner school")
     then_i_am_asked_to_confirm_partner_school(school)
     when_i_click_on("Cancel")
     then_i_return_to_partner_school_page(school)
-    when_i_click_on("Remove partner school")
+    when_i_click_on("Delete partner school")
     then_i_am_asked_to_confirm_partner_school(school)
-    when_i_click_on("Remove partner school")
-    then_the_partner_school_is_removed(school)
+    when_i_click_on("Delete partner school")
+    then_the_partner_school_is_deleted(school)
     and_a_partner_provider_remains_called("Another school")
     and_a_notification_email_is_not_sent_to(school_user)
   end
@@ -89,11 +89,11 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
 
   def then_i_am_asked_to_confirm_partner_school(school)
     expect(page).to have_title(
-      "Are you sure you want to remove this partner school? - #{school.name} " \
+      "Are you sure you want to delete this partner school? - #{school.name} " \
         "- #{provider.name} - Manage school placements",
     )
     expect(page).to have_content school.name
-    expect(page).to have_content "Are you sure you want to remove this partner school?"
+    expect(page).to have_content "Are you sure you want to delete this partner school?"
   end
 
   def then_i_return_to_partner_school_page(school)
@@ -101,7 +101,7 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
                                       ignore_query: true
   end
 
-  def then_the_partner_school_is_removed(school)
+  def then_the_partner_school_is_deleted(school)
     partner_schools_is_selected_in_secondary_nav
 
     expect(provider.partner_schools.find_by(id: school.id)).to be_nil

--- a/spec/system/placements/support/providers/partner_schools/support_user_deletes_a_partner_school_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/support_user_deletes_a_partner_school_spec.rb
@@ -37,6 +37,38 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
     and_a_notification_email_is_sent_to(school_user)
   end
 
+  context "when the provider has placements associated with the partnership" do
+    let(:english) { create(:subject, name: "English") }
+    let(:maths) { create(:subject, name: "Mathematics") }
+    let(:science) { create(:subject, name: "Science") }
+
+    let(:placements_school) { school.becomes(Placements::School) }
+    let(:english_placement) { create(:placement, school: placements_school, provider:, subject: english) }
+    let(:maths_placement) { create(:placement, school: placements_school, provider:, subject: maths) }
+    let(:science_placement) { create(:placement, school: placements_school, provider:, subject: science) }
+
+    before do
+      english_placement
+      maths_placement
+      science_placement
+    end
+
+    scenario "Support user deletes a partner school, and see the placements listed" do
+      when_i_visit_the_partner_schools_page_for(provider:, school:)
+      and_i_click_on("Delete partner school")
+      then_i_am_asked_to_confirm_partner_school(school)
+      and_i_see_a_list_of_associated_placements_with_partner_school_and_provider
+      when_i_click_on("Cancel")
+      then_i_return_to_partner_school_page(school)
+      when_i_click_on("Delete partner school")
+      then_i_am_asked_to_confirm_partner_school(school)
+      when_i_click_on("Delete partner school")
+      then_the_partner_school_is_deleted(school)
+      and_a_partner_provider_remains_called("Another school")
+      and_a_notification_email_is_sent_to(school_user)
+    end
+  end
+
   scenario "Support user deletes a partner school, which is not onboarded on the placements service" do
     given_the_school_is_not_onboarded_on_placements_service(school)
     when_i_visit_the_partner_schools_page_for(provider:, school:)
@@ -137,5 +169,11 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
 
   def given_the_school_is_not_onboarded_on_placements_service(school)
     school.update!(placements_service: false)
+  end
+
+  def and_i_see_a_list_of_associated_placements_with_partner_school_and_provider
+    expect(page).to have_link("English (opens in new tab)")
+    expect(page).to have_link("Mathematics (opens in new tab)")
+    expect(page).to have_link("Science (opens in new tab)")
   end
 end


### PR DESCRIPTION
## Context

- Content changes for Support User view of the Remove/Delete Partner school journey.

## Changes proposed in this pull request

- Move content of `remove` page to a partial for use with both support user and school user.

## Guidance to review
- Sign in as Colin (Support User)
- Click on a Provider (with Partner Schools)
- Click on "Partner schools" in the Navbar
- Click on the partner school you wish to remove
- Click "Delete partner school"
- You should see the content changes linked to [Lucid](https://lucid.app/lucidspark/262e5d35-0c1f-4f90-aa60-c3b00a9a53ef/edit?referringApp=slack&shared=true&page=0_0#)
Click "Delete partner school"
You should see the flash message "Partner school deleted"

## Link to Trello card

https://trello.com/c/mPbpQoxa/694-support-console-improve-provider-user-partner-school-journey-content

## Screenshots

https://github.com/user-attachments/assets/1a47eb24-5623-438b-9604-a6a0f01f65cc

![screencapture-placements-localhost-3000-providers-0069ec8a-3131-4a55-8934-b320a18f66dd-partner-schools-00027385-1ffc-4107-b71a-742743c41dd8-remove-2024-08-19-10_15_38](https://github.com/user-attachments/assets/82ca0665-45b6-4eb4-927a-f2c4155c082a)
