### PR TITLE
Update placements index placement window

### DIFF
--- a/app/decorators/placement_decorator.rb
+++ b/app/decorators/placement_decorator.rb
@@ -38,7 +38,7 @@ class PlacementDecorator < Draper::Decorator
 
   def term_names
     if terms.exists?
-      terms.order_by_term.pluck(:name).join(" - ")
+      terms.order_by_term.pluck(:name).join(", ")
     else
       I18n.t("placements.schools.placements.terms.any_term")
     end

--- a/app/decorators/placement_decorator.rb
+++ b/app/decorators/placement_decorator.rb
@@ -35,4 +35,12 @@ class PlacementDecorator < Draper::Decorator
     reload unless new_record?
     additional_subjects.map(&:name).sort.to_sentence
   end
+
+  def term_names
+    if terms.exists?
+      terms.order_by_term.pluck(:name).join(" - ")
+    else
+      I18n.t("placements.schools.placements.terms.any_term")
+    end
+  end
 end

--- a/app/views/placements/schools/placements/_table.html.erb
+++ b/app/views/placements/schools/placements/_table.html.erb
@@ -4,6 +4,7 @@
     <% head.with_row do |row| %>
       <% row.with_cell(header: true, text: t(".subject")) %>
       <% row.with_cell(header: true, text: t(".mentor")) %>
+      <% row.with_cell(header: true, text: t(".expected_date")) %>
       <% row.with_cell(header: true, text: t(".provider")) %>
     <% end %>
   <% end %>
@@ -24,6 +25,7 @@
           )) %>
         <% end %>
         <% row.with_cell(text: placement.mentor_names, html_attributes: { class: table_text_class(placement.mentor_names) }) %>
+        <% row.with_cell(text: placement.term_names) %>
         <% row.with_cell(text: placement.provider_name, html_attributes: { class: table_text_class(placement.provider_name) }) %>
       <% end %>
     <% end %>

--- a/app/views/placements/schools/placements/index.html.erb
+++ b/app/views/placements/schools/placements/index.html.erb
@@ -2,7 +2,7 @@
 <%= render "placements/schools/primary_navigation", school: @school, current_navigation: :placements %>
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-l"><%= t(".placements") %></h1>
       <% if @school.school_contact.present? %>
         <%= govuk_button_link_to(t(".add_placement"), new_add_placement_placements_school_placements_path) %>

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -35,6 +35,7 @@ en:
         table:
           subject: Subject
           mentor: Mentor
+          expected_date: Expected date
           provider: Provider
         add_placement:
           edit:
@@ -51,6 +52,7 @@ en:
           autumn: Autumn
           spring: Spring
           summer: Summer
+          any_term: Any time in the academic year
         not_yet_known: Not yet known
         year_groups:
           year_1: Year 1

--- a/spec/decorators/placement_decorator_spec.rb
+++ b/spec/decorators/placement_decorator_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe PlacementDecorator do
         placement.terms << term1
         placement.terms << term2
 
-        expect(placement.decorate.term_names).to eq("Spring term - Autumn term")
+        expect(placement.decorate.term_names).to eq("Spring term, Autumn term")
       end
     end
   end

--- a/spec/decorators/placement_decorator_spec.rb
+++ b/spec/decorators/placement_decorator_spec.rb
@@ -111,4 +111,36 @@ RSpec.describe PlacementDecorator do
       expect(placement.decorate.additional_subject_names).to eq("French and Spanish")
     end
   end
+
+  describe "#term_names" do
+    context "when the placement has no terms" do
+      it "returns Any term" do
+        placement = build(:placement)
+
+        expect(placement.decorate.term_names).to eq("Any time in the academic year")
+      end
+    end
+
+    context "when the placement has one term" do
+      it "returns the term name" do
+        placement = create(:placement)
+        term = create(:placements_term, :autumn)
+        placement.terms << term
+
+        expect(placement.decorate.term_names).to eq("Autumn term")
+      end
+    end
+
+    context "when the placement has multiple terms" do
+      it "returns a list of term names" do
+        placement = create(:placement)
+        term1 = create(:placements_term, :autumn)
+        term2 = create(:placements_term, :spring)
+        placement.terms << term1
+        placement.terms << term2
+
+        expect(placement.decorate.term_names).to eq("Spring term - Autumn term")
+      end
+    end
+  end
 end

--- a/spec/system/placements/schools/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/schools/placements/view_placements_list_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe "Placement school user views a list of placements", service: :pla
       given_i_sign_in_as_anne
       then_i_see_the_provider_name("Not yet known")
     end
+
+    scenario "when the placement has no terms" do
+      given_a_placement_exists
+      given_i_sign_in_as_anne
+      then_i_see_term_name("Any time in the academic year")
+    end
+
+    scenario "when the placement has terms" do
+      given_a_placement_exists(with_term: true)
+      given_i_sign_in_as_anne
+      then_i_see_term_name("Autumn term")
+    end
   end
 
   private
@@ -53,8 +65,8 @@ RSpec.describe "Placement school user views a list of placements", service: :pla
     click_on "Sign in using DfE Sign In"
   end
 
-  def given_a_placement_exists
-    create(:placement, school:)
+  def given_a_placement_exists(with_term: false)
+    with_term ? create(:placement, school:, terms: [create(:placements_term, :autumn)]) : create(:placement, school:)
   end
 
   def then_i_see_the_placements_page
