### PR TITLE
Create reusable sign in test helpers

### DIFF
--- a/spec/support/dfe_sign_in_user_helper.rb
+++ b/spec/support/dfe_sign_in_user_helper.rb
@@ -1,4 +1,21 @@
 module DfESignInUserHelper
+  def sign_in_placements_user(organisations: [], with_dfe_sign_id: true, sign_in: true)
+    @current_user = create(:placements_user)
+    @current_user.update!(dfe_sign_in_uid: nil) unless with_dfe_sign_id
+    organisations.each do |organisation|
+      create(:user_membership, user: @current_user, organisation:)
+    end
+    sign_in ? sign_in_as(@current_user) : user_exists_in_dfe_sign_in(user: @current_user)
+  end
+  alias_method :given_i_am_signed_in_as_a_placements_user, :sign_in_placements_user
+
+  def sign_in_placements_support_user(with_dfe_sign_id: true, sign_in: true)
+    @current_user = create(:placements_support_user)
+    @current_user.update!(dfe_sign_in_uid: nil) unless with_dfe_sign_id
+    sign_in ? sign_in_as(@current_user) : user_exists_in_dfe_sign_in(user: @current_user)
+  end
+  alias_method :given_i_am_signed_in_as_a_placements_support_user, :sign_in_placements_support_user
+
   def sign_in_as(user)
     user_exists_in_dfe_sign_in(user:)
 

--- a/spec/support/shared_examples/system/placements/edit_a_placement_wizard.rb
+++ b/spec/support/shared_examples/system/placements/edit_a_placement_wizard.rb
@@ -387,14 +387,6 @@ RSpec.shared_examples "an edit placement wizard", :js do
 
   private
 
-  def and_i_visit_the_sign_in_path
-    visit sign_in_path
-  end
-
-  def and_i_click_sign_in
-    click_on "Sign in using DfE Sign In"
-  end
-
   def then_i_should_see_the_mentor_name_in_the_placement_details(
     mentor_name:, change_link: "Change"
   )

--- a/spec/system/good_job_dashboard_spec.rb
+++ b/spec/system/good_job_dashboard_spec.rb
@@ -2,13 +2,13 @@ require "rails_helper"
 
 RSpec.describe "GoodJob admin dashboard", service: :placements, type: :system do
   scenario "Access the dashboard as a support user" do
-    given_i_am_a_support_user
+    given_i_am_signed_in_as_a_placements_support_user
     when_i_go_to_the_dashboard_path
     then_i_can_see_the_dashboard
   end
 
   scenario "Cannot access the dashboard as a regular user" do
-    given_i_am_a_regular_user
+    given_i_am_signed_in_as_a_placements_user
     when_i_go_to_the_dashboard_path
     then_i_cannot_see_the_dashboard
   end
@@ -19,14 +19,6 @@ RSpec.describe "GoodJob admin dashboard", service: :placements, type: :system do
   end
 
   private
-
-  def given_i_am_a_support_user
-    sign_in_as create(:placements_support_user)
-  end
-
-  def given_i_am_a_regular_user
-    sign_in_as create(:placements_user)
-  end
 
   def when_i_go_to_the_dashboard_path
     visit "/good_job"

--- a/spec/system/infinite_redirect_spec.rb
+++ b/spec/system/infinite_redirect_spec.rb
@@ -1,10 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Infinite redirect", service: :placements, type: :system do
-  let!(:user) { create(:placements_support_user) }
-
   scenario "When the support users permissions are removed they aren't stuck in an infinite loop" do
-    given_i_am_a_support_user
+    given_i_am_signed_in_as_a_placements_support_user
     when_i_view_all_organisations
     and_the_support_user_is_removed_as_a_support_user
     and_i_click_link("Organisations")
@@ -14,16 +12,12 @@ RSpec.describe "Infinite redirect", service: :placements, type: :system do
 
   private
 
-  def given_i_am_a_support_user
-    sign_in_as user
-  end
-
   def when_i_view_all_organisations
     visit placements_support_organisations_path
   end
 
   def and_the_support_user_is_removed_as_a_support_user
-    user.update!(type: "Placements::User")
+    @current_user.update!(type: "Placements::User")
   end
 
   def and_i_click_link(text)

--- a/spec/system/placements/authenticate_user_spec.rb
+++ b/spec/system/placements/authenticate_user_spec.rb
@@ -10,20 +10,12 @@ RSpec.describe "Authentication", service: :placements, type: :system do
   end
 
   scenario "As a user who has signed in" do
-    given_there_is_an_existing_placements_user_with_a_school_for(anne)
-    when_i_visit_the_sign_in_path
-    and_i_click_sign_in
+    given_i_am_signed_in_as_a_placements_user(organisations: [school])
     and_i_visit_placements_schools_details_path
     then_i_am_able_to_access_the_page
   end
 
   private
-
-  def given_there_is_an_existing_user_for(user_name)
-    user = create(:placements_user, user_name.downcase.to_sym)
-    create(:user_membership, user:, organisation: school, email: user.email)
-    user
-  end
 
   def when_i_visit_placements_schools_details_path
     visit placements_school_path(school.id)
@@ -37,23 +29,5 @@ RSpec.describe "Authentication", service: :placements, type: :system do
     expect(page).to have_content("NameSchool")
   end
 
-  def when_i_visit_the_sign_in_path
-    visit sign_in_path
-  end
-
-  def when_i_click_sign_in
-    click_on "Sign in using DfE Sign In"
-  end
-
-  def given_there_is_an_existing_placements_user_with_a_school_for(user)
-    user_exists_in_dfe_sign_in(user:)
-    create(
-      :user_membership,
-      user:,
-      organisation: school,
-    )
-  end
-
-  alias_method :and_i_click_sign_in, :when_i_click_sign_in
   alias_method :and_i_visit_placements_schools_details_path, :when_i_visit_placements_schools_details_path
 end

--- a/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
+++ b/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
@@ -13,13 +13,11 @@ RSpec.describe "Placements support user removes a user from an organisation", se
     let(:mary) { create(:placements_user, :mary) }
 
     before do
-      [anne, mary].each do |user|
-        create(:user_membership, user:, organisation: school)
-      end
+      create(:user_membership, user: anne, organisation: school)
+      given_i_am_signed_in_as_a_placements_user(organisations: [school])
     end
 
     scenario "user is removed from a school" do
-      given_i_am_signed_in_as_mary
       and_i_visit_the_user_page(anne)
       when_i_click_on("Delete user")
       then_i_am_asked_to_confirm(anne, school)
@@ -33,8 +31,7 @@ RSpec.describe "Placements support user removes a user from an organisation", se
     end
 
     scenario "I try to remove myself from a school" do
-      given_i_am_signed_in_as_mary
-      when_i_try_to_visit_the_remove_path_for(mary, school)
+      when_i_try_to_visit_the_remove_path_for(@current_user, school)
       then_i_am_redirected_back
     end
   end
@@ -45,13 +42,11 @@ RSpec.describe "Placements support user removes a user from an organisation", se
     let(:mary) { create(:placements_user, :mary) }
 
     before "message is sent to user" do
-      [anne, mary].each do |user|
-        create(:user_membership, user:, organisation: provider)
-      end
+      create(:user_membership, user: anne, organisation: provider)
+      given_i_am_signed_in_as_a_placements_user(organisations: [provider])
     end
 
     scenario "user is removed from a provider" do
-      given_i_am_signed_in_as_mary
       and_i_visit_the_user_page(anne)
       when_i_click_on("Delete user")
       then_i_am_asked_to_confirm(anne, provider)
@@ -65,19 +60,12 @@ RSpec.describe "Placements support user removes a user from an organisation", se
     end
 
     scenario "I try to remove myself from a school" do
-      given_i_am_signed_in_as_mary
-      when_i_try_to_visit_the_remove_path_for(mary, provider)
+      when_i_try_to_visit_the_remove_path_for(@current_user, provider)
       then_i_am_redirected_back
     end
   end
 
   private
-
-  def given_i_am_signed_in_as_mary
-    user_exists_in_dfe_sign_in(user: mary)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def email_removal_notification(email, _organisation)
     ActionMailer::Base.deliveries.find do |delivery|

--- a/spec/system/placements/organisations/users/user_views_other_users_spec.rb
+++ b/spec/system/placements/organisations/users/user_views_other_users_spec.rb
@@ -4,17 +4,19 @@ RSpec.describe "Placements user views other users in their organisation", servic
   let(:school) { create(:placements_school, name: "Placements School 1") }
   let(:provider) { create(:placements_provider, name: "Placements Provider 1") }
   let(:anne) { create(:placements_user, :anne) }
-  let(:mary) { create(:placements_user, :mary) }
 
   describe "schools" do
+    before do
+      create(:user_membership, user: anne, organisation: school)
+    end
+
     scenario "user can view other school users" do
-      user_exists_in_dfe_sign_in(user: mary)
-      given_users_have_been_assigned_to_the(organisation: school)
+      given_i_am_signed_in_as_a_placements_user(organisations: [school])
       when_i_visit_the_users_page
       then_i_see_the_organisation_users
       and_users_is_selected_in_schools_primary_nav
-      when_i_click_on_a_users_name(mary.full_name)
-      then_i_see_user_details(:school, user: mary)
+      when_i_click_on_a_users_name(@current_user.full_name)
+      then_i_see_user_details(:school, user: @current_user)
       and_users_is_selected_in_schools_primary_nav
       and_i_do_not_see_the_remove_user_link
       when_i_click_back
@@ -26,35 +28,30 @@ RSpec.describe "Placements user views other users in their organisation", servic
   end
 
   describe "providers" do
+    before do
+      create(:user_membership, user: anne, organisation: provider)
+    end
+
     scenario "users can view other provider users" do
-      user_exists_in_dfe_sign_in(user: anne)
-      given_users_have_been_assigned_to_the(organisation: provider)
+      given_i_am_signed_in_as_a_placements_user(organisations: [provider])
       when_i_visit_the_users_page
       then_i_see_the_organisation_users
       and_users_is_selected_in_providers_primary_nav
-      when_i_click_on_a_users_name(mary.full_name)
-      then_i_see_user_details(:provider, user: mary)
+      when_i_click_on_a_users_name(@current_user.full_name)
+      then_i_see_user_details(:provider, user: @current_user)
       and_users_is_selected_in_providers_primary_nav
-      and_i_see_the_remove_user_link
+      and_i_do_not_see_the_remove_user_link
       when_i_click_back
       when_i_click_on_a_users_name(anne.full_name)
       then_i_see_user_details(:provider, user: anne)
       and_users_is_selected_in_providers_primary_nav
-      and_i_do_not_see_the_remove_user_link
+      and_i_see_the_remove_user_link
     end
   end
 
   private
 
-  def given_users_have_been_assigned_to_the(organisation:)
-    [mary, anne].each do |user|
-      create(:user_membership, user:, organisation:)
-    end
-  end
-
   def when_i_visit_the_users_page
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
     within(".app-primary-navigation__nav") do
       click_on "Users"
     end
@@ -64,8 +61,8 @@ RSpec.describe "Placements user views other users in their organisation", servic
     expect(page).to have_content anne.full_name
     expect(page).to have_content anne.email
 
-    expect(page).to have_content mary.full_name
-    expect(page).to have_content mary.email
+    expect(page).to have_content @current_user.full_name
+    expect(page).to have_content @current_user.email
   end
 
   def when_i_click_on_a_users_name(user_name)

--- a/spec/system/placements/organisations/view_organisations_spec.rb
+++ b/spec/system/placements/organisations/view_organisations_spec.rb
@@ -10,11 +10,9 @@ RSpec.describe "View organisations", service: :placements, type: :system do
   let(:school_without_placement) { create(:school) }
 
   scenario "I sign in as user Mary with multiple organistions" do
-    user = given_the_placements_user("Mary")
-    user_exists_in_dfe_sign_in(user:)
-    and_user_has_multiple_organisations(user:)
-    when_i_visit_sign_in_path
-    when_i_click_sign_in
+    given_i_am_signed_in_as_a_placements_user(organisations: [
+      multi_org_school, multi_org_provider, claims_school, no_service_school
+    ])
     i_am_redirected_to_organisation_index
     and_i_only_see_placement_schools
     when_i_click_on_school_name
@@ -28,46 +26,21 @@ RSpec.describe "View organisations", service: :placements, type: :system do
   end
 
   scenario "I sign in as user Anne with one school" do
-    user = given_the_placements_user("Anne")
-    user_exists_in_dfe_sign_in(user:)
-    and_user_has_one_school(user:)
-    when_i_visit_sign_in_path
-    when_i_click_sign_in
-    then_i_see_the_one_school(one_school)
+    given_i_am_signed_in_as_a_placements_user(organisations: [one_school])
+    then_i_see_the_one_school
   end
 
   scenario "I sign in as user Anne with one provider" do
-    user = given_the_placements_user("Anne")
-    user_exists_in_dfe_sign_in(user:)
-    and_user_has_one_provider(user:)
-    when_i_visit_sign_in_path
-    when_i_click_sign_in
+    given_i_am_signed_in_as_a_placements_user(organisations: [one_provider])
     then_i_see_the_one_provider
   end
 
   scenario "I cannot view a school unless it is a placements school" do
