### PR TITLE
Add term selection step to placements wizard

### DIFF
--- a/app/models/placements/term.rb
+++ b/app/models/placements/term.rb
@@ -8,7 +8,20 @@
 #  updated_at :datetime         not null
 #
 class Placements::Term < ApplicationRecord
-  VALID_NAMES = ["Summer term", "Spring term", "Autumn term"].freeze
+  SUMMER_TERM = "Summer term".freeze
+  SPRING_TERM = "Spring term".freeze
+  AUTUMN_TERM = "Autumn term".freeze
+  VALID_NAMES = [SUMMER_TERM, SPRING_TERM, AUTUMN_TERM].freeze
+
+  scope :order_by_term, lambda {
+    order(Arel.sql("
+      CASE
+        WHEN name = '#{SUMMER_TERM}' THEN '1'
+        WHEN name = '#{SPRING_TERM}' THEN '2'
+        WHEN name = '#{AUTUMN_TERM}' THEN '3'
+      END
+    "))
+  }
 
   validates :name, presence: true, inclusion: { in: VALID_NAMES }
 

--- a/app/views/placements/wizards/add_placement_wizard/_check_your_answers_step.html.erb
+++ b/app/views/placements/wizards/add_placement_wizard/_check_your_answers_step.html.erb
@@ -57,6 +57,15 @@
           <% end %>
         <% end %>
 
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".expected_date")) %>
+          <% row.with_value(text: @wizard.steps[:terms].term_names || t(".any_term")) %>
+          <% row.with_action(text: t(".change"),
+                             href: step_path(:terms),
+                             visually_hidden_text: t(".expected_date"),
+                             classes: ["govuk-link--no-visited-state"]) %>
+        <% end %>
+
         <% if @wizard.steps.include?(:mentors) %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".mentor")) %>

--- a/app/views/placements/wizards/add_placement_wizard/_terms_step.erb
+++ b/app/views/placements/wizards/add_placement_wizard/_terms_step.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title, terms_step.errors.any? ? t(".title_with_error", contextual_text:) : t(".title", contextual_text:) %>
+
+<%= form_for(terms_step, url: current_step_path, method: :put) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <span class="govuk-caption-l"><%= contextual_text %></span>
+
+        <%= f.govuk_check_boxes_fieldset :term_ids,
+          legend: { size: "l",
+                    text: t(".select_a_term") },
+          hint: { text: t(".description") } do %>
+          <% terms_step.terms_for_selection.each_with_index do |term, index| %>
+            <%= f.govuk_check_box :term_ids, term.id, label: { text: term.name }, link_errors: index.zero? %>
+          <% end %>
+          <%= f.govuk_check_box_divider %>
+          <%= f.govuk_check_box :term_ids, "any_term", label: { text: t(".any_term") }, checked: terms_step.terms.empty?, exclusive: true %>
+        <% end %>
+
+        <%= f.govuk_submit t(".continue") %>
+      </div>
+    </div>
+<% end %>

--- a/app/wizards/placements/add_placement_wizard.rb
+++ b/app/wizards/placements/add_placement_wizard.rb
@@ -37,6 +37,7 @@ module Placements
       placement = school.placements.build
       placement.academic_year = ::Placements::AcademicYear.current
       placement.subject = steps[:subject].subject
+      placement.terms = steps[:terms].terms
 
       if steps[:additional_subjects].present?
         placement.additional_subjects = steps[:additional_subjects].additional_subjects
@@ -48,10 +49,6 @@ module Placements
 
       if steps[:mentors].present?
         placement.mentors = steps[:mentors].mentors
-      end
-
-      if steps[:terms].present?
-        placement.terms = steps[:terms].terms
       end
 
       placement

--- a/app/wizards/placements/add_placement_wizard.rb
+++ b/app/wizards/placements/add_placement_wizard.rb
@@ -13,6 +13,8 @@ module Placements
       add_step(SubjectStep)
       add_step(AdditionalSubjectsStep) if steps[:subject].subject_has_child_subjects?
       add_step(YearGroupStep) if placement_phase == School::PRIMARY_PHASE
+      # AcademicYearStep goes here
+      add_step(TermsStep)
       add_step(MentorsStep) if school.mentors.present?
       add_step(CheckYourAnswersStep)
       add_step(PreviewPlacementStep) if current_step == :preview_placement
@@ -46,6 +48,10 @@ module Placements
 
       if steps[:mentors].present?
         placement.mentors = steps[:mentors].mentors
+      end
+
+      if steps[:terms].present?
+        placement.terms = steps[:terms].terms
       end
 
       placement

--- a/app/wizards/placements/add_placement_wizard/terms_step.rb
+++ b/app/wizards/placements/add_placement_wizard/terms_step.rb
@@ -1,0 +1,39 @@
+class Placements::AddPlacementWizard::TermsStep < Placements::BaseStep
+  attribute :term_ids, default: []
+
+  validates :term_ids, presence: true
+
+  def term_ids=(value)
+    super normalised_term_ids(value)
+  end
+
+  def term_names
+    return if term_ids == ANY_TERM
+
+    terms.pluck(:name).to_sentence
+  end
+
+  def terms_for_selection
+    Placements::Term.order_by_term
+  end
+
+  def terms
+    return terms_for_selection.none if term_ids == ANY_TERM
+
+    terms_for_selection.where(id: term_ids)
+  end
+
+  private
+
+  ANY_TERM = %w[any_term].freeze
+
+  def normalised_term_ids(term_ids)
+    if term_ids.blank?
+      []
+    elsif term_ids.include?("any_term")
+      ANY_TERM
+    else
+      terms_for_selection.where(id: term_ids).ids
+    end
+  end
+end

--- a/app/wizards/placements/add_placement_wizard/terms_step.rb
+++ b/app/wizards/placements/add_placement_wizard/terms_step.rb
@@ -32,6 +32,8 @@ class Placements::AddPlacementWizard::TermsStep < Placements::BaseStep
       []
     elsif term_ids.include?("any_term")
       ANY_TERM
+    elsif term_ids.sort == terms_for_selection.ids.sort
+      ANY_TERM
     else
       terms_for_selection.where(id: term_ids).ids
     end