@@ -93,8 +105,14 @@ RSpec.describe "Placement school user views a list of placements", service: :pla
     end
   end
 
-  def then_i_see_the_provider_name(name)
+  def then_i_see_term_name(name)
     within("tbody tr:nth-child(1) td:nth-child(3)") do
+      expect(page).to have_content name
+    end
+  end
+
+  def then_i_see_the_provider_name(name)
+    within("tbody tr:nth-child(1) td:nth-child(4)") do
       expect(page).to have_content name
     end
   end

--- a/spec/system/placements/support/schools/placements/support_user_views_placements_spec.rb
+++ b/spec/system/placements/support/schools/placements/support_user_views_placements_spec.rb
@@ -49,6 +49,22 @@ RSpec.describe "Placements / Support / Schools / Placements / Support User views
       and_i_dont_see_placements_from_another_school
       then_i_see_the_provider_is_not_assigned
     end
+
+    scenario "when the placement has no terms" do
+      user_exists_in_dfe_sign_in(user: colin)
+      given_i_sign_in
+      when_i_visit_the_support_school_placements_page(school)
+      then_i_see_a_list_of_the_schools_placements
+      then_i_see_the_term_name("Any time in the academic year")
+    end
+
+    scenario "when the placement has terms" do
+      user_exists_in_dfe_sign_in(user: colin)
+      given_i_sign_in
+      and_the_placement_has_terms(placement1)
+      when_i_visit_the_support_school_placements_page(school)
+      then_i_see_the_term_name("Autumn term")
+    end
   end
 
   private
@@ -77,6 +93,10 @@ RSpec.describe "Placements / Support / Schools / Placements / Support User views
     end
 
     within("tbody tr:nth-child(1) td:nth-child(3)") do
+      expect(page).to have_content("Any time in the academic year")
+    end
+
+    within("tbody tr:nth-child(1) td:nth-child(4)") do
       expect(page).to have_content(placement1.provider.name)
     end
   end
@@ -86,18 +106,29 @@ RSpec.describe "Placements / Support / Schools / Placements / Support User views
     expect(page).not_to have_content(placement3.mentors.map(&:full_name).to_sentence)
   end
 
+  def and_the_placement_has_terms(placement)
+    term = create(:placements_term, :autumn)
+    placement.terms << term
+  end
+
   def then_i_see_no_results
     expect(page).to have_content("There are no placements for #{another_school.name}.")
   end
 
-  def then_i_see_the_provider_name(name)
+  def then_i_see_the_term_name(name)
     within("tbody tr:nth-child(1) td:nth-child(3)") do
       expect(page).to have_content name
     end
   end
 
+  def then_i_see_the_provider_name(name)
+    within("tbody tr:nth-child(1) td:nth-child(4)") do
+      expect(page).to have_content name
+    end
+  end
+
   def then_i_see_the_provider_is_not_assigned
-    within("tbody tr:nth-child(2) td:nth-child(3)") do
+    within("tbody tr:nth-child(2) td:nth-child(4)") do
       expect(page).to have_content "Not yet known"
     end
   end

--- a/spec/system/placements/support/schools/placements/support_user_views_placements_spec.rb
+++ b/spec/system/placements/support/schools/placements/support_user_views_placements_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "Placements / Support / Schools / Placements / Support User views
   let!(:school) { create(:placements_school, mentors: [mentor1, mentor2]) }
   let!(:another_school) { create(:placements_school) }
   let!(:colin) { create(:placements_support_user, :colin) }
+  let(:term) { create(:placements_term, :autumn) }
 
   scenario "view a school's empty placements list" do
     user_exists_in_dfe_sign_in(user: colin)
@@ -61,7 +62,7 @@ RSpec.describe "Placements / Support / Schools / Placements / Support User views
     scenario "when the placement has terms" do
       user_exists_in_dfe_sign_in(user: colin)
       given_i_sign_in
-      and_the_placement_has_terms(placement1)
+      and_the_placement_has_terms(placement1, term)
       when_i_visit_the_support_school_placements_page(school)
       then_i_see_the_term_name("Autumn term")
     end
@@ -106,8 +107,7 @@ RSpec.describe "Placements / Support / Schools / Placements / Support User views
     expect(page).not_to have_content(placement3.mentors.map(&:full_name).to_sentence)
   end
 
-  def and_the_placement_has_terms(placement)
-    term = create(:placements_term, :autumn)
+  def and_the_placement_has_terms(placement, term)
     placement.terms << term
   end
 


### PR DESCRIPTION
## Context

School users need to be able to see the expected date for their created placements.

## Changes proposed in this pull request

- [x] Increase width of table to full-width
- [x] Add expected date to the placements index page
- [x] Create a new `term_names` method for the placements decorator
- [x] Test the new functionality

## Guidance to review

- Log in as Anne
- View placements
- Verify the changes are correct

## Link to Trello card

[[School] Update placements index with academic year and placement date](https://trello.com/c/6pgdwKt3/706-school-update-placements-index-with-academic-year-and-placement-date)

## Screenshots

![image](https://github.com/user-attachments/assets/a371db96-5731-47e3-b48e-107885f3501a)
