### PR TITLE
Update grant conditions

### DIFF
--- a/app/views/claims/schools/_grant_conditions.html.erb
+++ b/app/views/claims/schools/_grant_conditions.html.erb
@@ -23,10 +23,10 @@
 
       <h2 class="govuk-heading-m" id="introduction">1. Introduction</h2>
       <p class="govuk-body">
-        Best Practice Network (BPN) and National Institute of Teaching (NIoT) have adopted the <%= govuk_link_to("2024/25 ITT criteria", "https://www.gov.uk/government/publications/initial-teacher-training-criteria/initial-teacher-training-itt-criteria-and-supporting-advice") %> a year early to pilot the new Quality Requirements. As a result, all schools (early adopters) who have hosted a trainee for these providers will need to have introduced the general mentor role in the 2023/24 academic year. Mentors working in these schools will need to complete up to 20 hours of initial mentor training with these providers.
+        As detailed in the <%= govuk_link_to("initial teacher training reform guidance", "https://www.gov.uk/government/publications/initial-teacher-training-reform-funding-guidance") %> in the 2024/25 academic year (between 1 September 2024 and 31 August 2025), mentors working in schools that offer initial teacher training (ITT) placements will need to complete up to 20 hours of initial mentor training with an accredited training provider.
       </p>
       <p class="govuk-body">
-        Early adopter schools can claim for the actual hours of training undertaken by the mentor to a maximum of 20 hours, per accredited provider during the 2023/24 academic year. <%= govuk_link_to("Guidance explaining the general mentor training", "https://www.gov.uk/government/publications/initial-teacher-training-reform-funding-guidance") %>, in addition to the lead mentor and intensive training and practice element of the ITT curriculum was updated in March 2024.
+        Schools can claim for the actual hours of training undertaken by the mentor to a maximum of 20 hours, per accredited provider. <%= govuk_link_to "Guidance explaining the general mentor training", "https://www.gov.uk/government/publications/initial-teacher-training-reform-funding-guidance" %>, in addition to the lead mentor and intensive training and practice element of the ITT curriculum was updated in March 2024.
       </p>
       <p class="govuk-body">
         <%= govuk_link_to("Guidance explaining what schools need to do to offer ITT placements", "https://www.gov.uk/guidance/offer-a-trainee-teacher-placement") %> from September 2024, was published in November 2023.
@@ -40,15 +40,15 @@
         <li>overtime payment to the mentor, if they are training outside normal working hours (teacher workload should be carefully considered in such cases)</li>
         <li>paying for any costs that come from reducing a mentor’s other responsibilities so they have time to train</li>
       </ul>
-      <p class="govuk-body">This funding applies to early adopter schools that:</p>
+      <p class="govuk-body">This funding applies to schools that:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>offer placements to ITT trainees, including special schools, pupil referral units, independent schools, early years settings and further education organisations</li>
-        <li>have mentors working with ITT trainees who started or returned to their training at any time between 1 September 2023 and 31 May 2024 (1 June 2023 for apprenticeship trainees)</li>
-        <li>have mentors that intended to work with ITT trainees who would have started their training any time between 1 September 2023 and 31 May 2024 (1 June for apprenticeship trainees), but the provider was unable to place the trainee/ the trainee withdrew after the mentor training took place.</li>
+        <li>have mentors working with ITT trainees who started or returned to their training at any time between 1 September 2024 and 31 May 2025 (1 June 2024 for apprenticeship trainees)</li>
+        <li>have mentors that intended to work with ITT trainees who would have started their training any time between 1 September 2024 and 31 May 2025 (1 June for apprenticeship trainees), but the provider was unable to place the trainee/ the trainee withdrew after the mentor training took place.</li>
       </ul>
 
       <h2 class="govuk-heading-m" id="eligibility">3. Eligibility</h2>
-      <p class="govuk-body">Any type of institution within England that hosted an ITT trainee on a course where the accredited provider was BPN or NIoT; or intended to host an ITT trainee on a BPN or NIoT course leading to the award of QTS (except Assessment Only), is eligible to claim funding, including special schools, pupil referral units, early years settings, further education organisations and independent schools.</p>
+      <p class="govuk-body">Any type of institution within England that hosted an ITT trainee or intended to host an ITT trainee on a course leading to the award of QTS (except Assessment Only), is eligible to claim funding, including special schools, pupil referral units, early years settings, further education organisations and independent schools.</p>
       <h3 class="govuk-heading-s">Placement duration</h3>
       <p class="govuk-body">There is no minimum placement duration for an organisation to submit a claim for general mentor funding.</p>
       <h3 class="govuk-heading-s">Eligible type of training</h3>
