### PR TITLE
Placements index: Move location search to filter sidebar

### DIFF
--- a/app/components/placement/summary_component.html.erb
+++ b/app/components/placement/summary_component.html.erb
@@ -1,9 +1,7 @@
 <li class="app-search-results__item">
-  <h2 class="app-search-result__item-title">
+  <h2 class="govuk-heading-m">
     <%= govuk_link_to(placements_provider_placement_path(provider, placement), no_visited_state: true) do %>
-      <span><%= school.name %></span>
-      <br>
-      <span><%= placement.title %></span>
+      <span><%= placement.title %></span> – <span><%= school.name %></span>
     <% end %>
   </h2>
 

--- a/app/components/placement/summary_component.html.erb
+++ b/app/components/placement/summary_component.html.erb
@@ -1,7 +1,7 @@
 <li class="app-search-results__item">
   <h2 class="govuk-heading-m">
     <%= govuk_link_to(placements_provider_placement_path(provider, placement), no_visited_state: true) do %>
-      <span><%= placement.title %></span> – <span><%= school.name %></span>
+      <%= placement.title %> – <%= school.name %>
     <% end %>
   </h2>
 

--- a/app/controllers/placements/providers/placements_controller.rb
+++ b/app/controllers/placements/providers/placements_controller.rb
@@ -60,6 +60,7 @@ class Placements::Providers::PlacementsController < Placements::ApplicationContr
       :placements_to_show,
       :academic_year_id,
       :only_partner_schools,
+      :search_location,
       school_ids: [],
       subject_ids: [],
       term_ids: [],

--- a/app/forms/placements/placements/filter_form.rb
+++ b/app/forms/placements/placements/filter_form.rb
@@ -21,14 +21,14 @@ class Placements::Placements::FilterForm < ApplicationForm
     attributes.except("placements_to_show", "academic_year_id").values.compact.flatten.any?
   end
 
-  def clear_filters_path(*)
+  def clear_filters_path
     placements_provider_placements_path(
       @provider,
       filters: { placements_to_show:, academic_year_id: },
     )
   end
 
-  def index_path_without_filter(filter:, value: nil, search_location: nil)
+  def index_path_without_filter(filter:, value: nil)
     without_filter = if SINGULAR_ATTRIBUTES.include?(filter)
                        compacted_attributes.reject { |key, _| key == filter }
                      else
@@ -37,7 +37,6 @@ class Placements::Placements::FilterForm < ApplicationForm
 
     placements_provider_placements_path(
       @provider,
-      search_location,
       params: { filters: without_filter },
     )
   end

--- a/app/forms/placements/placements/filter_form.rb
+++ b/app/forms/placements/placements/filter_form.rb
@@ -21,10 +21,10 @@ class Placements::Placements::FilterForm < ApplicationForm
     attributes.except("placements_to_show", "academic_year_id").values.compact.flatten.any?
   end
 
-  def clear_filters_path(search_location: nil)
+  def clear_filters_path(*)
     placements_provider_placements_path(
       @provider,
-      search_location: nil, filters: { placements_to_show:, academic_year_id: },
+      filters: { placements_to_show:, academic_year_id: },
     )
   end
 
@@ -37,6 +37,7 @@ class Placements::Placements::FilterForm < ApplicationForm
 
     placements_provider_placements_path(
       @provider,
+      search_location,
       params: { filters: without_filter },
     )
   end

--- a/app/forms/placements/placements/filter_form.rb
+++ b/app/forms/placements/placements/filter_form.rb
@@ -3,6 +3,7 @@ class Placements::Placements::FilterForm < ApplicationForm
 
   attribute :school_ids, default: []
   attribute :subject_ids, default: []
+  attribute :search_location, default: nil
   attribute :year_groups, default: []
   attribute :term_ids, default: []
   attribute :placements_to_show, default: "available_placements"
@@ -23,7 +24,7 @@ class Placements::Placements::FilterForm < ApplicationForm
   def clear_filters_path(search_location: nil)
     placements_provider_placements_path(
       @provider,
-      search_location:, filters: { placements_to_show:, academic_year_id: },
+      search_location: nil, filters: { placements_to_show:, academic_year_id: },
     )
   end
 
