### PR TITLE
Add missing test coverage

### DIFF
--- a/app/views/claims/schools/mentors/_remove_mentor.html.erb
+++ b/app/views/claims/schools/mentors/_remove_mentor.html.erb
@@ -11,3 +11,4 @@
   <%= govuk_button_to(t(".remove_mentor"), claims_school_mentor_path(@school, @mentor), warning: true, method: :delete, class: "govuk-button govuk-button--warning") %>
 
   <%= govuk_link_to t(".cancel"), claims_school_mentors_path(@school), no_visited_state: true %>
+</div>

--- a/app/views/claims/support/schools/mentors/_cannot_remove_mentor.html.erb
+++ b/app/views/claims/support/schools/mentors/_cannot_remove_mentor.html.erb
@@ -11,3 +11,4 @@
   </div>
 
   <%= govuk_link_to t(".cancel"), claims_support_school_mentors_path(@school), no_visited_state: true %>
+</div>

--- a/app/views/claims/support/schools/mentors/remove.html.erb
+++ b/app/views/claims/support/schools/mentors/remove.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <% if policy(@mentor_membership).destroy? %>
-  <%= render partial: "claims/schools/mentors/remove_mentor" %>
+  <%= render "remove_mentor" %>
 <% else %>
-  <%= render partial: "claims/schools/mentors/cannot_remove_mentor" %>
+  <%= render "cannot_remove_mentor" %>
 <% end %>


### PR DESCRIPTION
## Context

Undercover demands coverage to be satisfied.

## Changes proposed in this pull request

- [x] Whilst investigating the missing coverage I found two views without closing `</div>` tags
- [x] The test was valid, but the view was pointing at the non-support views, I have updated the partial paths. 

## Guidance to review

- [x] Log in as Colin and remove a mentor

## Link to Trello card

[Add test missing test coverage for app/controllers/claims/support/schools/mentors_controller.rb
](https://trello.com/c/svKeX0OS/841-add-test-missing-test-coverage-for-app-controllers-claims-support-schools-mentorscontrollerrb)
