### PR TITLE
School user → Mentors UI changes

### DIFF
--- a/app/helpers/placements/translations_helper.rb
+++ b/app/helpers/placements/translations_helper.rb
@@ -1,5 +1,5 @@
 module Placements::TranslationsHelper
   def embedded_link_text(translations)
-    sanitize translations, tags: %w[a]
+    sanitize translations, tags: %w[a], attributes: %w[href target class]
   end
 end

--- a/app/views/placements/schools/mentors/index.html.erb
+++ b/app/views/placements/schools/mentors/index.html.erb
@@ -6,6 +6,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+      <p class="govuk-body"><%= t(".intro_text") %></p>
 
       <%= govuk_button_link_to(t(".add_mentor"), new_add_mentor_placements_school_mentors_path) %>
 
@@ -32,7 +33,7 @@
         <% end %>
         <%= render PaginationComponent.new(pagy: @pagy) %>
       <% else %>
-        <p>
+        <p class="govuk-body">
           <%= t("no_records_for", records: "mentors", for: @school.name) %>
         </p>
       <% end %>

--- a/app/views/placements/wizards/add_mentor_wizard/_check_your_answers_step.html.erb
+++ b/app/views/placements/wizards/add_mentor_wizard/_check_your_answers_step.html.erb
@@ -1,13 +1,14 @@
-<% caption = current_user.support_user? ? "#{t(".add_mentor")} #{contextual_text}" : t(".add_mentor") %>
 <% content_for :page_title, t(".page_title", contextual_text:) %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= form_with(model: check_your_answers_step, url: current_step_path, method: :put) do |f| %>
-        <span class="govuk-caption-l"><%= caption %></span>
-        <h1 class="govuk-heading-l"><%= t(".check_your_answers") %></h1>
+        <h1 class="govuk-heading-l"><%= t(".confirm_details") %></h1>
 
+        <p class="govuk-body"><%= t(".intro_text") %></p>
+
+        <h2 class="govuk-heading-m"><%= t(".mentor") %></h2>
         <%= govuk_summary_list do |summary_list| %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: Mentor.human_attribute_name("first_name")) %>
@@ -38,9 +39,8 @@
         <p class="govuk-inset-text">
           <%= embedded_link_text(
                 t(".confirm_mentor_informed",
-                  mentor_name: @wizard.steps[:mentor].mentor.full_name,
                   link: govuk_link_to(
-                    t(".privacy_notice"), placements_privacy_path, no_visited_state: true
+                    t(".privacy_notice"), placements_privacy_path, new_tab: true, no_visited_state: true
                   )),
               ) %>
         </p>

--- a/config/locales/en/placements/schools/mentors.yml
+++ b/config/locales/en/placements/schools/mentors.yml
@@ -7,7 +7,8 @@ en:
             add_mentor: Add mentor
             cancel: Cancel
         index:
-          heading: Mentors
+          heading: Mentors at your school
+          intro_text: Add mentors to be able to assign them to your placements.
           trn: Teacher reference number (TRN)
           add_mentor: Add mentor
           page_title: Mentors

--- a/config/locales/en/placements/wizards/add_mentor_wizard.yml
+++ b/config/locales/en/placements/wizards/add_mentor_wizard.yml
@@ -18,18 +18,19 @@ en:
           help_with_the_trn: Help with the TRN
           date_of_birth_hint: For example, 31 3 1980
         check_your_answers_step:
-          page_title: Check your answers - Add mentor - %{contextual_text}
-          add_mentor: Add mentor
+          page_title: Confirm mentor details - Add mentor - %{contextual_text}
+          add_mentor: Confirm and add mentor
           cancel: Cancel
           change: Change
-          check_your_answers: Check your answers
+          confirm_details: Confirm mentor details
+          intro_text: Once added, you will be able to assign them to placements.
+          mentor: Mentor
           trn: Teacher reference number (TRN)
           date_of_birth: Date of birth
           confirm_mentor_informed: |
