### PR TITLE
Add missing `visually_hidden_text` to change links

### DIFF
--- a/app/views/claims/schools/mentors/check.html.erb
+++ b/app/views/claims/schools/mentors/check.html.erb
@@ -35,7 +35,8 @@
                                href: new_claims_school_mentor_path(params: mentor_form.as_form_params),
                                html_attributes: {
                                  class: "govuk-link--no-visited-state",
-                               }) %>
+                               },
+                               visually_hidden_text: t(".trn")) %>
           <% end %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".date_of_birth")) %>
@@ -44,7 +45,8 @@
                                href: new_claims_school_mentor_path(params: mentor_form.as_form_params),
                                html_attributes: {
                                  class: "govuk-link--no-visited-state",
-                               }) %>
+                               },
+                               visually_hidden_text: t(".date_of_birth")) %>
           <% end %>
         <% end %>
         <%= govuk_inset_text(

--- a/app/views/claims/support/schools/check.html.erb
+++ b/app/views/claims/support/schools/check.html.erb
@@ -24,7 +24,8 @@
                                href: new_claims_support_school_path(@school_form.as_form_params),
                                html_attributes: {
                                  class: "govuk-link--no-visited-state",
-                               }) %>
+                               },
+                               visually_hidden_text: t(".organisation_name")) %>
           <% end %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".ukprn")) %>

--- a/app/views/claims/support/schools/mentors/check.html.erb
+++ b/app/views/claims/support/schools/mentors/check.html.erb
@@ -35,7 +35,8 @@
                                href: new_claims_support_school_mentor_path(params: mentor_form.as_form_params),
                                html_attributes: {
                                  class: "govuk-link--no-visited-state",
-                               }) %>
+                               },
+                               visually_hidden_text: t(".trn")) %>
           <% end %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".date_of_birth")) %>
@@ -44,7 +45,8 @@
                                href: new_claims_school_mentor_path(params: mentor_form.as_form_params),
                                html_attributes: {
                                  class: "govuk-link--no-visited-state",
-                               }) %>
+                               },
+                               visually_hidden_text: t(".trn")) %>
           <% end %>
         <% end %>
         <%= f.govuk_submit t(".save_mentor") %>

--- a/app/views/claims/support/schools/mentors/check.html.erb
+++ b/app/views/claims/support/schools/mentors/check.html.erb
@@ -46,7 +46,7 @@
                                html_attributes: {
                                  class: "govuk-link--no-visited-state",
                                },
-                               visually_hidden_text: t(".trn")) %>
+                               visually_hidden_text: t(".date_of_birth")) %>
           <% end %>
         <% end %>
         <%= f.govuk_submit t(".save_mentor") %>

--- a/app/views/claims/support/schools/users/check.html.erb
+++ b/app/views/claims/support/schools/users/check.html.erb
@@ -35,7 +35,8 @@
                     new_claims_support_school_user_path(
                       @user_form.as_form_params.merge(school_id: @school.id),
                     ),
-                    no_visited_state: true) %>
+                    no_visited_state: true,
+                    visually_hidden_suffix: t(".first_name")) %>
                 </li>
               </ul>
             </dd>
@@ -52,7 +53,8 @@
                     new_claims_support_school_user_path(
                       @user_form.as_form_params.merge(school_id: @school.id),
                     ),
-                    no_visited_state: true) %>
+                    no_visited_state: true,
+                    visually_hidden_suffix: t(".last_name")) %>
                 </li>
               </ul>
             </dd>
@@ -69,7 +71,8 @@
                     new_claims_support_school_user_path(
                       @user_form.as_form_params.merge(school_id: @school.id),
                     ),
-                    no_visited_state: true) %>
+                    no_visited_state: true,
+                    visually_hidden_suffix: t(".email")) %>
                 </li>
               </ul>
             </dd>

--- a/app/views/placements/wizards/add_mentor_wizard/_check_your_answers_step.html.erb
+++ b/app/views/placements/wizards/add_mentor_wizard/_check_your_answers_step.html.erb
@@ -24,6 +24,7 @@
             <% row.with_value(text: @wizard.steps[:mentor].mentor.trn) %>
             <% row.with_action(text: t(".change"),
                                href: step_path(:mentor),
+                               visually_hidden_text: t(".trn"),
                                classes: ["govuk-link--no-visited-state"]) %>
           <% end %>
           <% summary_list.with_row do |row| %>
@@ -31,6 +32,7 @@
             <% row.with_value(text: safe_l(@wizard.steps[:mentor].date_of_birth, format: :short)) %>
             <% row.with_action(text: t(".change"),
                                href: step_path(:mentor),
+                               visually_hidden_text: t(".date_of_birth"),
                                classes: ["govuk-link--no-visited-state"]) %>
           <% end %>
         <% end %>

--- a/app/views/placements/wizards/add_school_contact_wizard/_check_your_answers_step.html.erb
+++ b/app/views/placements/wizards/add_school_contact_wizard/_check_your_answers_step.html.erb
@@ -16,6 +16,7 @@
             <% row.with_value(text: @wizard.steps[:school_contact].first_name) %>
             <% row.with_action(text: t(".change"),
                                href: step_path(:school_contact),
+                               visually_hidden_text: User.human_attribute_name(:first_name),
                                classes: ["govuk-link--no-visited-state"]) %>
           <% end %>
           <% summary_list.with_row do |row| %>