--- a/app/wizards/placements/add_placement_wizard/terms_step.rb
+++ b/app/wizards/placements/add_placement_wizard/terms_step.rb
@@ -10,7 +10,7 @@ class Placements::AddPlacementWizard::TermsStep < Placements::BaseStep
   def term_names
     return if term_ids == ANY_TERM
 
-    terms.pluck(:name).to_sentence
+    terms.pluck(:name).join(", ")
   end
 
   def terms_for_selection

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -20,6 +20,10 @@ en:
           attributes:
             mentor_ids:
               blank: Select a mentor or not yet known
+        placements/add_placement_wizard/terms_step:
+          attributes:
+            term_ids:
+              blank: Select a term or any time in the academic year
         placements/add_placement_wizard/phase_step:
           attributes:
             phase:

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -14,6 +14,8 @@ en:
           attributes:
             mentor_ids:
               invalid: Select a mentor or not yet known
+            term_ids:
+              invalid: Select a term or any time in the academic year
             provider_id:
               invalid: Select a provider or not yet known
             year_group:

--- a/config/locales/en/placements/wizards/add_placement_wizard.yml
+++ b/config/locales/en/placements/wizards/add_placement_wizard.yml
@@ -60,6 +60,8 @@ en:
           publish_placement: Publish placement
           preview_placement: Preview placement
           not_yet_known: Not yet known
+          expected_date: Expected date
+          any_term: Any time in the academic year
         preview_placement_step:
           page_title: Preview placement - %{contextual_text}
           important: Important
@@ -68,3 +70,13 @@ en:
           edit_placement: Edit placement
         update:
           success: Placement published
+        terms_step:
+          title: Select when the placement could be - %{contextual_text}
+          title_with_error: "Error: Select when the placement could be - %{contextual_text}"
+          select_a_term: Select when the placement could be
+          description: | 
+            Terms are used as an estimate as some providers have different start and end dates.
+            Discuss specific dates with your chosen provider once the placment is published.
+          any_term: Any time in the academic year
+          continue: Continue
+          

--- a/spec/models/placements/term_spec.rb
+++ b/spec/models/placements/term_spec.rb
@@ -21,4 +21,16 @@ RSpec.describe Placements::Term, type: :model do
     it { is_expected.to have_many(:placement_windows).class_name("Placements::PlacementWindow") }
     it { is_expected.to have_many(:placements).through(:placement_windows) }
   end
+
+  describe "scopes" do
+    describe "#order_by_term" do
+      let!(:autumn_term) { create(:placements_term, :autumn) }
+      let!(:spring_term) { create(:placements_term, :spring) }
+      let!(:summer_term) { create(:placements_term, :summer) }
+
+      it "returns a collection of terms, in the order of Summer, Spring, Autumn" do
+        expect(described_class.order_by_term).to eq([summer_term, spring_term, autumn_term])
+      end
+    end
+  end
 end

--- a/spec/requests/placements/schools/placements/add_placement_spec.rb
+++ b/spec/requests/placements/schools/placements/add_placement_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "'Add placement' journey", service: :placements, type: :request d
   let(:school) { create(:placements_school, :secondary, name: "Hogwarts") }
   let(:school_id) { school.id }
   let(:drama) { create(:subject, :secondary, name: "Drama") }
+  let(:summer_term) { create(:placements_term, :summer) }
   let(:start_path) { new_add_placement_placements_school_placements_path(school_id:) }
 
   before { sign_in_as current_user }
@@ -13,6 +14,7 @@ RSpec.describe "'Add placement' journey", service: :placements, type: :request d
     before do
       # Populate the wizard so it has some existing state
       put step_path(:subject), params: { "placements_add_placement_wizard_subject_step[subject_id]" => drama.id }
+      put step_path(:terms), params: { "placements_add_placement_wizard_terms_step[term_ids]" => [summer_term.id] }
     end
 
     it "resets the wizard state" do
@@ -32,6 +34,7 @@ RSpec.describe "'Add placement' journey", service: :placements, type: :request d
       # Populate the wizard so it's ready to submit
       get start_path
       put step_path(:subject), params: { "placements_add_placement_wizard_subject_step[subject_id]" => drama.id }
+      put step_path(:terms), params: { "placements_add_placement_wizard_terms_step[term_ids]" => [summer_term.id] }
     end
 
     it "creates a placement" do

--- a/spec/requests/placements/support/schools/placements/add_placement_spec.rb
+++ b/spec/requests/placements/support/schools/placements/add_placement_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Support console / 'Add placement' journey", service: :placements
   let(:school) { create(:placements_school, :secondary, name: "Hogwarts") }
   let(:school_id) { school.id }
   let(:drama) { create(:subject, :secondary, name: "Drama") }
+  let(:summer_term) { create(:placements_term, :summer) }
   let(:start_path) { new_add_placement_placements_support_school_placements_path(school_id:) }
 
   before { sign_in_as current_user }
@@ -13,6 +14,7 @@ RSpec.describe "Support console / 'Add placement' journey", service: :placements
     before do
       # Populate the wizard so it has some existing state
       put step_path(:subject), params: { "placements_add_placement_wizard_subject_step[subject_id]" => drama.id }
+      put step_path(:terms), params: { "placements_add_placement_wizard_terms_step[term_ids]" => [summer_term.id] }
     end
 
     it "resets the wizard state" do
@@ -32,6 +34,7 @@ RSpec.describe "Support console / 'Add placement' journey", service: :placements
       # Populate the wizard so it's ready to submit
       get start_path
       put step_path(:subject), params: { "placements_add_placement_wizard_subject_step[subject_id]" => drama.id }
+      put step_path(:terms), params: { "placements_add_placement_wizard_terms_step[term_ids]" => [summer_term.id] }
     end
 
     it "creates a placement" do

--- a/spec/support/shared_examples/system/placements/add_a_placement_wizard.rb
+++ b/spec/support/shared_examples/system/placements/add_a_placement_wizard.rb
@@ -590,6 +590,29 @@ RSpec.shared_examples "an add a placement wizard" do
           then_i_see_the_check_your_answers_page("Secondary", mentor_1, spring_term.name)
         end
 
