### PR TITLE
Replace hardcoded link with `:back`

### DIFF
--- a/app/models/placements/academic_year.rb
+++ b/app/models/placements/academic_year.rb
@@ -16,6 +16,10 @@ class Placements::AcademicYear < AcademicYear
     for_date(Date.current)
   end
 
+  def current?
+    self == self.class.current
+  end
+
   def next
     Placements::AcademicYear.for_date(starts_on + 1.year)
   end

--- a/app/views/placements/schools/placements/show.html.erb
+++ b/app/views/placements/schools/placements/show.html.erb
@@ -3,7 +3,7 @@
 <%= render "placements/schools/primary_navigation", school: @school, current_navigation: :placements %>
 
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: placements_school_placements_path(@school.id)) %>
+  <%= govuk_back_link(href: :back) %>
 <% end %>
 
 <div class="govuk-width-container">

--- a/spec/models/placements/academic_year_spec.rb
+++ b/spec/models/placements/academic_year_spec.rb
@@ -31,6 +31,19 @@ RSpec.describe Placements::AcademicYear, type: :model do
     end
   end
 
+  describe "#current?" do
+    let!(:current_academic_year) { described_class.current }
+    let!(:next_academic_year) { current_academic_year.next }
+
+    it "returns true if the academic year is the current academic year" do
+      expect(current_academic_year.current?).to be(true)
+    end
+
+    it "returns false if the academic year is not the current academic year" do
+      expect(next_academic_year.current?).to be(false)
+    end
+  end
+
   describe "#next" do
     let(:next_start_year) { current_academic_year.starts_on.year + 1 }
     let(:next_end_year) { current_academic_year.ends_on.year + 1 }

--- a/spec/system/placements/schools/placements/navigate_placements_spec.rb
+++ b/spec/system/placements/schools/placements/navigate_placements_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.describe "Placements / Schools / Placements / Navigate placements",
+               service: :placements, type: :system do
+  let!(:academic_year) { Placements::AcademicYear.current }
+  let!(:school) { create(:placements_school, name: "School 1", phase: "Primary") }
+  let!(:placement_for_current_academic_year) { create(:placement, school:).decorate }
+  let!(:placement_for_next_academic_year) { create(:placement, school:, academic_year: academic_year.next).decorate }
+
+  before do
+    given_i_sign_in_as_anne
+  end
+
+  context "when viewing placements from the current academic year" do
+    scenario "User can view a placement and return to the placements page" do
+      when_i_visit_the_placements_page
+      then_i_see_the_placements_page_for(academic_year)
+      when_i_view_a_placement(placement_for_current_academic_year)
+      and_i_click_link("Back")
+      then_i_see_the_placements_page_for(academic_year)
+    end
+  end
+
+  context "when viewing placements from the next academic year" do
+    scenario "User can view a placement and return to the placements page" do
+      when_i_visit_the_placements_page
+      then_i_see_the_placements_page_for(academic_year)
+      and_i_click_link("Next year (#{academic_year.next.name})")
+      then_i_see_the_placements_page_for(academic_year.next)
+      when_i_view_a_placement(placement_for_next_academic_year)
+      and_i_click_link("Back")
+      then_i_see_the_placements_page_for(academic_year.next)
+    end
+  end
+
+  private
+
+  def and_there_is_an_existing_user_for(user_name)
+    user = create(:placements_user, user_name.downcase.to_sym)
+    user_exists_in_dfe_sign_in(user:)
+    create(:user_membership, user:, organisation: school)
+  end
+
+  def and_i_visit_the_sign_in_path
+    visit sign_in_path
+  end
+
+  def and_i_click_sign_in
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def given_i_sign_in_as_anne
+    and_there_is_an_existing_user_for("Anne")
+    and_i_visit_the_sign_in_path
+    and_i_click_sign_in
+  end
+
+  def when_i_visit_the_placements_page
+    visit placements_school_placements_path(school)
+  end
+
+  def then_i_see_the_placements_page_for(academic_year)
+    placement = academic_year.current? ? placement_for_current_academic_year : placement_for_next_academic_year
+    navigation_text = academic_year.current? ? "This year (#{academic_year.name})" : "Next year (#{academic_year.name})"
+
+    find("a[aria-current=page]", text: navigation_text)
+    expect(page).to have_content("Placements")
+    expect(page).to have_link("Add placement")
+    expect(page).to have_link(placement.title)
+  end
+
+  def and_i_click_link(text)
+    click_link text
+  end
+
+  def when_i_view_a_placement(placement)
+    click_link placement.title
+  end
+end


### PR DESCRIPTION
## Context

There’s a bug where the ‘Back’ link on the placement details page doesn’t return you to the correct tab on the placements index page.

This applies to school users where they have ‘Current year’ and ‘Next year’ tabs for switching between placements in different academic years.

## Changes proposed in this pull request

- [x] Made use of the `:back` helper

## Guidance to review

- Log in as Anne
- Navigate to placements
- Select "Next year (2025 to 2026)"
- View a placement
- Click back
- "Next year (2025 to 2026)" should still be selected

## Link to Trello card

[School user → Placements → Placement details: Make sure the 'back' link retains the currently selected academic year tab
](https://trello.com/c/hbZ4f3rH/796-school-user-%E2%86%92-placements-%E2%86%92-placement-details-make-sure-the-back-link-retains-the-currently-selected-academic-year-tab)
