### PR TITLE
Add commit SHA to the healthcheck endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,4 +76,8 @@ RUN apk add --no-cache proj-util
 COPY --from=builder /app /app
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 
+# Set the SHA environment variable for the healthcheck
+ARG COMMIT_SHA
+ENV SHA=${COMMIT_SHA}
+
 CMD bundle exec rails server -b 0.0.0.0

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,4 +1,4 @@
 OkComputer.mount_at = "healthcheck"
 
 OkComputer::Registry.register "database", OkComputer::ActiveRecordCheck.new
-OkComputer::Registry.register "Commit SHA", OkComputer::AppVersionCheck.new
+OkComputer::Registry.register "sha", OkComputer::AppVersionCheck.new

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,3 +1,4 @@
 OkComputer.mount_at = "healthcheck"
 
 OkComputer::Registry.register "database", OkComputer::ActiveRecordCheck.new
+OkComputer::Registry.register "Commit SHA", OkComputer::AppVersionCheck.new


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Add the `SHA` environment variable the `Dockerfile`
- Add the `OkComputer::AppVersionCheck.new` to the `OkComputer` initialiser.

## Guidance to review

- Navigate to the `/healthcheck/all` endpoint and view the commit sha in the review app.

## Link to Trello card

[Add a health check to show the currently deployed commit SHA
](https://trello.com/c/Bfhgfq76/777-add-a-health-check-to-show-the-currently-deployed-commit-sha)

## Screenshots

![image](https://github.com/user-attachments/assets/7ef28687-efcb-4425-8cb0-5d5e223e6990)

