### PR TITLE
Remove unnecessary fields from provider placements index view

### DIFF
--- a/app/components/placement/summary_component.html.erb
+++ b/app/components/placement/summary_component.html.erb
@@ -49,30 +49,6 @@
     </div>
     <div class="app-result-detail__row">
       <dt class="app-result-detail__key">
-        <%= t(".gender") %>
-      </dt>
-      <dd class="app-result-detail__value">
-        <%= school.gender %>
-      </dd>
-    </div>
-    <div class="app-result-detail__row">
-      <dt class="app-result-detail__key">
-        <%= t(".religious_character") %>
-      </dt>
-      <dd class="app-result-detail__value">
-        <%= school.religious_character %>
-      </dd>
-    </div>
-    <div class="app-result-detail__row">
-      <dt class="app-result-detail__key">
-        <%= t(".urban_or_rural") %>
-      </dt>
-      <dd class="app-result-detail__value">
-        <%= school.urban_or_rural %>
-      </dd>
-    </div>
-    <div class="app-result-detail__row">
-      <dt class="app-result-detail__key">
         <%= t(".ofsted_rating") %>
       </dt>
       <dd class="app-result-detail__value">

--- a/spec/components/placement/summary_component_spec.rb
+++ b/spec/components/placement/summary_component_spec.rb
@@ -40,10 +40,7 @@ RSpec.describe Placement::SummaryComponent, type: :component do
       expect(page).to have_content("London Primary School", count: 2)
       expect(page).to have_content("All-through", count: 2)
       expect(page).to have_content("4 to 11", count: 2)
-      expect(page).to have_content("Mixed", count: 2)
       expect(page).to have_content("Local authority maintained schools", count: 2)
-      expect(page).to have_content("Jewish", count: 2)
-      expect(page).to have_content("(England/Wales) Urban city and town", count: 2)
       expect(page).to have_content("Good", count: 2)
 
       # Subject details


### PR DESCRIPTION
## Context

- Remove fields user research has deemed unnecessary by providers.

## Changes proposed in this pull request

- Remove the gender field from placements/placements/index
- Remove the religious character field from placements/placements/index
- Remove the urban or rural field from placements/placements/index

## Guidance to review

- Sign in as Patricia (Provider user)
- Gender, Religious character and Urban or rural should not appear in Placement details on the index page.

## Link to Trello card

https://trello.com/c/aB1HgED5/715-provider-remove-religious-character-gender-and-urban-or-rural-fields-from-placements-index

## Screenshots

![screencapture-placements-localhost-3000-placements-2024-08-30-13_26_16](https://github.com/user-attachments/assets/5c16e8dd-31ec-4f05-b39e-d1a8d6d3e3ab)

