### PR TITLE
Add claims_private_beta flag to schools

### DIFF
--- a/app/models/claims/school.rb
+++ b/app/models/claims/school.rb
@@ -8,6 +8,7 @@
 #  address3                               :string
 #  admissions_policy                      :string
 #  claims_grant_conditions_accepted_at    :datetime
+#  claims_private_beta                    :boolean          default(FALSE)
 #  claims_service                         :boolean          default(FALSE)
 #  district_admin_code                    :string
 #  district_admin_name                    :string

--- a/app/models/placements/school.rb
+++ b/app/models/placements/school.rb
@@ -8,6 +8,7 @@
 #  address3                               :string
 #  admissions_policy                      :string
 #  claims_grant_conditions_accepted_at    :datetime
+#  claims_private_beta                    :boolean          default(FALSE)
 #  claims_service                         :boolean          default(FALSE)
 #  district_admin_code                    :string
 #  district_admin_name                    :string

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -8,6 +8,7 @@
 #  address3                               :string
 #  admissions_policy                      :string
 #  claims_grant_conditions_accepted_at    :datetime
+#  claims_private_beta                    :boolean          default(FALSE)
 #  claims_service                         :boolean          default(FALSE)
 #  district_admin_code                    :string
 #  district_admin_name                    :string

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -126,6 +126,7 @@ shared:
     - local_authority_code
     - claims_grant_conditions_accepted_at
     - claims_grant_conditions_accepted_by_id
+    - claims_private_beta
   :providers:
     - id
     - code

--- a/db/migrate/20241022112629_add_claims_private_beta_to_schools.rb
+++ b/db/migrate/20241022112629_add_claims_private_beta_to_schools.rb
@@ -1,0 +1,11 @@
+class AddClaimsPrivateBetaToSchools < ActiveRecord::Migration[7.2]
+  def change
+    add_column :schools, :claims_private_beta, :boolean, default: false
+
+    up_only do
+      Claims::School.find_each do |school|
+        school.update!(claims_private_beta: true)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_16_120228) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_22_112629) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -404,6 +404,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_16_120228) do
     t.string "local_authority_code"
     t.datetime "claims_grant_conditions_accepted_at"
     t.uuid "claims_grant_conditions_accepted_by_id"
+    t.boolean "claims_private_beta", default: false
     t.index ["claims_grant_conditions_accepted_by_id"], name: "index_schools_on_claims_grant_conditions_accepted_by_id"
     t.index ["claims_service"], name: "index_schools_on_claims_service"
     t.index ["latitude"], name: "index_schools_on_latitude"

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -8,6 +8,7 @@
 #  address3                               :string
 #  admissions_policy                      :string
 #  claims_grant_conditions_accepted_at    :datetime
+#  claims_private_beta                    :boolean          default(FALSE)
 #  claims_service                         :boolean          default(FALSE)
 #  district_admin_code                    :string
 #  district_admin_name                    :string

--- a/spec/models/claims/school_spec.rb
+++ b/spec/models/claims/school_spec.rb
@@ -8,6 +8,7 @@
 #  address3                               :string
 #  admissions_policy                      :string
 #  claims_grant_conditions_accepted_at    :datetime
+#  claims_private_beta                    :boolean          default(FALSE)
 #  claims_service                         :boolean          default(FALSE)
 #  district_admin_code                    :string
 #  district_admin_name                    :string

--- a/spec/models/placements/school_spec.rb
+++ b/spec/models/placements/school_spec.rb
@@ -8,6 +8,7 @@
 #  address3                               :string
 #  admissions_policy                      :string
 #  claims_grant_conditions_accepted_at    :datetime
+#  claims_private_beta                    :boolean          default(FALSE)
 #  claims_service                         :boolean          default(FALSE)
 #  district_admin_code                    :string
 #  district_admin_name                    :string

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -8,6 +8,7 @@
 #  address3                               :string
 #  admissions_policy                      :string
 #  claims_grant_conditions_accepted_at    :datetime
+#  claims_private_beta                    :boolean          default(FALSE)
 #  claims_service                         :boolean          default(FALSE)
 #  district_admin_code                    :string
 #  district_admin_name                    :string


### PR DESCRIPTION
## Context

We need a flag on Schools to determine the starting academic year of claims.

Private beta schools will see 2023-2024 as the starting academic year of claims, others will see 2024-2025.

We need to add in the flag now, rather than later, to ensure that the current Schools in production have been marked as private beta schools, before we add any additional schools to the list.

## Changes proposed in this pull request

- Add the `claims_private_beta` boolean attribute to the `schools` table.

## Guidance to review

- This is intended as additional information, for now. Changes to claims lists and their starting years will be added later down the line.
