### PR TITLE
Remove the account page from the placement service

### DIFF
--- a/app/constraints/claims_only_constraint.rb
+++ b/app/constraints/claims_only_constraint.rb
@@ -1,0 +1,5 @@
+class ClaimsOnlyConstraint
+  def matches?(request)
+    HostingEnvironment.current_service(request) == :claims
+  end
+end

--- a/app/constraints/support_user_constraint.rb
+++ b/app/constraints/support_user_constraint.rb
@@ -1,0 +1,7 @@
+class SupportUserConstraint
+  def matches?(request)
+    service = HostingEnvironment.current_service(request)
+    current_user = DfESignInUser.load_from_session(request.session, service:)&.user
+    current_user&.support_user?
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,6 +9,10 @@ module ApplicationHelper
     t("#{current_service}.service_name")
   end
 
+  def claims_service?
+    current_service == :claims
+  end
+
   def external_link(link)
     return if link.blank?
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,9 @@
       <% header.with_product_name(name: service_name) %>
 
       <% if current_user %>
-        <% header.with_navigation_item(text: t(".your_account"), href: account_path) %>
+        <% if current_service == :claims %>
+          <% header.with_navigation_item(text: t(".your_account"), href: account_path) %>
+        <% end %>
         <% header.with_navigation_item(text: t(".sign_out"), href: sign_out_path) %>
       <% end %>
     <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
       <% header.with_product_name(name: service_name) %>
 
       <% if current_user %>
-        <% if current_service == :claims %>
+        <% if claims_service? %>
           <% header.with_navigation_item(text: t(".your_account"), href: account_path) %>
         <% end %>
         <% header.with_navigation_item(text: t(".sign_out"), href: sign_out_path) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,17 +1,3 @@
-class SupportUserConstraint
-  def self.matches?(request)
-    service = HostingEnvironment.current_service(request)
-    current_user = DfESignInUser.load_from_session(request.session, service:)&.user
-    current_user&.support_user?
-  end
-end
-
-class ClaimsOnlyConstraint
-  def self.matches?(request)
-    HostingEnvironment.current_service(request) == :claims
-  end
-end
-
 Rails.application.routes.draw do
   scope via: :all do
     get "/404", to: "errors#not_found", as: :not_found
@@ -21,7 +7,7 @@ Rails.application.routes.draw do
   end
 
   # User Account Details
-  get "/account", to: "account#show", constraints: ClaimsOnlyConstraint
+  get "/account", to: "account#show", constraints: ClaimsOnlyConstraint.new
   get "/sign-in", to: "sessions#new", as: :sign_in
 
   # Persona Sign In
@@ -44,6 +30,6 @@ Rails.application.routes.draw do
   draw :claims
 
   # GoodJob admin interface – only accessible to support users
-  mount GoodJob::Engine => "/good_job", constraints: SupportUserConstraint
+  mount GoodJob::Engine => "/good_job", constraints: SupportUserConstraint.new
   get "/good_job", to: redirect("/support")
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,12 @@ class SupportUserConstraint
   end
 end
 
+class ClaimsOnlyConstraint
+  def self.matches?(request)
+    HostingEnvironment.current_service(request) == :claims
+  end
+end
+
 Rails.application.routes.draw do
   scope via: :all do
     get "/404", to: "errors#not_found", as: :not_found
@@ -15,7 +21,7 @@ Rails.application.routes.draw do
   end
 
   # User Account Details
-  get "/account", to: "account#show"
+  get "/account", to: "account#show", constraints: ClaimsOnlyConstraint
   get "/sign-in", to: "sessions#new", as: :sign_in
 
   # Persona Sign In

--- a/spec/constraints/claims_only_constraint_spec.rb
+++ b/spec/constraints/claims_only_constraint_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe ClaimsOnlyConstraint do
+  describe ".matches?" do
+    context "when current service is claims" do
+      it "returns true" do
+        allow(HostingEnvironment).to receive(:current_service).and_return(:claims)
+        expect(described_class.new.matches?({})).to be(true)
+      end
+    end
+
+    context "when the current service is placements" do
+      it "returns false" do
+        allow(HostingEnvironment).to receive(:current_service).and_return(:placements)
+        expect(described_class.new.matches?({})).to be(false)
+      end
+    end
+  end
+end

