### PR TITLE
Add walking time to travel time service object

### DIFF
--- a/app/decorators/school_decorator.rb
+++ b/app/decorators/school_decorator.rb
@@ -1,8 +1,7 @@
 class SchoolDecorator < OrganisationDecorator
   attribute :transit_travel_duration
-  attribute :transit_travel_distance
+  attribute :walk_travel_duration
   attribute :drive_travel_duration
-  attribute :drive_travel_distance
 
   def formatted_inspection_date
     return "" if last_inspection_date.blank?

--- a/app/services/placements/travel_time.rb
+++ b/app/services/placements/travel_time.rb
@@ -14,6 +14,7 @@ class Placements::TravelTime < ApplicationService
 
   DRIVE_TRAVEL_MODE = "DRIVE".freeze
   TRANSIT_TRAVEL_MODE = "TRANSIT".freeze
+  WALK_TRAVEL_MODE = "WALK".freeze
 
   def routes_client
     @routes_client ||= Google::RoutesApi.new
@@ -22,16 +23,17 @@ class Placements::TravelTime < ApplicationService
   def combine_destinations_with_travel_data
     drive_travel_data = travel_data(travel_mode: DRIVE_TRAVEL_MODE)
     transit_travel_data = travel_data(travel_mode: TRANSIT_TRAVEL_MODE)
+    walk_travel_data = travel_data(travel_mode: WALK_TRAVEL_MODE)
 
     destinations.map.with_index do |destination, index|
       drive_travel_datum = drive_travel_data.find { |datum| datum["destinationIndex"] == index }
       transit_travel_datum = transit_travel_data.find { |datum| datum["destinationIndex"] == index }
+      walk_travel_datum = walk_travel_data.find { |datum| datum["destinationIndex"] == index }
 
       destination.assign_attributes(
         drive_travel_duration: drive_travel_datum.dig("localizedValues", "duration", "text"),
-        drive_travel_distance: drive_travel_datum.dig("localizedValues", "distance", "text"),
         transit_travel_duration: transit_travel_datum.dig("localizedValues", "duration", "text"),
-        transit_travel_distance: transit_travel_datum.dig("localizedValues", "distance", "text"),
+        walk_travel_duration: walk_travel_datum.dig("localizedValues", "duration", "text"),
       )
     end
 

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -91,9 +91,8 @@ shared:
     - locked_at
   :schools:
     - transit_travel_duration
-    - transit_travel_distance
+    - walk_travel_duration
     - drive_travel_duration
-    - drive_travel_distance
   :school_contacts:
     - name
     - email_address

--- a/spec/decorators/school_decorator_spec.rb
+++ b/spec/decorators/school_decorator_spec.rb
@@ -5,8 +5,9 @@ RSpec.describe SchoolDecorator do
     subject(:school) { build(:school).decorate }
 
     it {
-      expect(school).to have_attributes(drive_travel_duration: nil, drive_travel_distance: nil,
-                                        transit_travel_duration: nil, transit_travel_distance: nil)
+      expect(school).to have_attributes(drive_travel_duration: nil,
+                                        transit_travel_duration: nil,
+                                        walk_travel_duration: nil)
     }
   end
 

--- a/spec/services/placements/travel_time_spec.rb
+++ b/spec/services/placements/travel_time_spec.rb
@@ -58,9 +58,8 @@ RSpec.describe Placements::TravelTime do
     it "returns the school collection, with the travel data appended" do
       results = service
       expect(results.pluck(:drive_travel_duration)).to eq ["36 mins", "42 mins", "46 mins"]
-      expect(results.pluck(:drive_travel_distance)).to eq ["17.5 mi", "20 mi", "22 mi"]
       expect(results.pluck(:transit_travel_duration)).to eq ["36 mins", "42 mins", "46 mins"]
-      expect(results.pluck(:transit_travel_distance)).to eq ["17.5 mi", "20 mi", "22 mi"]
+      expect(results.pluck(:walk_travel_duration)).to eq ["36 mins", "42 mins", "46 mins"]
     end
 
     it "returns the school collection, sorted by travel duration" do


### PR DESCRIPTION
## Context

We are adding travel duration between a user's search location and placement schools which appear in search results. A service object exists with drive and transit travel modes, but a walk travel mode is also needed. 

## Changes proposed in this pull request

- Adapt the travel time service object to include walking time, as well as driving and transit.
- Only travel time needed. Remove distance from object.

## Guidance to review

Run the following travel time tests:
- `spec/services/placements/travel_time_spec.rb`
- `spec/lib/google/routes_api_spec.rb`

Run the school decorator test (modified to add walking duration as an attribute):
- `spec/decorators/school_decorator_spec.rb`

## Link to Trello card

https://trello.com/c/TMFoYL9a/855-add-walking-time-to-travel-time-service-object