### PR TITLE
Create training allowance object

### DIFF
--- a/app/models/claims/training_allowance.rb
+++ b/app/models/claims/training_allowance.rb
@@ -1,8 +1,9 @@
 class Claims::TrainingAllowance
-  def initialize(mentor:, provider:, academic_year:)
+  def initialize(mentor:, provider:, academic_year:, claim_to_exclude: nil)
     @mentor = mentor
     @provider = provider
     @academic_year = academic_year
+    @claim_to_exclude = claim_to_exclude
   end
 
   def training_type
@@ -16,6 +17,9 @@ class Claims::TrainingAllowance
       6
     end
   end
+
+  def remaining_hours
+    total_hours - hours_completed
   end
 
   private

--- a/app/models/claims/training_allowance.rb
+++ b/app/models/claims/training_allowance.rb
@@ -11,7 +11,7 @@ class Claims::TrainingAllowance
   end
 
   def total_hours
-    training_type == INITIAL_TRAINING ? 20 : 6
+    training_type == INITIAL_TRAINING ? INITIAL_TRAINING_HOURS : REFRESHER_TRAINING_HOURS
   end
 
   def remaining_hours
@@ -27,9 +27,12 @@ class Claims::TrainingAllowance
   attr_reader :mentor, :provider, :academic_year, :claim_to_exclude
 
   INITIAL_TRAINING = :initial
+  INITIAL_TRAINING_HOURS = 20
   REFRESHER_TRAINING = :refresher
+  REFRESHER_TRAINING_HOURS = 6
 
-  private_constant :INITIAL_TRAINING, :REFRESHER_TRAINING
+  private_constant :INITIAL_TRAINING, :INITIAL_TRAINING_HOURS, :REFRESHER_TRAINING,
+                   :REFRESHER_TRAINING_HOURS
 
   def mentor_training_scope
     @mentor_training_scope ||= provider.mentor_trainings

--- a/app/models/claims/training_allowance.rb
+++ b/app/models/claims/training_allowance.rb
@@ -7,15 +7,11 @@ class Claims::TrainingAllowance
   end
 
   def training_type
-    has_initial_training? ? :refresher : :initial
+    has_initial_training? ? REFRESHER_TRAINING : INITIAL_TRAINING
   end
 
   def total_hours
-    if training_type == :initial
-      20
-    elsif training_type == :refresher
-      6
-    end
+    training_type == INITIAL_TRAINING ? 20 : 6
   end
 
   def remaining_hours
@@ -30,27 +26,26 @@ class Claims::TrainingAllowance
 
   attr_reader :mentor, :provider, :academic_year, :claim_to_exclude
 
+  INITIAL_TRAINING = :initial
+  REFRESHER_TRAINING = :refresher
+
+  private_constant :INITIAL_TRAINING, :REFRESHER_TRAINING
+
   def mentor_training_scope
     @mentor_training_scope ||= provider.mentor_trainings
                                        .where(mentor:)
                                        .joins(claim: { claim_window: :academic_year })
   end
 
-  def has_initial_training?(previous: true)
-    query = if previous
-              mentor_training_scope.where(claims: { status: :submitted, claim_windows: { academic_years: { ends_on: ..academic_year.starts_on } } })
-            else
-              mentor_training_scope.where(claims: { status: :submitted, claim_windows: { academic_year: } })
-            end
-
-    query.exists?
+  def has_initial_training?
+    mentor_training_scope.where(claims: { status: :submitted, claim_windows: { academic_years: { ends_on: ..academic_year.starts_on } } }).exists?
   end
 
   def hours_completed
     mentor_training_scope
       .where(claims: { status: :submitted, claim_windows: { academic_year: } })
       .merge(Claims::Claim.active)
-      .where.not(claim_id: [claim_to_exclude.id, claim_to_exclude&.previous_revision_id])
+      .where.not(claim_id: [claim_to_exclude&.id, claim_to_exclude&.previous_revision_id])
       .sum(:hours_completed)
   end
 end

--- a/app/models/claims/training_allowance.rb
+++ b/app/models/claims/training_allowance.rb
@@ -22,6 +22,10 @@ class Claims::TrainingAllowance
     total_hours - hours_completed
   end
 
