### PR TITLE
Add view component previews to settings page

### DIFF
--- a/app/controllers/claims/support/view_components_controller.rb
+++ b/app/controllers/claims/support/view_components_controller.rb
@@ -1,0 +1,7 @@
+class Claims::Support::ViewComponentsController < Claims::Support::ApplicationController
+  before_action :skip_authorization
+
+  def index
+    @previews = ViewComponent::Preview.all.filter { |preview| !preview.preview_name.start_with?("placements/") }.sort_by(&:preview_name)
+  end
+end

--- a/app/controllers/placements/support/view_components_controller.rb
+++ b/app/controllers/placements/support/view_components_controller.rb
@@ -1,0 +1,7 @@
+class Placements::Support::ViewComponentsController < Placements::ApplicationController
+  skip_after_action :verify_policy_scoped
+
+  def index
+    @previews = ViewComponent::Preview.all.filter { |preview| !preview.preview_name.start_with?("claims/") }.sort_by(&:preview_name)
+  end
+end

--- a/app/views/claims/support/settings/index.html.erb
+++ b/app/views/claims/support/settings/index.html.erb
@@ -11,6 +11,7 @@
         govuk_link_to(t(".claim_windows"), claims_support_claim_windows_path, no_visited_state: true),
         govuk_link_to(t(".emails"), claims_support_mailers_path, no_visited_state: true),
         (govuk_link_to(t(".reset_database"), reset_claims_support_database_path, no_visited_state: true) unless HostingEnvironment.env.production?),
+        govuk_link_to(t(".view_components"), claims_support_view_components_path, no_visited_state: true),
       ], spaced: true %>
     </div>
   </div>

--- a/app/views/claims/support/view_components/index.html.erb
+++ b/app/views/claims/support/view_components/index.html.erb
@@ -1,0 +1,21 @@
+<% render "claims/support/primary_navigation", current: :settings %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: claims_support_settings_path) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+
+  <% @previews.each do |view_component| %>
+    <% next if view_component.examples.empty? %>
+
+    <h2 class="govuk-heading-m"><%= view_component.preview_name.delete_prefix("claims/").titleize %></h2>
+
+    <% example_links = view_component.examples.map do |example| %>
+      <% govuk_link_to(example, url_for(controller: "/view_components", action: :previews, path: "#{view_component.preview_name}/#{example}"), no_visited_state: true, new_tab: true) %>
+    <% end %>
+
+    <%= govuk_list example_links, type: :bullet %>
+  <% end %>
+</div>

--- a/app/views/placements/support/settings/index.html.erb
+++ b/app/views/placements/support/settings/index.html.erb
@@ -8,6 +8,7 @@
       <%= govuk_list [
         govuk_link_to(t(".background_jobs"), "/good_job", no_visited_state: true, new_tab: true),
         govuk_link_to(t(".emails"), placements_support_mailers_path, no_visited_state: true),
+        govuk_link_to(t(".view_components"), placements_support_view_components_path, no_visited_state: true),
       ], spaced: true %>
     </div>
   </div>

--- a/app/views/placements/support/view_components/index.html.erb
+++ b/app/views/placements/support/view_components/index.html.erb
@@ -1,0 +1,19 @@
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: claims_support_settings_path) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+
+  <% @previews.each do |view_component| %>
+    <% next if view_component.examples.empty? %>
+
+    <h2 class="govuk-heading-m"><%= view_component.preview_name.delete_prefix("claims/").titleize %></h2>
+
+    <% example_links = view_component.examples.map do |example| %>
+      <% govuk_link_to(example, url_for(controller: "/view_components", action: :previews, path: "#{view_component.preview_name}/#{example}"), no_visited_state: true, new_tab: true) %>
+    <% end %>
+
+    <%= govuk_list example_links, type: :bullet %>
+  <% end %>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,6 +43,7 @@ module IttMentorServices
     config.action_mailer.show_previews = true
     config.action_mailer.preview_paths << Rails.root.join("spec/mailers/previews").to_s
 
+    config.view_component.show_previews = true
     config.view_component.preview_paths << Rails.root.join("spec/components/previews").to_s
     config.view_component.default_preview_layout = "component_preview"
 

--- a/config/locales/en/claims/support/settings.yml
+++ b/config/locales/en/claims/support/settings.yml
@@ -8,3 +8,4 @@ en:
           claim_windows: Claim windows
           emails: Emails
           reset_database: Reset database
+          view_components: View components

--- a/config/locales/en/claims/support/view_components.yml
+++ b/config/locales/en/claims/support/view_components.yml
@@ -1,5 +1,5 @@
 en:
-  placements:
+  claims:
     support:
       view_components:
         index:

--- a/config/locales/en/placements/support/settings.yml
+++ b/config/locales/en/placements/support/settings.yml
@@ -4,5 +4,6 @@ en:
       settings:
         index:
           heading: Settings
