### PR TITLE
Order claims support users list by name

### DIFF
--- a/app/controllers/claims/support/support_users_controller.rb
+++ b/app/controllers/claims/support/support_users_controller.rb
@@ -3,7 +3,7 @@ class Claims::Support::SupportUsersController < Claims::Support::ApplicationCont
   before_action :authorize_support_user
 
   def index
-    @pagy, @support_users = pagy(Claims::SupportUser.order(created_at: :desc))
+    @pagy, @support_users = pagy(Claims::SupportUser.order_by_full_name)
   end
 
   def new


### PR DESCRIPTION
## Context

We want to order Support Users by their name.

## Changes proposed in this pull request

- Order Support Users by name.

## Guidance to review

- Visit the support users page.
- Add some support users.
- You should see them ordered alphabetically.