### PR TITLE
Add status and type of establishment headers and outputs to CSV

### DIFF
--- a/app/services/claims/claim/generate_csv.rb
+++ b/app/services/claims/claim/generate_csv.rb
@@ -1,7 +1,7 @@
 require "csv"
 
 class Claims::Claim::GenerateCSV < ApplicationService
-  HEADERS = %w[claim_reference urn school_name local_authority claim_amount establishment_type date_submitted].freeze
+  HEADERS = %w[claim_reference urn school_name local_authority claim_amount type_of_establishment establishment_type date_submitted claim_status].freeze
 
   def initialize(claims:)
     @claims = claims
@@ -18,8 +18,10 @@ class Claims::Claim::GenerateCSV < ApplicationService
           claim.school.name,
           claim.school.local_authority_name,
           claim.amount.format(symbol: false, decimal_mark: ".", no_cents: false),
+          claim.school.type_of_establishment,
           claim.school.group,
           claim.submitted_at&.iso8601,
+          claim.status,
         ]
       end
     end

--- a/spec/services/claims/claim/generate_csv_spec.rb
+++ b/spec/services/claims/claim/generate_csv_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Claims::Claim::GenerateCSV do
   let(:claims) { Claims::Claim.all }
 
   before do
-    school1 = create(:claims_school, :claims, name: "School name 1", region: regions(:inner_london), urn: "1234", local_authority_name: "blah", local_authority_code: "BLA", group: "Academy")
-    school2 = create(:claims_school, :claims, name: "School name 2", region: regions(:outer_london), urn: "5678", local_authority_name: "blah", local_authority_code: "BLA", group: "Academy")
-    school3 = create(:claims_school, :claims, name: "School name 3", region: regions(:fringe), urn: "5679", local_authority_name: "blah", local_authority_code: "BLA", group: "Academy")
+    school1 = create(:claims_school, :claims, name: "School name 1", region: regions(:inner_london), urn: "1234", local_authority_name: "blah", local_authority_code: "BLA", type_of_establishment: "Academy converter", group: "Academy")
+    school2 = create(:claims_school, :claims, name: "School name 2", region: regions(:outer_london), urn: "5678", local_authority_name: "blah", local_authority_code: "BLA", type_of_establishment: "Academy converter", group: "Academy")
+    school3 = create(:claims_school, :claims, name: "School name 3", region: regions(:fringe), urn: "5679", local_authority_name: "blah", local_authority_code: "BLA", type_of_establishment: "Academy converter", group: "Academy")
 
     claim1 = create(:claim, status: :submitted, submitted_at: Time.zone.local(2023, 8, 29, 22, 35, 0), school: school1, reference: "12345678")
     claim2 = create(:claim, status: :submitted, submitted_at: Time.zone.local(2023, 8, 29, 22, 35, 0), school: school2, reference: "12345679")
@@ -33,17 +33,17 @@ RSpec.describe Claims::Claim::GenerateCSV do
   end
 
   it "inserts the correct headers" do
-    expect(generate_claims_csv.lines.first.chomp).to eq("claim_reference,urn,school_name,local_authority,claim_amount,establishment_type,date_submitted")
+    expect(generate_claims_csv.lines.first.chomp).to eq("claim_reference,urn,school_name,local_authority,claim_amount,type_of_establishment,establishment_type,date_submitted,claim_status")
   end
 
   it "contains all claims" do
     expect(generate_claims_csv.lines.sort).to eq([
-      "claim_reference,urn,school_name,local_authority,claim_amount,establishment_type,date_submitted\n",
-      "12345670,5679,School name 3,blah,45.10,Academy,\n",
-      "12345671,5679,School name 3,blah,90.20,Academy,2023-08-29T22:35:00Z\n",
-      "12345677,5679,School name 3,blah,676.50,Academy,2023-08-29T22:35:00Z\n",
-      "12345678,1234,School name 1,blah,536.00,Academy,2023-08-29T22:35:00Z\n",
-      "12345679,5678,School name 2,blah,482.50,Academy,2023-08-29T22:35:00Z\n",
+      "claim_reference,urn,school_name,local_authority,claim_amount,type_of_establishment,establishment_type,date_submitted,claim_status\n",
+      "12345670,5679,School name 3,blah,45.10,Academy converter,Academy,,draft\n",
+      "12345671,5679,School name 3,blah,90.20,Academy converter,Academy,2023-08-29T22:35:00Z,submitted\n",
+      "12345677,5679,School name 3,blah,676.50,Academy converter,Academy,2023-08-29T22:35:00Z,submitted\n",
+      "12345678,1234,School name 1,blah,536.00,Academy converter,Academy,2023-08-29T22:35:00Z,submitted\n",
+      "12345679,5678,School name 2,blah,482.50,Academy converter,Academy,2023-08-29T22:35:00Z,submitted\n",
     ].sort)
   end
 end


### PR DESCRIPTION
## Context

ESFA has requested the type_of_establishment of each school in order to assist lookup the bank details of a School. If a school belongs to a local authority, their payment will go there.

The status field is required for ESFA to confirm that they have received Claims that are all in the correct status.

## Changes proposed in this pull request

- Add the type_of_establishment field from School the Claims::Claim::GenerateCSV output.
- Add the status of the Claim to the Claims::Claim::GenerateCSV service.

## Guidance to review

- Log in as a school user and create a new claim.
- Log out and log in as support user Colin.
- Click on the claims tab.
- Press 'Download CSV' in the top-left corner of the claims index page.
- Review the resulting CSV file.

## Link to Trello card

https://trello.com/c/drfnuwOA/741-add-typeofestablishment-and-status-to-claims-csv-download

## Screenshots

<img width="690" alt="Screenshot 2024-09-03 at 14 53 05" src="https://github.com/user-attachments/assets/26bb227a-c9d5-4c67-9a8f-f556ed3d3627">