-            I confirm that %{mentor_name} has been informed that the Department for Education will 
-            store their information in line with the %{link} and have provided them with a 
-            copy of this notice for reference.
-          privacy_notice: privacy notice
+            Mentor data is stored in line with the %{link}. 
+            I confirm that I have read, understood and accept how DfE uses mentor information as part of the Manage school placements service.
+          privacy_notice: Department for Education's (DfE) privacy notice
         no_results_step:
           page_title: No results found for ‘%{trn}’ - %{contextual_text}
           caption: Mentor not found

--- a/spec/system/placements/schools/mentors/user_adds_mentor_spec.rb
+++ b/spec/system/placements/schools/mentors/user_adds_mentor_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "Placements school user adds mentors to schools", service: :place
       then_i_see_form_with_trn_and_date_of_birth(claims_mentor.trn, 1, 1, 1990)
       when_i_click_on("Continue")
       then_i_see_check_page_for(claims_mentor)
-      when_i_click_on("Add mentor")
+      when_i_click_on("Confirm and add mentor")
       then_mentor_is_added(claims_mentor.full_name)
     end
   end
@@ -119,7 +119,7 @@ RSpec.describe "Placements school user adds mentors to schools", service: :place
       then_i_see_form_with_trn_and_date_of_birth(placements_mentor.trn, 1, 1, 1990)
       when_i_click_on("Continue")
       then_i_see_check_page_for(placements_mentor)
-      when_i_click_on("Add mentor")
+      when_i_click_on("Confirm and add mentor")
       then_mentor_is_added(placements_mentor.full_name)
     end
   end
@@ -157,7 +157,7 @@ RSpec.describe "Placements school user adds mentors to schools", service: :place
       when_i_enter_date_of_birth(1, 1, 1990)
       and_i_click_on("Continue")
       then_i_see_check_page_for(new_mentor)
-      when_i_click_on("Add mentor")
+      when_i_click_on("Confirm and add mentor")
       then_mentor_is_added(new_mentor.full_name)
     end
   end
@@ -194,8 +194,8 @@ RSpec.describe "Placements school user adds mentors to schools", service: :place
 
   def then_i_see_check_page_for(mentor)
     expect_organisations_to_be_selected_in_primary_navigation
-    expect(page).to have_content "Add mentor"
-    expect(page).to have_content "Check your answers"
+    expect(page).to have_content "Confirm and add mentor"
+    expect(page).to have_content "Confirm mentor details"
     name_row = page.all(".govuk-summary-list__row")[0]
     within(name_row) do
       expect(page).to have_content "First name"

--- a/spec/system/placements/support/schools/mentors/support_user_adds_a_mentor_spec.rb
+++ b/spec/system/placements/support/schools/mentors/support_user_adds_a_mentor_spec.rb
@@ -91,16 +91,16 @@ RSpec.describe "Placements support user adds mentors to schools", service: :plac
       when_i_enter_trn(claims_mentor.trn)
       when_i_enter_date_of_birth(1, 1, 1990)
       and_i_click_on("Continue")
-      then_i_see_check_page_for(claims_mentor, school)
+      then_i_see_check_page_for(claims_mentor)
       when_i_click_on("Back")
       then_i_see_form_with_trn_and_date_of_birth(claims_mentor.trn, 1, 1, 1990)
       when_i_click_on("Continue")
-      then_i_see_check_page_for(claims_mentor, school)
+      then_i_see_check_page_for(claims_mentor)
       when_i_click_on("Change")
       then_i_see_form_with_trn_and_date_of_birth(claims_mentor.trn, 1, 1, 1990)
       when_i_click_on("Continue")
-      then_i_see_check_page_for(claims_mentor, school)
-      when_i_click_on("Add mentor")
+      then_i_see_check_page_for(claims_mentor)
+      when_i_click_on("Confirm and add mentor")
       then_mentor_is_added(claims_mentor.full_name)
     end
   end
