### PR TITLE
Add Azure Storage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,6 +116,9 @@ gem "okcomputer"
 # OpenStruct [https://github.com/ruby/ostruct]
 gem "ostruct", "~> 0.6.0"
 
+# Azure Storage adapter for Active Storage
+gem "azure-blob"
+
 group :development do
   gem "annotate", require: false
   gem "prettier_print", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,8 @@ GEM
     audited (5.7.0)
       activerecord (>= 5.2, < 8.0)
       activesupport (>= 5.2, < 8.0)
+    azure-blob (0.5.2)
+      rexml
     base64 (0.2.0)
     better_html (2.1.1)
       actionview (>= 6.0)
@@ -684,6 +686,7 @@ DEPENDENCIES
   amazing_print
   annotate
   audited
+  azure-blob
   better_html
   bootsnap
   brakeman

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -22,6 +22,27 @@ shared:
     - remote_address
     - request_uuid
     - created_at
+  :active_storage_variant_records:
+    - id
+    - blob_id
+    - variation_digest
+  :active_storage_blobs:
+    - id
+    - key
+    - filename
+    - content_type
+    - metadata
+    - service_name
+    - byte_size
+    - checksum
+    - created_at
+  :active_storage_attachments:
+    - id
+    - name
+    - record_type
+    - record_id
+    - blob_id
+    - created_at
   :good_job_settings:
     - id
     - created_at

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,8 +30,8 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
-  # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  # Store uploaded files in Azure Storage (see config/storage.yml for options).
+  config.active_storage.service = :azure
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -21,12 +21,11 @@ local:
 #   bucket: your_own_bucket-<%= Rails.env %>
 
 # Use bin/rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
-# microsoft:
-#   service: AzureStorage
-#   storage_account_name: your_account_name
-#   storage_access_key: <%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
-#   container: your_container_name-<%= Rails.env %>
-
+azure:
+  service: AzureBlob
+  storage_account_name: <%= ENV["AZURE_STORAGE_ACCOUNT_NAME"] %>
+  storage_access_key: <%= ENV["AZURE_STORAGE_ACCESS_KEY"] %>
+  container: <%= ENV["AZURE_STORAGE_CONTAINER"] %>
 # mirror:
 #   service: Mirror
 #   primary: local

--- a/db/migrate/20241016120228_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20241016120228_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,58 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [:key], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index %i[record_type record_id name blob_id], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index %i[blob_id variation_digest], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+
+  def primary_and_foreign_key_types
+    config = Rails.configuration.generators
+    setting = config.options[config.orm][:primary_key_type]
+    primary_key_type = setting || :primary_key
+    foreign_key_type = setting || :bigint
+    [primary_key_type, foreign_key_type]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_09_164610) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_16_120228) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -31,6 +31,34 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_09_164610) do
     t.date "ends_on"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.uuid "record_id", null: false
+    t.uuid "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
   create_table "audits", force: :cascade do |t|
@@ -447,6 +475,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_09_164610) do
     t.index ["type", "email"], name: "index_users_on_type_and_email", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "claim_windows", "academic_years"
   add_foreign_key "claims", "providers"
   add_foreign_key "claims", "schools"

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -17,8 +17,12 @@ module "application_configuration" {
       ENVIRONMENT_NAME = var.environment
       PGSSLMODE        = local.postgres_ssl_mode
   })
+
   secret_variables = {
-    DATABASE_URL = module.postgres.url
+    DATABASE_URL               = module.postgres.url
+    AZURE_STORAGE_ACCOUNT_NAME = local.azure_storage_account_name
+    AZURE_STORAGE_ACCESS_KEY   = local.azure_storage_access_key
+    AZURE_STORAGE_CONTAINER    = local.azure_storage_container
   }
 }
 

--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cluster": "production",
   "namespace": "bat-production",
-  "enable_monitoring" : true,
-  "app_replicas" : 2,
-  "worker_replicas" : 2,
+  "enable_monitoring": true,
+  "app_replicas": 2,
+  "worker_replicas": 2,
   "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
   "postgres_enable_high_availability": true,
   "enable_postgres_backup_storage": true,
