### PR TITLE
Add sent_to_esfa to the list of StatusTag statuses

### DIFF
--- a/app/components/claim/status_tag_component.rb
+++ b/app/components/claim/status_tag_component.rb
@@ -25,6 +25,7 @@ class Claim::StatusTagComponent < ApplicationComponent
     {
       draft: "grey",
       submitted: "blue",
+      sent_to_esfa: "light-blue",
     }.with_indifferent_access
   end
 end

--- a/app/components/claim/status_tag_component.rb
+++ b/app/components/claim/status_tag_component.rb
@@ -23,6 +23,7 @@ class Claim::StatusTagComponent < ApplicationComponent
 
   def status_colours
     {
+      internal_draft: "grey",
       draft: "grey",
       submitted: "blue",
       sent_to_esfa: "light-blue",

--- a/spec/components/claim/status_tag_component_spec.rb
+++ b/spec/components/claim/status_tag_component_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe Claim::StatusTagComponent, type: :component do
+  subject(:component) { described_class.new(claim:) }
+
+  before do
+    render_inline(component)
+  end
+
+  context "when the claim's status is 'draft'" do
+    let(:claim) { build(:claim, status: :draft) }
+
+    it "renders a grey tag" do
+      expect(page).to have_css(".govuk-tag--grey", text: "Draft")
+    end
+  end
+
+  context "when the claim's status is 'submitted'" do
+    let(:claim) { build(:claim, status: :submitted) }
+
+    it "renders a blue tag" do
+      expect(page).to have_css(".govuk-tag--blue", text: "Submitted")
+    end
+  end
+
+  context "when the claim's status is 'sent_to_esfa'" do
+    let(:claim) { build(:claim, status: :sent_to_esfa) }
+
+    it "renders a light blue tag" do
+      expect(page).to have_css(".govuk-tag--light-blue", text: "Sent to ESFA")
+    end
+  end
+end

--- a/spec/components/claim/status_tag_component_spec.rb
+++ b/spec/components/claim/status_tag_component_spec.rb
@@ -30,4 +30,14 @@ RSpec.describe Claim::StatusTagComponent, type: :component do
       expect(page).to have_css(".govuk-tag--light-blue", text: "Sent to ESFA")
     end
   end
+
+  Claims::Claim.statuses.each_key do |status|
+    context "with a claim of status '#{status}'" do
+      let(:claim) { build(:claim, status:) }
+
+      it "renders successfully" do
+        expect(page).to have_css(".govuk-tag")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

We want to show "Sent to ESFA" in the status tags. It seems I've forgotten to add it to the `Claim::StatusTagComponent`'s list of accepted statuses.

## Changes proposed in this pull request

- Add `sent_to_esfa` to the list of status colors in the `Claim::StatusTagComponent` view component.
- Add a set of tests to ensure the `Claim::StatusTagComponent` knows how to render all Claim statuses.