### PR TITLE
Rename the partner schools filter option

### DIFF
--- a/config/locales/en/placements/placements.yml
+++ b/config/locales/en/placements/placements.yml
@@ -15,9 +15,9 @@ en:
         enter_a_location: Enter a location
         location_search_example: For example, Sunderland or SR2
       filter:
-        partner_schools: Partner schools
+        partner_schools: Schools I work with
         terms: Expected date
-        only_show_partner_schools: Only show placements offered by my partner schools
+        only_show_partner_schools: Only show placements from schools I work with
         school: School
         subject: Subject
         school_phase: School phase

--- a/spec/system/placements/placements/searches_filter_options_for_placements_spec.rb
+++ b/spec/system/placements/placements/searches_filter_options_for_placements_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe "Placements / Placements / Searches filter options for a placemen
   end
 
   def then_i_see_checkbox_option_for(filter_name, option_name)
-    checkboxes = page.find("legend", text: filter_name).sibling(".govuk-checkboxes")
+    checkboxes = page.find("legend", exact_text: filter_name).sibling(".govuk-checkboxes")
     within(checkboxes) do
       expect(page).to have_content(option_name)
     end
@@ -138,7 +138,7 @@ RSpec.describe "Placements / Placements / Searches filter options for a placemen
   alias_method :and_i_search_the_school_filter_with, :when_i_search_the_school_filter_with
 
   def and_i_do_not_see_checkbox_option_for(filter_name, option_name)
-    checkboxes = page.find("legend", text: filter_name).sibling(".govuk-checkboxes")
+    checkboxes = page.find("legend", exact_text: filter_name).sibling(".govuk-checkboxes")
     within(checkboxes) do
       expect(page).not_to have_content(option_name)
     end

--- a/spec/system/placements/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/placements/view_placements_list_spec.rb
@@ -173,13 +173,13 @@ RSpec.describe "Placements / Placements / View placements list",
         and_i_can_not_see_any_selected_filters
       end
 
-      scenario "User can remove a partner school filter" do
+      scenario "User can remove a schools I work with filter" do
         given_a_partnership_exists_between(provider, primary_school)
         when_i_visit_the_placements_index_page({ filters: { only_partner_schools: true } })
         then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
         and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
-        and_i_can_see_a_preset_filter("Partner schools", "Partner schools")
-        when_i_click_to_remove_filter("Partner schools", "Partner schools")
+        and_i_can_see_a_preset_filter("Schools I work with", "Schools I work with")
+        when_i_click_to_remove_filter("Schools I work with", "Schools I work with")
         then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
         and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
         and_i_can_not_see_any_selected_filters
@@ -233,7 +233,7 @@ RSpec.describe "Placements / Placements / View placements list",
         )
         then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
         and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
-        and_i_can_see_a_preset_filter("Partner schools", "Partner schools")
+        and_i_can_see_a_preset_filter("Schools I work with", "Schools I work with")
         and_i_can_see_a_preset_filter("School", "Primary School")
         and_i_can_see_a_preset_filter("Subject", "Primary with mathematics")
         and_i_can_see_a_preset_filter("Primary year group", "Year 1")


### PR DESCRIPTION
## Context

We have removed the term "Partner schools" for users, instead using the term "Schools I work with"

## Changes proposed in this pull request

- [x] Rename the filter
- [x] Update specs

## Guidance to review

- Log in as Patricia
- Test the "Schools I work" with filter

## Link to Trello card

[Update wording for the 'partner schools' filter](https://trello.com/c/pyzW4YPx/838-update-wording-for-the-partner-schools-filter)

## Screenshots

![image](https://github.com/user-attachments/assets/b6f2cbbb-f066-42cf-8be7-c02598b77828)
![image](https://github.com/user-attachments/assets/ff80c5cc-fd21-4892-8a9e-7d9129a11605)