+  def available?
+    remaining_hours.positive?
+  end
+
   private
 
   attr_reader :mentor, :provider, :academic_year, :claim_to_exclude

--- a/app/models/claims/training_allowance.rb
+++ b/app/models/claims/training_allowance.rb
@@ -1,0 +1,19 @@
+class Claims::TrainingAllowance
+  def initialize(mentor:, provider:, academic_year:)
+    @mentor = mentor
+    @provider = provider
+    @academic_year = academic_year
+  end
+
+  def training_type
+    has_previous_training? ? :refresher : :initial
+  end
+
+  private
+
+  attr_reader :mentor, :provider, :academic_year
+
+  def has_previous_training?
+    provider.mentor_trainings.includes(claim: :claim_window).where(claim: { status: :submitted, claim_window: { academic_year: } }).exists?
+  end
+end

--- a/app/models/claims/training_allowance.rb
+++ b/app/models/claims/training_allowance.rb
@@ -7,13 +7,29 @@ class Claims::TrainingAllowance
 
   def training_type
     has_previous_training? ? :refresher : :initial
+    has_initial_training? ? :refresher : :initial
+  end
   end
 
   private
 
   attr_reader :mentor, :provider, :academic_year
+  def mentor_training_scope
+    @mentor_training_scope ||= provider.mentor_trainings
+                                       .where(mentor:)
+                                       .joins(claim: { claim_window: :academic_year })
+  end
 
   def has_previous_training?
     provider.mentor_trainings.includes(claim: :claim_window).where(claim: { status: :submitted, claim_window: { academic_year: } }).exists?
+  def has_initial_training?(previous: true)
+    query = if previous
+              mentor_training_scope.where(claims: { status: :submitted, claim_windows: { academic_years: { ends_on: ..academic_year.starts_on } } })
+            else
+              mentor_training_scope.where(claims: { status: :submitted, claim_windows: { academic_year: } })
+            end
+
+    query.exists?
+  end
   end
 end

--- a/spec/models/claims/training_allowance_spec.rb
+++ b/spec/models/claims/training_allowance_spec.rb
@@ -58,15 +58,145 @@ RSpec.describe Claims::TrainingAllowance, type: :model do
     end
   end
 
-      describe "#total_hours" do
-
+  describe "#total_hours" do
+    context "when the mentor has received initial training" do
+      it "returns 20" do
+        expect(training_allowance.total_hours).to eq(20)
       end
-
-      describe "#remaining_hours" do
-
-      end
-
-      describe "#available?" do
-
     end
