### PR TITLE
Stop support users accessing non support path

### DIFF
--- a/app/components/placement/summary_component.html.erb
+++ b/app/components/placement/summary_component.html.erb
@@ -49,30 +49,6 @@
     </div>
     <div class="app-result-detail__row">
       <dt class="app-result-detail__key">
-        <%= t(".gender") %>
-      </dt>
-      <dd class="app-result-detail__value">
-        <%= school.gender %>
-      </dd>
-    </div>
-    <div class="app-result-detail__row">
-      <dt class="app-result-detail__key">
-        <%= t(".religious_character") %>
-      </dt>
-      <dd class="app-result-detail__value">
-        <%= school.religious_character %>
-      </dd>
-    </div>
-    <div class="app-result-detail__row">
-      <dt class="app-result-detail__key">
-        <%= t(".urban_or_rural") %>
-      </dt>
-      <dd class="app-result-detail__value">
-        <%= school.urban_or_rural %>
-      </dd>
-    </div>
-    <div class="app-result-detail__row">
-      <dt class="app-result-detail__key">
         <%= t(".ofsted_rating") %>
       </dt>
       <dd class="app-result-detail__value">

--- a/app/controllers/placements/application_controller.rb
+++ b/app/controllers/placements/application_controller.rb
@@ -20,10 +20,16 @@ class Placements::ApplicationController < ApplicationController
   private
 
   def authorize_support_user!
-    user_not_authorized if support_controller? && !current_user.support_user?
+    user_not_authorized if (support_controller? && !current_user.support_user?) ||
+      (!support_controller? && restricted_placements_controller? && current_user.support_user?)
   end
 
   def support_controller?
-    self.class.name.start_with? "Placements::Support::"
+    @support_controller ||= self.class.name.start_with? "Placements::Support::"
+  end
+
+  def restricted_placements_controller?
+    # All users should be able to access routes to the PagesController
+    !instance_of?(::Placements::PagesController)
   end
 end

--- a/app/controllers/placements/providers/partner_schools/placements_controller.rb
+++ b/app/controllers/placements/providers/partner_schools/placements_controller.rb
@@ -1,4 +1,5 @@
-class Placements::Providers::PartnerSchools::PlacementsController < ApplicationController
+class Placements::Providers::PartnerSchools::PlacementsController < Placements::ApplicationController
+  skip_after_action :verify_policy_scoped, only: %i[index]
   before_action :set_provider, only: %i[index show]
   before_action :set_partner_school, only: %i[index show]
 

--- a/spec/components/placement/summary_component_spec.rb
+++ b/spec/components/placement/summary_component_spec.rb
@@ -40,10 +40,7 @@ RSpec.describe Placement::SummaryComponent, type: :component do
       expect(page).to have_content("London Primary School", count: 2)
       expect(page).to have_content("All-through", count: 2)
       expect(page).to have_content("4 to 11", count: 2)
-      expect(page).to have_content("Mixed", count: 2)
       expect(page).to have_content("Local authority maintained schools", count: 2)
-      expect(page).to have_content("Jewish", count: 2)
-      expect(page).to have_content("(England/Wales) Urban city and town", count: 2)
       expect(page).to have_content("Good", count: 2)
 
       # Subject details