+        it "I select all terms separately" do
+          school.update!(phase: "Nursery")
+          when_i_visit_the_placements_page
+          and_i_click_on("Add placement")
+          when_i_choose_a_phase("Secondary")
+          and_i_click_on("Continue")
+          when_i_choose_a_subject(subject_2.name)
+          and_i_click_on("Continue")
+          when_i_check_a_term(summer_term.name)
+          and_i_click_on("Continue")
+          when_i_check_a_mentor(mentor_1.full_name)
+          and_i_click_on("Continue")
+          when_i_change_my_term
+          then_i_see_the_add_a_term_page
+          when_i_check_a_term(summer_term.name)
+          when_i_check_a_term(spring_term.name)
+          when_i_check_a_term(autumn_term.name)
+          and_i_click_on("Continue")
+          then_i_see_the_add_a_placement_mentor_page
+          and_i_click_on("Continue")
+          then_i_see_the_check_your_answers_page("Secondary", mentor_1, "Any time in the academic year")
+        end
+
         it "I do not decide to change my term" do
           school.update!(phase: "Nursery")
           when_i_visit_the_placements_page

--- a/spec/support/shared_examples/system/placements/add_a_placement_wizard.rb
+++ b/spec/support/shared_examples/system/placements/add_a_placement_wizard.rb
@@ -4,6 +4,15 @@ RSpec.shared_examples "an add a placement wizard" do
   let!(:subject_3) { create(:subject, name: "Secondary subject 2", subject_area: :secondary) }
   let!(:mentor_1) { create(:placements_mentor) }
   let!(:mentor_2) { create(:placements_mentor) }
+  let(:summer_term) { create(:placements_term, :summer) }
+  let(:spring_term) { create(:placements_term, :spring) }
+  let(:autumn_term) { create(:placements_term, :autumn) }
+
+  before do
+    summer_term
+    spring_term
+    autumn_term
+  end
 
   context "when the school has a school contact" do
     let(:school) { build(:placements_school, name: "School 1", phase: "Primary") }
@@ -24,10 +33,13 @@ RSpec.shared_examples "an add a placement wizard" do
           then_i_see_the_add_year_group_page("Year 1")
           when_i_choose_a_year_group("Year 1")
           and_i_click_on("Continue")
+          then_i_see_the_add_a_term_page
+          when_i_check_a_term(summer_term.name)
+          and_i_click_on("Continue")
           then_i_see_the_add_a_placement_mentor_page
           when_i_check_a_mentor(mentor_1.full_name)
           and_i_click_on("Continue")
-          then_i_see_the_check_your_answers_page(school.phase, mentor_1)
+          then_i_see_the_check_your_answers_page(school.phase, mentor_1, summer_term.name)
           and_i_cannot_change_the_phase
           when_i_click_on("Publish placement")
           then_i_see_the_placements_page
@@ -43,10 +55,13 @@ RSpec.shared_examples "an add a placement wizard" do
           then_i_see_the_add_year_group_page("Year 1")
           when_i_choose_a_year_group("Year 1")
           and_i_click_on("Continue")
+          then_i_see_the_add_a_term_page
+          when_i_check_a_term(summer_term.name)
+          and_i_click_on("Continue")
           then_i_see_the_add_a_placement_mentor_page
           when_i_check_a_mentor("Not yet known")
           and_i_click_on("Continue")
-          then_i_see_the_check_your_answers_page(school.phase, nil)
+          then_i_see_the_check_your_answers_page(school.phase, nil, summer_term.name)
           when_i_change_my_mentor
           then_see_that_not_known_is_selected
           when_i_click_on("Continue")
@@ -64,6 +79,9 @@ RSpec.shared_examples "an add a placement wizard" do
           then_i_see_the_add_year_group_page("Year 1")
           when_i_choose_a_year_group("Year 1")
           and_i_click_on("Continue")
+          then_i_see_the_add_a_term_page
+          when_i_check_a_term(summer_term.name)
+          and_i_click_on("Continue")
           then_i_see_the_add_a_placement_mentor_page
           when_i_expand_the_summary_text
           and_i_click_on("add mentors to your school's profile")
@@ -80,7 +98,10 @@ RSpec.shared_examples "an add a placement wizard" do
           then_i_see_the_add_year_group_page("Year 1")
           when_i_choose_a_year_group("Year 1")
           and_i_click_on("Continue")
-          then_i_see_the_check_your_answers_page(school.phase, nil)
+          then_i_see_the_add_a_term_page
+          when_i_check_a_term(summer_term.name)
+          and_i_click_on("Continue")
+          then_i_see_the_check_your_answers_page(school.phase, nil, summer_term.name)
         end
       end
 
@@ -99,10 +120,13 @@ RSpec.shared_examples "an add a placement wizard" do
           then_i_see_the_add_year_group_page("Year 1")
           when_i_choose_a_year_group("Year 1")
           and_i_click_on("Continue")
+          then_i_see_the_add_a_term_page
+          when_i_check_a_term(summer_term.name)
+          and_i_click_on("Continue")
           then_i_see_the_add_a_placement_mentor_page
           when_i_check_a_mentor(mentor_1.full_name)
           and_i_click_on("Continue")
-          then_i_see_the_check_your_answers_page(school.phase, mentor_1)
+          then_i_see_the_check_your_answers_page(school.phase, mentor_1, summer_term.name)
 
           check_your_answers_page = page.current_path
 
@@ -122,6 +146,12 @@ RSpec.shared_examples "an add a placement wizard" do
           and_i_click_on "Cancel"
           then_i_see_the_placements_page
 
+          # 'Cancel' link on the 'Term' page
+          given_i_visit check_your_answers_page
+          when_i_click_on "Change Expected date"
+          and_i_click_on "Cancel"
+          then_i_see_the_placements_page
+
           # 'Cancel' link on the 'Mentor' page
           given_i_visit check_your_answers_page
           when_i_click_on "Change Mentor"
@@ -137,12 +167,17 @@ RSpec.shared_examples "an add a placement wizard" do
             and_i_click_on("Continue")
             when_i_choose_a_year_group("Year 1")
             and_i_click_on("Continue")
+            when_i_check_a_term(summer_term.name)
+            and_i_click_on("Continue")
             when_i_check_a_mentor(mentor_1.full_name)
             and_i_click_on("Continue")
-            then_i_see_the_check_your_answers_page(school.phase, mentor_1)
+            then_i_see_the_check_your_answers_page(school.phase, mentor_1, summer_term.name)
 
             when_i_click_on("Back")
             then_my_chosen_mentor_is_checked(mentor_1.full_name)
