### PR TITLE
Provider user and school user -> Flash message wayfinding changes

### DIFF
--- a/app/controllers/placements/organisations/users/add_user_controller.rb
+++ b/app/controllers/placements/organisations/users/add_user_controller.rb
@@ -22,6 +22,7 @@ class Placements::Organisations::Users::AddUserController < Placements::Applicat
       @wizard.reset_state
       redirect_to index_path, flash: {
         heading: t(".success_heading"),
+        body: t(".success_body", user_name: user.full_name),
       }
     end
   end

--- a/app/controllers/placements/partnerships/add_partnership_controller.rb
+++ b/app/controllers/placements/partnerships/add_partnership_controller.rb
@@ -25,6 +25,7 @@ class Placements::Partnerships::AddPartnershipController < Placements::Applicati
       @wizard.reset_state
       redirect_to index_path, flash: {
         heading: t(".success_heading"),
+        body: t(".success_body", partner_name: @wizard.partner_organisation.name),
       }
     end
   end

--- a/app/controllers/placements/providers/partner_schools_controller.rb
+++ b/app/controllers/placements/providers/partner_schools_controller.rb
@@ -7,7 +7,8 @@ class Placements::Providers::PartnerSchoolsController < Placements::Partnerships
   def destroy
     super
 
-    flash[:heading] = t(".partner_school_deleted")
+    flash[:heading] = t(".success_heading")
+    flash[:body] = t(".success_body", school_name: @partner_school.name)
   end
 
   private

--- a/app/controllers/placements/schools/mentors/add_mentor_controller.rb
+++ b/app/controllers/placements/schools/mentors/add_mentor_controller.rb
@@ -17,11 +17,11 @@ class Placements::Schools::Mentors::AddMentorController < Placements::Applicatio
     elsif @wizard.next_step.present?
       redirect_to step_path(@wizard.next_step)
     else
-      @wizard.create_mentor
+      mentor = @wizard.create_mentor
       @wizard.reset_state
       redirect_to index_path, flash: {
         heading: t(".success_heading"),
-        body: t(".success_body"),
+        body: t(".success_body", user_name: mentor.full_name),
       }
     end
   end

--- a/app/controllers/placements/schools/partner_providers_controller.rb
+++ b/app/controllers/placements/schools/partner_providers_controller.rb
@@ -7,7 +7,8 @@ class Placements::Schools::PartnerProvidersController < Placements::Partnerships
   def destroy
     super
 
-    flash[:heading] = t(".partner_provider_deleted")
+    flash[:heading] = t(".success_heading")
+    flash[:body] = t(".success_body", partner_name: @partner_provider.name)
   end
 
   private

--- a/config/locales/en/placements/providers/partner_schools.yml
+++ b/config/locales/en/placements/providers/partner_schools.yml
@@ -31,7 +31,8 @@ en:
           you_are_currently_assigned_to: "You are currently assigned to:"
           school_will_be_sent_an_email: We will send an email to %{school_name}. This will let them know you have deleted them as a partner school for %{provider_name}.
         destroy: 
-          partner_school_deleted: Partner school deleted
+          success_heading: School deleted
+          success_body: "%{school_name} can no longer assign you to their placements."
         placements:
           details:
             placement_contact: Placement contact

--- a/config/locales/en/placements/providers/partner_schools/add_partner_school.yml
+++ b/config/locales/en/placements/providers/partner_schools/add_partner_school.yml
@@ -4,7 +4,8 @@ en:
       partner_schools:
         add_partner_school:
           edit:
-            caption: Partner school details
+            caption: School details
             cancel: Cancel
           update:
-            success_heading: Partner school added
+            success_heading: School added
+            success_body: "%{partner_name} can now assign you to their placements."

--- a/config/locales/en/placements/providers/users/add_user.yml
+++ b/config/locales/en/placements/providers/users/add_user.yml
@@ -8,3 +8,4 @@ en:
             cancel: Cancel
           update:
             success_heading: User added
+            success_body: "%{user_name} can now access placement information."

--- a/config/locales/en/placements/schools/mentors.yml
+++ b/config/locales/en/placements/schools/mentors.yml
@@ -8,7 +8,7 @@ en:
             cancel: Cancel
           update:
             success_heading: Mentor added
