### PR TITLE
Add expected date filter

### DIFF
--- a/app/controllers/placements/placements_controller.rb
+++ b/app/controllers/placements/placements_controller.rb
@@ -9,6 +9,7 @@ class Placements::PlacementsController < Placements::ApplicationController
     @establishment_groups = compact_school_attribute_values(:group)
     @schools = schools_scope.order_by_name.select(:id, :name)
     @year_groups ||= Placement.year_groups_as_options
+    @terms = Placements::Term.order_by_term.select(:id, :name)
     scope = policy_scope(Placements::PlacementsQuery.call(params: query_params))
 
     @pagy, @placements = pagy(scope)
@@ -61,6 +62,7 @@ class Placements::PlacementsController < Placements::ApplicationController
       :only_partner_schools,
       school_ids: [],
       subject_ids: [],
+      term_ids: [],
       establishment_groups: [],
       year_groups: [],
     )

--- a/app/forms/placements/placements/filter_form.rb
+++ b/app/forms/placements/placements/filter_form.rb
@@ -4,6 +4,7 @@ class Placements::Placements::FilterForm < ApplicationForm
   attribute :school_ids, default: []
   attribute :subject_ids, default: []
   attribute :year_groups, default: []
+  attribute :term_ids, default: []
   attribute :placements_to_show, default: "available_placements"
   attribute :academic_year_id, default: Placements::AcademicYear.current.id
   attribute :only_partner_schools, :boolean, default: false
@@ -42,6 +43,7 @@ class Placements::Placements::FilterForm < ApplicationForm
       only_partner_schools:,
       placements_to_show:,
       academic_year_id:,
+      term_ids:,
     }
   end
 
@@ -51,6 +53,10 @@ class Placements::Placements::FilterForm < ApplicationForm
 
   def subjects
     @subjects ||= Subject.where(id: subject_ids).order_by_name
+  end
+
+  def terms
+    @terms ||= Placements::Term.where(id: term_ids).order_by_term
   end
 
   private

--- a/app/queries/placements/placements_query.rb
+++ b/app/queries/placements/placements_query.rb
@@ -2,13 +2,14 @@ class Placements::PlacementsQuery < ApplicationQuery
   MAX_LOCATION_DISTANCE = 50
 
   def call
-    scope = Placement.includes(:school, :subject, :additional_subjects, :academic_year, :provider)
+    scope = Placement.includes(:school, :subject, :additional_subjects, :academic_year, :terms, :provider)
 
     scope = school_condition(scope)
     scope = partner_school_condition(scope)
     scope = subject_condition(scope)
     scope = placements_to_show_condition(scope)
     scope = academic_year_condition(scope)
+    scope = term_condition(scope)
     scope = year_group_condition(scope)
     order_condition(scope)
   end
@@ -48,6 +49,14 @@ class Placements::PlacementsQuery < ApplicationQuery
 
   def academic_year_condition(scope)
     scope.where(academic_year_id: filter_params[:academic_year_id])
+  end
+
+  def term_condition(scope)
+    return scope if filter_params[:term_ids].blank?
+
+    scope.left_outer_joins(:terms)
+         .where(terms: { id: filter_params[:term_ids] })
+         .or(scope.where.missing(:terms))
   end
 
   def year_group_condition(scope)

--- a/app/views/placements/placements/_filter.html.erb
+++ b/app/views/placements/placements/_filter.html.erb
@@ -26,6 +26,26 @@
             </div>
           </div>
 
+          <% if filter_form.terms.present? %>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".terms") %></h3>
+            <ul class="app-filter-tags">
+              <% filter_form.terms.each do |term| %>
+                <li>
+                  <%= govuk_link_to(
+                        term.name,
+                        filter_form.index_path_without_filter(
+                          filter: "term_ids",
+                          value: term.id,
+                          search_location:,
+                        ),
+                        class: "app-filter__tag",
+                        no_visited_state: true,
+                      ) %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+
           <% if filter_form.subject_ids.present? %>
             <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".subject") %></h3>
             <ul class="app-filter-tags">
@@ -157,6 +177,21 @@
                 label: { text: @next_academic_year.display_name },
                 checked: filter_form.academic_year_id == @next_academic_year.id,
                 multiple: false %>
