### PR TITLE
Redirect to organisations_path if current organisation is absent

### DIFF
--- a/app/controllers/placements/placements_controller.rb
+++ b/app/controllers/placements/placements_controller.rb
@@ -28,6 +28,8 @@ class Placements::PlacementsController < Placements::ApplicationController
   end
 
   def set_current_organisation
+    return redirect_to organisations_path if current_user.current_organisation.blank?
+
     @provider = current_user.current_organisation
   end
 

--- a/spec/requests/placements/providers/placements_spec.rb
+++ b/spec/requests/placements/providers/placements_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe "Placements", service: :placements, type: :request do
+  let(:provider) { build(:placements_provider) }
+  let(:current_user) { create(:placements_user, providers: [provider]) }
+
+  before do
+    sign_in_as current_user
+  end
+
+  describe "GET /placements" do
+    context "when an organisation is present" do
+      before do
+        get placements_placements_path
+      end
+
+      it "returns http success" do
+        expect(response).to have_http_status(:success)
+      end
+
+      it "renders the placements index page" do
+        expect(response).to render_template("placements/index")
+      end
+    end
+
+    context "when an organisation is not present" do
+      let(:dfe_sign_in_user_double) { instance_double(DfESignInUser) }
+
+      before do
+        allow(DfESignInUser).to receive(:new).and_return(dfe_sign_in_user_double)
+        allow(dfe_sign_in_user_double).to receive(:user).and_return(current_user)
+        allow(current_user).to receive(:current_organisation).and_return(nil)
+        get placements_placements_path
+      end
+
+      it "redirects the user to the organisations page if the current user does not have a current organisation" do
+        expect(response).to redirect_to placements_organisations_path
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We noticed a situation where a user with two accounts (or sharing a browser) could log out and be redirected back to a page they shouldn't be able to see. This was specifically occuring when a provider logged out and a school user logged in.

## Changes proposed in this pull request

- [x] Redirect to the organisations page if no organisation is present
- [x] Add a request spec to prove the functionality

## Guidance to review

- Log in as patricia
- Visit the placement page
- Log out
- Log in as Anne
- You should now see the school placements page

## Link to Trello card

[Redirect away from "/placements" if current organisation is not set
](https://trello.com/c/zf9X9KBB/722-redirect-away-from-placements-if-current-organisation-is-not-set)
