### PR TITLE
Matchers return true or false

### DIFF
--- a/spec/support/govuk_component_matchers.rb
+++ b/spec/support/govuk_component_matchers.rb
@@ -12,6 +12,17 @@ module GovukComponentMatchers
     end
   end
 
+  matcher :have_result_detail_row do |expected_key, expected_value|
+    match do |page|
+      key = page.find(".app-result-detail__key", text: expected_key)
+      row = key.find(:xpath, "..", class: "app-result-detail__row")
+      row.find(".app-result-detail__value", text: expected_value)
+      true
+    rescue Capybara::ElementNotFound
+      false
+    end
+  end
+
   matcher :have_h1 do |text|
     match do |page|
       page.find("h1[class^='govuk-heading-']", text:)

--- a/spec/support/govuk_component_matchers.rb
+++ b/spec/support/govuk_component_matchers.rb
@@ -6,19 +6,37 @@ module GovukComponentMatchers
       key = page.find(".govuk-summary-list__key", text: expected_key)
       row = key.find(:xpath, "..", class: "govuk-summary-list__row")
       row.find(".govuk-summary-list__value", text: expected_value)
+      true
+    rescue Capybara::ElementNotFound
+      false
     end
   end
 
   matcher :have_h1 do |text|
-    match { |page| page.find("h1[class^='govuk-heading-']", text:) }
+    match do |page|
+      page.find("h1[class^='govuk-heading-']", text:)
+      true
+    rescue Capybara::ElementNotFound
+      false
+    end
   end
 
   matcher :have_h2 do |text|
-    match { |page| page.find("h2[class^='govuk-heading-']", text:) }
+    match do |page|
+      page.find("h2[class^='govuk-heading-']", text:)
+      true
+    rescue Capybara::ElementNotFound
+      false
+    end
   end
 
   matcher :have_h3 do |text|
-    match { |page| page.find("h3[class^='govuk-heading-']", text:) }
+    match do |page|
+      page.find("h3[class^='govuk-heading-']", text:)
+      true
+    rescue Capybara::ElementNotFound
+      false
+    end
   end
 
   matcher :have_success_banner do |text|
@@ -26,6 +44,9 @@ module GovukComponentMatchers
       within ".govuk-notification-banner.govuk-notification-banner--success" do
         page.find(".govuk-notification-banner__title", text: "Success")
         page.find(".govuk-notification-banner__heading", text:)
+        true
+      rescue Capybara::ElementNotFound
+        false
       end
     end
   end
@@ -37,6 +58,9 @@ module GovukComponentMatchers
         page.find(".govuk-error-summary__list a", text:)
       end
       page.find(".govuk-error-message", text:)
+      true
+    rescue Capybara::ElementNotFound
+      false
     end
   end
 
@@ -55,6 +79,9 @@ module GovukComponentMatchers
 
       # assert there is only one current nav item
       page.all("a[aria-current='page']", count: 1)
+      true
+    rescue Capybara::ElementNotFound
+      false
     end
   end
 end


### PR DESCRIPTION
## Context

Our matcher helpers should return `true` or `false` to allow us to use `to` and `not_to`

## Changes proposed in this pull request

- [x] Explictly returns `true` if there are no errors
- [x] Rescues the `Capybara::ElementNotFound` error to return `false`
- [x] Adds matcher for `have_result_detail_row`

## Guidance to review

- Review changes in file

## Link to Trello card

[Update matchers to return true or false](https://trello.com/c/Yi2Y602i/911-update-matchers-to-return-true-or-false)
