### PR TITLE
Add nursery and reception year group options

### DIFF
--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -44,6 +44,8 @@ class Placement < ApplicationRecord
 
   attribute :year_group, :string
   enum :year_group, {
+    nursery: "nursery",
+    reception: "reception",
     year_1: "year_1",
     year_2: "year_2",
     year_3: "year_3",

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -59,6 +59,10 @@ en:
           any_term: Any time in the academic year
         not_yet_known: Not yet known
         year_groups:
+          nursery: Nursery
+          nursery_description: 3 to 4 years
+          reception: Reception
+          reception_description: 4 to 5 years
           year_1: Year 1
           year_1_description: 5 to 6 years
           year_2: Year 2

--- a/db/migrate/20241008153148_add_new_year_groups_to_placement_year_group.rb
+++ b/db/migrate/20241008153148_add_new_year_groups_to_placement_year_group.rb
@@ -1,0 +1,6 @@
+class AddNewYearGroupsToPlacementYearGroup < ActiveRecord::Migration[7.2]
+  def change
+    add_enum_value :placement_year_group, "nursery", before: "year_1"
+    add_enum_value :placement_year_group, "reception", before: "year_1"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,7 +20,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_09_164610) do
   create_enum "claim_status", ["internal_draft", "draft", "submitted", "payment_in_progress"]
   create_enum "mentor_training_type", ["refresher", "initial"]
   create_enum "placement_status", ["draft", "published"]
-  create_enum "placement_year_group", ["year_1", "year_2", "year_3", "year_4", "year_5", "year_6"]
+  create_enum "placement_year_group", ["nursery", "reception", "year_1", "year_2", "year_3", "year_4", "year_5", "year_6"]
   create_enum "provider_type", ["scitt", "lead_school", "university"]
   create_enum "service", ["claims", "placements"]
   create_enum "subject_area", ["primary", "secondary"]

--- a/spec/models/placement_spec.rb
+++ b/spec/models/placement_spec.rb
@@ -109,6 +109,8 @@ RSpec.describe Placement, type: :model do
 
       expect(options).to eq(
         [
+          OpenStruct.new(value: "nursery", name: "Nursery", description: "3 to 4 years"),
+          OpenStruct.new(value: "reception", name: "Reception", description: "4 to 5 years"),
           OpenStruct.new(value: "year_1", name: "Year 1", description: "5 to 6 years"),
           OpenStruct.new(value: "year_2", name: "Year 2", description: "6 to 7 years"),
           OpenStruct.new(value: "year_3", name: "Year 3", description: "7 to 8 years"),


### PR DESCRIPTION
## Context

We want to enable schools to add EY placements to increase uptake of the service

## Changes proposed in this pull request

- [x] Adds the nursey option for placements year group 
- [x] Adds the reception option for placements year group

## Guidance to review

- Log in as Anne
- Create a primary placement
- Select one of the new options
- Create the placement

- Log in as Patricia
- Filter by one of the new options
- Confirm the placement is visible

## Link to Trello card

[Implement nursery for placement year groups
](https://trello.com/c/LFtTK5GZ/861-implement-nursery-for-placement-year-groups)

## Screenshots

<img width="1020" alt="image" src="https://github.com/user-attachments/assets/62148093-edbe-4cd4-9ed2-d50166b168de">
<img width="1017" alt="image" src="https://github.com/user-attachments/assets/4ea2efff-2799-42f9-98dd-a9787af2a9d5">
<img width="381" alt="image" src="https://github.com/user-attachments/assets/9e11dc34-a7c4-4a48-b869-51cb2652cd8e">

