### PR TITLE
DateAttributes should return nil when all date components are nil

### DIFF
--- a/app/forms/concerns/date_attributes.rb
+++ b/app/forms/concerns/date_attributes.rb
@@ -30,9 +30,9 @@ module DateAttributes
       define_method attribute_name do
         year, month, day = %w[year month day].map { |date_part| send("#{attribute_name}_#{date_part}") }
 
-        if year.present? && month.present? && day.present?
+        if [year, month, day].all?(&:present?)
           Date.new(year.to_i, month.to_i, day.to_i)
-        else
+        elsif [year, month, day].any?(&:present?)
           IncompleteDate.new(year, month, day)
         end
       end

--- a/spec/forms/application_form_spec.rb
+++ b/spec/forms/application_form_spec.rb
@@ -150,6 +150,10 @@ RSpec.describe ApplicationForm do
 
         expect(example_form.date_of_birth).to eq(DateAttributes::IncompleteDate.new(2024, 5, nil))
       end
+
+      it "returns nil if all of the date components are missing" do
+        expect(example_form.date_of_birth).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

Date attributes are returning empty `IncompleteDate` objects when all date components are `nil`. This causes some strange behaviours, such as the the `Claims::ClaimWindowForm#initialize` method not setting the date attributes as they are not `nil`, they are `IncompleteDate` objects by default.

## Changes proposed in this pull request

- A date attribute will return `nil` when all date components are `nil` instead of an `IncompleteDate` with all components as `nil`.

## Guidance to review

- Try editing a claim window.
- The date should now be pre-populated.

## Screenshots

| Before | After |
| ------ | ----- |
| ![CleanShot 2024-09-04 at 11 20 54](https://github.com/user-attachments/assets/cbf48e5a-2278-4341-a3af-2c2a7a67a635) | ![CleanShot 2024-09-04 at 11 21 27](https://github.com/user-attachments/assets/da312654-3e0c-4059-a9de-f0ab34d07531) |
