### PR TITLE
Change Placements::BaseWizard/BaseStep to top-level namespace

### DIFF
--- a/app/controllers/placements/organisations/users/add_user_controller.rb
+++ b/app/controllers/placements/organisations/users/add_user_controller.rb
@@ -35,7 +35,7 @@ class Placements::Organisations::Users::AddUserController < Placements::Applicat
   end
 
   def state_key
-    @state_key ||= params.fetch(:state_key, Placements::BaseWizard.generate_state_key)
+    @state_key ||= params.fetch(:state_key, BaseWizard.generate_state_key)
   end
 
   def current_step_path

--- a/app/controllers/placements/partnerships/add_partnership_controller.rb
+++ b/app/controllers/placements/partnerships/add_partnership_controller.rb
@@ -38,7 +38,7 @@ class Placements::Partnerships::AddPartnershipController < Placements::Applicati
   end
 
   def state_key
-    @state_key ||= params.fetch(:state_key, Placements::BaseWizard.generate_state_key)
+    @state_key ||= params.fetch(:state_key, BaseWizard.generate_state_key)
   end
 
   def current_step_path

--- a/app/controllers/placements/schools/mentors/add_mentor_controller.rb
+++ b/app/controllers/placements/schools/mentors/add_mentor_controller.rb
@@ -38,7 +38,7 @@ class Placements::Schools::Mentors::AddMentorController < Placements::Applicatio
   end
 
   def state_key
-    @state_key ||= params.fetch(:state_key, Placements::BaseWizard.generate_state_key)
+    @state_key ||= params.fetch(:state_key, BaseWizard.generate_state_key)
   end
 
   def current_step_path

--- a/app/controllers/placements/schools/placements/add_placement_controller.rb
+++ b/app/controllers/placements/schools/placements/add_placement_controller.rb
@@ -49,7 +49,7 @@ class Placements::Schools::Placements::AddPlacementController < Placements::Appl
   end
 
   def state_key
-    @state_key ||= params.fetch(:state_key, Placements::BaseWizard.generate_state_key)
+    @state_key ||= params.fetch(:state_key, BaseWizard.generate_state_key)
   end
 
   def current_step_path

--- a/app/controllers/placements/schools/placements/edit_placement_controller.rb
+++ b/app/controllers/placements/schools/placements/edit_placement_controller.rb
@@ -49,7 +49,7 @@ class Placements::Schools::Placements::EditPlacementController < Placements::App
   end
 
   def state_key
-    @state_key ||= params.fetch(:state_key, Placements::BaseWizard.generate_state_key)
+    @state_key ||= params.fetch(:state_key, BaseWizard.generate_state_key)
   end
 
   def current_step_path

--- a/app/controllers/placements/schools/school_contacts/add_school_contact_controller.rb
+++ b/app/controllers/placements/schools/school_contacts/add_school_contact_controller.rb
@@ -39,7 +39,7 @@ class Placements::Schools::SchoolContacts::AddSchoolContactController < Placemen
   end
 
   def state_key
-    @state_key ||= params.fetch(:state_key, Placements::BaseWizard.generate_state_key)
+    @state_key ||= params.fetch(:state_key, BaseWizard.generate_state_key)
   end
 
   def current_step_path

--- a/app/controllers/placements/schools/school_contacts/edit_school_contact_controller.rb
+++ b/app/controllers/placements/schools/school_contacts/edit_school_contact_controller.rb
@@ -43,7 +43,7 @@ class Placements::Schools::SchoolContacts::EditSchoolContactController < Placeme
   end
 
   def state_key
-    @state_key ||= params.fetch(:state_key, Placements::BaseWizard.generate_state_key)
+    @state_key ||= params.fetch(:state_key, BaseWizard.generate_state_key)
   end
 
   def current_step_path

--- a/app/controllers/placements/support/organisations/add_organisation_controller.rb
+++ b/app/controllers/placements/support/organisations/add_organisation_controller.rb
@@ -36,7 +36,7 @@ class Placements::Support::Organisations::AddOrganisationController < Placements
   end
 
   def state_key
-    @state_key ||= params.fetch(:state_key, Placements::BaseWizard.generate_state_key)
+    @state_key ||= params.fetch(:state_key, BaseWizard.generate_state_key)
   end
 
   def current_step_path

--- a/app/controllers/placements/support/support_users/add_support_user_controller.rb
+++ b/app/controllers/placements/support/support_users/add_support_user_controller.rb
@@ -41,7 +41,7 @@ class Placements::Support::SupportUsers::AddSupportUserController < Placements::
   end
 
   def state_key
