### PR TITLE
Claims academic year filter

### DIFF
--- a/app/assets/stylesheets/components/claim/card.scss
+++ b/app/assets/stylesheets/components/claim/card.scss
@@ -27,7 +27,7 @@
     justify-content: space-between;
     gap: govuk-spacing(2);
 
-    .claim-card__body__provider {
+    .claim-card__body__details {
       flex-grow: 1;
       max-width: 66%;
     }

--- a/app/components/claim/card_component.html.erb
+++ b/app/components/claim/card_component.html.erb
@@ -7,7 +7,8 @@
   </div>
 
   <div class="claim-card__body">
-    <div class="claim-card__body__provider">
+    <div class="claim-card__body__details">
+      <div class="govuk-body-s"><%= t(".academic_year") %> <%= claim.academic_year_name %></div>
       <div class="govuk-body-s"><%= claim.provider.name %></div>
     </div>
 

--- a/app/components/claim/card_component.html.erb
+++ b/app/components/claim/card_component.html.erb
@@ -8,7 +8,7 @@
 
   <div class="claim-card__body">
     <div class="claim-card__body__details">
-      <div class="govuk-body-s"><%= t(".academic_year") %> <%= claim.academic_year_name %></div>
+      <div class="govuk-body-s"><%= claim.academic_year_name %></div>
       <div class="govuk-body-s"><%= claim.provider.name %></div>
     </div>
 

--- a/app/controllers/claims/support/claims_controller.rb
+++ b/app/controllers/claims/support/claims_controller.rb
@@ -8,6 +8,7 @@ class Claims::Support::ClaimsController < Claims::Support::ApplicationController
     @pagy, @claims = pagy(@filtered_claims)
     @schools = Claims::School.all
     @providers = Claims::Provider.private_beta_providers
+    @academic_years = AcademicYear.order_by_date
   end
 
   def show; end
@@ -44,6 +45,7 @@ class Claims::Support::ClaimsController < Claims::Support::ApplicationController
       provider_ids: [],
       school_ids: [],
       statuses: [],
+      academic_year_ids: [],
     )
   end
 

--- a/app/controllers/claims/support/claims_controller.rb
+++ b/app/controllers/claims/support/claims_controller.rb
@@ -8,7 +8,7 @@ class Claims::Support::ClaimsController < Claims::Support::ApplicationController
     @pagy, @claims = pagy(@filtered_claims)
     @schools = Claims::School.all
     @providers = Claims::Provider.private_beta_providers
-    @academic_years = AcademicYear.order_by_date
+    @academic_years = AcademicYear.where(id: Claims::ClaimWindow.select(:academic_year_id)).order_by_date
   end
 
   def show; end

--- a/app/forms/claims/support/claims/filter_form.rb
+++ b/app/forms/claims/support/claims/filter_form.rb
@@ -13,10 +13,12 @@ class Claims::Support::Claims::FilterForm < ApplicationForm
   attribute :school_ids, default: []
   attribute :provider_ids, default: []
   attribute :statuses, default: []
+  attribute :academic_year_ids, default: []
 
   def initialize(params = {})
     params[:school_ids].compact_blank! if params[:school_ids].present?
     params[:provider_ids].compact_blank! if params[:provider_ids].present?
+    params[:academic_year_ids].compact_blank! if params[:academic_year_ids].present?
 
     super(params)
   end
@@ -26,7 +28,8 @@ class Claims::Support::Claims::FilterForm < ApplicationForm
       provider_ids.present? ||
       submitted_after.present? ||
       submitted_before.present? ||
-      statuses.present?
+      statuses.present? ||
+      academic_year_ids.present?
   end
 
   def index_path_without_filter(filter:, value: nil)
@@ -73,6 +76,10 @@ class Claims::Support::Claims::FilterForm < ApplicationForm
     @providers ||= Claims::Provider.find(provider_ids)
   end
 