+
+            when_i_click_on("Back")
+            then_my_chosen_term_is_checked("Summer term")
 
             when_i_click_on("Back")
             then_my_chosen_year_group_is_selected("Year 1")
@@ -156,24 +191,47 @@ RSpec.shared_examples "an add a placement wizard" do
         end
 
         context "when I've checked my answers and I click on change" do
-          it "when I do not enter valid options" do
-            when_i_visit_the_placements_page
-            and_i_click_on("Add placement")
-            and_i_click_on("Continue")
-            then_i_see_the_add_a_placement_subject_page(school.phase)
-            and_i_see_the_error_message("Select a subject")
+          context "when I uncheck mentors" do
+            it "when I do not enter valid options" do
+              when_i_visit_the_placements_page
+              and_i_click_on("Add placement")
+              and_i_click_on("Continue")
+              then_i_see_the_add_a_placement_subject_page(school.phase)
+              and_i_see_the_error_message("Select a subject")
+              when_i_choose_a_subject(subject_1.name)
+              and_i_click_on("Continue")
+              then_i_see_the_add_year_group_page("Year 1")
+              and_i_click_on("Continue")
+              and_i_see_the_error_message("Select a year group")
+              when_i_choose_a_year_group("Year 1")
+              and_i_click_on("Continue")
+              when_i_check_a_term(summer_term.name)
+              and_i_click_on("Continue")
+              then_i_see_the_add_a_placement_mentor_page
+              when_i_uncheck("Not yet known")
+              when_i_click_on("Continue")
+              and_i_see_the_error_message("Select a mentor or not yet known")
+            end
+          end
 
-            when_i_choose_a_subject(subject_1.name)
-            and_i_click_on("Continue")
-            then_i_see_the_add_year_group_page("Year 1")
-            and_i_click_on("Continue")
-            and_i_see_the_error_message("Select a year group")
-            when_i_choose_a_year_group("Year 1")
-            and_i_click_on("Continue")
-            then_i_see_the_add_a_placement_mentor_page
-            when_i_uncheck("Not yet known")
-            when_i_click_on("Continue")
-            and_i_see_the_error_message("Select a mentor or not yet known")
+          context "when I uncheck terms" do
+            it "when I do not enter valid options" do
+              when_i_visit_the_placements_page
+              and_i_click_on("Add placement")
+              and_i_click_on("Continue")
+              then_i_see_the_add_a_placement_subject_page(school.phase)
+              and_i_see_the_error_message("Select a subject")
+              when_i_choose_a_subject(subject_1.name)
+              and_i_click_on("Continue")
+              then_i_see_the_add_year_group_page("Year 1")
+              and_i_click_on("Continue")
+              and_i_see_the_error_message("Select a year group")
+              when_i_choose_a_year_group("Year 1")
+              and_i_click_on("Continue")
+              when_i_uncheck("Any time in the academic year")
+              and_i_click_on("Continue")
+              and_i_see_the_error_message("Select a term or any time in the academic year")
+            end
           end
         end
 
@@ -185,9 +243,11 @@ RSpec.shared_examples "an add a placement wizard" do
             and_i_click_on("Continue")
             when_i_choose_a_year_group("Year 1")
             and_i_click_on("Continue")
+            when_i_check_a_term(summer_term.name)
+            and_i_click_on("Continue")
             when_i_check_a_mentor(mentor_1.full_name)
             and_i_click_on("Continue")
-            then_i_see_the_check_your_answers_page(school.phase, mentor_1)
+            then_i_see_the_check_your_answers_page(school.phase, mentor_1, summer_term.name)
             when_i_click_on("Preview placement")
             then_i_see_the_preview_page(phase: school.phase, subject: subject_1)
           end
@@ -199,13 +259,15 @@ RSpec.shared_examples "an add a placement wizard" do
             and_i_click_on("Continue")
             when_i_choose_a_year_group("Year 1")
             and_i_click_on("Continue")
+            when_i_check_a_term(summer_term.name)
+            and_i_click_on("Continue")
             when_i_check_a_mentor(mentor_1.full_name)
             and_i_click_on("Continue")
-            then_i_see_the_check_your_answers_page(school.phase, mentor_1)
+            then_i_see_the_check_your_answers_page(school.phase, mentor_1, summer_term.name)
             when_i_click_on("Preview placement")
             then_i_see_the_preview_page(phase: school.phase, subject: subject_1)
             and_i_click_on("Back")
-            then_i_see_the_check_your_answers_page(school.phase, mentor_1)
+            then_i_see_the_check_your_answers_page(school.phase, mentor_1, summer_term.name)
           end
 
           it "I can go back and edit my placement" do
@@ -215,13 +277,15 @@ RSpec.shared_examples "an add a placement wizard" do
             and_i_click_on("Continue")
             when_i_choose_a_year_group("Year 1")
             and_i_click_on("Continue")
+            when_i_check_a_term(summer_term.name)
+            and_i_click_on("Continue")
             when_i_check_a_mentor(mentor_1.full_name)
             and_i_click_on("Continue")
-            then_i_see_the_check_your_answers_page(school.phase, mentor_1)
+            then_i_see_the_check_your_answers_page(school.phase, mentor_1, summer_term.name)
             when_i_click_on("Preview placement")
             then_i_see_the_preview_page(phase: school.phase, subject: subject_1)
             and_i_click_on("Edit placement")
-            then_i_see_the_check_your_answers_page(school.phase, mentor_1)
+            then_i_see_the_check_your_answers_page(school.phase, mentor_1, summer_term.name)
           end
 
           it "I can publish my placement" do
@@ -231,9 +295,11 @@ RSpec.shared_examples "an add a placement wizard" do
             and_i_click_on("Continue")
             when_i_choose_a_year_group("Year 1")
             and_i_click_on("Continue")
+            when_i_check_a_term(summer_term.name)
+            and_i_click_on("Continue")
             when_i_check_a_mentor(mentor_1.full_name)
             and_i_click_on("Continue")
-            then_i_see_the_check_your_answers_page(school.phase, mentor_1)
+            then_i_see_the_check_your_answers_page(school.phase, mentor_1, summer_term.name)
             when_i_click_on("Preview placement")
             then_i_see_the_preview_page(phase: school.phase, subject: subject_1)
             and_i_click_on("Publish placement")