--- a/spec/requests/placements/user_authorization_spec.rb
+++ b/spec/requests/placements/user_authorization_spec.rb
@@ -1,0 +1,137 @@
+require "rails_helper"
+
+RSpec.describe "User authorization", service: :placements, type: :request do
+  let(:support_user) { create(:placements_support_user) }
+
+  let(:school) { create(:placements_school) }
+  let(:provider) { create(:placements_provider) }
+
+  let(:all_app_routes) do
+    Rails.application.routes.routes.collect { |route|
+      ActionDispatch::Routing::RouteWrapper.new route
+    }.reject(&:internal?)
+  end
+
+  let(:placements_routes) do
+    all_app_routes.select do |route|
+      route.controller&.include?("placements") &&
+        route.verb == "GET"
+    end
+  end
+
+  context "when visiting a pages route" do
+    let(:placements_pages_routes) do
+      placements_routes.select do |route|
+        route.controller&.include?("pages")
+      end
+    end
+
+    context "when the current user is a support user" do
+      before { sign_in_as support_user }
+
+      it "grants access" do
+        placements_pages_routes.each do |route|
+          get route.path.gsub("(.:format)", "")
+          expect(response).to have_http_status(:ok), "Could not load: #{route.path}"
+        end
+      end
+    end
+
+    context "when the current user is not a support user" do
+      let(:non_support_user) { create(:placements_user) }
+
+      before { sign_in_as non_support_user }
+
+      it "grants access" do
+        placements_pages_routes.each do |route|
+          get route.path.gsub("(.:format)", "")
+          expect(response).to have_http_status(:ok), "Could not load: #{route.path}"
+        end
+      end
+    end
+  end
+
+  context "when visiting a schools route" do
+    let(:placements_school_routes) do
+      placements_routes.select do |route|
+        route.controller&.include?("/schools/") &&
+          !route.controller&.include?("support") &&
+          route.action == "index"
+      end
+    end
+
+    context "when the current user is a support user" do
+      before { sign_in_as support_user }
+
+      it "denies access" do
+        placements_school_routes.each do |route|
+          get route.path.gsub("(.:format)", "").gsub(":school_id", school.id)
+          expect(response).not_to have_http_status(:ok), "Route loaded when it shouldn't have: #{path}"
+          expect(response.location).to eq(placements_root_url)
+          expect(flash[:alert]).to eq("You cannot perform this action")
+        end
+      end
+    end
+
+    context "when the current user is not support user" do
+      context "when associated with the school" do
+        let(:school_user) { create(:placements_user, schools: [school]) }
+
+        before { sign_in_as school_user }
+
+        it "grants access" do
+          placements_school_routes.each do |route|
+            get route.path.gsub("(.:format)", "").gsub(":school_id", school.id)
+            expect(response).to have_http_status(:ok), "Could not load: #{path}"
+          end
+        end
+      end
+    end
+
+    context "when visiting a provider route" do
+      let(:placements_provider_routes) do
+        placements_routes.select do |route|
+          route.controller&.include?("/providers/") &&
+            !route.controller&.include?("support") &&
+            route.action == "index"
+        end
+      end
+
+      context "when the current user is a support user" do
+        before { sign_in_as support_user }
+
+        it "denies access" do
+          placements_provider_routes.each do |route|
+            puts route.path
+            get route.path.gsub("(.:format)", "")
+              .gsub(":provider_id", provider.id)
+              .gsub(":partner_school_id", school.id)
+            expect(response).not_to have_http_status(:ok), "Route loaded when it shouldn't have: #{path}"
+            expect(response.location).to eq(placements_root_url)
+            expect(flash[:alert]).to eq("You cannot perform this action")
+          end
+        end
+      end
+
+      context "when the current user is not support user" do
+        context "when associated with the school" do
+          let(:provider_user) { create(:placements_user, providers: [provider]) }
+
+          before do
+            sign_in_as provider_user
+            create(:placements_partnership, school:, provider:)
+          end
+
+          it "grants access" do
+            placements_provider_routes.each do |route|
+              get route.path.gsub("(.:format)", "")
+                .gsub(":provider_id", provider.id)
+                .gsub(":partner_school_id", school.id)
+              expect(response).to have_http_status(:ok), "Could not load: #{path}"
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

- Prevent support users from accessing non-support user pages

## Changes proposed in this pull request

- Add additional conditions for preventing support users access non-support pages `authorize_support_user!`

## Guidance to review

- Sign in as Colin (Support User)
- Visit a non-support URL
- You will be redirected page with a message "You cannot perform this action"

## Link to Trello card

https://trello.com/c/tQ5JE1d2/721-stop-support-users-from-accessing-non-support-paths