--- a/spec/constraints/support_user_constraint_spec.rb
+++ b/spec/constraints/support_user_constraint_spec.rb
@@ -1,0 +1,143 @@
+require "rails_helper"
+
+RSpec.describe SupportUserConstraint do
+  let!(:claims_support_user) { create(:claims_support_user) }
+  let!(:claims_user) { create(:claims_user) }
+  let!(:placements_support_user) { create(:placements_support_user) }
+  let!(:placements_user) { create(:placements_user) }
+  let(:request) { Struct.new(:session).new({}) }
+
+  describe ".matches?" do
+    context "when current service is claims" do
+      context "when the user is a claims support user" do
+        it "returns true" do
+          allow(HostingEnvironment).to receive(:current_service).and_return(:claims)
+          allow(DfESignInUser).to receive(:load_from_session).and_return(
+            DfESignInUser.new(
+              dfe_sign_in_uid: 123,
+              email: claims_support_user.email,
+              first_name: claims_support_user.first_name,
+              last_name: claims_support_user.last_name,
+              service: :claims,
+            ),
+          )
+          expect(described_class.new.matches?(request)).to be(true)
+        end
+      end
+
+      context "when the user is a placements support user" do
+        it "returns nil" do
+          allow(HostingEnvironment).to receive(:current_service).and_return(:claims)
+          allow(DfESignInUser).to receive(:load_from_session).and_return(
+            DfESignInUser.new(
+              dfe_sign_in_uid: 123,
+              email: placements_support_user.email,
+              first_name: placements_support_user.first_name,
+              last_name: placements_support_user.last_name,
+              service: :claims,
+            ),
+          )
+          expect(described_class.new.matches?(request)).to be_nil
+        end
+      end
+
+      context "when the user is a claims user" do
+        it "returns true" do
+          allow(HostingEnvironment).to receive(:current_service).and_return(:claims)
+          allow(DfESignInUser).to receive(:load_from_session).and_return(
+            DfESignInUser.new(
+              dfe_sign_in_uid: 123,
+              email: claims_user.email,
+              first_name: claims_user.first_name,
+              last_name: claims_user.last_name,
+              service: :claims,
+            ),
+          )
+          expect(described_class.new.matches?(request)).to be(false)
+        end
+      end
+
+      context "when the user is a placements user" do
+        it "returns true" do
+          allow(HostingEnvironment).to receive(:current_service).and_return(:claims)
+          allow(DfESignInUser).to receive(:load_from_session).and_return(
+            DfESignInUser.new(
+              dfe_sign_in_uid: 123,
+              email: placements_user.email,
+              first_name: placements_user.first_name,
+              last_name: placements_user.last_name,
+              service: :claims,
+            ),
+          )
+          expect(described_class.new.matches?(request)).to be_nil
+        end
+      end
+    end
+
+    context "when the current service is placements" do
+      context "when the user is a placements support user" do
+        it "returns nil" do
+          allow(HostingEnvironment).to receive(:current_service).and_return(:placements)
+          allow(DfESignInUser).to receive(:load_from_session).and_return(
+            DfESignInUser.new(
+              dfe_sign_in_uid: 123,
+              email: placements_support_user.email,
+              first_name: placements_support_user.first_name,
+              last_name: placements_support_user.last_name,
+              service: :placements,
+            ),
+          )
+          expect(described_class.new.matches?(request)).to be(true)
+        end
+      end
+
+      context "when the user is a claims support user" do
+        it "returns true" do
+          allow(HostingEnvironment).to receive(:current_service).and_return(:placements)
+          allow(DfESignInUser).to receive(:load_from_session).and_return(
+            DfESignInUser.new(
+              dfe_sign_in_uid: 123,
+              email: claims_support_user.email,
+              first_name: claims_support_user.first_name,
+              last_name: claims_support_user.last_name,
+              service: :placements,
+            ),
+          )
+          expect(described_class.new.matches?(request)).to be_nil
+        end
+      end
+
+      context "when the user is a placements user" do
+        it "returns true" do
+          allow(HostingEnvironment).to receive(:current_service).and_return(:placements)
+          allow(DfESignInUser).to receive(:load_from_session).and_return(
+            DfESignInUser.new(
+              dfe_sign_in_uid: 123,
+              email: placements_user.email,
+              first_name: placements_user.first_name,
+              last_name: placements_user.last_name,
+              service: :placements,
+            ),
+          )
+          expect(described_class.new.matches?(request)).to be(false)
+        end
+      end
+
+      context "when the user is a claims user" do
+        it "returns true" do
+          allow(HostingEnvironment).to receive(:current_service).and_return(:placements)
+          allow(DfESignInUser).to receive(:load_from_session).and_return(
+            DfESignInUser.new(
+              dfe_sign_in_uid: 123,
+              email: claims_user.email,
+              first_name: claims_user.first_name,
+              last_name: claims_user.last_name,
+              service: :placements,
+            ),
+          )
+          expect(described_class.new.matches?(request)).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -54,4 +54,20 @@ RSpec.describe ApplicationHelper do
       end
     end
   end
