### PR TITLE
Remove qa from cicd for accessibility testing

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        environment: [qa, staging, sandbox] ## add future nonprod environments here
+        environment: [staging, sandbox] ## add future nonprod environments here
     environment:
       name: ${{ matrix.environment }}
       url: ${{ steps.deploy.outputs.environment_url }}


### PR DESCRIPTION
## Context

Temporarily remove the QA env from the cicd automated build and deploy workflow,
so that accessibility testing can be performed and normal work can still continue.

## Changes proposed in this pull request

Remove qa from non-prod matrix in the build-and-deploy workflow

## Guidance to review

check code
