### PR TITLE
[Part 2] associate placements to placements academic year

### DIFF
--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -2,23 +2,26 @@
 #
 # Table name: placements
 #
-#  id          :uuid             not null, primary key
-#  year_group  :enum
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  provider_id :uuid
-#  school_id   :uuid
-#  subject_id  :uuid
+#  id               :uuid             not null, primary key
+#  year_group       :enum
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  academic_year_id :uuid             not null
+#  provider_id      :uuid
+#  school_id        :uuid
+#  subject_id       :uuid
 #
 # Indexes
 #
-#  index_placements_on_provider_id  (provider_id)
-#  index_placements_on_school_id    (school_id)
-#  index_placements_on_subject_id   (subject_id)
-#  index_placements_on_year_group   (year_group)
+#  index_placements_on_academic_year_id  (academic_year_id)
+#  index_placements_on_provider_id       (provider_id)
+#  index_placements_on_school_id         (school_id)
+#  index_placements_on_subject_id        (subject_id)
+#  index_placements_on_year_group        (year_group)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (academic_year_id => academic_years.id)
 #  fk_rails_...  (provider_id => providers.id)
 #  fk_rails_...  (school_id => schools.id)
 #  fk_rails_...  (subject_id => subjects.id)
@@ -30,8 +33,9 @@ class Placement < ApplicationRecord
   has_many :placement_additional_subjects, class_name: "Placements::PlacementAdditionalSubject", dependent: :destroy
   has_many :additional_subjects, through: :placement_additional_subjects, source: :subject
 
+  belongs_to :academic_year, class_name: "Placements::AcademicYear"
   belongs_to :school, class_name: "Placements::School"
-  belongs_to :provider, optional: true, class_name: "::Provider"
+  belongs_to :provider, class_name: "::Provider", optional: true
   belongs_to :subject, class_name: "::Subject"
 
   accepts_nested_attributes_for :mentors, allow_destroy: true

--- a/app/models/placements/academic_year.rb
+++ b/app/models/placements/academic_year.rb
@@ -10,6 +10,8 @@
 #  updated_at :datetime         not null
 #
 class Placements::AcademicYear < AcademicYear
+  has_many :placements
+
   def self.current
     for_date(Date.current)
   end

--- a/app/wizards/placements/add_placement_wizard.rb
+++ b/app/wizards/placements/add_placement_wizard.rb
@@ -33,7 +33,7 @@ module Placements
 
     def build_placement
       placement = school.placements.build
-      placement.academic_year = ::Placements::AcademicYear.current_academic_year
+      placement.academic_year = ::Placements::AcademicYear.current
       placement.subject = steps[:subject].subject
 
       if steps[:additional_subjects].present?

--- a/app/wizards/placements/add_placement_wizard.rb
+++ b/app/wizards/placements/add_placement_wizard.rb
@@ -33,6 +33,7 @@ module Placements
 
     def build_placement
       placement = school.placements.build
+      placement.academic_year = ::Placements::AcademicYear.current_academic_year
       placement.subject = steps[:subject].subject
 
       if steps[:additional_subjects].present?

--- a/db/migrate/20240822150107_change_academic_year_for_placements.rb
+++ b/db/migrate/20240822150107_change_academic_year_for_placements.rb
@@ -1,0 +1,5 @@
+class ChangeAcademicYearForPlacements < ActiveRecord::Migration[7.1]
+  def change
+    add_check_constraint :placements, "academic_year_id IS NOT NULL", name: "placements_academic_year_id_null", validate: false
+  end
+end

--- a/db/migrate/20240822150354_validate_change_academic_year_for_placements.rb
+++ b/db/migrate/20240822150354_validate_change_academic_year_for_placements.rb
@@ -1,0 +1,12 @@
+class ValidateChangeAcademicYearForPlacements < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :placements, name: "placements_academic_year_id_null"
+    change_column_null :placements, :academic_year_id, false
+    remove_check_constraint :placements, name: "placements_academic_year_id_null"
+  end
+
+  def down
+    add_check_constraint :placements, "academic_year_id IS NOT NULL", name: "placements_academic_year_id_null", validate: false
+    change_column_null :placements, :academic_year_id, true
+  end
+end

