### PR TITLE
Remove the app-phase-banner-—no-border-bottom css

### DIFF
--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -6,7 +6,6 @@
 @import "inline_code";
 @import "link";
 @import "organisation_list_item";
-@import "phase_banner";
 @import "primary_navigation";
 @import "search_results";
 @import "secondary_navigation";

--- a/app/assets/stylesheets/components/_phase_banner.scss
+++ b/app/assets/stylesheets/components/_phase_banner.scss
@@ -1,5 +1,0 @@
-.app-phase-banner {
-  &.app-phase-banner--no-border-bottom {
-    border-bottom: 0;
-  }
-}

--- a/app/views/claims/schools/_primary_navigation.html.erb
+++ b/app/views/claims/schools/_primary_navigation.html.erb
@@ -8,8 +8,6 @@
         ],
       )) %>
     <% end %>
-  <% else %>
-    <% content_for(:no_phase_banner_border, true) %>
   <% end %>
 
   <%= render PrimaryNavigationComponent.new do |component| %>

--- a/app/views/claims/support/_primary_navigation.html.erb
+++ b/app/views/claims/support/_primary_navigation.html.erb
@@ -5,6 +5,4 @@
     <% component.with_navigation_item t(".support_users"), claims_support_support_users_path, current: local_assigns[:current] == :users %>
     <% component.with_navigation_item t(".settings"), claims_support_settings_path, current: local_assigns[:current] == :settings %>
   <% end %>
-
-  <% content_for(:no_phase_banner_border, true) %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,7 +41,7 @@
     <% end %>
 
     <div class="govuk-width-container">
-      <%= govuk_phase_banner(tag: { text: hosting_environment_phase(current_service), colour: hosting_environment_color }, classes: [class_names("app-phase-banner", "app-phase-banner__env--#{HostingEnvironment.env}", "app-phase-banner--no-border-bottom": content_for(:no_phase_banner_border) || support_controller?)]) do %>
+      <%= govuk_phase_banner(tag: { text: hosting_environment_phase(current_service), colour: hosting_environment_color }, classes: [class_names("app-phase-banner", "app-phase-banner__env--#{HostingEnvironment.env}")]) do %>
         <%== t(".#{current_service}.phase_banner.description", feedback_link: govuk_link_to(t(".#{current_service}.phase_banner.feedback"), feedback_url, target: "_blank", rel: "noreferrer", class: "govuk-link--no-visited-state")) %>
       <% end %>
 


### PR DESCRIPTION
## Context

- At the request of @ollietreend, remove the `app-phase-banner-no-border-bottom` css

## Changes proposed in this pull request

Remove the `app-phase-banner-no-border-bottom` css

## Link to Trello card

https://trello.com/c/gFl95hLX/886-remove-app-phase-banner-no-border-bottom-css

## Screenshots

![screencapture-placements-localhost-3000-providers-001da1d4-4c8c-4f56-b365-bfd7549273c6-placements-2024-10-23-16_15_37](https://github.com/user-attachments/assets/1d0f3645-39df-482e-8796-f69ea1a5e79c)

