### PR TITLE
UI changes to provider placements index

### DIFF
--- a/app/components/placement/summary_component.html.erb
+++ b/app/components/placement/summary_component.html.erb
@@ -33,6 +33,22 @@
     </div>
     <div class="app-result-detail__row">
       <dt class="app-result-detail__key">
+        <%= t(".academic_year") %>
+      </dt>
+      <dd class="app-result-detail__value">
+        <%= placement.academic_year.display_name %>
+      </dd>
+    </div>
+        <div class="app-result-detail__row">
+      <dt class="app-result-detail__key">
+        <%= t(".terms") %>
+      </dt>
+      <dd class="app-result-detail__value">
+        <%= placement.term_names %>
+      </dd>
+    </div>
+    <div class="app-result-detail__row">
+      <dt class="app-result-detail__key">
         <%= t(".age_range") %>
       </dt>
       <dd class="app-result-detail__value">

--- a/config/locales/en/components/placement/summary_component.yml
+++ b/config/locales/en/components/placement/summary_component.yml
@@ -3,6 +3,8 @@ en:
     placement:
       summary_component:
         phase: Phase
+        academic_year: Academic year
+        terms: Expected date
         age_range: Age range
         establishment_group: Establishment group
         gender: Gender

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -77,6 +77,7 @@ en:
             Before you add a placement, you must %{link_to} so that the teacher training providers can contact you.
           add_itt_placement_contact: add a placement contact
         show:
+          any_time: Any time in the academic year
           delete_placement: Delete placement
           preview_placement: You can %{href} as it appears to providers.
           preview_link: preview this placement

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -77,7 +77,6 @@ en:
             Before you add a placement, you must %{link_to} so that the teacher training providers can contact you.
           add_itt_placement_contact: add a placement contact
         show:
-          any_time: Any time in the academic year
           delete_placement: Delete placement
           preview_placement: You can %{href} as it appears to providers.
           preview_link: preview this placement

--- a/spec/components/placement/summary_component_spec.rb
+++ b/spec/components/placement/summary_component_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Placement::SummaryComponent, type: :component do
 
   let(:subject_1) { create(:subject, name: "Biology") }
   let(:subject_2) { create(:subject, name: "Classics") }
+  let(:academic_year) { create(:placements_academic_year) }
+  let(:terms) { [create(:placements_term, :summer)] }
   let(:school) do
     create(
       :placements_school,
@@ -23,8 +25,8 @@ RSpec.describe Placement::SummaryComponent, type: :component do
       longitude: -0.570409,
     )
   end
-  let(:placement_1) { create(:placement, school:, subject: placement_subject, mentors:) }
-  let(:placement_2) { create(:placement, school:, subject: subject_2, mentors:) }
+  let(:placement_1) { create(:placement, school:, subject: placement_subject, mentors:, academic_year:, terms:) }
+  let(:placement_2) { create(:placement, school:, subject: subject_2, mentors:, academic_year:, terms:) }
   let(:provider) { create(:provider) }
 
   context "when given multiple placements" do
@@ -46,6 +48,12 @@ RSpec.describe Placement::SummaryComponent, type: :component do
       # Subject details
       expect(page).to have_content("Biology", count: 1)
       expect(page).to have_content("Classics", count: 1)
+
+      # Academic year details
+      expect(page).to have_content("2023 to 2024", count: 2)
+      
+      # Expected date details
+      expect(page).to have_content("Summer term", count: 2)
     end
   end
 

--- a/spec/components/placement/summary_component_spec.rb
+++ b/spec/components/placement/summary_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Placement::SummaryComponent, type: :component do
 
   let(:subject_1) { create(:subject, name: "Biology") }
   let(:subject_2) { create(:subject, name: "Classics") }
-  let(:academic_year) { create(:placements_academic_year) }
+  let(:academic_year) { Placements::AcademicYear.current }
   let(:terms) { [create(:placements_term, :summer)] }
   let(:school) do
     create(
@@ -50,8 +50,8 @@ RSpec.describe Placement::SummaryComponent, type: :component do
       expect(page).to have_content("Classics", count: 1)
 
       # Academic year details
-      expect(page).to have_content("2023 to 2024", count: 2)
-      
+      expect(page).to have_content(academic_year.name, count: 2)
+
       # Expected date details
       expect(page).to have_content("Summer term", count: 2)
     end


### PR DESCRIPTION
## Context

Providers need to see the academic year and expected date in the search results summary to assist them in finding the right placements.

## Changes proposed in this pull request

- Add the academic year field to the placements/placements/index page.
- Add the expected date field to the placements/placements/index page.
- Add specs to cover this functionality

## Guidance to review

- Login as Patricia.
- View default search results on placements index, or do a new search.
- Review result summaries.
- You should see academic year and expected date now included in the summary table.

## Link to Trello card

https://trello.com/c/s475bfon/714-provider-update-placements-index-with-academic-year-and-placement-date

## Screenshots

<img width="1053" alt="Screenshot 2024-08-30 at 15 32 10" src="https://github.com/user-attachments/assets/aa6ac687-c3ab-4929-84d0-9a6f617fb1e5">