-            success_body: You can now assign them to placements.
+            success_body: You can now assign %{user_name} to placements.
         index:
           heading: Mentors
           trn: Teacher reference number (TRN)

--- a/config/locales/en/placements/schools/partner_providers.yml
+++ b/config/locales/en/placements/schools/partner_providers.yml
@@ -27,4 +27,5 @@ en:
           provider_will_be_sent_an_email: We will send an email to %{provider_name} to let them know they are no longer a partner provider. It is your responsibility to confirm with them whether they should still fulfil existing assigned placements.
           placements_with_provider: "Placements with this provider are:"
         destroy:
-          partner_provider_deleted: Partner provider deleted
+          success_heading: Provider deleted
+          success_body: You can no longer assign %{partner_name} to your placements.

--- a/config/locales/en/placements/schools/partner_providers/add_partner_provider.yml
+++ b/config/locales/en/placements/schools/partner_providers/add_partner_provider.yml
@@ -4,7 +4,8 @@ en:
       partner_providers:
         add_partner_provider:
           edit:
-            caption: Partner provider details
+            caption: Provider details
             cancel: Cancel
           update:
-            success_heading: Partner provider added
+            success_heading: Provider added
+            success_body: You can now add %{partner_name} to your placements.

--- a/config/locales/en/placements/schools/users/add_user.yml
+++ b/config/locales/en/placements/schools/users/add_user.yml
@@ -8,3 +8,4 @@ en:
             cancel: Cancel
           update:
             success_heading: User added
+            success_body: "%{user_name} can now view, edit and create placements at your school."

--- a/config/locales/en/placements/support/providers/partner_schools.yml
+++ b/config/locales/en/placements/support/providers/partner_schools.yml
@@ -23,4 +23,5 @@ en:
             page_title: "Are you sure you want to delete this partner school? - %{school_name} - %{provider_name}"
             cancel: Cancel
           destroy:
-            partner_school_deleted: Partner school deleted
+              success_heading: School deleted
+              success_body: "%{school_name} can no longer assign you to their placements."

--- a/config/locales/en/placements/support/providers/partner_schools/add_partner_school.yml
+++ b/config/locales/en/placements/support/providers/partner_schools/add_partner_school.yml
@@ -8,4 +8,5 @@ en:
               caption: Partner school details - %{organisation_name}
               cancel: Cancel
             update:
-              success_heading: Partner school added
+              success_heading: School added
+              success_body: "%{partner_name} can now assign you to their placements."

--- a/config/locales/en/placements/support/providers/users/add_user.yml
+++ b/config/locales/en/placements/support/providers/users/add_user.yml
@@ -10,3 +10,4 @@ en:
               cancel: Cancel
             update:
               success_heading: User added
+              success_body: "%{user_name} can now access placement information."

--- a/config/locales/en/placements/support/schools/partner_providers.yml
+++ b/config/locales/en/placements/support/schools/partner_providers.yml
@@ -26,4 +26,5 @@ en:
             you_will_no_longer: You will no longer be able to assign this provider to placements. They will remain assigned to current placements unless you delete them.
             provider_will_be_sent_an_email: We will send an email to %{provider_name} to let them know they are no longer a partner provider. It is your responsibility to confirm with them whether they should still fulfil existing assigned placements.
           destroy:
-            partner_provider_deleted: Partner provider deleted
+            success_heading: Provider deleted
+            success_body: You can no longer assign %{partner_name} to your placements.

--- a/config/locales/en/placements/support/schools/partner_providers/add_partner_provider.yml
+++ b/config/locales/en/placements/support/schools/partner_providers/add_partner_provider.yml
@@ -8,4 +8,5 @@ en:
               caption: Partner provider details - %{organisation_name}
               cancel: Cancel
             update:
-              success_heading: Partner provider added
+              success_heading: Provider added
+              success_body: You can now add %{partner_name} to your placements.

--- a/config/locales/en/placements/support/schools/users/add_user.yml
+++ b/config/locales/en/placements/support/schools/users/add_user.yml
@@ -10,3 +10,4 @@ en:
               cancel: Cancel
             update:
               success_heading: User added
+              success_body: "%{user_name} can now view, edit and create placements at your school."

--- a/config/locales/en/placements/wizards/add_placement_wizard.yml
+++ b/config/locales/en/placements/wizards/add_placement_wizard.yml
@@ -75,7 +75,7 @@ en:
           publish_placement: Publish placement
           edit_placement: Edit placement
         update:
