### PR TITLE
[Support] Remove provider user

### DIFF
--- a/app/views/placements/providers/users/_delete.html.erb
+++ b/app/views/placements/providers/users/_delete.html.erb
@@ -1,13 +1,14 @@
 <%# caption:, user:, organisation:, delete_link: %>
+
 <label class="govuk-label govuk-label--l">
   <span class="govuk-caption-l"><%= caption %></span>
   <%= t(".are_you_sure") %>
 </label>
 
-<%= simple_format(t(".user_will_no_longer", user_name: user.full_name)) %>
+<%= simple_format(t(".user_will_no_longer", user_name: @user.full_name)) %>
 
 <%= render GovukComponent::WarningTextComponent.new(
-  text: t(".user_will_be_sent_an_email", organisation_name: organisation.name),
+  text: t(".user_will_be_sent_an_email", organisation_name: @organisation.name),
 ) %>
 
 <%= govuk_button_to t(".delete_user"), delete_link, warning: true, method: :delete %>

--- a/app/views/placements/providers/users/remove.html.erb
+++ b/app/views/placements/providers/users/remove.html.erb
@@ -8,10 +8,10 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "delete",
-        caption: @user.full_name.to_s,
-        user: @user,
-        organisation: @organisation,
-        delete_link: placements_provider_user_path(@organisation, @user) %>
+                 caption: @user.full_name.to_s,
+                 user: @user,
+                 organisation: @organisation,
+                 delete_link: placements_provider_user_path(@organisation, @user) %>
 
       <p class="govuk-body">
         <%= govuk_link_to(t(".cancel"), placements_provider_user_path(@organisation, @user), no_visited_state: true) %>

--- a/app/views/placements/support/providers/users/remove.html.erb
+++ b/app/views/placements/support/providers/users/remove.html.erb
@@ -8,10 +8,10 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "placements/providers/users/delete",
-        caption: "#{@user.full_name} - #{@organisation.name}",
-        user: @user,
-        organisation: @organisation,
-        delete_link: placements_support_provider_user_path(@organisation, @user) %>
+                 caption: "#{@user.full_name} - #{@organisation.name}",
+                 user: @user,
+                 organisation: @organisation,
+                 delete_link: placements_support_provider_user_path(@organisation, @user) %>
 
       <p class="govuk-body">
         <%= govuk_link_to(t(".cancel"), placements_support_provider_user_path(@organisation, @user), no_visited_state: true) %>

--- a/config/locales/en/placements/providers/users.yml
+++ b/config/locales/en/placements/providers/users.yml
@@ -10,7 +10,7 @@ en:
           change_organisation: Change organisation
           delete_user: Delete user
         destroy:
-          user_removed: User deleted
+          user_deleted: User deleted
         remove:
           page_title: Are you sure you want to delete this user? - %{user_name}
           cancel: Cancel

--- a/config/locales/en/placements/providers/users.yml
+++ b/config/locales/en/placements/providers/users.yml
@@ -10,12 +10,14 @@ en:
           change_organisation: Change organisation
           delete_user: Delete user
         destroy:
-          user_deleted: User deleted
+          user_removed: User deleted
         remove:
           page_title: Are you sure you want to delete this user? - %{user_name}
           cancel: Cancel
         delete:
           are_you_sure: Are you sure you want to delete this user?
           delete_user: Delete user
+          change_organisation: Change organisation
           user_will_no_longer: '%{user_name} will no longer be able to access placement information.'
-          user_will_be_sent_an_email: The user will be sent an email to tell them you deleted them from %{organisation_name}.
+          user_will_be_sent_an_email: The user will be sent an email to tell them you deleted them from %{organisation_name}
+        you_cannot_perform_this_action: You cannot perform this action

--- a/config/locales/en/placements/support/providers/users.yml
+++ b/config/locales/en/placements/support/providers/users.yml
@@ -13,7 +13,10 @@ en:
                 email: Email
           remove:
             page_title: Are you sure you want to delete this user? - %{user_name} - %{organisation_name}