@@ -56,27 +56,27 @@
       <h3 class="govuk-heading-s">School location</h3>
       <p class="govuk-body">Only educational organisations located in England are eligible to apply for this grant funding.</p>
       <h3 class="govuk-heading-s">Mentors who cannot continue with mentoring</h3>
-      <p class="govuk-body">An early adopter school can claim funding when a mentor starts their initial training between 6 April 2023 and 31 May 2024, begins mentoring a trainee but then cannot continue mentoring for any reason. The school should arrange a new mentor for the trainee. The school can claim funding for both mentors if they both started their training between 6 April 2023 and 31 May 2024.</p>
+      <p class="govuk-body">A school can claim funding when a mentor starts their initial training between 6 April 2024 and 31 May 2025, begins mentoring a trainee but then cannot continue mentoring for any reason. The school should arrange a new mentor for the trainee. The school can claim funding for both mentors if they both started their training between 6 April 2024 and 31 May 2025.</p>
       <h3 class="govuk-heading-s">Mentors training with different providers</h3>
       <p class="govuk-body">Each accredited ITT provider can develop their own mentor training, which can result in different training for mentors working with different providers. If a school hosts trainees from different providers, a mentor might have to undertake their initial mentor training with each provider, but accredited ITT providers should consider prior training when deciding what aspects of their mentor training a mentor should complete.</p>
-      <p class="govuk-body">Early adopter schools can claim funding for the time a mentor spends training at each provider.</p>
-      <p class="govuk-body">For schools to claim this funding, a mentor must have worked with a trainee who started or intended to start their ITT in the 2023/24 academic year (between 1 September 2023 and 31 May 2024, 1 June 2023 for apprenticeship trainees). Schools must ensure a trainee has one dedicated mentor during their placement (unless the mentor works in a job-share). Other teachers may support elements of the trainee’s placement, but schools can only claim funding for the training time of the trainee’s dedicated mentor.</p>
+      <p class="govuk-body">Schools can claim funding for the time a mentor spends training at each provider.</p>
+      <p class="govuk-body">For schools to claim this funding, a mentor must have worked with a trainee who started or intended to start their ITT in the 2024/25 academic year (between 1 September 2024 and 31 May 2025, 1 June 2024 for apprenticeship trainees). Schools must ensure a trainee has one dedicated mentor during their placement (unless the mentor works in a job-share). Other teachers may support elements of the trainee’s placement, but schools can only claim funding for the training time of the trainee’s dedicated mentor.</p>
       <p class="govuk-body">This funding is not available to schools if a mentor only works with high potential initial teacher training (HPITT) trainees, as funding is provided separately for such mentors.</p>
       <h3 class="govuk-heading-s">Mentors working with multiple schools</h3>
       <p class="govuk-body">Mentors can work with multiple schools while undertaking their training. For example, if a mentor is working across multiple schools in a trust then those schools can only claim for a total of 20 hours of funding per mentor with a single accredited ITT provider.</p>
       <p class="govuk-body">For instance, if school A claimed 10 hours of funding for mentor A, with provider A, then school B could only claim 10 hours for mentor A, with provider A. If school A claimed 20 hours of funding for mentor A, with provider A, then school B could not claim any funding for mentor A with provider A.</p>
       <h3 class="govuk-heading-s">Trainees that defer or withdraw from their training</h3>
-      <p class="govuk-body">Early adopter schools can claim mentor funding if a mentor works with a trainee who:</p>
+      <p class="govuk-body">Schools can claim mentor funding if a mentor works with a trainee who:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>deferred in a previous academic year and then returns to their course in the 2023/24 academic year for any time on school placement</li>
+        <li>deferred in a previous academic year and then returns to their course in the 2024/25 academic year for any time on school placement</li>
         <li>defers or withdraws after a mentor has started their initial mentor training – mentors can continue with their training if they commit to being a mentor in the following academic year</li>
       </ul>