+
+    context "when the mentor has received refresher training" do
+      let(:claim_window) { build(:claim_window, :current, academic_year: previous_academic_year) }
+      let(:claim) { build(:claim, :submitted, claim_window:) }
+      let(:mentor_training) { create(:mentor_training, mentor:, provider:, claim:) }
+
+      before do
+        mentor_training
+      end
+
+      it "returns 6" do
+        expect(training_allowance.total_hours).to eq(6)
+      end
+    end
+  end
+
+  describe "initial training" do
+    let(:claim_window) { build(:claim_window, :current, academic_year:) }
+    let(:claim) { build(:claim, :submitted, claim_window:) }
+    let(:hours_completed) { 5 }
+    let(:mentor_training) { create(:mentor_training, mentor:, provider:, claim:, hours_completed:) }
+
+    before { mentor_training }
+
+    it "returns 15" do
+      expect(training_allowance.training_type).to eq(:initial)
+      expect(training_allowance.total_hours).to eq(20)
+      expect(training_allowance.remaining_hours).to eq(15)
+      expect(training_allowance).to be_available
+    end
+  end
+  
+  describe "refresher training" do
+    let(:claim_window) { build(:claim_window, :current, academic_year:) }
+    let(:claim) { build(:claim, :submitted, claim_window:, provider:) }
+    let(:hours_completed) { 5 }
+    let(:mentor_training) { create(:mentor_training, mentor:, provider:, claim:, hours_completed:) }
+
+    let(:previous_claim_window) { build(:claim_window, starts_on: 8.days.ago, ends_on: 4.days.ago, academic_year: previous_academic_year) }
+    let(:previous_claim) { build(:claim, :submitted, claim_window: previous_claim_window, provider:) }
+    let(:previous_mentor_training) { create(:mentor_training, mentor:, provider:, claim: previous_claim, hours_completed: nil) }
+
+    before do
+      mentor_training
+      previous_mentor_training
+    end
+
+    it "returns 15" do
+      expect(training_allowance.training_type).to eq(:refresher)
+      expect(training_allowance.total_hours).to eq(6)
+      expect(training_allowance.remaining_hours).to eq(1)
+      expect(training_allowance).to be_available
+    end
+  end
+
+  describe "#remaining_hours" do
+    let(:claim_window) { build(:claim_window, :current, academic_year: previous_academic_year) }
+    let(:claim) { build(:claim, :submitted, claim_window:) }
+    let(:mentor_training) { create(:mentor_training, mentor:, provider:, claim:, hours_completed:) }
+
+    context "with initial training" do
+      context "when no hours have been completed" do
+        let(:hours_completed) { nil }
+
+        before { mentor_training }
+
+        it "returns 20" do
+          expect(training_allowance.remaining_hours).to eq(20)
+        end
+      end
+
+      context "when some of the hours have been completed" do
+        let(:hours_completed) { 13 }
+
+        before { mentor_training }
+
+        it "returns 7" do
+          expect(training_allowance.remaining_hours).to eq(7)
+        end
+      end
+
+      context "when all of the hours have been completed" do
+        let(:hours_completed) { 20 }
+
+        before { mentor_training }
+
+        it "returns 0" do
+          expect(training_allowance.remaining_hours).to eq(0)
+        end
+      end
+
+      context "when a claim has been provided to be excluded" do
+        subject(:training_allowance) do
+          described_class.new(mentor:, provider:, academic_year:)
+        end
+
+        let(:excluded_claim) { create(:claim, :submitted, claim_window:) }
+        let(:excluded_mentor_training) do
+          create(:mentor_training, mentor:, provider:, claim: excluded_claim, hours_completed: 5)
+        end
+
+        before { excluded_mentor_training }
+
+        it "does not include the hours from the excluded claim" do
+          expect(training_allowance.remaining_hours).to eq(6)
+        end
+      end
+    end
+  end
+
+  describe "#available?" do
+    let(:claim_window) { build(:claim_window, :current, academic_year: previous_academic_year) }
+    let(:claim) { build(:claim, :submitted, claim_window:) }
+    let(:mentor_training) { create(:mentor_training, mentor:, provider:, claim:, hours_completed:) }
+
+    context "when there are remaining hours" do
+      let(:hours_completed) { 13 }
+
+      before { mentor_training }
+
+      it "returns true" do
+        expect(training_allowance.available?).to be(true)
+      end
+    end
+
+    context "when there are no remaining hours" do
+      let(:hours_completed) { 20 }
+
+      before { mentor_training }
+
+      it "returns false" do
+        expect(training_allowance.available?).to be(false)
+      end
+    end
+  end
 end

--- a/spec/models/claims/training_allowance_spec.rb
+++ b/spec/models/claims/training_allowance_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Claims::TrainingAllowance, type: :model do
-  describe "#training_type" do
-    subject(:training_allowance) { Claims::TrainingAllowance.new(mentor:, provider:, academic_year:) }
+  subject(:training_allowance) { described_class.new(mentor:, provider:, academic_year:) }
 
     let!(:mentor) { create(:claims_mentor) }
     let!(:academic_year) do
@@ -12,24 +11,49 @@ RSpec.describe Claims::TrainingAllowance, type: :model do
              name: "2019 to 2020")
     end
     let!(:provider) { create(:claims_provider) }