--- a/db/migrate/20240822150528_add_academic_year_foreign_key_to_placements.rb
+++ b/db/migrate/20240822150528_add_academic_year_foreign_key_to_placements.rb
@@ -1,0 +1,5 @@
+class AddAcademicYearForeignKeyToPlacements < ActiveRecord::Migration[7.1]
+  def change
+    add_foreign_key :placements, :academic_years, validate: false
+  end
+end

--- a/db/migrate/20240822150613_validate_add_academic_year_foreign_key_to_placements.rb
+++ b/db/migrate/20240822150613_validate_add_academic_year_foreign_key_to_placements.rb
@@ -1,0 +1,5 @@
+class ValidateAddAcademicYearForeignKeyToPlacements < ActiveRecord::Migration[7.1]
+  def change
+    validate_foreign_key :placements, :academic_years
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_22_141750) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_22_150613) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -448,6 +448,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_22_141750) do
   add_foreign_key "placement_additional_subjects", "subjects"
   add_foreign_key "placement_mentor_joins", "mentors"
   add_foreign_key "placement_mentor_joins", "placements"
+  add_foreign_key "placements", "academic_years"
   add_foreign_key "placements", "providers"
   add_foreign_key "placements", "schools"
   add_foreign_key "placements", "subjects"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -268,7 +268,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_22_141750) do
     t.uuid "provider_id"
     t.uuid "subject_id"
     t.enum "year_group", enum_type: "placement_year_group"
-    t.uuid "academic_year_id"
+    t.uuid "academic_year_id", null: false
     t.index ["academic_year_id"], name: "index_placements_on_academic_year_id"
     t.index ["provider_id"], name: "index_placements_on_provider_id"
     t.index ["school_id"], name: "index_placements_on_school_id"

--- a/spec/factories/academic_years.rb
+++ b/spec/factories/academic_years.rb
@@ -19,10 +19,8 @@ FactoryBot.define do
   end
 
   factory :placements_academic_year, class: "Placements::AcademicYear", parent: :academic_year do
-    trait :current do
-      starts_on { Date.parse("1 September #{Date.current.year - 1}") }
-      ends_on { Date.parse("31 August #{Date.current.year}") }
-      name { "#{starts_on.year} to #{ends_on.year}" }
-    end
+    starts_on { Date.parse("1 September #{Date.current.year - 1}") }
+    ends_on { Date.parse("31 August #{Date.current.year}") }
+    name { "#{starts_on.year} to #{ends_on.year}" }
   end
 end

--- a/spec/factories/placements.rb
+++ b/spec/factories/placements.rb
@@ -2,23 +2,26 @@
 #
 # Table name: placements
 #
-#  id          :uuid             not null, primary key
-#  year_group  :enum
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  provider_id :uuid
-#  school_id   :uuid
-#  subject_id  :uuid
+#  id               :uuid             not null, primary key
+#  year_group       :enum
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  academic_year_id :uuid             not null
+#  provider_id      :uuid
+#  school_id        :uuid
+#  subject_id       :uuid
 #
 # Indexes
 #
-#  index_placements_on_provider_id  (provider_id)
-#  index_placements_on_school_id    (school_id)
-#  index_placements_on_subject_id   (subject_id)
-#  index_placements_on_year_group   (year_group)
+#  index_placements_on_academic_year_id  (academic_year_id)
+#  index_placements_on_provider_id       (provider_id)
+#  index_placements_on_school_id         (school_id)
+#  index_placements_on_subject_id        (subject_id)
+#  index_placements_on_year_group        (year_group)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (academic_year_id => academic_years.id)
 #  fk_rails_...  (provider_id => providers.id)
 #  fk_rails_...  (school_id => schools.id)
 #  fk_rails_...  (subject_id => subjects.id)