@@ -36,7 +37,7 @@ class Placements::Placements::FilterForm < ApplicationForm
 
     placements_provider_placements_path(
       @provider,
-      params: { filters: without_filter, search_location: },
+      params: { filters: without_filter },
     )
   end
 
@@ -49,6 +50,7 @@ class Placements::Placements::FilterForm < ApplicationForm
       placements_to_show:,
       academic_year_id:,
       term_ids:,
+      search_location:,
     }
   end
 
@@ -66,7 +68,7 @@ class Placements::Placements::FilterForm < ApplicationForm
 
   private
 
-  SINGULAR_ATTRIBUTES = %w[only_partner_schools placements_to_show].freeze
+  SINGULAR_ATTRIBUTES = %w[only_partner_schools placements_to_show search_location].freeze
 
   def compacted_attributes
     @compacted_attributes ||= attributes.compact_blank

--- a/app/views/placements/providers/placements/_filter.html.erb
+++ b/app/views/placements/providers/placements/_filter.html.erb
@@ -19,7 +19,7 @@
               <p class="govuk-body">
                 <%= govuk_link_to(
                   t("clear_filters"),
-                  filter_form.clear_filters_path(search_location:),
+                  filter_form.clear_filters_path,
                   no_visited_state: true,
                 ) %>
               </p>
@@ -35,7 +35,6 @@
                         filter_form.index_path_without_filter(
                           filter: "search_location",
                           value: @search_location,
-                          search_location:,
                         ),
                         class: "app-filter__tag",
                         no_visited_state: true,
@@ -54,7 +53,6 @@
                         filter_form.index_path_without_filter(
                           filter: "term_ids",
                           value: term.id,
-                          search_location:,
                         ),
                         class: "app-filter__tag",
                         no_visited_state: true,
@@ -74,7 +72,6 @@
                         filter_form.index_path_without_filter(
                           filter: "subject_ids",
                           value: subject.id,
-                          search_location:,
                         ),
                         class: "app-filter__tag",
                         no_visited_state: true,
@@ -112,7 +109,6 @@
                       filter_form.index_path_without_filter(
                         filter: "only_partner_schools",
                         value: true,
-                        search_location:,
                       ),
                       class: "app-filter__tag",
                       no_visited_state: true,
@@ -131,7 +127,6 @@
                     filter_form.index_path_without_filter(
                       filter: "school_ids",
                       value: school.id,
-                      search_location:,
                     ),
                     class: "app-filter__tag",
                     no_visited_state: true,

--- a/app/views/placements/providers/placements/_filter.html.erb
+++ b/app/views/placements/providers/placements/_filter.html.erb
@@ -26,6 +26,24 @@
             </div>
           </div>
 
+          <% if @search_location.present? %>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".search_location") %></h3>
+            <ul class="app-filter-tags">
+                <li>
+                  <%= govuk_link_to(
+                        @search_location,
+                        filter_form.index_path_without_filter(
+                          filter: "search_location",
+                          value: @search_location,
+                          search_location:,
+                        ),
+                        class: "app-filter__tag",
+                        no_visited_state: true,
+                      ) %>
+                </li>
+            </ul>
+          <% end %>
+
           <% if filter_form.terms.present? %>
             <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".terms") %></h3>
             <ul class="app-filter-tags">
@@ -133,7 +151,19 @@
           method: "get",
         ) do |form| %>
           <%= form.govuk_submit t("apply_filters") %>
