### PR TITLE
Drop data_migrations table if exists

### DIFF
--- a/db/migrate/20240913144518_drop_data_migrations_table_if_exists.rb
+++ b/db/migrate/20240913144518_drop_data_migrations_table_if_exists.rb
@@ -1,0 +1,9 @@
+class DropDataMigrationsTableIfExists < ActiveRecord::Migration[7.2]
+  def up
+    drop_table :data_migrations, if_exists: true
+  end
+
+  def down
+    raise IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_03_124152) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_13_144518) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -88,9 +88,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_03_124152) do
     t.index ["reference"], name: "index_claims_on_reference"
     t.index ["school_id"], name: "index_claims_on_school_id"
     t.index ["submitted_by_type", "submitted_by_id"], name: "index_claims_on_submitted_by"
-  end
-
-  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
   end
 
   create_table "flipflop_features", force: :cascade do |t|


### PR DESCRIPTION
## Context

We recently removed the `data_migrate` gem https://github.com/DFE-Digital/itt-mentor-services/pull/1022.

We should drop the `data_migrations` table if it exists. It will exist in environments, such as production, where the `data_migrations` table was added previously via the `data_migrate` gem.

On new machines it will be missing, hence the need for the `if_exists: true`.

## Changes proposed in this pull request

- Drop the `data_migrations` table if it exists.

## Guidance to review

\-