### PR TITLE
Update validation rules to support claiming for refresher training

### DIFF
--- a/app/forms/claims/claim/mentors_form.rb
+++ b/app/forms/claims/claim/mentors_form.rb
@@ -53,7 +53,7 @@ class Claims::Claim::MentorsForm < ApplicationForm
         mentor_id:,
         provider_id: claim.provider_id,
         claim_id: claim.id,
-      )
+      ).tap(&:set_training_type)
     end
   end
 end

--- a/app/models/claims/mentor_training.rb
+++ b/app/models/claims/mentor_training.rb
@@ -36,8 +36,6 @@ class Claims::MentorTraining < ApplicationRecord
     refresher: "refresher",
   }, default: :initial, validate: true
 
-  before_validation :set_training_type
-
   validates :hours_completed,
             allow_nil: true,
             # TODO: Remove this 'unless' condition once claim revisions have been removed.
@@ -60,21 +58,17 @@ class Claims::MentorTraining < ApplicationRecord
   delegate :full_name, to: :mentor, prefix: true, allow_nil: true
   delegate :name, to: :provider, prefix: true, allow_nil: true
 
-  private
-
   def set_training_type
-    return if training_allowance.nil?
-
     self.training_type = training_allowance.training_type
   end
+
+  private
 
   def max_hours
     training_allowance.remaining_hours
   end
 
   def training_allowance
-    return if [mentor, provider, claim].any?(&:nil?)
-
     @training_allowance ||= Claims::TrainingAllowance.new(
       mentor:,
       provider:,

--- a/spec/factories/claims/claim_windows.rb
+++ b/spec/factories/claims/claim_windows.rb
@@ -26,5 +26,11 @@ FactoryBot.define do
       ends_on { 2.days.from_now }
       association :academic_year, :current
     end
+
+    trait :historic do
+      starts_on { 2.years.ago }
+      ends_on { starts_on + 2.months }
+      academic_year { AcademicYear.for_date(starts_on) }
+    end
   end
 end

--- a/spec/forms/claims/claim/mentors_form_spec.rb
+++ b/spec/forms/claims/claim/mentors_form_spec.rb
@@ -16,13 +16,25 @@ describe Claims::Claim::MentorsForm, type: :model do
   end
 
   describe "save" do
+    before do
+      # Give mentor2 initial training in a previous academic year, making them eligible for refresher training this year
+      create(
+        :claim, :submitted,
+        claim_window: build(:claim_window, :historic),
+        mentor_trainings: [build(:mentor_training, provider: claim.provider, mentor: mentor2, hours_completed: 20)]
+      )
+    end
+
     it "creates mentor trainings on the claim" do
       mentor_ids = [mentor1, mentor2].map(&:id)
       form = described_class.new(claim:, mentor_ids:)
 
       expect {
         form.save!
-      }.to change { claim.reload.mentor_trainings }.to contain_exactly(have_attributes(mentor_id: mentor1.id, provider_id: claim.provider_id), have_attributes(mentor_id: mentor2.id, provider_id: claim.provider_id))
+      }.to change { claim.reload.mentor_trainings }.to contain_exactly(
+        have_attributes(mentor_id: mentor1.id, provider_id: claim.provider_id, training_type: "initial"),
+        have_attributes(mentor_id: mentor2.id, provider_id: claim.provider_id, training_type: "refresher"),
+      )
     end
   end
 

--- a/spec/models/claims/mentor_training_spec.rb
+++ b/spec/models/claims/mentor_training_spec.rb
@@ -27,7 +27,7 @@
 require "rails_helper"
 
 RSpec.describe Claims::MentorTraining, type: :model do
-  subject(:mentor_training) { described_class.new }
+  subject(:mentor_training) { build(:mentor_training) }
 
   let(:draft_claim) { build(:claim, :draft) }
 
@@ -50,10 +50,10 @@ RSpec.describe Claims::MentorTraining, type: :model do
     end
   end
 
-  context "with initial training" do
+  describe "#hours_completed" do
     subject(:mentor_training) { create(:mentor_training, claim: draft_claim) }
 
-    describe "#hours_completed" do
+    context "with initial training" do
       let(:maximum_hours_allowed) { 20 }
 
       it {
@@ -64,27 +64,17 @@ RSpec.describe Claims::MentorTraining, type: :model do
       }
     end
 
-    describe "#training_type" do
-      it "is initial" do
-        expect(mentor_training.training_type).to eq("initial")
-      end
-    end
-  end
-
-  context "with refresher training" do
-    subject(:mentor_training) { create(:mentor_training, claim: draft_claim, mentor:, provider:) }
-
-    let(:mentor) { build(:claims_mentor) }
-    let(:provider) { build(:claims_provider) }
-    let(:historic_claim) { build(:claim, :submitted, claim_window: build(:claim_window, :historic)) }
-
-    before do
-      # Create initial training in a previous academic year
-      create(:mentor_training, mentor:, provider:, claim: historic_claim)
-    end
-
-    describe "#hours_completed" do
+    context "with refresher training" do
       let(:maximum_hours_allowed) { 6 }