-          <%= form.hidden_field :search_location, value: search_location %>
+
+          <div class="app-filter__option">
+            <h1 class="govuk-label-wrapper">
+              <label class="govuk-label govuk-label--s"><%= t(".search_by_location") %></label>
+            </h1>
+
+          <div class="app-filter__option">
+            <div class="govuk-form-group">
+              <%= form.govuk_text_field :search_location, type: :search, value: search_location, label: { hidden: true }, caption: { text: t(".location_search_prompt") } %>
+            <p class="govuk-body-s secondary-text"><%= t(".google_attribution") %></p>
+            </div>
+          </div>
+      </div>
 
           <div class="app-filter__option">
             <%= form.govuk_radio_buttons_fieldset(

--- a/app/views/placements/providers/placements/index.html.erb
+++ b/app/views/placements/providers/placements/index.html.erb
@@ -1,13 +1,10 @@
-<% content_for(:page_title) { t(".placements") } %>
+<% content_for(:page_title) { t(".find_placements") } %>
 <%= render "placements/providers/primary_navigation", provider: @provider, current_navigation: :placements %>
 
 <div class="govuk-width-container" data-controller="filter">
   <h1 class="govuk-heading-l">
-    <%= t(".placements") %>
+    <%= t(".find_placements") %>
   </h1>
-  <h2 class="govuk-heading-m">
-    <%= t(".placements_found", count: @pagy.count) %>
-  </h2>
   <div>
     <button class="govuk-button govuk-button--secondary show-filter-button" type="button" data-action="click->filter#open">
       <%= t("show_filter") %>
@@ -19,17 +16,12 @@
     </div>
 
     <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m"><%= t(".enter_a_location") %></h2>
-      <%= render partial: "shared/search_form", locals: {
-        url: placements_provider_placements_path(@provider),
-        label: { hidden: true },
-        caption: { text: t(".location_search_example") },
-        name: :search_location,
-        clear_search_url: placements_provider_placements_path(@provider, filters: filter_form.attributes),
-        filters: filter_form.attributes,
-        value: @search_location,
-      } %>
+        <h2 class="govuk-heading-m">
+          <%= t(".placements_found", count: @pagy.count) %>
+        </h2>
+
       <% if @placements.any? %>
+        <p class="govuk-hint"><%= @search_location.blank? ? t(".results_sorted_alpha") : t(".results_sorted_distance", search_location: @search_location) %></p>
         <ul class="app-search-results">
           <%= render(Placement::SummaryComponent.with_collection(@placements, provider: @provider, location_coordinates:)) %>
         </ul>

--- a/config/locales/en/placements/providers/placements.yml
+++ b/config/locales/en/placements/providers/placements.yml
@@ -8,18 +8,23 @@ en:
       placements:
         index:
           placements_found:
-            zero: No placements found
-            one: 1 placement found
-            other: "%{count} placements found"
-          placements: Placements
+            zero: No placements
+            one: 1 placement
+            other: "%{count} placements"
+          find_placements: Find placements
           no_results: There are no placements that match your selection. Try searching again, or removing one or more filters.
           enter_a_location: Enter a location
-          location_search_example: For example, Sunderland or SR2
+          results_sorted_alpha: Results sorted alphabetically
+          results_sorted_distance: Results sorted by distance from %{search_location}
         filter:
+          google_attribution: Powered by Google
+          location_search_prompt: Enter a town, city or postcode
           partner_schools: Schools I work with
           terms: Expected date
           only_show_partner_schools: Only show placements from schools I work with
           school: School
+          search_location: Location
+          search_by_location: Search by location
           subject: Subject
           school_phase: School phase
           establishment_group: Establishment group

--- a/spec/forms/placements/placements/filter_form_spec.rb
+++ b/spec/forms/placements/placements/filter_form_spec.rb
@@ -205,6 +205,7 @@ describe Placements::Placements::FilterForm, type: :model do
           academic_year_id: current_academic_year.id,
           school_ids: [],
           only_partner_schools: false,
+          search_location: nil,
           subject_ids: [],
           term_ids: [],
           year_groups: [],

--- a/spec/system/placements/placements/searching_for_a_placement_spec.rb
+++ b/spec/system/placements/placements/searching_for_a_placement_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Placements / Placements / Searching for a placements list",
     scenario "User sees a list of placements ordered by distance, closest to the given search" do
       when_i_visit_the_placements_index_page
       and_i_fill_in_location_search_with("London")
-      and_i_click_on("Search")
+      and_i_click_on("Apply filters")
       then_i_see_placements_for(school_name: "London School", list_item: 0, distance: 0.0)
       and_i_see_placements_for(school_name: "Guildford School", list_item: 1, distance: 26.7)
       and_i_do_not_see_placements_for(school_name: "Bath School")
@@ -58,7 +58,7 @@ RSpec.describe "Placements / Placements / Searching for a placements list",
     scenario "User sees a list of placements ordered by distance, closest to the given search" do
       when_i_visit_the_placements_index_page
       and_i_fill_in_location_search_with("Guildford")
-      and_i_click_on("Search")
+      and_i_click_on("Apply filters")
       then_i_see_placements_for(school_name: "Guildford School", list_item: 0, distance: 0.0)
       and_i_see_placements_for(school_name: "London School", list_item: 1, distance: 26.7)
       and_i_do_not_see_placements_for(school_name: "Bath School")
@@ -71,7 +71,7 @@ RSpec.describe "Placements / Placements / Searching for a placements list",
     scenario "User sees a list of placements ordered by distance, closest to the given search" do
       when_i_visit_the_placements_index_page
       and_i_fill_in_location_search_with("WC1")
-      and_i_click_on("Search")
+      and_i_click_on("Apply filters")
       then_i_see_placements_for(school_name: "London School", list_item: 0, distance: 0.0)
       and_i_see_placements_for(school_name: "Guildford School", list_item: 1, distance: 26.7)
       and_i_do_not_see_placements_for(school_name: "Bath School")
@@ -90,7 +90,7 @@ RSpec.describe "Placements / Placements / Searching for a placements list",
         },
       )
       and_i_fill_in_location_search_with("WC1")
