### PR TITLE
Add academic year filter to placements index

### DIFF
--- a/app/controllers/placements/placements_controller.rb
+++ b/app/controllers/placements/placements_controller.rb
@@ -3,7 +3,8 @@ class Placements::PlacementsController < Placements::ApplicationController
   helper_method :filter_form, :location_coordinates
 
   def index
-    @current_academic_year = Placements::AcademicYear.current
+    @current_academic_year = Placements::AcademicYear.current.decorate
+    @next_academic_year = @current_academic_year.next.decorate
     @subjects = Subject.order_by_name.select(:id, :name)
     @establishment_groups = compact_school_attribute_values(:group)
     @schools = schools_scope.order_by_name.select(:id, :name)

--- a/app/controllers/placements/placements_controller.rb
+++ b/app/controllers/placements/placements_controller.rb
@@ -3,6 +3,7 @@ class Placements::PlacementsController < Placements::ApplicationController
   helper_method :filter_form, :location_coordinates
 
   def index
+    @current_academic_year = Placements::AcademicYear.current
     @subjects = Subject.order_by_name.select(:id, :name)
     @establishment_groups = compact_school_attribute_values(:group)
     @schools = schools_scope.order_by_name.select(:id, :name)
@@ -55,6 +56,7 @@ class Placements::PlacementsController < Placements::ApplicationController
   def filter_params
     params.fetch(:filters, {}).permit(
       :placements_to_show,
+      :academic_year_id,
       :only_partner_schools,
       school_ids: [],
       subject_ids: [],

--- a/app/decorators/academic_year_decorator.rb
+++ b/app/decorators/academic_year_decorator.rb
@@ -1,0 +1,14 @@
+class AcademicYearDecorator < Draper::Decorator
+  delegate_all
+
+  def display_name
+    case academic_year
+    when Placements::AcademicYear.current
+      I18n.t("placements.academic_year.current_academic_year", academic_year: academic_year.name)
+    when Placements::AcademicYear.current.next
+      I18n.t("placements.academic_year.next_academic_year", academic_year: academic_year.name)
+    else
+      I18n.t("placements.academic_year.previous_academic_year", academic_year: academic_year.name)
+    end
+  end
+end

--- a/app/forms/placements/placements/filter_form.rb
+++ b/app/forms/placements/placements/filter_form.rb
@@ -5,11 +5,12 @@ class Placements::Placements::FilterForm < ApplicationForm
   attribute :subject_ids, default: []
   attribute :year_groups, default: []
   attribute :placements_to_show, default: "available_placements"
+  attribute :academic_year_id, default: Placements::AcademicYear.current.id
   attribute :only_partner_schools, :boolean, default: false
 
   def initialize(params = {})
     params.each_value { |v| v.compact_blank! if v.is_a?(Array) }
-
+    
     super(params)
   end
 
@@ -40,6 +41,7 @@ class Placements::Placements::FilterForm < ApplicationForm
       year_groups:,
       only_partner_schools:,
       placements_to_show:,
+      academic_year_id:,
     }
   end
 

--- a/app/forms/placements/placements/filter_form.rb
+++ b/app/forms/placements/placements/filter_form.rb
@@ -10,16 +10,16 @@ class Placements::Placements::FilterForm < ApplicationForm
 
   def initialize(params = {})
     params.each_value { |v| v.compact_blank! if v.is_a?(Array) }
-    
+
     super(params)
   end
 
   def filters_selected?
-    attributes.except("placements_to_show").values.compact.flatten.any?
+    attributes.except("placements_to_show", "academic_year_id").values.compact.flatten.any?
   end
 
   def clear_filters_path(search_location: nil)
-    placements_placements_path(search_location:, filters: { placements_to_show: })
+    placements_placements_path(search_location:, filters: { placements_to_show:, academic_year_id: })
   end
 
   def index_path_without_filter(filter:, value: nil, search_location: nil)