-    user = given_the_placements_user("Anne")
-    user_exists_in_dfe_sign_in(user:)
-    and_user_has_a_school_without_a_service(user:)
-    when_i_visit_sign_in_path
-    when_i_click_sign_in
+    given_i_am_signed_in_as_a_placements_user(organisations: [one_school, school_without_placement])
     then_i_am_redirected_to_404_when_i_visit_the_school
   end
 
   private
-
-  def user(user_name)
-    create(:placements_user, user_name.downcase.to_sym)
-  end
-
-  def given_the_placements_user(user_name)
-    user(user_name)
-  end
-
-  def and_user_has_a_school_without_a_service(user:)
-    create(:user_membership, user:, organisation: create(:school, :placements))
-    create(:user_membership, user:, organisation: school_without_placement)
-  end
 
   def then_i_am_redirected_to_404_when_i_visit_the_school
     expect { visit placements_school_path(school_without_placement) }.to raise_error(ActiveRecord::RecordNotFound)
@@ -75,13 +48,6 @@ RSpec.describe "View organisations", service: :placements, type: :system do
 
   def then_i_am_redirected_to_404
     expect(page).to have_content("ERROR")
-  end
-
-  def and_user_has_multiple_organisations(user:)
-    create(:user_membership, user:, organisation: multi_org_school)
-    create(:user_membership, user:, organisation: multi_org_provider)
-    create(:user_membership, user:, organisation: claims_school)
-    create(:user_membership, user:, organisation: no_service_school)
   end
 
   def when_i_click_on_school_name
@@ -122,17 +88,9 @@ RSpec.describe "View organisations", service: :placements, type: :system do
     end
   end
 
-  def and_user_has_one_school(user:)
-    create(:user_membership, user:, organisation: one_school)
-  end
-
-  def and_user_has_one_provider(user:)
-    create(:user_membership, user:, organisation: one_provider)
-  end
-
-  def then_i_see_the_one_school(school)
+  def then_i_see_the_one_school
     expect(page).not_to have_content "Change organisation"
-    then_i_see_the_school_page(school)
+    then_i_see_the_school_page(one_school)
   end
 
   def then_i_see_the_one_provider

--- a/spec/system/placements/providers/partner_schools/add_a_partner_school_spec.rb
+++ b/spec/system/placements/providers/partner_schools/add_a_partner_school_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Placements / Providers / Partner schools / Add a partner school"
   let!(:school_user) { create(:placements_user, schools: [school]) }
 
   before do
-    given_i_sign_in_as_patricia
+    given_i_am_signed_in_as_a_placements_user(organisations: [provider])
   end
 
   scenario "User adds a partner school", :js, retry: 3 do
@@ -134,14 +134,6 @@ RSpec.describe "Placements / Providers / Partner schools / Add a partner school"
   end
 
   private
-
-  def given_i_sign_in_as_patricia
-    user = create(:placements_user, :patricia)
-    create(:user_membership, user:, organisation: provider)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_click_on(text)
     click_on text

--- a/spec/system/placements/providers/partner_schools/add_a_partner_school_without_javascript_spec.rb
+++ b/spec/system/placements/providers/partner_schools/add_a_partner_school_without_javascript_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Placements / Providers / Partner schools / Add a partner school 
     create(:school, :placements, name: "London")
     create(:school, :claims, name: "Claims")
 
-    given_i_sign_in_as_patricia
+    given_i_am_signed_in_as_a_placements_user(organisations: [provider])
   end
 
   scenario "User adds a partner school" do
@@ -98,14 +98,6 @@ RSpec.describe "Placements / Providers / Partner schools / Add a partner school 
   end
 
   private
-
-  def given_i_sign_in_as_patricia
-    user = create(:placements_user, :patricia)
-    create(:user_membership, user:, organisation: provider)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_click_on(text)
     click_on text

--- a/spec/system/placements/providers/partner_schools/placements/view_a_placement_for_partner_school_spec.rb
+++ b/spec/system/placements/providers/partner_schools/placements/view_a_placement_for_partner_school_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Placements / Providers / Partner schools / Placements / View a p
 
   before do
     placements_partnership
-    given_i_sign_in_as_patricia
+    given_i_am_signed_in_as_a_placements_user(organisations: [provider])
   end
 
   scenario "User views a placement for a partner school" do
@@ -19,14 +19,6 @@ RSpec.describe "Placements / Providers / Partner schools / Placements / View a p
   end
 
   private
-
-  def given_i_sign_in_as_patricia
-    user = create(:placements_user, :patricia)
-    create(:user_membership, user:, organisation: provider)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_view_the_partner_school_placements_page
     visit placements_provider_partner_school_placements_path(provider, school)

--- a/spec/system/placements/providers/partner_schools/placements/view_placements_for_partner_school_spec.rb
+++ b/spec/system/placements/providers/partner_schools/placements/view_placements_for_partner_school_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Placements / Providers / Partner schools / Placements / View pla
 
   before do
     placements_partnership
-    given_i_sign_in_as_patricia
+    given_i_am_signed_in_as_a_placements_user(organisations: [provider])
   end
 
   scenario "User views placements for a partner school" do
@@ -21,16 +21,6 @@ RSpec.describe "Placements / Providers / Partner schools / Placements / View pla
   end
 
   private
-
-  def given_i_sign_in_as_patricia
-    user = create(:placements_user, :patricia)
-    create(:user_membership, user:, organisation: provider)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
-
-  alias_method :and_i_sign_in_as_patricia, :given_i_sign_in_as_patricia
 
   def when_i_view_the_partner_school_show_page
     visit placements_provider_partner_school_path(provider, school)

--- a/spec/system/placements/providers/partner_schools/remove_a_partner_school_spec.rb
+++ b/spec/system/placements/providers/partner_schools/remove_a_partner_school_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Placements / Providers / Partner schools / Remove a partner scho
   end
 
   scenario "User removes a partner school" do
-    given_i_sign_in_as_patricia
+    given_i_am_signed_in_as_a_placements_user(organisations: [provider])
     when_i_view_the_partner_school_show_page
     and_i_click_on("Delete school")
     then_i_am_asked_to_confirm_partner_school(school)
@@ -54,7 +54,7 @@ RSpec.describe "Placements / Providers / Partner schools / Remove a partner scho
     end
 
     scenario "User removes a partner school, and see the placements listed" do
-      given_i_sign_in_as_patricia
+      given_i_am_signed_in_as_a_placements_user(organisations: [provider])
       when_i_view_the_partner_school_show_page
       and_i_click_on("Delete school")
       then_i_am_asked_to_confirm_partner_school(school)
@@ -72,7 +72,7 @@ RSpec.describe "Placements / Providers / Partner schools / Remove a partner scho
 
   scenario "User removes a partner school, which is not onboarded on the placements service" do
     given_the_school_is_not_onboarded_on_placements_service(school)
-    given_i_sign_in_as_patricia
+    given_i_am_signed_in_as_a_placements_user(organisations: [provider])
     when_i_view_the_partner_school_show_page
     and_i_click_on("Delete school")
     then_i_am_asked_to_confirm_partner_school(school)
@@ -87,14 +87,6 @@ RSpec.describe "Placements / Providers / Partner schools / Remove a partner scho
   end
 
   private
-
-  def given_i_sign_in_as_patricia
-    user = create(:placements_user, :patricia)
-    create(:user_membership, user:, organisation: provider)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_view_the_partner_school_show_page
     visit placements_provider_partner_school_path(provider, school)

--- a/spec/system/placements/providers/partner_schools/view_a_partner_school_spec.rb
+++ b/spec/system/placements/providers/partner_schools/view_a_partner_school_spec.rb
@@ -9,20 +9,12 @@ RSpec.describe "Placements / Providers / Partner schools / Views a partner schoo
   before { partnership }
 
   scenario "User views a provider partner school" do
-    given_i_sign_in_as_patricia
+    given_i_am_signed_in_as_a_placements_user(organisations: [provider])
     when_i_view_the_partner_school_show_page
     then_i_see_the_details_of(school)
   end
 
   private
-
-  def given_i_sign_in_as_patricia
-    user = create(:placements_user, :patricia)
-    create(:user_membership, user:, organisation: provider)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_view_the_partner_school_show_page
     visit placements_provider_partner_school_path(provider, school)

--- a/spec/system/placements/providers/partner_schools/view_partner_schools_list_spec.rb
+++ b/spec/system/placements/providers/partner_schools/view_partner_schools_list_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Placements / Providers / Partner schools / View a list of partne
   let!(:another_school) { create(:placements_school, name: "Shelbyville Elementary School", urn: "5678") }
 
   scenario "User views provider partner schools page where provider has no partner schools" do
-    given_i_sign_in_as_patricia
+    given_i_am_signed_in_as_a_placements_user(organisations: [provider])
     when_i_view_the_partner_schools_page
     then_i_see_the_empty_state
   end
@@ -16,22 +16,13 @@ RSpec.describe "Placements / Providers / Partner schools / View a list of partne
   scenario "User views provider partner schools page where provider has partner schools" do
     given_a_partnership_exists_between(school, provider)
     and_a_partnership_exists_between(another_school, another_provider)
-    and_i_sign_in_as_patricia
+    given_i_am_signed_in_as_a_placements_user(organisations: [provider])
     when_i_view_the_partner_schools_page
     then_i_see_partner_school(school)
     and_i_cannot_see_partner_school(another_school)
   end
 
   private
-
-  def given_i_sign_in_as_patricia
-    user = create(:placements_user, :patricia)
-    create(:user_membership, user:, organisation: provider)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
-  alias_method :and_i_sign_in_as_patricia, :given_i_sign_in_as_patricia
 
   def when_i_view_the_partner_schools_page
     visit placements_provider_partner_schools_path(provider)

--- a/spec/system/placements/providers/placements/searches_filter_options_for_placements_spec.rb
+++ b/spec/system/placements/providers/placements/searches_filter_options_for_placements_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Placements / Providers / Placements / Searches filter options fo
     guildford_placement
     bath_placement
 
-    given_i_sign_in_as_patricia
+    given_i_am_signed_in_as_a_placements_user(organisations: [provider])
     when_i_visit_the_placements_index_page
   end
 
@@ -93,14 +93,6 @@ RSpec.describe "Placements / Providers / Placements / Searches filter options fo
   end
 
   private
-
-  def given_i_sign_in_as_patricia
-    user = create(:placements_user, :patricia)
-    create(:user_membership, user:, organisation: provider)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_click_on(text)
     click_on text

--- a/spec/system/placements/providers/placements/searching_for_a_placement_spec.rb
+++ b/spec/system/placements/providers/placements/searching_for_a_placement_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Placements / Providers / Placements / Searching for a placements
     guildford_placement
     bath_placement
 
-    given_i_sign_in_as_patricia
+    given_i_am_signed_in_as_a_placements_user(organisations: [provider])
   end
 
   context "when searching for placements near a location (London)" do
@@ -132,14 +132,6 @@ RSpec.describe "Placements / Providers / Placements / Searching for a placements
   end
 
   private
-
-  def given_i_sign_in_as_patricia
-    user = create(:placements_user, :patricia)
-    create(:user_membership, user:, organisation: provider)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_click_on(text)
     click_on text

--- a/spec/system/placements/providers/placements/view_a_placement_spec.rb
+++ b/spec/system/placements/providers/placements/view_a_placement_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Placements / Providers / Placements / View a placement",
     create(:placement, subject: placement_subject, school:, additional_subjects:, academic_year:, terms:)
   end
 
-  before { given_i_sign_in_as_patricia }
+  before { given_i_am_signed_in_as_a_placements_user(organisations: [provider]) }
 
   context "when the placement has a subject without child subjects" do
     let(:placement_subject) { subject_1 }
@@ -68,14 +68,6 @@ RSpec.describe "Placements / Providers / Placements / View a placement",
   end
 
   private
-
-  def given_i_sign_in_as_patricia
-    user = create(:placements_user, :patricia)
-    create(:user_membership, user:, organisation: provider)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_visit_the_placement_show_page
     visit placements_provider_placement_path(provider, placement)

--- a/spec/system/placements/providers/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/providers/placements/view_placements_list_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Placements / Providers / Placements / View placements list",
   let(:placement_3) { create(:placement, subject: subject_3, school: secondary_school, provider: build(:placements_provider)) }
 
   before do
-    given_i_sign_in_as_patricia
+    given_i_am_signed_in_as_a_placements_user(organisations: [provider])
   end
 
   scenario "User views all placements page, when no placements exist" do
@@ -317,14 +317,6 @@ RSpec.describe "Placements / Providers / Placements / View placements list",
   end
 
   private
-
-  def given_i_sign_in_as_patricia
-    user = create(:placements_user, :patricia)
-    create(:user_membership, user:, organisation: provider)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_click_on(text)
     click_on text

--- a/spec/system/placements/providers/remembering_the_current_provider_spec.rb
+++ b/spec/system/placements/providers/remembering_the_current_provider_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Remembering the current provider", service: :placements, type: :
   let(:provider_two) { build(:placements_provider, name: "Ctrl + Alt + Teach") }
 
   scenario "A multi-org user switches between different providers" do
