### PR TITLE
Provider user -> placements index academic year text change

### DIFF
--- a/config/locales/en/placements/placements.yml
+++ b/config/locales/en/placements/placements.yml
@@ -1,9 +1,9 @@
 en:
   placements:
     academic_year:
-      current_academic_year: This academic year (%{academic_year})
-      next_academic_year: Next academic year (%{academic_year})
-      previous_academic_year: Previous academic year (%{academic_year})
+      current_academic_year: This year (%{academic_year})
+      next_academic_year: Next year (%{academic_year})
+      previous_academic_year: Previous year (%{academic_year})
     placements:
       index:
         placements_found:

--- a/spec/decorators/academic_year_decorator_spec.rb
+++ b/spec/decorators/academic_year_decorator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe AcademicYearDecorator do
       let(:decorated_academic_year) { current_academic_year.decorate }
 
       it "returns the academic year name with 'This academic year'" do
-        expect(decorated_academic_year.display_name).to eq("This academic year (#{current_academic_year.name})")
+        expect(decorated_academic_year.display_name).to eq("This year (#{current_academic_year.name})")
       end
     end
 
@@ -17,7 +17,7 @@ RSpec.describe AcademicYearDecorator do
       let(:decorated_academic_year) { next_academic_year.decorate }
 
       it "returns the academic year name with 'Next academic year'" do
-        expect(decorated_academic_year.display_name).to eq("Next academic year (#{next_academic_year.name})")
+        expect(decorated_academic_year.display_name).to eq("Next year (#{next_academic_year.name})")
       end
     end
 
@@ -26,7 +26,7 @@ RSpec.describe AcademicYearDecorator do
       let(:decorated_academic_year) { previous_academic_year.decorate }
 
       it "returns the academic year name with 'Previous academic year'" do
-        expect(decorated_academic_year.display_name).to eq("Previous academic year (#{previous_academic_year.name})")
+        expect(decorated_academic_year.display_name).to eq("Previous year (#{previous_academic_year.name})")
       end
     end
   end

--- a/spec/support/shared_examples/system/placements/add_a_placement_wizard.rb
+++ b/spec/support/shared_examples/system/placements/add_a_placement_wizard.rb
@@ -918,16 +918,16 @@ RSpec.shared_examples "an add a placement wizard" do
 
   def then_i_see_the_academic_year_page
     expect(page).to have_content("Select an academic year")
-    expect(page).to have_content("This academic year (#{current_academic_year.name})")
-    expect(page).to have_content("Next academic year (#{next_academic_year.name})")
+    expect(page).to have_content("This year (#{current_academic_year.name})")
+    expect(page).to have_content("Next year (#{next_academic_year.name})")
   end
 
   def when_i_choose_an_academic_year(academic_year_name)
-    page.choose("This academic year (#{academic_year_name})")
+    page.choose("This year (#{academic_year_name})")
   end
 
   def then_my_chosen_academic_year_is_selected(academic_year_name)
-    expect(page).to have_checked_field("This academic year (#{academic_year_name})")
+    expect(page).to have_checked_field("This year (#{academic_year_name})")
   end
 
   alias_method :and_i_click_on, :when_i_click_on

--- a/spec/wizards/placements/add_placement_wizard/academic_year_step_spec.rb
+++ b/spec/wizards/placements/add_placement_wizard/academic_year_step_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe Placements::AddPlacementWizard::AcademicYearStep, type: :model do
     let!(:next_academic_year) { current_academic_year.next }
     let!(:academic_years) do
       [
-        OpenStruct.new(value: current_academic_year.id, name: "This academic year (#{current_academic_year.name})"),
-        OpenStruct.new(value: next_academic_year.id, name: "Next academic year (#{next_academic_year.name})"),
+        OpenStruct.new(value: current_academic_year.id, name: "This year (#{current_academic_year.name})"),
+        OpenStruct.new(value: next_academic_year.id, name: "Next year (#{next_academic_year.name})"),
       ]
     end
 


### PR DESCRIPTION
## Context

Small text change in line with wayfinder design changes.

## Changes proposed in this pull request

**Index (search results)**
- Change ‘Academic year’ filter options: "this <s>academic</s> year (2024 to 2025)", "next <s>academic</s> year (2025 to 2026)".

## Guidance to review

- Log in as provider user.
- Navigate to the placements tab.
- Review the radio buttons in the left-hand-side filter menu.

## Link to Trello card

https://trello.com/c/q2DK3GHj/800-provider-user-%E2%86%92-placements

## Screenshots

<img width="986" alt="Screenshot 2024-09-20 at 10 45 26" src="https://github.com/user-attachments/assets/01f84d29-4ed8-4065-a23a-90a16ed0f182">
