### PR TITLE
Add Ruby LSP RSpec addon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -121,6 +121,10 @@ group :development do
   gem "syntax_tree", require: false
   gem "syntax_tree-haml", require: false
   gem "syntax_tree-rbs", require: false
+
+  # Ruby LSP addon for RSpec [https://github.com/Shopify/ruby-lsp]
+  gem "ruby-lsp-rspec", require: false
+
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "rails-erd"
   gem "web-console"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -400,6 +400,7 @@ GEM
       activerecord (>= 6.1)
       activesupport (>= 6.1)
     prettier_print (1.2.1)
+    prism (1.0.0)
     propshaft (0.9.1)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
@@ -484,7 +485,8 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
-    rbs (2.8.4)
+    rbs (3.5.3)
+      logger
     rdoc (6.7.0)
       psych (>= 4.0.0)
     redcarpet (3.6.0)
@@ -557,6 +559,13 @@ GEM
       rubocop (~> 1.61)
     ruby-graphviz (1.2.5)
       rexml
+    ruby-lsp (0.17.17)
+      language_server-protocol (~> 3.17.0)
+      prism (~> 1.0)
+      rbs (>= 3, < 4)
+      sorbet-runtime (>= 0.5.10782)
+    ruby-lsp-rspec (0.1.12)
+      ruby-lsp (~> 0.17.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
@@ -593,6 +602,7 @@ GEM
     skylight (6.0.4)
       activesupport (>= 5.2.0)
     smart_properties (1.17.0)
+    sorbet-runtime (0.5.11558)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.1)
@@ -726,6 +736,7 @@ DEPENDENCIES
   rspec-rails
   rspec-retry!
   rubocop-govuk
+  ruby-lsp-rspec
   selenium-webdriver
   sentry-rails
   shoulda-matchers


### PR DESCRIPTION
Enables support for running RSpec tests inside your IDE (VS Code, in my case).

See [ruby-lsp-rspec][1] for an example of how this works.

Can be used in combination with the [Ruby LSP extension for VS Code][2].

[1]: https://github.com/st0012/ruby-lsp-rspec
[2]: https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp

<img src="https://github.com/st0012/ruby-lsp-rspec/raw/main/misc/example.gif" alt="">