-    given_i_sign_in_with_access_to_multiple_providers
+    given_i_am_signed_in_as_a_placements_user(organisations: [provider_one, provider_two])
 
     when_i_click_on "The Chalkboard Champions"
     then_my_current_provider_is "The Chalkboard Champions"
@@ -20,13 +20,6 @@ RSpec.describe "Remembering the current provider", service: :placements, type: :
   end
 
   private
-
-  def given_i_sign_in_with_access_to_multiple_providers
-    user = create(:placements_user, providers: [provider_one, provider_two])
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_click_on(text)
     click_on text

--- a/spec/system/placements/providers/view_provider_details_spec.rb
+++ b/spec/system/placements/providers/view_provider_details_spec.rb
@@ -16,20 +16,12 @@ RSpec.describe "Placements / Providers / View provider details", service: :place
   end
 
   scenario "User views their provider's details" do
-    given_i_sign_in_as_patricia
+    given_i_am_signed_in_as_a_placements_user(organisations: [provider])
     when_i_view_my_organisation_details_page
     then_i_see_the_details_for_my_provider
   end
 
   private
-
-  def given_i_sign_in_as_patricia
-    user = create(:placements_user, :patricia)
-    create(:user_membership, user:, organisation: provider)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_view_my_organisation_details_page
     visit placements_provider_path(provider)

--- a/spec/system/placements/schools/mentors/delete_a_mentor_spec.rb
+++ b/spec/system/placements/schools/mentors/delete_a_mentor_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Placements / Schools / Mentors / Delete a mentor", service: :pla
 
   before do
     given_the_school_has_mentors(school:, mentors: [mentor_1, mentor_2])
-    given_i_sign_in_as_anne
+    given_i_am_signed_in_as_a_placements_user(organisations: [school])
   end
 
   context "when the mentor has no placements" do
@@ -45,30 +45,6 @@ RSpec.describe "Placements / Schools / Mentors / Delete a mentor", service: :pla
   end
 
   private
-
-  def and_there_is_an_existing_user_for(user_name)
-    user = create(:placements_user, user_name.downcase.to_sym)
-    user_exists_in_dfe_sign_in(user:)
-    and_user_has_one_school(user:)
-  end
-
-  def and_i_visit_the_sign_in_path
-    visit sign_in_path
-  end
-
-  def and_i_click_sign_in
-    click_on "Sign in using DfE Sign In"
-  end
-
-  def given_i_sign_in_as_anne
-    and_there_is_an_existing_user_for("Anne")
-    and_i_visit_the_sign_in_path
-    and_i_click_sign_in
-  end
-
-  def and_user_has_one_school(user:)
-    create(:user_membership, user:, organisation: school)
-  end
 
   def given_the_school_has_mentors(school:, mentors:)
     mentors.each do |mentor|

--- a/spec/system/placements/schools/mentors/user_adds_mentor_spec.rb
+++ b/spec/system/placements/schools/mentors/user_adds_mentor_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Placements school user adds mentors to schools", service: :place
   let(:placements_mentor) { create(:placements_mentor) }
   let(:new_mentor) { build(:placements_mentor) }
 
-  before { given_i_sign_in_as_anne }
+  before { given_i_am_signed_in_as_a_placements_user(organisations: [school]) }
 
   scenario "I can navigate back to the index page" do
     given_i_navigate_to_schools_mentors_list
@@ -212,14 +212,6 @@ RSpec.describe "Placements school user adds mentors to schools", service: :place
   end
 
   private
-
-  def given_i_sign_in_as_anne
-    user = create(:placements_user, :anne)
-    create(:user_membership, user:, organisation: school)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def given_a_claims_mentor_exists
     create(:claims_mentor_membership, school: another_school, mentor: claims_mentor)

--- a/spec/system/placements/schools/mentors/view_a_mentor_spec.rb
+++ b/spec/system/placements/schools/mentors/view_a_mentor_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe "Placements / Schools / Mentors / View a mentor", service: :place
   end
 
   before do
-    school
-    given_i_sign_in_as_anne
+    given_i_am_signed_in_as_a_placements_user(organisations: [school])
   end
 
   scenario "User views a school mentor's details" do
@@ -25,26 +24,6 @@ RSpec.describe "Placements / Schools / Mentors / View a mentor", service: :place
   end
 
   private
-
-  def and_there_is_an_existing_user_for(user_name)
-    user = create(:placements_user, user_name.downcase.to_sym)
-    user_exists_in_dfe_sign_in(user:)
-    and_user_has_one_school(user:)
-  end
-
-  def and_i_visit_the_sign_in_path
-    visit sign_in_path
-  end
-
-  def and_i_click_sign_in
-    click_on "Sign in using DfE Sign In"
-  end
-
-  def given_i_sign_in_as_anne
-    and_there_is_an_existing_user_for("Anne")
-    and_i_visit_the_sign_in_path
-    and_i_click_sign_in
-  end
 
   def given_a_mentor_exists_in(school:)
     create(:placements_mentor_membership, school:, mentor:)
@@ -65,9 +44,5 @@ RSpec.describe "Placements / Schools / Mentors / View a mentor", service: :place
       expect(page).to have_content(last_name)
       expect(page).to have_content(trn)
     end
-  end
-
-  def and_user_has_one_school(user:)
-    create(:user_membership, user:, organisation: school)
   end
 end

--- a/spec/system/placements/schools/mentors/view_mentors_spec.rb
+++ b/spec/system/placements/schools/mentors/view_mentors_spec.rb
@@ -6,42 +6,21 @@ RSpec.describe "Placements / Schools / Mentors / View mentors", service: :placem
   let!(:mentor3) { create(:mentor, trn: "1231233") }
   let!(:school) { create(:placements_school, mentors: [mentor1, mentor2]) }
   let!(:another_school) { create(:placements_school) }
-  let!(:anne) do
-    create(
-      :placements_user,
-      :anne,
-      user_memberships: [create(:user_membership, organisation: school)],
-    )
-  end
-  let!(:mary) do
-    create(
-      :placements_user,
-      :mary,
-      user_memberships: [create(:user_membership, organisation: another_school)],
-    )
-  end
 
   scenario "View a school's mentors as a user" do
-    user_exists_in_dfe_sign_in(user: anne)
-    given_i_sign_in
+    given_i_am_signed_in_as_a_placements_user(organisations: [school])
     when_i_visit_the_school_mentors_page(school)
     then_i_see_a_list_of_the_schools_mentors
     and_i_dont_see_mentors_from_another_school
   end
 
   scenario "View a school's empty mentors list" do
-    user_exists_in_dfe_sign_in(user: mary)
-    given_i_sign_in
+    given_i_am_signed_in_as_a_placements_user(organisations: [another_school])
     when_i_visit_the_school_mentors_page(another_school)
     then_i_see_no_results
   end
 
   private
-
-  def given_i_sign_in
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_visit_the_school_mentors_page(school)
     visit placements_school_mentors_path(school)

--- a/spec/system/placements/schools/partner_providers/add_a_partner_provider_spec.rb
+++ b/spec/system/placements/schools/partner_providers/add_a_partner_provider_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Placements / Schools / Partner providers / Add a partner provide
   let!(:provider_user) { create(:placements_user, providers: [provider]) }
 
   before do
-    given_i_sign_in_as_anne
+    given_i_am_signed_in_as_a_placements_user(organisations: [school])
   end
 
   scenario "User adds a partner provider", :js, retry: 3 do
@@ -134,14 +134,6 @@ RSpec.describe "Placements / Schools / Partner providers / Add a partner provide
   end
 
   private
-
-  def given_i_sign_in_as_anne
-    user = create(:placements_user, :anne)
-    create(:user_membership, user:, organisation: school)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_view_the_partner_providers_page
     visit placements_school_partner_providers_path(school)

--- a/spec/system/placements/schools/partner_providers/add_a_partner_provider_without_javascript_spec.rb
+++ b/spec/system/placements/schools/partner_providers/add_a_partner_provider_without_javascript_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Placements / Schools / Partner providers / Add a partner provide
     create(:provider, :placements, name: "London")
     create(:claims_provider, name: "Claims")
 
-    given_i_sign_in_as_anne
+    given_i_am_signed_in_as_a_placements_user(organisations: [school])
   end
 
   scenario "User adds a partner provider" do
@@ -98,14 +98,6 @@ RSpec.describe "Placements / Schools / Partner providers / Add a partner provide
   end
 
   private
-
-  def given_i_sign_in_as_anne
-    user = create(:placements_user, :anne)
-    create(:user_membership, user:, organisation: school)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_visit_the_add_partner_provider_page
     visit new_add_partner_provider_placements_school_partner_providers_path(school)

--- a/spec/system/placements/schools/partner_providers/remove_a_partner_provider_spec.rb
+++ b/spec/system/placements/schools/partner_providers/remove_a_partner_provider_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Placements / Schools / Partner providers / Remove a partner prov
   end
 
   scenario "User removes a partner provider" do
-    given_i_sign_in_as_anne
+    given_i_am_signed_in_as_a_placements_user(organisations: [school])
     when_i_view_the_partner_provider_show_page
     and_i_click_on("Delete provider")
     then_i_am_asked_to_confirm_partner_provider(provider)
@@ -39,7 +39,7 @@ RSpec.describe "Placements / Schools / Partner providers / Remove a partner prov
 
   scenario "User removes a partner provider, which is not onboarded on the placements service" do
     given_the_provider_is_not_onboarded_on_placements_service(provider)
-    given_i_sign_in_as_anne
+    given_i_am_signed_in_as_a_placements_user(organisations: [school])
     when_i_view_the_partner_provider_show_page
     and_i_click_on("Delete provider")
     then_i_am_asked_to_confirm_partner_provider(provider)
@@ -54,14 +54,6 @@ RSpec.describe "Placements / Schools / Partner providers / Remove a partner prov
   end
 
   private
-
-  def given_i_sign_in_as_anne
-    user = create(:placements_user, :anne)
-    create(:user_membership, user:, organisation: school)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_view_the_partner_provider_show_page
     visit placements_school_partner_provider_path(school, provider)

--- a/spec/system/placements/schools/partner_providers/view_a_partner_provider_spec.rb
+++ b/spec/system/placements/schools/partner_providers/view_a_partner_provider_spec.rb
@@ -9,20 +9,12 @@ RSpec.describe "Placements / Schools / Partner providers / Views a partner provi
   before { partnership }
 
   scenario "User views a school partner provider" do
-    given_i_sign_in_as_anne
+    given_i_am_signed_in_as_a_placements_user(organisations: [school])
     when_i_view_the_partner_provider_show_page
     then_i_see_the_details_of(provider)
   end
 
   private
-
-  def given_i_sign_in_as_anne
-    user = create(:placements_user, :anne)
-    create(:user_membership, user:, organisation: school)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_view_the_partner_provider_show_page
     visit placements_school_partner_provider_path(school, provider)

--- a/spec/system/placements/schools/partner_providers/view_partner_providers_list_spec.rb
+++ b/spec/system/placements/schools/partner_providers/view_partner_providers_list_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Placements / Schools / Partner providers / View a list of partne
   let!(:another_provider) { create(:placements_provider, name: "Burns University", ukprn: "5678") }
 
   scenario "User views school partner providers page where school has no partner providers" do
-    given_i_sign_in_as_anne
+    given_i_am_signed_in_as_a_placements_user(organisations: [school])
     when_i_view_the_partner_providers_page
     then_i_see_the_empty_state
   end
@@ -16,22 +16,13 @@ RSpec.describe "Placements / Schools / Partner providers / View a list of partne
   scenario "User views school partner providers page where school has partner providers" do
     given_a_partnership_exists_between(school, provider)
     and_a_partnership_exists_between(another_school, another_provider)
-    and_i_sign_in_as_anne
+    given_i_am_signed_in_as_a_placements_user(organisations: [school])
     when_i_view_the_partner_providers_page
     then_i_see_partner_provider(provider)
     and_i_cannot_see_partner_provider(another_provider)
   end
 
   private
-
-  def given_i_sign_in_as_anne
-    user = create(:placements_user, :anne)
-    create(:user_membership, user:, organisation: school)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
-  alias_method :and_i_sign_in_as_anne, :given_i_sign_in_as_anne
 
   def when_i_view_the_partner_providers_page
     visit placements_school_partner_providers_path(school)

--- a/spec/system/placements/schools/placements/add_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/add_a_placement_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Placements / Schools / Placements / Add a placement",
                service: :placements, type: :system do
   before do
-    given_i_sign_in_as_anne
+    given_i_am_signed_in_as_a_placements_user(organisations: [school])
   end
 
   context "when the school has no school contact assigned" do
@@ -21,26 +21,6 @@ RSpec.describe "Placements / Schools / Placements / Add a placement",
   it_behaves_like "an add a placement wizard"
 
   private
