### PR TITLE
Remove current organisation

### DIFF
--- a/app/controllers/placements/application_controller.rb
+++ b/app/controllers/placements/application_controller.rb
@@ -2,21 +2,6 @@ class Placements::ApplicationController < ApplicationController
   after_action :verify_policy_scoped, if: ->(c) { c.action_name == "index" }
   before_action :authorize_support_user!
 
-  def current_user
-    @current_user ||= sign_in_user&.user&.tap do |user|
-      organisation_id = session.dig("current_organisation", "id")
-      organisation_type = session.dig("current_organisation", "type")
-      organisation = user.user_memberships.find_by(organisation_id:, organisation_type:)&.organisation
-
-      user.current_organisation = case organisation
-                                  when School
-                                    organisation.becomes(Placements::School)
-                                  when Provider
-                                    organisation.becomes(Placements::Provider)
-                                  end
-    end
-  end
-
   private
 
   def authorize_support_user!

--- a/app/controllers/placements/organisations_controller.rb
+++ b/app/controllers/placements/organisations_controller.rb
@@ -24,12 +24,7 @@ class Placements::OrganisationsController < Placements::ApplicationController
   def load_organisation(membership)
     organisation = membership.organisation
 
-    set_current_organisation(organisation)
     redirect_to landing_page_path(organisation)
-  end
-
-  def set_current_organisation(organisation)
-    session["current_organisation"] = { "id" => organisation.id, "type" => organisation.class.name }
   end
 
   def landing_page_path(organisation)

--- a/app/controllers/placements/providers/placements_controller.rb
+++ b/app/controllers/placements/providers/placements_controller.rb
@@ -10,7 +10,10 @@ class Placements::Providers::PlacementsController < Placements::ApplicationContr
     @schools = schools_scope.order_by_name.select(:id, :name)
     @year_groups ||= Placement.year_groups_as_options
     @terms = Placements::Term.order_by_term.select(:id, :name)
-    scope = policy_scope(Placements::PlacementsQuery.call(params: query_params))
+    scope = policy_scope(
+      Placements::PlacementsQuery.call(params: query_params),
+      policy_scope_class: Placements::Provider::PlacementPolicy::Scope,
+    )
 
     @pagy, @placements = pagy(scope)
   end

--- a/app/models/placements/support_user.rb
+++ b/app/models/placements/support_user.rb
@@ -20,6 +20,4 @@
 #
 class Placements::SupportUser < User
   include ActsAsSupportUser
-
-  attribute :current_organisation
 end

--- a/app/models/placements/user.rb
+++ b/app/models/placements/user.rb
@@ -28,8 +28,6 @@ class Placements::User < User
            source: :organisation,
            source_type: "Provider"
 
-  attribute :current_organisation
-
   def service
     :placements
   end

--- a/app/policies/placement_policy.rb
+++ b/app/policies/placement_policy.rb
@@ -1,13 +1,9 @@
 class PlacementPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      if user.current_organisation.is_a?(Placements::School)
-        scope.where(school: user.current_organisation)
-      elsif user.current_organisation.is_a?(Placements::Provider) || user.support_user?
-        scope
-      else
-        scope.none
-      end
+      return scope if user.support_user?
+
+      scope.where(school: user.schools)
     end
   end
 

--- a/app/policies/placements/mentor_policy.rb
+++ b/app/policies/placements/mentor_policy.rb
@@ -3,7 +3,7 @@ class Placements::MentorPolicy < ApplicationPolicy
     def resolve
       return scope if user.support_user?
 
-      scope.where(id: Placements::MentorMembership.select(:mentor_id).where(school: user.schools))
+      scope.where(id: user.schools.joins(:mentor_memberships).select(:mentor_id))
     end
   end
 end

--- a/app/policies/placements/mentor_policy.rb
+++ b/app/policies/placements/mentor_policy.rb
@@ -3,7 +3,7 @@ class Placements::MentorPolicy < ApplicationPolicy
     def resolve
       return scope if user.support_user?
 