-      <p class="govuk-body">Schools cannot claim funding if a trainee withdraws or defers before a mentor starts their training, after the 23/24 academic year has started.</p>
-      <p class="govuk-body">If the mentor undertook their training before the start of the 23/24 academic year, and a trainee subsequently withdraws or defers, schools can claim funding for the total amount of training but may be required to submit evidence of organising a placement for a trainee.</p>
+      <p class="govuk-body">Schools cannot claim funding if a trainee withdraws or defers before a mentor starts their training, after the 24/25 academic year has started.</p>
+      <p class="govuk-body">If the mentor undertook their training before the start of the 24/25 academic year, and a trainee subsequently withdraws or defers, schools can claim funding for the total amount of training but may be required to submit evidence of organising a placement for a trainee.</p>
       <p class="govuk-body">If a trainee withdraws mid-year, the school, accredited provider and the mentor can decide whether the mentor completes the training. The school can claim funding for the total amount of training undertaken.</p>
 
-      <h2 class="govuk-heading-m" id="conditions-of-funding">4. Conditions of funding</h2>
-      <p class="govuk-body">Early adopter schools will be able to claim this funding at the end of the 2023/24 academic year and will be paid in arrears between September 2024 and January 2025. When schools make a claim, DfE will not ask for evidence where the information provided can be validated through its services including, but not limited to, Publish teacher training courses, Register trainee teachers and Get information about schools. Where this information cannot be validated, as part of the claim process, DfE may ask for evidence of:</p>
+      <h2 class="govuk-heading-m" id="conditions-of-this-funding">4. Conditions of this funding</h2>
+      <p class="govuk-body">Schools will be able to claim this funding at the end of the 2024/25 academic year and will be paid in arrears between September 2025 and January 2026. When schools make a claim, DfE will not ask for evidence where the information provided can be validated through its services including, but not limited to, Publish teacher training courses, Register trainee teachers and Get information about schools. Where this information cannot be validated, as part of the claim process, DfE may ask for evidence of:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>a mentor’s employment at the school, such as a copy of their employment contract or payslips from the 2024/25 academic year</li>
         <li>arranging placements at their school for ITT trainees, such as communication with providers</li>
@@ -91,20 +91,20 @@
         <li>the workplace of the mentor</li>
       </ul>
       <p class="govuk-body">DfE will inform organisations of all the claims where they are listed as the accredited ITT provider.</p>
-      <p class="govuk-body">For an early adopter school to claim this funding, the mentor must:</p>
+      <p class="govuk-body">For a school to claim this funding, the mentor must:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>be employed by the school making the claim</li>
         <li>undertake up to 20 hours of initial mentor training, per accredited ITT provider</li>
         <li>mentor at least one trainee, or intended to mentor a trainee (as evidenced by schools arranging placements for ITT trainees at their schools)</li>
       </ul>
-      <p class="govuk-body">Mentor training typically takes place at the start of the academic year or during the preceding summer term. In some instances, training can take place later than the start of the autumn term due to some courses starting later. Mentors can start their initial mentor training between 6 April 2023 and 31 May 2024 for courses starting in the 2023/24 academic year.</p>
-      <p class="govuk-body">To claim funding for training that began in advance of the 23/24 academic year, early adopter schools may need to provide evidence of agreeing to host placements at their school for ITT trainees, such as communication with providers to organise this. This evidence may be requested where a mentor did not mentor a trainee during the academic year.</p>
+      <p class="govuk-body">Mentor training typically takes place at the start of the academic year or during the preceding summer term. In some instances, training can take place later than the start of the autumn term due to some courses starting later. Mentors can start their initial mentor training between 6 April 2024 and 31 May 2025 for courses starting in the 2024/25 academic year.</p>
+      <p class="govuk-body">To claim funding for training that began in advance of the 24/25 academic year, schools may need to provide evidence of agreeing to host placements at their school for ITT trainees, such as communication with providers to organise this. This evidence may be requested where a mentor did not mentor a trainee during the academic year.</p>
       <p class="govuk-body">Schools can only claim funding for one mentor per trainee, unless the mentor withdraws. If the mentor role is undertaken by staff on a job-share basis then the school can claim full funding for both staff members.</p>
       <p class="govuk-body">The funding can be used to cover costs incurred by the school in implementing the general mentor role, including backfill of the mentor whilst they were training.</p>
       <p class="govuk-body">These specific grant conditions are in addition to the <%= govuk_link_to("standard grant terms and conditions", "https://www.gov.uk/government/publications/grant-funding-agreement-terms-and-conditions") %>.</p>
 
       <h2 class="govuk-heading-m" id="funding">5. Funding</h2>
