### PR TITLE
Remove duplicated caption

### DIFF
--- a/app/views/placements/wizards/add_mentor_wizard/_check_your_answers_step.html.erb
+++ b/app/views/placements/wizards/add_mentor_wizard/_check_your_answers_step.html.erb
@@ -1,3 +1,4 @@
+<% caption = current_user.support_user? ? "#{t(".add_mentor")} #{contextual_text}" : t(".add_mentor") %>
 <% content_for :page_title, t(".page_title", contextual_text:) %>
 
 <div class="govuk-width-container">
@@ -5,7 +6,7 @@
     <div class="govuk-grid-column-two-thirds">
       <%= form_with(model: check_your_answers_step, url: current_step_path, method: :put) do |f| %>
         <label class="govuk-label govuk-label--l">
-          <span class="govuk-caption-l"><%= t(".add_mentor_caption", contextual_text:) %></span>
+          <span class="govuk-caption-l"><%= caption %></span>
           <%= t(".check_your_answers") %>
         </label>
 

--- a/config/locales/en/placements/wizards/add_mentor_wizard.yml
+++ b/config/locales/en/placements/wizards/add_mentor_wizard.yml
@@ -5,7 +5,6 @@ en:
         mentor_step:
           page_title: Find teacher - %{contextual_text}
           page_title_with_error: "Error: %{error} - %{contextual_text}"
-          add_mentor_caption: "%{contextual_text}"
           caption: Mentor details
           cancel: Cancel
           continue: Continue
@@ -20,7 +19,6 @@ en:
           date_of_birth_hint: For example, 31 3 1980
         check_your_answers_step:
           page_title: Check your answers - Add mentor - %{contextual_text}
-          add_mentor_caption: Add mentor %{contextual_text}
           add_mentor: Add mentor
           cancel: Cancel
           change: Change


### PR DESCRIPTION
## Context

This is a 🐛 

## Changes proposed in this pull request

- [x] Remove the duplicated caption

## Guidance to review

School journey:
- Log in as Anne
- Add a mentor
- Enter mentor details: 1234565, 09 01 1991
- Click continue
- Caption should read "Add mentor"

Support journey:
- Log in as Colin
- Select a school
- Add a mentor
- Enter mentor details: 1234565, 09 01 1991
- Click continue
- Caption should read "Add mentor - <school name>"

## Link to Trello card

[Remove duplicate Add Mentor page caption](https://trello.com/c/JthFlmEa/760-remove-duplicate-add-mentor-page-caption)

## Screenshots

Support
![image](https://github.com/user-attachments/assets/1f6ee6bb-cb8a-48ec-8810-5faa9cf2a834)

School
![image](https://github.com/user-attachments/assets/ea0f4107-3b22-44e2-bb76-b553dc0bb724)
