### PR TITLE
Add placement uncheck default checkboxes

### DIFF
--- a/app/views/placements/wizards/add_placement_wizard/_mentors_step.html.erb
+++ b/app/views/placements/wizards/add_placement_wizard/_mentors_step.html.erb
@@ -15,7 +15,7 @@
             <%= f.govuk_check_box :mentor_ids, mentor.id, label: { text: mentor.full_name }, link_errors: index.zero? %>
           <% end %>
           <%= f.govuk_check_box_divider %>
-          <%= f.govuk_check_box :mentor_ids, "not_known", label: { text: t(".not_known") }, checked: mentors_step.mentors.empty?, exclusive: true %>
+          <%= f.govuk_check_box :mentor_ids, "not_known", label: { text: t(".not_known") }, checked: mentors_step.mentor_ids.include?("not_known"), exclusive: true %>
         <% end %>
 
         <%= govuk_details(

--- a/app/views/placements/wizards/add_placement_wizard/_terms_step.erb
+++ b/app/views/placements/wizards/add_placement_wizard/_terms_step.erb
@@ -15,7 +15,7 @@
             <%= f.govuk_check_box :term_ids, term.id, label: { text: term.name }, link_errors: index.zero? %>
           <% end %>
           <%= f.govuk_check_box_divider %>
-          <%= f.govuk_check_box :term_ids, "any_term", label: { text: t(".any_term") }, checked: terms_step.terms.empty?, exclusive: true %>
+          <%= f.govuk_check_box :term_ids, "any_term", label: { text: t(".any_term") }, checked: terms_step.term_ids.include?("any_term"), exclusive: true %>
         <% end %>
 
         <%= f.govuk_submit t(".continue") %>

--- a/spec/support/shared_examples/system/placements/add_a_placement_wizard.rb
+++ b/spec/support/shared_examples/system/placements/add_a_placement_wizard.rb
@@ -213,6 +213,47 @@ RSpec.shared_examples "an add a placement wizard" do
           end
         end
 
+        context "when I view a page with checkboxes" do
+          context "when I view the terms step" do
+            it "when I first visit the page" do
+              when_i_visit_the_placements_page
+              and_i_click_on("Add placement")
+              then_i_see_the_add_a_placement_subject_page(school.phase)
+              when_i_choose_a_subject(subject_1.name)
+              and_i_click_on("Continue")
+              then_i_see_the_add_year_group_page("Year 1")
+              when_i_choose_a_year_group("Year 1")
+              and_i_click_on("Continue")
+              then_i_see_the_academic_year_page
+              when_i_choose_an_academic_year(current_academic_year.name)
+              and_i_click_on("Continue")
+              then_i_see_the_add_a_term_page
+              then_no_terms_checkboxes_are_checked
+            end
+          end
+
+          context "when I view the mentor step" do
+            it "when I first visit the page" do
+              when_i_visit_the_placements_page
+              and_i_click_on("Add placement")
+              then_i_see_the_add_a_placement_subject_page(school.phase)
+              when_i_choose_a_subject(subject_1.name)
+              and_i_click_on("Continue")
+              then_i_see_the_add_year_group_page("Year 1")
+              when_i_choose_a_year_group("Year 1")
+              and_i_click_on("Continue")
+              then_i_see_the_academic_year_page
+              when_i_choose_an_academic_year(current_academic_year.name)
+              and_i_click_on("Continue")
+              then_i_see_the_add_a_term_page
+              when_i_check_a_term(summer_term.name)
+              and_i_click_on("Continue")
+              then_i_see_the_add_a_placement_mentor_page
+              then_no_mentor_checkboxes_are_checked
+            end
+          end
+        end
+
         context "when I've checked my answers and I click on change" do
           it "when I do not enter valid options" do
             when_i_visit_the_placements_page
@@ -932,6 +973,19 @@ RSpec.shared_examples "an add a placement wizard" do
 
   def then_my_chosen_academic_year_is_selected(academic_year_name)
     expect(page).to have_checked_field("This academic year (#{academic_year_name})")
+  end
+
+  def then_no_terms_checkboxes_are_checked
+    expect(page).not_to have_checked_field("Any time in the academic year")
+    expect(page).not_to have_checked_field(summer_term.name)
+    expect(page).not_to have_checked_field(spring_term.name)
+    expect(page).not_to have_checked_field(autumn_term.name)
+  end
+
+  def then_no_mentor_checkboxes_are_checked
+    expect(page).not_to have_checked_field(mentor_1.full_name)
+    expect(page).not_to have_checked_field(mentor_2.full_name)
+    expect(page).not_to have_checked_field("Not yet known")
   end
 
   alias_method :and_i_click_on, :when_i_click_on

--- a/spec/support/shared_examples/system/placements/add_a_placement_wizard.rb
+++ b/spec/support/shared_examples/system/placements/add_a_placement_wizard.rb
@@ -213,47 +213,6 @@ RSpec.shared_examples "an add a placement wizard" do
           end
         end
 
-        context "when I view a page with checkboxes" do
-          context "when I view the terms step" do
-            it "when I first visit the page" do
-              when_i_visit_the_placements_page
-              and_i_click_on("Add placement")
-              then_i_see_the_add_a_placement_subject_page(school.phase)
-              when_i_choose_a_subject(subject_1.name)
-              and_i_click_on("Continue")
-              then_i_see_the_add_year_group_page("Year 1")
-              when_i_choose_a_year_group("Year 1")
-              and_i_click_on("Continue")
-              then_i_see_the_academic_year_page
-              when_i_choose_an_academic_year(current_academic_year.name)
-              and_i_click_on("Continue")
-              then_i_see_the_add_a_term_page
-              then_no_terms_checkboxes_are_checked
-            end
-          end
-
-          context "when I view the mentor step" do
-            it "when I first visit the page" do
-              when_i_visit_the_placements_page
-              and_i_click_on("Add placement")
-              then_i_see_the_add_a_placement_subject_page(school.phase)
-              when_i_choose_a_subject(subject_1.name)
-              and_i_click_on("Continue")
-              then_i_see_the_add_year_group_page("Year 1")
-              when_i_choose_a_year_group("Year 1")
-              and_i_click_on("Continue")
-              then_i_see_the_academic_year_page
-              when_i_choose_an_academic_year(current_academic_year.name)
-              and_i_click_on("Continue")
-              then_i_see_the_add_a_term_page
-              when_i_check_a_term(summer_term.name)
-              and_i_click_on("Continue")
-              then_i_see_the_add_a_placement_mentor_page
-              then_no_mentor_checkboxes_are_checked
-            end
-          end
-        end
-
         context "when I've checked my answers and I click on change" do
           it "when I do not enter valid options" do
             when_i_visit_the_placements_page
@@ -281,7 +240,7 @@ RSpec.shared_examples "an add a placement wizard" do
             and_i_click_on("Continue")
 
             # Term error
-            when_i_uncheck("Any time in the academic year")
+            then_i_see_the_add_a_term_page
             and_i_click_on("Continue")
             and_i_see_the_error_message("Select a term or any time in the academic year")
             when_i_check_a_term(summer_term.name)
@@ -289,9 +248,11 @@ RSpec.shared_examples "an add a placement wizard" do
 
             # Mentor error
             then_i_see_the_add_a_placement_mentor_page
-            when_i_uncheck("Not yet known")
             when_i_click_on("Continue")
             and_i_see_the_error_message("Select a mentor or not yet known")
+            when_i_check_a_mentor(mentor_1.full_name)
+            and_i_click_on("Continue")
+            then_i_see_the_check_your_answers_page(school.phase, mentor_1, summer_term.name)
           end
         end
 
@@ -864,7 +825,6 @@ RSpec.shared_examples "an add a placement wizard" do
   end
 
   def when_i_check_a_term(term_name)
-    uncheck "Any time in the academic year"
     check term_name
   end
 
@@ -881,7 +841,6 @@ RSpec.shared_examples "an add a placement wizard" do
   end
 
   def when_i_check_a_mentor(mentor_name)
-    uncheck "Not yet known"
     check mentor_name
   end
 
@@ -951,10 +910,6 @@ RSpec.shared_examples "an add a placement wizard" do
     end
   end
 
-  def when_i_uncheck(text)
-    uncheck(text)
-  end
-
   def then_i_see_the_preview_page(phase:, subject:)
     expect(page).to have_content("This is a preview of how your placement will appear to teacher training providers.")
     expect(page).to have_content(phase)
@@ -973,19 +928,6 @@ RSpec.shared_examples "an add a placement wizard" do
 
   def then_my_chosen_academic_year_is_selected(academic_year_name)
     expect(page).to have_checked_field("This academic year (#{academic_year_name})")
-  end
-
-  def then_no_terms_checkboxes_are_checked
-    expect(page).not_to have_checked_field("Any time in the academic year")
-    expect(page).not_to have_checked_field(summer_term.name)
-    expect(page).not_to have_checked_field(spring_term.name)
-    expect(page).not_to have_checked_field(autumn_term.name)
-  end
-
-  def then_no_mentor_checkboxes_are_checked
-    expect(page).not_to have_checked_field(mentor_1.full_name)
-    expect(page).not_to have_checked_field(mentor_2.full_name)
-    expect(page).not_to have_checked_field("Not yet known")
   end
 
   alias_method :and_i_click_on, :when_i_click_on


### PR DESCRIPTION
## Context

Expected UI behaviour.

## Changes proposed in this pull request

- [x] Change default checkbox logic to have no options selected on first page load.

## Guidance to review

School user:
- Log in as Anne
- Add a placement
- Verify that steps with checkboxes are not checked before you select an option
- Select the last option (Any time in the academic year/Not yet know)
- Navigate to Check your answers
- Change the terms/mentors and confirm that your selection is checked.

Support user:
- Log in as Colin
- Select a school
- Add a placement
- Verify that steps with checkboxes are not checked before you select an option
- Select the last option (Any time in the academic year/Not yet know)
- Navigate to Check your answers
- Change the terms/mentors and confirm that your selection is checked.

## Link to Trello card

['Add placement' wizard → checkboxes should be unchecked by default](https://trello.com/c/Dm5fbL0T/750-add-placement-wizard-%E2%86%92-checkboxes-should-be-unchecked-by-default)

## Screenshots

![image](https://github.com/user-attachments/assets/905784e0-7ff0-41b9-933c-50169ef2a7a9)
![image](https://github.com/user-attachments/assets/01b46cba-f72f-4c6f-bf81-ff4ed984ad6f)
