### PR TITLE
Remove the text_or_dash helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,8 +25,4 @@ module ApplicationHelper
       "-"
     end
   end
-
-  def text_or_dash(value)
-    value.nil? ? "-" : value
-  end
 end


### PR DESCRIPTION
## Context

The `text_or_dash` help is no longer used and prevents `ApplicationHelper` from 100% coverage.

## Changes proposed in this pull request

- Remove the `text_or_dash` helper method.

## Guidance to review

\-