--- a/app/queries/placements/placements_query.rb
+++ b/app/queries/placements/placements_query.rb
@@ -47,8 +47,6 @@ class Placements::PlacementsQuery < ApplicationQuery
   end
 
   def academic_year_condition(scope)
-    return scope if filter_params[:academic_year_id].blank?
-
     scope.where(academic_year_id: filter_params[:academic_year_id])
   end
 

--- a/app/queries/placements/placements_query.rb
+++ b/app/queries/placements/placements_query.rb
@@ -2,12 +2,13 @@ class Placements::PlacementsQuery < ApplicationQuery
   MAX_LOCATION_DISTANCE = 50
 
   def call
-    scope = Placement.includes(:school, :subject, :additional_subjects, :provider)
+    scope = Placement.includes(:school, :subject, :additional_subjects, :academic_year, :provider)
 
     scope = school_condition(scope)
     scope = partner_school_condition(scope)
     scope = subject_condition(scope)
     scope = placements_to_show_condition(scope)
+    scope = academic_year_condition(scope)
     scope = year_group_condition(scope)
     order_condition(scope)
   end
@@ -43,6 +44,12 @@ class Placements::PlacementsQuery < ApplicationQuery
     else
       scope
     end
+  end
+
+  def academic_year_condition(scope)
+    return scope if filter_params[:academic_year_id].blank?
+
+    scope.where(academic_year_id: filter_params[:academic_year_id])
   end
 
   def year_group_condition(scope)

--- a/app/views/placements/placements/_filter.html.erb
+++ b/app/views/placements/placements/_filter.html.erb
@@ -140,6 +140,26 @@
             <% end %>
           </div>
 
+        <div class="app-filter__option">
+            <%= form.govuk_radio_buttons_fieldset(
+              :academic_year_id,
+              legend: { text: "Academic year", size: "s" },
+              small: true,
+              multiple: false,
+            ) do %>
+              <%= form.govuk_radio_button :academic_year_id,
+                @current_academic_year.id,
+                label: { text: "This academic year (#{@current_academic_year.name})" },
+                checked: filter_form.academic_year_id == @current_academic_year.id,
+                multiple: false %>
+              <%= form.govuk_radio_button :academic_year_id,
+                @current_academic_year.next.id,
+                label: { text: "Next academic year (#{@current_academic_year.next.name})" },
+                checked: filter_form.academic_year_id == @current_academic_year.next.id,
+                multiple: false %>
+            <% end %>
+          </div>
+
           <div class="app-filter__option" data-controller="filter-search">
             <%= form.govuk_check_boxes_fieldset(
               :subject_ids,

--- a/app/views/placements/placements/_filter.html.erb
+++ b/app/views/placements/placements/_filter.html.erb
@@ -143,19 +143,19 @@
         <div class="app-filter__option">
             <%= form.govuk_radio_buttons_fieldset(
               :academic_year_id,
-              legend: { text: "Academic year", size: "s" },
+              legend: { text: t(".academic_year.label"), size: "s" },
               small: true,
               multiple: false,
             ) do %>
               <%= form.govuk_radio_button :academic_year_id,
                 @current_academic_year.id,
-                label: { text: "This academic year (#{@current_academic_year.name})" },
+                label: { text: @current_academic_year.display_name },
                 checked: filter_form.academic_year_id == @current_academic_year.id,
                 multiple: false %>
               <%= form.govuk_radio_button :academic_year_id,
-                @current_academic_year.next.id,
-                label: { text: "Next academic year (#{@current_academic_year.next.name})" },
-                checked: filter_form.academic_year_id == @current_academic_year.next.id,
+                @next_academic_year.id,
+                label: { text: @next_academic_year.display_name },
+                checked: filter_form.academic_year_id == @next_academic_year.id,
                 multiple: false %>
             <% end %>
           </div>

--- a/app/views/placements/wizards/add_placement_wizard/_check_your_answers_step.html.erb
+++ b/app/views/placements/wizards/add_placement_wizard/_check_your_answers_step.html.erb
@@ -60,7 +60,7 @@
         <% if @wizard.steps.include?(:academic_year) %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".academic_year")) %>
