### PR TITLE
Downcase the environment name on the Claims reset database page

### DIFF
--- a/app/views/claims/support/databases/reset.en.html.erb
+++ b/app/views/claims/support/databases/reset.en.html.erb
@@ -7,7 +7,7 @@
 
 <div class="govuk-width-container">
   <span class="govuk-caption-l">Reset database</span>
-  <h1 class="govuk-heading-l">Are you sure you want to reset the <%= hosting_environment_phase(current_service) %> environment database?</h1>
+  <h1 class="govuk-heading-l">Are you sure you want to reset the <%= hosting_environment_phase(current_service).downcase %> environment database?</h1>
 
   <p class="govuk-body">This action will truncate the following tables:</p>
 

--- a/spec/system/claims/support/reset_database_spec.rb
+++ b/spec/system/claims/support/reset_database_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Reset claims database", service: :claims, type: :system do
 
   scenario "Support user resets claims database for testing purposes" do
     when_i_visit_the_reset_database_page
-    then_i_see "Are you sure you want to reset the Test environment database?"
+    then_i_see "Are you sure you want to reset the test environment database?"
 
     when_i_click_on "Reset database"
     then_i_see "Database has been reset"


### PR DESCRIPTION
## Context

The environment name should not be capitalized.

## Changes proposed in this pull request

- Downcase the environment name.

## Guidance to review

- Environment name in the page title on the reset page is all lowercase letters.

## Screenshots

![CleanShot 2024-09-18 at 10 43 27](https://github.com/user-attachments/assets/0aec4fbd-abc7-4682-ad1a-7b54699b4c18)