+  let!(:mentor) { create(:claims_mentor) }
+  let!(:provider) { create(:claims_provider) }
+  let!(:academic_year) do
+    create(:academic_year,
+           starts_on: Date.parse("1 September 2019"),
+           ends_on: Date.parse("31 August 2020"),
+           name: "2019 to 2020")
+  end
+  let!(:previous_academic_year) do
+    create(:academic_year,
+           starts_on: Date.parse("1 September 2018"),
+           ends_on: Date.parse("31 August 2019"),
+           name: "2018 to 2019")
+  end
 
-    context "when the mentor has not received training in a previous academic year" do
+  describe "#training_type" do
+    context "when the mentor has not received training in the previous academic year" do
       it "returns initial" do
         expect(training_allowance.training_type).to eq(:initial)
       end
     end
 
-    context "when the mentor has received training in a previous academic year" do
-      let(:claim_window) { build(:claim_window, academic_year:) }
-      let(:claim) { build(:claim, claim_window:) }
-      let(:mentor_training) { create(:mentor_training, :submitted, mentor:, provider:, claim:) }
+    context "when the mentor has received training in the previous academic year" do
+      let(:claim_window) { build(:claim_window, :current, academic_year: previous_academic_year) }
+      let(:claim) { build(:claim, :submitted, claim_window:) }
+      let(:mentor_training) { create(:mentor_training, mentor:, provider:, claim:) }
 
-      before do
-        mentor_training
-      end
+      before { mentor_training }
 
       it "returns refresher" do
         expect(training_allowance.training_type).to eq(:refresher)
+      end
+    end
+
+    context "when the provider has trained a different mentor for the academic year" do
+      let(:claim_window) { build(:claim_window, :current, academic_year:) }
+      let(:claim) { build(:claim, :submitted, claim_window:) }
+      let(:mentor_training) { create(:mentor_training, provider:, claim:) }
+
+      before { mentor_training }
+
+      it "returns initial" do
+        expect(training_allowance.training_type).to eq(:initial)
       end
     end
   end

--- a/spec/models/claims/training_allowance_spec.rb
+++ b/spec/models/claims/training_allowance_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe Claims::TrainingAllowance, type: :model do
+  describe "#training_type" do
+    subject(:training_allowance) { Claims::TrainingAllowance.new(mentor:, provider:, academic_year:) }
+
+    let!(:mentor) { create(:claims_mentor) }
+    let!(:academic_year) do
+      create(:academic_year,
+             starts_on: Date.parse("1 September 2019"),
+             ends_on: Date.parse("31 August 2020"),
+             name: "2019 to 2020")
+    end
+    let!(:provider) { create(:claims_provider) }
+
+    context "when the mentor has not received training in a previous academic year" do
+      it "returns initial" do
+        expect(training_allowance.training_type).to eq(:initial)
+      end
+    end
+
+    context "when the mentor has received training in a previous academic year" do
+      let(:claim_window) { build(:claim_window, academic_year:) }
+      let(:claim) { build(:claim, claim_window:) }
+      let(:mentor_training) { create(:mentor_training, :submitted, mentor:, provider:, claim:) }
+
+      before do
+        mentor_training
+      end
+
+      it "returns refresher" do
+        expect(training_allowance.training_type).to eq(:refresher)
+      end
+    end
+  end
+
+      describe "#total_hours" do
+
+      end
+
+      describe "#remaining_hours" do
+
+      end
+
+      describe "#available?" do
+
+    end
+end

--- a/spec/models/claims/training_allowance_spec.rb
+++ b/spec/models/claims/training_allowance_spec.rb
@@ -33,21 +33,6 @@ RSpec.describe Claims::TrainingAllowance, type: :model do
       end
     end
 
-    context "when a draft claim exists and the mentor has not completed any training for the academic year" do
-      let(:draft_claim) { build(:claim, :draft, claim_window:) }
-
-      before do
-        create(:mentor_training, mentor:, provider:, claim: draft_claim, hours_completed: 1)
-      end
-
-      it "does not include the draft claim" do
-        expect(training_allowance.training_type).to eq(:initial)
-        expect(training_allowance.total_hours).to eq(20)
-        expect(training_allowance.remaining_hours).to eq(20)
-        expect(training_allowance).to be_available
-      end
-    end
-
     context "when an internal draft claim exists and the mentor has not completed any training for the academic year" do
       let(:internal_draft_claim) { build(:claim, status: :internal_draft, claim_window:) }
 
