### PR TITLE
Fix flaky spec

### DIFF
--- a/spec/models/claims/claim_spec.rb
+++ b/spec/models/claims/claim_spec.rb
@@ -109,9 +109,7 @@ RSpec.describe Claims::Claim, type: :model do
         claim2 = create(:claim, :submitted)
         create(:claim, :internal_draft)
 
-        expect(described_class.active).to eq(
-          [claim1, claim2],
-        )
+        expect(described_class.active).to contain_exactly(claim1, claim2)
       end
     end
 


### PR DESCRIPTION
Order is not important for this test as there is no order specified on the scope. This test failed because we order our default ordering is by UUID, meaning the array isn't guaranteed to be returned in order of creation.

## Context

We noticed this spec fail whilst pairing, and flaky tests can be frustrating!

## Changes proposed in this pull request

- [x] Substitue the `eq` matcher to `contain_exactly` as order isn't important.

## Guidance to review

- Review the changes

## Link to Trello card

[Fix flaky test](https://trello.com/c/SnYxdLq3/840-fix-flaky-test)
