### PR TITLE
Rename sent_to_esfa claim status to payment_in_progress

### DIFF
--- a/app/components/claim/status_tag_component.rb
+++ b/app/components/claim/status_tag_component.rb
@@ -26,7 +26,7 @@ class Claim::StatusTagComponent < ApplicationComponent
       internal_draft: "grey",
       draft: "grey",
       submitted: "blue",
-      sent_to_esfa: "light-blue",
+      payment_in_progress: "light-blue",
     }.with_indifferent_access
   end
 end

--- a/app/models/claims/claim.rb
+++ b/app/models/claims/claim.rb
@@ -70,7 +70,7 @@ class Claims::Claim < ApplicationRecord
          internal_draft: "internal_draft",
          draft: "draft",
          submitted: "submitted",
-         sent_to_esfa: "sent_to_esfa",
+         payment_in_progress: "payment_in_progress",
        },
        validate: true
 

--- a/db/migrate/20241009164610_rename_sent_to_esfa_claim_status_to_payment_in_progress.rb
+++ b/db/migrate/20241009164610_rename_sent_to_esfa_claim_status_to_payment_in_progress.rb
@@ -1,0 +1,5 @@
+class RenameSentToESFAClaimStatusToPaymentInProgress < ActiveRecord::Migration[7.2]
+  def change
+    rename_enum_value :claim_status, from: "sent_to_esfa", to: "payment_in_progress"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_27_160048) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_09_164610) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
-  create_enum "claim_status", ["internal_draft", "draft", "submitted", "sent_to_esfa"]
+  create_enum "claim_status", ["internal_draft", "draft", "submitted", "payment_in_progress"]
   create_enum "mentor_training_type", ["refresher", "initial"]
   create_enum "placement_status", ["draft", "published"]
   create_enum "placement_year_group", ["year_1", "year_2", "year_3", "year_4", "year_5", "year_6"]

--- a/spec/components/claim/status_tag_component_spec.rb
+++ b/spec/components/claim/status_tag_component_spec.rb
@@ -23,11 +23,11 @@ RSpec.describe Claim::StatusTagComponent, type: :component do
     end
   end
 
-  context "when the claim's status is 'sent_to_esfa'" do
-    let(:claim) { build(:claim, status: :sent_to_esfa) }
+  context "when the claim's status is 'payment_in_progress'" do
+    let(:claim) { build(:claim, status: :payment_in_progress) }
 
     it "renders a light blue tag" do
-      expect(page).to have_css(".govuk-tag--light-blue", text: "Sent to ESFA")
+      expect(page).to have_css(".govuk-tag--light-blue", text: "Payment in progress")
     end
   end
 

--- a/spec/helpers/claims/claim_helper_spec.rb
+++ b/spec/helpers/claims/claim_helper_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Claims::ClaimHelper do
   describe "#claim_statuses_for_selection" do
     it "returns an array of claims statuses, except draft statuses" do
-      expect(claim_statuses_for_selection).to contain_exactly("submitted", "sent_to_esfa")
+      expect(claim_statuses_for_selection).to contain_exactly("submitted", "payment_in_progress")
     end
   end
 end

--- a/spec/models/claims/claim_spec.rb
+++ b/spec/models/claims/claim_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Claims::Claim, type: :model do
           internal_draft: "internal_draft",
           draft: "draft",
           submitted: "submitted",
-          sent_to_esfa: "sent_to_esfa",
+          payment_in_progress: "payment_in_progress",
         )
         .backed_by_column_of_type(:enum)
     end


### PR DESCRIPTION
## Context

After some revision, we've decided to exclude explicitly showing ESFA to users, as some (or many) may not be familiar with the acronym.

## Changes proposed in this pull request

- Rename `sent_to_esfa` enum value of claim statuses to `payment_in_progress`.

## Guidance to review

- The `ESFA` acronym is still required in inflections, as it is also used in the migration file name/class mapping.