@@ -131,22 +116,6 @@ RSpec.describe Claims::TrainingAllowance, type: :model do
       before { previous_mentor_training }
 
       it "returns the expected results" do
-        expect(training_allowance.training_type).to eq(:refresher)
-        expect(training_allowance.total_hours).to eq(6)
-        expect(training_allowance.remaining_hours).to eq(6)
-        expect(training_allowance).to be_available
-      end
-    end
-
-    context "when a draft claim exists and the mentor has not completed any training for the academic year" do
-      let(:draft_claim) { build(:claim, :draft, claim_window:) }
-
-      before do
-        previous_mentor_training
-        create(:mentor_training, mentor:, provider:, claim: draft_claim, hours_completed: 1)
-      end
-
-      it "does not include the draft claim" do
         expect(training_allowance.training_type).to eq(:refresher)
         expect(training_allowance.total_hours).to eq(6)
         expect(training_allowance.remaining_hours).to eq(6)

--- a/spec/models/claims/training_allowance_spec.rb
+++ b/spec/models/claims/training_allowance_spec.rb
@@ -1,16 +1,9 @@
 require "rails_helper"
 
 RSpec.describe Claims::TrainingAllowance, type: :model do
-  subject(:training_allowance) { described_class.new(mentor:, provider:, academic_year:) }
+  subject(:training_allowance) { described_class.new(mentor:, provider:, academic_year:, claim_to_exclude:) }
 
-    let!(:mentor) { create(:claims_mentor) }
-    let!(:academic_year) do
-      create(:academic_year,
-             starts_on: Date.parse("1 September 2019"),
-             ends_on: Date.parse("31 August 2020"),
-             name: "2019 to 2020")
-    end
-    let!(:provider) { create(:claims_provider) }
+  let(:claim_to_exclude) { nil }
   let!(:mentor) { create(:claims_mentor) }
   let!(:provider) { create(:claims_provider) }
   let!(:academic_year) do
@@ -26,176 +19,149 @@ RSpec.describe Claims::TrainingAllowance, type: :model do
            name: "2018 to 2019")
   end
 
-  describe "#training_type" do
-    context "when the mentor has not received training in the previous academic year" do
-      it "returns initial" do
-        expect(training_allowance.training_type).to eq(:initial)
-      end
-    end
-
-    context "when the mentor has received training in the previous academic year" do
-      let(:claim_window) { build(:claim_window, :current, academic_year: previous_academic_year) }
-      let(:claim) { build(:claim, :submitted, claim_window:) }
-      let(:mentor_training) { create(:mentor_training, mentor:, provider:, claim:) }
-
-      before { mentor_training }
-
-      it "returns refresher" do
-        expect(training_allowance.training_type).to eq(:refresher)
-      end
-    end
-
-    context "when the provider has trained a different mentor for the academic year" do
-      let(:claim_window) { build(:claim_window, :current, academic_year:) }
-      let(:claim) { build(:claim, :submitted, claim_window:) }
-      let(:mentor_training) { create(:mentor_training, provider:, claim:) }
-
-      before { mentor_training }
-
-      it "returns initial" do
-        expect(training_allowance.training_type).to eq(:initial)
-      end
-    end
-  end
-
-  describe "#total_hours" do
-    context "when the mentor has received initial training" do
-      it "returns 20" do
-        expect(training_allowance.total_hours).to eq(20)
-      end
-    end
-
-    context "when the mentor has received refresher training" do
-      let(:claim_window) { build(:claim_window, :current, academic_year: previous_academic_year) }
-      let(:claim) { build(:claim, :submitted, claim_window:) }
-      let(:mentor_training) { create(:mentor_training, mentor:, provider:, claim:) }
-
-      before do
-        mentor_training
-      end
-
-      it "returns 6" do
-        expect(training_allowance.total_hours).to eq(6)
-      end
-    end
-  end
-
   describe "initial training" do
     let(:claim_window) { build(:claim_window, :current, academic_year:) }
     let(:claim) { build(:claim, :submitted, claim_window:) }
