### PR TITLE
Re-enable deployments to the QA environment

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        environment: [staging, sandbox] ## add future nonprod environments here
+        environment: [qa, staging, sandbox] ## add future nonprod environments here
     environment:
       name: ${{ matrix.environment }}
       url: ${{ steps.deploy.outputs.environment_url }}


### PR DESCRIPTION
Reverts DFE-Digital/itt-mentor-services#954

Deployments to the QA environment were temporarily disabled while an accessibility assessment was being carried out.

That assessment has now concluded, so we can re-enable deployments to the QA environment.