### PR TITLE
Update Claims start page content

### DIFF
--- a/app/views/claims/pages/start.en.html.erb
+++ b/app/views/claims/pages/start.en.html.erb
@@ -8,7 +8,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <p class="govuk-body">
-        Use this service to claim for mentors who supported, or intended to support, trainee teachers from September 2023 to July 2024.
+        Use this service to claim for mentors who supported trainee teachers from September 2023 to July 2024.
       </p>
 
       <% if claim_window.current? %>

--- a/spec/system/claims/start_page_spec.rb
+++ b/spec/system/claims/start_page_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Start Page", freeze: "17 July 2024", service: :claims, type: :sy
       expect(page).to have_content("Claim funding for mentor training")
     end
 
-    expect(page).to have_content("Use this service to claim for mentors who supported, or intended to support, trainee teachers from September 2023 to July 2024.")
+    expect(page).to have_content("Use this service to claim for mentors who supported trainee teachers from September 2023 to July 2024.")
     expect(page).to have_content("The service is open for claims. Deadline to submit claims is: 11:59pm on Friday 19 July 2024")
     expect(page).to have_content("You must wait until May 2025 to claim for training that took place from April 2024 for the school year starting September 2025.")
     expect(page).to have_content(


### PR DESCRIPTION
## Context

The Claims start page content is now outdated. We want to update it to reflect the correct content based on the current dates.

## Changes proposed in this pull request

- Update start page content.

## Guidance to review

- Content makes sense.