-          success_heading: Placement published
+          success_heading: Placement added
         terms_step:
           title: Select when the placement could be - %{contextual_text}
           title_with_error: "Error: Select when the placement could be - %{contextual_text}"

--- a/spec/support/shared_examples/system/placements/add_a_placement_wizard.rb
+++ b/spec/support/shared_examples/system/placements/add_a_placement_wizard.rb
@@ -49,7 +49,7 @@ RSpec.shared_examples "an add a placement wizard" do
           when_i_click_on("Publish placement")
           then_i_see_the_placements_page
           and_i_see_my_placement(school.phase)
-          and_i_see_success_message("Placement published")
+          and_i_see_success_message("Placement added")
         end
 
         it "when I select not known for the mentor" do
@@ -76,7 +76,7 @@ RSpec.shared_examples "an add a placement wizard" do
           and_i_click_on("Publish placement")
           then_i_see_the_placements_page
           and_i_see_my_placement(school.phase)
-          and_i_see_success_message("Placement published")
+          and_i_see_success_message("Placement added")
         end
 
         it "I am redirected to the add mentor page if I click on the link in the help text" do
@@ -334,7 +334,7 @@ RSpec.shared_examples "an add a placement wizard" do
             and_i_click_on("Publish placement")
             then_i_see_the_placements_page
             and_i_see_my_placement(school.phase)
-            and_i_see_success_message("Placement published")
+            and_i_see_success_message("Placement added")
           end
         end
       end
@@ -366,7 +366,7 @@ RSpec.shared_examples "an add a placement wizard" do
         when_i_click_on("Publish placement")
         then_i_see_the_placements_page
         and_i_see_my_placement(school.phase)
-        and_i_see_success_message("Placement published")
+        and_i_see_success_message("Placement added")
       end
 
       context "when I select a subject with child subjects" do
@@ -395,7 +395,7 @@ RSpec.shared_examples "an add a placement wizard" do
           when_i_click_on("Publish placement")
           then_i_see_the_placements_page
           and_i_see_my_placement(school.phase)
-          and_i_see_success_message("Placement published")
+          and_i_see_success_message("Placement added")
         end
 
         it "I see a validation message if I do not select an additional subject" do
@@ -460,7 +460,7 @@ RSpec.shared_examples "an add a placement wizard" do
           when_i_click_on("Publish placement")
           then_i_see_the_placements_page
           and_i_see_my_placement("Primary")
-          and_i_see_success_message("Placement published")
+          and_i_see_success_message("Placement added")
         end
       end
 
@@ -488,7 +488,7 @@ RSpec.shared_examples "an add a placement wizard" do
           and_i_click_on("Publish placement")
           then_i_see_the_placements_page
           and_i_see_my_placement("Secondary")
-          and_i_see_success_message("Placement published")
+          and_i_see_success_message("Placement added")
         end
       end
 

--- a/spec/system/placements/providers/partner_schools/add_a_partner_school_spec.rb
+++ b/spec/system/placements/providers/partner_schools/add_a_partner_school_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe "Placements / Providers / Partner schools / Add a partner school"
   end
 
   def then_i_see_the_check_details_page_for_school(school_name)
-    expect(page).to have_css(".govuk-caption-l", text: "Partner school details")
+    expect(page).to have_css(".govuk-caption-l", text: "School details")
     expect(page).to have_content("Check your answers")
     org_name_row = page.all(".govuk-summary-list__row")[0]
     expect(org_name_row).to have_content(school_name)
@@ -141,7 +141,7 @@ RSpec.describe "Placements / Providers / Partner schools / Add a partner school"
   end
 
   def and_i_see_success_message
-    expect(page).to have_content "Partner school added"
+    expect(page).to have_content "School added"
   end
 
   def given_a_partnership_exists_between(school, provider)

--- a/spec/system/placements/providers/partner_schools/add_a_partner_school_without_javascript_spec.rb
+++ b/spec/system/placements/providers/partner_schools/add_a_partner_school_without_javascript_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe "Placements / Providers / Partner schools / Add a partner school 
   alias_method :when_i_choose, :then_i_choose
 
   def then_i_see_the_check_details_page_for_school(school_name)
