### PR TITLE
Re-order terms names to Autumn -> Spring -> Summer

### DIFF
--- a/app/models/placements/term.rb
+++ b/app/models/placements/term.rb
@@ -16,9 +16,9 @@ class Placements::Term < ApplicationRecord
   scope :order_by_term, lambda {
     order(Arel.sql("
       CASE
-        WHEN name = '#{SUMMER_TERM}' THEN '1'
+        WHEN name = '#{AUTUMN_TERM}' THEN '1'
         WHEN name = '#{SPRING_TERM}' THEN '2'
-        WHEN name = '#{AUTUMN_TERM}' THEN '3'
+        WHEN name = '#{SUMMER_TERM}' THEN '3'
       END
     "))
   }

--- a/spec/decorators/placement_decorator_spec.rb
+++ b/spec/decorators/placement_decorator_spec.rb
@@ -134,12 +134,12 @@ RSpec.describe PlacementDecorator do
     context "when the placement has multiple terms" do
       it "returns a list of term names" do
         placement = create(:placement)
-        term1 = create(:placements_term, :autumn)
-        term2 = create(:placements_term, :spring)
+        term1 = create(:placements_term, :spring)
+        term2 = create(:placements_term, :autumn)
         placement.terms << term1
         placement.terms << term2
 
-        expect(placement.decorate.term_names).to eq("Spring term, Autumn term")
+        expect(placement.decorate.term_names).to eq("Autumn term, Spring term")
       end
     end
   end

--- a/spec/models/placements/term_spec.rb
+++ b/spec/models/placements/term_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Placements::Term, type: :model do
       let!(:spring_term) { create(:placements_term, :spring) }
       let!(:summer_term) { create(:placements_term, :summer) }
 
-      it "returns a collection of terms, in the order of Summer, Spring, Autumn" do
+      it "returns a collection of terms, in the order of Autumn, Spring, Summer" do
         expect(described_class.order_by_term).to eq([autumn_term, spring_term, summer_term])
       end
     end

--- a/spec/models/placements/term_spec.rb
+++ b/spec/models/placements/term_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Placements::Term, type: :model do
       let!(:summer_term) { create(:placements_term, :summer) }
 
       it "returns a collection of terms, in the order of Summer, Spring, Autumn" do
-        expect(described_class.order_by_term).to eq([summer_term, spring_term, autumn_term])
+        expect(described_class.order_by_term).to eq([autumn_term, spring_term, summer_term])
       end
     end
   end

--- a/spec/wizards/placements/add_placement_wizard/terms_step_spec.rb
+++ b/spec/wizards/placements/add_placement_wizard/terms_step_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Placements::AddPlacementWizard::TermsStep, type: :model do
 
     it "returns mentors for the school, ordered by name" do
       expect(step.terms_for_selection).to eq([
-        summer_term, spring_term, autumn_term
+        autumn_term, spring_term, summer_term
       ])
     end
   end
@@ -46,7 +46,7 @@ RSpec.describe Placements::AddPlacementWizard::TermsStep, type: :model do
 
       it "returns the names of the terms as a string" do
         expect(step.term_names).to eq(
-          "#{summer_term.name}, #{spring_term.name}, #{autumn_term.name}",
+          "#{autumn_term.name}, #{spring_term.name}, #{summer_term.name}",
         )
       end
     end

--- a/spec/wizards/placements/add_placement_wizard/terms_step_spec.rb
+++ b/spec/wizards/placements/add_placement_wizard/terms_step_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Placements::AddPlacementWizard::TermsStep, type: :model do
       autumn_term
     end
 
-    it "returns mentors for the school, ordered by name" do
+    it "returns all terms in order" do
       expect(step.terms_for_selection).to eq([
         autumn_term, spring_term, summer_term
       ])


### PR DESCRIPTION
## Context

Currently they’re being displayed in the reverse order. The order should be updated to match [the prototype](https://bat-school-placements-18b07385d8a1.herokuapp.com/school-users/v3/add-placement-window).

## Changes proposed in this pull request

- Change the term order
- Update specs to reflect the change in order

## Guidance to review

- Log in as Anne/Colin
- Add a placement, check that the terms are now Autumn -> Spring -> Summer
- Edit the placment
- check that the terms are now Autumn -> Spring -> Summer

- Log in as Patricia
- Navigate to the placements page
- Check that the expected date filter is Autumn -> Spring -> Summer

## Link to Trello card

[Fix the sort order of placement terms
](https://trello.com/c/4CBv1lHL/749-fix-the-sort-order-of-placement-terms)

## Screenshots

Anne:
![image](https://github.com/user-attachments/assets/0ed7681b-368c-4d54-9b34-416aff0e6c73)

Colin:
![image](https://github.com/user-attachments/assets/64cdfca8-03d0-4c4b-a377-f79d327653d3)

Patricia:
![image](https://github.com/user-attachments/assets/542a318f-bad9-422b-8254-318f9aa64c65)

