### PR TITLE
Optimise travel time performance 

### DIFF
--- a/app/components/placement/summary_component.rb
+++ b/app/components/placement/summary_component.rb
@@ -1,30 +1,18 @@
 class Placement::SummaryComponent < ApplicationComponent
   with_collection_parameter :placement
-  attr_reader :placement, :school, :provider, :location_coordinates, :search_location
+  attr_reader :placement, :school, :provider, :location_coordinates
 
-  def initialize(provider:, placement:, location_coordinates: nil, search_location: nil, classes: [], html_attributes: {})
+  def initialize(provider:, placement:, location_coordinates: nil, classes: [], html_attributes: {})
     super(classes:, html_attributes:)
 
     @provider = provider
     @placement = placement.decorate
     @school = @placement.school
     @location_coordinates = location_coordinates
-    @search_location = search_location
-
-    calculate_travel_time
   end
 
   def distance_from_location
     distance = @school.distance_to(@location_coordinates).round(1)
     I18n.t("components.placement.summary_component.distance_in_miles", distance:)
-  end
-
-  def calculate_travel_time
-    return if search_location.blank?
-
-    @calculate_travel_time ||= Placements::TravelTime.call(
-      origin_address: search_location,
-      destinations: [@school],
-    )
   end
 end

--- a/app/controllers/placements/providers/placements_controller.rb
+++ b/app/controllers/placements/providers/placements_controller.rb
@@ -12,6 +12,12 @@ class Placements::Providers::PlacementsController < Placements::ApplicationContr
     @terms = Placements::Term.order_by_term.select(:id, :name)
     query = Placements::PlacementsQuery.call(params: query_params)
     @pagy, @placements = pagy(placements.merge(query))
+    @placements = @placements.decorate
+
+    Placements::TravelTime.call(
+      origin_address: search_location,
+      destinations: @placements.map(&:school),
+    )
   end
 
   def show

--- a/app/controllers/placements/providers/placements_controller.rb
+++ b/app/controllers/placements/providers/placements_controller.rb
@@ -65,7 +65,7 @@ class Placements::Providers::PlacementsController < Placements::ApplicationContr
 
     Placements::TravelTime.call(
       origin_address: search_location,
-      destinations: @placements.map(&:school),
+      destinations: @placements.map(&:school).uniq, # travel times are attributes on decorated schools
     )
   end
 

--- a/app/controllers/placements/providers/placements_controller.rb
+++ b/app/controllers/placements/providers/placements_controller.rb
@@ -14,10 +14,7 @@ class Placements::Providers::PlacementsController < Placements::ApplicationContr
     @pagy, @placements = pagy(placements.merge(query))
     @placements = @placements.decorate
 
-    Placements::TravelTime.call(
-      origin_address: search_location,
-      destinations: @placements.map(&:school),
-    )
+    calculate_travel_time
   end
 
   def show
@@ -61,6 +58,15 @@ class Placements::Providers::PlacementsController < Placements::ApplicationContr
       # latitude and longitude
       location.coordinates
     end
+  end
+
+  def calculate_travel_time
+    return if search_location.blank?
+
+    Placements::TravelTime.call(
+      origin_address: search_location,
+      destinations: @placements.map(&:school),
+    )
   end
 
   def filter_params

--- a/app/views/placements/providers/placements/index.html.erb
+++ b/app/views/placements/providers/placements/index.html.erb
@@ -23,7 +23,7 @@
       <% if @placements.any? %>
         <p class="govuk-hint"><%= @search_location.blank? ? t(".results_sorted_alpha") : t(".results_sorted_distance", search_location: @search_location) %></p>
         <ul class="app-search-results">
-          <%= render(Placement::SummaryComponent.with_collection(@placements, provider: @provider, location_coordinates:, search_location: @search_location)) %>
+          <%= render(Placement::SummaryComponent.with_collection(@placements, provider: @provider, location_coordinates:)) %>
         </ul>
         <%= render PaginationComponent.new(pagy: @pagy) %>
       <% else %>