-            <% row.with_value(text: @wizard.steps[:academic_year].academic_year_display_name(@wizard.steps[:academic_year].academic_year)) %>
+            <% row.with_value(text: @wizard.steps[:academic_year].academic_year.display_name) %>
             <% row.with_action(text: t(".change"),
                                href: step_path(:academic_year),
                                visually_hidden_text: t(".academic_year"),

--- a/app/wizards/placements/add_placement_wizard/academic_year_step.rb
+++ b/app/wizards/placements/add_placement_wizard/academic_year_step.rb
@@ -10,16 +10,8 @@ class Placements::AddPlacementWizard::AcademicYearStep < Placements::BaseStep
     ]
   end
 
-  def academic_year_display_name(academic_year)
-    if academic_year == current_academic_year
-      I18n.t("placements.wizards.add_placement_wizard.academic_year_step.current_academic_year", academic_year: academic_year.name)
-    else
-      I18n.t("placements.wizards.add_placement_wizard.academic_year_step.next_academic_year", academic_year: academic_year.name)
-    end
-  end
-
   def academic_year
-    @academic_year ||= Placements::AcademicYear.find(academic_year_id)
+    @academic_year ||= Placements::AcademicYear.find(academic_year_id).decorate
   end
 
   private
@@ -29,6 +21,6 @@ class Placements::AddPlacementWizard::AcademicYearStep < Placements::BaseStep
   end
 
   def create_struct_for_academic_year_selection(academic_year)
-    OpenStruct.new value: academic_year.id, name: academic_year_display_name(academic_year)
+    OpenStruct.new value: academic_year.id, name: academic_year.decorate.display_name
   end
 end

--- a/config/locales/en/placements/placements.yml
+++ b/config/locales/en/placements/placements.yml
@@ -1,5 +1,9 @@
 en:
   placements:
+    academic_year:
+      current_academic_year: This academic year (%{academic_year})
+      next_academic_year: Next academic year (%{academic_year})
+      previous_academic_year: Previous academic year (%{academic_year})
     placements:
       index:
         placements_found:
@@ -26,6 +30,8 @@ en:
           assigned_to_me: Assigned to me
           all_placements: All placements
         year_group: Primary year group
+        academic_year:
+          label: Academic year
       placement_details:
         contact_details: Contact details
         itt_placement_contact: Placement contact

--- a/config/locales/en/placements/wizards/add_placement_wizard.yml
+++ b/config/locales/en/placements/wizards/add_placement_wizard.yml
@@ -8,8 +8,6 @@ en:
           title: Select an academic year - %{contextual_text}
           title_with_error: "Error: Select an academic year - %{contextual_text}"
           select_an_academic_year: Select an academic year
-          current_academic_year: This academic year (%{academic_year})
-          next_academic_year: Next academic year (%{academic_year})
           continue: Continue
         phase_step:
           title: Select a phase - %{contextual_text}

--- a/spec/decorators/academic_year_decorator_spec.rb
+++ b/spec/decorators/academic_year_decorator_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe AcademicYearDecorator do
+  describe "#display_name" do
+    let(:current_academic_year) { Placements::AcademicYear.current }
+
+    context "when the academic year is the current academic year" do
+      let(:decorated_academic_year) { current_academic_year.decorate }
+
+      it "returns the academic year name with 'This academic year'" do
+        expect(decorated_academic_year.display_name).to eq("This academic year (#{current_academic_year.name})")
+      end
+    end
+
+    context "when the academic year is the next academic year" do
+      let(:next_academic_year) { current_academic_year.next }
+      let(:decorated_academic_year) { next_academic_year.decorate }
+
+      it "returns the academic year name with 'Next academic year'" do
+        expect(decorated_academic_year.display_name).to eq("Next academic year (#{next_academic_year.name})")
+      end
+    end
+
+    context "when the academic year is the previous academic year" do
+      let(:previous_academic_year) { current_academic_year.previous }
+      let(:decorated_academic_year) { previous_academic_year.decorate }
+
+      it "returns the academic year name with 'Previous academic year'" do
+        expect(decorated_academic_year.display_name).to eq("Previous academic year (#{previous_academic_year.name})")
+      end
+    end
+  end
+end

