### PR TITLE
Bring navigation component attr_readers into private scope

### DIFF
--- a/app/components/primary_navigation_component.rb
+++ b/app/components/primary_navigation_component.rb
@@ -2,8 +2,6 @@ class PrimaryNavigationComponent < ApplicationComponent
   renders_many :navigation_items, "NavigationItemComponent"
 
   class NavigationItemComponent < ApplicationComponent
-    attr_reader :name, :url, :current
-
     def initialize(name, url, current: false, classes: [], html_attributes: {})
       @name = name
       @url = url
@@ -19,6 +17,8 @@ class PrimaryNavigationComponent < ApplicationComponent
     end
 
     private
+
+    attr_reader :name, :url, :current
 
     def current?(url)
       current || current_page?(url)

--- a/app/components/secondary_navigation_component.rb
+++ b/app/components/secondary_navigation_component.rb
@@ -2,8 +2,6 @@ class SecondaryNavigationComponent < ApplicationComponent
   renders_many :navigation_items, "NavigationItemComponent"
 
   class NavigationItemComponent < ApplicationComponent
-    attr_reader :name, :url
-
     def initialize(name, url, current: false, classes: [], html_attributes: {})
       @name = name
       @url = url
@@ -20,7 +18,7 @@ class SecondaryNavigationComponent < ApplicationComponent
 
     private
 
-    attr_reader :current
+    attr_reader :name, :url, :current
 
     def current?(url)
       current || current_page?(url)


### PR DESCRIPTION
## Context

A recent-ish change added `attr_reader :current` to the `SecondaryNavigationComponent` under the `private` scope.

We should move all `attr_reader` calls into a private scope for navigation components.

## Changes proposed in this pull request

- Move `attr_reader` calls of navigation components into `private` scopes.

## Guidance to review

\-