### PR TITLE
Update rubocop.yml to allow shared system spec to use scenario

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,8 @@ Lint/MissingSuper:
 
 RSpec/Dialect:
   Enabled: true
+  Exclude:
+    - spec/support/shared_examples/system/**/*.rb
   PreferredMethods:
     background: :before
     given: :let

--- a/spec/support/shared_examples/system/placements/add_a_placement_wizard.rb
+++ b/spec/support/shared_examples/system/placements/add_a_placement_wizard.rb
@@ -26,7 +26,7 @@ RSpec.shared_examples "an add a placement wizard" do
           create(:placements_mentor_membership, mentor: mentor_2, school:)
         end
 
-        it "I can create my placement" do
+        scenario "I can create my placement" do
           when_i_visit_the_placements_page
           and_i_click_on("Add placement")
           then_i_see_the_add_a_placement_subject_page(school.phase)
@@ -52,7 +52,7 @@ RSpec.shared_examples "an add a placement wizard" do
           and_i_see_success_message("Placement added")
         end
 
-        it "when I select not known for the mentor" do
+        scenario "when I select not known for the mentor" do
           when_i_visit_the_placements_page
           and_i_click_on("Add placement")
           when_i_choose_a_subject(subject_1.name)
@@ -79,7 +79,7 @@ RSpec.shared_examples "an add a placement wizard" do
           and_i_see_success_message("Placement added")
         end
 
-        it "I am redirected to the add mentor page if I click on the link in the help text" do
+        scenario "I am redirected to the add mentor page if I click on the link in the help text" do
           when_i_visit_the_placements_page
           and_i_click_on("Add placement")
           when_i_choose_a_subject(subject_1.name)
@@ -101,7 +101,7 @@ RSpec.shared_examples "an add a placement wizard" do
       end
 
       context "when I have no mentors" do
-        it "I do not see the add mentors page" do
+        scenario "I do not see the add mentors page" do
           when_i_visit_the_placements_page
           and_i_click_on("Add placement")
           when_i_choose_a_subject(subject_1.name)
@@ -125,7 +125,7 @@ RSpec.shared_examples "an add a placement wizard" do
           create(:placements_mentor_membership, mentor: mentor_2, school:)
         end
 
-        it "I can navigate back to the index page with cancel" do
+        scenario "I can navigate back to the index page with cancel" do
           when_i_visit_the_placements_page
           and_i_click_on("Add placement")
           then_i_see_the_add_a_placement_subject_page(school.phase)
@@ -177,7 +177,7 @@ RSpec.shared_examples "an add a placement wizard" do
         end
 
         context "when navigating back through the steps" do
-          it "my selected options are rendered and I go to the previous step" do
+          scenario "my selected options are rendered and I go to the previous step" do
             when_i_visit_the_placements_page
             and_i_click_on("Add placement")
             when_i_choose_a_subject(subject_1.name)
@@ -214,7 +214,7 @@ RSpec.shared_examples "an add a placement wizard" do
         end
 
         context "when I've checked my answers and I click on change" do
-          it "when I do not enter valid options" do
+          scenario "when I do not enter valid options" do
             when_i_visit_the_placements_page
             and_i_click_on("Add placement")
             and_i_click_on("Continue")
@@ -257,7 +257,7 @@ RSpec.shared_examples "an add a placement wizard" do
         end
 
         context "when I preview my placement" do
-          it "I can see the placement details" do
+          scenario "I can see the placement details" do
             when_i_visit_the_placements_page
             and_i_click_on("Add placement")
             when_i_choose_a_subject(subject_1.name)
@@ -275,7 +275,7 @@ RSpec.shared_examples "an add a placement wizard" do
             then_i_see_the_preview_page(phase: school.phase, subject: subject_1)
           end
 
-          it "I can go back to the check your answers page" do
+          scenario "I can go back to the check your answers page" do
             when_i_visit_the_placements_page
             and_i_click_on("Add placement")
             when_i_choose_a_subject(subject_1.name)
