### PR TITLE
Fix maintenance page temp ingress url

### DIFF
--- a/terraform/application/config/production_app_env.yml
+++ b/terraform/application/config/production_app_env.yml
@@ -4,12 +4,12 @@ HOSTING_ENV: production
 # Primary hostname for the Funding Mentors service
 CLAIMS_HOST: claim-funding-for-mentor-training.education.gov.uk
 # Additional hostnames that may be used – e.g. the CDN origin (comma separated)
-CLAIMS_HOSTS: claim-funding-for-mentor-training.education.gov.uk,track-and-pay-production.teacherservices.cloud,track-and-pay-tmp.teacherservices.cloud
+CLAIMS_HOSTS: claim-funding-for-mentor-training.education.gov.uk,track-and-pay-production.teacherservices.cloud,track-and-pay-temp.teacherservices.cloud
 
 # Primary hostname for the School Placements service
 PLACEMENTS_HOST: manage-school-placements.education.gov.uk
 # Additional hostnames that may be used – e.g. the CDN origin (comma separated)
-PLACEMENTS_HOSTS: manage-school-placements.education.gov.uk,manage-school-placements-production.teacherservices.cloud,manage-school-placements-tmp.teacherservices.cloud
+PLACEMENTS_HOSTS: manage-school-placements.education.gov.uk,manage-school-placements-production.teacherservices.cloud,manage-school-placements-temp.teacherservices.cloud
 
 # API integrations
 GIAS_CSV_BASE_URL: https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public

--- a/terraform/application/config/staging_app_env.yml
+++ b/terraform/application/config/staging_app_env.yml
@@ -5,12 +5,12 @@ SKYLIGHT_ENV: staging
 # Primary hostname for the Funding Mentors service
 CLAIMS_HOST: staging.claim-funding-for-mentor-training.education.gov.uk
 # Additional hostnames that may be used – e.g. the CDN origin (comma separated)
-CLAIMS_HOSTS: staging.claim-funding-for-mentor-training.education.gov.uk,track-and-pay-staging.test.teacherservices.cloud,track-and-pay-tmp.test.teacherservices.cloud
+CLAIMS_HOSTS: staging.claim-funding-for-mentor-training.education.gov.uk,track-and-pay-staging.test.teacherservices.cloud,track-and-pay-temp.test.teacherservices.cloud
 
 # Primary hostname for the School Placements service
 PLACEMENTS_HOST: staging.manage-school-placements.education.gov.uk
 # Additional hostnames that may be used – e.g. the CDN origin (comma separated)
-PLACEMENTS_HOSTS: staging.manage-school-placements.education.gov.uk,manage-school-placements-staging.test.teacherservices.cloud,manage-school-placements-tmp.test.teacherservices.cloud
+PLACEMENTS_HOSTS: staging.manage-school-placements.education.gov.uk,manage-school-placements-staging.test.teacherservices.cloud,manage-school-placements-temp.test.teacherservices.cloud
 
 # API integrations
 GIAS_CSV_BASE_URL: https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public


### PR DESCRIPTION
## Context

maintenance page temp ingress is incorrectly listed as -tmp instead of -temp in app env

## Changes proposed in this pull request

Update CLAIMS_HOSTS and PLACEMENTS_HOSTS in staging & production app_env.yml

## Guidance to review

Check it matches the path in maintenance_page/manifests/env/ingress_temp*
make staging terraform-plan
make production terraform-plan

## Link to Trello card

https://trello.com/c/YdpEced1/2007-fix-maintenance-temp-ingress