-    let(:hours_completed) { 5 }
     let(:mentor_training) { create(:mentor_training, mentor:, provider:, claim:, hours_completed:) }
 
-    before { mentor_training }
+    context "when the mentor has not completed any training for the academic year" do
+      it "returns the expected results" do
+        expect(training_allowance.training_type).to eq(:initial)
+        expect(training_allowance.total_hours).to eq(20)
+        expect(training_allowance.remaining_hours).to eq(20)
+        expect(training_allowance).to be_available
+      end
+    end
 
-    it "returns 15" do
-      expect(training_allowance.training_type).to eq(:initial)
-      expect(training_allowance.total_hours).to eq(20)
-      expect(training_allowance.remaining_hours).to eq(15)
-      expect(training_allowance).to be_available
+    context "when the mentor has completed training for the academic year" do
+      before { mentor_training }
+
+      context "when the mentor has completed 5 hours of training in the current academic year" do
+        let(:hours_completed) { 5 }
+
+        it "returns the expected results" do
+          expect(training_allowance.training_type).to eq(:initial)
+          expect(training_allowance.total_hours).to eq(20)
+          expect(training_allowance.remaining_hours).to eq(15)
+          expect(training_allowance).to be_available
+        end
+      end
+
+      context "when the mentor has completed 20 hours of training in the current academic year" do
+        let(:hours_completed) { 20 }
+
+        it "returns the expected results" do
+          expect(training_allowance.training_type).to eq(:initial)
+          expect(training_allowance.total_hours).to eq(20)
+          expect(training_allowance.remaining_hours).to eq(0)
+          expect(training_allowance).not_to be_available
+        end
+      end
+
+      context "when the mentor has completed 10 hours of training in the current academic year for a claim they want to exclude" do
+        let(:hours_completed) { 10 }
+        let(:claim_to_exclude) { claim }
+
+        it "returns the expected results" do
+          expect(training_allowance.training_type).to eq(:initial)
+          expect(training_allowance.total_hours).to eq(20)
+          expect(training_allowance.remaining_hours).to eq(20)
+          expect(training_allowance).to be_available
+        end
+
+        context "when a second claim has been made whilst excluding a previous claim" do
+          let(:second_claim) { build(:claim, :submitted, claim_window:, provider:) }
+          let(:second_mentor_training) { create(:mentor_training, mentor:, provider:, claim: second_claim, hours_completed: 3) }
+
+          before do
+            second_mentor_training
+          end
+
+          it "does not exclude other claims" do
+            expect(training_allowance.training_type).to eq(:initial)
+            expect(training_allowance.total_hours).to eq(20)
+            expect(training_allowance.remaining_hours).to eq(17)
+            expect(training_allowance).to be_available
+          end
+        end
+      end
     end
   end
-  
+
   describe "refresher training" do
     let(:claim_window) { build(:claim_window, :current, academic_year:) }
     let(:claim) { build(:claim, :submitted, claim_window:, provider:) }
-    let(:hours_completed) { 5 }
     let(:mentor_training) { create(:mentor_training, mentor:, provider:, claim:, hours_completed:) }
 
     let(:previous_claim_window) { build(:claim_window, starts_on: 8.days.ago, ends_on: 4.days.ago, academic_year: previous_academic_year) }
     let(:previous_claim) { build(:claim, :submitted, claim_window: previous_claim_window, provider:) }
-    let(:previous_mentor_training) { create(:mentor_training, mentor:, provider:, claim: previous_claim, hours_completed: nil) }
+    let(:previous_mentor_training) { create(:mentor_training, mentor:, provider:, claim: previous_claim, hours_completed: 20) }
 
-    before do
-      mentor_training
-      previous_mentor_training
+    context "when the mentor has not completed any training for the academic year" do
+      before { previous_mentor_training }
+
+      it "returns the expected results" do
+        expect(training_allowance.training_type).to eq(:refresher)
+        expect(training_allowance.total_hours).to eq(6)
+        expect(training_allowance.remaining_hours).to eq(6)
+        expect(training_allowance).to be_available
+      end
     end
 
