### PR TITLE
Ensure GOVUK tags are inline

### DIFF
--- a/app/assets/stylesheets/components/_tag.scss
+++ b/app/assets/stylesheets/components/_tag.scss
@@ -1,3 +1,4 @@
 .govuk-tag {
   max-width: unset;
+  white-space: nowrap;
 }


### PR DESCRIPTION
## Context

![Screenshot 2024-10-23 at 15 40 49@2x](https://github.com/user-attachments/assets/b2729b00-31bd-4d3c-b3bd-db67266e7381)

We want to avoid the above display from happening:

## Changes proposed in this pull request

- Add `white-space: nowrap` to govuk tags.

## Guidance to review

- Visit the review app, there will be no wrapping of long status names.