+
+  describe "#claims_service?" do
+    context "when current_service is claims" do
+      it "returns true" do
+        allow(HostingEnvironment).to receive(:current_service).and_return(:claims)
+        expect(claims_service?).to be(true)
+      end
+    end
+
+    context "when current_service is placements" do
+      it "returns true" do
+        allow(HostingEnvironment).to receive(:current_service).and_return(:placements)
+        expect(claims_service?).to be(false)
+      end
+    end
+  end
 end

--- a/spec/requests/account_spec.rb
+++ b/spec/requests/account_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "Account", type: :request do
+  describe "GET /account" do
+    context "when the service is claims", service: :claims do
+      it "returns http success" do
+        claims_user = create(:claims_user)
+        sign_in_as claims_user
+
+        get "/account"
+
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template("account/show")
+      end
+    end
+
+    context "when the service is placments", service: :placements do
+      it "returns http success" do
+        placements_user = create(:placements_user)
+        sign_in_as placements_user
+
+        expect { get "/account" }.to raise_error(ActionController::RoutingError)
+      end
+    end
+  end
+end

--- a/spec/system/placements/sign_in_as_a_placements_user_spec.rb
+++ b/spec/system/placements/sign_in_as_a_placements_user_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
           and_i_visit_a_school_show_page
           then_i_am_redirected_to_the_sign_in_page
           when_i_click_sign_in
-          then_i_see_school_show_page
+          then_i_see_school_show_page()
           when_i_visit_the placements_root_path
           and_i_click_on "Start now"
           then_i_see_a_list_of_organisations
@@ -266,12 +266,12 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
   end
 
   def and_i_visit_a_school_show_page
-    visit placements_support_school_path(School.last)
+    visit placements_support_school_path(organisation)
   end
 
   def then_i_see_school_show_page
-    expect(page).to have_current_path placements_support_school_path(School.last), ignore_query: true
-    expect(page).to have_content("Placement School")
+    expect(page).to have_current_path placements_support_school_path(organisation), ignore_query: true
+    expect(page).to have_content(organisation.name)
   end
 
   def and_there_are_placement_organisations

--- a/spec/system/placements/sign_in_as_a_placements_user_spec.rb
+++ b/spec/system/placements/sign_in_as_a_placements_user_spec.rb
@@ -7,9 +7,6 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
     when_i_click_sign_in
     then_i_dont_get_redirected_to_support_organisations
     and_i_see_an_empty_organsations_page
-
-    and_i_visit_my_account_page
-    then_i_see_user_details_for_anne
   end
 
   context "when the user is assigned to a school" do