-    @state_key ||= params.fetch(:state_key, Placements::BaseWizard.generate_state_key)
+    @state_key ||= params.fetch(:state_key, BaseWizard.generate_state_key)
   end
 
   def back_link_path

--- a/app/wizards/base_step.rb
+++ b/app/wizards/base_step.rb
@@ -1,4 +1,4 @@
-class Placements::BaseStep
+class BaseStep
   include ActiveModel::Model
   include ActiveModel::Attributes
 

--- a/app/wizards/base_wizard.rb
+++ b/app/wizards/base_wizard.rb
@@ -1,4 +1,4 @@
-class Placements::BaseWizard
+class BaseWizard
   attr_reader :state, :params, :current_step, :steps
 
   def self.generate_state_key

--- a/app/wizards/placements/add_mentor_wizard/check_your_answers_step.rb
+++ b/app/wizards/placements/add_mentor_wizard/check_your_answers_step.rb
@@ -1,2 +1,2 @@
-class Placements::AddMentorWizard::CheckYourAnswersStep < Placements::BaseStep
+class Placements::AddMentorWizard::CheckYourAnswersStep < BaseStep
 end

--- a/app/wizards/placements/add_mentor_wizard/mentor_step.rb
+++ b/app/wizards/placements/add_mentor_wizard/mentor_step.rb
@@ -1,4 +1,4 @@
-class Placements::AddMentorWizard::MentorStep < Placements::BaseStep
+class Placements::AddMentorWizard::MentorStep < BaseStep
   include ActiveModel::Attributes
 
   attribute :trn

--- a/app/wizards/placements/add_mentor_wizard/no_results_step.rb
+++ b/app/wizards/placements/add_mentor_wizard/no_results_step.rb
@@ -1,2 +1,2 @@
-class Placements::AddMentorWizard::NoResultsStep < Placements::BaseStep
+class Placements::AddMentorWizard::NoResultsStep < BaseStep
 end

--- a/app/wizards/placements/add_organisation_wizard/check_your_answers_step.rb
+++ b/app/wizards/placements/add_organisation_wizard/check_your_answers_step.rb
@@ -1,2 +1,2 @@
-class Placements::AddOrganisationWizard::CheckYourAnswersStep < Placements::BaseStep
+class Placements::AddOrganisationWizard::CheckYourAnswersStep < BaseStep
 end

--- a/app/wizards/placements/add_organisation_wizard/organisation_selection_step.rb
+++ b/app/wizards/placements/add_organisation_wizard/organisation_selection_step.rb
@@ -1,4 +1,4 @@
-class Placements::AddOrganisationWizard::OrganisationSelectionStep < Placements::BaseStep
+class Placements::AddOrganisationWizard::OrganisationSelectionStep < BaseStep
   attribute :id
 
   validate :id_presence

--- a/app/wizards/placements/add_organisation_wizard/organisation_type_step.rb
+++ b/app/wizards/placements/add_organisation_wizard/organisation_type_step.rb
@@ -1,4 +1,4 @@
-class Placements::AddOrganisationWizard::OrganisationTypeStep < Placements::BaseStep
+class Placements::AddOrganisationWizard::OrganisationTypeStep < BaseStep
   PROVIDER = "provider".freeze
   SCHOOL = "school".freeze
   ORGANISATION_TYPES = [PROVIDER, SCHOOL].freeze

--- a/app/wizards/placements/add_partnership_wizard/check_your_answers_step.rb
+++ b/app/wizards/placements/add_partnership_wizard/check_your_answers_step.rb
@@ -1,2 +1,2 @@
-class Placements::AddPartnershipWizard::CheckYourAnswersStep < Placements::BaseStep
+class Placements::AddPartnershipWizard::CheckYourAnswersStep < BaseStep
 end

--- a/app/wizards/placements/add_partnership_wizard/partnership_selection_step.rb
+++ b/app/wizards/placements/add_partnership_wizard/partnership_selection_step.rb
@@ -1,4 +1,4 @@
-class Placements::AddPartnershipWizard::PartnershipSelectionStep < Placements::BaseStep
+class Placements::AddPartnershipWizard::PartnershipSelectionStep < BaseStep
   attribute :id
 
   validate :id_presence

--- a/app/wizards/placements/add_placement_wizard/academic_year_step.rb
+++ b/app/wizards/placements/add_placement_wizard/academic_year_step.rb
@@ -1,4 +1,4 @@
-class Placements::AddPlacementWizard::AcademicYearStep < Placements::BaseStep
+class Placements::AddPlacementWizard::AcademicYearStep < BaseStep
   attribute :academic_year_id
 
   validates :academic_year_id, presence: true