-      scope.where(id: Placements::MentorMembership.select(:mentor_id).where(school: user.current_organisation))
+      scope.where(id: Placements::MentorMembership.select(:mentor_id).where(school: user.schools))
     end
   end
 end

--- a/app/policies/placements/provider/placement_policy.rb
+++ b/app/policies/placements/provider/placement_policy.rb
@@ -1,0 +1,7 @@
+class Placements::Provider::PlacementPolicy < ApplicationPolicy
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      scope
+    end
+  end
+end

--- a/app/policies/placements/user_policy.rb
+++ b/app/policies/placements/user_policy.rb
@@ -1,11 +1,11 @@
 class Placements::UserPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      if user.support_user?
-        scope
-      else
-        scope.where(id: UserMembership.select(:user_id).where(organisation: user.current_organisation))
-      end
+      return scope if user.support_user?
+
+      memberships = UserMembership.where(organisation: user.schools)
+        .or(UserMembership.where(organisation: user.providers))
+      scope.where(id: memberships.select(:user_id))
     end
   end
 end

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -3,7 +3,7 @@ class ProviderPolicy < ApplicationPolicy
     def resolve
       return scope if user.support_user?
 
-      scope.where(id: Placements::Partnership.select(:provider_id).where(school: user.schools))
+      scope.where(id: user.schools.joins(:partnerships).select(:provider_id))
     end
   end
 end

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -3,7 +3,7 @@ class ProviderPolicy < ApplicationPolicy
     def resolve
       return scope if user.support_user?
 
-      scope.where(id: user.current_organisation.partner_providers.select(:id))
+      scope.where(id: Placements::Partnership.select(:provider_id).where(school: user.schools))
     end
   end
 end

--- a/app/policies/school_policy.rb
+++ b/app/policies/school_policy.rb
@@ -3,11 +3,7 @@ class SchoolPolicy < ApplicationPolicy
     def resolve
       return scope if user.support_user?
 
-      if user.current_organisation.is_a?(Placements::School)
-        scope.where(id: user.current_organisation.partner_providers.select(:id))
-      else
-        scope.where(id: user.current_organisation.partner_schools.select(:id))
-      end
+      scope.where(id: Placements::Partnership.select(:school_id).where(provider: user.providers))
     end
   end
 end

--- a/app/policies/school_policy.rb
+++ b/app/policies/school_policy.rb
@@ -3,7 +3,7 @@ class SchoolPolicy < ApplicationPolicy
     def resolve
       return scope if user.support_user?
 
-      scope.where(id: Placements::Partnership.select(:school_id).where(provider: user.providers))
+      scope.where(id: user.providers.joins(:partnerships).select(:school_id))
     end
   end
 end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -103,7 +103,6 @@ shared:
     - first_name
     - last_name
     - email
-    - current_organisation
   :mentors:
     - first_name
     - last_name

--- a/spec/models/placements/support_user_spec.rb
+++ b/spec/models/placements/support_user_spec.rb
@@ -21,10 +21,6 @@
 require "rails_helper"
 
 RSpec.describe Placements::SupportUser do
-  describe "attributes" do
-    it { is_expected.to have_attributes(current_organisation: nil) }
-  end
-
   context "with validations" do
     subject { build(:placements_support_user) }
 

--- a/spec/models/placements/user_spec.rb
+++ b/spec/models/placements/user_spec.rb
@@ -38,10 +38,6 @@ RSpec.describe Placements::User do
     end
   end
 
-  describe "attributes" do
-    it { is_expected.to have_attributes(current_organisation: nil) }
-  end
-
   describe "default scope" do
     let(:email) { "same_email@email.co.uk" }
     let!(:user_with_placements_service) { create(:placements_user, email:) }

--- a/spec/policies/placement_policy_spec.rb
+++ b/spec/policies/placement_policy_spec.rb
@@ -67,33 +67,11 @@ RSpec.describe PlacementPolicy do
       let(:placement_2) { create(:placement) }
 
       before do
-        user.current_organisation = school
         placement_2
       end
 
       it "returns the school's placements" do
         expect(placement_policy::Scope.new(user, scope).resolve).to eq([placement_1])
