### PR TITLE
"Show filter" button added to Support user -> organisation index

### DIFF
--- a/app/views/placements/support/organisations/_filter.html.erb
+++ b/app/views/placements/support/organisations/_filter.html.erb
@@ -1,12 +1,15 @@
 <%# locals: (search_param: "", filters: []) -%>
 
-<div class="app-filter-layout">
+<div class="app-filter-layout display-none-on-mobile" data-filter-target="filter">
   <div class="app-filter-layout__filter">
     <div class="app-filter__header">
       <div class="app-filter__header-title">
         <h2 class="govuk-heading-m"><%= t("placements.support.organisations.index.filter") %></h2>
       </div>
       <div class="app-filter__header-action"></div>
+        <button class="app-filter__close" type="button" data-action="click->filter#close">
+          <%= t("close") %>
+        </button>
     </div>
     <div class="app-filter-layout__content">
      <% if filters.any? %>

--- a/app/views/placements/support/organisations/index.html.erb
+++ b/app/views/placements/support/organisations/index.html.erb
@@ -1,11 +1,16 @@
 <%= content_for :page_title, t(".title", organisation_count: @pagy.count) %>
 <%= render "placements/support/primary_navigation", current_navigation: :organisations %>
-<div class="govuk-width-container">
+<div class="govuk-width-container" data-controller="filter">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l"><%= t(".title", organisation_count: @pagy.count) %></h1>
       <%= govuk_button_link_to(t(".add_organisation"), new_add_organisation_placements_support_organisations_path) %>
     </div>
+  </div>
+  <div>
+    <button class="govuk-button govuk-button--secondary show-filter-button" type="button" data-action="click->filter#open">
+      <%= t("show_filter") %>
+    </button>
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">


### PR DESCRIPTION
## Context

This change fixes a bug through which the filter sidebar presented as a full-screen overlay on smaller viewports. It is now possible to show and hide the panel at the user's discretion.

## Changes proposed in this pull request

- "Show filter" button added to the organisation index 
- Show/hide functionality added for side panel, including a 'Close' button

## Guidance to review

- Log in as support user.
- You will land on the organisation index page.
- Reduce browser window size until the smaller viewport settings appear.
- The "Show filter" button should appear.
- Click the "Show filter" button.
- The filter panel should appear on the right-hand side.
- Close the panel.

## Link to Trello card

https://trello.com/c/5gqD2wIZ/790-fix-filter-panel-always-showing-and-obscuring-page-content

## Screenshots

<img width="595" alt="Screenshot 2024-09-17 at 13 34 29" src="https://github.com/user-attachments/assets/37d7adc9-bfb3-46db-8113-0344d7c2e915">
<br>
<br>
<br>
<br>
<img width="589" alt="Screenshot 2024-09-17 at 13 34 40" src="https://github.com/user-attachments/assets/14c20d8c-4d1c-47ef-acc8-004db8b09ba2">

