### PR TITLE
UI changes to placements show page

### DIFF
--- a/app/decorators/placement_decorator.rb
+++ b/app/decorators/placement_decorator.rb
@@ -1,6 +1,7 @@
 class PlacementDecorator < Draper::Decorator
   delegate_all
   decorates_association :school
+  decorates_association :academic_year
 
   delegate :name, to: :subject, prefix: true, allow_nil: true
 

--- a/app/views/placements/schools/placements/_details.html.erb
+++ b/app/views/placements/schools/placements/_details.html.erb
@@ -13,7 +13,7 @@
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: t(".attributes.placements.subject")) %>
     <% row.with_value do %>
-        <% placement.subject_name %>
+      <% placement.subject_name %>
     <% end %>
   <% end %>
   <% if placement.subject_has_child_subjects? %>
@@ -34,6 +34,23 @@
         visually_hidden_text: t(".attributes.placements.year_group"),
       ) %>
     <% end %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t(".attributes.placements.academic_year")) %>
+    <% row.with_value do %>
+      <% placement.academic_year.display_name %>
+    <% end %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t(".attributes.placements.terms")) %>
+    <% row.with_value do %>
+      <%= placement.term_names %>
+    <% end %>
+    <% row.with_action(
+      text: t(".change"),
+      href: edit_attribute_path(:terms),
+      visually_hidden_text: t(".attributes.placements.terms"),
+    ) %>
   <% end %>
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: t(".attributes.placements.mentor")) %>

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -95,6 +95,8 @@ en:
               school_level: School level
               subject: Subject
               additional_subjects: Additional subjects
+              academic_year: Academic year
+              terms: Expected date
               year_group: Year group
               mentor: Mentor
               status: Status


### PR DESCRIPTION
## Context

In line with UI design changes, academic year and expected dates offer the school user the ability to provide more period-specific information about the placements they are listing.

## Changes proposed in this pull request

- Add the 'Academic year' field to the placement show page
- Add the 'Expected date' field to the placement show page
- Add the change link to the edit placement wizard for the expected date field

## Guidance to review

- Log in as a Anne
- Click 'Add a placement'
- Create a placement, including selecting a term on the term step
- Return to the index 
- Click into the newly created placement
- Check that the relevant academic year shows
- Check the show page includes the name of the chosen term
- Repeat this but choose all three terms
- Check the show page includes 'Any time in the academic year'
- Repeat this but choose 'Any time in the academic year'
- Check the show page includes 'Any time in the academic year'

## Link to Trello card

https://trello.com/c/wIDHzSps/711-school-update-placements-show-with-academic-year-and-placement-date

## Screenshots

<img width="776" alt="Screenshot 2024-08-30 at 14 59 13" src="https://github.com/user-attachments/assets/1893c6b1-ef08-4fb5-b4d2-5d90599a03eb">

<img width="795" alt="Screenshot 2024-08-30 at 15 00 20" src="https://github.com/user-attachments/assets/a82479a7-3e3e-4b08-ab9b-d7721af62010">