@@ -119,12 +119,12 @@ RSpec.describe "Placements support user adds mentors to schools", service: :plac
       when_i_enter_trn(placements_mentor.trn)
       when_i_enter_date_of_birth(1, 1, 1990)
       and_i_click_on("Continue")
-      then_i_see_check_page_for(placements_mentor, school)
+      then_i_see_check_page_for(placements_mentor)
       when_i_click_on("Back")
       then_i_see_form_with_trn_and_date_of_birth(placements_mentor.trn, 1, 1, 1990)
       when_i_click_on("Continue")
-      then_i_see_check_page_for(placements_mentor, school)
-      when_i_click_on("Add mentor")
+      then_i_see_check_page_for(placements_mentor)
+      when_i_click_on("Confirm and add mentor")
       then_mentor_is_added(placements_mentor.full_name)
     end
   end
@@ -161,8 +161,8 @@ RSpec.describe "Placements support user adds mentors to schools", service: :plac
       when_i_enter_trn(new_mentor.trn)
       when_i_enter_date_of_birth(1, 1, 1990)
       and_i_click_on("Continue")
-      then_i_see_check_page_for(new_mentor, school)
-      when_i_click_on("Add mentor")
+      then_i_see_check_page_for(new_mentor)
+      when_i_click_on("Confirm and add mentor")
       then_mentor_is_added(new_mentor.full_name)
     end
   end
@@ -197,10 +197,10 @@ RSpec.describe "Placements support user adds mentors to schools", service: :plac
     find("span", text: "Help with the TRN").click
   end
 
-  def then_i_see_check_page_for(mentor, school)
+  def then_i_see_check_page_for(mentor)
     expect_organisations_to_be_selected_in_primary_navigation
-    expect(page).to have_content "Add mentor - #{school.name}"
-    expect(page).to have_content "Check your answers"
+    expect(page).to have_content "Confirm and add mentor"
+    expect(page).to have_content "Confirm mentor details"
     name_row = page.all(".govuk-summary-list__row")[0]
     within(name_row) do
       expect(page).to have_content "First name"


### PR DESCRIPTION
## Context

Wayfinder changes in line with updated designs.

## Changes proposed in this pull request

**Index**
- Change H1: Mentors at your school
- Add intro text: Add mentors to be able to assign them to your placements.

**Check your answers**
- Remove H1 caption
- Change H1: Confirm mentor details
- Add intro text: Once added, you will be able to assign them to placements.
- Add H2: Mentor
- Change inset text: Mentor data is stored in line with the [Department for Education's (DfE) privacy notice (opens in new tab)](https://bat-school-placements-18b07385d8a1.herokuapp.com/school-users/v3/add-mentor-check). I confirm that I have read, understood and accept how DfE uses mentor information as part of the Manage school placements service.
- The ‘privacy notice’ link should still have the same destination as before. However, it should now open in a new tab (which it didn’t previously).
- Change button text: Confirm and add mentor

## Guidance to review

- Log in as school user.
- Click 'Mentors' tab.
- Review the index header - it should now read "Confirm mentor details" and there should be no caption.
- Add a mentor using dummy details (trn: 1234565, dob: 09/1/1991).
- Review the 'Check your answers' page, which should now reflect the changes outlined above. Including a new header: 'Confirm mentor details'.
- Click the privacy notice link to make sure it opens in a new tab.
- Complete the process by pressing 'Confirm and add mentor'.

## Link to Trello card

https://trello.com/c/E2Qf4C7G/798-school-user-%E2%86%92-mentors

## Screenshots

<img width="678" alt="Screenshot 2024-09-18 at 14 58 04" src="https://github.com/user-attachments/assets/adc227ea-be89-42f1-88e3-5e5c97219d55">

<img width="675" alt="Screenshot 2024-09-18 at 14 58 20" src="https://github.com/user-attachments/assets/2b1338ea-9aea-4cc4-bade-ee9f13c0fccb">