--- a/app/wizards/placements/add_placement_wizard/additional_subjects_step.rb
+++ b/app/wizards/placements/add_placement_wizard/additional_subjects_step.rb
@@ -1,4 +1,4 @@
-class Placements::AddPlacementWizard::AdditionalSubjectsStep < Placements::BaseStep
+class Placements::AddPlacementWizard::AdditionalSubjectsStep < BaseStep
   attribute :additional_subject_ids, default: []
 
   validates :additional_subject_ids, presence: true,

--- a/app/wizards/placements/add_placement_wizard/check_your_answers_step.rb
+++ b/app/wizards/placements/add_placement_wizard/check_your_answers_step.rb
@@ -1,3 +1,3 @@
-class Placements::AddPlacementWizard::CheckYourAnswersStep < Placements::BaseStep
+class Placements::AddPlacementWizard::CheckYourAnswersStep < BaseStep
   # Silence is bliss
 end

--- a/app/wizards/placements/add_placement_wizard/mentors_step.rb
+++ b/app/wizards/placements/add_placement_wizard/mentors_step.rb
@@ -1,4 +1,4 @@
-class Placements::AddPlacementWizard::MentorsStep < Placements::BaseStep
+class Placements::AddPlacementWizard::MentorsStep < BaseStep
   attribute :mentor_ids, default: []
 
   validates :mentor_ids, presence: true

--- a/app/wizards/placements/add_placement_wizard/phase_step.rb
+++ b/app/wizards/placements/add_placement_wizard/phase_step.rb
@@ -1,4 +1,4 @@
-class Placements::AddPlacementWizard::PhaseStep < Placements::BaseStep
+class Placements::AddPlacementWizard::PhaseStep < BaseStep
   attribute :phase
 
   VALID_PHASES = [Placements::School::PRIMARY_PHASE, Placements::School::SECONDARY_PHASE].freeze

--- a/app/wizards/placements/add_placement_wizard/preview_placement_step.rb
+++ b/app/wizards/placements/add_placement_wizard/preview_placement_step.rb
@@ -1,4 +1,4 @@
-class Placements::AddPlacementWizard::PreviewPlacementStep < Placements::BaseStep
+class Placements::AddPlacementWizard::PreviewPlacementStep < BaseStep
   delegate :build_placement, to: :wizard
 
   def placement

--- a/app/wizards/placements/add_placement_wizard/subject_step.rb
+++ b/app/wizards/placements/add_placement_wizard/subject_step.rb
@@ -1,4 +1,4 @@
-class Placements::AddPlacementWizard::SubjectStep < Placements::BaseStep
+class Placements::AddPlacementWizard::SubjectStep < BaseStep
   attribute :subject_id
 
   validates :subject_id, presence: true, inclusion: { in: ->(step) { step.subjects_for_selection.ids } }

--- a/app/wizards/placements/add_placement_wizard/terms_step.rb
+++ b/app/wizards/placements/add_placement_wizard/terms_step.rb
@@ -1,4 +1,4 @@
-class Placements::AddPlacementWizard::TermsStep < Placements::BaseStep
+class Placements::AddPlacementWizard::TermsStep < BaseStep
   attribute :term_ids, default: []
 
   validates :term_ids, presence: true

--- a/app/wizards/placements/add_placement_wizard/year_group_step.rb
+++ b/app/wizards/placements/add_placement_wizard/year_group_step.rb
@@ -1,4 +1,4 @@
-class Placements::AddPlacementWizard::YearGroupStep < Placements::BaseStep
+class Placements::AddPlacementWizard::YearGroupStep < BaseStep
   attribute :year_group, default: nil
 
   validates :year_group, presence: true

--- a/app/wizards/placements/add_school_contact_wizard/check_your_answers_step.rb
+++ b/app/wizards/placements/add_school_contact_wizard/check_your_answers_step.rb
@@ -1,2 +1,2 @@
-class Placements::AddSchoolContactWizard::CheckYourAnswersStep < Placements::BaseStep
+class Placements::AddSchoolContactWizard::CheckYourAnswersStep < BaseStep
 end

--- a/app/wizards/placements/add_school_contact_wizard/school_contact_step.rb
+++ b/app/wizards/placements/add_school_contact_wizard/school_contact_step.rb
@@ -1,4 +1,4 @@
-class Placements::AddSchoolContactWizard::SchoolContactStep < Placements::BaseStep
+class Placements::AddSchoolContactWizard::SchoolContactStep < BaseStep
   attribute :first_name
   attribute :last_name
   attribute :email_address