+  def academic_years
+    @academic_years ||= AcademicYear.find(academic_year_ids)
+  end
+
   def query_params
     {
       search:,
@@ -83,6 +90,7 @@ class Claims::Support::Claims::FilterForm < ApplicationForm
       submitted_after:,
       submitted_before:,
       statuses:,
+      academic_year_ids:,
     }
   end
 

--- a/app/models/academic_year.rb
+++ b/app/models/academic_year.rb
@@ -14,6 +14,8 @@ class AcademicYear < ApplicationRecord
   validates :starts_on, presence: true
   validates :ends_on, presence: true, comparison: { greater_than_or_equal_to: :starts_on }
 
+  scope :order_by_date, -> { order(starts_on: :asc) }
+
   START_DATE = {
     day: 1,
     month: 9, # September

--- a/app/models/claims/claim.rb
+++ b/app/models/claims/claim.rb
@@ -77,6 +77,7 @@ class Claims::Claim < ApplicationRecord
   delegate :name, to: :provider, prefix: true, allow_nil: true
   delegate :users, to: :school, prefix: true
   delegate :full_name, to: :submitted_by, prefix: true, allow_nil: true
+  delegate :name, to: :academic_year, prefix: true, allow_nil: true
 
   def valid_mentor_training_hours?
     mentor_trainings_without_current_claim = Claims::MentorTraining.joins(:claim)

--- a/app/queries/claims/claims_query.rb
+++ b/app/queries/claims/claims_query.rb
@@ -7,6 +7,7 @@ class Claims::ClaimsQuery < ApplicationQuery
     scope = submitted_after(scope)
     scope = submitted_before(scope)
     scope = status_condition(scope)
+    scope = academic_year_condition(scope)
 
     scope.order_created_at_desc
   end
@@ -47,5 +48,11 @@ class Claims::ClaimsQuery < ApplicationQuery
     return scope if params[:statuses].blank?
 
     scope.where(status: params[:statuses])
+  end
+
+  def academic_year_condition(scope)
+    return scope if params[:academic_year_ids].blank?
+
+    scope.where(claim_window_id: Claims::ClaimWindow.select(:id).where(academic_year_id: params[:academic_year_ids]))
   end
 end

--- a/app/views/claims/schools/claims/check.html.erb
+++ b/app/views/claims/schools/claims/check.html.erb
@@ -20,6 +20,11 @@
         <% end %>
 
         <% summary_list.with_row do |row| %>
+          <% row.with_key(text: Claims::ClaimWindow.human_attribute_name(:academic_year)) %>
+          <% row.with_value(text: Claims::ClaimWindow.current.academic_year_name) %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
           <% row.with_key(text: Claims::Claim.human_attribute_name(:accredited_provider)) %>
           <% row.with_value(text: @claim.provider_name) %>
           <% unless @claim.draft? %>

--- a/app/views/claims/schools/claims/show.html.erb
+++ b/app/views/claims/schools/claims/show.html.erb
@@ -30,7 +30,7 @@
 
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: Claims::ClaimWindow.human_attribute_name(:academic_year)) %>
-          <% row.with_value(text: @claim.claim_window.academic_year_name) %>
+          <% row.with_value(text: @claim.academic_year_name) %>
         <% end %>
 
         <% if @claim.provider %>

--- a/app/views/claims/schools/claims/show.html.erb
+++ b/app/views/claims/schools/claims/show.html.erb
@@ -28,6 +28,11 @@
           <% row.with_value(text: @school.name) %>
         <% end %>
 
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: Claims::ClaimWindow.human_attribute_name(:academic_year)) %>
+          <% row.with_value(text: @claim.claim_window.academic_year_name) %>
+        <% end %>
+
         <% if @claim.provider %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: Claims::Claim.human_attribute_name(:accredited_provider)) %>

--- a/app/views/claims/support/claims/_details.html.erb
+++ b/app/views/claims/support/claims/_details.html.erb
@@ -4,6 +4,11 @@
     <% row.with_value(text: govuk_link_to(claim.school.name, claims_support_school_path(claim.school))) %>
   <% end %>
 
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: Claims::Claim.human_attribute_name(:academic_year)) %>
+    <% row.with_value(text: claim.academic_year_name) %>
+  <% end %>
+
   <% if claim.provider %>
     <% summary_list.with_row do |row| %>
       <% row.with_key(text: Claims::Claim.human_attribute_name(:accredited_provider)) %>

