### PR TITLE
Move mentor TRN to analytics blocklist

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -67,7 +67,6 @@ shared:
     - updated_at
   :mentors:
     - id
-    - trn
     - created_at
     - updated_at
   :claims:
@@ -191,8 +190,8 @@ shared:
     - created_at
     - updated_at
   :placement_windows:
-      - id
-      - placement_id
-      - term_id
-      - created_at
-      - updated_at
+    - id
+    - placement_id
+    - term_id
+    - created_at
+    - updated_at

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -106,6 +106,7 @@ shared:
   :mentors:
     - first_name
     - last_name
+    - trn
   :providers:
     - email_address
     - telephone


### PR DESCRIPTION
## Context

We don't currently need the mentor TRN in our analytics platform.

## Changes proposed in this pull request

- Stop sending mentor TRNs to BigQuery.

## Guidance to review

- TRNs are no longer sent.