+            are_you_sure: Are you sure you want to delete this user?
+            delete_user: Delete user
             cancel: Cancel
+            user_will_be_sent_an_email: The user will be sent an email to tell them you deleted them from %{organisation_name}
           show:
             delete_user: Delete user
           destroy:

--- a/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
+++ b/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Placements support user removes a user from an organisation", se
     let(:school) { create(:placements_school) }
     let(:anne) { create(:placements_user, :anne) }
     let(:mary) { create(:placements_user, :mary) }
+    let(:success_message) { "User removed" }
 
     before do
       [anne, mary].each do |user|
@@ -43,6 +44,7 @@ RSpec.describe "Placements support user removes a user from an organisation", se
     let(:provider) { create(:placements_provider) }
     let(:anne) { create(:placements_user, :anne) }
     let(:mary) { create(:placements_user, :mary) }
+    let(:success_message) { "User deleted" }
 
     before "message is sent to user" do
       [anne, mary].each do |user|
@@ -175,7 +177,7 @@ RSpec.describe "Placements support user removes a user from an organisation", se
 
     expect(user.user_memberships.find_by(organisation:)).to be_nil
     within(".govuk-notification-banner__content") do
-      expect(page).to have_content "User deleted"
+      expect(page).to have_content success_message
     end
 
     expect(page).not_to have_content user.full_name

--- a/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
+++ b/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Placements support user removes a user from an organisation", se
     let(:school) { create(:placements_school) }
     let(:anne) { create(:placements_user, :anne) }
     let(:mary) { create(:placements_user, :mary) }
-    let(:success_message) { "User removed" }
+    let(:success_message) { "User deleted" }
 
     before do
       [anne, mary].each do |user|
@@ -19,7 +19,7 @@ RSpec.describe "Placements support user removes a user from an organisation", se
       end
     end
 
-    scenario "user is removed from a school" do
+    scenario "user is deleted from a school" do
       given_i_am_signed_in_as_mary
       and_i_visit_the_user_page(anne)
       when_i_click_on("Delete user")
@@ -29,7 +29,7 @@ RSpec.describe "Placements support user removes a user from an organisation", se
       when_i_click_on("Delete user")
       then_i_am_asked_to_confirm(anne, school)
       when_i_click_on("Delete user")
-      then_the_the_user_is_removed_from_the_organisation(anne, school)
+      then_the_the_user_is_deleted_from_the_organisation(anne, school)
       and_message_is_sent_to_user(anne, school)
     end
 
@@ -52,7 +52,7 @@ RSpec.describe "Placements support user removes a user from an organisation", se
       end
     end
 
-    scenario "user is removed from a provider" do
+    scenario "user is deleted from a provider" do
       given_i_am_signed_in_as_mary
       and_i_visit_the_user_page(anne)
       when_i_click_on("Delete user")
@@ -62,7 +62,7 @@ RSpec.describe "Placements support user removes a user from an organisation", se
       when_i_click_on("Delete user")
       then_i_am_asked_to_confirm(anne, provider)
       when_i_click_on("Delete user")
-      then_the_the_user_is_removed_from_the_organisation(anne, provider)
+      then_the_the_user_is_deleted_from_the_organisation(anne, provider)
       and_message_is_sent_to_user(anne, provider)
     end
 
@@ -167,7 +167,7 @@ RSpec.describe "Placements support user removes a user from an organisation", se
     end
   end
 
-  def then_the_the_user_is_removed_from_the_organisation(user, organisation)
+  def then_the_the_user_is_deleted_from_the_organisation(user, organisation)
     case organisation
     when School
       users_is_selected_in_schools_primary_nav

--- a/spec/system/placements/support/users/support_user_deletes_a_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_deletes_a_user_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe "Placements support user deletes a user from an organisation", se
     end
   end
 