--- a/app/wizards/placements/add_support_user_wizard/check_your_answers_step.rb
+++ b/app/wizards/placements/add_support_user_wizard/check_your_answers_step.rb
@@ -1,2 +1,2 @@
-class Placements::AddSupportUserWizard::CheckYourAnswersStep < Placements::BaseStep
+class Placements::AddSupportUserWizard::CheckYourAnswersStep < BaseStep
 end

--- a/app/wizards/placements/add_support_user_wizard/support_user_step.rb
+++ b/app/wizards/placements/add_support_user_wizard/support_user_step.rb
@@ -1,4 +1,4 @@
-class Placements::AddSupportUserWizard::SupportUserStep < Placements::BaseStep
+class Placements::AddSupportUserWizard::SupportUserStep < BaseStep
   attribute :first_name
   attribute :last_name
   attribute :email

--- a/app/wizards/placements/add_user_wizard/check_your_answers_step.rb
+++ b/app/wizards/placements/add_user_wizard/check_your_answers_step.rb
@@ -1,2 +1,2 @@
-class Placements::AddUserWizard::CheckYourAnswersStep < Placements::BaseStep
+class Placements::AddUserWizard::CheckYourAnswersStep < BaseStep
 end

--- a/app/wizards/placements/add_user_wizard/user_step.rb
+++ b/app/wizards/placements/add_user_wizard/user_step.rb
@@ -1,4 +1,4 @@
-class Placements::AddUserWizard::UserStep < Placements::BaseStep
+class Placements::AddUserWizard::UserStep < BaseStep
   attribute :first_name
   attribute :last_name
   attribute :email

--- a/app/wizards/placements/edit_placement_wizard/provider_step.rb
+++ b/app/wizards/placements/edit_placement_wizard/provider_step.rb
@@ -1,4 +1,4 @@
-class Placements::EditPlacementWizard::ProviderStep < Placements::BaseStep
+class Placements::EditPlacementWizard::ProviderStep < BaseStep
   attribute :provider_id
 
   validates :provider_id, inclusion: { in: ->(step) { step.providers_for_selection.ids } }, if: -> { provider_id != NOT_KNOWN }

--- a/docs/conventions/wizards.md
+++ b/docs/conventions/wizards.md
@@ -48,7 +48,7 @@ Think of step objects as a hybrid between form objects and decorators:
 
 ```ruby
 # app/wizards/placements/add_placement_wizard/subject_step.rb
-class Placements::AddPlacementWizard::SubjectStep < Placements::BaseStep
+class Placements::AddPlacementWizard::SubjectStep < BaseStep
   attribute :subject_id
   validates :subject_id, presence: true
 
@@ -64,7 +64,7 @@ end
 
 ```ruby
 # app/wizards/placements/add_placement_wizard/mentors_step.rb
-class Placements::AddPlacementWizard::MentorsStep < Placements::BaseStep
+class Placements::AddPlacementWizard::MentorsStep < BaseStep
   attribute :mentor_ids
   validates :mentor_ids, presence: true
 
@@ -76,7 +76,7 @@ end
 
 ```ruby
 # app/wizards/placements/add_placement_wizard/check_your_answers_step.rb
-class Placements::AddPlacementWizard::CheckYourAnswersStep < Placements::BaseStep
+class Placements::AddPlacementWizard::CheckYourAnswersStep < BaseStep
   # This step has no attributes of its own
 end
 ```

--- a/spec/requests/placements/schools/placements/add_placement_spec.rb
+++ b/spec/requests/placements/schools/placements/add_placement_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "'Add placement' journey", service: :placements, type: :request d
   let!(:state_key) { SecureRandom.uuid }
 
   before do
-    allow(Placements::BaseWizard).to receive(:generate_state_key).and_return(state_key)
+    allow(BaseWizard).to receive(:generate_state_key).and_return(state_key)
     sign_in_as current_user
   end
 

--- a/spec/requests/placements/schools/placements/edit_placement_spec.rb
+++ b/spec/requests/placements/schools/placements/edit_placement_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "'Edit placement' journey", service: :placements, type: :request 
   let!(:state_key) { SecureRandom.uuid }
 
   before do
-    allow(Placements::BaseWizard).to receive(:generate_state_key).and_return(state_key)
+    allow(BaseWizard).to receive(:generate_state_key).and_return(state_key)
     sign_in_as current_user
   end
 

--- a/spec/requests/placements/support/schools/placements/edit_placement_spec.rb
+++ b/spec/requests/placements/support/schools/placements/edit_placement_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Support console / 'Edit placement' journey", service: :placement
   let!(:state_key) { SecureRandom.uuid }
 
   before do