-    it "returns 15" do
-      expect(training_allowance.training_type).to eq(:refresher)
-      expect(training_allowance.total_hours).to eq(6)
-      expect(training_allowance.remaining_hours).to eq(1)
-      expect(training_allowance).to be_available
-    end
-  end
+    context "when the mentor has completed training for the academic year" do
+      before do
+        mentor_training
+        previous_mentor_training
+      end
 
-  describe "#remaining_hours" do
-    let(:claim_window) { build(:claim_window, :current, academic_year: previous_academic_year) }
-    let(:claim) { build(:claim, :submitted, claim_window:) }
-    let(:mentor_training) { create(:mentor_training, mentor:, provider:, claim:, hours_completed:) }
+      context "when the mentor has completed 5 hours of training in the current academic year and 20 hours in the previous academic year" do
+        let(:hours_completed) { 5 }
 
-    context "with initial training" do
-      context "when no hours have been completed" do
-        let(:hours_completed) { nil }
-
-        before { mentor_training }
-
-        it "returns 20" do
-          expect(training_allowance.remaining_hours).to eq(20)
+        it "returns the expected results" do
+          expect(training_allowance.training_type).to eq(:refresher)
+          expect(training_allowance.total_hours).to eq(6)
+          expect(training_allowance.remaining_hours).to eq(1)
+          expect(training_allowance).to be_available
         end
       end
 
-      context "when some of the hours have been completed" do
-        let(:hours_completed) { 13 }
+      context "when the mentor has completed 6 hours of training in the current academic year and 20 hours in the previous academic year" do
+        let(:hours_completed) { 6 }
 
-        before { mentor_training }
-
-        it "returns 7" do
-          expect(training_allowance.remaining_hours).to eq(7)
-        end
-      end
-
-      context "when all of the hours have been completed" do
-        let(:hours_completed) { 20 }
-
-        before { mentor_training }
-
-        it "returns 0" do
+        it "returns the expected results" do
+          expect(training_allowance.training_type).to eq(:refresher)
+          expect(training_allowance.total_hours).to eq(6)
           expect(training_allowance.remaining_hours).to eq(0)
+          expect(training_allowance).not_to be_available
         end
       end
 
-      context "when a claim has been provided to be excluded" do
-        subject(:training_allowance) do
-          described_class.new(mentor:, provider:, academic_year:)
-        end
+      context "when the mentor has completed 3 hours of training in the current academic year and 20 hours in the previous academic year for a claim they want to exclude" do
+        let(:hours_completed) { 6 }
+        let(:claim_to_exclude) { claim }
 
-        let(:excluded_claim) { create(:claim, :submitted, claim_window:) }
-        let(:excluded_mentor_training) do
-          create(:mentor_training, mentor:, provider:, claim: excluded_claim, hours_completed: 5)
-        end
-
-        before { excluded_mentor_training }
-
-        it "does not include the hours from the excluded claim" do
+        it "excludes the excluded claim" do
+          expect(training_allowance.training_type).to eq(:refresher)
+          expect(training_allowance.total_hours).to eq(6)
           expect(training_allowance.remaining_hours).to eq(6)
+          expect(training_allowance).to be_available
         end
-      end
-    end
-  end
 
-  describe "#available?" do
-    let(:claim_window) { build(:claim_window, :current, academic_year: previous_academic_year) }
-    let(:claim) { build(:claim, :submitted, claim_window:) }
-    let(:mentor_training) { create(:mentor_training, mentor:, provider:, claim:, hours_completed:) }
+        context "when a second claim has been made whilst excluding a previous claim" do
+          let(:second_claim) { build(:claim, :submitted, claim_window:, provider:) }
+          let(:second_mentor_training) { create(:mentor_training, mentor:, provider:, claim: second_claim, hours_completed: 3) }
 
-    context "when there are remaining hours" do
-      let(:hours_completed) { 13 }
+          before do
+            second_mentor_training
+          end
 