--- a/spec/system/placements/providers/placements/searching_for_a_placement_spec.rb
+++ b/spec/system/placements/providers/placements/searching_for_a_placement_spec.rb
@@ -118,7 +118,10 @@ RSpec.describe "Placements / Providers / Placements / Searching for a placements
   end
 
   context "when searching for a location that doesn't exist" do
-    before { stub_unknown_geocoder_search }
+    before do
+      stub_unknown_geocoder_search
+      stub_routes_api_travel_time
+    end
 
     scenario "User sees a message that no placements were found" do
       when_i_visit_the_placements_index_page
@@ -237,6 +240,14 @@ RSpec.describe "Placements / Providers / Placements / Searching for a placements
     body = [
       {
         "destinationIndex" => 0,
+        "localizedValues" => {
+          "distance" => { "text" => "20 mi" },
+          "duration" => { "text" => "42 mins" },
+          "staticDuration" => { "text" => "36 mins" },
+        },
+      },
+      {
+        "destinationIndex" => 1,
         "localizedValues" => {
           "distance" => { "text" => "20 mi" },
           "duration" => { "text" => "42 mins" },

--- a/spec/system/placements/providers/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/providers/placements/view_placements_list_spec.rb
@@ -302,9 +302,9 @@ RSpec.describe "Placements / Providers / Placements / View placements list",
       end
 
       scenario "User filters are preserved when using the back button" do
-        when_i_visit_the_placements_index_page({ search_location: "London" })
-        when_i_check_filter_option("subject-ids", subject_1.id)
-        and_i_click_on("Apply filters")
+        when_i_visit_the_placements_index_page(
+          { filters: { search_location: "London", subject_ids: [subject_1.id] } },
+        )
         and_i_navigate_to("2")
         when_i_click_on_the_first_placement
         and_i_click_on("Back")
@@ -479,18 +479,21 @@ RSpec.describe "Placements / Providers / Placements / View placements list",
     allow(Geocoder).to receive(:search).and_return(geocoder_results)
   end
 
-  def stub_routes_api_travel_time
-    body = [
-      {
-        "destinationIndex" => 0,
-        "localizedValues" => {
-          "distance" => { "text" => "20 mi" },
-          "duration" => { "text" => "42 mins" },
-          "staticDuration" => { "text" => "36 mins" },
-        },
+  def create_destination_for_routes_api_travel_time(index)
+    {
+      "destinationIndex" => index,
+      "localizedValues" => {
+        "distance" => { "text" => "20 mi" },
+        "duration" => { "text" => "42 mins" },
+        "staticDuration" => { "text" => "36 mins" },
       },
-    ].to_json
+    }
+  end
 
-    stub_request(:post, "https://routes.googleapis.com/distanceMatrix/v2:computeRouteMatrix").to_return(status: 200, body:, headers: { "Content-Type" => "application/json" })
+  def stub_routes_api_travel_time
+    body = (0..30).map { |index| create_destination_for_routes_api_travel_time(index) }.to_json
+
+    stub_request(:post, "https://routes.googleapis.com/distanceMatrix/v2:computeRouteMatrix")
+      .to_return(status: 200, body:, headers: { "Content-Type" => "application/json" })
   end
 end


### PR DESCRIPTION
## Context

Previously we called Placements::TravelTime in `summary_component.rb`, meaning we performed 3x API calls for every single listing shown on the page. At 25 listings per page, that’s 75 external calls to the Google Routes API.

This PR moves the service call to the placements controller so that `calculate_travel_time` is called once for the entire collection of results.

## Changes proposed in this pull request

- Move `calculate_travel_time` (which calls the Placements::TravelTime service object) to the placements controller
- Remove logic from `summary_component.rb`
- Add additional response hashes to `routes_api` travel time stubs to reflect that a whole collection of results is now decorated and populated, as opposed to a single result

## Guidance to review

- Review placements controller and `calculate_travel_time` method
- Run test `spec/system/placements/providers/placements/searching_for_a_placement_spec.rb`
- Run test `spec/system/placements/providers/placements/view_placements_list_spec.rb`

## Link to Trello card

https://trello.com/c/0NEkMKfM/888-optimise-performance-of-travel-time-calculations