-  def then_the_user_is_deleted_from_the_organisation(organisation, message: "User removed")
+  def then_the_user_is_deleted_from_the_organisation(organisation, message: "User deleted")
     organisations_is_selected_in_primary_nav
     users_is_selected_in_secondary_nav(organisation)
     expect(user.user_memberships.find_by(organisation:)).to be_nil

--- a/spec/system/placements/support/users/support_user_deletes_a_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_deletes_a_user_spec.rb
@@ -42,13 +42,13 @@ RSpec.describe "Placements support user deletes a user from an organisation", se
       given_i_am_signed_in_as_a_support_user
       and_i_visit_the_user_page(provider)
       when_i_click_on("Delete user")
-      then_i_am_asked_to_confirm(provider)
+      then_i_am_asked_to_confirm_the_deletion(provider)
       when_i_click_on("Cancel")
       then_i_return_to_user_page(provider)
       when_i_click_on("Delete user")
-      then_i_am_asked_to_confirm(provider)
+      then_i_am_asked_to_confirm_the_deletion(provider)
       when_i_click_on("Delete user")
-      then_the_user_is_deleted_from_the_organisation(provider)
+      then_the_user_is_deleted_from_the_organisation(provider, message: "User deleted")
       and_email_is_sent(user.email, provider)
     end
   end
@@ -115,6 +115,16 @@ RSpec.describe "Placements support user deletes a user from an organisation", se
     expect(page).to have_content "The user will be sent an email to tell them you deleted them from #{organisation.name}"
   end
 
+  def then_i_am_asked_to_confirm_the_deletion(organisation)
+    organisations_is_selected_in_primary_nav
+    expect(page).to have_title(
+      "Are you sure you want to delete this user? - #{user.full_name} - #{organisation.name} - Manage school placements",
+    )
+    expect(page).to have_content "#{user.full_name} - #{organisation.name}"
+    expect(page).to have_content "Are you sure you want to delete this user?"
+    expect(page).to have_content "The user will be sent an email to tell them you deleted them from #{organisation.name}"
+  end
+
   def organisations_is_selected_in_primary_nav
     within(".app-primary-navigation__nav") do
       expect(page).to have_link "Organisations", current: "page"
@@ -146,12 +156,12 @@ RSpec.describe "Placements support user deletes a user from an organisation", se
     end
   end
 
-  def then_the_user_is_deleted_from_the_organisation(organisation)
+  def then_the_user_is_deleted_from_the_organisation(organisation, message: "User removed")
     organisations_is_selected_in_primary_nav
     users_is_selected_in_secondary_nav(organisation)
     expect(user.user_memberships.find_by(organisation:)).to be_nil
     within(".govuk-notification-banner__content") do
-      expect(page).to have_content "User deleted"
+      expect(page).to have_content message
     end
 
     expect(page).not_to have_content user.full_name


### PR DESCRIPTION
## Context

We are updating the app content to be more consistent, as part of this we are chaning remove to delete.

## Changes proposed in this pull request

- [x] Add `_delete.html.erb` partial
- [x] Make use of the new partial in both support and provider views
- [x] Update specs

## Guidance to review

- Log in as Colin
- Navigate to a provider
- Select users in the top nav
- Click on a user
- Confirm button reads "Delete user"
- Click on "Delete user"
- Confirm the text on this page all reads as "delete"
- Click on "Delete user"
- Confirm the text reads "User deleted"

## Link to Trello card

[[Support console] Improve provider user, user content](https://trello.com/c/ketAqBM0/692-support-console-improve-provider-user-user-content)

## Screenshots

![image](https://github.com/user-attachments/assets/11fbd795-29d4-4f44-9247-b97e0326a400)
![image](https://github.com/user-attachments/assets/fb215dc1-5255-4a60-b770-29cf3a4c8eb5)
![image](https://github.com/user-attachments/assets/aec7b98e-4bf5-49cc-ae3b-8a23fe97ba7b)