-      and_i_click_on("Search")
+      and_i_click_on("Apply filters")
       then_i_see_placements_for(school_name: "London School", list_item: 0, distance: 0.0)
       and_i_do_not_see_placements_for(school_name: "Bath School")
       and_i_do_not_see_placements_for(school_name: "York School")
@@ -104,7 +104,7 @@ RSpec.describe "Placements / Placements / Searching for a placements list",
     scenario "User sees a message that no placements were found" do
       when_i_visit_the_placements_index_page
       and_i_fill_in_location_search_with("Chicken")
-      and_i_click_on("Search")
+      and_i_click_on("Apply filters")
       then_i_see_the_empty_state
     end
   end
@@ -142,7 +142,7 @@ RSpec.describe "Placements / Placements / Searching for a placements list",
   end
 
   def and_i_fill_in_location_search_with(search_text)
-    fill_in "search-location-field", with: search_text
+    fill_in "filters-search-location-field", with: search_text
   end
 
   def then_i_see_placements_for(school_name:, list_item:, distance:)

--- a/spec/system/placements/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/placements/view_placements_list_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Placements / Placements / View placements list",
 
     scenario "User can view available placements by default" do
       when_i_visit_the_placements_index_page
-      then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+      then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
       and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Physics")
       and_i_can_see_the_status_tag_for_placement_1
     end
@@ -61,7 +61,7 @@ RSpec.describe "Placements / Placements / View placements list",
       placement_3.update!(provider:)
       and_i_check_filter_option("placements-to-show", "assigned-to-me")
       and_i_click_on("Apply filters")
-      and_i_can_not_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+      and_i_can_not_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
       then_i_can_see_a_placement_for_school_and_subject("Secondary School", "Physics")
     end
 
@@ -69,10 +69,23 @@ RSpec.describe "Placements / Placements / View placements list",
       when_i_visit_the_placements_index_page
       and_i_check_filter_option("placements-to-show", "all-placements")
       and_i_click_on("Apply filters")
-      then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+      then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
       and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
       and_i_can_see_the_status_tag_for_placement_1
       and_i_can_see_the_status_tag_for_placement_2
+    end
+
+    context "when filtering placements by location" do
+      before { stub_london_geocoder_search }
+
+      scenario "User can filter placements by location" do
+        when_i_visit_the_placements_index_page
+        and_i_enter_location_in_search_box("London")
+        and_i_click_on("Apply filters")
+        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
+        and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
+        and_i_can_see_search_location_is_set_as("London")
+      end
     end
 
     scenario "User can filter placements by term" do
@@ -80,13 +93,13 @@ RSpec.describe "Placements / Placements / View placements list",
       # Show all placements
       and_i_check_filter_option("placements-to-show", "all-placements")
       and_i_click_on("Apply filters")
-      then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+      then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
       and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
       and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Physics")
       when_i_check_filter_option("term-ids", summer_term.id)
       and_i_click_on("Apply filters")
       # This placement has the summer term we're filtering for
-      then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+      then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
       # This placement has no terms (aka any term), so should always be visible
       and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Physics")
       # This placement has the autumn term, and should not be visible