@@ -13,8 +13,14 @@
     "start_minute": 0
   },
   "statuscake_alerts": {
-      "website_url": [ "https://claim-funding-for-mentor-training.education.gov.uk/healthcheck/all","https://manage-school-placements.education.gov.uk/healthcheck/all" ],
-      "ssl_url": [ "https://claim-funding-for-mentor-training.education.gov.uk","https://manage-school-placements.education.gov.uk" ],
-      "contact_groups": [311842, 282453]
+    "website_url": [
+      "https://claim-funding-for-mentor-training.education.gov.uk/healthcheck/all",
+      "https://manage-school-placements.education.gov.uk/healthcheck/all"
+    ],
+    "ssl_url": [
+      "https://claim-funding-for-mentor-training.education.gov.uk",
+      "https://manage-school-placements.education.gov.uk"
+    ],
+    "contact_groups": [311842, 282453]
   }
 }

--- a/terraform/application/config/qa.tfvars.json
+++ b/terraform/application/config/qa.tfvars.json
@@ -1,4 +1,4 @@
 {
-    "cluster": "test",
-    "namespace": "bat-qa"
-  }
+  "cluster": "test",
+  "namespace": "bat-qa"
+}

--- a/terraform/application/config/sandbox.tfvars.json
+++ b/terraform/application/config/sandbox.tfvars.json
@@ -1,9 +1,12 @@
 {
-    "cluster": "production",
-    "namespace": "bat-production",
-    "enable_monitoring" : true,
-    "statuscake_alerts": {
-        "website_url": [ "https://sandbox.claim-funding-for-mentor-training.education.gov.uk/healthcheck/all","https://sandbox.manage-school-placements.education.gov.uk/healthcheck/all" ],
-        "contact_groups": [311842]
-    }
+  "cluster": "production",
+  "namespace": "bat-production",
+  "enable_monitoring": true,
+  "statuscake_alerts": {
+    "website_url": [
+      "https://sandbox.claim-funding-for-mentor-training.education.gov.uk/healthcheck/all",
+      "https://sandbox.manage-school-placements.education.gov.uk/healthcheck/all"
+    ],
+    "contact_groups": [311842]
+  }
 }

--- a/terraform/application/config/staging.tfvars.json
+++ b/terraform/application/config/staging.tfvars.json
@@ -1,11 +1,14 @@
 {
-    "cluster": "test",
-    "namespace": "bat-staging",
-    "enable_monitoring" : true,
-    "statuscake_alerts": {
-        "website_url": [ "https://staging.claim-funding-for-mentor-training.education.gov.uk/healthcheck/all","https://staging.manage-school-placements.education.gov.uk/healthcheck/all" ],
-        "contact_groups": [311842]
-    },
-    "enable_postgres_backup_storage": true,
-    "postgres_flexible_server_sku": "B_Standard_B2s"
-  }
+  "cluster": "test",
+  "namespace": "bat-staging",
+  "enable_monitoring": true,
+  "statuscake_alerts": {
+    "website_url": [
+      "https://staging.claim-funding-for-mentor-training.education.gov.uk/healthcheck/all",
+      "https://staging.manage-school-placements.education.gov.uk/healthcheck/all"
+    ],
+    "contact_groups": [311842]
+  },
+  "enable_postgres_backup_storage": true,
+  "postgres_flexible_server_sku": "B_Standard_B2s"
+}

--- a/terraform/application/storage_account.tf
+++ b/terraform/application/storage_account.tf
@@ -1,0 +1,31 @@
+resource "azurerm_storage_account" "general_storage_account" {
+  name                             = local.azure_storage_account_name
+  resource_group_name              = local.app_resource_group_name
+  location                         = "UK South"
+  account_tier                     = "Standard"
+  account_replication_type         = "LRS"
+  allow_nested_items_to_be_public  = false
+  cross_tenant_replication_enabled = false
+
+  dynamic "blob_properties" {
+    for_each = var.environment == "production" ? [1] : []
+
+    content {
+      delete_retention_policy {
+        days = 7
+      }
+
+      container_delete_retention_policy {
+        days = 7
+      }
+    }
+  }
+
+  lifecycle { ignore_changes = [tags] }
+}
+
+resource "azurerm_storage_container" "general_container" {
+  name                  = "storage"
+  storage_account_name  = azurerm_storage_account.general_storage_account.name
+  container_access_type = "private"
+}

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -43,31 +43,31 @@ variable "enable_monitoring" {
 }
 variable "app_replicas" {
   description = "number of replicas of the web app"
-  default = 1
+  default     = 1
 }
 variable "worker_replicas" {
   description = "number of replicas of the workers"
-  default = 1
+  default     = 1
 }
 variable "key_vault_resource_group" {
   default     = null
   description = "The name of the key vault resorce group"
 }
 