-    expect(page).to have_css(".govuk-caption-l", text: "Partner school details")
+    expect(page).to have_css(".govuk-caption-l", text: "School details")
     expect(page).to have_content("Check your answers")
     org_name_row = page.all(".govuk-summary-list__row")[0]
     expect(org_name_row).to have_content(school_name)
@@ -150,7 +150,7 @@ RSpec.describe "Placements / Providers / Partner schools / Add a partner school 
   end
 
   def and_i_see_success_message
-    expect(page).to have_content "Partner school added"
+    expect(page).to have_content "School added"
   end
 
   def given_a_partnership_exists_between(school, provider)

--- a/spec/system/placements/providers/partner_schools/remove_a_partner_school_spec.rb
+++ b/spec/system/placements/providers/partner_schools/remove_a_partner_school_spec.rb
@@ -128,10 +128,10 @@ RSpec.describe "Placements / Providers / Partner schools / Remove a partner scho
 
     expect(provider.partner_schools.find_by(id: school.id)).to be_nil
     within(".govuk-notification-banner__content") do
-      expect(page).to have_content "Partner school deleted"
+      expect(page).to have_content "School deleted"
     end
 
-    expect(page).not_to have_content school.name
+    expect(page).to have_content school.name, count: 1
   end
 
   def and_a_partner_provider_remains_called(provider_name)

--- a/spec/system/placements/schools/partner_providers/add_a_partner_provider_spec.rb
+++ b/spec/system/placements/schools/partner_providers/add_a_partner_provider_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe "Placements / Schools / Partner providers / Add a partner provide
   end
 
   def then_i_see_the_check_details_page_for_provider(provider_name)
-    expect(page).to have_css(".govuk-caption-l", text: "Partner provider details")
+    expect(page).to have_css(".govuk-caption-l", text: "Provider details")
     expect(page).to have_content("Check your answers")
     org_name_row = page.all(".govuk-summary-list__row")[0]
     expect(org_name_row).to have_content(provider_name)
@@ -141,7 +141,7 @@ RSpec.describe "Placements / Schools / Partner providers / Add a partner provide
   end
 
   def and_i_see_success_message
-    expect(page).to have_content "Partner provider added"
+    expect(page).to have_content "Provider added"
   end
 
   def given_a_partnership_exists_between(school, provider)

--- a/spec/system/placements/schools/partner_providers/add_a_partner_provider_without_javascript_spec.rb
+++ b/spec/system/placements/schools/partner_providers/add_a_partner_provider_without_javascript_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe "Placements / Schools / Partner providers / Add a partner provide
   alias_method :when_i_choose, :then_i_choose
 
   def then_i_see_the_check_details_page_for_provider(provider_name)
-    expect(page).to have_css(".govuk-caption-l", text: "Partner provider details")
+    expect(page).to have_css(".govuk-caption-l", text: "Provider details")
     expect(page).to have_content("Check your answers")
     org_name_row = page.all(".govuk-summary-list__row")[0]
     expect(org_name_row).to have_content(provider_name)
@@ -148,7 +148,7 @@ RSpec.describe "Placements / Schools / Partner providers / Add a partner provide
   end
 
   def and_i_see_success_message
-    expect(page).to have_content "Partner provider added"
+    expect(page).to have_content "Provider added"
   end
 
   def given_a_partnership_exists_between(school, provider)

--- a/spec/system/placements/schools/partner_providers/remove_a_partner_provider_spec.rb
+++ b/spec/system/placements/schools/partner_providers/remove_a_partner_provider_spec.rb
@@ -95,10 +95,10 @@ RSpec.describe "Placements / Schools / Partner providers / Remove a partner prov
 
     expect(school.partner_providers.find_by(id: provider.id)).to be_nil
     within(".govuk-notification-banner__content") do
-      expect(page).to have_content "Partner provider deleted"
+      expect(page).to have_content "Provider deleted"
     end
 
-    expect(page).not_to have_content provider.name
+    expect(page).to have_content provider.name, count: 1
   end
 
   def and_a_partner_provider_remains_called(provider_name)

--- a/spec/system/placements/support/providers/partner_schools/support_user_adds_a_partner_school_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/support_user_adds_a_partner_school_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
   end
 
   def and_i_see_success_message
-    expect(page).to have_content "Partner school added"
+    expect(page).to have_content "School added"
   end
 
   def partner_school_notification(user)