-          background_jobs: Background Jobs
+          background_jobs: Background jobs
           emails: Emails
+          view_components: View components

--- a/config/locales/en/placements/support/view_components.yml
+++ b/config/locales/en/placements/support/view_components.yml
@@ -1,0 +1,6 @@
+en:
+  placements:
+    support:
+      mailers:
+        index:
+          heading: Emails

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -118,6 +118,7 @@ scope module: :claims, as: :claims, constraints: {
     get :settings, to: "settings#index"
 
     resources :mailers, only: :index
+    resources :view_components, only: :index
 
     resources :claim_windows do
       get :new_check, path: :check, on: :collection

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -22,6 +22,7 @@ scope module: :placements,
     get :settings, to: "settings#index"
 
     resources :mailers, only: :index
+    resources :view_components, only: :index
 
     resources :support_users, only: %i[index show destroy] do
       member { get :remove }

--- a/spec/components/previews/placement/status_tag_component_preview.rb
+++ b/spec/components/previews/placement/status_tag_component_preview.rb
@@ -1,6 +1,6 @@
-class Placement::SummaryComponentPreview < ApplicationComponentPreview
+class Placement::StatusTagComponentPreview < ApplicationComponentPreview
   def default
-    placement = create(:placement)
+    placement = FactoryBot.build(:placement)
 
     render(Placement::StatusTagComponent.new(placement:))
   end

--- a/spec/components/previews/placement_status_tag_component_preview.rb
+++ b/spec/components/previews/placement_status_tag_component_preview.rb
@@ -1,9 +1,0 @@
-class PlacementStatusTagComponentPreview < ApplicationComponentPreview
-  def draft_status
-    render Placement::StatusTagComponent.new("draft")
-  end
-
-  def published_status
-    render Placement::StatusTagComponent.new("published")
-  end
-end

--- a/spec/system/claims/support/view_view_components_spec.rb
+++ b/spec/system/claims/support/view_view_components_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe "View View components", service: :claims, type: :system do
+  let(:support_user) { create(:claims_support_user) }
+
+  before do
+    user_exists_in_dfe_sign_in(user: support_user)
+    given_i_sign_in
+  end
+
+  scenario "User visits the view components page" do
+    when_i_visit_the_view_components_page
+    then_i_can_see_the_list_of_claims_view_component_templates
+  end
+
+  private
+
+  def given_i_sign_in
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def when_i_visit_the_view_components_page
+    click_on "Settings"
+    click_on "View components"
+  end
+
+  def then_i_can_see_the_list_of_claims_view_component_templates
+    expect(page).to have_content("Claim/Card Component")
+    expect(page).to have_link("default (opens in new tab)", href: "/rails/view_components/claim/card_component/default")
+
+    expect(page).to have_content("Claim/Mentor Training Form/Disclaimer Component")
+    expect(page).to have_link("default (opens in new tab)", href: "/rails/view_components/claims/claim/mentor_training_form/disclaimer_component/default")
+  end
+end

--- a/spec/system/placements/support/view_view_components_spec.rb
+++ b/spec/system/placements/support/view_view_components_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe "View Emails", service: :placements, type: :system do
+  let(:support_user) { create(:placements_support_user) }
+
+  before do
+    user_exists_in_dfe_sign_in(user: support_user)
+    given_i_sign_in
+  end
+
+  scenario "User visits the emails page" do
+    when_i_visit_the_emails_page
+    then_i_can_see_the_list_of_placements_email_templates
+  end
+
+  private
+
+  def given_i_sign_in
+    visit sign_in_path
+    click_on "Sign in using DfE Sign In"
+  end
+
+  def when_i_visit_the_emails_page
+    click_on "Settings"
+    click_on "View components"
+  end
+
+  def then_i_can_see_the_list_of_placements_email_templates
+    expect(page).to have_content("Placement/Status Tag Component")
+    expect(page).to have_link("default (opens in new tab)", href: "/rails/view_components/placement/status_tag_component/default")
+
+    expect(page).to have_content("Placement/Summary Component")
+    expect(page).to have_link("default (opens in new tab)", href: "/rails/view_components/placement/summary_component/default")
+  end
+end


### PR DESCRIPTION
## Context

To rapidly iterate on development of view components, we want to be able to see multiple variants.

## Changes proposed in this pull request

- Add links to view components to the Settings pages for ease of access.
- Fix a view component preview bug.

## Guidance to review

- You can visit the Settings page and see "View components".
- Visiting the "View components" link should show a list of service-specific component previews and shared component previews.
  - \* Right now, some components are not under the `Claims` or `Placements` namespaces, hence some undesired results. This can be fixed by namespacing the components correctly.
- Preview pages should only be visible to Support Users.
- Components that use `FactoryBot` break right now.
  - Many solutions here, but offloading those to be considered in the future.