-variable "azure_maintenance_window" { 
-  default = null 
+variable "azure_maintenance_window" {
+  default = null
 }
-variable "postgres_flexible_server_sku" { 
-  default = "B_Standard_B1ms" 
+variable "postgres_flexible_server_sku" {
+  default = "B_Standard_B1ms"
 }
-variable "postgres_enable_high_availability" { 
-  default = false 
+variable "postgres_enable_high_availability" {
+  default = false
 }
-variable "azure_enable_backup_storage" { 
-  default = false 
+variable "azure_enable_backup_storage" {
+  default = false
 }
-variable "enable_container_monitoring" { 
-  default = false 
+variable "enable_container_monitoring" {
+  default = false
 }
 
 variable "statuscake_contact_groups" {
@@ -88,7 +88,7 @@ locals {
   postgres_ssl_mode       = var.enable_postgres_ssl ? "require" : "disable"
   app_env_values_from_yml = yamldecode(file("${path.module}/config/${var.config}_app_env.yml"))
   ingress_domain_map = {
-    INGRESS_CLAIMS_HOST = "track-and-pay-${var.environment}.${module.cluster_data.ingress_domain}"
+    INGRESS_CLAIMS_HOST     = "track-and-pay-${var.environment}.${module.cluster_data.ingress_domain}"
     INGRESS_PLACEMENTS_HOST = "manage-school-placements-${var.environment}.${module.cluster_data.ingress_domain}"
   }
   claims_domain_map = (


### PR DESCRIPTION
## Context

In preparation for the upcoming Payments/Sampling/Clawback flows, we want to be able to store CSV files attached to ActiveRecord records.

Namely, when we generate CSVs, we want to save a snapshot of the file sent to ESFA and Providers.

This PR implements the foundational ActiveStorage and Azure Storage functionality.

## Changes proposed in this pull request

- Add Azure Storage to terraform configuration.
- Setup Rails' Azure Storage ActiveStorage service for testing.
- Add all ActiveStorage tables to the `analytics_blocklist.yml`.

## Guidance to review

I've run the following code to validate file read/write capabilities:

```ruby
class Claims::SupportUser < User
  has_one_attached :avatar
end

support_user = Claims::SupportUser.last
support_user.avatar.attach(io: URI.open("https://avatars.githubusercontent.com/u/4231530?s=40&v=4"), filename: "avatar.png") # My GitHub avatar
support_user.avatar.url # => "https://s189t01ittmsrvsa.blob.core.windows.net/storage/r1whzefgb4yj39dwedtwfhfsjt85?sp=r&sv=2024-05-04&se=2024-10-16T12%3A33%3A04Z&sr=b&rscd=inline%3B+filename%3D%22avatar.png%22%3B+filename*%3DUTF-8%27%27avatar.png&rsct=image%2Fjpeg&sig=qV4CAnHfNASQc8PVg64H8zVYUN53n%2FItnsRe0M58K%2Bk%3D"
```

Try visiting the link here:

~~https://s189t01ittmsrvsa.blob.core.windows.net/storage/r1whzefgb4yj39dwedtwfhfsjt85?sp=r&sv=2024-05-04&se=2024-10-16T12%3A33%3A04Z&sr=b&rscd=inline%3B+filename%3D%22avatar.png%22%3B+filename*%3DUTF-8%27%27avatar.png&rsct=image%2Fjpeg&sig=qV4CAnHfNASQc8PVg64H8zVYUN53n%2FItnsRe0M58K%2Bk%3D~~

Link has expired. Good.
