### PR TITLE
Move all mentor attributes into the analytics blocklist

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -65,10 +65,6 @@ shared:
     - school_id
     - created_at
     - updated_at
-  :mentors:
-    - id
-    - created_at
-    - updated_at
   :claims:
     - id
     - school_id

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -104,9 +104,12 @@ shared:
     - last_name
     - email
   :mentors:
+    - id
     - first_name
     - last_name
     - trn
+    - created_at
+    - updated_at
   :providers:
     - email_address
     - telephone


### PR DESCRIPTION
## Context

DfE Analytics seems to be behaving strangely, for now, we want to remove all mentor fields from being sent.

- Requested change from Data team.

## Changes proposed in this pull request

- Remove all mentor fields from DfE analytics.
- Add all mentor fields to DfE analytics blocklist.

## Guidance to review

\-