### PR TITLE
Use mobile navigation on tablet viewports

### DIFF
--- a/app/assets/stylesheets/components/_header.scss
+++ b/app/assets/stylesheets/components/_header.scss
@@ -1,5 +1,5 @@
 .app-header {
-  @include govuk-media-query($from: tablet) {
+  @include govuk-media-query($from: desktop) {
     .govuk-header__container {
       display: flex;
       justify-content: space-between;


### PR DESCRIPTION
## Context

There’s a styling bug with the responsive nav menu which occurs at specific viewport dimensions.

At 1x zoom level, this bug is present between viewport widths 640px – 768px.

## Changes proposed in this pull request

- [x] Add media query to add margin to the navigation list between the affected viewport sizes.

## Guidance to review

- Log in as Anne
- Open the inspect toolbar
- Set the viewport to the widths above
- Check the menu items no longer overlap

## Link to Trello card

[Fix menu button overlaying menu content when zoomed](https://trello.com/c/x8noUE1P/789-fix-menu-button-overlaying-menu-content-when-zoomed)

## Screenshots

https://github.com/user-attachments/assets/4bdbc399-fd7a-4028-8194-69876ba14e8e
