### PR TITLE
Use sub-queries in policy scopes

### DIFF
--- a/app/policies/placements/mentor_policy.rb
+++ b/app/policies/placements/mentor_policy.rb
@@ -3,13 +3,7 @@ class Placements::MentorPolicy < ApplicationPolicy
     def resolve
       return scope if user.support_user?
 
-      scope.where(
-        mentor_memberships: { school: user.current_organisation },
-      ).or(
-        scope.where(
-          id: Placements::MentorMembership.select(:mentor_id).where(school: user.current_organisation),
-        ),
-      )
+      scope.where(id: Placements::MentorMembership.select(:mentor_id).where(school: user.current_organisation))
     end
   end
 end

--- a/app/policies/placements/mentor_policy.rb
+++ b/app/policies/placements/mentor_policy.rb
@@ -3,7 +3,13 @@ class Placements::MentorPolicy < ApplicationPolicy
     def resolve
       return scope if user.support_user?
 
-      scope.joins(:mentor_memberships).where(mentor_memberships: { school: user.current_organisation })
+      scope.where(
+        mentor_memberships: { school: user.current_organisation },
+      ).or(
+        scope.where(
+          id: Placements::MentorMembership.select(:mentor_id).where(school: user.current_organisation),
+        ),
+      )
     end
   end
 end

--- a/app/policies/placements/user_policy.rb
+++ b/app/policies/placements/user_policy.rb
@@ -4,7 +4,7 @@ class Placements::UserPolicy < ApplicationPolicy
       if user.support_user?
         scope
       else
-        scope.joins(:user_memberships).where(user_memberships: { organisation: user.current_organisation })
+        scope.where(id: UserMembership.select(:user_id).where(organisation: user.current_organisation))
       end
     end
   end


### PR DESCRIPTION
## Context

The joins in our policy scopes were returning duplicate records unintentioanlly, we've moved to subqueries to avoid this.

## Changes proposed in this pull request

- [x] Refactor the `user_policy.rb` scope to use a subquery.
- [x] Refactor the `mentor_policy.rb` scope to use a subquery.

## Guidance to review

- There should be no discernable differences to users
- Test suite should pass

## Link to Trello card

[Duplicates are appearing in the users list for schools and providers](https://trello.com/c/5Apc51qs/781-duplicates-are-appearing-in-the-users-list-for-schools-and-providers)