@@ -295,7 +295,7 @@ RSpec.shared_examples "an add a placement wizard" do
             then_i_see_the_check_your_answers_page(school.phase, mentor_1, summer_term.name)
           end
 
-          it "I can go back and edit my placement" do
+          scenario "I can go back and edit my placement" do
             when_i_visit_the_placements_page
             and_i_click_on("Add placement")
             when_i_choose_a_subject(subject_1.name)
@@ -315,7 +315,7 @@ RSpec.shared_examples "an add a placement wizard" do
             then_i_see_the_check_your_answers_page(school.phase, mentor_1, summer_term.name)
           end
 
-          it "I can publish my placement" do
+          scenario "I can publish my placement" do
             when_i_visit_the_placements_page
             and_i_click_on("Add placement")
             when_i_choose_a_subject(subject_1.name)
@@ -346,7 +346,7 @@ RSpec.shared_examples "an add a placement wizard" do
         create(:placements_mentor_membership, mentor: mentor_2, school:)
       end
 
-      it "I can create my placement" do
+      scenario "I can create my placement" do
         school.update!(phase: "Secondary")
         when_i_visit_the_placements_page
         and_i_click_on("Add placement")
@@ -373,7 +373,7 @@ RSpec.shared_examples "an add a placement wizard" do
         let!(:subject_3) { create(:subject, name: "Secondary subject 3", subject_area: :secondary, parent_subject: subject_2) }
         let!(:subject_4) { create(:subject, name: "Secondary subject 4", subject_area: :secondary) }
 
-        it "I can create my placement" do
+        scenario "I can create my placement" do
           school.update!(phase: "Secondary")
           when_i_visit_the_placements_page
           and_i_click_on("Add placement")
@@ -398,7 +398,7 @@ RSpec.shared_examples "an add a placement wizard" do
           and_i_see_success_message("Placement added")
         end
 
-        it "I see a validation message if I do not select an additional subject" do
+        scenario "I see a validation message if I do not select an additional subject" do
           school.update!(phase: "Secondary")
           when_i_visit_the_placements_page
           and_i_click_on("Add placement")
@@ -410,7 +410,7 @@ RSpec.shared_examples "an add a placement wizard" do
           and_i_see_the_error_message("Select an additional subject")
         end
 
-        it "If I change the subject, I do not see the additional subject page" do
+        scenario "If I change the subject, I do not see the additional subject page" do
           school.update!(phase: "Secondary")
           when_i_visit_the_placements_page
           and_i_click_on("Add placement")
@@ -434,7 +434,7 @@ RSpec.shared_examples "an add a placement wizard" do
       end
 
       context "and I choose the Primary phase" do
-        it "I can create my placement" do
+        scenario "I can create my placement" do
           school.update!(phase: "Nursery")
           when_i_visit_the_placements_page
           and_i_click_on("Add placement")
@@ -465,7 +465,7 @@ RSpec.shared_examples "an add a placement wizard" do
       end
 
       context "and I choose the Secondary phase" do
-        it "I can create my placement" do
+        scenario "I can create my placement" do
           school.update!(phase: "Nursery")
           when_i_visit_the_placements_page
           and_i_click_on("Add placement")
@@ -493,7 +493,7 @@ RSpec.shared_examples "an add a placement wizard" do
       end
 
       context "and I do not choose a phase" do
-        it "I see an error message" do
+        scenario "I see an error message" do
           school.update!(phase: "Nursery")
           when_i_visit_the_placements_page
           and_i_click_on("Add placement")
@@ -504,7 +504,7 @@ RSpec.shared_examples "an add a placement wizard" do
       end
 
       context "and I click on change my phase" do
-        it "I decide to change my phase" do
+        scenario "I decide to change my phase" do
           school.update!(phase: "Nursery")
           when_i_visit_the_placements_page
           and_i_click_on("Add placement")
@@ -538,7 +538,7 @@ RSpec.shared_examples "an add a placement wizard" do
           and_my_selection_has_changed_to("Primary")
         end
 