-
-  def given_i_sign_in_as_anne
-    and_there_is_an_existing_user_for("Anne")
-    and_i_visit_the_sign_in_path
-    and_i_click_sign_in
-  end
-
-  def and_there_is_an_existing_user_for(user_name)
-    user = create(:placements_user, user_name.downcase.to_sym)
-    user_exists_in_dfe_sign_in(user:)
-    create(:user_membership, user:, organisation: school)
-  end
-
-  def and_i_visit_the_sign_in_path
-    visit sign_in_path
-  end
-
-  def and_i_click_sign_in
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_visit_the_placements_page
     visit placements_school_placements_path(school)

--- a/spec/system/placements/schools/placements/delete_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/delete_a_placement_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Placements / Schools / Placements / Delete a placement",
   let(:subject_2) { build(:subject, name: "Subject 2", subject_area: :primary) }
 
   before do
-    given_i_sign_in_as_anne
+    given_i_am_signed_in_as_a_placements_user(organisations: [school])
     placement_2
     when_i_visit_the_placement_show_page(placement_1)
   end
@@ -34,28 +34,8 @@ RSpec.describe "Placements / Schools / Placements / Delete a placement",
 
   private
 
-  def and_there_is_an_existing_user_for(user_name)
-    user = create(:placements_user, user_name.downcase.to_sym)
-    user_exists_in_dfe_sign_in(user:)
-    create(:user_membership, user:, organisation: school)
-  end
-
-  def and_i_visit_the_sign_in_path
-    visit sign_in_path
-  end
-
-  def and_i_click_sign_in
-    click_on "Sign in using DfE Sign In"
-  end
-
   def when_i_visit_the_placement_show_page(placement)
     visit placements_school_placement_path(school, placement)
-  end
-
-  def given_i_sign_in_as_anne
-    and_there_is_an_existing_user_for("Anne")
-    and_i_visit_the_sign_in_path
-    and_i_click_sign_in
   end
 
   def when_i_click_on(text)

--- a/spec/system/placements/schools/placements/edit_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/edit_a_placement_spec.rb
@@ -2,23 +2,11 @@ require "rails_helper"
 
 RSpec.describe "Placements / Schools / Placements / Edit a placement",
                service: :placements, type: :system do
-  before { given_i_sign_in_as_anne }
+  before { given_i_am_signed_in_as_a_placements_user(organisations: [school]) }
 
   it_behaves_like "an edit placement wizard"
 
   private
