### PR TITLE
Remove nulldb AR adapter

### DIFF
--- a/.github/actions/deploy-environment/action.yml
+++ b/.github/actions/deploy-environment/action.yml
@@ -19,46 +19,46 @@ runs:
   using: composite
 
   steps:
-          - uses: hashicorp/setup-terraform@v3
-            with:
-              terraform_version: 1.6.4
-              terraform_wrapper: false
+    - uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: 1.6.4
+        terraform_wrapper: false
 
-          - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
-            with:
-              azure-credentials: ${{ inputs.azure-credentials }}
+    - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+      with:
+        azure-credentials: ${{ inputs.azure-credentials }}
 
-          - name: Terraform Apply
-            shell: bash
-            run: |
-              make ci ${{ inputs.environment }} terraform-apply
-            env:
-              DOCKER_IMAGE_TAG: ${{ inputs.docker-image }}
-              PR_NUMBER: ${{ inputs.pull-request-number }}
+    - name: Terraform Apply
+      shell: bash
+      run: |
+        make ci ${{ inputs.environment }} terraform-apply
+      env:
+        DOCKER_IMAGE_TAG: ${{ inputs.docker-image }}
+        PR_NUMBER: ${{ inputs.pull-request-number }}
 
-          - name: Extract Terraform outputs
-            shell: bash
-            id: set_outputs
-            run: |
-              output=$(terraform -chdir=terraform/application output -json ingress_hostnames)
-              echo "HOSTNAMES=$output" >> $GITHUB_ENV
+    - name: Extract Terraform outputs
+      shell: bash
+      id: set_outputs
+      run: |
+        output=$(terraform -chdir=terraform/application output -json ingress_hostnames)
+        echo "HOSTNAMES=$output" >> $GITHUB_ENV
 
-          - name: Set up Ruby 3.3.1
-            uses: ruby/setup-ruby@v1
-            with:
-              ruby-version: 3.3.1
-              bundler-cache: true
+    - name: Set up Ruby 3.3.1
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.3.1
+        bundler-cache: true
 
-          - name: Run RSpec tests
-            shell: bash
-            run: |
-             CLAIMS_EXTERNAL_HOST=$(echo $HOSTNAMES | jq -r '.[0]')
-             PLACEMENTS_EXTERNAL_HOST=$(echo $HOSTNAMES | jq -r '.[1]')
+    - name: Run RSpec tests
+      shell: bash
+      run: |
+        CLAIMS_EXTERNAL_HOST=$(echo $HOSTNAMES | jq -r '.[0]')
+        PLACEMENTS_EXTERNAL_HOST=$(echo $HOSTNAMES | jq -r '.[1]')
 
-             export CLAIMS_EXTERNAL_HOST=$CLAIMS_EXTERNAL_HOST
-             export PLACEMENTS_EXTERNAL_HOST=$PLACEMENTS_EXTERNAL_HOST
+        export CLAIMS_EXTERNAL_HOST=$CLAIMS_EXTERNAL_HOST
+        export PLACEMENTS_EXTERNAL_HOST=$PLACEMENTS_EXTERNAL_HOST
 
-             bin/bundle exec rspec --tag smoke_test -b
-            env:
-                SMOKE_TEST: "true"
-                HOSTNAMES: ${{ env.HOSTNAMES }}
+        bin/bundle exec rspec spec/system/smoke_tests --tag smoke_test -b
+      env:
+        SMOKE_TEST: "true"
+        HOSTNAMES: ${{ env.HOSTNAMES }}

--- a/Gemfile
+++ b/Gemfile
@@ -133,8 +133,6 @@ group :development do
 end
 
 group :test do
-  # Return null object for active record connection rather than raising error
-  gem "activerecord-nulldb-adapter"
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   # The accessible selectors gem is maintained by Citizens Advice, not yet a registered gem.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,8 +85,6 @@ GEM
       activemodel (= 7.2.1)
       activesupport (= 7.2.1)
       timeout (>= 0.4.0)
-    activerecord-nulldb-adapter (0.5.1)
-      activerecord (>= 5.2.0)
     activerecord-session_store (2.1.0)
       actionpack (>= 6.1)
       activerecord (>= 6.1)
@@ -671,7 +669,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  activerecord-nulldb-adapter
   activerecord-session_store
   amazing_print
   annotate

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,9 +29,7 @@ Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 #
 # Rails.root.glob('spec/support/**/*.rb').sort.each { |f| require f }
 
-if ENV["SMOKE_TEST"] == "true"
-  ActiveRecord::Base.establish_connection adapter: :nulldb
-else
+unless ENV["SMOKE_TEST"] == "true"
   # Checks for pending migrations and applies them before tests are run.
   # If you are not using ActiveRecord, you can remove these lines.
   begin
@@ -46,15 +44,17 @@ RSpec.configure do |config|
   config.include DfESignInUserHelper
   config.include GeocodingHelper
 
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_paths = [Rails.root.join("spec/fixtures")]
+  unless ENV["SMOKE_TEST"] == "true"
+    # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
+    config.fixture_paths = [Rails.root.join("spec/fixtures")]
 
-  config.global_fixtures = :all unless ENV["SMOKE_TEST"] == "true"
+    config.global_fixtures = :all
 
-  # If you're not using ActiveRecord, or you'd prefer not to run each of your
-  # examples within a transaction, remove the following line or assign false
-  # instead of true.
-  config.use_transactional_fixtures = true
+    # If you're not using ActiveRecord, or you'd prefer not to run each of your
+    # examples within a transaction, remove the following line or assign false
+    # instead of true.
+    config.use_transactional_fixtures = true
+  end
 
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -90,9 +90,8 @@ RSpec.configure do |config|
   #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
   #   config.filter_run_when_matching :focus
 
-  config.filter_run_excluding smoke_test: true
+  config.filter_run_excluding :smoke_test
 
-  #
   #   # Allows RSpec to persist some state between runs in order to support
   #   # the `--only-failures` and `--next-failure` CLI options. We recommend
   #   # you configure your source control system to ignore this file.


### PR DESCRIPTION
## Context

Upon upgrading to Rails 7.2, AR adapters need to be registered. The NullDb adapter has not been updated to support Rails 7.2.

By looking at our usage, we needed the nulldb adapter to prevent db queries from happening within smoke tests.

## Changes proposed in this pull request

- Remove the NullDb adapater.
- Don't run fixtures nor maintain test schema when running smoke tests.
- Format the GA deploy action YAML file.

## Guidance to review

This gets around potentially multiple issues by running smoke tests specifically on the `specs/system/smoke_tests` directory.