@@ -96,31 +109,31 @@ RSpec.describe "Placements / Placements / View placements list",
     scenario "User can filter placements by partner school" do
       given_a_partnership_exists_between(provider, primary_school)
       when_i_visit_the_placements_index_page
-      then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+      then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
       and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
       when_i_check_filter_option("only-partner-schools", true)
       and_i_click_on("Apply filters")
-      then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+      then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
       and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
     end
 
     scenario "User can filter placements by school" do
       when_i_visit_the_placements_index_page
-      then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+      then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
       and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
       when_i_check_filter_option("school-ids", primary_school.id)
       and_i_click_on("Apply filters")
-      then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+      then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
       and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
     end
 
     scenario "User can filter placements by subject" do
       when_i_visit_the_placements_index_page
-      then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+      then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
       and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
       when_i_check_filter_option("subject-ids", subject_1.id)
       and_i_click_on("Apply filters")
-      then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+      then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
       and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
     end
 
@@ -137,26 +150,26 @@ RSpec.describe "Placements / Placements / View placements list",
 
       scenario "User can filter placements by additional subjects" do
         when_i_visit_the_placements_index_page
-        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
         and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
         and_i_can_see_a_placement_for_school_and_subject("Secondary School", "French and Spanish")
         when_i_check_filter_option("subject-ids", additional_subject.id)
         and_i_click_on("Apply filters")
         then_i_can_see_a_placement_for_school_and_subject("Secondary School", "French and Spanish")
-        and_i_can_not_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+        and_i_can_not_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
         and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
       end
 
       scenario "User can filter placements by subject and additional subjects together" do
         when_i_visit_the_placements_index_page
-        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
         and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
-        and_i_can_see_a_placement_for_school_and_subject("Secondary School", "French")
+        and_i_can_see_a_placement_for_school_and_subject("Secondary School", "French and Spanish")
         when_i_check_filter_option("subject-ids", additional_subject.id)
         when_i_check_filter_option("subject-ids", subject_1.id)
         and_i_click_on("Apply filters")
-        then_i_can_see_a_placement_for_school_and_subject("Secondary School", "French")
-        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+        then_i_can_see_a_placement_for_school_and_subject("Secondary School", "French and Spanish")
+        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
         and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
       end
     end
@@ -164,11 +177,11 @@ RSpec.describe "Placements / Placements / View placements list",
     context "when a filter is pre-selected in the URL params" do
       scenario "User can remove a terms filter" do
         when_i_visit_the_placements_index_page({ filters: { term_ids: [summer_term.id] } })
-        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
         and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
         and_i_can_see_a_preset_filter("Expected date", "Summer term")
         when_i_click_to_remove_filter("Expected date", "Summer term")
-        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
         and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
         and_i_can_not_see_any_selected_filters
       end
@@ -176,44 +189,44 @@ RSpec.describe "Placements / Placements / View placements list",
       scenario "User can remove a schools I work with filter" do
         given_a_partnership_exists_between(provider, primary_school)
         when_i_visit_the_placements_index_page({ filters: { only_partner_schools: true } })
-        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
         and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
         and_i_can_see_a_preset_filter("Schools I work with", "Schools I work with")
         when_i_click_to_remove_filter("Schools I work with", "Schools I work with")
-        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
         and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
         and_i_can_not_see_any_selected_filters
       end
 
       scenario "User can remove a school filter" do
         when_i_visit_the_placements_index_page({ filters: { school_ids: [primary_school.id] } })
-        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
         and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
         and_i_can_see_a_preset_filter("School", "Primary School")
         when_i_click_to_remove_filter("School", "Primary School")
-        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
         and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
         and_i_can_not_see_any_selected_filters
       end
 
       scenario "User can remove a subject filter" do
         when_i_visit_the_placements_index_page({ filters: { subject_ids: [subject_1.id] } })
-        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
         and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
         and_i_can_see_a_preset_filter("Subject", "Primary with mathematics")
         when_i_click_to_remove_filter("Subject", "Primary with mathematics")
-        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
         and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
         and_i_can_not_see_any_selected_filters
       end
 
       scenario "User can remove a year group filter" do
         when_i_visit_the_placements_index_page({ filters: { year_groups: [:year_1] } })
