### PR TITLE
Tweak claims status filters to use humanize instead of titleize

### DIFF
--- a/app/views/claims/support/claims/_filter.html.erb
+++ b/app/views/claims/support/claims/_filter.html.erb
@@ -46,7 +46,7 @@
               <% filter_form.statuses.each do |status| %>
                 <li>
                  <%= govuk_link_to(
-                   status.titleize,
+                   status.humanize,
                    filter_form.index_path_without_filter(filter: "statuses", value: status),
                    class: "app-filter__tag",
                    no_visited_state: true,
@@ -148,7 +148,7 @@
             ) do %>
 
               <% claim_statuses_for_selection.each do |status| %>
-                <%= form.govuk_check_box :statuses, status, label: { text: status.titleize } %>
+                <%= form.govuk_check_box :statuses, status, label: { text: status.humanize } %>
                <% end %>
              <% end %>
           </div>


### PR DESCRIPTION
## Context

Instead of "Sent To ESFA", we want the status filter to read as "Sent to ESFA" to match the status tags.

## Changes proposed in this pull request

- Use `#humanize` instead of `#titleize` in the claims status filters.

## Guidance to review

Claim statuses in the claims filter should show "humanized" statuses, rather than "titleized".

## Screenshots

![CleanShot 2024-09-26 at 13 42 22](https://github.com/user-attachments/assets/c375e6df-645c-4e8f-8aca-80d716e6b10e)