### PR TITLE
Use `db:prepare:with_data` for database migrations

### DIFF
--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -47,7 +47,7 @@ resource "kubernetes_job" "migrations" {
           name    = "migrate"
           image   = var.docker_image
           command = ["bundle"]
-          args    = ["exec", "rails", "db:prepare", "data:migrate"]
+          args    = ["exec", "rails", "db:prepare:with_data"]
 
           env_from {
             config_map_ref {
@@ -102,7 +102,7 @@ resource "kubernetes_job" "migrations" {
 }
 
 module "web_application" {
-  source = "./vendor/modules/aks//aks/application"
+  source     = "./vendor/modules/aks//aks/application"
   depends_on = [kubernetes_job.migrations]
 
   is_web = true
@@ -124,7 +124,7 @@ module "web_application" {
 }
 
 module "worker_application" {
-  source = "./vendor/modules/aks//aks/application"
+  source     = "./vendor/modules/aks//aks/application"
   depends_on = [kubernetes_job.migrations]
 
   name    = "worker"


### PR DESCRIPTION
## Context

This was added in v9.4.2 of the `data_migrate` gem.

This should, in theory, be more effective when running migrations against existing environments. It's especially useful to use the `with_data` migration commands because it'll run schema changes and data changes sequentially in chronological order.

## Changes proposed in this pull request

Run data migrations in-line with schema migrations.
