### PR TITLE
Replace H4 in content header component with span

### DIFF
--- a/app/components/content_header_component.html.erb
+++ b/app/components/content_header_component.html.erb
@@ -1,8 +1,8 @@
 <div class="content-header">
   <div class="content-header-title">
-    <h4 class="govuk-heading-s govuk-heading-s govuk-!-margin-bottom-0">
+    <span class="govuk-heading-s govuk-heading-s govuk-!-margin-bottom-0">
      <%= title %>
-    </h4>
+    </span>
   </div>
 
   <div class="content-header-actions">


### PR DESCRIPTION
## Context

This change will contribute to resolving an identified accessibility issue relating to heading structure while maintaining the existing UI.

## Changes proposed in this pull request

- In the content header component, replace the h4 header text with a span while keeping the same classes so the styling remains unchanged.

## Guidance to review

- Log in as a multi-org user.
- Choose any institution.
- Navigate to the organisation switcher at the top of the page (where you can find a 'change organisation' hyperlink).
- Check that the name of the school on the switcher appears with the correct styling.
- Use 'dev tools' in the browser to confirm that the component contains a 'span' in place of an 'h4'.

## Link to Trello card

https://trello.com/c/yE34nofc/791-remove-h4-from-the-organisation-switcher-component

## Screenshots

<img width="1018" alt="Screenshot 2024-09-17 at 09 47 52" src="https://github.com/user-attachments/assets/30b1320e-84bb-4d92-89ad-724972035bb9">