--- a/spec/factories/placements.rb
+++ b/spec/factories/placements.rb
@@ -28,8 +28,9 @@
 #
 FactoryBot.define do
   factory :placement do
+    academic_year { Placements::AcademicYear.current }
+
     association :school, factory: :placements_school
     association :subject, factory: :subject
-    association :academic_year, factory: :placements_academic_year
   end
 end

--- a/spec/forms/placements/placements/filter_form_spec.rb
+++ b/spec/forms/placements/placements/filter_form_spec.rb
@@ -4,6 +4,7 @@ describe Placements::Placements::FilterForm, type: :model do
   include Rails.application.routes.url_helpers
 
   let(:provider) { create(:placements_provider) }
+  let(:current_academic_year) { Placements::AcademicYear.current }
 
   describe "#filters_selected?" do
     subject(:filter_form) { described_class.new(params).filters_selected? }
@@ -54,7 +55,10 @@ describe Placements::Placements::FilterForm, type: :model do
 
     it "returns the placements index page path" do
       expect(filter_form.clear_filters_path).to eq(
-        placements_placements_path(filters: { placements_to_show: "available_placements" }),
+        placements_placements_path(filters: {
+          placements_to_show: "available_placements",
+          academic_year_id: current_academic_year.id,
+        }),
       )
     end
   end
@@ -76,6 +80,7 @@ describe Placements::Placements::FilterForm, type: :model do
         ).to eq(
           placements_placements_path(filters: {
             placements_to_show: "available_placements",
+            academic_year_id: current_academic_year.id,
             school_ids: %w[school_id_2],
           }),
         )
@@ -94,7 +99,10 @@ describe Placements::Placements::FilterForm, type: :model do
             value: false,
           ),
         ).to eq(
-          placements_placements_path(filters: { placements_to_show: "available_placements" }),
+          placements_placements_path(filters: {
+            placements_to_show: "available_placements",
+            academic_year_id: current_academic_year.id,
+          }),
         )
       end
     end
@@ -113,6 +121,7 @@ describe Placements::Placements::FilterForm, type: :model do
         ).to eq(
           placements_placements_path(filters: {
             placements_to_show: "available_placements",
+            academic_year_id: current_academic_year.id,
             subject_ids: %w[subject_id_2],
           }),
         )
@@ -133,6 +142,7 @@ describe Placements::Placements::FilterForm, type: :model do
         ).to eq(
           placements_placements_path(filters: {
             placements_to_show: "available_placements",
+            academic_year_id: current_academic_year.id,
             year_groups: %w[year_group_2],
           }),
         )
