### PR TITLE
Add GOV.UK Component matchers for system specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,6 +41,7 @@ RSpec.configure do |config|
   config.include ViewComponent::TestHelpers, type: :component
   config.include DfESignInUserHelper
   config.include GeocodingHelper
+  config.include GovukComponentMatchers, type: :system
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [Rails.root.join("spec/fixtures")]

--- a/spec/support/govuk_component_matchers.rb
+++ b/spec/support/govuk_component_matchers.rb
@@ -1,0 +1,60 @@
+module GovukComponentMatchers
+  extend RSpec::Matchers::DSL
+
+  matcher :have_summary_list_row do |expected_key, expected_value|
+    match do |page|
+      key = page.find(".govuk-summary-list__key", text: expected_key)
+      row = key.find(:xpath, "..", class: "govuk-summary-list__row")
+      row.find(".govuk-summary-list__value", text: expected_value)
+    end
+  end
+
+  matcher :have_h1 do |text|
+    match { |page| page.find("h1[class^='govuk-heading-']", text:) }
+  end
+
+  matcher :have_h2 do |text|
+    match { |page| page.find("h2[class^='govuk-heading-']", text:) }
+  end
+
+  matcher :have_h3 do |text|
+    match { |page| page.find("h3[class^='govuk-heading-']", text:) }
+  end
+
+  matcher :have_success_banner do |text|
+    match do |page|
+      within ".govuk-notification-banner.govuk-notification-banner--success" do
+        page.find(".govuk-notification-banner__title", text: "Success")
+        page.find(".govuk-notification-banner__heading", text:)
+      end
+    end
+  end
+
+  matcher :have_validation_error do |text|
+    match do |page|
+      within ".govuk-error-summary" do
+        page.find(".govuk-error-summary__title", text: "There is a problem")
+        page.find(".govuk-error-summary__list a", text:)
+      end
+      page.find(".govuk-error-message", text:)
+    end
+  end
+
+  def primary_navigation
+    page.find(".app-primary-navigation")
+  end
+
+  def secondary_navigation
+    page.find(".app-secondary-navigation")
+  end
+
+  # Usage: expect(primary_navigation).to have_current_item("Schools")
+  matcher :have_current_item do |text|
+    match do |page|
+      page.find("a[aria-current='page']", text:)
+
+      # assert there is only one current nav item
+      page.all("a[aria-current='page']", count: 1)
+    end
+  end
+end

--- a/spec/system/placements/organisations/users/add_users_spec.rb
+++ b/spec/system/placements/organisations/users/add_users_spec.rb
@@ -262,20 +262,11 @@ RSpec.describe "Placements users invite other users to organisations", service: 
   end
 
   def and_user_is_selected_in_school_primary_navigation
-    within(".app-primary-navigation__nav") do
-      expect(page).to have_link "Placements", current: "false"
-      expect(page).to have_link "Mentors", current: "false"
-      expect(page).to have_link "Users", current: "page"
-      expect(page).to have_link "Organisation details", current: "false"
-    end
+    expect(primary_navigation).to have_current_item("Users")
   end
 
   def and_user_is_selected_in_provider_primary_navigation
-    within(".app-primary-navigation__nav") do
-      expect(page).to have_link "Placements", current: "false"
-      expect(page).to have_link "Users", current: "page"
-      expect(page).to have_link "Organisation details", current: "false"
-    end
+    expect(primary_navigation).to have_current_item("Users")
   end
 
   def email_invite_notification(email, _organisation)

--- a/spec/system/placements/schools/mentors/view_a_mentor_spec.rb
+++ b/spec/system/placements/schools/mentors/view_a_mentor_spec.rb
@@ -37,12 +37,9 @@ RSpec.describe "Placements / Schools / Mentors / View a mentor", service: :place
   end
 
   def then_i_see_the_mentor_details(first_name:, last_name:, trn:)
-    expect(page).to have_content("#{first_name} #{last_name}")
-
-    within(".govuk-summary-list") do
-      expect(page).to have_content(first_name)
-      expect(page).to have_content(last_name)
-      expect(page).to have_content(trn)
-    end
+    expect(page).to have_h1("#{first_name} #{last_name}")
+    expect(page).to have_summary_list_row("First name", first_name)
+    expect(page).to have_summary_list_row("Last name", last_name)
+    expect(page).to have_summary_list_row("Teacher reference number (TRN)", trn)
   end
 end


### PR DESCRIPTION
## Context

Currently, many of our system specs rely on using the `expect(page).to have_content` matcher to assert that certain items are on the page. However this is fairly low-accuracy and likely to lead to false positives, because it only asserts that the content exists _somewhere_ on the page.

More often, we actually want to assert that the required content exists within a specific element or component on the page. I've therefore opened this PR to introduce some matchers to help us to write more specific system specs.

## Changes proposed in this pull request

New RSpec matchers for use in system specs:

### Headings

H1, H2 and H3 matchers for [GOV.UK-styled headings](https://design-system.service.gov.uk/styles/headings/).

```ruby
expect(page).to have_h1("Heading level one")
expect(page).to have_h2("Heading level two")
expect(page).to have_h3("Heading level three")
```

### Summary lists

Check that [summary list](https://design-system.service.gov.uk/components/summary-list/) rows exist with the specified key and value.

```ruby
expect(page).to have_summary_list_row("First name", "Joe")
expect(page).to have_summary_list_row("Last name", "Bloggs")
```

If your page contains multiple summary lists with duplicate keys, you'll need to wrap these assertions in a `within` block.

### Success banners

```ruby
expect(page).to have_success_banner("Mentor added")
```

### Validation errors

```ruby
expect(page).to have_validation_error("Select a subject")
```

### Check the currently selected navbar item

```ruby
expect(primary_navigation).to have_current_item("Schools")
expect(secondary_navigation).to have_current_item("School details")
```

You can also use `primary_navigation` and `secondary_navigation` helper methods elsewhere in your spec:

```ruby
within(secondary_navigation) { click_link "Placements" }
```

## Guidance to review

I've implemented these matchers in one existing system spec to prove that they work as expected.

## Link to Trello card

https://trello.com/c/FoiI0Krf/908-create-some-govuk-component-matchers-for-system-specs