@@ -59,9 +56,6 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
     when_i_visit_the_sign_in_path
     when_i_click_sign_in
     then_i_see_a_list_of_organisations
-
-    and_i_visit_my_account_page
-    then_i_see_user_details_for_colin
   end
 
   context "when response from dfe sign in is invalid" do
@@ -111,8 +105,6 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
         when_i_visit_the_sign_in_path
         when_i_click_sign_in
         then_i_dont_get_redirected_to_support_organisations
-        and_i_visit_my_account_page
-        then_i_see_user_details_for_anne
       end
     end
 
@@ -123,9 +115,6 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
         when_i_visit_the_sign_in_path
         when_i_click_sign_in
         then_i_see_a_list_of_organisations
-
-        and_i_visit_my_account_page
-        then_i_see_user_details_for_colin
       end
     end
   end
@@ -246,10 +235,10 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
         scenario "I am redirected to the support organisation list page" do
           given_there_is_an_existing_support_user_for("Colin")
           and_there_are_placement_organisations
-          and_i_visit_my_account_page
+          and_i_visit_a_school_show_page
           then_i_am_redirected_to_the_sign_in_page
           when_i_click_sign_in
-          then_i_see_user_details_for_colin
+          then_i_see_school_show_page
           when_i_visit_the placements_root_path
           and_i_click_on "Start now"
           then_i_see_a_list_of_organisations
@@ -276,6 +265,15 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
     visit sign_in_path
   end
 
+  def and_i_visit_a_school_show_page
+    visit placements_support_school_path(School.last)
+  end
+
+  def then_i_see_school_show_page
+    expect(page).to have_current_path placements_support_school_path(School.last), ignore_query: true
+    expect(page).to have_content("Placement School")
+  end
+
   def and_there_are_placement_organisations
     create(:school, :placements, name: "Placement School")
     create(:placements_provider, name: "Provider 1")
@@ -289,11 +287,6 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
     click_on text
   end
 
-  def and_i_visit_my_account_page
-    visit account_path
-  end
-  alias_method :when_i_visit_my_account_page, :and_i_visit_my_account_page
-
   def when_i_visit_the(path)
     visit path
   end
@@ -306,24 +299,6 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
 
   def then_i_dont_get_redirected_to_support_organisations
     expect(page).to have_no_current_path placements_support_organisations_path, ignore_query: true
-  end
-
-  def then_i_see_user_details_for_anne
-    expect(page).to have_current_path account_path
-    page_has_user_content(
-      first_name: "Anne",
-      last_name: "Wilson",
-      email: "anne_wilson@example.org",
-    )
-  end
-
-  def then_i_see_user_details_for_colin
-    expect(page).to have_current_path account_path
-    page_has_user_content(
-      first_name: "Colin",
-      last_name: "Chapman",
-      email: "colin.chapman@education.gov.uk",
-    )
   end
 
   def page_has_user_content(first_name:, last_name:, email:)

--- a/spec/system/placements/sign_in_as_a_placements_user_spec.rb
+++ b/spec/system/placements/sign_in_as_a_placements_user_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
           and_i_visit_a_school_show_page
           then_i_am_redirected_to_the_sign_in_page
           when_i_click_sign_in
-          then_i_see_school_show_page()
+          then_i_see_school_show_page
           when_i_visit_the placements_root_path
           and_i_click_on "Start now"
           then_i_see_a_list_of_organisations


### PR DESCRIPTION
## Context

- Remove the account page from the placements service

## Changes proposed in this pull request

- Remove 'Account' nav item from the header
- Remove '/account` from the routes for placements service

## Guidance to review

- Sign in as any user on the placements service
- The 'Account' item in the header nav should no longer appear.
- visiting `/account` should no longer work for the placements service.

## Link to Trello card

https://trello.com/c/fsvC2q4R/858-remove-the-account-page-from-the-placements-service

## Screenshots

![Screenshot 2024-10-04 at 15 37 11](https://github.com/user-attachments/assets/f2351ad9-a3ac-4f2f-a0e4-3f5e9b242ece)