@@ -258,10 +324,12 @@ RSpec.shared_examples "an add a placement wizard" do
         then_i_see_the_add_a_placement_subject_page(school.phase)
         when_i_choose_a_subject(subject_2.name)
         and_i_click_on("Continue")
+        when_i_check_a_term(summer_term.name)
+        and_i_click_on("Continue")
         then_i_see_the_add_a_placement_mentor_page
         when_i_check_a_mentor(mentor_1.full_name)
         and_i_click_on("Continue")
-        then_i_see_the_check_your_answers_page(school.phase, mentor_1)
+        then_i_see_the_check_your_answers_page(school.phase, mentor_1, summer_term.name)
         and_i_cannot_change_the_phase
         when_i_click_on("Publish placement")
         then_i_see_the_placements_page
@@ -282,10 +350,12 @@ RSpec.shared_examples "an add a placement wizard" do
           and_i_click_on("Continue")
           and_i_check_the_subject(subject_3.name)
           and_i_click_on("Continue")
+          when_i_check_a_term(summer_term.name)
+          and_i_click_on("Continue")
           then_i_see_the_add_a_placement_mentor_page
           when_i_check_a_mentor(mentor_1.full_name)
           and_i_click_on("Continue")
-          then_i_see_the_check_your_answers_page(school.phase, mentor_1)
+          then_i_see_the_check_your_answers_page(school.phase, mentor_1, summer_term.name)
           and_i_cannot_change_the_phase
           when_i_click_on("Publish placement")
           then_i_see_the_placements_page
@@ -317,7 +387,7 @@ RSpec.shared_examples "an add a placement wizard" do
           then_i_see_the_add_a_placement_subject_page(school.phase)
           when_i_choose_a_subject(subject_4.name)
           and_i_click_on("Continue")
-          then_i_see_the_add_a_placement_mentor_page
+          then_i_see_the_add_a_term_page
         end
       end
     end
@@ -342,10 +412,12 @@ RSpec.shared_examples "an add a placement wizard" do
           then_i_see_the_add_year_group_page("Year 1")
           when_i_choose_a_year_group("Year 1")
           and_i_click_on("Continue")
+          when_i_check_a_term(summer_term.name)
+          and_i_click_on("Continue")
           then_i_see_the_add_a_placement_mentor_page
           when_i_check_a_mentor(mentor_1.full_name)
           and_i_click_on("Continue")
-          then_i_see_the_check_your_answers_page("Primary", mentor_1)
+          then_i_see_the_check_your_answers_page("Primary", mentor_1, summer_term.name)
           and_i_can_change_the_phase
           when_i_click_on("Publish placement")
           then_i_see_the_placements_page
@@ -366,10 +438,12 @@ RSpec.shared_examples "an add a placement wizard" do
           when_i_choose_a_subject(subject_2.name)
           and_i_choose_the_subject(subject_3.name)
           and_i_click_on("Continue")
+          when_i_check_a_term(summer_term.name)
+          and_i_click_on("Continue")
           then_i_see_the_add_a_placement_mentor_page
           when_i_check_a_mentor(mentor_1.full_name)
           and_i_click_on("Continue")
-          then_i_see_the_check_your_answers_page("Secondary", mentor_1)
+          then_i_see_the_check_your_answers_page("Secondary", mentor_1, summer_term.name)
           and_i_click_on("Publish placement")
           then_i_see_the_placements_page
           and_i_see_my_placement("Secondary")
@@ -397,6 +471,8 @@ RSpec.shared_examples "an add a placement wizard" do
           and_i_click_on("Continue")
           when_i_choose_a_subject(subject_2.name)
           and_i_click_on("Continue")
+          when_i_check_a_term(summer_term.name)
+          and_i_click_on("Continue")
           when_i_check_a_mentor(mentor_1.full_name)
           and_i_click_on("Continue")
           when_i_change_my_phase
@@ -409,9 +485,11 @@ RSpec.shared_examples "an add a placement wizard" do
           then_i_see_the_add_year_group_page("Year 1")
           when_i_choose_a_year_group("Year 1")
           and_i_click_on("Continue")
+          then_i_see_the_add_a_term_page
+          and_i_click_on("Continue")
           then_i_see_the_add_a_placement_mentor_page
           and_i_click_on("Continue")
-          then_i_see_the_check_your_answers_page("Primary", mentor_1)
+          then_i_see_the_check_your_answers_page("Primary", mentor_1, summer_term.name)
           and_my_selection_has_changed_to("Primary")
         end
 
@@ -423,6 +501,8 @@ RSpec.shared_examples "an add a placement wizard" do
           and_i_click_on("Continue")
           when_i_choose_a_subject(subject_2.name)
           and_i_click_on("Continue")
+          when_i_check_a_term(summer_term.name)
+          and_i_click_on("Continue")
           when_i_check_a_mentor(mentor_1.full_name)
           and_i_click_on("Continue")
           when_i_change_my_phase
@@ -430,9 +510,11 @@ RSpec.shared_examples "an add a placement wizard" do
           and_i_click_on("Continue")
           then_i_see_the_add_a_placement_subject_page("Secondary")
           and_i_click_on("Continue")
+          then_i_see_the_add_a_term_page
+          and_i_click_on("Continue")
           then_i_see_the_add_a_placement_mentor_page
           and_i_click_on("Continue")
-          then_i_see_the_check_your_answers_page("Secondary", mentor_1)
+          then_i_see_the_check_your_answers_page("Secondary", mentor_1, summer_term.name)
           and_my_selection_has_not_changed_to("Primary")
         end
       end
@@ -446,15 +528,19 @@ RSpec.shared_examples "an add a placement wizard" do
           and_i_click_on("Continue")
           when_i_choose_a_subject(subject_2.name)
           and_i_click_on("Continue")
+          when_i_check_a_term(summer_term.name)
+          and_i_click_on("Continue")
           when_i_check_a_mentor(mentor_1.full_name)
           and_i_click_on("Continue")
           when_i_change_my_subject
           then_i_see_the_add_a_placement_subject_page("Secondary")
           when_i_choose_a_subject(subject_3.name)
           and_i_click_on("Continue")
+          then_i_see_the_add_a_term_page
+          and_i_click_on("Continue")
           then_i_see_the_add_a_placement_mentor_page
           and_i_click_on("Continue")
