### PR TITLE
Display travel time on placements in search results

### DIFF
--- a/app/components/placement/summary_component.html.erb
+++ b/app/components/placement/summary_component.html.erb
@@ -12,7 +12,7 @@
     <% if location_coordinates.present? %>
       <div class="app-result-detail__row">
         <dt class="app-result-detail__key">
-          <%= t(".distance") %> 
+          <%= t(".distance") %>
         </dt>
         <dd class="app-result-detail__value">
           <%= distance_from_location %>

--- a/app/components/placement/summary_component.html.erb
+++ b/app/components/placement/summary_component.html.erb
@@ -77,7 +77,7 @@
         <%= t(".public_transport") %>
       </dt>
       <dd class="app-result-detail__value">
-        <%= @school.transit_travel_duration %>
+        <%= @school.formatted_duration("transit") %>
       </dd>
     </div>
           <div class="app-result-detail__row">
@@ -85,7 +85,7 @@
         <%= t(".driving") %>
       </dt>
       <dd class="app-result-detail__value">
-        <%= @school.drive_travel_duration %>
+        <%= @school.formatted_duration("drive") %>
       </dd>
     </div>
     <div class="app-result-detail__row">
@@ -93,7 +93,7 @@
         <%= t(".walking") %>
       </dt>
       <dd class="app-result-detail__value">
-        <%= @school.walk_travel_duration %>
+        <%= @school.formatted_duration("walk") %>
       </dd>
     </div>
   <% end %>

--- a/app/components/placement/summary_component.html.erb
+++ b/app/components/placement/summary_component.html.erb
@@ -4,7 +4,6 @@
       <%= placement.title %> – <%= school.name %>
     <% end %>
   </h2>
-
   <div class="app-result-detail">
     <%= render Placement::StatusTagComponent.new(placement:) %>
   </div>
@@ -13,7 +12,7 @@
     <% if location_coordinates.present? %>
       <div class="app-result-detail__row">
         <dt class="app-result-detail__key">
-          <%= t(".distance") %>
+          <%= t(".distance") %> 
         </dt>
         <dd class="app-result-detail__value">
           <%= distance_from_location %>
@@ -69,5 +68,34 @@
         <%= school.rating %>
       </dd>
     </div>
+      <% if location_coordinates.present? %>
+      <div class="app-result-detail">
+        <h3 class="govuk-heading-s govuk-!-margin-top-3 govuk-!-margin-bottom-0"><%= t(".travel_time") %></h3>
+      </div>
+      <div class="app-result-detail__row">
+      <dt class="app-result-detail__key">
+        <%= t(".public_transport") %>
+      </dt>
+      <dd class="app-result-detail__value">
+        <%= @school.transit_travel_duration %>
+      </dd>
+    </div>
+          <div class="app-result-detail__row">
+      <dt class="app-result-detail__key">
+        <%= t(".driving") %>
+      </dt>
+      <dd class="app-result-detail__value">
+        <%= @school.drive_travel_duration %>
+      </dd>
+    </div>
+    <div class="app-result-detail__row">
+      <dt class="app-result-detail__key">
+        <%= t(".walking") %>
+      </dt>
+      <dd class="app-result-detail__value">
+        <%= @school.walk_travel_duration %>
+      </dd>
+    </div>
+  <% end %>
   </dl>
 </li>

--- a/app/components/placement/summary_component.rb
+++ b/app/components/placement/summary_component.rb
@@ -1,18 +1,30 @@
 class Placement::SummaryComponent < ApplicationComponent
   with_collection_parameter :placement
-  attr_reader :placement, :school, :provider, :location_coordinates
+  attr_reader :placement, :school, :provider, :location_coordinates, :search_location
 
-  def initialize(provider:, placement:, location_coordinates: nil, classes: [], html_attributes: {})
+  def initialize(provider:, placement:, location_coordinates: nil, search_location: nil, classes: [], html_attributes: {})
     super(classes:, html_attributes:)
 
     @provider = provider
     @placement = placement.decorate
     @school = @placement.school
     @location_coordinates = location_coordinates
+    @search_location = search_location
+
+    calculate_travel_time
   end
 
   def distance_from_location
     distance = @school.distance_to(@location_coordinates).round(1)
     I18n.t("components.placement.summary_component.distance_in_miles", distance:)
+  end
+
+  def calculate_travel_time
+    return if search_location.blank?
+
+    @calculate_travel_time ||= Placements::TravelTime.call(
+      origin_address: search_location,
+      destinations: [@school],
+    )
   end
 end

--- a/app/decorators/school_decorator.rb
+++ b/app/decorators/school_decorator.rb
@@ -3,6 +3,13 @@ class SchoolDecorator < OrganisationDecorator
   attribute :walk_travel_duration
   attribute :drive_travel_duration
 
+  def formatted_duration(mode)
+    duration = send("#{mode}_travel_duration")
+    return "" if duration.blank?
+
+    duration.gsub(/\bmins\b/, I18n.t("components.placement.summary_component.minutes"))
+  end
+
   def formatted_inspection_date
     return "" if last_inspection_date.blank?
 

--- a/app/views/placements/providers/placements/index.html.erb
+++ b/app/views/placements/providers/placements/index.html.erb
@@ -23,7 +23,7 @@
       <% if @placements.any? %>
         <p class="govuk-hint"><%= @search_location.blank? ? t(".results_sorted_alpha") : t(".results_sorted_distance", search_location: @search_location) %></p>
         <ul class="app-search-results">