--- a/spec/system/placements/support/providers/partner_schools/support_user_adds_a_partner_school_without_javascript_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/support_user_adds_a_partner_school_without_javascript_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
   end
 
   def and_i_see_success_message
-    expect(page).to have_content "Partner school added"
+    expect(page).to have_content "School added"
   end
 
   def partner_school_notification(user)

--- a/spec/system/placements/support/providers/partner_schools/support_user_deletes_a_partner_school_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/support_user_deletes_a_partner_school_spec.rb
@@ -138,10 +138,10 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
 
     expect(provider.partner_schools.find_by(id: school.id)).to be_nil
     within(".govuk-notification-banner__content") do
-      expect(page).to have_content "Partner school deleted"
+      expect(page).to have_content "School deleted"
     end
 
-    expect(page).not_to have_content school.name
+    expect(page).to have_content school.name, count: 1
   end
 
   def and_a_partner_provider_remains_called(provider_name)

--- a/spec/system/placements/support/schools/partner_providers/support_user_adds_a_partner_provider_spec.rb
+++ b/spec/system/placements/support/schools/partner_providers/support_user_adds_a_partner_provider_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe "Placements / Support / Schools / Partner providers / Support use
   end
 
   def and_i_see_success_message
-    expect(page).to have_content "Partner provider added"
+    expect(page).to have_content "Provider added"
   end
 
   def given_a_partnership_exists_between(school, provider)

--- a/spec/system/placements/support/schools/partner_providers/support_user_adds_a_partner_provider_without_javascript_spec.rb
+++ b/spec/system/placements/support/schools/partner_providers/support_user_adds_a_partner_provider_without_javascript_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe "Placements / Support / Schools / Partner providers / Support use
   end
 
   def and_i_see_success_message
-    expect(page).to have_content "Partner provider added"
+    expect(page).to have_content "Provider added"
   end
 
   def given_a_partnership_exists_between(school, provider)

--- a/spec/system/placements/support/schools/partner_providers/support_user_deletes_a_partner_provider_spec.rb
+++ b/spec/system/placements/support/schools/partner_providers/support_user_deletes_a_partner_provider_spec.rb
@@ -91,10 +91,10 @@ RSpec.describe "Placements / Support / Schools / Partner providers / Support use
 
     expect(school.partner_providers.find_by(id: provider.id)).to be_nil
     within(".govuk-notification-banner__content") do
-      expect(page).to have_content "Partner provider deleted"
+      expect(page).to have_content "Provider deleted"
     end
 
-    expect(page).not_to have_content provider.name
+    expect(page).to have_content provider.name, count: 1
   end
 
   def and_a_partner_provider_remains_called(provider_name)


### PR DESCRIPTION
## Context

Notification banners were refactored in this PR ([#1068](https://github.com/DFE-Digital/itt-mentor-services/pull/1068)) in order for the flash messages to be updated in line with recent wayfinding changes.

## Changes proposed in this pull request

Changes are detailed on the confluence pages and are in line with wayfinding changes that rename 'partner provider' and 'partner school' to simply 'provider' and 'school'. In some cases, body text has been added to the flash messages. 

The changes affect the wizard journeys for:
- School user -> add/delete mentor
- School user -> add/delete placement
- School user -> add/delete provider
- School user -> add/delete user
- Provider user -> add/delete mentor
- Provider user -> add/delete placement
- Provider user -> add/delete school
- Provider user -> add/delete user

## Guidance to review

_Changes to flash messages are indicated with cursor prompts in the attached screenshot video of one example._

- Log in as a school user
- Complete the wizard journeys for adding and deleting a mentor, placement, provider, and user.
- Check that provider is consistently referred to as '<s>partner</s> provider' in flash messages.
- Check that any new body text in flash messages reads correctly.
- Check that each flash message is a green success flash message.

- Log in as a provider user.
- Complete the wizard journeys for adding and deleting a mentor, placement, school, and user.
- Check that school is consistently referred to as '<s>partner</s> school' in flash messages.
- Check that any new body text in flash messages reads correctly.
- Check that each flash message is a green success flash message.

## Link to Trello card

https://trello.com/c/DSe7B6P4/821-update-flash-message-content

## Screenshots

https://github.com/user-attachments/assets/d885db06-fe0e-4474-8528-29aa10eb1329
