### PR TITLE
Convert selecting all three terms on add placement journey

### DIFF
--- a/app/wizards/placements/add_placement_wizard/terms_step.rb
+++ b/app/wizards/placements/add_placement_wizard/terms_step.rb
@@ -32,6 +32,8 @@ class Placements::AddPlacementWizard::TermsStep < Placements::BaseStep
       []
     elsif term_ids.include?("any_term")
       ANY_TERM
+    elsif term_ids.sort == terms_for_selection.ids.sort
+      ANY_TERM
     else
       terms_for_selection.where(id: term_ids).ids
     end

--- a/app/wizards/placements/add_placement_wizard/terms_step.rb
+++ b/app/wizards/placements/add_placement_wizard/terms_step.rb
@@ -10,7 +10,7 @@ class Placements::AddPlacementWizard::TermsStep < Placements::BaseStep
   def term_names
     return if term_ids == ANY_TERM
 
-    terms.pluck(:name).to_sentence
+    terms.pluck(:name).join(", ")
   end
 
   def terms_for_selection

--- a/spec/support/shared_examples/system/placements/add_a_placement_wizard.rb
+++ b/spec/support/shared_examples/system/placements/add_a_placement_wizard.rb
@@ -590,6 +590,29 @@ RSpec.shared_examples "an add a placement wizard" do
           then_i_see_the_check_your_answers_page("Secondary", mentor_1, spring_term.name)
         end
 
+        it "I select all terms separately" do
+          school.update!(phase: "Nursery")
+          when_i_visit_the_placements_page
+          and_i_click_on("Add placement")
+          when_i_choose_a_phase("Secondary")
+          and_i_click_on("Continue")
+          when_i_choose_a_subject(subject_2.name)
+          and_i_click_on("Continue")
+          when_i_check_a_term(summer_term.name)
+          and_i_click_on("Continue")
+          when_i_check_a_mentor(mentor_1.full_name)
+          and_i_click_on("Continue")
+          when_i_change_my_term
+          then_i_see_the_add_a_term_page
+          when_i_check_a_term(summer_term.name)
+          when_i_check_a_term(spring_term.name)
+          when_i_check_a_term(autumn_term.name)
+          and_i_click_on("Continue")
+          then_i_see_the_add_a_placement_mentor_page
+          and_i_click_on("Continue")
+          then_i_see_the_check_your_answers_page("Secondary", mentor_1, "Any time in the academic year")
+        end
+
         it "I do not decide to change my term" do
           school.update!(phase: "Nursery")
           when_i_visit_the_placements_page

--- a/spec/wizards/placements/add_placement_wizard/terms_step_spec.rb
+++ b/spec/wizards/placements/add_placement_wizard/terms_step_spec.rb
@@ -77,11 +77,25 @@ RSpec.describe Placements::AddPlacementWizard::TermsStep, type: :model do
       end
     end
 
-    context "when the value includes term ids" do
-      it "retains the term ids" do
-        step.term_ids = terms.pluck(:id)
+    context "when the value includes all 3 terms (summer, spring, autumn)" do
+      it "return any_term" do
+        step.term_ids = terms.pluck(:id).sort
 
-        expect(step.term_ids).to match_array(terms.pluck(:id))
+        expect(step.term_ids).to eq(%w[any_term])
+      end
+    end
+
+    context "when the value includes term ids (but not all term ids)" do
+      before do
+        summer_term
+        spring_term
+        autumn_term
+      end
+
+      it "retains the term ids" do
+        step.term_ids = [summer_term.id]
+
+        expect(step.term_ids).to match_array(summer_term.id)
       end
     end
   end

--- a/spec/wizards/placements/add_placement_wizard/terms_step_spec.rb
+++ b/spec/wizards/placements/add_placement_wizard/terms_step_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Placements::AddPlacementWizard::TermsStep, type: :model do
 
       it "returns the names of the terms as a string" do
         expect(step.term_names).to eq(
-          "#{summer_term.name}, #{spring_term.name}, and #{autumn_term.name}",
+          "#{summer_term.name}, #{spring_term.name}, #{autumn_term.name}",
         )
       end
     end


### PR DESCRIPTION
## Context

- When a user selects all the terms during the add placement journey, this should convert to "Any time in the academic year"

## Changes proposed in this pull request

- Add a clause in the `normalised_term_ids` method, to convert the value to "Any time in the academic year" when all terms are selected.

## Guidance to review

- Sign in as Anne (School User)
- Navigate to "Placements" using the Navbar
- Click "Add placement"
- Follow the add placement journey
- When you reach the "Select when the placement could be" step, select all the terms and continue the add placement journey
On the check your answers page, you will see the terms have been converted to "Any time in the academic year"

## Link to Trello card

https://trello.com/c/YDmoo8mY/709-add-placement-wizard-if-all-three-expected-date-checkboxes-are-selected-convert-to-any-time

## Screenshots

https://github.com/user-attachments/assets/5da4377d-4b7f-479b-9547-ff3417d08026