-    allow(Placements::BaseWizard).to receive(:generate_state_key).and_return(state_key)
+    allow(BaseWizard).to receive(:generate_state_key).and_return(state_key)
     sign_in_as current_user
   end
 

--- a/spec/support/shared_examples/requests/placements/add_a_mentor.rb
+++ b/spec/support/shared_examples/requests/placements/add_a_mentor.rb
@@ -5,7 +5,7 @@ RSpec.shared_examples "an 'Add mentor' journey" do
 
   before do
     sign_in_as current_user
-    allow(Placements::BaseWizard).to receive(:generate_state_key).and_return(state_key)
+    allow(BaseWizard).to receive(:generate_state_key).and_return(state_key)
   end
 
   context "when starting a new wizard journey" do

--- a/spec/wizards/placements/base_step_spec.rb
+++ b/spec/wizards/placements/base_step_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 # A mock wizard so we can test the base class
 require_relative "./burger_order_wizard_mock"
 
-RSpec.describe Placements::BaseStep, type: :model do
+RSpec.describe BaseStep, type: :model do
   subject(:step) { BurgerOrderWizard::ChooseBurgerStep.new(wizard:, attributes:) }
 
   let(:wizard) { instance_double(BurgerOrderWizard) }

--- a/spec/wizards/placements/base_wizard_spec.rb
+++ b/spec/wizards/placements/base_wizard_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 # A mock wizard so we can test the base class
 require_relative "./burger_order_wizard_mock"
 
-RSpec.describe Placements::BaseWizard do
+RSpec.describe BaseWizard do
   subject(:wizard) { BurgerOrderWizard.new(state:, params:, current_step:) }
 
   let(:state) { {} }
@@ -14,7 +14,7 @@ RSpec.describe Placements::BaseWizard do
   describe "#steps" do
     it "is a Hash of Step objects" do
       expect(wizard.steps).to be_a(Hash)
-      expect(wizard.steps.values).to all be_a(Placements::BaseStep)
+      expect(wizard.steps.values).to all be_a(BaseStep)
     end
 
     it "holds steps in order of the user journey" do

--- a/spec/wizards/placements/burger_order_wizard_mock.rb
+++ b/spec/wizards/placements/burger_order_wizard_mock.rb
@@ -1,6 +1,6 @@
 # A mock wizard implementation so we can test BaseWizard and BaseStep without
 # being dependent on a particular wizard implementation within the app itself.
-class BurgerOrderWizard < Placements::BaseWizard
+class BurgerOrderWizard < BaseWizard
   def define_steps
     # Define the wizard steps here
     add_step(ChooseBurgerStep)
@@ -10,12 +10,12 @@ class BurgerOrderWizard < Placements::BaseWizard
     add_step(CheckYourAnswersStep)
   end
 
-  class ChooseBurgerStep < Placements::BaseStep
+  class ChooseBurgerStep < BaseStep
     attribute :burger
     validates :burger, inclusion: { in: %w[beef chicken veggie] }
   end
 
-  class MealDealStep < Placements::BaseStep
+  class MealDealStep < BaseStep
     attribute :make_it_a_meal_deal
     validates :make_it_a_meal_deal, inclusion: { in: %w[yes no] }
 
@@ -24,17 +24,17 @@ class BurgerOrderWizard < Placements::BaseWizard
     end
   end
 
-  class ChooseSideStep < Placements::BaseStep
+  class ChooseSideStep < BaseStep
     attribute :side
     validates :side, inclusion: { in: %w[fries salad coleslaw] }
   end
 
-  class ChooseDrinkStep < Placements::BaseStep
+  class ChooseDrinkStep < BaseStep
     attribute :drink
     validates :drink, inclusion: { in: %w[cola water tea coffee] }
   end
 
-  class CheckYourAnswersStep < Placements::BaseStep
+  class CheckYourAnswersStep < BaseStep
     # This is a read-only step, so it doesn't have attributes.
   end
 end


### PR DESCRIPTION
## Context

We are going to adopt the wizard pattern across the entire app so changing the namespace will allow the base classes to be used outside of a placements context.

## Changes proposed in this pull request

- Placements::BaseWizard -> BaseWizard
- Placements::BaseStep -> BaseStep
- References in controllers updated.
- BaseStep and BaseWizard files moved out of placements subfolder to resolve zeitwerk constant autoloading error.

## Guidance to review

- Run full test suite.
- Test at least two wizard journeys on the review app.

## Link to Trello card

https://trello.com/c/hr4VYjyt/899-promote-placementsbasewizard-to-top-level-namespace