### PR TITLE
Add the "sent_to_esfa" claim status

### DIFF
--- a/app/models/claims/claim.rb
+++ b/app/models/claims/claim.rb
@@ -66,7 +66,12 @@ class Claims::Claim < ApplicationRecord
   scope :not_draft_status, -> { where.not(status: DRAFT_STATUSES) }
 
   enum :status,
-       { internal_draft: "internal_draft", draft: "draft", submitted: "submitted" },
+       {
+         internal_draft: "internal_draft",
+         draft: "draft",
+         submitted: "submitted",
+         sent_to_esfa: "sent_to_esfa",
+       },
        validate: true
 
   delegate :name, to: :provider, prefix: true, allow_nil: true

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -15,4 +15,5 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "DfE"
   inflect.acronym "QA"
   inflect.acronym "CSV"
+  inflect.acronym "ESFA"
 end

--- a/db/migrate/20240913143256_add_sent_to_esfa_to_claim_status_enum.rb
+++ b/db/migrate/20240913143256_add_sent_to_esfa_to_claim_status_enum.rb
@@ -1,0 +1,5 @@
+class AddSentToESFAToClaimStatusEnum < ActiveRecord::Migration[7.2]
+  def change
+    add_enum_value :claim_status, "sent_to_esfa"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,7 +17,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_13_144518) do
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
-  create_enum "claim_status", ["internal_draft", "draft", "submitted"]
+  create_enum "claim_status", ["internal_draft", "draft", "submitted", "sent_to_esfa"]
   create_enum "mentor_training_type", ["refresher", "initial"]
   create_enum "placement_status", ["draft", "published"]
   create_enum "placement_year_group", ["year_1", "year_2", "year_3", "year_4", "year_5", "year_6"]

--- a/spec/helpers/claims/claim_helper_spec.rb
+++ b/spec/helpers/claims/claim_helper_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Claims::ClaimHelper do
   describe "#claim_statuses_for_selection" do
     it "returns an array of claims statuses, except draft statuses" do
-      expect(claim_statuses_for_selection).to contain_exactly("submitted")
+      expect(claim_statuses_for_selection).to contain_exactly("submitted", "sent_to_esfa")
     end
   end
 end

--- a/spec/models/claims/claim_spec.rb
+++ b/spec/models/claims/claim_spec.rb
@@ -90,7 +90,12 @@ RSpec.describe Claims::Claim, type: :model do
 
     it "defines the expected values" do
       expect(claim).to define_enum_for(:status)
-        .with_values(internal_draft: "internal_draft", draft: "draft", submitted: "submitted")
+        .with_values(
+          internal_draft: "internal_draft",
+          draft: "draft",
+          submitted: "submitted",
+          sent_to_esfa: "sent_to_esfa",
+        )
         .backed_by_column_of_type(:enum)
     end
   end


### PR DESCRIPTION
## Context

We've already sent some claims to ESFA. We want to create a distinction between these claims and the new claims that are submitted to the service. 

## Changes proposed in this pull request

- Add the `sent_to_esfa` claim status.

## Guidance to review

Once this change is live, I'll SSH into the service to update the status of the claims that have already been sent to ESFA.