### PR TITLE
Remove redundant comment from Terraform config

### DIFF
--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -28,7 +28,6 @@ module "application_configuration" {
 
 # Run database migrations
 # https://guides.rubyonrails.org/active_record_migrations.html#preparing-the-database
-# https://github.com/ilyakatz/data-migrate
 # Terraform waits for this to complete before starting web_application and worker_application
 resource "kubernetes_job" "migrations" {
   metadata {


### PR DESCRIPTION
We dropped the data_migrate gem in PR #1022, but it looks like we forgot to tidy up this reference to the gem.

This comment is no longer helpful since we no longer use the gem.