-      <p class="govuk-body">The amount of funding early adopter schools will receive depends on:</p>
+      <p class="govuk-body">The amount of funding schools will receive depends on:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>the location of the school (recognising the different costs in different areas of the country)</li>
         <li>how many hours a mentor has spent training (which can be up to a maximum of 20 hours, per accredited ITT provider)</li>
@@ -129,7 +129,7 @@
               Up to £876 (£43.80 per hour) — for schools outside London (the rest of England)<br><br>Up to £902 (£45.10 per hour) — for schools in the fringe region (the area between Outer London and the rest of England)<br><br>Up to £965 (£48.25 per hour) — for schools in Outer London<br><br>Up to £1,072 (£53.60 per hour) — for schools in Inner London
             <% end %>
             <% row.with_cell do %>
-              Academic year 2023/24
+              Academic year 2024/25
             <% end %>
             <% row.with_cell do %>
               Schools who host ITT trainees
@@ -142,8 +142,9 @@
       <% end %>
 
       <h2 class="govuk-heading-m" id="payments">6. Payments</h2>
-      <p class="govuk-body">Payments will be made in arrears from September 2024. Early adopter schools will be able to submit a claim via a new GOV.UK service. The service will open in May 2024 and schools will be able to submit their claims once their mentors have completed their training.</p>
-      <p class="govuk-body">Early adopter schools must complete their claims by the end of July to receive payment from the Educational and Skills Funding Agency (ESFA) in late September/early October. If schools miss the payment window, they will be able to submit a claim in September, with payment being made in December 2024.</p>
+      <p class="govuk-body">Payments will be made in arrears from September 2025. Schools will be able to submit a claim via a new GOV.UK service. The service will open in May 2025 and schools will be able to submit their claims once their mentors have completed their training.</p>
+      <p class="govuk-body">Schools must complete their claims by the end of July to receive payment from the Educational and Skills Funding Agency (ESFA) in late September/early October. If schools miss the payment window, they will be able to submit a claim in September, with payment being made in December 2025.</p>
+      <p class="govuk-body">DfE will begin communicating details of this new service to schools and providers from September 2024.</p>
       <p class="govuk-body">If you would like additional information about the payments email <%= govuk_mail_to(t("claims.support_email")) %>.</p>
 
       <h2 class="govuk-heading-m" id="variation">7. Variation</h2>

--- a/config/locales/en/claims/pages.yml
+++ b/config/locales/en/claims/pages.yml
@@ -6,7 +6,7 @@ en:
       privacy:
         page_title: Claim funding for mentor training privacy notice
       grant_conditions:
-        page_title: General mentor training conditions of grant for early adopters
+        page_title: General mentor training conditions of grant
       feedback:
         page_title: Give feedback on Claim funding for mentor training
       accessibility:

--- a/config/locales/en/claims/schools/grant_conditions.yml
+++ b/config/locales/en/claims/schools/grant_conditions.yml
@@ -1,5 +1,0 @@
-en:
-  claims:
-    schools:
-      grant_conditions:
-        page_title: General mentor training conditions of grant for early adopters

--- a/spec/system/claims/grant_conditions_spec.rb
+++ b/spec/system/claims/grant_conditions_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Grant conditions Page", service: :claims, type: :system do
 
   def then_i_can_see_the_grant_conditions_page
     within(".govuk-heading-l") do
-      expect(page).to have_content("General mentor training conditions of grant for early adopters")
+      expect(page).to have_content("General mentor training conditions of grant")
     end
   end
 end


### PR DESCRIPTION
## Context

Now that we've closed the final window for the 2023/24 academic year claims, we need to update the grant conditions page to the 24/25 academic year, along with dropping the "early adopter" wording.

## Changes proposed in this pull request

- Update the Grant Conditions to match the [prototype](https://itt-mentoring-beta-dev-a238297da236.herokuapp.com/grant-conditions).

## Guidance to review

- The prototype and application content should match.