+
+      before do
+        # Create initial training in a previous academic year
+        create(
+          :claim, :submitted,
+          claim_window: build(:claim_window, :historic),
+          mentor_trainings: [build(:mentor_training, mentor: mentor_training.mentor, provider: mentor_training.provider)]
+        )
+      end
 
       it {
         expect(mentor_training).to validate_numericality_of(:hours_completed)
@@ -92,12 +82,6 @@ RSpec.describe Claims::MentorTraining, type: :model do
           .is_greater_than(0)
           .is_less_than_or_equal_to(maximum_hours_allowed)
       }
-    end
-
-    describe "#training_type" do
-      it "is refresher" do
-        expect(mentor_training.training_type).to eq("refresher")
-      end
     end
   end
 
@@ -134,5 +118,17 @@ RSpec.describe Claims::MentorTraining, type: :model do
 
   describe "#full_name" do
     it { is_expected.to delegate_method(:full_name).to(:mentor).with_prefix.allow_nil }
+  end
+
+  describe "#set_training_type" do
+    it "sets the training type as calculated by Claims::TrainingAllowance" do
+      mock_training_allowance = instance_double(Claims::TrainingAllowance)
+      allow(Claims::TrainingAllowance).to receive(:new).and_return(mock_training_allowance)
+      allow(mock_training_allowance).to receive(:training_type).and_return("pineapple")
+
+      mentor_training.set_training_type
+
+      expect(mentor_training.training_type).to eq("pineapple")
+    end
   end
 end

--- a/spec/services/claims/provider/generate_csv_spec.rb
+++ b/spec/services/claims/provider/generate_csv_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Claims::Provider::GenerateCSV do
     let(:mentor_training_for_claim_for_school_c_mentor_4) do
       create(:mentor_training,
              mentor: mentor_4,
-             hours_completed: 20,
+             hours_completed: 18,
              provider:,
              claim: claim_for_school_c)
     end
@@ -93,14 +93,14 @@ RSpec.describe Claims::Provider::GenerateCSV do
     let(:mentor_training_for_claim_for_another_academic_year_mentor_4) do
       create(:mentor_training,
              mentor: mentor_4,
-             hours_completed: 20,
+             hours_completed: 6,
              provider:,
              claim: claim_for_another_academic_year)
     end
     let(:mentor_training_for_draft_claim) do
       create(:mentor_training,
              mentor: mentor_4,
-             hours_completed: 20,
+             hours_completed: 2,
              provider:,
              claim: draft_claim)
     end
@@ -128,7 +128,7 @@ RSpec.describe Claims::Provider::GenerateCSV do
         "School A,1111111,AAA AAA,Mentor A,12\n",
         "School A,1111111,AAA AAA,Mentor B,14\n",
         "School B,2222222,BBB BBB,Mentor C,6\n",
-        "School C,3333333,CCC CCC,Mentor D,20\n",
+        "School C,3333333,CCC CCC,Mentor D,18\n",
       ])
     end
 


### PR DESCRIPTION
## Context

This PR completes the implementation of functionality required for claiming refresher training. It's just the tip of the iceberg, and it follows on from #994, #1014, #1166, #1167, and #1168.

After this PR is merged, all the required logic and validation should be in place to support users claiming up to 20 hours of initial training, or up to 6 hours of refresher training, depending on whether or not the mentor has trained with that particular provider before.

> [!NOTE]  
> **There are still areas throughout the app which refer to a 20 hour limit of training.** This content will need updating ahead of refresher training becoming available to end users. This PR completes the development work required to support refresher training, but it doesn't update any content.

## Changes proposed in this pull request

- **Make the validation rule for `Claims::MentorTraining#hours_completed` dynamic**
  So it's limited to either 20 hours, or 6 hours, depending on the training type. This removes the hardcoded references to 20 hours in favour of using the Training Allowance calculator, further solidifying that as the source of truth for calculating the number of claimable hours.
- **Store the training type in the Mentor Training record**
  Updates the `Claims::MentorTraining#training_type` field so it gets persisted to the database correctly. Before this, it would always persist to the database as "initial" training. This could be useful in future when looking back on historic claims.
- **Add a system spec for refresher training**
  To provide confidence that the service is now ready to accept claims for refresher training.

## Guidance to review

- Read through the spec and make sure the proposed expectations cover the scenarios

## Link to Trello card

https://trello.com/c/TUWOipzZ/824-add-test-coverage-for-refresher-training-and-remove-some-hardcoded-training-allowance-limits