-      end
-    end
-
-    context "when the user is a provider user" do
-      let(:user) { create(:placements_user, providers: [provider]) }
-      let(:provider) { create(:placements_provider) }
-
-      before do
-        user.current_organisation = provider
-      end
-
-      it "returns the provider's placements" do
-        expect(placement_policy::Scope.new(user, scope).resolve).to eq(scope)
-      end
-    end
-
-    context "when the user is none of the above" do
-      let(:user) { create(:placements_user) }
-
-      it "returns no placements" do
-        expect(placement_policy::Scope.new(user, scope).resolve).to eq(scope.none)
       end
     end
   end

--- a/spec/policies/placements/mentor_policy_spec.rb
+++ b/spec/policies/placements/mentor_policy_spec.rb
@@ -21,7 +21,6 @@ describe Placements::MentorPolicy do
       let(:mentor_2) { create(:placements_mentor) }
 
       before do
-        user.current_organisation = school
         mentor_2
       end
 

--- a/spec/policies/placements/provider/placement_policy_spec.rb
+++ b/spec/policies/placements/provider/placement_policy_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe Placements::Provider::PlacementPolicy do
+  subject(:placement_policy) { described_class }
+
+  describe "scope" do
+    let(:scope) { Placement.all }
+
+    before do
+      create_list(:placement, 3)
+    end
+
+    context "when the user is a support user" do
+      let(:user) { create(:placements_support_user) }
+
+      it "returns all placements" do
+        expect(placement_policy::Scope.new(user, scope).resolve).to eq(scope)
+      end
+    end
+
+    context "when the user is a provider user" do
+      let(:provider) { build(:placements_provider) }
+      let(:user) { create(:placements_user, providers: [provider]) }
+
+      it "returns the school's placements" do
+        expect(placement_policy::Scope.new(user, scope).resolve).to eq(scope)
+      end
+    end
+  end
+end

--- a/spec/policies/placements/user_policy_spec.rb
+++ b/spec/policies/placements/user_policy_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Placements::UserPolicy do
       let(:user_2) { create(:placements_user) }
 
       before do
-        user_1.current_organisation = school
         user_2
       end
 

--- a/spec/policies/provider_policy_spec.rb
+++ b/spec/policies/provider_policy_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe ProviderPolicy do
       let(:provider_2) { create(:placements_provider) }
 
       before do
-        user.current_organisation = school
         provider_2
       end
 

--- a/spec/policies/school_policy_spec.rb
+++ b/spec/policies/school_policy_spec.rb
@@ -18,10 +18,6 @@ RSpec.describe SchoolPolicy do
       let(:user) { create(:placements_user, schools: [school]) }
       let(:school) { create(:placements_school) }
 
-      before do
-        user.current_organisation = school
-      end
-
       it "returns the school's partner providers" do
         expect(school_policy::Scope.new(user, scope).resolve).to eq(school.partner_providers)
       end
@@ -30,10 +26,6 @@ RSpec.describe SchoolPolicy do
     context "when the user is a provider user" do
       let(:user) { create(:placements_user, providers: [provider]) }
       let(:provider) { create(:placements_provider) }
-
-      before do
-        user.current_organisation = provider
-      end
 
       it "returns the provider's partner schools" do
         expect(school_policy::Scope.new(user, scope).resolve).to eq(provider.partner_schools)

--- a/spec/policies/user_membership_policy_spec.rb
+++ b/spec/policies/user_membership_policy_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe UserMembershipPolicy do
       let(:user_membership_2) { create(:user_membership) }
 
       before do
-        user.current_organisation = school
         user_membership_2
       end
 


### PR DESCRIPTION
## Context

- Remove the concept of `current_organisation` throughout the service

## Changes proposed in this pull request

- Remove `current_organisation` attribute from user models
- Remove `current_organisation` from policies

## Guidance to review

- Test most of the features of the service to ensure nothing has broken.

## Link to Trello card

https://trello.com/c/onvm1r3x/853-remove-the-concept-of-the-current-user-having-a-current-organisation