-          then_i_see_the_check_your_answers_page("Secondary", mentor_1)
+          then_i_see_the_check_your_answers_page("Secondary", mentor_1, summer_term.name)
           and_my_selection_has_changed_to(subject_3.name)
         end
 
@@ -466,15 +552,62 @@ RSpec.shared_examples "an add a placement wizard" do
           and_i_click_on("Continue")
           when_i_choose_a_subject(subject_2.name)
           and_i_click_on("Continue")
+          when_i_check_a_term(summer_term.name)
+          and_i_click_on("Continue")
           when_i_check_a_mentor(mentor_1.full_name)
           and_i_click_on("Continue")
           when_i_change_my_subject
           then_i_see_the_add_a_placement_subject_page("Secondary")
           and_i_click_on("Continue")
+          then_i_see_the_add_a_term_page
+          and_i_click_on("Continue")
           then_i_see_the_add_a_placement_mentor_page
           and_i_click_on("Continue")
-          then_i_see_the_check_your_answers_page("Secondary", mentor_1)
+          then_i_see_the_check_your_answers_page("Secondary", mentor_1, summer_term.name)
           and_my_selection_has_not_changed_to(subject_3.name)
+        end
+      end
+
+      context "and I click on change my term" do
+        it "I decide to change my term" do
+          school.update!(phase: "Nursery")
+          when_i_visit_the_placements_page
+          and_i_click_on("Add placement")
+          when_i_choose_a_phase("Secondary")
+          and_i_click_on("Continue")
+          when_i_choose_a_subject(subject_2.name)
+          and_i_click_on("Continue")
+          when_i_check_a_term(summer_term.name)
+          and_i_click_on("Continue")
+          when_i_check_a_mentor(mentor_1.full_name)
+          and_i_click_on("Continue")
+          when_i_change_my_term
+          then_i_see_the_add_a_term_page
+          when_i_check_a_term(spring_term.name)
+          and_i_click_on("Continue")
+          then_i_see_the_add_a_placement_mentor_page
+          and_i_click_on("Continue")
+          then_i_see_the_check_your_answers_page("Secondary", mentor_1, spring_term.name)
+        end
+
+        it "I do not decide to change my term" do
+          school.update!(phase: "Nursery")
+          when_i_visit_the_placements_page
+          and_i_click_on("Add placement")
+          when_i_choose_a_phase("Secondary")
+          and_i_click_on("Continue")
+          when_i_choose_a_subject(subject_2.name)
+          and_i_click_on("Continue")
+          when_i_check_a_term(summer_term.name)
+          and_i_click_on("Continue")
+          when_i_check_a_mentor(mentor_1.full_name)
+          and_i_click_on("Continue")
+          when_i_change_my_term
+          then_i_see_the_add_a_term_page
+          and_i_click_on("Continue")
+          then_i_see_the_add_a_placement_mentor_page
+          and_i_click_on("Continue")
+          then_i_see_the_check_your_answers_page("Secondary", mentor_1, summer_term.name)
         end
       end
 
@@ -487,13 +620,15 @@ RSpec.shared_examples "an add a placement wizard" do
           and_i_click_on("Continue")
           when_i_choose_a_subject(subject_2.name)
           and_i_click_on("Continue")
+          when_i_check_a_term(summer_term.name)
+          and_i_click_on("Continue")
           when_i_check_a_mentor(mentor_1.full_name)
           and_i_click_on("Continue")
           when_i_change_my_mentor
           then_i_see_the_add_a_placement_mentor_page
           when_i_check_a_mentor(mentor_2.full_name)
           and_i_click_on("Continue")
-          then_i_see_the_check_your_answers_page("Secondary", mentor_2)
+          then_i_see_the_check_your_answers_page("Secondary", mentor_2, summer_term.name)
         end
 
         it "I do not decide to change my mentor" do
@@ -504,12 +639,14 @@ RSpec.shared_examples "an add a placement wizard" do
           and_i_click_on("Continue")
           when_i_choose_a_subject(subject_2.name)
           and_i_click_on("Continue")
+          when_i_check_a_term(summer_term.name)
+          and_i_click_on("Continue")
           when_i_check_a_mentor(mentor_1.full_name)
           and_i_click_on("Continue")
           when_i_change_my_mentor
           then_i_see_the_add_a_placement_mentor_page
           and_i_click_on("Continue")
-          then_i_see_the_check_your_answers_page("Secondary", mentor_1)
+          then_i_see_the_check_your_answers_page("Secondary", mentor_1, summer_term.name)
         end
       end
     end
@@ -588,6 +725,19 @@ RSpec.shared_examples "an add a placement wizard" do
     expect(page).to have_content(mentor_2.full_name)
   end
 
+  def then_i_see_the_add_a_term_page
+    expect(page).to have_content("Placement details")
+    expect(page).to have_content("Select when the placement could be")
+    expect(page).to have_content(summer_term.name)
+    expect(page).to have_content(spring_term.name)
+    expect(page).to have_content(autumn_term.name)
+  end
+
+  def when_i_check_a_term(term_name)
+    uncheck "Any time in the academic year"
+    check term_name
+  end
+
   def and_my_chosen_subject_is_selected(subject_name)
     expect(page).to have_checked_field(subject_name)
   end
@@ -596,16 +746,21 @@ RSpec.shared_examples "an add a placement wizard" do
     expect(page).to have_checked_field(year_group)
   end
 
+  def and_my_chosen_term_is_checked(term_name)
+    expect(page).to have_checked_field(term_name)
+  end
+
   def when_i_check_a_mentor(mentor_name)
     uncheck "Not yet known"
     check mentor_name
   end
 
-  def then_i_see_the_check_your_answers_page(phase, mentor)
+  def then_i_see_the_check_your_answers_page(phase, mentor, term_name)
     expect(page).to have_content("Check your answers")
     expect(page).to have_content(phase)
     expect(page).to have_content("#{phase} subject")
     expect(page).to have_content(mentor.full_name) if mentor.present?
+    expect(page).to have_content(term_name) if term_name.present?
   end
 
   def and_my_chosen_mentor_is_checked(mentor_name)
@@ -644,6 +799,10 @@ RSpec.shared_examples "an add a placement wizard" do
     click_link "Change Mentor"
   end
 