-        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
         and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
         and_i_can_see_a_preset_filter("Primary year group", "Year 1")
         when_i_click_to_remove_filter("Primary year group", "Year 1")
-        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
         and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
         and_i_can_not_see_any_selected_filters
       end
@@ -231,7 +244,7 @@ RSpec.describe "Placements / Placements / View placements list",
             },
           },
         )
-        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
         and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
         and_i_can_see_a_preset_filter("Schools I work with", "Schools I work with")
         and_i_can_see_a_preset_filter("School", "Primary School")
@@ -239,7 +252,7 @@ RSpec.describe "Placements / Placements / View placements list",
         and_i_can_see_a_preset_filter("Primary year group", "Year 1")
         and_i_can_see_a_preset_filter("Expected date", "Summer term")
         when_i_click_on("Clear filters")
-        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
         and_i_can_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
         and_i_can_not_see_any_selected_filters
       end
@@ -249,10 +262,10 @@ RSpec.describe "Placements / Placements / View placements list",
       before { stub_london_geocoder_search }
 
       scenario "User can filter placements by school, and the location search persists" do
-        when_i_visit_the_placements_index_page({ search_location: "London" })
+        when_i_visit_the_placements_index_page({ filters: { search_location: "London" } })
         and_i_check_filter_option("school-ids", primary_school.id)
         and_i_click_on("Apply filters")
-        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+        then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
         and_i_can_not_see_a_placement_for_school_and_subject("Secondary School", "Chemistry")
         and_i_can_see_search_location_is_set_as("London")
         and_i_see_placements_for(school_name: "Primary School", list_item: 0, distance: 0.0)
@@ -261,25 +274,13 @@ RSpec.describe "Placements / Placements / View placements list",
       context "when a filter is pre-selected in the URL params" do
         scenario "User can remove a school filter, and the location search persists" do
           when_i_visit_the_placements_index_page(
-            { search_location: "London", filters: { school_ids: [primary_school.id] } },
+            { filters: { search_location: "London", school_ids: [primary_school.id] } },
           )
           and_i_can_see_a_preset_filter("School", "Primary School")
           when_i_click_to_remove_filter("School", "Primary School")
-          then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
+          then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics (Year 1)")
           and_i_can_see_search_location_is_set_as("London")
           and_i_see_placements_for(school_name: "Primary School", list_item: 0, distance: 0.0)
-        end
-
-        scenario "User can clear the location search, and the filters persist" do
-          when_i_visit_the_placements_index_page(
-            { search_location: "London", filters: { school_ids: [primary_school.id] } },
-          )
-          and_i_can_see_search_location_is_set_as("London")
-          and_i_can_see_a_preset_filter("School", "Primary School")
-          when_i_click_on("Clear filters")
-          then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
-          and_i_can_see_a_preset_filter("School", "Primary School")
-          and_i_can_see_search_location_is_set_as(nil)
         end
       end
     end
@@ -342,15 +343,14 @@ RSpec.describe "Placements / Placements / View placements list",
   end
 
   def then_i_can_see_a_placement_for_school_and_subject(school_name, subject_name)
-    expect(page).to have_selector("span", text: subject_name)
-    expect(page).to have_selector("span", text: school_name)
+    expect(page).to have_selector("a", text: "#{subject_name} – #{school_name}")
   end
 
   alias_method :and_i_can_see_a_placement_for_school_and_subject,
                :then_i_can_see_a_placement_for_school_and_subject
 
   def then_i_can_not_see_a_placement_for_school_and_subject(school_name, subject_name)
-    expect(page).not_to have_content("#{school_name} - #{subject_name}")
+    expect(page).not_to have_selector("a", text: "#{subject_name} – #{school_name}")
   end
 
   alias_method :and_i_can_not_see_a_placement_for_school_and_subject,
@@ -377,6 +377,10 @@ RSpec.describe "Placements / Placements / View placements list",
   end
 
   alias_method :and_i_can_see_a_preset_filter, :then_i_can_see_a_preset_filter
+
+  def and_i_enter_location_in_search_box(location)
+    fill_in "filters-search-location-field", with: location
+  end
 
   def when_i_click_to_remove_filter(_filter, value)
     selected_filters = page.find(".app-filter-layout__selected")

