### PR TITLE
Fix issue with calling nil? on httparty response when caching

### DIFF
--- a/lib/google/routes_api.rb
+++ b/lib/google/routes_api.rb
@@ -11,7 +11,8 @@ module Google
             "X-Goog-FieldMask" => "localizedValues,destinationIndex"
 
     def travel_time(origin_address, destinations, travel_mode: "DRIVE")
-      self.class.post("/distanceMatrix/v2:computeRouteMatrix", body: options(origin_address, destinations, travel_mode))
+      response = self.class.post("/distanceMatrix/v2:computeRouteMatrix", body: options(origin_address, destinations, travel_mode))
+      JSON.parse(response.body)
     end
 
     private

--- a/spec/lib/google/routes_api_spec.rb
+++ b/spec/lib/google/routes_api_spec.rb
@@ -48,6 +48,6 @@ RSpec.describe Google::RoutesApi do
           "X-Goog-Fieldmask" => "localizedValues,destinationIndex",
         },
       )
-      .to_return(status: 200, body: "", headers: {})
+      .to_return(status: 200, body: {}.to_json, headers: {})
   end
 end


### PR DESCRIPTION
## Context

- The deprecation warning is triggered because `Rails.cache.fetch` calls `nil?` on the `Httparty::Response`. 
To resolve this, call `body` on the `Httparty::Response` and then convert it to JSON.

## Changes proposed in this pull request

- Convert `Httparty::Response` body to `JSON` to stop deprecation issue.

## Guidance to review

- Run `bundle exec rspec spec/system`
- The HTTParty DEPRECATION warning should no longer appear.

## Link to Trello card

https://trello.com/c/zOpZRPLt/889-resolve-httparty-deprecation-notices-in-system-specs