+  def when_i_change_my_term
+    click_link "Change Expected date"
+  end
+
   def and_my_selection_has_changed_to(selection)
     expect(page).to have_content(selection)
   end
@@ -678,4 +837,5 @@ RSpec.shared_examples "an add a placement wizard" do
   alias_method :then_my_chosen_subject_is_selected, :and_my_chosen_subject_is_selected
   alias_method :then_my_chosen_mentor_is_checked, :and_my_chosen_mentor_is_checked
   alias_method :then_my_chosen_year_group_is_selected, :and_my_chosen_year_group_is_selected
+  alias_method :then_my_chosen_term_is_checked, :and_my_chosen_term_is_checked
 end

--- a/spec/support/shared_examples/system/placements/add_a_placement_wizard.rb
+++ b/spec/support/shared_examples/system/placements/add_a_placement_wizard.rb
@@ -412,12 +412,12 @@ RSpec.shared_examples "an add a placement wizard" do
           then_i_see_the_add_year_group_page("Year 1")
           when_i_choose_a_year_group("Year 1")
           and_i_click_on("Continue")
-          when_i_check_a_term(summer_term.name)
+          when_i_check_a_term("Any time in the academic year")
           and_i_click_on("Continue")
           then_i_see_the_add_a_placement_mentor_page
           when_i_check_a_mentor(mentor_1.full_name)
           and_i_click_on("Continue")
-          then_i_see_the_check_your_answers_page("Primary", mentor_1, summer_term.name)
+          then_i_see_the_check_your_answers_page("Primary", mentor_1, "Any time in the academic year")
           and_i_can_change_the_phase
           when_i_click_on("Publish placement")
           then_i_see_the_placements_page

--- a/spec/wizards/placements/add_placement_wizard/terms_step_spec.rb
+++ b/spec/wizards/placements/add_placement_wizard/terms_step_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe Placements::AddPlacementWizard::TermsStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Placements::AddPlacementWizard).tap do |mock_wizard|
+      allow(mock_wizard).to receive(:school).and_return(school)
+    end
+  end
+
+  let(:summer_term) { create(:placements_term, :summer) }
+  let(:spring_term) { create(:placements_term, :spring) }
+  let(:autumn_term) { create(:placements_term, :autumn) }
+  let(:terms) { [summer_term, spring_term, autumn_term] }
+
+  let(:school) { create(:placements_school) }
+
+  let(:attributes) { nil }
+
+  describe "attributes" do
+    it { is_expected.to have_attributes(term_ids: []) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:term_ids) }
+  end
+
+  describe "#terms_for_selection" do
+    before do
+      summer_term
+      spring_term
+      autumn_term
+    end
+
+    it "returns mentors for the school, ordered by name" do
+      expect(step.terms_for_selection).to eq([
+        summer_term, spring_term, autumn_term
+      ])
+    end
+  end
+
+  describe "#term_ids=" do
+    context "when the value is blank" do
+      it "remains blank" do
+        step.term_ids = []
+
+        expect(step.term_ids).to eq([])
+      end
+    end
+
+    context "when the value includes 'any_term'" do
+      it "removes all values except any_term" do
+        step.term_ids = ["any_term", summer_term.id]
+
+        expect(step.term_ids).to eq(%w[any_term])
+      end
+    end
+
+    context "when the value includes term ids" do
+      it "retains the term ids" do
+        step.term_ids = terms.pluck(:id)
+
+        expect(step.term_ids).to match_array(terms.pluck(:id))
+      end
+    end
+  end
+end

--- a/spec/wizards/placements/add_placement_wizard/terms_step_spec.rb
+++ b/spec/wizards/placements/add_placement_wizard/terms_step_spec.rb
@@ -77,11 +77,25 @@ RSpec.describe Placements::AddPlacementWizard::TermsStep, type: :model do
       end
     end
 
-    context "when the value includes term ids" do
-      it "retains the term ids" do
-        step.term_ids = terms.pluck(:id)
+    context "when the value includes all 3 terms (summer, spring, autumn)" do
+      it "return any_term" do
+        step.term_ids = terms.pluck(:id).sort
 
-        expect(step.term_ids).to match_array(terms.pluck(:id))
+        expect(step.term_ids).to eq(%w[any_term])
+      end
+    end
+
+    context "when the value includes term ids (but not all term ids)" do
+      before do
+        summer_term
+        spring_term
+        autumn_term
+      end
+
+      it "retains the term ids" do
+        step.term_ids = [summer_term.id]
+
+        expect(step.term_ids).to match_array(summer_term.id)
       end
     end
   end

--- a/spec/wizards/placements/add_placement_wizard/terms_step_spec.rb
+++ b/spec/wizards/placements/add_placement_wizard/terms_step_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Placements::AddPlacementWizard::TermsStep, type: :model do
 
       it "returns the names of the terms as a string" do
         expect(step.term_names).to eq(
-          "#{summer_term.name}, #{spring_term.name}, and #{autumn_term.name}",
+          "#{summer_term.name}, #{spring_term.name}, #{autumn_term.name}",
         )
       end
     end

--- a/spec/wizards/placements/add_placement_wizard/terms_step_spec.rb
+++ b/spec/wizards/placements/add_placement_wizard/terms_step_spec.rb
@@ -40,6 +40,26 @@ RSpec.describe Placements::AddPlacementWizard::TermsStep, type: :model do
     end
   end
 
+  describe "#term_names" do
+    context "when term_ids contains term ids" do
+      let(:attributes) { { term_ids: [terms.pluck(:id)] } }
+
+      it "returns the names of the terms as a string" do
+        expect(step.term_names).to eq(
+          "#{summer_term.name}, #{spring_term.name}, and #{autumn_term.name}",
+        )
+      end
+    end
+
+    context "when term_ids is 'any_term'" do
+      let(:attributes) { { term_ids: %w[any_term] } }
+
+      it "returns nil" do
+        expect(step.term_names).to be_nil
+      end
+    end
+  end
+
   describe "#term_ids=" do
     context "when the value is blank" do
       it "remains blank" do

--- a/spec/wizards/placements/add_placement_wizard_spec.rb
+++ b/spec/wizards/placements/add_placement_wizard_spec.rb
@@ -30,30 +30,30 @@ RSpec.describe Placements::AddPlacementWizard do
     context "with a primary school" do
       let(:school) { primary_school }
 