-        it "I do not decide to change my phase" do
+        scenario "I do not decide to change my phase" do
           school.update!(phase: "Nursery")
           when_i_visit_the_placements_page
           and_i_click_on("Add placement")
@@ -569,7 +569,7 @@ RSpec.shared_examples "an add a placement wizard" do
       end
 
       context "and I click on change my subject" do
-        it "I decide to change my subject" do
+        scenario "I decide to change my subject" do
           school.update!(phase: "Nursery")
           when_i_visit_the_placements_page
           and_i_click_on("Add placement")
@@ -598,7 +598,7 @@ RSpec.shared_examples "an add a placement wizard" do
           and_my_selection_has_changed_to(subject_3.name)
         end
 
-        it "I do not decide to change my subject" do
+        scenario "I do not decide to change my subject" do
           school.update!(phase: "Nursery")
           when_i_visit_the_placements_page
           and_i_click_on("Add placement")
@@ -627,7 +627,7 @@ RSpec.shared_examples "an add a placement wizard" do
       end
 
       context "and I click on change my term" do
-        it "I decide to change my term" do
+        scenario "I decide to change my term" do
           school.update!(phase: "Nursery")
           when_i_visit_the_placements_page
           and_i_click_on("Add placement")
@@ -650,7 +650,7 @@ RSpec.shared_examples "an add a placement wizard" do
           then_i_see_the_check_your_answers_page("Secondary", mentor_1, spring_term.name)
         end
 
-        it "I select all terms separately" do
+        scenario "I select all terms separately" do
           school.update!(phase: "Nursery")
           when_i_visit_the_placements_page
           and_i_click_on("Add placement")
@@ -675,7 +675,7 @@ RSpec.shared_examples "an add a placement wizard" do
           then_i_see_the_check_your_answers_page("Secondary", mentor_1, "Any time in the academic year")
         end
 
-        it "I do not decide to change my term" do
+        scenario "I do not decide to change my term" do
           school.update!(phase: "Nursery")
           when_i_visit_the_placements_page
           and_i_click_on("Add placement")
@@ -699,7 +699,7 @@ RSpec.shared_examples "an add a placement wizard" do
       end
 
       context "and I click on change my mentor" do
-        it "I decide to change my mentor" do
+        scenario "I decide to change my mentor" do
           school.update!(phase: "Nursery")
           when_i_visit_the_placements_page
           and_i_click_on("Add placement")
@@ -720,7 +720,7 @@ RSpec.shared_examples "an add a placement wizard" do
           then_i_see_the_check_your_answers_page("Secondary", mentor_2, summer_term.name)
         end
 
-        it "I do not decide to change my mentor" do
+        scenario "I do not decide to change my mentor" do
           school.update!(phase: "Nursery")
           when_i_visit_the_placements_page
           and_i_click_on("Add placement")

--- a/spec/support/shared_examples/system/placements/edit_a_placement_wizard.rb
+++ b/spec/support/shared_examples/system/placements/edit_a_placement_wizard.rb
@@ -7,7 +7,7 @@ RSpec.shared_examples "an edit placement wizard", :js do
   let(:provider_2) { create(:provider, :placements, name: "Provider 2") }
 
   context "when the school has no partner providers" do
