### PR TITLE
Remove the tag from the reset database page title

### DIFF
--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -11,4 +11,3 @@
 @import "secondary_navigation";
 @import "search_results";
 @import "typography";
-@import "tag";

--- a/app/assets/stylesheets/components/_tag.scss
+++ b/app/assets/stylesheets/components/_tag.scss
@@ -1,5 +1,0 @@
-.govuk-tag {
-  &.govuk-tag--middle {
-    vertical-align: middle;
-  }
-}

--- a/app/views/claims/support/databases/reset.en.html.erb
+++ b/app/views/claims/support/databases/reset.en.html.erb
@@ -7,7 +7,7 @@
 
 <div class="govuk-width-container">
   <span class="govuk-caption-l">Reset database</span>
-  <h1 class="govuk-heading-l">Are you sure you want to reset the <%= govuk_tag text: hosting_environment_phase(current_service), colour: hosting_environment_color, classes: "govuk-tag--middle" %> database?</h1>
+  <h1 class="govuk-heading-l">Are you sure you want to reset the <%= hosting_environment_phase(current_service) %> environment database?</h1>
 
   <p class="govuk-body">This action will truncate the following tables:</p>
 

--- a/spec/system/claims/support/reset_database_spec.rb
+++ b/spec/system/claims/support/reset_database_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Reset claims database", service: :claims, type: :system do
 
   scenario "Support user resets claims database for testing purposes" do
     when_i_visit_the_reset_database_page
-    then_i_see "Are you sure you want to reset the Test database?"
+    then_i_see "Are you sure you want to reset the Test environment database?"
 
     when_i_click_on "Reset database"
     then_i_see "Database has been reset"


### PR DESCRIPTION
## Context

We don't want to have tags within page titles.

## Changes proposed in this pull request

- Swap out tag for plaintext.
- Add "environment" word in for clarity.

## Guidance to review

- Reset database page no longer shows a tag in the page title.