+            <% end %>
+          </div>
+
+          <div class="app-filter__option">
+            <%= form.govuk_check_boxes_fieldset(
+              :term_ids,
+              legend: { text: t(".terms"), size: "s" },
+              multiple: false,
+              small: true,
+            ) do %>
+              <% @terms.each do |term| %>
+                <%= form.govuk_check_box :term_ids,
+                                         term.id,
+                                         label: { text: term.name } %>
+              <% end %>
             <% end %>
           </div>
 

--- a/config/locales/en/placements/placements.yml
+++ b/config/locales/en/placements/placements.yml
@@ -16,6 +16,7 @@ en:
         location_search_example: For example, Sunderland or SR2
       filter:
         partner_schools: Partner schools
+        terms: Expected date
         only_show_partner_schools: Only show placements offered by my partner schools
         school: School
         subject: Subject

--- a/spec/factories/placements/terms.rb
+++ b/spec/factories/placements/terms.rb
@@ -9,7 +9,7 @@
 #
 FactoryBot.define do
   factory :placements_term, class: "Placements::Term" do
-    name { "Any time in the academic year" }
+    name { "Spring term" }
 
     trait :spring do
       name { "Spring term" }

--- a/spec/forms/placements/placements/filter_form_spec.rb
+++ b/spec/forms/placements/placements/filter_form_spec.rb
@@ -25,6 +25,14 @@ describe Placements::Placements::FilterForm, type: :model do
       end
     end
 
+    context "when given term id params" do
+      let(:params) { { term_ids: %w[term_id] } }
+
+      it "returns true" do
+        expect(filter_form).to be(true)
+      end
+    end
+
     context "when given year group params" do
       let(:params) { { year_groups: %w[year_group] } }
 
@@ -128,6 +136,27 @@ describe Placements::Placements::FilterForm, type: :model do
       end
     end
 
+    context "when removing term id params" do
+      let(:params) do
+        { term_ids: %w[term_id_1 term_id_2] }
+      end
+
+      it "returns the placements index page path without the given term id param" do
+        expect(
+          filter_form.index_path_without_filter(
+            filter: "term_ids",
+            value: "term_id_1",
+          ),
+        ).to eq(
+          placements_placements_path(filters: {
+            placements_to_show: "available_placements",
+            academic_year_id: current_academic_year.id,
+            term_ids: %w[term_id_2],
+          }),
+        )
+      end
+    end
+
     context "when removing year group params" do
       let(:params) do
         { year_groups: %w[year_group_1 year_group_2] }
@@ -159,6 +188,7 @@ describe Placements::Placements::FilterForm, type: :model do
           school_ids: [],
           only_partner_schools: false,
           subject_ids: [],
+          term_ids: [],
           year_groups: [],
         },
       )
@@ -182,6 +212,16 @@ describe Placements::Placements::FilterForm, type: :model do
       expect(
         described_class.new(subject_ids: subjects.pluck(:id)).subjects,
       ).to match_array(subjects)
+    end
+  end
+
+  describe "#terms" do
+    it "returns the terms associated with the term_id params given" do
+      terms = create_list(:placements_term, 2, :spring)
+
+      expect(
+        described_class.new(term_ids: terms.pluck(:id)).terms,
+      ).to match_array(terms)
     end
   end
 end


### PR DESCRIPTION
## Context

Now that expected date has been added, providers need to be able to filter for their desired terms

## Changes proposed in this pull request

- [x] Update `placement_terms` factory to use a valid default value
- [x] Add the `term_id` field to the filter form
- [x] Add the `term_condition` to the placements query
- [x] Add the filter UI to the placements index page
- [x] Update specs to test the functionality

## Guidance to review

- Log in as Patricia
- Navigate to the placements page
- Select a term from the Expected date filter
- Click on "Apply filters"
- Placements with that term, or "Any time in the academic year" will be visible
- Click on "Clear filters"
- All placements will now be visible

## Link to Trello card

[[Provider] Add expected date filter to placements index](https://trello.com/c/R2P0M8B6/713-provider-add-expected-date-filter-to-placements-index)

## Screenshots

![image](https://github.com/user-attachments/assets/79da0379-17a3-4d2c-ae6e-81af6953279a)