--- a/app/views/claims/support/claims/_filter.html.erb
+++ b/app/views/claims/support/claims/_filter.html.erb
@@ -24,6 +24,22 @@
             </div>
           </div>
 
+          <% if filter_form.academic_year_ids.present? %>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t("claims.support.claims.index.academic_year") %></h3>
+            <ul class="app-filter-tags">
+              <% filter_form.academic_years.each do |academic_year| %>
+                <li>
+                  <%= govuk_link_to(
+                    academic_year.name,
+                    filter_form.index_path_without_filter(filter: "academic_year_ids", value: academic_year.id),
+                    class: "app-filter__tag",
+                    no_visited_state: true,
+                  ) %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+
           <% if filter_form.statuses.present? %>
             <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t("claims.support.claims.index.status") %></h3>
             <ul class="app-filter-tags">
@@ -103,6 +119,21 @@
           <%= form.govuk_submit t("apply_filters") %>
 
           <%= form.hidden_field :search, value: filter_form.search %>
+
+          <div class="app-filter__option">
+            <%= form.govuk_check_boxes_fieldset(
+              :academic_year_ids,
+              legend: {
+                text: t("claims.support.claims.index.academic_year"),
+                size: "s",
+              },
+              small: true,
+              ) do %>
+              <% @academic_years.each do |academic_year| %>
+                <%= form.govuk_check_box :academic_year_ids, academic_year.id, label: { text: academic_year.name } %>
+              <% end %>
+            <% end %>
+          </div>
 
           <div class="app-filter__option">
             <%= form.govuk_check_boxes_fieldset(

--- a/app/views/claims/support/claims/_filter.html.erb
+++ b/app/views/claims/support/claims/_filter.html.erb
@@ -120,20 +120,22 @@
 
           <%= form.hidden_field :search, value: filter_form.search %>
 
-          <div class="app-filter__option">
-            <%= form.govuk_check_boxes_fieldset(
-              :academic_year_ids,
-              legend: {
-                text: t("claims.support.claims.index.academic_year"),
-                size: "s",
-              },
-              small: true,
-            ) do %>
-              <% @academic_years.each do |academic_year| %>
-                <%= form.govuk_check_box :academic_year_ids, academic_year.id, label: { text: academic_year.name } %>
+          <% if @academic_years.many? %>
+            <div class="app-filter__option">
+              <%= form.govuk_check_boxes_fieldset(
+                :academic_year_ids,
+                legend: {
+                  text: t("claims.support.claims.index.academic_year"),
+                  size: "s",
+                },
+                small: true,
+              ) do %>
+                <% @academic_years.each do |academic_year| %>
+                  <%= form.govuk_check_box :academic_year_ids, academic_year.id, label: { text: academic_year.name } %>
+                <% end %>
               <% end %>
-            <% end %>
-          </div>
+            </div>
+          <% end %>
 
           <div class="app-filter__option">
             <%= form.govuk_check_boxes_fieldset(

--- a/app/views/claims/support/claims/_filter.html.erb
+++ b/app/views/claims/support/claims/_filter.html.erb
@@ -128,7 +128,7 @@
                 size: "s",
               },
               small: true,
-              ) do %>
+            ) do %>
               <% @academic_years.each do |academic_year| %>
                 <%= form.govuk_check_box :academic_year_ids, academic_year.id, label: { text: academic_year.name } %>
               <% end %>

--- a/app/views/claims/support/claims/index.html.erb
+++ b/app/views/claims/support/claims/index.html.erb
@@ -26,7 +26,7 @@
           <%= f.govuk_text_field :search, type: :search, value: filter_form.search, label: { text: t(".search_label"), size: "s" } %>
           <%= f.govuk_submit t(".submit") %>
 