-      before { mentor_training }
-
-      it "returns true" do
-        expect(training_allowance.available?).to be(true)
-      end
-    end
-
-    context "when there are no remaining hours" do
-      let(:hours_completed) { 20 }
-
-      before { mentor_training }
-
-      it "returns false" do
-        expect(training_allowance.available?).to be(false)
+          it "does not exclude other claims" do
+            expect(training_allowance.training_type).to eq(:refresher)
+            expect(training_allowance.total_hours).to eq(6)
+            expect(training_allowance.remaining_hours).to eq(3)
+            expect(training_allowance).to be_available
+          end
+        end
       end
     end
   end

--- a/spec/models/claims/training_allowance_spec.rb
+++ b/spec/models/claims/training_allowance_spec.rb
@@ -33,6 +33,36 @@ RSpec.describe Claims::TrainingAllowance, type: :model do
       end
     end
 
+    context "when a draft claim exists and the mentor has not completed any training for the academic year" do
+      let(:draft_claim) { build(:claim, :draft, claim_window:) }
+
+      before do
+        create(:mentor_training, mentor:, provider:, claim: draft_claim, hours_completed: 1)
+      end
+
+      it "does not include the draft claim" do
+        expect(training_allowance.training_type).to eq(:initial)
+        expect(training_allowance.total_hours).to eq(20)
+        expect(training_allowance.remaining_hours).to eq(20)
+        expect(training_allowance).to be_available
+      end
+    end
+
+    context "when an internal draft claim exists and the mentor has not completed any training for the academic year" do
+      let(:internal_draft_claim) { build(:claim, status: :internal_draft, claim_window:) }
+
+      before do
+        create(:mentor_training, mentor:, provider:, claim: internal_draft_claim, hours_completed: 1)
+      end
+
+      it "does not include the internal draft claim" do
+        expect(training_allowance.training_type).to eq(:initial)
+        expect(training_allowance.total_hours).to eq(20)
+        expect(training_allowance.remaining_hours).to eq(20)
+        expect(training_allowance).to be_available
+      end
+    end
+
     context "when the mentor has completed training for the academic year" do
       before { mentor_training }
 
@@ -101,6 +131,38 @@ RSpec.describe Claims::TrainingAllowance, type: :model do
       before { previous_mentor_training }
 
       it "returns the expected results" do
+        expect(training_allowance.training_type).to eq(:refresher)
+        expect(training_allowance.total_hours).to eq(6)
+        expect(training_allowance.remaining_hours).to eq(6)
+        expect(training_allowance).to be_available
+      end
+    end
+
+    context "when a draft claim exists and the mentor has not completed any training for the academic year" do
+      let(:draft_claim) { build(:claim, :draft, claim_window:) }
+
+      before do
+        previous_mentor_training
+        create(:mentor_training, mentor:, provider:, claim: draft_claim, hours_completed: 1)
+      end
+
+      it "does not include the draft claim" do
+        expect(training_allowance.training_type).to eq(:refresher)
+        expect(training_allowance.total_hours).to eq(6)
+        expect(training_allowance.remaining_hours).to eq(6)
+        expect(training_allowance).to be_available
+      end
+    end
+
+    context "when an internal draft claim exists and the mentor has not completed any training for the academic year" do
+      let(:internal_draft_claim) { build(:claim, status: :internal_draft, claim_window:) }
+
+      before do
+        previous_mentor_training
+        create(:mentor_training, mentor:, provider:, claim: internal_draft_claim, hours_completed: 1)
+      end
+
+      it "does not include the internal draft claim" do
         expect(training_allowance.training_type).to eq(:refresher)
         expect(training_allowance.total_hours).to eq(6)
         expect(training_allowance.remaining_hours).to eq(6)


### PR DESCRIPTION
## Context

Create a class that will calculate how much training can be claimed for a given mentor.

## Changes proposed in this pull request

- Adds a new `Claims::TrainingAllowance` model that combines the features of several existing classes into a single class.

## Guidance to review

Work through the spec file and check that all of the possible scenarios are covered, alternatively this can be tested via a rails console with existing claims data to confirm the expected results.

## Link to Trello card

[Introduce a Training Allowance object](https://trello.com/c/l2QqUCci/739-introduce-a-training-allowance-object)
