### PR TITLE
Update claim confirmation content to latest dates

### DIFF
--- a/config/locales/en/claims/schools/claims.yml
+++ b/config/locales/en/claims/schools/claims.yml
@@ -6,7 +6,7 @@ en:
           page_title: Claim submitted
           claim_submitted: Claim submitted
           processing_your_claim: Processing your claim
-          processing_your_claim_guidance: We will process this claim at the end of July 2024 and all payments will be paid from September 2024.
+          processing_your_claim_guidance: We will process this claim at the end of September 2024 and all payments will be paid from December 2024..
           give_us_feedback: Give us feedback
           what_do_you_think: What do you think of this service? (opens in a new tab)
           feedback_link_html: "%{feedback_link}"

--- a/spec/system/claims/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/schools/claims/create_claim_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe "Create claim", service: :claims, type: :system do
     expect(page).to have_content("We have emailed you a copy of your claim.")
     expect(page).to have_content("This claim will be shared with #{claim.provider_name}.")
     expect(page).to have_content("We will check your claim before processing payment. If we need to contact you for further information, we will use the email you used to access this service.")
-    expect(page).to have_content("We will process this claim at the end of July 2024 and all payments will be paid from September 2024.")
+    expect(page).to have_content("We will process this claim at the end of September 2024 and all payments will be paid from December 2024.")
   end
 
   def then_i_expect_the_training_hours_for(hours, mentor)


### PR DESCRIPTION
## Context

We need to update the confirmation content with updated dates for the new claim window.

## Changes proposed in this pull request

- Update the content of the claim confirmation page to be accurate with the upcoming claim window's payment dates.

## Guidance to review

- Content on the claim confirmation page should show "December 2024" as the expected payment dates.