-          <% filter_form.attributes.except("search", "school_ids", "provider_ids").each do |key, value| %>
+          <% filter_form.attributes.except("search", "school_ids", "provider_ids", "academic_year_ids").each do |key, value| %>
             <%= f.hidden_field key, value: %>
           <% end %>
 

--- a/app/views/claims/support/schools/claims/check.html.erb
+++ b/app/views/claims/support/schools/claims/check.html.erb
@@ -15,6 +15,11 @@
 
       <%= govuk_summary_list do |summary_list| %>
         <% summary_list.with_row do |row| %>
+          <% row.with_key(text: Claims::ClaimWindow.human_attribute_name(:academic_year)) %>
+          <% row.with_value(text: Claims::ClaimWindow.current.academic_year_name) %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
           <% row.with_key(text: Claims::Claim.human_attribute_name(:accredited_provider)) %>
           <% row.with_value(text: @claim.provider_name) %>
           <% row.with_action(text: t("change"),
@@ -87,6 +92,6 @@
       <p class="govuk-body">
         <%= govuk_link_to t("cancel"), claims_support_school_claims_path(@school), no_visited_state: true %>
       </p>
-    <div>
-  <div>
+    </div>
+  </div>
 </div>

--- a/config/locales/en/claims/support/claims.yml
+++ b/config/locales/en/claims/support/claims.yml
@@ -15,6 +15,7 @@ en:
           school_ids: School
           provider_ids: Accredited provider
           provider: Accredited provider
+          academic_year: Academic year
           submit: Search
           clear: Clear search
           status: Status

--- a/config/locales/en/components/claim/card_component.yml
+++ b/config/locales/en/components/claim/card_component.yml
@@ -3,4 +3,3 @@ en:
     claim:
       card_component:
         claim_title: "%{reference} - %{school_name}"
-        academic_year: Academic year

--- a/config/locales/en/components/claim/card_component.yml
+++ b/config/locales/en/components/claim/card_component.yml
@@ -3,3 +3,4 @@ en:
     claim:
       card_component:
         claim_title: "%{reference} - %{school_name}"
+        academic_year: Academic year

--- a/spec/components/claim/card_component_spec.rb
+++ b/spec/components/claim/card_component_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Claim::CardComponent, type: :component do
     expect(page).to have_content(claim.reference)
     expect(page).to have_content("Submitted")
 
-    expect(page).to have_content("Academic year #{claim.academic_year_name}")
+    expect(page).to have_content(claim.academic_year_name)
     expect(page).to have_content(claim.provider.name)
     expect(page).to have_content("08/04/2024")
     expect(page).to have_content("£1,072.00")

--- a/spec/components/claim/card_component_spec.rb
+++ b/spec/components/claim/card_component_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Claim::CardComponent, type: :component do
     expect(page).to have_content(claim.reference)
     expect(page).to have_content("Submitted")
 
+    expect(page).to have_content("Academic year #{claim.academic_year_name}")
     expect(page).to have_content(claim.provider.name)
     expect(page).to have_content("08/04/2024")
     expect(page).to have_content("£1,072.00")

--- a/spec/forms/claims/support/claims/filter_form_spec.rb
+++ b/spec/forms/claims/support/claims/filter_form_spec.rb
@@ -18,6 +18,7 @@ describe Claims::Support::Claims::FilterForm, type: :model do
         school_ids: [],
         provider_ids: [],
         statuses: [],
+        academic_year_ids: [],
       )
     end
   end
@@ -32,6 +33,13 @@ describe Claims::Support::Claims::FilterForm, type: :model do
 
     it "returns true if provider_ids present" do
       params = { provider_ids: %w[provider_id] }
+      form = described_class.new(params)
+
+      expect(form.filters_selected?).to be(true)
+    end
+
+    it "returns true if academic_year_ids present" do
+      params = { academic_year_ids: %w[academic_year_id] }
       form = described_class.new(params)
 
       expect(form.filters_selected?).to be(true)