@@ -27,5 +30,6 @@ FactoryBot.define do
   factory :placement do
     association :school, factory: :placements_school
     association :subject, factory: :subject
+    association :academic_year, factory: :placements_academic_year
   end
 end

--- a/spec/models/placement_spec.rb
+++ b/spec/models/placement_spec.rb
@@ -2,23 +2,26 @@
 #
 # Table name: placements
 #
-#  id          :uuid             not null, primary key
-#  year_group  :enum
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  provider_id :uuid
-#  school_id   :uuid
-#  subject_id  :uuid
+#  id               :uuid             not null, primary key
+#  year_group       :enum
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  academic_year_id :uuid             not null
+#  provider_id      :uuid
+#  school_id        :uuid
+#  subject_id       :uuid
 #
 # Indexes
 #
-#  index_placements_on_provider_id  (provider_id)
-#  index_placements_on_school_id    (school_id)
-#  index_placements_on_subject_id   (subject_id)
-#  index_placements_on_year_group   (year_group)
+#  index_placements_on_academic_year_id  (academic_year_id)
+#  index_placements_on_provider_id       (provider_id)
+#  index_placements_on_school_id         (school_id)
+#  index_placements_on_subject_id        (subject_id)
+#  index_placements_on_year_group        (year_group)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (academic_year_id => academic_years.id)
 #  fk_rails_...  (provider_id => providers.id)
 #  fk_rails_...  (school_id => schools.id)
 #  fk_rails_...  (subject_id => subjects.id)
@@ -33,9 +36,10 @@ RSpec.describe Placement, type: :model do
     it { is_expected.to have_many(:placement_additional_subjects).class_name("Placements::PlacementAdditionalSubject").dependent(:destroy) }
     it { is_expected.to have_many(:additional_subjects).through(:placement_additional_subjects).class_name("Subject") }
 
-    it { is_expected.to belong_to(:school) }
-    it { is_expected.to belong_to(:provider).optional }
-    it { is_expected.to belong_to(:subject) }
+    it { is_expected.to belong_to(:academic_year).class_name("Placements::AcademicYear") }
+    it { is_expected.to belong_to(:school).class_name("Placements::School") }
+    it { is_expected.to belong_to(:provider).class_name("::Provider").optional }
+    it { is_expected.to belong_to(:subject).class_name("::Subject") }
   end
 
   describe "validations" do

--- a/spec/models/placements/academic_year_spec.rb
+++ b/spec/models/placements/academic_year_spec.rb
@@ -12,8 +12,12 @@
 require "rails_helper"
 
 RSpec.describe Placements::AcademicYear, type: :model do
+  describe "associations" do
+    it { is_expected.to have_many(:placements) }
+  end
+
   describe ".current" do
-    let!(:current_academic_year) { create(:placements_academic_year, :current) }
+    let!(:current_academic_year) { create(:placements_academic_year) }
 
     it "returns the academic year for the current date" do
       expect(described_class.current).to eq(current_academic_year)


### PR DESCRIPTION
## Context

Placements now have a concept of their academic year, this work allows us to reference that data from the placements model.

## Changes proposed in this pull request

- Add the `belongs_to` association to the `Placement` for `Placements::AcademicYear`
- Adds the `has_many` association to the `Placements::AcademicYear` for `Placement`
- Converts the `null: true` to `null: false` for the `academic_year_id` column
- Adds the foreign key for the `academic_year_id` column
- Populates all new placements via the placements wizard with the current academic year

## Guidance to review

- Smoke test the app, there are no user facing changes.

## Link to Trello card

[Associate Placement to Placements::AcademicYear](https://trello.com/c/avhLfMpn/704-associate-placement-to-placementsacademicyear)