@@ -23,6 +24,7 @@
             <% row.with_value(text: @wizard.steps[:school_contact].last_name) %>
             <% row.with_action(text: t(".change"),
                                href: step_path(:school_contact),
+                               visually_hidden_text: User.human_attribute_name(:last_name),
                                classes: ["govuk-link--no-visited-state"]) %>
 
           <% end %>
@@ -31,6 +33,7 @@
             <% row.with_value(text: @wizard.steps[:school_contact].email_address) %>
             <% row.with_action(text: t(".change"),
                                href: step_path(:school_contact),
+                               visually_hidden_text: User.human_attribute_name(:email_address),
                                classes: ["govuk-link--no-visited-state"]) %>
           <% end %>
         <% end %>

--- a/app/views/placements/wizards/add_support_user_wizard/_check_your_answers_step.html.erb
+++ b/app/views/placements/wizards/add_support_user_wizard/_check_your_answers_step.html.erb
@@ -16,6 +16,7 @@
             <% row.with_value(text: @wizard.steps[:support_user].first_name) %>
             <% row.with_action(text: t(".change"),
                                href: step_path(:support_user),
+                               visually_hidden_text: User.human_attribute_name(:first_name),
                                classes: ["govuk-link--no-visited-state"]) %>
 
           <% end %>
@@ -24,6 +25,7 @@
             <% row.with_value(text: @wizard.steps[:support_user].last_name) %>
             <% row.with_action(text: t(".change"),
                                href: step_path(:support_user),
+                               visually_hidden_text: User.human_attribute_name(:last_name),
                                classes: ["govuk-link--no-visited-state"]) %>
 
           <% end %>
@@ -32,6 +34,7 @@
             <% row.with_value(text: @wizard.steps[:support_user].email) %>
             <% row.with_action(text: t(".change"),
                                href: step_path(:support_user),
+                               visually_hidden_text: User.human_attribute_name(:email),
                                classes: ["govuk-link--no-visited-state"]) %>
           <% end %>
         <% end %>

--- a/app/views/placements/wizards/add_user_wizard/_check_your_answers_step.html.erb
+++ b/app/views/placements/wizards/add_user_wizard/_check_your_answers_step.html.erb
@@ -17,6 +17,7 @@
             <% row.with_value(text: @wizard.steps[:user].first_name) %>
             <% row.with_action(text: t(".change"),
                                href: step_path(:user),
+                               visually_hidden_text: User.human_attribute_name(:first_name),
                                classes: ["govuk-link--no-visited-state"]) %>
           <% end %>
           <% summary_list.with_row do |row| %>
@@ -24,6 +25,7 @@
             <% row.with_value(text: @wizard.steps[:user].last_name) %>
             <% row.with_action(text: t(".change"),
                                href: step_path(:user),
+                               visually_hidden_text: User.human_attribute_name(:last_name),
                                classes: ["govuk-link--no-visited-state"]) %>
 
           <% end %>
@@ -32,6 +34,7 @@
             <% row.with_value(text: @wizard.steps[:user].email) %>
             <% row.with_action(text: t(".change"),
                                href: step_path(:user),
+                               visually_hidden_text: User.human_attribute_name(:email),
                                classes: ["govuk-link--no-visited-state"]) %>
           <% end %>
         <% end %>

--- a/app/views/shared/organisations/_organisation_details.html.erb
+++ b/app/views/shared/organisations/_organisation_details.html.erb
@@ -6,6 +6,7 @@
     <% if change_link.present? %>
       <% row.with_action(text: t(".change"),
                          href: change_link,
+                         visually_hidden_text: t(".organisation_name"),
                          classes: ["govuk-link--no-visited-state"]) %>
     <% end %>
   <% end %>

--- a/app/views/shared/schools/_school_contact_details.html.erb
+++ b/app/views/shared/schools/_school_contact_details.html.erb
@@ -7,6 +7,7 @@
       <% if changeable %>
         <% row.with_action(text: t(".change"),
                            href: new_edit_school_contact_placements_school_school_contact_path(school, school_contact),
+                           visually_hidden_text: t(".first_name"),
                            classes: ["govuk-link--no-visited-state"]) %>
       <% end %>
     <% end %>
@@ -16,6 +17,7 @@
       <% if changeable %>
         <% row.with_action(text: t(".change"),
                            href: new_edit_school_contact_placements_school_school_contact_path(school, school_contact),
+                           visually_hidden_text: t(".last_name"),
                            classes: ["govuk-link--no-visited-state"]) %>
       <% end %>
     <% end %>
@@ -25,6 +27,7 @@
       <% if changeable %>
         <% row.with_action(text: t(".change"),
                            href: new_edit_school_contact_placements_school_school_contact_path(school, school_contact),
+                           visually_hidden_text: t(".email"),
                            classes: ["govuk-link--no-visited-state"]) %>
       <% end %>
     <% end %>


### PR DESCRIPTION
## Context

For all “Change” links in the app (i.e. across both services), make sure visually_hidden_text is present.

Re-use the ‘key’ text as the hidden text.

For example, if the summary list key is “First name” then the visually hidden text should also be “First name”. That will produce the link “Change First name” which means there is context for screen reader users.

## Changes proposed in this pull request

- [x] Adds visually hidden text to all change links that did not have it.

## Guidance to review

- Have a look at the updated views in the review app and inspect the HTML to see the visually hidden text

## Link to Trello card

[Add visually hidden text to all "change" links](https://trello.com/c/HQnpex17/788-add-visually-hidden-text-to-all-change-links)