@@ -145,6 +155,7 @@ describe Placements::Placements::FilterForm, type: :model do
       expect(described_class.new.query_params).to eq(
         {
           placements_to_show: "available_placements",
+          academic_year_id: current_academic_year.id,
           school_ids: [],
           only_partner_schools: false,
           subject_ids: [],

--- a/spec/models/academic_year_spec.rb
+++ b/spec/models/academic_year_spec.rb
@@ -29,14 +29,14 @@ RSpec.describe AcademicYear, type: :model do
   describe ".for_date" do
     let!(:existing_academic_year) do
       create(:academic_year,
-             name: "2024 to 2025",
-             starts_on: Date.parse("1 September 2024"),
-             ends_on: Date.parse("31 August 2025"))
+             name: "2022 to 2023",
+             starts_on: Date.parse("1 September 2022"),
+             ends_on: Date.parse("31 August 2023"))
     end
 
     context "when date is within an existing academic year" do
       it "returns the existing academic year" do
-        date = Date.parse("7 November 2024")
+        date = Date.parse("7 November 2022")
         expect(described_class.for_date(date)).to eq(existing_academic_year)
       end
     end

--- a/spec/models/placements/academic_year_spec.rb
+++ b/spec/models/placements/academic_year_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe Placements::AcademicYear, type: :model do
   end
 
   context "when the previous academic year does not exist" do
-
     it "creates a new academic year for the previous year" do
       expect { current_academic_year.previous }.to change(described_class, :count).by(1)
 

--- a/spec/models/placements/academic_year_spec.rb
+++ b/spec/models/placements/academic_year_spec.rb
@@ -12,20 +12,18 @@
 require "rails_helper"
 
 RSpec.describe Placements::AcademicYear, type: :model do
-  let!(:current_academic_year) { described_class.find_by(starts_on: ..Date.current, ends_on: Date.current..) }
+  let!(:current_academic_year) do
+    create(:placements_academic_year,
+           starts_on: Date.parse("1 September 2024"),
+           ends_on: Date.parse("31 August 2025"),
+           name: "2024 to 2025")
+  end
 
   describe "associations" do
     it { is_expected.to have_many(:placements) }
   end
 
   describe ".current" do
-    let!(:current_academic_year) do
-      create(:placements_academic_year,
-             starts_on: Date.parse("1 September 2024"),
-             ends_on: Date.parse("31 August 2025"),
-             name: "2024 to 2025")
-    end
-
     it "returns the academic year for the current date" do
       Timecop.travel(Date.parse("1 September 2024")) do
         expect(described_class.current).to eq(current_academic_year)
@@ -67,13 +65,17 @@ RSpec.describe Placements::AcademicYear, type: :model do
   end
 
   describe "#previous" do
-    let(:previous_start_year) { current_academic_year.starts_on.year - 1 }
-    let(:previous_end_year) { current_academic_year.ends_on.year - 1 }
+    let!(:current_academic_year) do
+      create(:placements_academic_year,
+             starts_on: Date.parse("1 September 2024"),
+             ends_on: Date.parse("31 August 2025"),
+             name: "2024 to 2025")
+    end
     let!(:previous_academic_year) do
       create(:placements_academic_year,
-             starts_on: Date.parse("1 September #{previous_start_year}"),
-             ends_on: Date.parse("31 August #{previous_end_year}"),
-             name: "#{previous_start_year} to #{previous_end_year}")
+             starts_on: Date.parse("1 September 2023"),
+             ends_on: Date.parse("31 August 2024"),
+             name: "2023 to 2024")
     end
 
     it "returns the previous academic year" do

--- a/spec/models/placements/academic_year_spec.rb
+++ b/spec/models/placements/academic_year_spec.rb
@@ -14,8 +14,8 @@ require "rails_helper"
 RSpec.describe Placements::AcademicYear, type: :model do
   let!(:current_academic_year) do
     create(:placements_academic_year,
-           starts_on: Date.parse("1 September 2024"),
-           ends_on: Date.parse("31 August 2025"),
+           starts_on: Date.parse("1 September 2020"),
+           ends_on: Date.parse("31 August 2021"),
            name: "2024 to 2025")
   end
 
@@ -25,7 +25,7 @@ RSpec.describe Placements::AcademicYear, type: :model do
 
   describe ".current" do
     it "returns the academic year for the current date" do
-      Timecop.travel(Date.parse("1 September 2024")) do
+      Timecop.travel(Date.parse("1 September 2020")) do
         expect(described_class.current).to eq(current_academic_year)
       end
     end
@@ -47,35 +47,22 @@ RSpec.describe Placements::AcademicYear, type: :model do
   end
 
   context "when the next academic year does not exist" do
-    let!(:current_academic_year) do
-      create(:placements_academic_year,
-             starts_on: Date.parse("1 September 2030"),
-             ends_on: Date.parse("31 August 2031"),
-             name: "2030 to 2031")
-    end
-
     it "creates a new academic year for the next year" do
       expect { current_academic_year.next }.to change(described_class, :count).by(1)
 
       created_academic_year = current_academic_year.next
