### PR TITLE
Create incident-cheatsheet.md

### DIFF
--- a/docs/incident-cheatsheet.md
+++ b/docs/incident-cheatsheet.md
@@ -6,18 +6,20 @@ Stay calm and refer to the [incident playbook](https://tech-docs.teacherservices
 
 ## Maintenance Page
 
+To stop users accessing the app, [enable the maintenance page](https://github.com/DFE-Digital/itt-mentor-services/actions/workflows/enable-maintenance.yml).
+
 ### Temporary Ingress URL
 
 After enabling the maintenance page, use the temporary ingress URL to access the environment for tasks like health checks or verifying code deployments. Find the URL in the "Enable maintenance app summary" section of the GitHub action under TEMP URLS for both the claims and placements services.
 
 ### Terraform File
 
-The `application.tf` file is in the root of the repository. Update the `send_traffic_to_maintenance_page` variable to `true` to persist the maintenance page between deployments. Missing this step will disable the maintenance page unintentionally.
+The `application.tf` file is located at [terraform/application/application.tf](/terraform/application/application.tf). Update the [`send_traffic_to_maintenance_page` variable to `true`](https://github.com/DFE-Digital/itt-mentor-services/blob/1d1d321cd90f33b94f1485c7e49acea9267d9e33/terraform/application/application.tf#L125) to persist the maintenance page between deployments. Missing this step will disable the maintenance page unintentionally when deploying new releases.
 
 ### Maintenance Page HTML
 
-The `maintenance_page.html` file is in the `maintenance_page/html` directory. This file is displayed when the maintenance page is enabled.
+The maintenance page is located at [maintenance_page/html/index.html](/maintenance_page/html/index.html). This file is displayed when the maintenance page is enabled.
 
 ## Current Deployment SHA Ref
 
-To find the SHA ref of the current deployment, check the health check endpoint at `/healthcheck/sha` from the temporary ingress URL. The SHA ref is listed under the "sha" label.
+To find the SHA ref of the current deployment, check the health check endpoint at `/healthcheck/sha`. Use the temporary ingress URL if the maintenance page is enabled. The SHA ref is listed under the "sha" label.

--- a/docs/incident-cheatsheet.md
+++ b/docs/incident-cheatsheet.md
@@ -1,0 +1,23 @@
+# Incident Cheatsheet
+
+## Incident Response
+
+Stay calm and refer to the [incident playbook](https://tech-docs.teacherservices.cloud/operating-a-service/incident-playbook.html). This cheatsheet supplements the playbook with service-specific details.
+
+## Maintenance Page
+
+### Temporary Ingress URL
+
+After enabling the maintenance page, use the temporary ingress URL to access the environment for tasks like health checks or verifying code deployments. Find the URL in the "Enable maintenance app summary" section of the GitHub action under TEMP URLS for both the claims and placements services.
+
+### Terraform File
+
+The `application.tf` file is in the root of the repository. Update the `send_traffic_to_maintenance_page` variable to `true` to persist the maintenance page between deployments. Missing this step will disable the maintenance page unintentionally.
+
+### Maintenance Page HTML
+
+The `maintenance_page.html` file is in the `maintenance_page/html` directory. This file is displayed when the maintenance page is enabled.
+
+## Current Deployment SHA Ref
+
+To find the SHA ref of the current deployment, check the health check endpoint at `/healthcheck/all` from the temporary ingress URL. The SHA ref is listed under the "commit SHA" label.

--- a/docs/incident-cheatsheet.md
+++ b/docs/incident-cheatsheet.md
@@ -20,4 +20,4 @@ The `maintenance_page.html` file is in the `maintenance_page/html` directory. Th
 
 ## Current Deployment SHA Ref
 
-To find the SHA ref of the current deployment, check the health check endpoint at `/healthcheck/all` from the temporary ingress URL. The SHA ref is listed under the "commit SHA" label.
+To find the SHA ref of the current deployment, check the health check endpoint at `/healthcheck/sha` from the temporary ingress URL. The SHA ref is listed under the "sha" label.


### PR DESCRIPTION
## Context

To help developers find the things they need during an incident. This cheatsheet should serve to supplement the existing incident documentation, covering bits which are specific to this service.

## Changes proposed in this pull request

- [x] Add the `incident-cheatsheat.md` doc.

## Guidance to review

- Read through the documentation and check that it all makes sense.

## Link to Trello card

[Create an "Incident cheatsheet" document](https://trello.com/c/LbPB73Z2/780-create-an-incident-cheatsheet-document)