-
-  def given_i_sign_in_as_anne
-    and_there_is_an_existing_user_for("Anne")
-    and_i_visit_the_sign_in_path
-    and_i_click_sign_in
-  end
-
-  def and_there_is_an_existing_user_for(user_name)
-    user = create(:placements_user, user_name.downcase.to_sym)
-    user_exists_in_dfe_sign_in(user:)
-    create(:user_membership, user:, organisation: school)
-  end
 
   def then_i_am_redirected_to_add_a_partner_provider
     expect(page).to have_current_path(

--- a/spec/system/placements/schools/placements/navigate_placements_spec.rb
+++ b/spec/system/placements/schools/placements/navigate_placements_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Placements / Schools / Placements / Navigate placements",
   let!(:placement_for_next_academic_year) { create(:placement, school:, academic_year: academic_year.next).decorate }
 
   before do
-    given_i_sign_in_as_anne
+    given_i_am_signed_in_as_a_placements_user(organisations: [school])
   end
 
   context "when viewing placements from the current academic year" do
@@ -34,26 +34,6 @@ RSpec.describe "Placements / Schools / Placements / Navigate placements",
   end
 
   private
-
-  def and_there_is_an_existing_user_for(user_name)
-    user = create(:placements_user, user_name.downcase.to_sym)
-    user_exists_in_dfe_sign_in(user:)
-    create(:user_membership, user:, organisation: school)
-  end
-
-  def and_i_visit_the_sign_in_path
-    visit sign_in_path
-  end
-
-  def and_i_click_sign_in
-    click_on "Sign in using DfE Sign In"
-  end
-
-  def given_i_sign_in_as_anne
-    and_there_is_an_existing_user_for("Anne")
-    and_i_visit_the_sign_in_path
-    and_i_click_sign_in
-  end
 
   def when_i_visit_the_placements_page
     visit placements_school_placements_path(school)

--- a/spec/system/placements/schools/placements/view_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/view_a_placement_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
   let(:partnership) { create(:placements_partnership, provider:, school:) }
 
   before do
-    given_i_sign_in_as_anne
+    given_i_am_signed_in_as_a_placements_user(organisations: [school])
   end
 
   context "with subjects" do
@@ -181,31 +181,11 @@ RSpec.describe "Placements / Schools / Placements / View a placement",
 
   private
 
-  def and_there_is_an_existing_user_for(user_name)
-    user = create(:placements_user, user_name.downcase.to_sym)
-    user_exists_in_dfe_sign_in(user:)
-    create(:user_membership, user:, organisation: school)
-  end
-
-  def and_i_visit_the_sign_in_path
-    visit sign_in_path
-  end
-
-  def and_i_click_sign_in
-    click_on "Sign in using DfE Sign In"
-  end
-
   def when_i_visit_the_placement_show_page
     visit placements_school_placement_path(school, placement)
   end
 
   alias_method :given_i_visit_the_placement_show_page, :when_i_visit_the_placement_show_page
-
-  def given_i_sign_in_as_anne
-    and_there_is_an_existing_user_for("Anne")
-    and_i_visit_the_sign_in_path
-    and_i_click_sign_in
-  end
 
   def given_a_placement_has_one_subject(placements_subject)
     placement.update(subject: placements_subject)

--- a/spec/system/placements/schools/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/schools/placements/view_placements_list_spec.rb
@@ -5,52 +5,52 @@ RSpec.describe "Placement school user views a list of placements", service: :pla
   let!(:another_school) { create(:placements_school) }
 
   scenario "View school placements page where school has no placements" do
-    given_i_sign_in_as_anne
+    given_i_am_signed_in_as_a_placements_user(organisations: [school])
     then_i_see_the_placements_page
     then_i_see_the_empty_state
   end
 
   scenario "where placements for another school exists" do
     given_placement_exists_for_another_school
-    given_i_sign_in_as_anne
+    given_i_am_signed_in_as_a_placements_user(organisations: [school])
     then_i_see_the_empty_state
   end
 
   context "with placements" do
     scenario "where placement has multiple mentors" do
       given_a_placement_exists_with_multiple_mentors
-      given_i_sign_in_as_anne
+      given_i_am_signed_in_as_a_placements_user(organisations: [school])
       then_i_see_mentor_names("Bart Simpson and Lisa Simpson")
       and_i_see_subject_names("Biology")
     end
 
     scenario "where placement has no mentors attached" do
       given_a_placement_exists
-      given_i_sign_in_as_anne
+      given_i_am_signed_in_as_a_placements_user(organisations: [school])
       then_i_see_mentor_names("Not yet known")
     end
 
     scenario "when the placement has a provider" do
       given_a_placement_exists_with_a_provider
-      given_i_sign_in_as_anne
+      given_i_am_signed_in_as_a_placements_user(organisations: [school])
       then_i_see_the_provider_name("Springfield University")
     end
 
     scenario "when the placement does not have a provider" do
       given_a_placement_exists
-      given_i_sign_in_as_anne
+      given_i_am_signed_in_as_a_placements_user(organisations: [school])
       then_i_see_the_provider_name("Not yet known")
     end
 
     scenario "when the placement has no terms" do
       given_a_placement_exists
-      given_i_sign_in_as_anne
+      given_i_am_signed_in_as_a_placements_user(organisations: [school])
       then_i_see_term_name("Any time in the academic year")
     end
 
     scenario "when the placement has terms" do
       given_a_placement_exists(with_term: true)
-      given_i_sign_in_as_anne
+      given_i_am_signed_in_as_a_placements_user(organisations: [school])
       then_i_see_term_name("Autumn term")
     end
 
@@ -64,20 +64,20 @@ RSpec.describe "Placement school user views a list of placements", service: :pla
       let!(:next_academic_year_placement) { create(:placement, school:, academic_year: next_academic_year, subject: next_subject) }
 
       scenario "when I view placements for the current academic year" do
-        given_i_sign_in_as_anne
+        given_i_am_signed_in_as_a_placements_user(organisations: [school])
         then_i_see_placement(current_academic_year_placement)
         and_i_do_not_see_placement(next_academic_year_placement)
       end
 
       scenario "when I view placements for the next academic year" do
-        given_i_sign_in_as_anne
+        given_i_am_signed_in_as_a_placements_user(organisations: [school])
         when_i_click_on("Next year (#{next_academic_year.name})")
         then_i_see_placement(next_academic_year_placement)
         and_i_do_not_see_placement(current_academic_year_placement)
       end
 
       scenario "I can switch between academic years" do
-        given_i_sign_in_as_anne
+        given_i_am_signed_in_as_a_placements_user(organisations: [school])
         then_i_see_placement(current_academic_year_placement)
         and_i_do_not_see_placement(next_academic_year_placement)
 
@@ -93,14 +93,6 @@ RSpec.describe "Placement school user views a list of placements", service: :pla
   end
 
   private
-
-  def given_i_sign_in_as_anne
-    user = create(:placements_user, :anne)
-    create(:user_membership, user:, organisation: school)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def given_a_placement_exists(with_term: false)
     with_term ? create(:placement, school:, terms: [create(:placements_term, :autumn)]) : create(:placement, school:)

--- a/spec/system/placements/schools/school_contacts/add_a_school_contact_spec.rb
+++ b/spec/system/placements/schools/school_contacts/add_a_school_contact_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Placements / Schools / School Contacts / Add a school contact",
   let(:school) { build(:placements_school, with_school_contact: false) }
 
   before do
-    given_i_sign_in_as_anne
+    given_i_am_signed_in_as_a_placements_user(organisations: [school])
   end
 
   scenario "User adds a school contact to their organisation" do
@@ -120,14 +120,6 @@ RSpec.describe "Placements / Schools / School Contacts / Add a school contact",
   end
 
   private
-
-  def given_i_sign_in_as_anne
-    user = create(:placements_user, :anne)
-    create(:user_membership, user:, organisation: school)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_view_my_organisation_details_page
     visit placements_school_path(school)

--- a/spec/system/placements/schools/school_contacts/edit_a_school_contact_spec.rb
+++ b/spec/system/placements/schools/school_contacts/edit_a_school_contact_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Placements / Schools / School Contacts / Edit a school contact",
   let(:school_contact) { school.school_contact }
 
   before do
-    given_i_sign_in_as_anne
+    given_i_am_signed_in_as_a_placements_user(organisations: [school])
     school_contact
   end
 
@@ -84,14 +84,6 @@ RSpec.describe "Placements / Schools / School Contacts / Edit a school contact",
   end
 
   private
-
-  def given_i_sign_in_as_anne
-    user = create(:placements_user, :anne)
-    create(:user_membership, user:, organisation: school)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_view_my_organisation_details_page
     visit placements_school_path(school)

--- a/spec/system/placements/sign_in_as_a_placements_user_spec.rb
+++ b/spec/system/placements/sign_in_as_a_placements_user_spec.rb
@@ -2,9 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Sign In as a Placements User", service: :placements, type: :system do
   scenario "I sign in as a non-support user, with no organisation" do
-    given_there_is_an_existing_user_for("Anne")
-    when_i_visit_the_sign_in_path
-    when_i_click_sign_in
+    given_i_am_signed_in_as_a_placements_user
     then_i_dont_get_redirected_to_support_organisations
     and_i_see_an_empty_organsations_page
   end
@@ -13,10 +11,7 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
     let!(:organisation) { create(:school, :placements, name: "Placement School") }
 
     scenario "I sign in as a school user and see my schools placements" do
-      given_there_is_an_existing_user_for("Anne")
-      and_the_user_is_part_of_an_organisation(organisation)
-      when_i_visit_the_sign_in_path
-      when_i_click_sign_in
+      given_i_am_signed_in_as_a_placements_user(organisations: [organisation])
       then_i_dont_get_redirected_to_support_organisations
       then_i_can_see_the_placements_school_placements_page
     end
@@ -26,10 +21,7 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
     let!(:organisation) { create(:provider, :placements, name: "Provider") }
 
     scenario "I sign in as a provider user and see the placements list page" do
-      given_there_is_an_existing_user_for("Anne")
-      and_the_user_is_part_of_an_organisation(organisation)
-      when_i_visit_the_sign_in_path
-      when_i_click_sign_in
+      given_i_am_signed_in_as_a_placements_user(organisations: [organisation])
       then_i_dont_get_redirected_to_support_organisations
       then_i_can_see_the_placements_page
     end
@@ -40,38 +32,30 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
     let(:provider_organisation) { create(:provider, :placements, name: "Provider") }
 
     scenario "I sign in as a multi organisation user and see a list of my organisations" do
-      given_there_is_an_existing_user_for("Anne")
-      and_the_user_is_part_of_an_organisation(organisation)
-      and_the_user_is_part_of_an_organisation(provider_organisation)
-      when_i_visit_the_sign_in_path
-      when_i_click_sign_in
+      given_i_am_signed_in_as_a_placements_user(organisations: [organisation, provider_organisation])
       then_i_dont_get_redirected_to_support_organisations
       then_i_am_redirected_to_the_organisations_page
     end
   end
 
   scenario "I sign in as a support user" do
-    given_there_is_an_existing_support_user_for("Colin")
-    and_there_are_placement_organisations
-    when_i_visit_the_sign_in_path
-    when_i_click_sign_in
+    given_there_are_placement_organisations
+    given_i_am_signed_in_as_a_placements_support_user
     then_i_see_a_list_of_organisations
   end
 
   context "when response from dfe sign in is invalid" do
     scenario "I sign in as user colin" do
       invalid_dfe_sign_in_response
-      when_i_visit_the_sign_in_path
-      when_i_click_sign_in
+      when_i_visit_the(sign_in_path)
+      when_i_click_on("Sign in using DfE Sign In")
       i_do_not_have_access_to_the_service
     end
   end
 
   context "when normal user tries to access support user page" do
     scenario "I sign in as user mary trying to access support user page" do
-      given_there_is_an_existing_user_for("Mary")
-      when_i_visit_the_sign_in_path
-      when_i_click_sign_in
+      given_i_am_signed_in_as_a_placements_user
       visit_support_page
       i_do_not_have_access_to_support_page
     end
@@ -80,20 +64,19 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
   context "when dsi fails" do
     scenario "I try to sign in as support user" do
       when_dsi_fails
-      when_i_visit_the_sign_in_path
-      when_i_click_sign_in
+      when_i_visit_the(sign_in_path)
+      when_i_click_on("Sign in using DfE Sign In")
       then_i_am_redirect_to_internal_server_error
     end
   end
 
   context "when the user has both a support and non-support account" do
     scenario "I sign in as user colin and accesses the support user page" do
-      given_there_is_an_existing_user_for("Colin")
-      given_there_is_an_existing_support_user_for("Colin")
-      and_there_are_placement_organisations
+      given_there_are_placement_organisations
+      given_i_am_signed_in_as_a_placements_user
+      and_the_placements_user_is_also_a_support_user
+      when_i_visit_the(sign_in_path)
 
-      when_i_visit_the_sign_in_path
-      when_i_click_sign_in
       then_i_see_a_list_of_organisations
     end
   end
@@ -101,19 +84,15 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
   context "when the user does not have a DfE ID" do
     context "when the user is not a support user" do
       scenario "I sign in as user Anne, using my email address" do
-        given_there_is_an_existing_user_for("Anne", with_dfe_sign_id: false)
-        when_i_visit_the_sign_in_path
-        when_i_click_sign_in
+        given_i_am_signed_in_as_a_placements_user(with_dfe_sign_id: false)
         then_i_dont_get_redirected_to_support_organisations
       end
     end
 
     context "when the user is a support user" do
       scenario "I sign in as support user Colin, using my email address" do
-        given_there_is_an_existing_support_user_for("Colin", with_dfe_sign_id: false)
-        and_there_are_placement_organisations
-        when_i_visit_the_sign_in_path
-        when_i_click_sign_in
+        given_there_are_placement_organisations
+        given_i_am_signed_in_as_a_placements_support_user(with_dfe_sign_id: false)
         then_i_see_a_list_of_organisations
       end
     end
@@ -122,10 +101,10 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
   context "when I use a deep link without being logged in" do
     context "when I am a support user" do
       scenario "when I sign in as Colin I am redirected to my requested page" do
-        given_there_is_an_existing_support_user_for("Colin")
+        given_i_am_signed_in_as_a_placements_support_user(sign_in: false)
         when_i_visit_the_support_users_path
         then_i_am_redirected_to_the_sign_in_page
-        when_i_click_sign_in
+        when_i_click_on("Sign in using DfE Sign In")
         then_i_am_redirected_to_the_support_users_page
       end
     end
@@ -135,21 +114,21 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
       let(:provider_organisation) { create(:provider, :placements, name: "Provider") }
 
       scenario "when I sign in as a school user I am redirected to my requested page" do
-        given_there_is_an_existing_user_for("Anne")
-        and_the_user_is_part_of_an_organisation(organisation)
+        given_i_am_signed_in_as_a_placements_user(organisations: [organisation], sign_in: false)
         when_i_visit_the_school_users_path(organisation)
         then_i_am_redirected_to_the_sign_in_page
-        when_i_click_sign_in
+        when_i_click_on("Sign in using DfE Sign In")
         then_i_am_redirected_to_the_school_users_page(organisation)
       end
 
       scenario "when I sign in as a multi-organisation user I am redirected to my organisations page" do
-        given_there_is_an_existing_user_for("Anne")
-        and_the_user_is_part_of_an_organisation(organisation)
-        and_the_user_is_part_of_an_organisation(provider_organisation)
+        given_i_am_signed_in_as_a_placements_user(
+          organisations: [organisation, provider_organisation],
+          sign_in: false,
+        )
         when_i_visit_the_school_users_path(organisation)
         then_i_am_redirected_to_the_sign_in_page
-        when_i_click_sign_in
+        when_i_click_on("Sign in using DfE Sign In")
         then_i_am_redirected_to_the_school_users_page(organisation)
       end
     end
@@ -158,11 +137,10 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
       let!(:organisation) { create(:school, :placements, name: "Deep Link Placement School") }
 
       scenario "when I sign in as a school user I am redirect to the placements page" do
-        given_there_is_an_existing_user_for("Anne")
-        and_the_user_is_part_of_an_organisation(organisation)
+        given_i_am_signed_in_as_a_placements_user(organisations: [organisation], sign_in: false)
         when_i_visit_the(sign_in_path)
         then_i_am_redirected_to_the_sign_in_page
-        when_i_click_sign_in
+        when_i_click_on("Sign in using DfE Sign In")
         then_i_can_see_the_placements_school_placements_page
       end
     end
@@ -171,11 +149,10 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
       let!(:organisation) { create(:school, :placements, name: "Deep Link Placement School") }
 
       scenario "when I sign in as a school user I am redirect to the placements page" do
-        given_there_is_an_existing_user_for("Anne")
-        and_the_user_is_part_of_an_organisation(organisation)
+        given_i_am_signed_in_as_a_placements_user(organisations: [organisation], sign_in: false)
         when_i_visit_the(sign_out_path)
         then_i_am_redirected_to_the_sign_in_page
-        when_i_click_sign_in
+        when_i_click_on("Sign in using DfE Sign In")
         then_i_can_see_the_placements_school_placements_page
       end
     end
@@ -185,11 +162,10 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
 
       context "when I sign in as a school user" do
         scenario "I am redirected to the placements page for my school" do
-          given_there_is_an_existing_user_for("Anne")
-          and_the_user_is_part_of_an_organisation(organisation)
+          given_i_am_signed_in_as_a_placements_user(organisations: [organisation], sign_in: false)
           when_i_visit_the_school_users_path(organisation)
           then_i_am_redirected_to_the_sign_in_page
-          when_i_click_sign_in
+          when_i_click_on("Sign in using DfE Sign In")
           then_i_am_redirected_to_the_school_users_page(organisation)
           when_i_visit_the placements_root_path
           and_i_click_on "Start now"
@@ -201,11 +177,10 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
         let!(:organisation) { create(:provider, :placements, name: "Provider") }
 
         scenario "I am redirected to the placements page for my school" do
-          given_there_is_an_existing_user_for("Anne")
-          and_the_user_is_part_of_an_organisation(organisation)
+          given_i_am_signed_in_as_a_placements_user(organisations: [organisation], sign_in: false)
           when_i_visit_the_provider_users_path(organisation)
           then_i_am_redirected_to_the_sign_in_page
-          when_i_click_sign_in
+          when_i_click_on("Sign in using DfE Sign In")
           then_i_am_redirected_to_the_provider_users_page(organisation)
           when_i_visit_the placements_root_path
           and_i_click_on "Start now"
@@ -218,12 +193,13 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
         let!(:provider_organisation) { create(:provider, :placements, name: "Provider") }
 
         scenario "I am redirected to the list of my organisations" do
-          given_there_is_an_existing_user_for("Anne")
-          and_the_user_is_part_of_an_organisation(organisation)
-          and_the_user_is_part_of_an_organisation(provider_organisation)
+          given_i_am_signed_in_as_a_placements_user(
+            organisations: [organisation, provider_organisation],
+            sign_in: false,
+          )
           when_i_visit_the_school_users_path(organisation)
           then_i_am_redirected_to_the_sign_in_page
-          when_i_click_sign_in
+          when_i_click_on("Sign in using DfE Sign In")
           then_i_am_redirected_to_the_school_users_page(organisation)
           when_i_visit_the placements_root_path
           and_i_click_on "Start now"
@@ -233,11 +209,11 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
 
       context "when I sign in as support user Colin" do
         scenario "I am redirected to the support organisation list page" do
-          given_there_is_an_existing_support_user_for("Colin")
-          and_there_are_placement_organisations
+          given_there_are_placement_organisations
+          given_i_am_signed_in_as_a_placements_support_user(sign_in: false)
           and_i_visit_a_school_show_page
           then_i_am_redirected_to_the_sign_in_page
-          when_i_click_sign_in
+          when_i_click_on("Sign in using DfE Sign In")
           then_i_see_school_show_page
           when_i_visit_the placements_root_path
           and_i_click_on "Start now"
@@ -249,22 +225,6 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
 
   private
 
-  def given_there_is_an_existing_user_for(user_name, with_dfe_sign_id: true)
-    user = create(:placements_user, user_name.downcase.to_sym)
-    user.update!(dfe_sign_in_uid: nil) unless with_dfe_sign_id
-    user_exists_in_dfe_sign_in(user:)
-  end
-
-  def given_there_is_an_existing_support_user_for(user_name, with_dfe_sign_id: true)
-    user = create(:placements_support_user, user_name.downcase.to_sym)
-    user.update!(dfe_sign_in_uid: nil) unless with_dfe_sign_id
-    user_exists_in_dfe_sign_in(user:)
-  end
-
-  def when_i_visit_the_sign_in_path
-    visit sign_in_path
-  end
-
   def and_i_visit_a_school_show_page
     visit placements_school_path(organisation)
   end
@@ -274,18 +234,15 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
     expect(page).to have_content(organisation.name)
   end
 
-  def and_there_are_placement_organisations
+  def given_there_are_placement_organisations
     create(:school, :placements, name: "Placement School")
     create(:placements_provider, name: "Provider 1")
-  end
-
-  def when_i_click_sign_in
-    click_on "Sign in using DfE Sign In"
   end
 
   def and_i_click_on(text)
     click_on text
   end
+  alias_method :when_i_click_on, :and_i_click_on
 
   def when_i_visit_the(path)
     visit path
@@ -374,5 +331,9 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
 
   def then_i_am_redirected_to_the_provider_users_page(organisation)
     expect(page).to have_current_path(placements_provider_users_path(organisation))
+  end
+
+  def and_the_placements_user_is_also_a_support_user
+    @current_user.update!(type: Placements::SupportUser)
   end
 end

--- a/spec/system/placements/sign_out_as_a_placements_user_spec.rb
+++ b/spec/system/placements/sign_out_as_a_placements_user_spec.rb
@@ -10,9 +10,7 @@ RSpec.describe "Sign out as a Placements User", service: :placements, type: :sys
   end
 
   scenario "I sign out" do
-    given_there_is_an_existing_placements_user_with_a_school_for(colin)
-    when_i_visit_the_sign_in_path
-    when_i_click_sign_in
+    given_i_am_signed_in_as_a_placements_support_user
     i_should_see_a_sign_out_button
     when_i_click_sign_out
     i_expect_to_be_on_sign_in_page
@@ -21,23 +19,6 @@ RSpec.describe "Sign out as a Placements User", service: :placements, type: :sys
   end
 
   private
-
-  def given_there_is_an_existing_placements_user_with_a_school_for(user)
-    user_exists_in_dfe_sign_in(user:)
-    create(
-      :user_membership,
-      user:,
-      organisation: create(:school, :placements),
-    )
-  end
-
-  def when_i_visit_the_sign_in_path
-    visit sign_in_path
-  end
-
-  def when_i_click_sign_in
-    click_on "Sign in using DfE Sign In"
-  end
 
   def i_should_see_a_sign_out_button
     expect(page).to have_content("Sign out")

--- a/spec/system/placements/support/organisations/support_filtering_and_searching_for_organisation_spec.rb
+++ b/spec/system/placements/support/organisations/support_filtering_and_searching_for_organisation_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Support user filters and searches for organisations", service: :placements, type: :system do
   before do
-    given_i_am_signed_in_as_a_support_user
+    given_i_am_signed_in_as_a_placements_support_user
     and_placement_schools_and_providers_exist
     then_i_see_support_navigation_with_organisation_selected
   end
@@ -181,13 +181,6 @@ RSpec.describe "Support user filters and searches for organisations", service: :
 
     expect(page).not_to have_content("University of Westminster")
     expect(page).not_to have_content("Lead Partner London")
-  end
-
-  def given_i_am_signed_in_as_a_support_user
-    user = create(:placements_support_user, :colin)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
   end
 
   def then_i_see_support_navigation_with_organisation_selected

--- a/spec/system/placements/support/organisations/support_user_selects_an_organisation_type_to_add_spec.rb
+++ b/spec/system/placements/support/organisations/support_user_selects_an_organisation_type_to_add_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Placements / Support / Organisations / Support User Selects An Organisation Type To Add",
                service: :placements, type: :system do
   before do
-    given_i_sign_in_as_colin
+    given_i_am_signed_in_as_a_placements_support_user
   end
 
   scenario "Colin selects to add an ITT provider" do
@@ -76,25 +76,6 @@ RSpec.describe "Placements / Support / Organisations / Support User Selects An O
 
   def given_i_navigate_to_the_organisations_list
     visit placements_support_organisations_path
-  end
-
-  def and_there_is_an_existing_user_for(user_name)
-    user = create(:placements_support_user, user_name.downcase.to_sym)
-    user_exists_in_dfe_sign_in(user:)
-  end
-
-  def and_i_visit_the_sign_in_page
-    visit sign_in_path
-  end
-
-  def and_i_click_sign_in
-    click_on "Sign in using DfE Sign In"
-  end
-
-  def given_i_sign_in_as_colin
-    and_there_is_an_existing_user_for("Colin")
-    and_i_visit_the_sign_in_page
-    and_i_click_sign_in
   end
 
   def and_i_click_on(text)

--- a/spec/system/placements/support/providers/partner_schools/support_user_adds_a_partner_school_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/support_user_adds_a_partner_school_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
   end
 
   before do
-    given_i_am_signed_in_as_a_support_user
+    given_i_am_signed_in_as_a_placements_support_user
   end
 
   scenario "Support user adds a partner school", :js, retry: 3 do
@@ -120,13 +120,6 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
   end
 
   private
-
-  def given_i_am_signed_in_as_a_support_user
-    user = create(:placements_support_user, :colin)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_visit_the_partner_schools_page_for(provider)
     visit placements_provider_partner_schools_path(provider)

--- a/spec/system/placements/support/providers/partner_schools/support_user_adds_a_partner_school_without_javascript_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/support_user_adds_a_partner_school_without_javascript_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
     create(:school, :placements, name: "London")
     create(:school, :claims, name: "Claims")
 
-    given_i_am_signed_in_as_a_support_user
+    given_i_am_signed_in_as_a_placements_support_user
   end
 
   scenario "Support user adds a partner school" do
@@ -98,13 +98,6 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
   end
 
   private
-
-  def given_i_am_signed_in_as_a_support_user
-    user = create(:placements_support_user, :colin)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_visit_the_add_partner_school_page_for(provider)
     visit new_add_partner_school_placements_provider_partner_schools_path(provider)

--- a/spec/system/placements/support/providers/partner_schools/support_user_deletes_a_partner_school_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/support_user_deletes_a_partner_school_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
   before do
     partnership
     another_partnership
-    given_i_am_signed_in_as_a_support_user
+    given_i_am_signed_in_as_a_placements_support_user
   end
 
   scenario "Support user deletes a partner school" do
@@ -85,13 +85,6 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
   end
 
   private
-
-  def given_i_am_signed_in_as_a_support_user
-    user = create(:placements_support_user, :colin)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_visit_the_partner_schools_page_for(provider:, school:)
     visit placements_provider_partner_school_path(provider, school)

--- a/spec/system/placements/support/providers/partner_schools/view_a_partner_school_as_support_user_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/view_a_partner_school_as_support_user_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Placements / Support/ Providers / Partner schools / View a partn
 
   before do
     partnership
-    given_i_am_signed_in_as_a_support_user
+    given_i_am_signed_in_as_a_placements_support_user
   end
 
   scenario "Support User views a provider partner school" do
@@ -18,13 +18,6 @@ RSpec.describe "Placements / Support/ Providers / Partner schools / View a partn
   end
 
   private
-
-  def given_i_am_signed_in_as_a_support_user
-    user = create(:placements_support_user, :colin)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_visit_the_partner_schools_page_for(provider)
     visit placements_provider_partner_schools_path(provider)

--- a/spec/system/placements/support/providers/partner_schools/view_partner_school_list_as_support_user_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/view_partner_school_list_as_support_user_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Placements / Support / Providers / Partner schools / View a part
   let!(:another_school) { create(:placements_school, name: "Shelbyville Elementary School", urn: "5678") }
 
   before do
-    given_i_am_signed_in_as_a_support_user
+    given_i_am_signed_in_as_a_placements_support_user
   end
 
   scenario "Support user views provider partner schools page for a provider with no partner schools" do
@@ -25,13 +25,6 @@ RSpec.describe "Placements / Support / Providers / Partner schools / View a part
   end
 
   private
-
-  def given_i_am_signed_in_as_a_support_user
-    user = create(:placements_support_user, :colin)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_visit_the_partner_schools_page_for(provider)
     visit placements_provider_partner_schools_path(provider)

--- a/spec/system/placements/support/providers/support_user_adds_a_provider_spec.rb
+++ b/spec/system/placements/support/providers/support_user_adds_a_provider_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Placements / Support / Providers / Support User adds a Provider"
   let(:provider) { create(:provider, name: "Provider 1") }
 
   before do
-    given_i_sign_in_as_colin
+    given_i_am_signed_in_as_a_placements_support_user
     provider
   end
 
@@ -64,19 +64,6 @@ RSpec.describe "Placements / Support / Providers / Support User adds a Provider"
   end
 
   private
-
-  def and_there_is_an_existing_user_for(user_name)
-    user = create(:placements_support_user, user_name.downcase.to_sym)
-    user_exists_in_dfe_sign_in(user:)
-  end
-
-  def and_i_visit_the_sign_in_page
-    visit sign_in_path
-  end
-
-  def and_i_click_sign_in
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_visit_the_add_organisation_page
     visit new_add_organisation_placements_support_organisations_path

--- a/spec/system/placements/support/providers/support_user_adds_a_provider_without_javascript_spec.rb
+++ b/spec/system/placements/support/providers/support_user_adds_a_provider_without_javascript_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Support User adds a Provider without JavaScript", service: :plac
     create(:provider, name: "Manchester 2")
     create(:provider, name: "London")
 
-    given_i_sign_in_as_colin
+    given_i_am_signed_in_as_a_placements_support_user
   end
 
   scenario "Colin adds a new Provider" do
@@ -78,25 +78,6 @@ RSpec.describe "Support User adds a Provider without JavaScript", service: :plac
   end
 
   private
-
-  def and_there_is_an_existing_user_for(user_name)
-    user = create(:placements_support_user, user_name.downcase.to_sym)
-    user_exists_in_dfe_sign_in(user:)
-  end
-
-  def and_i_visit_the_sign_in_page
-    visit sign_in_path
-  end
-
-  def and_i_click_sign_in
-    click_on "Sign in using DfE Sign In"
-  end
-
-  def given_i_sign_in_as_colin
-    and_there_is_an_existing_user_for("Colin")
-    and_i_visit_the_sign_in_page
-    and_i_click_sign_in
-  end
 
   def when_i_visit_the_add_organisation_page
     visit new_add_organisation_placements_support_organisations_path

--- a/spec/system/placements/support/schools/mentors/support_user_adds_a_mentor_spec.rb
+++ b/spec/system/placements/support/schools/mentors/support_user_adds_a_mentor_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Placements support user adds mentors to schools", service: :plac
   let(:placements_mentor) { create(:placements_mentor) }
   let(:new_mentor) { build(:placements_mentor) }
 
-  before { given_i_sign_in_as_colin }
+  before { given_i_am_signed_in_as_a_placements_support_user }
 
   scenario "I can navigate back to the index page" do
     given_i_navigate_to_schools_mentors_list(school)
@@ -168,13 +168,6 @@ RSpec.describe "Placements support user adds mentors to schools", service: :plac
   end
 
   private
-
-  def given_i_sign_in_as_colin
-    user = create(:placements_support_user, :colin)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def given_a_claims_mentor_exists
     create(:claims_mentor_membership, school: another_school, mentor: claims_mentor)

--- a/spec/system/placements/support/schools/mentors/support_user_deletes_a_mentor_spec.rb
+++ b/spec/system/placements/support/schools/mentors/support_user_deletes_a_mentor_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Placements / Support / Schools / Mentor / Support User deletes a
 
   before do
     given_the_school_has_mentors(school:, mentors: [mentor_1, mentor_2])
-    given_i_sign_in_as_colin
+    given_i_am_signed_in_as_a_placements_support_user
   end
 
   context "when the mentor has no placements" do
@@ -45,25 +45,6 @@ RSpec.describe "Placements / Support / Schools / Mentor / Support User deletes a
   end
 
   private
-
-  def and_there_is_an_existing_user_for(user_name)
-    user = create(:placements_support_user, user_name.downcase.to_sym)
-    user_exists_in_dfe_sign_in(user:)
-  end
-
-  def and_i_visit_the_sign_in_path
-    visit sign_in_path
-  end
-
-  def and_i_click_sign_in
-    click_on "Sign in using DfE Sign In"
-  end
-
-  def given_i_sign_in_as_colin
-    and_there_is_an_existing_user_for("Colin")
-    and_i_visit_the_sign_in_path
-    and_i_click_sign_in
-  end
 
   def given_the_school_has_mentors(school:, mentors:)
     mentors.each do |mentor|

--- a/spec/system/placements/support/schools/mentors/support_user_views_a_mentor_spec.rb
+++ b/spec/system/placements/support/schools/mentors/support_user_views_a_mentor_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Placements / Support / Schools / Mentor / Support User views a m
 
   before do
     school
-    given_i_sign_in_as_colin
+    given_i_am_signed_in_as_a_placements_support_user
   end
 
   scenario "Support User views a school mentor's details" do
@@ -27,25 +27,6 @@ RSpec.describe "Placements / Support / Schools / Mentor / Support User views a m
   end
 
   private
-
-  def and_there_is_an_existing_user_for(user_name)
-    user = create(:placements_support_user, user_name.downcase.to_sym)
-    user_exists_in_dfe_sign_in(user:)
-  end
-
-  def and_i_visit_the_sign_in_path
-    visit sign_in_path
-  end
-
-  def and_i_click_sign_in
-    click_on "Sign in using DfE Sign In"
-  end
-
-  def given_i_sign_in_as_colin
-    and_there_is_an_existing_user_for("Colin")
-    and_i_visit_the_sign_in_path
-    and_i_click_sign_in
-  end
 
   def given_a_mentor_exists_in(school:)
     create(:placements_mentor_membership, school:, mentor:)

--- a/spec/system/placements/support/schools/mentors/support_user_views_mentors_spec.rb
+++ b/spec/system/placements/support/schools/mentors/support_user_views_mentors_spec.rb
@@ -7,29 +7,21 @@ RSpec.describe "Placements / Support / Schools / Mentor / Support User views men
   let!(:mentor3) { create(:mentor, trn: "1231233") }
   let!(:school) { create(:placements_school, mentors: [mentor1, mentor2]) }
   let!(:another_school) { create(:placements_school) }
-  let!(:colin) { create(:placements_support_user, :colin) }
+
+  before { given_i_am_signed_in_as_a_placements_support_user }
 
   scenario "View a school's mentors as a support user" do
-    user_exists_in_dfe_sign_in(user: colin)
-    given_i_sign_in
     when_i_visit_the_school_mentors_page(school)
     then_i_see_a_list_of_the_schools_mentors
     and_i_dont_see_mentors_from_another_school
   end
 
   scenario "View a school's empty mentors list" do
-    user_exists_in_dfe_sign_in(user: colin)
-    given_i_sign_in
     when_i_visit_the_school_mentors_page(another_school)
     then_i_see_no_results
   end
 
   private
-
-  def given_i_sign_in
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_visit_the_school_mentors_page(school)
     visit placements_school_mentors_path(school)

--- a/spec/system/placements/support/schools/partner_providers/support_user_adds_a_partner_provider_spec.rb
+++ b/spec/system/placements/support/schools/partner_providers/support_user_adds_a_partner_provider_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Placements / Support / Schools / Partner providers / Support use
   end
 
   before do
-    given_i_am_signed_in_as_a_support_user
+    given_i_am_signed_in_as_a_placements_support_user
   end
 
   scenario "Support user adds a partner provider", :js, retry: 3 do
@@ -120,13 +120,6 @@ RSpec.describe "Placements / Support / Schools / Partner providers / Support use
   end
 
   private
-
-  def given_i_am_signed_in_as_a_support_user
-    user = create(:placements_support_user, :colin)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_visit_the_partner_providers_page_for(school)
     visit placements_school_partner_providers_path(school)

--- a/spec/system/placements/support/schools/partner_providers/support_user_adds_a_partner_provider_without_javascript_spec.rb
+++ b/spec/system/placements/support/schools/partner_providers/support_user_adds_a_partner_provider_without_javascript_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Placements / Support / Schools / Partner providers / Support use
     create(:provider, :placements, name: "London")
     create(:claims_provider, name: "Claims")
 
-    given_i_am_signed_in_as_a_support_user
+    given_i_am_signed_in_as_a_placements_support_user
   end
 
   scenario "Support user adds a partner provider" do
@@ -98,13 +98,6 @@ RSpec.describe "Placements / Support / Schools / Partner providers / Support use
   end
 
   private
-
-  def given_i_am_signed_in_as_a_support_user
-    user = create(:placements_support_user, :colin)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_visit_the_add_partner_provider_page_for(school)
     visit new_add_partner_provider_placements_school_partner_providers_path(school)

--- a/spec/system/placements/support/schools/partner_providers/support_user_deletes_a_partner_provider_spec.rb
+++ b/spec/system/placements/support/schools/partner_providers/support_user_deletes_a_partner_provider_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Placements / Support / Schools / Partner providers / Support use
   before do
     partnership
     another_partnership
-    given_i_am_signed_in_as_a_support_user
+    given_i_am_signed_in_as_a_placements_support_user
   end
 
   scenario "Support user deletes a partner provider" do
@@ -53,13 +53,6 @@ RSpec.describe "Placements / Support / Schools / Partner providers / Support use
   end
 
   private
-
-  def given_i_am_signed_in_as_a_support_user
-    user = create(:placements_support_user, :colin)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_view_the_partner_provider_show_page_for(school:, provider:)
     visit placements_school_partner_provider_path(school, provider)

--- a/spec/system/placements/support/schools/partner_providers/view_a_partner_provider_as_support_user_spec.rb
+++ b/spec/system/placements/support/schools/partner_providers/view_a_partner_provider_as_support_user_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Placements / Support / Schools / Partner providers / View a part
 
   before do
     partnership
-    given_i_am_signed_in_as_a_support_user
+    given_i_am_signed_in_as_a_placements_support_user
   end
 
   scenario "Support user views a school partner provider" do
@@ -18,13 +18,6 @@ RSpec.describe "Placements / Support / Schools / Partner providers / View a part
   end
 
   private
-
-  def given_i_am_signed_in_as_a_support_user
-    user = create(:placements_support_user, :colin)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_visit_the_partner_providers_page_for(school)
     visit placements_school_partner_providers_path(school)

--- a/spec/system/placements/support/schools/partner_providers/view_partner_school_list_as_support_user_spec.rb
+++ b/spec/system/placements/support/schools/partner_providers/view_partner_school_list_as_support_user_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Placements / Support / Schools / Partner providers / View partne
   let!(:another_provider) { create(:placements_provider, name: "Burns University", ukprn: "5678") }
 
   before do
-    given_i_am_signed_in_as_a_support_user
+    given_i_am_signed_in_as_a_placements_support_user
   end
 
   scenario "Support user views school partner providers page where school has no partner providers" do
@@ -25,13 +25,6 @@ RSpec.describe "Placements / Support / Schools / Partner providers / View partne
   end
 
   private
-
-  def given_i_am_signed_in_as_a_support_user
-    user = create(:placements_support_user, :colin)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_visit_the_partner_providers_page_for(school)
     visit placements_school_partner_providers_path(school)

--- a/spec/system/placements/support/schools/placements/support_user_adds_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/support_user_adds_a_placement_spec.rb
@@ -3,32 +3,12 @@ require "rails_helper"
 RSpec.describe "Placements / Support / Schools / Placements / Add a placement",
                service: :placements, type: :system do
   before do
-    given_i_sign_in_as_colin
+    given_i_am_signed_in_as_a_placements_support_user
   end
 
   it_behaves_like "an add a placement wizard"
 
   private
-
-  def given_i_sign_in_as_colin
-    and_there_is_an_existing_user_for("Colin")
-    and_i_visit_the_sign_in_path
-    and_i_click_sign_in
-  end
-
-  def and_there_is_an_existing_user_for(user_name)
-    user = create(:placements_support_user, user_name.downcase.to_sym)
-    user_exists_in_dfe_sign_in(user:)
-    create(:user_membership, user:, organisation: school)
-  end
-
-  def and_i_visit_the_sign_in_path
-    visit sign_in_path
-  end
-
-  def and_i_click_sign_in
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_visit_the_placements_page
     visit placements_school_placements_path(school)

--- a/spec/system/placements/support/schools/placements/support_user_deletes_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/support_user_deletes_a_placement_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Placements / Support / Schools / Placement / Support User delete
 
   before do
     placement_2
-    given_i_sign_in_as_colin
+    given_i_am_signed_in_as_a_placements_support_user
     when_i_visit_the_show_page_for(school, placement_1)
   end
 
@@ -39,25 +39,6 @@ RSpec.describe "Placements / Support / Schools / Placement / Support User delete
   end
 
   private
-
-  def and_there_is_an_existing_user_for(user_name)
-    user = create(:placements_support_user, user_name.downcase.to_sym)
-    user_exists_in_dfe_sign_in(user:)
-  end
-
-  def and_i_visit_the_sign_in_path
-    visit sign_in_path
-  end
-
-  def and_i_click_sign_in
-    click_on "Sign in using DfE Sign In"
-  end
-
-  def given_i_sign_in_as_colin
-    and_there_is_an_existing_user_for("Colin")
-    and_i_visit_the_sign_in_path
-    and_i_click_sign_in
-  end
 
   def when_i_visit_the_show_page_for(school, placement)
     visit placements_school_placement_path(school, placement)

--- a/spec/system/placements/support/schools/placements/support_user_edits_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/support_user_edits_a_placement_spec.rb
@@ -2,17 +2,11 @@ require "rails_helper"
 
 RSpec.describe "Placements / Support / Schools / Placements / Edit a placement",
                service: :placements, type: :system do
-  before { given_i_sign_in_as_colin }
+  before { given_i_am_signed_in_as_a_placements_support_user }
 
   it_behaves_like "an edit placement wizard"
 
   private
-
-  def given_i_sign_in_as_colin
-    and_there_is_an_existing_user_for("Colin")
-    and_i_visit_the_sign_in_path
-    and_i_click_sign_in
-  end
 
   def and_there_is_an_existing_user_for(user_name)
     user = create(:placements_support_user, user_name.downcase.to_sym)

--- a/spec/system/placements/support/schools/placements/support_user_views_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/support_user_views_a_placement_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Placements / Support / Schools / Placement / Support User views 
 
   before do
     school
-    given_i_sign_in_as_colin
+    given_i_am_signed_in_as_a_placements_support_user
   end
 
   describe "school phases" do
@@ -173,25 +173,6 @@ RSpec.describe "Placements / Support / Schools / Placement / Support User views 
   end
 
   private
-
-  def and_there_is_an_existing_user_for(user_name)
-    user = create(:placements_support_user, user_name.downcase.to_sym)
-    user_exists_in_dfe_sign_in(user:)
-  end
-
-  def and_i_visit_the_sign_in_path
-    visit sign_in_path
-  end
-
-  def and_i_click_sign_in
-    click_on "Sign in using DfE Sign In"
-  end
-
-  def given_i_sign_in_as_colin
-    and_there_is_an_existing_user_for("Colin")
-    and_i_visit_the_sign_in_path
-    and_i_click_sign_in
-  end
 
   def when_i_visit_the_show_page_for(school, placement)
     visit placements_school_placement_path(school, placement)

--- a/spec/system/placements/support/schools/placements/support_user_views_placements_spec.rb
+++ b/spec/system/placements/support/schools/placements/support_user_views_placements_spec.rb
@@ -14,28 +14,23 @@ RSpec.describe "Placements / Support / Schools / Placements / Support User views
   let!(:placement3) { create(:placement, mentors: [mentor3], subject: subject3) }
   let!(:school) { create(:placements_school, mentors: [mentor1, mentor2]) }
   let!(:another_school) { create(:placements_school) }
-  let!(:colin) { create(:placements_support_user, :colin) }
   let(:term) { create(:placements_term, :autumn) }
 
+  before { given_i_am_signed_in_as_a_placements_support_user }
+
   scenario "view a school's empty placements list" do
-    user_exists_in_dfe_sign_in(user: colin)
-    given_i_sign_in
     when_i_visit_the_school_placements_page(another_school)
     then_i_see_no_results
   end
 
   context "with placements" do
     scenario "view a school's placements as a support user" do
-      user_exists_in_dfe_sign_in(user: colin)
-      given_i_sign_in
       when_i_visit_the_school_placements_page(school)
       then_i_see_a_list_of_the_schools_placements
       and_i_dont_see_placements_from_another_school
     end
 
     scenario "where the placement has a provider" do
-      user_exists_in_dfe_sign_in(user: colin)
-      given_i_sign_in
       when_i_visit_the_school_placements_page(school)
       then_i_see_a_list_of_the_schools_placements
       and_i_dont_see_placements_from_another_school
@@ -43,8 +38,6 @@ RSpec.describe "Placements / Support / Schools / Placements / Support User views
     end
 
     scenario "where the placement has no provider" do
-      user_exists_in_dfe_sign_in(user: colin)
-      given_i_sign_in
       when_i_visit_the_school_placements_page(school)
       then_i_see_a_list_of_the_schools_placements
       and_i_dont_see_placements_from_another_school
@@ -52,16 +45,12 @@ RSpec.describe "Placements / Support / Schools / Placements / Support User views
     end
 
     scenario "when the placement has no terms" do
-      user_exists_in_dfe_sign_in(user: colin)
-      given_i_sign_in
       when_i_visit_the_school_placements_page(school)
       then_i_see_a_list_of_the_schools_placements
       then_i_see_the_term_name("Any time in the academic year")
     end
 
     scenario "when the placement has terms" do
-      user_exists_in_dfe_sign_in(user: colin)
-      given_i_sign_in
       and_the_placement_has_terms(placement1, term)
       when_i_visit_the_school_placements_page(school)
       then_i_see_the_term_name("Autumn term")
@@ -69,11 +58,6 @@ RSpec.describe "Placements / Support / Schools / Placements / Support User views
   end
 
   private
-
-  def given_i_sign_in
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_visit_the_school_placements_page(school)
     visit placements_school_placements_path(school)

--- a/spec/system/placements/support/schools/support_user_adds_a_school_spec.rb
+++ b/spec/system/placements/support/schools/support_user_adds_a_school_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Placements / Support / Schools / Support User adds a School",
 
   before do
     school
-    given_i_sign_in_as_colin
+    given_i_am_signed_in_as_a_placements_support_user
   end
 
   after { Capybara.app_host = nil }
@@ -63,25 +63,6 @@ RSpec.describe "Placements / Support / Schools / Support User adds a School",
   end
 
   private
-
-  def and_there_is_an_existing_user_for(user_name)
-    user = create(:placements_support_user, user_name.downcase.to_sym)
-    user_exists_in_dfe_sign_in(user:)
-  end
-
-  def and_i_visit_the_sign_in_path
-    visit sign_in_path
-  end
-
-  def and_i_click_sign_in
-    click_on "Sign in using DfE Sign In"
-  end
-
-  def given_i_sign_in_as_colin
-    and_there_is_an_existing_user_for("Colin")
-    and_i_visit_the_sign_in_path
-    and_i_click_sign_in
-  end
 
   def when_i_visit_the_add_organisation_page
     visit new_add_organisation_placements_support_organisations_path

--- a/spec/system/placements/support/schools/support_user_adds_a_school_without_javascript_spec.rb
+++ b/spec/system/placements/support/schools/support_user_adds_a_school_without_javascript_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Support User adds a School without JavaScript", service: :placem
     create(:school, name: "Manchester 2")
     create(:school, name: "London")
 
-    given_i_sign_in_as_colin
+    given_i_am_signed_in_as_a_placements_support_user
   end
 
   scenario "Colin adds a new School" do
@@ -78,25 +78,6 @@ RSpec.describe "Support User adds a School without JavaScript", service: :placem
   end
 
   private
-
-  def and_there_is_an_existing_user_for(user_name)
-    user = create(:placements_support_user, user_name.downcase.to_sym)
-    user_exists_in_dfe_sign_in(user:)
-  end
-
-  def and_i_visit_the_sign_in_page
-    visit sign_in_path
-  end
-
-  def and_i_click_sign_in
-    click_on "Sign in using DfE Sign In"
-  end
-
-  def given_i_sign_in_as_colin
-    and_there_is_an_existing_user_for("Colin")
-    and_i_visit_the_sign_in_page
-    and_i_click_sign_in
-  end
 
   def when_i_visit_the_add_organisation_page
     visit new_add_organisation_placements_support_organisations_path

--- a/spec/system/placements/support/schools/view_school_as_support_user_spec.rb
+++ b/spec/system/placements/support/schools/view_school_as_support_user_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Placements / Organisations / Support user views a School", type:
   end
 
   scenario "Support user navigates to different organisations on the list" do
-    given_i_am_signed_in_as_a_support_user
+    given_i_am_signed_in_as_a_placements_support_user
     when_i_click_on_a_organisation_name(school.name)
     and_i_click_on("Organisation details")
     then_i_see_the_school_details
@@ -20,13 +20,6 @@ RSpec.describe "Placements / Organisations / Support user views a School", type:
   end
 
   private
-
-  def given_i_am_signed_in_as_a_support_user
-    user = create(:placements_support_user, :colin)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def when_i_click_on_a_organisation_name(name)
     click_on name

--- a/spec/system/placements/support/support_users/support_user_adds_a_support_user_spec.rb
+++ b/spec/system/placements/support/support_users/support_user_adds_a_support_user_spec.rb
@@ -8,10 +8,8 @@ RSpec.describe "Placements / Support Users / Support user adds a support user",
     perform_enqueued_jobs { example.run }
   end
 
-  let!(:support_user) { create(:placements_support_user, :colin) }
-
   scenario "Add a support user" do
-    when_i_sign_in_as_a_support_user(support_user)
+    given_i_am_signed_in_as_a_placements_support_user
     and_i_visit_the_support_users_page
     and_i_click_on_add_a_support_user
     and_i_fill_in_the_support_user_form(email_address: "john.doe@education.gov.uk")
@@ -22,7 +20,7 @@ RSpec.describe "Placements / Support Users / Support user adds a support user",
   end
 
   scenario "Attempt to add a support user without an @education.gov.uk email address" do
-    when_i_sign_in_as_a_support_user(support_user)
+    given_i_am_signed_in_as_a_placements_support_user
     and_i_visit_the_support_users_page
     and_i_click_on_add_a_support_user
     and_i_fill_in_the_support_user_form(email_address: "john.doe@example.com")
@@ -32,7 +30,7 @@ RSpec.describe "Placements / Support Users / Support user adds a support user",
 
   scenario "Attempt to add a support user with an email that already exists in the system" do
     given_there_is_a_support_user_with(email_address: "john.doe@education.gov.uk")
-    when_i_sign_in_as_a_support_user(support_user)
+    given_i_am_signed_in_as_a_placements_support_user
     and_i_visit_the_support_users_page
     and_i_click_on_add_a_support_user
     and_i_fill_in_the_support_user_form(email_address: "john.doe@education.gov.uk")
@@ -41,7 +39,7 @@ RSpec.describe "Placements / Support Users / Support user adds a support user",
   end
 
   scenario "Make changes while adding a support user" do
-    when_i_sign_in_as_a_support_user(support_user)
+    given_i_am_signed_in_as_a_placements_support_user
     and_i_visit_the_support_users_page
     and_i_click_on_add_a_support_user
     and_i_fill_in_the_support_user_form(email_address: "john.doe@education.gov.uk")
@@ -57,12 +55,6 @@ RSpec.describe "Placements / Support Users / Support user adds a support user",
 
   def given_there_is_a_support_user_with(email_address:)
     create(:placements_support_user, email: email_address)
-  end
-
-  def when_i_sign_in_as_a_support_user(support_user)
-    user_exists_in_dfe_sign_in(user: support_user)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
   end
 
   def and_i_visit_the_support_users_page

--- a/spec/system/placements/support/support_users/support_user_re_adds_a_discarded_support_user_spec.rb
+++ b/spec/system/placements/support/support_users/support_user_re_adds_a_discarded_support_user_spec.rb
@@ -8,15 +8,13 @@ RSpec.describe "Placements / Support Users / Support user re-adds a discarded su
     perform_enqueued_jobs { example.run }
   end
 
-  let!(:support_user) { create(:placements_support_user, :colin) }
-
   scenario "Re-add a discarded support user" do
     given_a_discarded_support_user_with(
       email_address: "john.doe@education.gov.uk",
       first_name: "John",
       last_name: "Doe",
     )
-    when_i_sign_in_as_a_support_user(support_user)
+    given_i_am_signed_in_as_a_placements_support_user
     and_i_visit_the_support_users_page
     and_i_click_on_add_a_support_user
     and_i_fill_in_the_support_user_form(
@@ -41,7 +39,7 @@ RSpec.describe "Placements / Support Users / Support user re-adds a discarded su
       first_name: "John",
       last_name: "Doe",
     )
-    when_i_sign_in_as_a_support_user(support_user)
+    given_i_am_signed_in_as_a_placements_support_user
     and_i_visit_the_support_users_page
     and_i_click_on_add_a_support_user
     and_i_fill_in_the_support_user_form(
@@ -66,7 +64,7 @@ RSpec.describe "Placements / Support Users / Support user re-adds a discarded su
       first_name: "John",
       last_name: "Doe",
     )
-    when_i_sign_in_as_a_support_user(support_user)
+    given_i_am_signed_in_as_a_placements_support_user
     and_i_visit_the_support_users_page
     and_i_click_on_add_a_support_user
     and_i_fill_in_the_support_user_form(
@@ -82,12 +80,6 @@ RSpec.describe "Placements / Support Users / Support user re-adds a discarded su
 
   def given_a_discarded_support_user_with(email_address:, first_name:, last_name:)
     create(:placements_support_user, :discarded, email: email_address, first_name:, last_name:)
-  end
-
-  def when_i_sign_in_as_a_support_user(support_user)
-    user_exists_in_dfe_sign_in(user: support_user)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
   end
 
   def and_i_visit_the_support_users_page

--- a/spec/system/placements/support/support_users/support_user_removes_a_support_user_spec.rb
+++ b/spec/system/placements/support/support_users/support_user_removes_a_support_user_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Placements / Support Users / Support users removes a support use
   let!(:support_user_to_be_removed) { create(:placements_support_user) }
 
   scenario "Remove a support user" do
-    when_i_sign_in_as_a_support_user(support_user)
+    given_i_am_signed_in_as_a_placements_support_user
     and_i_visit_the_support_users_page
     and_i_click_on_a_support_user(support_user_to_be_removed)
     and_i_click_on_remove
@@ -23,7 +23,7 @@ RSpec.describe "Placements / Support Users / Support users removes a support use
   end
 
   scenario "A support user can not remove themselves as a support user" do
-    when_i_sign_in_as_a_support_user(support_user)
+    given_i_sign_in_as(support_user)
     and_i_visit_the_support_users_page
     and_i_click_on_a_support_user(support_user)
     then_i_can_not_see_a_remove_link

--- a/spec/system/placements/support/support_users/support_user_views_a_support_user_spec.rb
+++ b/spec/system/placements/support/support_users/support_user_views_a_support_user_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "Placements / Support Users / Support user views a support user", service: :placements, type: :system do
-  let!(:support_user) { create(:placements_support_user, :colin) }
+  let!(:support_user) { create(:placements_support_user) }
 
   scenario "View a support user" do
-    when_i_sign_in_as_a_support_user(support_user)
+    given_i_am_signed_in_as_a_placements_support_user
     and_i_visit_the_support_users_page
     and_i_click_on_a_support_user(support_user)
     i_see_the_details_of_the_support_user(support_user)
@@ -12,27 +12,21 @@ RSpec.describe "Placements / Support Users / Support user views a support user",
 
   private
 
-  def when_i_sign_in_as_a_support_user(support_user)
-    user_exists_in_dfe_sign_in(user: support_user)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
-
   def and_i_visit_the_support_users_page
     within(".govuk-header__navigation-list") do
       click_on "Support users"
     end
   end
 
-  def and_i_click_on_a_support_user(_support_user)
-    click_on "Colin Chapman"
+  def and_i_click_on_a_support_user(support_user)
+    click_on support_user.full_name
   end
 
-  def i_see_the_details_of_the_support_user(_support_user)
-    expect(page).to have_selector("h1", text: "Colin Chapman")
+  def i_see_the_details_of_the_support_user(support_user)
+    expect(page).to have_selector("h1", text: support_user.full_name)
 
-    expect(page).to have_content "Colin"
-    expect(page).to have_content "Chapman"
-    expect(page).to have_content "colin.chapman@education.gov.uk"
+    expect(page).to have_content support_user.first_name
+    expect(page).to have_content support_user.last_name
+    expect(page).to have_content support_user.email
   end
 end

--- a/spec/system/placements/support/support_users/support_user_views_support_users_spec.rb
+++ b/spec/system/placements/support/support_users/support_user_views_support_users_spec.rb
@@ -6,18 +6,12 @@ RSpec.describe "Placements / Support Users / Support user views support users",
   let!(:support_user_2) { create(:placements_support_user, created_at: "2024-01-01") }
 
   scenario "View list of all support users" do
-    when_i_sign_in_as_a_support_user(support_user)
+    given_i_sign_in_as(support_user)
     and_i_visit_the_support_users_page
     i_see_the_list_of_all_support_users_ordered_by_latest_created_at_first
   end
 
   private
-
-  def when_i_sign_in_as_a_support_user(support_user)
-    user_exists_in_dfe_sign_in(user: support_user)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
-  end
 
   def and_i_visit_the_support_users_page
     within(".govuk-header__navigation-list") do

--- a/spec/system/placements/support/users/support_user_deletes_a_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_deletes_a_user_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Placements support user deletes a user from an organisation", se
     end
 
     scenario "user is deleted from a school" do
-      given_i_am_signed_in_as_a_support_user
+      given_i_am_signed_in_as_a_placements_support_user
       and_i_visit_the_user_page(school)
       when_i_click_on("Delete user")
       then_i_am_asked_to_confirm(school)
@@ -39,7 +39,7 @@ RSpec.describe "Placements support user deletes a user from an organisation", se
     end
 
     scenario "user is deleted from a provider" do
-      given_i_am_signed_in_as_a_support_user
+      given_i_am_signed_in_as_a_placements_support_user
       and_i_visit_the_user_page(provider)
       when_i_click_on("Delete user")
       then_i_am_asked_to_confirm(provider)
@@ -64,7 +64,7 @@ RSpec.describe "Placements support user deletes a user from an organisation", se
     end
 
     scenario "user is deleted from one organisation but when other memberships exist" do
-      given_i_am_signed_in_as_a_support_user
+      given_i_am_signed_in_as_a_placements_support_user
       and_i_visit_the_user_page(school)
       when_i_delete_user_from_school
       then_user_is_still_member_of_provider
@@ -84,13 +84,6 @@ RSpec.describe "Placements support user deletes a user from an organisation", se
     visit placements_provider_users_path(provider)
 
     expect(page).to have_content user.full_name
-  end
-
-  def given_i_am_signed_in_as_a_support_user
-    user = create(:placements_support_user, :colin)
-    user_exists_in_dfe_sign_in(user:)
-    visit sign_in_path
-    click_on "Sign in using DfE Sign In"
   end
 
   def and_i_visit_the_user_page(organisation)

--- a/spec/system/placements/support/users/support_user_invites_a_new_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_invites_a_new_user_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
   end
 
   before do
-    given_i_am_signed_in_as_a_support_user
+    given_i_am_signed_in_as_a_placements_support_user
   end
 
   describe "School" do
@@ -115,26 +115,6 @@ RSpec.describe "Placements / Support / Users / Support User Invites A New User",
   end
 
   private
-
-  def and_there_is_an_existing_user_for(user_name)
-    user = create(:placements_support_user, user_name.downcase.to_sym)
-    user_exists_in_dfe_sign_in(user:)
-  end
-
-  def and_i_visit_root_path
-    visit placements_root_path
-  end
-
-  def and_i_click_on_sign_in
-    click_on "Start now"
-    click_on "Sign in using DfE Sign In"
-  end
-
-  def given_i_am_signed_in_as_a_support_user
-    and_there_is_an_existing_user_for("Colin")
-    and_i_visit_root_path
-    and_i_click_on_sign_in
-  end
 
   def when_i_visit_the_users_page_for(organisation:)
     click_on organisation.name

--- a/spec/system/placements/support/users/support_user_views_a_user_spec.rb
+++ b/spec/system/placements/support/users/support_user_views_a_user_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Placements / Support / Users / Support User Views A User", servi
   end
 
   before do
-    given_i_am_signed_in_as_a_support_user
+    given_i_am_signed_in_as_a_placements_support_user
   end
 
   describe "schools" do
@@ -51,25 +51,6 @@ RSpec.describe "Placements / Support / Users / Support User Views A User", servi
   end
 
   private
-
-  def and_there_is_an_existing_user_for(user_name)
-    user = create(:placements_support_user, user_name.downcase.to_sym)
-    user_exists_in_dfe_sign_in(user:)
-  end
-
-  def and_i_visit_the_sign_in_page
-    visit sign_in_path
-  end
-
-  def and_i_click_sign_in
-    click_on "Sign in using DfE Sign In"
-  end
-
-  def given_i_am_signed_in_as_a_support_user
-    and_there_is_an_existing_user_for("Colin")
-    and_i_visit_the_sign_in_page
-    and_i_click_sign_in
-  end
 
   def given_users_have_been_assigned_to_the(organisation:)
     [mary, anne].each do |user|

--- a/spec/system/placements/support/view_emails_spec.rb
+++ b/spec/system/placements/support/view_emails_spec.rb
@@ -4,8 +4,7 @@ RSpec.describe "View Emails", service: :placements, type: :system do
   let(:support_user) { create(:placements_support_user) }
 
   before do
-    user_exists_in_dfe_sign_in(user: support_user)
-    given_i_sign_in
+    given_i_am_signed_in_as_a_placements_support_user
   end
 
   scenario "User visits the emails page" do


### PR DESCRIPTION
## Context

- Make reusable helper methods to sign in placements users and support users in test suite.

## Changes proposed in this pull request

- Create a helper method to sign in Placements Support Users
- Create a helper method to sign in Placements Users (School/Provider Users)
- Replace methods within test suite with the new helpers.

## Guidance to review

- Review the code.
- Run `parallel_rspec` and make sure nothing is broken.

## Link to Trello card

https://trello.com/c/njUXh2LV/869-create-reusable-test-helpers-for-common-sign-in-behaviour