-    it "User is redirected to add a partner provider" do
+    scenario "User is redirected to add a partner provider" do
       when_i_visit_the_placement_show_page
       then_i_should_see_the_provider_is_not_known_yet_in_the_placement_details(
         change_link: "Add a partner provider",
@@ -32,7 +32,7 @@ RSpec.shared_examples "an edit placement wizard", :js do
     end
 
     context "with no provider" do
-      it "User edits the provider", :js do
+      scenario "User edits the provider", :js do
         when_i_visit_the_placement_show_page
         then_i_should_see_the_provider_is_not_known_yet_in_the_placement_details
         when_i_click_link(
@@ -49,7 +49,7 @@ RSpec.shared_examples "an edit placement wizard", :js do
         and_the_provider_is_notified_they_have_been_assigned_to_the_placement(provider_2_user)
       end
 
-      it "User does not select a provider" do
+      scenario "User does not select a provider" do
         when_i_visit_the_placement_show_page
         then_i_should_see_the_provider_is_not_known_yet_in_the_placement_details
         when_i_click_link(
@@ -61,7 +61,7 @@ RSpec.shared_examples "an edit placement wizard", :js do
         then_i_should_see_the_provider_is_not_known_yet_in_the_placement_details
       end
 
-      it "User edits the provider and cancels" do
+      scenario "User edits the provider and cancels" do
         when_i_visit_the_placement_show_page
         then_i_should_see_the_provider_is_not_known_yet_in_the_placement_details
         when_i_click_link(
@@ -74,7 +74,7 @@ RSpec.shared_examples "an edit placement wizard", :js do
         then_i_should_see_the_provider_is_not_known_yet_in_the_placement_details
       end
 
-      it "User clicks on back" do
+      scenario "User clicks on back" do
         when_i_visit_the_placement_show_page
         then_i_should_see_the_provider_is_not_known_yet_in_the_placement_details
         when_i_click_link(
@@ -88,7 +88,7 @@ RSpec.shared_examples "an edit placement wizard", :js do
     end
 
     context "with a provider" do
-      it "User edits the provider" do
+      scenario "User edits the provider" do
         given_the_placement_has_a_provider(provider_1)
         when_i_visit_the_placement_show_page
         then_i_should_see_the_provider_name_in_the_placement_details(
@@ -109,7 +109,7 @@ RSpec.shared_examples "an edit placement wizard", :js do
         and_the_provider_is_notified_they_have_been_assigned_to_the_placement(provider_2_user)
       end
 
-      it "User does not select a provider" do
+      scenario "User does not select a provider" do
         given_the_placement_has_a_provider(provider_1)
         when_i_visit_the_placement_show_page
         then_i_should_see_the_provider_name_in_the_placement_details(
@@ -133,7 +133,7 @@ RSpec.shared_examples "an edit placement wizard", :js do
   end
 
   context "when I edit the year group" do
-    it "User edits the year group" do
+    scenario "User edits the year group" do
       when_i_visit_the_placement_show_page
       then_i_should_see_the_year_group_in_the_placement_details(
         year_group_name: "Year 1",
@@ -153,7 +153,7 @@ RSpec.shared_examples "an edit placement wizard", :js do
   end
 
   context "when the school has no mentors" do
-    it "User is redirected to add a mentor" do
+    scenario "User is redirected to add a mentor" do
       when_i_visit_the_placement_show_page
       then_i_should_see_the_mentor_is_not_yet_known_in_the_placement_details(
         change_link: "Add a mentor",
@@ -173,7 +173,7 @@ RSpec.shared_examples "an edit placement wizard", :js do
     end
 
     context "with no mentors" do
-      it "User edits the mentors" do
+      scenario "User edits the mentors" do
         when_i_visit_the_placement_show_page
         then_i_should_see_the_mentor_is_not_yet_known_in_the_placement_details
         when_i_click_link(
@@ -188,7 +188,7 @@ RSpec.shared_examples "an edit placement wizard", :js do
         and_i_see_success_message("Mentor updated")
       end
 
-      it "User does not select a mentor" do
+      scenario "User does not select a mentor" do
         when_i_visit_the_placement_show_page
         then_i_should_see_the_mentor_is_not_yet_known_in_the_placement_details
         when_i_click_link(
@@ -201,7 +201,7 @@ RSpec.shared_examples "an edit placement wizard", :js do
         then_i_should_see_an_error_message
       end
 
-      it "User edits the mentor and cancels" do
+      scenario "User edits the mentor and cancels" do
         when_i_visit_the_placement_show_page
         then_i_should_see_the_mentor_is_not_yet_known_in_the_placement_details
         when_i_click_link(
@@ -214,7 +214,7 @@ RSpec.shared_examples "an edit placement wizard", :js do
         then_i_should_see_the_mentor_is_not_yet_known_in_the_placement_details
       end
 
-      it "User clicks on back" do
+      scenario "User clicks on back" do
         when_i_visit_the_placement_show_page
         then_i_should_see_the_mentor_is_not_yet_known_in_the_placement_details
         when_i_click_link(
@@ -230,7 +230,7 @@ RSpec.shared_examples "an edit placement wizard", :js do
     context "with mentors" do
       let(:placement) { create(:placement, school:, provider: provider_1, mentors: [mentor_1]) }
 
-      it "User edits the mentors" do
+      scenario "User edits the mentors" do
         when_i_visit_the_placement_show_page
         then_i_should_see_the_mentor_name_in_the_placement_details(
           mentor_name: mentor_1.full_name,
@@ -248,7 +248,7 @@ RSpec.shared_examples "an edit placement wizard", :js do
         and_i_see_success_message("Mentor updated")
       end
 
-      it "User does not select a mentor" do
+      scenario "User does not select a mentor" do
         when_i_visit_the_placement_show_page
         then_i_should_see_the_mentor_name_in_the_placement_details(
           mentor_name: mentor_1.full_name,
@@ -264,7 +264,7 @@ RSpec.shared_examples "an edit placement wizard", :js do
         then_i_should_see_an_error_message
       end
 
-      it "User edits the mentor and cancels" do
+      scenario "User edits the mentor and cancels" do
         when_i_visit_the_placement_show_page
         then_i_should_see_the_mentor_name_in_the_placement_details(
           mentor_name: mentor_1.full_name,
@@ -281,7 +281,7 @@ RSpec.shared_examples "an edit placement wizard", :js do
         )
       end
 
-      it "User clicks on back" do
+      scenario "User clicks on back" do
         when_i_visit_the_placement_show_page
         then_i_should_see_the_mentor_name_in_the_placement_details(
           mentor_name: mentor_1.full_name,
@@ -297,7 +297,7 @@ RSpec.shared_examples "an edit placement wizard", :js do
         )
       end
 
-      it "User selects not yet known" do
+      scenario "User selects not yet known" do
         when_i_visit_the_placement_show_page
         then_i_should_see_the_mentor_name_in_the_placement_details(
           mentor_name: mentor_1.full_name,
@@ -326,7 +326,7 @@ RSpec.shared_examples "an edit placement wizard", :js do
       autumn_term
     end
 
-    it "User selects a different term" do
+    scenario "User selects a different term" do
       when_i_visit_the_placement_show_page
       then_i_see_expected_date_in_the_placement_details(
         term: "Any time in the academic year",
@@ -344,7 +344,7 @@ RSpec.shared_examples "an edit placement wizard", :js do
       and_i_see_success_message("Expected date updated")
     end
 
-    it "User selects all 3 terms" do
+    scenario "User selects all 3 terms" do
       given_the_placement_has_terms([summer_term])
       when_i_visit_the_placement_show_page
       then_i_see_expected_date_in_the_placement_details(
@@ -365,7 +365,7 @@ RSpec.shared_examples "an edit placement wizard", :js do
       and_i_see_success_message("Expected date updated")
     end
 
-    it "User selects 'Any time in the academic year'" do
+    scenario "User selects 'Any time in the academic year'" do
       given_the_placement_has_terms([summer_term])
       when_i_visit_the_placement_show_page
       then_i_see_expected_date_in_the_placement_details(


### PR DESCRIPTION
## Context

- After some exploration, `shared_examples` aren't ideally suited to handle `system`/`feature` specs.
- As a result, the rubocop rules for `RSpec/Dialect` have been ignored for files in the `spec/support/shared_examples/system` directory.

## Changes proposed in this pull request

- Rubocop rule for `RSpec/Dialect` is now ignored for files in the `spec/support/shared_examples/system` directory.
- Shared system tests now use `scenario` instead of `it`

## Link to Trello card

https://trello.com/c/15g93JQU/870-configure-rubocop-so-shared-examples-can-use-system-spec-syntax