--- a/spec/system/placements/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/placements/view_placements_list_spec.rb
@@ -270,25 +270,13 @@ RSpec.describe "Placements / Placements / View placements list",
           and_i_see_placements_for(school_name: "Primary School", list_item: 0, distance: 0.0)
         end
 
-        scenario "User can clear all filters, and the location search persists" do
-          when_i_visit_the_placements_index_page(
-            { search_location: "London", filters: { school_ids: [primary_school.id] } },
-          )
-          and_i_can_see_a_preset_filter("School", "Primary School")
-          when_i_click_on("Clear filters")
-          then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
-          and_i_can_not_see_any_selected_filters
-          and_i_can_see_search_location_is_set_as("London")
-          and_i_see_placements_for(school_name: "Primary School", list_item: 0, distance: 0.0)
-        end
-
         scenario "User can clear the location search, and the filters persist" do
           when_i_visit_the_placements_index_page(
             { search_location: "London", filters: { school_ids: [primary_school.id] } },
           )
           and_i_can_see_search_location_is_set_as("London")
           and_i_can_see_a_preset_filter("School", "Primary School")
-          when_i_click_on("Clear search")
+          when_i_click_on("Clear filters")
           then_i_can_see_a_placement_for_school_and_subject("Primary School", "Primary with mathematics")
           and_i_can_see_a_preset_filter("School", "Primary School")
           and_i_can_see_search_location_is_set_as(nil)
@@ -354,14 +342,15 @@ RSpec.describe "Placements / Placements / View placements list",
   end
 
   def then_i_can_see_a_placement_for_school_and_subject(school_name, subject_name)
-    expect(page).to have_content("#{school_name} #{subject_name}")
+    expect(page).to have_selector("span", text: subject_name)
+    expect(page).to have_selector("span", text: school_name)
   end
 
   alias_method :and_i_can_see_a_placement_for_school_and_subject,
                :then_i_can_see_a_placement_for_school_and_subject
 
   def then_i_can_not_see_a_placement_for_school_and_subject(school_name, subject_name)
-    expect(page).not_to have_content("#{school_name} #{subject_name}")
+    expect(page).not_to have_content("#{school_name} - #{subject_name}")
   end
 
   alias_method :and_i_can_not_see_a_placement_for_school_and_subject,
@@ -409,11 +398,11 @@ RSpec.describe "Placements / Placements / View placements list",
   end
 
   def then_i_can_see_a_placement_for_placement_1
-    expect(page).to have_content("Primary School\nPrimary with mathematics")
+    expect(page).to have_content("Primary School – Primary with mathematics")
   end
 
   def and_i_cannot_see_a_placement_for_placement_2
-    expect(page).not_to have_content("Secondary School\nChemistry")
+    expect(page).not_to have_content("Secondary School - Chemistry")
   end
 
   def and_i_can_see_the_status_tag_for_placement_1
@@ -429,7 +418,7 @@ RSpec.describe "Placements / Placements / View placements list",
   end
 
   def and_i_can_see_search_location_is_set_as(search_location)
-    expect(page.find("#search-location-field").value).to eq(search_location)
+    expect(page.find("#filters-search-location-field").value).to eq(search_location)
   end
 
   def then_i_see_placements_for(school_name:, list_item:, distance:)


### PR DESCRIPTION
## Context

These design changes are in preparation of a new travel time feature on the placements index page. 

## Changes proposed in this pull request

- Page title and H1 change: “Find placements”.
- Location search bar moved to filter sidebar.
- Location search included as a selected filter tag. 
- Location search cleared by clearing filters.
- New paragraph tag shows "results sorted by" either alphabetical order or distance from the search location.
- Number of results move to results column.
- The structure of the titles of the search results has changed to [Subject] en dash [School name]. This means the links remain understandable for accessibility reasons, but puts the subject first.
- The size of the link becomes govuk-heading-m to make it stand out from the content and give visual hierarchy.

## Guidance to review

Please review the full travel time feature in this PR: https://github.com/DFE-Digital/itt-mentor-services/pull/1115.

## Link to Trello card

https://trello.com/c/oYsYxDX2/854-layout-changes-to-placements-search-page
