### PR TITLE
Add placement dates section to provider placements show page

### DIFF
--- a/app/components/placement/summary_component.html.erb
+++ b/app/components/placement/summary_component.html.erb
@@ -39,7 +39,7 @@
         <%= placement.academic_year.display_name %>
       </dd>
     </div>
-        <div class="app-result-detail__row">
+    <div class="app-result-detail__row">
       <dt class="app-result-detail__key">
         <%= t(".terms") %>
       </dt>

--- a/app/views/placements/placements/_placement_dates.html.erb
+++ b/app/views/placements/placements/_placement_dates.html.erb
@@ -1,0 +1,12 @@
+<%# locals: (school:, placement:) -%>
+<%= govuk_summary_list(actions: false) do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t(".academic_year")) %>
+    <% row.with_value(text: placement.academic_year.display_name) %>
+  <% end %>
+
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t(".terms")) %>
+    <% row.with_value(text: placement.term_names) %>
+  <% end %>
+<% end %>

--- a/app/views/placements/placements/_placement_details.html.erb
+++ b/app/views/placements/placements/_placement_details.html.erb
@@ -8,6 +8,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m govuk-!-margin-top-0">
+      <%= t(".itt_placement_dates") %>
+    </h2>
+    <%= render "placements/placements/placement_dates", school:, placement: %>
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-0">
       <%= t(".itt_placement_contact") %>
     </h2>
     <%= render "shared/schools/school_contact_details",

--- a/config/locales/en/placements/placements.yml
+++ b/config/locales/en/placements/placements.yml
@@ -35,12 +35,16 @@ en:
       placement_details:
         contact_details: Contact details
         itt_placement_contact: Placement contact
+        itt_placement_dates: Placement dates
         location: Location
         additional_details: Additional details
         placement: "Placement - %{school_name}"
       show:
         page_title: "%{subject_name} - Placements - %{school_name}"
         placement: "Placement - %{school_name}"
+      placement_dates:
+        academic_year: Academic year
+        terms: Expected date
       school_details:
         establishment_group: Establishment group
         school_phase: School phase

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -77,6 +77,7 @@ en:
             Before you add a placement, you must %{link_to} so that the teacher training providers can contact you.
           add_itt_placement_contact: add a placement contact
         show:
+          any_time: Any time in the academic year
           delete_placement: Delete placement
           preview_placement: You can %{href} as it appears to providers.
           preview_link: preview this placement

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -77,7 +77,6 @@ en:
             Before you add a placement, you must %{link_to} so that the teacher training providers can contact you.
           add_itt_placement_contact: add a placement contact
         show:
-          any_time: Any time in the academic year
           delete_placement: Delete placement
           preview_placement: You can %{href} as it appears to providers.
           preview_link: preview this placement

--- a/spec/system/placements/placements/view_a_placement_spec.rb
+++ b/spec/system/placements/placements/view_a_placement_spec.rb
@@ -27,8 +27,10 @@ RSpec.describe "Placements / Placements / View a placement",
   end
   let!(:subject_1) { create(:subject, name: "Biology") }
   let(:additional_subjects) { [] }
+  let(:academic_year) { create(:placements_academic_year).decorate }
+  let(:terms) { [create(:placements_term, :summer)] }
   let!(:placement) do
-    create(:placement, subject: placement_subject, school:, additional_subjects:)
+    create(:placement, subject: placement_subject, school:, additional_subjects:, academic_year:, terms:)
   end
 
   before { given_i_sign_in_as_patricia }
@@ -38,6 +40,7 @@ RSpec.describe "Placements / Placements / View a placement",
 
     scenario "User views a placement details" do
       when_i_visit_the_placement_show_page
+      then_i_see_the_placement_dates(academic_year, terms)
       then_i_see_details_for_the_school
       and_i_see_the_subject_name("Biology")
       and_i_see_the_itt_placement_contact_details_for_the_school
@@ -88,6 +91,16 @@ RSpec.describe "Placements / Placements / View a placement",
       expect(page).to have_link "Partner schools", current: "false"
       expect(page).to have_link "Users", current: "false"
       expect(page).to have_link "Organisation details", current: "false"
+    end
+  end
+
+  def then_i_see_the_placement_dates(academic_year, terms)
+    expect(page).to have_content("Placement dates")
+    expect(page).to have_content("Academic year")
+    expect(page).to have_content(academic_year.display_name)
+
+    terms.each do |term|
+      expect(page).to have_content(term.name)
     end
   end
 

--- a/spec/system/placements/placements/view_a_placement_spec.rb
+++ b/spec/system/placements/placements/view_a_placement_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Placements / Placements / View a placement",
   end
   let!(:subject_1) { create(:subject, name: "Biology") }
   let(:additional_subjects) { [] }
-  let(:academic_year) { create(:placements_academic_year).decorate }
+  let(:academic_year) { Placements::AcademicYear.current.decorate }
   let(:terms) { [create(:placements_term, :summer)] }
   let!(:placement) do
     create(:placement, subject: placement_subject, school:, additional_subjects:, academic_year:, terms:)


### PR DESCRIPTION
## Context

Placement dates (academic year and expect dates) are useful to the provider when looking for suitable placements.

## Changes proposed in this pull request

- Add the Placement dates section to the provider placement view.
- This section contains the academic year and expected date.
- Add specs to test this functionality.

## Guidance to review

- Login as Patricia
- View the list of placements
- Click through into any placement
- Review the placement dates section which should be the first section on the table
- It should include the academic year and the expected date

## Link to Trello card

https://trello.com/c/OzeTYcdi/716-provider-update-placements-show-page

## Screenshots

<img width="760" alt="Screenshot 2024-08-30 at 16 54 52" src="https://github.com/user-attachments/assets/1242a516-dbbd-4306-a51b-07c8c72e478d">