-          <%= render(Placement::SummaryComponent.with_collection(@placements, provider: @provider, location_coordinates:)) %>
+          <%= render(Placement::SummaryComponent.with_collection(@placements, provider: @provider, location_coordinates:, search_location: @search_location)) %>
         </ul>
         <%= render PaginationComponent.new(pagy: @pagy) %>
       <% else %>

--- a/config/locales/en/components/placement/summary_component.yml
+++ b/config/locales/en/components/placement/summary_component.yml
@@ -17,3 +17,4 @@ en:
         public_transport: Public transport
         driving: Driving
         walking: Walking
+        minutes: minutes

--- a/config/locales/en/components/placement/summary_component.yml
+++ b/config/locales/en/components/placement/summary_component.yml
@@ -13,3 +13,7 @@ en:
         ofsted_rating: Ofsted rating
         distance: "Distance"
         distance_in_miles: "%{distance} miles"
+        travel_time: Travel time
+        public_transport: Public transport
+        driving: Driving
+        walking: Walking

--- a/lib/google/routes_api.rb
+++ b/lib/google/routes_api.rb
@@ -17,7 +17,7 @@ module Google
     private
 
     def options(origin_address, destinations, travel_mode)
-      @options ||= {
+      {
         origins: [transform_origin(origin_address)],
         destinations: destinations.map { |destination| transform_destination(destination) },
         travelMode: travel_mode,

--- a/spec/system/placements/placements/searching_for_a_placement_spec.rb
+++ b/spec/system/placements/placements/searching_for_a_placement_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe "Placements / Placements / Searching for a placements list",
     bath_placement
 
     given_i_sign_in_as_patricia
+    stub_travel_time_service
   end
 
   context "when searching for placements near a location (London)" do
@@ -60,7 +61,7 @@ RSpec.describe "Placements / Placements / Searching for a placements list",
       and_i_fill_in_location_search_with("Guildford")
       and_i_click_on("Apply filters")
       then_i_see_placements_for(school_name: "Guildford School", list_item: 0, distance: 0.0)
-      and_i_see_placements_for(school_name: "London School", list_item: 1, distance: 26.7)
+      then_i_see_placements_for(school_name: "London School", list_item: 1, distance: 26.7)
       and_i_do_not_see_placements_for(school_name: "Bath School")
     end
   end
@@ -199,5 +200,12 @@ RSpec.describe "Placements / Placements / Searching for a placements list",
     allow(geocoder_results).to receive(:first).and_return(geocoder_result)
     allow(geocoder_result).to receive(:coordinates).and_return([55.378051, -3.435973])
     allow(Geocoder).to receive(:search).and_return(geocoder_results)
+  end
+
+  def stub_travel_time_service
+    allow(Placements::TravelTime).to receive(:call).and_return([
+      london_school.assign_attributes(transit_travel_duration: "0 mins", drive_travel_duration: "0 mins", walk_travel_duration: "0 mins"),
+      guildford_school.assign_attributes(transit_travel_duration: "0 mins", drive_travel_duration: "0 mins", walk_travel_duration: "0 mins"),
+    ])
   end
 end

--- a/spec/system/placements/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/placements/view_placements_list_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe "Placements / Placements / View placements list",
 
   before do
     given_i_sign_in_as_patricia
+    stub_travel_time_service
   end
 
   scenario "User views all placements page, when no placements exist" do
@@ -453,5 +454,12 @@ RSpec.describe "Placements / Placements / View placements list",
     allow(geocoder_results).to receive(:first).and_return(geocoder_result)
     allow(geocoder_result).to receive(:coordinates).and_return([51.5072178, -0.1275862])
     allow(Geocoder).to receive(:search).and_return(geocoder_results)
+  end
+
+  def stub_travel_time_service
+    allow(Placements::TravelTime).to receive(:call).and_return([
+      primary_school.assign_attributes(drive_travel_duration: "0 mins", transit_travel_duration: "0 mins", walk_travel_duration: "0 mins"),
+      secondary_school.assign_attributes(drive_travel_duration: "15 mins", transit_travel_duration: "20 mins", walk_travel_duration: "30 mins"),
+    ])
   end
 end


### PR DESCRIPTION
## Context

User is able to see travel times from the destination they have entered.

## Changes proposed in this pull request

**Placements index**
- A travel time section is added to the listing content.
- This displays travel time for Public transport, Driving, Walking.
- Format should be:
> - XX minutes (up to an hour)
> - XX hour XX minutes (1-2 hours)
> - XX hours XX minutes (2+ hours)

## Guidance to review

Please use this PR to review content changes for the travel time feature, including from https://github.com/DFE-Digital/itt-mentor-services/pull/1096.

- Login as a Provider User.
- You will land on the placements index page.
- Search a location for which there will be a result (e.g. a town or city close to seeded placements).
- Check that the location appears as a selected filter tag.
- Check that results are rendered as expected (is the results number correct?; does the paragraph say "results sorted by distance from [the location you searched]"?)
- Check that the location clears when the filter tag is cancelled or the 'clear filters' button is pressed.
- Check that all three travel modes appear with different travel times.
- Search a location for which there will be no result.
- Check that a 'no results' message appears and the 'sorted by' paragraph is not visible.
- Use a combination of filters to make sure both the filter and search interact as you would expect.

## Link to Trello card

https://trello.com/c/J1W9oboz/856-display-travel-time-in-placement-search-results

## Screenshots

https://github.com/user-attachments/assets/e8fb29f9-d19a-467f-bfcb-789a3b25d0dd