-      expect(created_academic_year.starts_on).to eq(Date.parse("1 September 2031"))
-      expect(created_academic_year.ends_on).to eq(Date.parse("31 August 2032"))
-      expect(created_academic_year.name).to eq("2031 to 2032")
+      expect(created_academic_year.starts_on).to eq(Date.parse("1 September 2021"))
+      expect(created_academic_year.ends_on).to eq(Date.parse("31 August 2022"))
+      expect(created_academic_year.name).to eq("2021 to 2022")
     end
   end
 
   describe "#previous" do
-    let!(:current_academic_year) do
-      create(:placements_academic_year,
-             starts_on: Date.parse("1 September 2024"),
-             ends_on: Date.parse("31 August 2025"),
-             name: "2024 to 2025")
-    end
     let!(:previous_academic_year) do
       create(:placements_academic_year,
-             starts_on: Date.parse("1 September 2023"),
-             ends_on: Date.parse("31 August 2024"),
-             name: "2023 to 2024")
+             starts_on: Date.parse("1 September 2019"),
+             ends_on: Date.parse("31 August 2020"),
+             name: "2019 to 2020")
     end
 
     it "returns the previous academic year" do
@@ -84,20 +71,14 @@ RSpec.describe Placements::AcademicYear, type: :model do
   end
 
   context "when the previous academic year does not exist" do
-    let!(:current_academic_year) do
-      create(:placements_academic_year,
-             starts_on: Date.parse("1 September 2030"),
-             ends_on: Date.parse("31 August 2031"),
-             name: "2030 to 2031")
-    end
 
     it "creates a new academic year for the previous year" do
       expect { current_academic_year.previous }.to change(described_class, :count).by(1)
 
       created_academic_year = current_academic_year.previous
-      expect(created_academic_year.starts_on).to eq(Date.parse("1 September 2029"))
-      expect(created_academic_year.ends_on).to eq(Date.parse("31 August 2030"))
-      expect(created_academic_year.name).to eq("2029 to 2030")
+      expect(created_academic_year.starts_on).to eq(Date.parse("1 September 2019"))
+      expect(created_academic_year.ends_on).to eq(Date.parse("31 August 2020"))
+      expect(created_academic_year.name).to eq("2019 to 2020")
     end
   end
 end

--- a/spec/models/placements/academic_year_spec.rb
+++ b/spec/models/placements/academic_year_spec.rb
@@ -12,7 +12,7 @@
 require "rails_helper"
 
 RSpec.describe Placements::AcademicYear, type: :model do
-  let!(:current_academic_year) { create(:placements_academic_year) }
+  let!(:current_academic_year) { described_class.find_by(starts_on: ..Date.current, ends_on: Date.current..) }
 
   describe "associations" do
     it { is_expected.to have_many(:placements) }


### PR DESCRIPTION
## Context

Now that placements have academic years, providers need the ability to filter by their desired academic year when choosing suitable placements

## Changes proposed in this pull request

- [x] Adds the academic year filter to the provider index page for placements
- [x] Creates an `AcademicYear` decorator to consolidate the display name logic
- [x] Refactors the `AcademicYearStep` to remove redundant functionality
- [x] Adds/updates specs to prove the functionality works

## Guidance to review

- Log in as Patricia
- Navigate to the placements index page
- Select "Next academic year (2024 to 2025)"
- Click on "Apply Filters"
- Verify that no placements are visible
- Log out
- Log in as Anne
- Create a placement for the "Next academic year (2024 to 2025)"
- Log out
- Log in as Patricia
- Navigate to the placements index page
- Select "Next academic year (2024 to 2025)"
- Click on "Apply Filters"
- Verify that one placement is visible

## Link to Trello card

[[Provider] Add academic year filter to placements index](https://trello.com/c/uI3kIWrK/712-provider-add-academic-year-filter-to-placements-index)

## Screenshots

![image](https://github.com/user-attachments/assets/b0a9a62a-2ba3-4014-b83f-d2d068f0d27e)
