### PR TITLE
Revert data_migrate down to 9.4.2 as 9.4.4 has been yanked

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,7 +111,7 @@ gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.14.0"
 gem "strong_migrations"
 
 # Data Migrate [https://github.com/ilyakatz/data-migrate]
-gem "data_migrate", "~> 9.4"
+gem "data_migrate", "9.4.2"
 
 # OK Computer [https://github.com/sportngin/okcomputer]
 gem "okcomputer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,7 +172,7 @@ GEM
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
     csv (3.3.0)
-    data_migrate (9.4.4)
+    data_migrate (9.4.2)
       activerecord (>= 6.1)
       railties (>= 6.1)
     date (3.3.4)
@@ -720,7 +720,7 @@ DEPENDENCIES
   climate_control
   cssbundling-rails
   csv
-  data_migrate (~> 9.4)
+  data_migrate (= 9.4.2)
   debug
   dfe-analytics!
   discard


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
