### PR TITLE
Only verify_policy_scoped on controllers that have index actions

### DIFF
--- a/app/controllers/placements/application_controller.rb
+++ b/app/controllers/placements/application_controller.rb
@@ -1,5 +1,5 @@
 class Placements::ApplicationController < ApplicationController
-  after_action :verify_policy_scoped, only: %i[index]
+  after_action :verify_policy_scoped, if: ->(c) { c.action_name == "index" }
   before_action :authorize_support_user!
 
   def current_user

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -65,6 +65,6 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
-  # Don't raise error when a before_action's only/except options reference missing actions.
-  config.action_controller.raise_on_missing_callback_actions = false
+  # Raise error when a before_action's only/except options reference missing actions.
+  config.action_controller.raise_on_missing_callback_actions = true
 end


### PR DESCRIPTION
## Context

Fix the issue causing the warning messages to avoid us having to disable the config for the warning,

## Changes proposed in this pull request

- [x] verify_policy_scoped conditionally if there is an index action

## Guidance to review

- [x] Developers should be able to use any of the wizard journeys without error/run the test suite and have it pass

## Link to Trello card

[Re-enable raise_on_missing_callback_actions config](https://trello.com/c/YQgg4Tm4/822-re-enable-raiseonmissingcallbackactions-config)
