### PR TITLE
Fix issue deleting placements with windows

### DIFF
--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -32,7 +32,7 @@ class Placement < ApplicationRecord
 
   has_many :placement_additional_subjects, class_name: "Placements::PlacementAdditionalSubject", dependent: :destroy
   has_many :additional_subjects, through: :placement_additional_subjects, source: :subject
-  has_many :placement_windows, class_name: "Placements::PlacementWindow"
+  has_many :placement_windows, class_name: "Placements::PlacementWindow", dependent: :destroy
   has_many :terms, class_name: "Placements::Term", through: :placement_windows
 
   belongs_to :academic_year, class_name: "Placements::AcademicYear"

--- a/app/models/placements/term.rb
+++ b/app/models/placements/term.rb
@@ -25,6 +25,6 @@ class Placements::Term < ApplicationRecord
 
   validates :name, presence: true, inclusion: { in: VALID_NAMES }
 
-  has_many :placement_windows, class_name: "Placements::PlacementWindow"
+  has_many :placement_windows, class_name: "Placements::PlacementWindow", dependent: :destroy
   has_many :placements, through: :placement_windows
 end

--- a/app/models/placements/term.rb
+++ b/app/models/placements/term.rb
@@ -25,6 +25,6 @@ class Placements::Term < ApplicationRecord
 
   validates :name, presence: true, inclusion: { in: VALID_NAMES }
 
-  has_many :placement_windows, class_name: "Placements::PlacementWindow", dependent: :destroy
+  has_many :placement_windows, class_name: "Placements::PlacementWindow", dependent: :restrict_with_exception
   has_many :placements, through: :placement_windows
 end

--- a/spec/models/placement_spec.rb
+++ b/spec/models/placement_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Placement, type: :model do
 
     it { is_expected.to have_many(:placement_additional_subjects).class_name("Placements::PlacementAdditionalSubject").dependent(:destroy) }
     it { is_expected.to have_many(:additional_subjects).through(:placement_additional_subjects).class_name("Subject") }
-    it { is_expected.to have_many(:placement_windows).class_name("Placements::PlacementWindow") }
+    it { is_expected.to have_many(:placement_windows).class_name("Placements::PlacementWindow").dependent(:destroy) }
     it { is_expected.to have_many(:terms).through(:placement_windows).class_name("Placements::Term") }
 
     it { is_expected.to belong_to(:academic_year).class_name("Placements::AcademicYear") }

--- a/spec/models/placements/term_spec.rb
+++ b/spec/models/placements/term_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Placements::Term, type: :model do
   end
 
   describe "associations" do
-    it { is_expected.to have_many(:placement_windows).class_name("Placements::PlacementWindow").dependent(:destroy) }
+    it { is_expected.to have_many(:placement_windows).class_name("Placements::PlacementWindow").dependent(:restrict_with_exception) }
     it { is_expected.to have_many(:placements).through(:placement_windows) }
   end
 

--- a/spec/models/placements/term_spec.rb
+++ b/spec/models/placements/term_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Placements::Term, type: :model do
   end
 
   describe "associations" do
-    it { is_expected.to have_many(:placement_windows).class_name("Placements::PlacementWindow") }
+    it { is_expected.to have_many(:placement_windows).class_name("Placements::PlacementWindow").dependent(:destroy) }
     it { is_expected.to have_many(:placements).through(:placement_windows) }
   end
 


### PR DESCRIPTION
## Context

- Fix issue when deleting placements which are associated with terms through placement windows.

## Changes proposed in this pull request

- Add destroy dependancy on placement windows in placement and term models.

## Guidance to review

- Sign in as Anne (School user)
- Find or make a placement with an associated term. (Summer, Autumn or Spring)
- Delete the placement.
- This should be deleted without any issues.

## Link to Trello card

https://trello.com/c/nqbJPqFn/898-investigate-and-resolve-placement-deletion-issue

## Screenshots

https://github.com/user-attachments/assets/8543d211-150b-4db1-b23e-d38e20a23079