-      it { is_expected.to eq %i[subject year_group mentors check_your_answers] }
+      it { is_expected.to eq %i[subject year_group terms mentors check_your_answers] }
     end
 
     context "with a secondary school" do
       let(:school) { secondary_school }
 
-      it { is_expected.to eq %i[subject mentors check_your_answers] }
+      it { is_expected.to eq %i[subject terms mentors check_your_answers] }
     end
 
     context "with an all-through school" do
       let(:school) { all_through_school }
 
-      it { is_expected.to eq %i[phase subject mentors check_your_answers] }
+      it { is_expected.to eq %i[phase subject terms mentors check_your_answers] }
 
       context "when the Primary phase has been chosen" do
         let(:state) { { "phase" => { "phase" => "Primary" } } }
 
-        it { is_expected.to eq %i[phase subject year_group mentors check_your_answers] }
+        it { is_expected.to eq %i[phase subject year_group terms mentors check_your_answers] }
       end
 
       context "when the Secondary phase has been chosen" do
         let(:state) { { "phase" => { "phase" => "Secondary" } } }
 
-        it { is_expected.to eq %i[phase subject mentors check_your_answers] }
+        it { is_expected.to eq %i[phase subject terms mentors check_your_answers] }
       end
     end
 
@@ -61,20 +61,20 @@ RSpec.describe Placements::AddPlacementWizard do
       let(:school) { secondary_school }
       let(:mentors) { [] }
 
-      it { is_expected.to eq %i[subject check_your_answers] }
+      it { is_expected.to eq %i[subject terms check_your_answers] }
     end
 
     context "when the chosen subject has child subjects" do
       let(:school) { secondary_school }
       let(:state) { { "subject" => { "subject_id" => modern_foreign_languages.id } } }
 
-      it { is_expected.to eq %i[subject additional_subjects mentors check_your_answers] }
+      it { is_expected.to eq %i[subject additional_subjects terms mentors check_your_answers] }
     end
 
     context "when the preview placement step is active" do
       let(:current_step) { :preview_placement }
 
-      it { is_expected.to eq %i[subject mentors check_your_answers preview_placement] }
+      it { is_expected.to eq %i[subject terms mentors check_your_answers preview_placement] }
     end
   end
 
@@ -90,6 +90,7 @@ RSpec.describe Placements::AddPlacementWizard do
         {
           "subject" => { "subject_id" => primary.id },
           "year_group" => { "year_group" => "year_3" },
+          "terms" => { "term_ids" => %w[any_term] },
           "mentors" => { "mentor_ids" => [selected_mentor.id] },
         }
       end
@@ -108,6 +109,7 @@ RSpec.describe Placements::AddPlacementWizard do
         {
           "subject" => { "subject_id" => primary.id },
           "year_group" => { "year_group" => "year_3" },
+          "terms" => { "term_ids" => %w[any_term] },
           "mentors" => { "mentor_ids" => mentor_not_known },
         }
       end
@@ -125,6 +127,7 @@ RSpec.describe Placements::AddPlacementWizard do
       let(:state) do
         {
           "subject" => { "subject_id" => drama.id },
+          "terms" => { "term_ids" => %w[any_term] },
           "mentors" => { "mentor_ids" => [selected_mentor.id] },
         }
       end
@@ -141,6 +144,7 @@ RSpec.describe Placements::AddPlacementWizard do
       let(:state) do
         {
           "subject" => { "subject_id" => drama.id },
+          "terms" => { "term_ids" => %w[any_term] },
           "mentors" => { "mentor_ids" => mentor_not_known },
         }
       end
@@ -158,6 +162,7 @@ RSpec.describe Placements::AddPlacementWizard do
         {
           "subject" => { "subject_id" => modern_foreign_languages.id },
           "additional_subjects" => { "additional_subject_ids" => [french.id, german.id] },
+          "terms" => { "term_ids" => %w[any_term] },
           "mentors" => { "mentor_ids" => mentor_not_known },
         }
       end
@@ -176,6 +181,7 @@ RSpec.describe Placements::AddPlacementWizard do
       let(:state) do
         {
           "subject" => { "subject_id" => drama.id },
+          "terms" => { "term_ids" => %w[any_term] },
         }
       end
 
@@ -188,15 +194,32 @@ RSpec.describe Placements::AddPlacementWizard do
 
     context "when there are invalid steps" do
       let(:school) { secondary_school }
-      let(:state) do
-        {
-          "subject" => { "subject_id" => drama.id },
-          "mentors" => { "mentor_ids" => [] }, # invalid
-        }
+
+      context "when not mentor is given in the mentors step" do
+        let(:state) do
+          {
+            "subject" => { "subject_id" => drama.id },
+            "terms" => { "term_ids" => %w[any_term] },
+            "mentors" => { "mentor_ids" => [] }, # invalid
+          }
+        end
+
+        it "raises an error" do
+          expect { wizard.create_placement }.to raise_error "Invalid wizard state"
+        end
       end
 
-      it "raises an error" do
-        expect { wizard.create_placement }.to raise_error "Invalid wizard state"
+      context "when no term is given in the terms step" do
+        let(:state) do
+          {
+            "subject" => { "subject_id" => drama.id },
+            "terms" => { "term_ids" => [] },
+          }
+        end
+
+        it "raises an error" do
+          expect { wizard.create_placement }.to raise_error "Invalid wizard state"
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

- Add a `TermsStep` to the `AddPlacementWizard`, so users can select the terms in which the placement could take place.

## Changes proposed in this pull request

- Add `TermsStep` to the `AddPlacementWizard`

## Guidance to review

- Sign in as Anne (School User)
- Navigate to "Placements" using the Navbar
- Click "Add placement"
- Follow the add placement journey
- Before selecting a mentor, you should now see a page to select the terms
- Select a term and continue the add placement journey
- On the check your answers page, you will see the term/s you have selected 


## Link to Trello card

https://trello.com/c/k8Fqqp62/708-add-placement-wizard-add-expected-date-step

## Screenshots

![screencapture-placements-localhost-3000-schools-00035955-7a30-4bb8-bac3-5f6993e727fa-placements-new-terms-2024-08-28-17_26_50](https://github.com/user-attachments/assets/7b73d7a2-5b73-4c30-8988-2d587901e7bb)

