### PR TITLE
Refactor methods on claims mentor training form

### DIFF
--- a/app/components/claims/claim/mentor_training_form/disclaimer_component.rb
+++ b/app/components/claims/claim/mentor_training_form/disclaimer_component.rb
@@ -1,6 +1,8 @@
 class Claims::Claim::MentorTrainingForm::DisclaimerComponent < ApplicationComponent
   attr_reader :mentor_training_form
 
+  delegate :training_allowance, to: :mentor_training_form
+
   def initialize(mentor_training_form:, classes: [], html_attributes: {})
     super(classes:, html_attributes:)
 
@@ -9,13 +11,13 @@ class Claims::Claim::MentorTrainingForm::DisclaimerComponent < ApplicationCompon
 
   def call
     govuk_inset_text do
-      tag.p(sanitize(t(".disclaimer", mentor_name:, provider_name:, count: mentor_training_form.max_hours))) +
+      tag.p(sanitize(t(".disclaimer", mentor_name:, provider_name:, count: training_allowance.remaining_hours))) +
         tag.p(sanitize(t(".disclaimer_contact", support_link:)))
     end
   end
 
   def render?
-    !mentor_training_form.max_hours_equals_maximum_claimable_hours?
+    training_allowance.remaining_hours < training_allowance.total_hours
   end
 
   private

--- a/app/forms/claims/claim/mentor_training_form.rb
+++ b/app/forms/claims/claim/mentor_training_form.rb
@@ -56,7 +56,7 @@ class Claims::Claim::MentorTrainingForm < ApplicationForm
   end
 
   def max_hours
-    @max_hours ||= training_allowance.remaining_hours
+    training_allowance.remaining_hours
   end
 
   def training_allowance

--- a/app/forms/claims/claim/mentor_training_form.rb
+++ b/app/forms/claims/claim/mentor_training_form.rb
@@ -55,10 +55,6 @@ class Claims::Claim::MentorTrainingForm < ApplicationForm
     end
   end
 
-  def custom_hours_selected?
-    @custom_hours_selected ||= hours_completed == "custom"
-  end
-
   def max_hours
     @max_hours ||= training_allowance.remaining_hours
   end
@@ -84,5 +80,9 @@ class Claims::Claim::MentorTrainingForm < ApplicationForm
 
   def previous_mentor_training
     mentor_trainings[mentor_trainings.index(mentor_training) - 1]
+  end
+
+  def custom_hours_selected?
+    hours_completed == "custom"
   end
 end

--- a/app/forms/claims/claim/mentor_training_form.rb
+++ b/app/forms/claims/claim/mentor_training_form.rb
@@ -63,8 +63,13 @@ class Claims::Claim::MentorTrainingForm < ApplicationForm
     @max_hours ||= training_allowance.remaining_hours
   end
 
-  def max_hours_equals_maximum_claimable_hours?
-    max_hours == training_allowance.total_hours
+  def training_allowance
+    @training_allowance ||= Claims::TrainingAllowance.new(
+      mentor:,
+      provider:,
+      academic_year:,
+      claim_to_exclude: claim,
+    )
   end
 
   private
@@ -79,14 +84,5 @@ class Claims::Claim::MentorTrainingForm < ApplicationForm
 
   def previous_mentor_training
     mentor_trainings[mentor_trainings.index(mentor_training) - 1]
-  end
-
-  def training_allowance
-    @training_allowance ||= Claims::TrainingAllowance.new(
-      mentor:,
-      provider:,
-      academic_year:,
-      claim_to_exclude: claim,
-    )
   end
 end

--- a/spec/forms/claims/claim/mentor_training_form_spec.rb
+++ b/spec/forms/claims/claim/mentor_training_form_spec.rb
@@ -150,28 +150,4 @@ describe Claims::Claim::MentorTrainingForm, type: :model do
       end
     end
   end
-
-  describe "#max_hours_equals_maximum_claimable_hours?" do
-    it "returns true when a mentor has 20 hours available to claim" do
-      expect(mentor_training_form.max_hours_equals_maximum_claimable_hours?).to be(true)
-    end
-
-    context "when a mentor has already claimed any amount of hours" do
-      let(:submitted_claim) { create(:claim, :submitted) }
-
-      before do
-        create(
-          :mentor_training,
-          claim: submitted_claim,
-          provider: mentor_training.provider,
-          mentor: mentor_training.mentor,
-          hours_completed: 1,
-        )
-      end
-
-      it "returns false" do
-        expect(mentor_training_form.max_hours_equals_maximum_claimable_hours?).to be(false)
-      end
-    end
-  end
 end

--- a/spec/forms/claims/support/claim/mentor_training_form_spec.rb
+++ b/spec/forms/claims/support/claim/mentor_training_form_spec.rb
@@ -150,28 +150,4 @@ describe Claims::Support::Claim::MentorTrainingForm, type: :model do
       end
     end
   end
-
-  describe "#max_hours_equals_maximum_claimable_hours?" do
-    it "returns true when a mentor has 20 hours available to claim" do
-      expect(mentor_training_form.max_hours_equals_maximum_claimable_hours?).to be(true)
-    end
-
-    context "when a mentor has already claimed any amount of hours" do
-      let(:submitted_claim) { create(:claim, :submitted) }
-
-      before do
-        create(
-          :mentor_training,
-          claim: submitted_claim,
-          provider: mentor_training.provider,
-          mentor: mentor_training.mentor,
-          hours_completed: 1,
-        )
-      end
-
-      it "returns false" do
-        expect(mentor_training_form.max_hours_equals_maximum_claimable_hours?).to be(false)
-      end
-    end
-  end
 end


### PR DESCRIPTION
## Context

These changes come off the back of a comment thread in a separate PR – see https://github.com/DFE-Digital/itt-mentor-services/pull/1062#discussion_r1787658239

We agreed that the changes I suggested were out of scope for that PR, so I've put them into a new one.

Now that we have a standalone 'training allowance' object, it feels unnecessary for the mentor training form to hide that object from the outside world through abstractions and wrapper methods.

## Changes proposed in this pull request

- Refactor to remove confusingly named method `mentor_training_form.max_hours_equals_maximum_claimable_hours?`
- Move the logic from that method into the single place it was being used (i.e. the 'disclaimer' component)
- Avoid double-memoizing methods, this is not necessary
- Make methods private where possible

## Guidance to review

This PR is based upon #1062 for now, since that branch hasn't been merged in to main yet.

To review this PR, see the commits:

1. [Move logic closer to the code that needs it](https://github.com/DFE-Digital/itt-mentor-services/pull/1086/commits/1fd325b7e0deee3dcdb4a08571efa32990bf178d)
2. [Make `custom_hours_selected?` method private](https://github.com/DFE-Digital/itt-mentor-services/pull/1086/commits/f6c22230f18d9637ffe0887f091b49b3ca6b3d83)
3. [Stop memoizing max_hours](https://github.com/DFE-Digital/itt-mentor-services/pull/1086/commits/d35742dcf0fa8f3352351c6de0163aa29cb00de1)

## Link to Trello card

Offshoot of: [Refactor the claim form to use Training Allowance](https://trello.com/c/mSePcH76/740-refactor-the-claim-form-to-use-training-allowance)