@@ -85,7 +93,7 @@ describe Claims::Support::Claims::FilterForm, type: :model do
 
       expect(call).to eq(
         claims_support_claims_path(
-          params: { claims_support_claims_filter_form: { school_ids: [], provider_ids: [] } },
+          params: { claims_support_claims_filter_form: { school_ids: [], provider_ids: [], academic_year_ids: [] } },
         ),
       )
     end
@@ -103,7 +111,7 @@ describe Claims::Support::Claims::FilterForm, type: :model do
 
         expect(call).to eq(
           claims_support_claims_path(
-            params: { claims_support_claims_filter_form: { school_ids: [], provider_ids: [] } },
+            params: { claims_support_claims_filter_form: { school_ids: [], provider_ids: [], academic_year_ids: [] } },
           ),
         )
       end
@@ -120,7 +128,7 @@ describe Claims::Support::Claims::FilterForm, type: :model do
 
         expect(call).to eq(
           claims_support_claims_path(
-            params: { claims_support_claims_filter_form: { school_ids: [], provider_ids: [] } },
+            params: { claims_support_claims_filter_form: { school_ids: [], provider_ids: [], academic_year_ids: [] } },
           ),
         )
       end
@@ -209,6 +217,25 @@ describe Claims::Support::Claims::FilterForm, type: :model do
     end
   end
 
+  describe "#academic_years" do
+    it "returns a collection of academic years based on academic_year_ids param" do
+      academic_year = AcademicYear.first
+      params = { academic_year_ids: [academic_year.id] }
+      call = described_class.new(params).academic_years
+
+      expect(call).to eq([academic_year])
+    end
+
+    context "when academic_year_ids is empty" do
+      it "returns empty array" do
+        params = { academic_year_ids: [] }
+        call = described_class.new(params).academic_years
+
+        expect(call).to eq([])
+      end
+    end
+  end
+
   describe "#query_params" do
     it "returns the query params meant for searching the database" do
       params = {
@@ -224,6 +251,7 @@ describe Claims::Support::Claims::FilterForm, type: :model do
         school_ids: %w[school_id],
         provider_ids: %w[provider_id],
         statuses: %w[submitted],
+        academic_year_ids: %w[academic_year_id],
       }
 
       call = described_class.new(params).query_params
@@ -237,6 +265,7 @@ describe Claims::Support::Claims::FilterForm, type: :model do
         submitted_after: Date.new(2024, 1, 2),
         submitted_before: Date.new(2023, 1, 2),
         statuses: %w[submitted],
+        academic_year_ids: %w[academic_year_id],
       )
     end
   end

--- a/spec/models/academic_year_spec.rb
+++ b/spec/models/academic_year_spec.rb
@@ -26,6 +26,28 @@ RSpec.describe AcademicYear, type: :model do
     it { is_expected.to validate_comparison_of(:ends_on).is_greater_than_or_equal_to(:starts_on) }
   end
 
