### PR TITLE
Add visually hidden labels to filter search inputs

### DIFF
--- a/app/javascript/controllers/filter_search_controller.js
+++ b/app/javascript/controllers/filter_search_controller.js
@@ -2,27 +2,41 @@ import { Controller } from "@hotwired/stimulus";
 
 // Connects to data-controller="filter-search"
 export default class extends Controller {
-  static targets = ["optionsList", "searchInput"];
+  static targets = ["optionsList", "searchInput", "legend"];
+
+  static instanceCounter = 0;
 
   connect() {
     const list = this.element.querySelector(".govuk-checkboxes, .govuk-radios");
-
-    if (!list) {
-      throw new Error("Could not find checkboxes or radios to attach to");
-    }
-
     list.dataset.filterSearchTarget = "optionsList";
+
+    const legend = this.element.querySelector("legend");
+    legend.dataset.filterSearchTarget = "legend";
+
+    // This will be unique for each filter-search instance
+    this.instanceId = this.constructor.instanceCounter++;
+
     const searchInput = this.createSearchInput();
     list.before(searchInput);
   }
 
   createSearchInput() {
-    const searchInput = document.createElement("input");
-    searchInput.type = "search";
-    searchInput.className = "govuk-input govuk-!-margin-bottom-1";
-    searchInput.dataset.action = `input->${this.identifier}#search`;
-    searchInput.dataset.filterSearchTarget = "searchInput";
-    return searchInput;
+    const container = document.createElement("div");
+
+    const inputId = `${this.identifier}-${this.instanceId}-input`;
+    const labelText = `Filter ${this.legendTarget.innerText}`;
+
+    container.innerHTML = `
+      <label for="${inputId}" class="govuk-label govuk-visually-hidden">
+        ${labelText}
+      </label>
+      <input type="search" id="${inputId}"
+        class="govuk-input govuk-!-margin-bottom-1"
+        data-action="input->${this.identifier}#search"
+        data-filter-search-target="searchInput">
+    `;
+
+    return container;
   }
 
   search() {

--- a/spec/system/claims/support/claims/view_claims_spec.rb
+++ b/spec/system/claims/support/claims/view_claims_spec.rb
@@ -148,11 +148,11 @@ RSpec.describe "View claims", :js, service: :claims, type: :system do
   end
 
   def when_i_search_the_school_filter_with(school_name)
-    find("legend", text: "School").sibling("input[type=search]").fill_in(with: school_name)
+    fill_in("Filter School", with: school_name)
   end
 
   def when_i_search_the_provider_filter_with(provider_name)
-    find("legend", text: "Accredited provider").sibling("input[type=search]").fill_in(with: provider_name)
+    fill_in("Filter Accredited provider", with: provider_name)
   end
 
   def then_i_see_only_my_filter_school_as_an_option

--- a/spec/system/placements/placements/searches_filter_options_for_placements_spec.rb
+++ b/spec/system/placements/placements/searches_filter_options_for_placements_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe "Placements / Placements / Searches filter options for a placemen
   alias_method :and_i_see_checkbox_option_for, :then_i_see_checkbox_option_for
 
   def when_i_search_the_school_filter_with(filter_name, option_name)
-    find("legend", text: filter_name).sibling("input[type=search]").fill_in(with: option_name)
+    fill_in("Filter #{filter_name}", with: option_name)
   end
   alias_method :and_i_search_the_school_filter_with, :when_i_search_the_school_filter_with
 


### PR DESCRIPTION
## Context

This PR addresses one of the accessibility issues raised by an external accessibility audit of the app. The filter search inputs were missing an associated label, which meant their purpose wasn't clear to those using a screen reader.

## Changes proposed in this pull request

I've added a visually hidden `<label>` tag to each search input.

This follows the approach taken by GOV.UK for their filter search inputs, as demonstrated by 'Organisation' filter on https://www.gov.uk/search/guidance-and-regulation

To make sure the `<input id="">` attribute is unique for each filter on the page, I've introduced an 'instance counter' variable to the filter-search Stimulus controller. This will be automatically incremented with each new instance of the controller, meaning it will always be unique.

I've also adjusted the system specs to make use of the new label. This proves that the label is present and correctly associated with the search input, despite it being visually hidden.

## Guidance to review

- There should be no visual changes to the UI.
- Do the tests pass?
- Can you see the visually hidden `<label>` elements using Chrome DevTools to inspect the page? (see the review app)

## Link to Trello card

https://trello.com/c/tpSIue0P/785-add-a-visually-hidden-label-to-filter-search-inputs

## Screenshots

### Before

The input is missing an associated label. The accessibility pane shows that the input does not have a name – notice the line "From label: _Not specified_".

<img width="1244" alt="Without label" src="https://github.com/user-attachments/assets/6bdd8047-aed9-4d74-9186-25725aada0fe">

### After

A visually hidden label is associated with the input. The accessibility panel reflects this change by showing it can now identify a name for the input.

<img width="1244" alt="With visually hidden label" src="https://github.com/user-attachments/assets/34056aa3-b817-4cb4-9810-97789a36a67f">
