### PR TITLE
Add secondary navigation to Support claims page

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,4 @@
 HOSTING_ENV=development
+
+# ENV feature flags
+FEATURE_FLAG_CLAIMS_TABS=true

--- a/.env.test
+++ b/.env.test
@@ -21,3 +21,6 @@ TEACHING_RECORD_API_KEY=secret
 GIAS_CSV_BASE_URL=https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public
 
 CLAIMS_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/secret
+
+# ENV feature flags
+FEATURE_FLAG_CLAIMS_TABS=true

--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -6,6 +6,7 @@
 @import "inline_code";
 @import "link";
 @import "organisation_list_item";
+@import "page_header";
 @import "phase_banner";
 @import "primary_navigation";
 @import "secondary_navigation";

--- a/app/assets/stylesheets/components/_page_header.scss
+++ b/app/assets/stylesheets/components/_page_header.scss
@@ -1,0 +1,27 @@
+.app-page-header {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  @include govuk-media-query($from: tablet) {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .app-page-header__title {
+    width: calc(2 / 3 * 100%);
+  }
+
+  .app-page-header__actions {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: center;
+    column-gap: govuk-spacing(2);
+
+    @include govuk-media-query($from: tablet) {
+      width: calc(1 / 3 * 100%);
+      flex-direction: row;
+    }
+  }
+}

--- a/app/controllers/claims/support/claims/clawbacks_controller.rb
+++ b/app/controllers/claims/support/claims/clawbacks_controller.rb
@@ -1,0 +1,16 @@
+class Claims::Support::Claims::ClawbacksController < Claims::ApplicationController
+  before_action :skip_authorization
+  before_action :set_claims
+
+  def show; end
+
+  def create
+    redirect_to claims_support_claims_clawback_path
+  end
+
+  private
+
+  def set_claims
+    @claims = Claims::Claim.none
+  end
+end

--- a/app/controllers/claims/support/claims/payments_controller.rb
+++ b/app/controllers/claims/support/claims/payments_controller.rb
@@ -1,0 +1,16 @@
+class Claims::Support::Claims::PaymentsController < Claims::ApplicationController
+  before_action :skip_authorization
+  before_action :set_claims
+
+  def show; end
+
+  def create
+    redirect_to claims_support_claims_payment_path
+  end
+
+  private
+
+  def set_claims
+    @claims = Claims::Claim.none
+  end
+end

--- a/app/controllers/claims/support/claims/samplings_controller.rb
+++ b/app/controllers/claims/support/claims/samplings_controller.rb
@@ -1,0 +1,16 @@
+class Claims::Support::Claims::SamplingsController < Claims::ApplicationController
+  before_action :skip_authorization
+  before_action :set_claims
+
+  def show; end
+
+  def create
+    redirect_to claims_support_claims_sampling_path
+  end
+
+  private
+
+  def set_claims
+    @claims = Claims::Claim.none
+  end
+end

--- a/app/views/claims/support/claims/_secondary_navigation.html.erb
+++ b/app/views/claims/support/claims/_secondary_navigation.html.erb
@@ -1,0 +1,8 @@
+<% if ENV["FEATURE_FLAG_CLAIMS_TABS"] == "true" %>
+  <%= render SecondaryNavigationComponent.new do |component| %>
+    <% component.with_navigation_item t(".claims"), claims_support_claims_path %>
+    <% component.with_navigation_item t(".payment"), claims_support_claims_payment_path %>
+    <% component.with_navigation_item t(".sampling"), claims_support_claims_sampling_path %>
+    <% component.with_navigation_item t(".clawback"), claims_support_claims_clawback_path %>
+  <% end %>
+<% end %>

--- a/app/views/claims/support/claims/clawbacks/show.html.erb
+++ b/app/views/claims/support/claims/clawbacks/show.html.erb
@@ -1,0 +1,24 @@
+<%= render "claims/support/primary_navigation", current: :claims %>
+<%= content_for :page_title, t(".heading") %>
+
+<div class="govuk-width-container" data-controller="filter">
+  <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+
+  <%= render "claims/support/claims/secondary_navigation" %>
+
+  <% if @claims.any? %>
+    List of Claims and filters
+  <% else %>
+    <%= form_with url: claims_support_claims_clawback_path do |f| %>
+      <%= govuk_list type: :number do |list| %>
+        <% t(".steps").each do |step| %>
+          <%= tag.li step %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_file_field :file, label: { text: t(".labels.file") } %>
+
+      <%= f.govuk_submit t(".submit") %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/claims/support/claims/index.html.erb
+++ b/app/views/claims/support/claims/index.html.erb
@@ -2,9 +2,18 @@
 <%= content_for :page_title, t(".heading", count: @pagy.count) %>
 
 <div class="govuk-width-container" data-controller="filter">
-  <h1 class="govuk-heading-l"><%= t(".heading", count: @pagy.count) %></h1>
+  <div class="app-page-header">
+    <div class="app-page-header__title">
+      <h1 class="govuk-heading-l"><%= t(".heading", count: @pagy.count) %></h1>
+    </div>
 
-  <%= govuk_link_to t(".download_csv"), download_csv_claims_support_claims_path(**request.query_parameters), class: "govuk-button", method: :get %>
+    <div class="app-page-header__actions">
+      <%= govuk_link_to t(".download_csv"), download_csv_claims_support_claims_path(**request.query_parameters), class: "govuk-button", method: :get %>
+    </div>
+  </div>
+
+  <%= render "claims/support/claims/secondary_navigation" %>
+
   <div>
     <button class="govuk-button govuk-button--secondary show-filter-button" type="button" data-action="click->filter#open"><%= t("show_filter") %></button>
   </div>

--- a/app/views/claims/support/claims/payments/show.html.erb
+++ b/app/views/claims/support/claims/payments/show.html.erb
@@ -1,0 +1,24 @@
+<%= render "claims/support/primary_navigation", current: :claims %>
+<%= content_for :page_title, t(".heading") %>
+
+<div class="govuk-width-container" data-controller="filter">
+  <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+
+  <%= render "claims/support/claims/secondary_navigation" %>
+
+  <% if @claims.any? %>
+    List of Claims and filters
+  <% else %>
+    <%= form_with url: claims_support_claims_payment_path do |f| %>
+      <%= govuk_list type: :number do |list| %>
+        <% t(".steps").each do |step| %>
+          <%= tag.li step %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_file_field :file, label: { text: t(".labels.file") } %>
+
+      <%= f.govuk_submit t(".submit") %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/claims/support/claims/samplings/show.html.erb
+++ b/app/views/claims/support/claims/samplings/show.html.erb
@@ -1,0 +1,24 @@
+<%= render "claims/support/primary_navigation", current: :claims %>
+<%= content_for :page_title, t(".heading") %>
+
+<div class="govuk-width-container" data-controller="filter">
+  <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+
+  <%= render "claims/support/claims/secondary_navigation" %>
+
+  <% if @claims.any? %>
+    List of Claims and filters
+  <% else %>
+    <%= form_with url: claims_support_claims_sampling_path do |f| %>
+      <%= govuk_list type: :number do |list| %>
+        <% t(".steps").each do |step| %>
+          <%= tag.li step %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_file_field :file, label: { text: t(".labels.file") } %>
+
+      <%= f.govuk_submit t(".submit") %>
+    <% end %>
+  <% end %>
+</div>

--- a/config/locales/en/claims/support/claims.yml
+++ b/config/locales/en/claims/support/claims.yml
@@ -2,6 +2,11 @@ en:
   claims:
     support:
       claims:
+        secondary_navigation:
+          claims: All claims
+          payment: Payments
+          sampling: Sampling
+          clawback: Clawback
         index:
           heading: Claims (%{count})
           download_csv: Download CSV

--- a/config/locales/en/claims/support/claims/clawbacks.yml
+++ b/config/locales/en/claims/support/claims/clawbacks.yml
@@ -1,0 +1,14 @@
+en:
+  claims:
+    support:
+      claims:
+        clawbacks:
+          show:
+            heading: Clawback
+            steps:
+              - Fetch the download CSV of sample claims.
+              - Upload it.
+              - Do we need any other instructions for the user here?
+            labels:
+              file: Upload a CSV
+            submit: Save and continue

--- a/config/locales/en/claims/support/claims/payments.yml
+++ b/config/locales/en/claims/support/claims/payments.yml
@@ -1,0 +1,16 @@
+en:
+  claims:
+    support:
+      claims:
+        payments:
+          show:
+            heading: Payments
+            steps:
+              - Download a CSV of all submitted claims.
+              - Send the CSV from step one to ESFA.
+              - Once ESFA have completed payments, they will return the CSV with successfully paid claims marked as "Paid".
+              - When ESFA return the CSV, upload it here.
+              - The CSV will the payments to the payments tab.
+            labels:
+              file: Upload a CSV
+            submit: Save and continue

--- a/config/locales/en/claims/support/claims/samplings.yml
+++ b/config/locales/en/claims/support/claims/samplings.yml
@@ -1,0 +1,14 @@
+en:
+  claims:
+    support:
+      claims:
+        samplings:
+          show:
+            heading: Sampling
+            steps:
+              - Fetch the download CSV of sample claims.
+              - Upload it.
+              - Do we need any other instructions for the user here?
+            labels:
+              file: Upload a CSV
+            submit: Save and continue

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -62,6 +62,14 @@ scope module: :claims, as: :claims, constraints: {
 
     resources :claims, only: %i[index show] do
       get :download_csv, on: :collection
+
+      if ENV["FEATURE_FLAG_CLAIMS_TABS"] == "true"
+        collection do
+          resource :payment, only: %i[show create], module: :claims, as: :claims_payment
+          resource :sampling, only: %i[show create], module: :claims, as: :claims_sampling
+          resource :clawback, only: %i[show create], module: :claims, as: :claims_clawback
+        end
+      end
     end
 
     resources :support_users, path: "support-users" do

--- a/spec/system/claims/support/claims/view_clawback_tab_spec.rb
+++ b/spec/system/claims/support/claims/view_clawback_tab_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe "View claims clawback tab", service: :claims, type: :system do
+  scenario "User views the clawback tab" do
+    given_i_sign_in
+    when_i_visit_the_claims_clawback_tab
+    then_i_should_see_the_clawback_instructions
+
+    when_i_click_on_the_submit_button
+    then_i_am_redirected_to_the_claims_clawback_tab
+  end
+
+  private
+
+  def given_i_sign_in
+    user_exists_in_dfe_sign_in(user: create(:claims_support_user))
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def when_i_visit_the_claims_clawback_tab
+    click_on "Claims"
+    click_on "Clawback"
+  end
+
+  def then_i_should_see_the_clawback_instructions
+    expect(page).to have_content("Clawback")
+    expect(page).to have_content("Fetch the download CSV of sample claims.")
+    expect(page).to have_content("Upload it.")
+    expect(page).to have_content("Do we need any other instructions for the user here?")
+  end
+
+  def when_i_click_on_the_submit_button
+    click_on "Save and continue"
+  end
+
+  def then_i_am_redirected_to_the_claims_clawback_tab
+    expect(page).to have_current_path(claims_support_claims_clawback_path)
+  end
+end

--- a/spec/system/claims/support/claims/view_payments_tab_spec.rb
+++ b/spec/system/claims/support/claims/view_payments_tab_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe "View claims payments tab", service: :claims, type: :system do
+  scenario "User views the payments tab" do
+    given_i_sign_in
+    when_i_visit_the_claims_payments_tab
+    then_i_should_see_the_payments_instructions
+
+    when_i_click_on_the_submit_button
+    then_i_am_redirected_to_the_claims_payments_tab
+  end
+
+  private
+
+  def given_i_sign_in
+    user_exists_in_dfe_sign_in(user: create(:claims_support_user))
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def when_i_visit_the_claims_payments_tab
+    click_on "Claims"
+    click_on "Payments"
+  end
+
+  def then_i_should_see_the_payments_instructions
+    expect(page).to have_content("Payments")
+    expect(page).to have_content("Download a CSV of all submitted claims.")
+    expect(page).to have_content("Send the CSV from step one to ESFA.")
+    expect(page).to have_content("Once ESFA have completed payments, they will return the CSV with successfully paid claims marked as \"Paid\".")
+    expect(page).to have_content("When ESFA return the CSV, upload it here.")
+    expect(page).to have_content("The CSV will the payments to the payments tab.")
+  end
+
+  def when_i_click_on_the_submit_button
+    click_on "Save and continue"
+  end
+
+  def then_i_am_redirected_to_the_claims_payments_tab
+    expect(page).to have_current_path(claims_support_claims_payment_path)
+  end
+end

--- a/spec/system/claims/support/claims/view_sampling_tab_spec.rb
+++ b/spec/system/claims/support/claims/view_sampling_tab_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe "View claims sampling tab", service: :claims, type: :system do
+  scenario "User views the sampling tab" do
+    given_i_sign_in
+    when_i_visit_the_claims_sampling_tab
+    then_i_should_see_the_sampling_instructions
+
+    when_i_click_on_the_submit_button
+    then_i_am_redirected_to_the_claims_sampling_tab
+  end
+
+  private
+
+  def given_i_sign_in
+    user_exists_in_dfe_sign_in(user: create(:claims_support_user))
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def when_i_visit_the_claims_sampling_tab
+    click_on "Claims"
+    click_on "Sampling"
+  end
+
+  def then_i_should_see_the_sampling_instructions
+    expect(page).to have_content("Sampling")
+    expect(page).to have_content("Fetch the download CSV of sample claims.")
+    expect(page).to have_content("Upload it.")
+    expect(page).to have_content("Do we need any other instructions for the user here?")
+  end
+
+  def when_i_click_on_the_submit_button
+    click_on "Save and continue"
+  end
+
+  def then_i_am_redirected_to_the_claims_sampling_tab
+    expect(page).to have_current_path(claims_support_claims_sampling_path)
+  end
+end

--- a/terraform/application/config/review_app_env.yml
+++ b/terraform/application/config/review_app_env.yml
@@ -15,3 +15,6 @@ SIGN_IN_METHOD: persona
 BIGQUERY_TABLE_NAME: events
 BIGQUERY_PROJECT_ID: rugged-abacus-218110
 BIGQUERY_DATASET: itt_mentor_events_qa
+
+# ENV feature flags
+FEATURE_FLAG_CLAIMS_TABS: true


### PR DESCRIPTION
## Context

We want to add in the following flows:

- Payments (Downloading CSV of claims, uploading CSV of payments)
- Sampling (Uploading CSV of claims to be sampled)
- Clawback (Uploading CSV of claims to be clawed back)

This is the initial PR to add in the tabs, without adding the functional parts to keep future change sets to a minimum.

## Changes proposed in this pull request

- This commit adds the "Payments", "Sampling", and "Clawback" tabs to the Claims page.

## Guidance to review

- Content will change in a future PR.
- This PR is a starting point to add in these flows in an incremental manner.

## Screenshots

![CleanShot 2024-08-20 at 17 17 13](https://github.com/user-attachments/assets/edb97aca-195a-4e65-b9e2-c7daeea7dfbc)

![CleanShot 2024-08-20 at 17 17 26](https://github.com/user-attachments/assets/cee4fb07-22db-4da4-b752-e6e0bbefabe1)