+  describe "scopes" do
+    describe "order_by_date" do
+      # Academic years already exist and to avoid duplicating logic for this test, I have chosen to exclude them.
+      let!(:academic_year_ids_to_exclude) { AcademicYear.ids }
+      let(:academic_year_1) { create(:academic_year, starts_on: Date.parse("1 September 2021"), ends_on: Date.parse("31 August 2022"), name: "2021 to 2022") }
+      let(:academic_year_2) { create(:academic_year, starts_on: Date.parse("1 September 2022"), ends_on: Date.parse("31 August 2023"), name: "2022 to 2023") }
+      let(:academic_year_3) { create(:academic_year, starts_on: Date.parse("1 September 2023"), ends_on: Date.parse("31 August 2024"), name: "2023 to 2024") }
+      let(:academic_year_4) { create(:academic_year, starts_on: Date.parse("1 September 2024"), ends_on: Date.parse("31 August 2025"), name: "2024 to 2025") }
+
+      before do
+        academic_year_2
+        academic_year_4
+        academic_year_3
+        academic_year_1
+      end
+
+      it "orders by starts_on date in ascending order" do
+        expect(described_class.where.not(id: academic_year_ids_to_exclude).order_by_date).to eq([academic_year_1, academic_year_2, academic_year_3, academic_year_4])
+      end
+    end
+  end
+
   describe ".for_date" do
     let!(:existing_academic_year) do
       create(:academic_year,

--- a/spec/models/academic_year_spec.rb
+++ b/spec/models/academic_year_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe AcademicYear, type: :model do
   describe "scopes" do
     describe "order_by_date" do
       # Academic years already exist and to avoid duplicating logic for this test, I have chosen to exclude them.
-      let!(:academic_year_ids_to_exclude) { AcademicYear.ids }
+      let!(:academic_year_ids_to_exclude) { described_class.ids }
       let(:academic_year_1) { create(:academic_year, starts_on: Date.parse("1 September 2021"), ends_on: Date.parse("31 August 2022"), name: "2021 to 2022") }
       let(:academic_year_2) { create(:academic_year, starts_on: Date.parse("1 September 2022"), ends_on: Date.parse("31 August 2023"), name: "2022 to 2023") }
       let(:academic_year_3) { create(:academic_year, starts_on: Date.parse("1 September 2023"), ends_on: Date.parse("31 August 2024"), name: "2023 to 2024") }

--- a/spec/models/claims/claim_spec.rb
+++ b/spec/models/claims/claim_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe Claims::Claim, type: :model do
     it { is_expected.to delegate_method(:name).to(:provider).with_prefix }
     it { is_expected.to delegate_method(:users).to(:school).with_prefix }
     it { is_expected.to delegate_method(:full_name).to(:submitted_by).with_prefix.allow_nil }
+    it { is_expected.to delegate_method(:name).to(:academic_year).with_prefix.allow_nil }
   end
 
   describe "auditing" do

--- a/spec/queries/claims/claims_query_spec.rb
+++ b/spec/queries/claims/claims_query_spec.rb
@@ -49,6 +49,20 @@ describe Claims::ClaimsQuery do
       end
     end
 
+    context "when given academic year ids" do
+      let(:academic_year) { build(:academic_year, starts_on: Date.parse("1 September 2001"), ends_on: Date.parse("31 August 2002"), name: "2001 to 2002") }
+      # The current claim window gets chosen by default for created claims, so we need to create one in the past
+      let(:claim_window) { build(:claim_window, academic_year:, starts_on: 2.weeks.ago, ends_on: 1.week.ago) }
+      let(:params) { { academic_year_ids: [academic_year.id] } }
+
+      it "filters the results by provided academic year ids" do
+        claim_belonging_to_filtered_academic_year = create(:claim, :submitted, claim_window:)
+        _claim_not_belonging_to_filtered_academic_year = create(:claim, :submitted)
+
+        expect(claims_query).to contain_exactly(claim_belonging_to_filtered_academic_year)
+      end
+    end
+
     context "when given submitted_after" do
       let(:params) { { submitted_after: 2.days.ago } }
 

--- a/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
     within("dl.govuk-summary-list:nth(1)") do
       within(".govuk-summary-list__row:nth(2)") do
         expect(page).to have_content("Academic year")
-        expect(page).to have_content(claim.claim_window.academic_year_name)
+        expect(page).to have_content(claim.academic_year_name)
       end
 
       within(".govuk-summary-list__row:nth(3)") do

--- a/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
 
   def when_i_click_change_provider
     within("dl.govuk-summary-list:nth(1)") do
-      within(".govuk-summary-list__row:nth(2)") do
+      within(".govuk-summary-list__row:nth(3)") do
         click_link("Change")
       end
     end
@@ -152,7 +152,7 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
 
   def when_i_click_change_mentors
     within("dl.govuk-summary-list:nth(1)") do
-      within(".govuk-summary-list__row:nth(3)") do
+      within(".govuk-summary-list__row:nth(4)") do
         click_link("Change")
       end
     end
@@ -228,11 +228,16 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
 
     within("dl.govuk-summary-list:nth(1)") do
       within(".govuk-summary-list__row:nth(2)") do
+        expect(page).to have_content("Academic year")
+        expect(page).to have_content(claim.claim_window.academic_year_name)
+      end
+
+      within(".govuk-summary-list__row:nth(3)") do
         expect(page).to have_content("Accredited provider")
         expect(page).to have_content(provider.name)
       end
 
-      within(".govuk-summary-list__row:nth(3)") do
+      within(".govuk-summary-list__row:nth(4)") do
         expect(page).to have_content("Mentors")
         mentors.each do |mentor|
           expect(page).to have_content(mentor.full_name)

--- a/spec/system/claims/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/schools/claims/create_claim_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Create claim", service: :claims, type: :system do
+  let!(:claim_window) { create(:claim_window, :current) }
   let(:mentor1) { build(:claims_mentor, first_name: "Anne") }
   let(:mentor2) { build(:claims_mentor, first_name: "Joe") }
   let!(:school) { create(:claims_school, mentors: [mentor1, mentor2], region: regions(:inner_london)) }
@@ -213,11 +214,16 @@ RSpec.describe "Create claim", service: :claims, type: :system do
 
     within("dl.govuk-summary-list:nth(1)") do
       within(".govuk-summary-list__row:nth(2)") do
+        expect(page).to have_content("Academic year")
+        expect(page).to have_content(claim_window.academic_year_name)
+      end
+
+      within(".govuk-summary-list__row:nth(3)") do
         expect(page).to have_content("Accredited provider")
         expect(page).to have_content(bpn.name)
       end
 
-      within(".govuk-summary-list__row:nth(3)") do
+      within(".govuk-summary-list__row:nth(4)") do
         expect(page).to have_content("Mentors")
         expect(page).to have_content(mentor1.full_name)
         expect(page).to have_content(mentor2.full_name)

--- a/spec/system/claims/schools/claims/view_claim_spec.rb
+++ b/spec/system/claims/schools/claims/view_claim_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe "View a claim", service: :claims, type: :system do
   def then_i_can_then_see_the_submitted_claim_details
     expect(page).to have_content("Claim - #{submitted_claim.reference}")
     expect(page).to have_content("SchoolA School")
+    expect(page).to have_content("Academic year#{submitted_claim.academic_year.name}")
     expect(page).to have_content("Submitted")
     expect(page).to have_content("Submitted by #{anne.full_name} on 5 March 2024.")
     expect(page).to have_content("Accredited providerBest Practice Network")
@@ -86,6 +87,7 @@ RSpec.describe "View a claim", service: :claims, type: :system do
   def then_i_can_then_see_the_draft_claim_details
     expect(page).to have_content("Claim - #{draft_claim.reference}")
     expect(page).to have_content("SchoolA School")
+    expect(page).to have_content("Academic year#{draft_claim.academic_year.name}")
     expect(page).to have_content("Draft")
     expect(page).not_to have_content("Submitted by")
     expect(page).to have_content("Accredited providerBest Practice Network")
@@ -101,6 +103,7 @@ RSpec.describe "View a claim", service: :claims, type: :system do
   def then_i_can_then_see_the_draft_claim_details_without_change_buttons
     expect(page).to have_content("Claim - #{draft_claim.reference}")
     expect(page).to have_content("SchoolA School")
+    expect(page).to have_content("Academic year#{draft_claim.academic_year.name}")
     expect(page).not_to have_content("Submitted by")
     expect(page).to have_content("Accredited providerBest Practice Network")
     expect(page).to have_content("Mentors\nBarry Garlow")

--- a/spec/system/claims/support/claims/view_a_claim_spec.rb
+++ b/spec/system/claims/support/claims/view_a_claim_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe "View claims", service: :claims, type: :system do
   def then_i_can_see_the_details_of_a_submitted_claim
     expect(page).to have_content("Claim - #{claim.reference}")
     expect(page).to have_content("School#{claim.school.name}")
+    expect(page).to have_content("Academic year#{claim.academic_year_name}")
     expect(page).to have_content("Submitted")
     expect(page).to have_content("Submitted by #{user.full_name} on 5 March 2024.")
     expect(page).to have_content("Accredited provider#{provider.name}")

--- a/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
 
   def when_i_click_change_provider
     within("dl.govuk-summary-list:nth(1)") do
-      within(".govuk-summary-list__row:nth(1)") do
+      within(".govuk-summary-list__row:nth(2)") do
         click_link("Change")
       end
     end
@@ -155,7 +155,7 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
 
   def when_i_click_change_mentors
     within("dl.govuk-summary-list:nth(1)") do
-      within(".govuk-summary-list__row:nth(2)") do
+      within(".govuk-summary-list__row:nth(3)") do
         click_link("Change")
       end
     end
@@ -229,11 +229,16 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
 
     within("dl.govuk-summary-list:nth(1)") do
       within(".govuk-summary-list__row:nth(1)") do
+        expect(page).to have_content("Academic year")
+        expect(page).to have_content(claim.academic_year_name)
+      end
+
+      within(".govuk-summary-list__row:nth(2)") do
         expect(page).to have_content("Accredited provider")
         expect(page).to have_content(provider.name)
       end
 
-      within(".govuk-summary-list__row:nth(2)") do
+      within(".govuk-summary-list__row:nth(3)") do
         expect(page).to have_content("Mentors")
         mentors.each do |mentor|
           expect(page).to have_content(mentor.full_name)

--- a/spec/system/claims/support/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/create_claim_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Create claim", service: :claims, type: :system do
+  let!(:claim_window) { create(:claim_window, :current) }
   let!(:school) { create(:claims_school) }
   let!(:mentor1) { create(:claims_mentor, first_name: "Anne", schools: [school]) }
   let!(:mentor2) { create(:claims_mentor, first_name: "Joe", schools: [school]) }
@@ -211,11 +212,16 @@ RSpec.describe "Create claim", service: :claims, type: :system do
 
     within("dl.govuk-summary-list:nth(1)") do
       within(".govuk-summary-list__row:nth(1)") do
+        expect(page).to have_content("Academic year")
+        expect(page).to have_content(claim_window.academic_year_name)
+      end
+
+      within(".govuk-summary-list__row:nth(2)") do
         expect(page).to have_content("Accredited provider")
         expect(page).to have_content(bpn.name)
       end
 
-      within(".govuk-summary-list__row:nth(2)") do
+      within(".govuk-summary-list__row:nth(3)") do
         expect(page).to have_content("Mentors")
         expect(page).to have_content(mentor1.full_name)
         expect(page).to have_content(mentor2.full_name)


### PR DESCRIPTION
## Context

We want to be able to see which Academic year each claim was made against.

We also want to be able to filter claims by academic year in the support console.

## Changes proposed in this pull request

- [x] Delegate `:name` to `AcademicYear` from a claim
- [x] Update the claim show page for support to display the academic year
- [x] Update the claim card for the index page to display the academic year
- [x] Add a new `order_by_date` scope to the `AcademicYear` to ensure correct order for filter display
- [x] Add an academic year condition to the claims query
- [x] Add academic_year_ids to the claims filter form
- [x] Wrote a system spec to cover the functionality

## Guidance to review

- Log in as Colin
- Navigate to the claims in the navigation
- Filter claims by the current academic year (2024 to 2025) 
- All claims should be displayed
- Clear all filters
- Filter claims by the next academic year (2025 to 2026)
- No claims should be displayed
- Clear the filter using the 2025 to 2026 pill
- All claims should be displayed

## Link to Trello card

[How we identify which claims are associated with each academic year / claim window (support console)](https://trello.com/c/a3HYWhwk/793-how-we-identify-which-claims-are-associated-with-each-academic-year-claim-window-support-console)

## Screenshots

![image](https://github.com/user-attachments/assets/853d4162-47d2-4d5f-9710-71e87222409f)
![image](https://github.com/user-attachments/assets/c5b6e0ed-3330-4e5f-b0bd-8289c6aec8df)
![image](https://github.com/user-attachments/assets/fca76257-1bf1-4794-8973-261d1273cf0e)
![image](https://github.com/user-attachments/assets/46eaa899-56b7-4c83-937d-421c083093fa)

