### PR TITLE
Refactor provider filter system specs

### DIFF
--- a/spec/support/govuk_component_matchers.rb
+++ b/spec/support/govuk_component_matchers.rb
@@ -23,6 +23,15 @@ module GovukComponentMatchers
     end
   end
 
+  matcher :have_filter_tag do |text|
+    match do |page|
+      page.find(".app-filter-tags .app-filter__tag", text:)
+      true
+    rescue Capybara::ElementNotFound
+      false
+    end
+  end
+
   matcher :have_h1 do |text|
     match do |page|
       page.find("h1[class^='govuk-heading-']", text:)

--- a/spec/system/placements/providers/placements/provider_user_filters_placements_by_academic_year_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_filters_placements_by_academic_year_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+RSpec.describe "Provider user filters placements by academic year", service: :placements, type: :system do
+  scenario do
+    given_that_placements_exist
+    and_i_am_signed_in
+
+    when_i_am_on_the_placements_index_page
+    then_i_see_the_placement_for_the_current_academic_year
+    and_i_see_this_year_is_selected_from_the_academic_year_filter
+
+    when_i_select_next_year_from_the_academic_year_filter
+    and_i_click_on_apply_filters
+    then_i_see_the_placement_for_the_next_academic_year
+    and_i_do_not_see_the_placement_for_the_current_academic_year
+    and_i_see_next_year_is_selected_from_the_academic_year_filter
+
+    when_i_select_this_year_from_the_academic_year_filter
+    and_i_click_on_apply_filters
+    then_i_see_the_placement_for_the_current_academic_year
+    and_i_see_this_year_is_selected_from_the_academic_year_filter
+  end
+
+  private
+
+  def given_that_placements_exist
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+    @primary_school = build(:placements_school, phase: "Primary", name: "Springfield Elementary")
+    @current_academic_year = Placements::AcademicYear.current
+    @next_academic_year = @current_academic_year.next
+
+    @primary_maths_subject = build(:subject, name: "Primary with mathematics", subject_area: "primary")
+    _current_academic_year_placement = create(:placement, school: @primary_school, subject: @primary_maths_subject,
+                                                          academic_year: @current_academic_year)
+
+    @primary_english_subject = build(:subject, name: "Primary with english", subject_area: "primary")
+    _next_academic_year_placement = create(:placement, school: @primary_school, subject: @primary_english_subject,
+                                                       academic_year: @next_academic_year)
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Find placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Find placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def then_i_see_the_placement_for_the_current_academic_year
+    expect(page).to have_h2("Primary with mathematics – Springfield Elementary")
+  end
+
+  def when_i_select_next_year_from_the_academic_year_filter
+    choose "Next year (#{@next_academic_year.name})"
+  end
+
+  def and_i_click_on_apply_filters
+    click_on "Apply filters"
+  end
+
+  def then_i_see_the_placement_for_the_next_academic_year
+    expect(page).to have_h2("Primary with english – Springfield Elementary")
+  end
+
+  def and_i_do_not_see_the_placement_for_the_current_academic_year
+    expect(page).not_to have_h2("Primary with mathematics – Springfield Elementary")
+  end
+
+  def and_i_see_next_year_is_selected_from_the_academic_year_filter
+    expect(page).to have_element(:legend, text: "Academic year", class: "govuk-fieldset__legend")
+    expect(page).to have_checked_field("Next year (#{@next_academic_year.name})")
+    expect(page).not_to have_checked_field("This year (#{@current_academic_year.name})")
+  end
+
+  def when_i_select_this_year_from_the_academic_year_filter
+    choose "This year (#{@current_academic_year.name})"
+  end
+
+  def and_i_see_this_year_is_selected_from_the_academic_year_filter
+    expect(page).to have_element(:legend, text: "Academic year", class: "govuk-fieldset__legend")
+    expect(page).to have_checked_field("This year (#{@current_academic_year.name})")
+    expect(page).not_to have_checked_field("Next year (#{@next_academic_year.name})")
+  end
+end

--- a/spec/system/placements/providers/placements/provider_user_filters_placements_by_expected_date_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_filters_placements_by_expected_date_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "Provider user filters placements by expected date", service: :pl
   end
 
   def and_i_do_not_see_the_spring_term_placement
-    expect(page).not_to have_h2("Primary with english – Springfield Elementar")
+    expect(page).not_to have_h2("Primary with english – Springfield Elementary")
   end
 
   def and_i_see_my_selected_expected_date_filter

--- a/spec/system/placements/providers/placements/provider_user_filters_placements_by_expected_date_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_filters_placements_by_expected_date_spec.rb
@@ -1,0 +1,139 @@
+require "rails_helper"
+
+RSpec.describe "Provider user filters placements by expected date", service: :placements, type: :system do
+  scenario do
+    given_that_placements_exist
+    and_i_am_signed_in
+
+    when_i_am_on_the_placements_index_page
+    then_i_see_all_placements
+    and_i_see_the_expected_date_filter
+
+    when_i_select_autumn_term_from_the_expected_date_filter
+    and_i_click_on_apply_filters
+    then_i_see_the_autumn_term_placement
+    and_i_do_not_see_the_spring_term_placement
+    and_i_see_my_selected_expected_date_filter
+
+    when_i_select_spring_term_from_the_expected_date_filter
+    and_i_click_on_apply_filters
+    then_i_see_all_placements
+    and_i_see_my_selected_expected_date_filters
+
+    when_i_click_on_the_autumn_term_expected_date_filter_tag
+    then_i_see_the_spring_term_placement
+    and_i_do_not_see_the_autumn_term_placement
+    and_i_do_not_see_the_autumn_term_selected_expected_date_filters
+
+    when_i_click_on_the_spring_term_expected_date_filter_tag
+    then_i_see_all_placements
+    and_i_do_not_see_any_selected_expected_date_filters
+  end
+
+  private
+
+  def given_that_placements_exist
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+    @primary_school = build(:placements_school, phase: "Primary", name: "Springfield Elementary")
+
+    @autumn_term = build(:placements_term, :autumn)
+    @primary_maths_subject = build(:subject, name: "Primary with mathematics", subject_area: "primary")
+    _autumn_term_placement = create(:placement, school: @primary_school, subject: @primary_maths_subject,
+                                                terms: [@autumn_term])
+
+    @spring_term = build(:placements_term, :spring)
+    @primary_english_subject = build(:subject, name: "Primary with english", subject_area: "primary")
+    _spring_term_placement = create(:placement, school: @primary_school, subject: @primary_english_subject,
+                                                terms: [@spring_term])
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Find placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Find placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def then_i_see_all_placements
+    expect(page).to have_h2("Primary with mathematics – Springfield Elementary")
+    expect(page).to have_h2("Primary with english – Springfield Elementary")
+  end
+
+  def and_i_see_the_expected_date_filter
+    expect(page).to have_element(:legend, text: "Expected date", class: "govuk-fieldset__legend")
+    expect(page).to have_field("Autumn term", type: "checkbox", checked: false)
+    expect(page).to have_field("Spring term", type: "checkbox", checked: false)
+  end
+
+  def when_i_select_autumn_term_from_the_expected_date_filter
+    check "Autumn term"
+  end
+
+  def and_i_click_on_apply_filters
+    click_on "Apply filters"
+  end
+
+  def then_i_see_the_autumn_term_placement
+    expect(page).to have_h2("Primary with mathematics – Springfield Elementary")
+  end
+
+  def and_i_do_not_see_the_spring_term_placement
+    expect(page).not_to have_h2("Primary with english – Springfield Elementar")
+  end
+
+  def and_i_see_my_selected_expected_date_filter
+    expect(page).to have_filter_tag("Autumn term")
+    expect(page).to have_checked_field("Autumn term")
+    expect(page).not_to have_checked_field("Spring term")
+    expect(page).not_to have_filter_tag("Spring term")
+  end
+
+  def when_i_select_spring_term_from_the_expected_date_filter
+    check "Spring term"
+  end
+
+  def and_i_see_my_selected_expected_date_filters
+    expect(page).to have_filter_tag("Autumn term")
+    expect(page).to have_checked_field("Autumn term")
+    expect(page).to have_filter_tag("Spring term")
+    expect(page).to have_checked_field("Spring term")
+  end
+
+  def when_i_click_on_the_autumn_term_expected_date_filter_tag
+    within ".app-filter-tags" do
+      click_on "Autumn term"
+    end
+  end
+
+  def then_i_see_the_spring_term_placement
+    expect(page).to have_h2("Primary with english – Springfield Elementary")
+  end
+
+  def and_i_do_not_see_the_autumn_term_placement
+    expect(page).not_to have_h2("Primary with mathematics – Springfield Elementary")
+  end
+
+  def and_i_do_not_see_the_autumn_term_selected_expected_date_filters
+    expect(page).not_to have_filter_tag("Autumn term")
+    expect(page).not_to have_checked_field("Autumn term")
+    expect(page).to have_filter_tag("Spring term")
+    expect(page).to have_checked_field("Spring term")
+  end
+
+  def when_i_click_on_the_spring_term_expected_date_filter_tag
+    within ".app-filter-tags" do
+      click_on "Spring term"
+    end
+  end
+
+  def and_i_do_not_see_any_selected_expected_date_filters
+    expect(page).not_to have_filter_tag("Autumn term")
+    expect(page).not_to have_checked_field("Autumn term")
+    expect(page).not_to have_filter_tag("Spring term")
+    expect(page).not_to have_checked_field("Spring term")
+  end
+end

--- a/spec/system/placements/providers/placements/provider_user_filters_placements_by_placements_to_show_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_filters_placements_by_placements_to_show_spec.rb
@@ -1,0 +1,101 @@
+require "rails_helper"
+
+RSpec.describe "Provider user filters placements by placements to show", service: :placements, type: :system do
+  scenario do
+    given_that_placements_exist
+    and_i_am_signed_in
+
+    when_i_am_on_the_placements_index_page
+    then_i_see_the_available_placement
+    and_i_see_available_placements_is_selected_from_the_placements_to_show_filter
+
+    when_i_select_assigned_to_me_from_the_placements_to_show_filter
+    and_i_click_on_apply_filters
+    then_i_see_the_placement_assigned_to_me
+    and_i_see_assigned_to_me_is_selected_from_placements_to_show_filter
+
+    when_i_select_all_placements_from_the_placements_to_show_filter
+    and_i_click_on_apply_filters
+    then_i_see_all_placements
+    and_i_see_all_placements_is_selected_from_placements_to_show_filter
+  end
+
+  private
+
+  def given_that_placements_exist
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+    @competing_provider = build(:placements_provider, name: "Asha'man Trust")
+    @primary_school = build(:placements_school, phase: "Primary", name: "Springfield Elementary")
+
+    @primary_maths_subject = build(:subject, name: "Primary with mathematics", subject_area: "primary")
+    _available_placement = create(:placement, school: @primary_school, subject: @primary_maths_subject)
+
+    @primary_english_subject = build(:subject, name: "Primary with english", subject_area: "primary")
+    _unavailable_placement = create(:placement, school: @primary_school, subject: @primary_english_subject,
+                                                provider: @competing_provider)
+
+    @primary_science_subject = build(:subject, name: "Primary with science", subject_area: "primary")
+    _assigned_placement = create(:placement, school: @primary_school, subject: @primary_science_subject,
+                                             provider: @provider)
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Find placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Find placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def then_i_see_the_available_placement
+    expect(page).to have_h2("Primary with mathematics – Springfield Elementary")
+  end
+
+  def and_i_see_available_placements_is_selected_from_the_placements_to_show_filter
+    expect(page).to have_element(:legend, text: "Placements to show", class: "govuk-fieldset__legend")
+    expect(page).to have_checked_field("Available placements")
+    expect(page).not_to have_checked_field("Assigned to me")
+    expect(page).not_to have_checked_field("All placements")
+  end
+
+  def when_i_select_assigned_to_me_from_the_placements_to_show_filter
+    choose "Assigned to me"
+  end
+
+  def and_i_click_on_apply_filters
+    click_on "Apply filters"
+  end
+
+  def then_i_see_the_placement_assigned_to_me
+    expect(page).to have_h2("Primary with science – Springfield Elementary")
+    expect(page).not_to have_h2("Primary with mathematics – Springfield Elementary")
+    expect(page).not_to have_h2("Primary with english – Springfield Elementary")
+  end
+
+  def and_i_see_assigned_to_me_is_selected_from_placements_to_show_filter
+    expect(page).to have_element(:legend, text: "Placements to show", class: "govuk-fieldset__legend")
+    expect(page).to have_checked_field("Assigned to me")
+    expect(page).not_to have_checked_field("Available placements")
+    expect(page).not_to have_checked_field("All placements")
+  end
+
+  def when_i_select_all_placements_from_the_placements_to_show_filter
+    choose "All placements"
+  end
+
+  def then_i_see_all_placements
+    expect(page).to have_h2("Primary with mathematics – Springfield Elementary")
+    expect(page).to have_h2("Primary with science – Springfield Elementary")
+    expect(page).to have_h2("Primary with english – Springfield Elementary")
+  end
+
+  def and_i_see_all_placements_is_selected_from_placements_to_show_filter
+    expect(page).to have_element(:legend, text: "Placements to show", class: "govuk-fieldset__legend")
+    expect(page).to have_checked_field("All placements")
+    expect(page).not_to have_checked_field("Available placements")
+    expect(page).not_to have_checked_field("Assigned to me")
+  end
+end

--- a/spec/system/placements/providers/placements/provider_user_filters_placements_by_primary_year_group_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_filters_placements_by_primary_year_group_spec.rb
@@ -1,0 +1,138 @@
+require "rails_helper"
+
+RSpec.describe "Provider user filters placements by primary year group", service: :placements, type: :system do
+  scenario do
+    given_that_placements_exist
+    and_i_am_signed_in
+
+    when_i_am_on_the_placements_index_page
+    then_i_see_all_placements
+    and_i_see_the_primary_year_group_filter
+
+    when_i_select_nursery_term_from_the_primary_year_group_filter
+    and_i_click_on_apply_filters
+    then_i_see_the_nursery_placement
+    and_i_do_not_see_the_year_1_placement
+    and_i_see_my_selected_primary_year_group_filter
+
+    when_i_select_year_1_from_the_primary_year_group_filter
+    and_i_click_on_apply_filters
+    then_i_see_all_placements
+    and_i_see_my_selected_primary_year_group_filters
+
+    when_i_click_on_the_nursery_primary_year_group_filter_tag
+    then_i_see_the_year_1_placement
+    and_i_do_not_see_the_nursery_placement
+    and_i_do_not_see_the_nursery_selected_primary_year_group_filters
+
+    when_i_click_on_the_year_1_primary_year_group_filter_tag
+    then_i_see_all_placements
+    and_i_do_not_see_any_selected_primary_year_group_filters
+  end
+
+  private
+
+  def given_that_placements_exist
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+    @primary_school = build(:placements_school, phase: "Primary", name: "Springfield Elementary")
+
+    @primary_maths_subject = build(:subject, name: "Primary with mathematics", subject_area: "primary")
+    _nursery_placement = create(:placement, school: @primary_school, subject: @primary_maths_subject,
+                                            year_group: :nursery)
+
+    @primary_english_subject = build(:subject, name: "Primary with english", subject_area: "primary")
+    _year_1_placement = create(:placement, school: @primary_school, subject: @primary_english_subject,
+                                           year_group: :year_1)
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Find placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Find placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def then_i_see_all_placements
+    expect(page).to have_h2("Primary with mathematics (Nursery) – Springfield Elementary")
+    expect(page).to have_h2("Primary with english (Year 1) – Springfield Elementary")
+  end
+
+  def and_i_see_the_primary_year_group_filter
+    expect(page).to have_element(:legend, text: "Primary year group", class: "govuk-fieldset__legend")
+    expect(page).to have_field("Nursery", type: "checkbox", checked: false)
+    expect(page).to have_field("Reception", type: "checkbox", checked: false)
+    expect(page).to have_field("Year 1", type: "checkbox", checked: false)
+  end
+
+  def when_i_select_nursery_term_from_the_primary_year_group_filter
+    check "Nursery"
+  end
+
+  def and_i_click_on_apply_filters
+    click_on "Apply filters"
+  end
+
+  def then_i_see_the_nursery_placement
+    expect(page).to have_h2("Primary with mathematics (Nursery) – Springfield Elementary")
+  end
+
+  def and_i_do_not_see_the_year_1_placement
+    expect(page).not_to have_h2("Primary with english (Year 1) – Springfield Elementar")
+  end
+
+  def and_i_see_my_selected_primary_year_group_filter
+    expect(page).to have_filter_tag("Nursery")
+    expect(page).to have_checked_field("Nursery")
+    expect(page).not_to have_filter_tag("Year 1")
+    expect(page).not_to have_checked_field("Year 1")
+  end
+
+  def when_i_select_year_1_from_the_primary_year_group_filter
+    check "Year 1"
+  end
+
+  def and_i_see_my_selected_primary_year_group_filters
+    expect(page).to have_filter_tag("Nursery")
+    expect(page).to have_checked_field("Nursery")
+    expect(page).to have_filter_tag("Year 1")
+    expect(page).to have_checked_field("Year 1")
+  end
+
+  def when_i_click_on_the_nursery_primary_year_group_filter_tag
+    within ".app-filter-tags" do
+      click_on "Nursery"
+    end
+  end
+
+  def then_i_see_the_year_1_placement
+    expect(page).to have_h2("Primary with english (Year 1) – Springfield Elementary")
+  end
+
+  def and_i_do_not_see_the_nursery_placement
+    expect(page).not_to have_h2("Primary with mathematics (Nursery) – Springfield Elementary")
+  end
+
+  def and_i_do_not_see_the_nursery_selected_primary_year_group_filters
+    expect(page).not_to have_filter_tag("Nursery")
+    expect(page).not_to have_checked_field("Nursery")
+    expect(page).to have_filter_tag("Year 1")
+    expect(page).to have_checked_field("Year 1")
+  end
+
+  def when_i_click_on_the_year_1_primary_year_group_filter_tag
+    within ".app-filter-tags" do
+      click_on "Year 1"
+    end
+  end
+
+  def and_i_do_not_see_any_selected_primary_year_group_filters
+    expect(page).not_to have_filter_tag("Nursery")
+    expect(page).not_to have_checked_field("Nursery")
+    expect(page).not_to have_filter_tag("Year 1")
+    expect(page).not_to have_checked_field("Year 1")
+  end
+end

--- a/spec/system/placements/providers/placements/provider_user_filters_placements_by_primary_year_group_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_filters_placements_by_primary_year_group_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "Provider user filters placements by primary year group", service
   end
 
   def and_i_do_not_see_the_year_1_placement
-    expect(page).not_to have_h2("Primary with english (Year 1) – Springfield Elementar")
+    expect(page).not_to have_h2("Primary with english (Year 1) – Springfield Elementary")
   end
 
   def and_i_see_my_selected_primary_year_group_filter

--- a/spec/system/placements/providers/placements/provider_user_filters_placements_by_school_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_filters_placements_by_school_spec.rb
@@ -1,0 +1,134 @@
+require "rails_helper"
+
+RSpec.describe "Provider user filters placements by school", service: :placements, type: :system do
+  scenario do
+    given_that_placements_exist
+    and_i_am_signed_in
+
+    when_i_am_on_the_placements_index_page
+    then_i_see_all_placements
+    and_i_see_the_school_filter
+
+    when_i_select_springfield_elementary_from_the_school_filter
+    and_i_click_on_apply_filters
+    then_i_see_the_springfield_elementary_placement
+    and_i_do_not_see_the_hogwarts_placement
+    and_i_see_the_spring_field_elementary_selected_school_filter
+
+    when_i_select_hogwarts_from_the_school_filter
+    and_i_click_on_apply_filters
+    then_i_see_all_placements
+    and_i_see_my_selected_school_filters
+
+    when_i_click_on_the_springfield_elementary_school_filter_tag
+    then_i_see_the_hogwarts_placement
+    and_i_do_not_see_the_springfield_elementary_placement
+    and_i_do_not_see_the_springfield_elementary_selected_school_filter
+
+    when_i_click_on_the_hogwarts_school_filter_tag
+    then_i_see_all_placements
+    and_i_do_not_see_any_selected_school_filters
+  end
+
+  private
+
+  def given_that_placements_exist
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+
+    @primary_school = build(:placements_school, phase: "Primary", name: "Springfield Elementary")
+    @primary_maths_subject = build(:subject, name: "Primary with mathematics", subject_area: "primary")
+    _primary_placement = create(:placement, school: @primary_school, subject: @primary_maths_subject)
+
+    @secondary_school = build(:placements_school, phase: "Secondary", name: "Hogwarts")
+    @secondary_english_subject = build(:subject, name: "English", subject_area: "secondary")
+    _secondary_placement = create(:placement, school: @secondary_school, subject: @secondary_english_subject)
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Find placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Find placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def then_i_see_all_placements
+    expect(page).to have_h2("Primary with mathematics – Springfield Elementary")
+    expect(page).to have_h2("English – Hogwarts")
+  end
+
+  def and_i_see_the_school_filter
+    expect(page).to have_element(:legend, text: "School", class: "govuk-fieldset__legend")
+    expect(page).to have_field("Springfield Elementary", type: "checkbox", checked: false)
+    expect(page).to have_field("Hogwarts", type: "checkbox", checked: false)
+  end
+
+  def when_i_select_springfield_elementary_from_the_school_filter
+    check "Springfield Elementary"
+  end
+
+  def and_i_click_on_apply_filters
+    click_on "Apply filters"
+  end
+
+  def then_i_see_the_springfield_elementary_placement
+    expect(page).to have_h2("Primary with mathematics – Springfield Elementary")
+  end
+
+  def and_i_do_not_see_the_hogwarts_placement
+    expect(page).not_to have_h2("English – Hogwarts")
+  end
+
+  def and_i_see_the_spring_field_elementary_selected_school_filter
+    expect(page).to have_filter_tag("Springfield Elementary")
+    expect(page).to have_checked_field("Springfield Elementary")
+    expect(page).not_to have_checked_field("Hogwarts")
+    expect(page).not_to have_filter_tag("Hogwarts")
+  end
+
+  def when_i_select_hogwarts_from_the_school_filter
+    check "Hogwarts"
+  end
+
+  def and_i_see_my_selected_school_filters
+    expect(page).to have_filter_tag("Springfield Elementary")
+    expect(page).to have_checked_field("Springfield Elementary")
+    expect(page).to have_filter_tag("Hogwarts")
+    expect(page).to have_checked_field("Hogwarts")
+  end
+
+  def when_i_click_on_the_springfield_elementary_school_filter_tag
+    within ".app-filter-tags" do
+      click_on "Springfield Elementary"
+    end
+  end
+
+  def then_i_see_the_hogwarts_placement
+    expect(page).to have_h2("English – Hogwarts")
+  end
+
+  def and_i_do_not_see_the_springfield_elementary_placement
+    expect(page).not_to have_h2("Primary with mathematics – Springfield Elementary")
+  end
+
+  def and_i_do_not_see_the_springfield_elementary_selected_school_filter
+    expect(page).not_to have_filter_tag("Springfield Elementary")
+    expect(page).not_to have_checked_field("Springfield Elementary")
+  end
+
+  def when_i_click_on_the_hogwarts_school_filter_tag
+    within ".app-filter-tags" do
+      click_on "Hogwarts"
+    end
+  end
+
+  def and_i_do_not_see_any_selected_school_filters
+    expect(page).not_to have_filter_tag("Springfield Elementary")
+    expect(page).not_to have_checked_field("Springfield Elementary")
+    expect(page).not_to have_filter_tag("Hogwarts")
+    expect(page).not_to have_checked_field("Hogwarts")
+  end
+end

--- a/spec/system/placements/providers/placements/provider_user_filters_placements_by_schools_i_work_with_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_filters_placements_by_schools_i_work_with_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+RSpec.describe "Provider user filters placements by schools I work with", service: :placements, type: :system do
+  scenario do
+    given_that_placements_exist
+    and_i_am_signed_in
+
+    when_i_am_on_the_placements_index_page
+    then_i_see_all_placements
+    and_i_see_the_schools_i_work_with_filter
+
+    when_i_select_only_show_placements_from_schools_i_work_with_from_the_schools_i_work_with_filter
+    and_i_click_on_apply_filters
+    then_i_see_the_school_i_work_with_placement
+    and_i_do_not_see_the_school_i_do_not_work_with_placement
+    and_i_see_my_selected_schools_i_work_with_filter
+
+    when_i_click_on_the_school_i_work_with_filter_tag
+    then_i_see_all_placements
+    and_i_do_not_see_any_selected_schools_i_work_with_filters
+  end
+
+  private
+
+  def given_that_placements_exist
+    @school_i_work_with = build(:placements_school, phase: "Primary", name: "Springfield Elementary")
+    @school_i_work_with_subject = build(:subject, name: "Primary with mathematics", subject_area: "primary")
+    _school_i_work_with_placement = create(:placement, school: @school_i_work_with,
+                                                       subject: @school_i_work_with_subject)
+
+    @provider = build(:placements_provider, name: "Aes Sedai Trust", partner_schools: [@school_i_work_with])
+
+    @school_i_do_not_work_with = build(:placements_school, phase: "Secondary", name: "Hogwarts")
+    @school_i_do_not_work_with_subject = build(:subject, name: "Primary with english", subject_area: "secondary")
+    _school_i_do_not_work_with_placement = create(:placement, school: @school_i_do_not_work_with,
+                                                              subject: @school_i_do_not_work_with_subject)
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Find placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Find placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def then_i_see_all_placements
+    expect(page).to have_h2("Primary with mathematics – Springfield Elementary")
+    expect(page).to have_h2("Primary with english – Hogwarts")
+  end
+
+  def and_i_see_the_schools_i_work_with_filter
+    expect(page).to have_element(:legend, text: "Schools I work with", class: "govuk-fieldset__legend",
+                                          match: :prefer_exact)
+    expect(page).to have_field("Only show placements from schools I work with", type: "checkbox", checked: false)
+  end
+
+  def when_i_select_only_show_placements_from_schools_i_work_with_from_the_schools_i_work_with_filter
+    check "Only show placements from schools I work with"
+  end
+
+  def and_i_click_on_apply_filters
+    click_on "Apply filters"
+  end
+
+  def then_i_see_the_school_i_work_with_placement
+    expect(page).to have_h2("Primary with mathematics – Springfield Elementary")
+  end
+
+  def and_i_do_not_see_the_school_i_do_not_work_with_placement
+    expect(page).not_to have_h2("Primary with english– Hogwarts")
+  end
+
+  def and_i_see_my_selected_schools_i_work_with_filter
+    expect(page).to have_filter_tag("Schools I work with")
+    expect(page).to have_checked_field("Only show placements from schools I work with")
+  end
+
+  def when_i_click_on_the_school_i_work_with_filter_tag
+    within ".app-filter-tags" do
+      click_on "Schools I work with"
+    end
+  end
+
+  def and_i_do_not_see_any_selected_schools_i_work_with_filters
+    expect(page).not_to have_filter_tag("Schools I work with")
+    expect(page).not_to have_checked_field("Only show placements from schools I work with")
+  end
+end

--- a/spec/system/placements/providers/placements/provider_user_filters_placements_by_search_by_location_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_filters_placements_by_search_by_location_spec.rb
@@ -1,0 +1,165 @@
+require "rails_helper"
+
+RSpec.describe "Provider user filters placements by search by location", service: :placements, type: :system do
+  scenario do
+    given_that_placements_exist
+    and_i_am_signed_in
+
+    when_i_am_on_the_placements_index_page
+    then_i_see_all_placements
+    and_i_see_the_search_by_location_filter
+
+    when_i_search_for_schools_near_guildford
+    and_i_click_on_apply_filters
+    then_i_see_the_guildford_school_placement
+    and_i_do_not_see_the_bath_school_placement
+    and_i_see_the_guildford_search_by_location_filter
+
+    when_i_search_for_schools_in_a_made_up_location
+    and_i_click_on_apply_filters
+    then_i_see_no_placements
+    and_i_see_my_made_up_location_search_by_location_filter
+    and_i_do_not_see_my_guildford_search_by_location_filter
+
+    when_i_click_on_the_made_up_location_search_by_location_filter_tag
+    then_i_see_all_placements
+    and_i_do_not_see_any_selected_search_by_location_filters
+  end
+
+  private
+
+  def given_that_placements_exist
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+
+    @guildford_school = build(:placements_school, phase: "Primary", name: "Springfield Elementary", latitude: 51.23622,
+                                                  longitude: -0.570409)
+    @primary_maths_subject = build(:subject, name: "Primary with mathematics", subject_area: "primary")
+    _guildford_school_placement = create(:placement, school: @guildford_school, subject: @primary_maths_subject)
+
+    @bath_school = build(:placements_school, phase: "Secondary", name: "Hogwarts", latitude: 51.3781018,
+                                             longitude: -2.3596827)
+    @secondary_english_subject = build(:subject, name: "English", subject_area: "secondary")
+    _bath_school_placement = create(:placement, school: @bath_school, subject: @secondary_english_subject)
+
+    stub_geocoder_results
+    stub_routes_request
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Find placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Find placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def then_i_see_all_placements
+    expect(page).to have_h2("Primary with mathematics – Springfield Elementary")
+    expect(page).to have_h2("English – Hogwarts")
+  end
+
+  def and_i_see_the_search_by_location_filter
+    expect(page).to have_field("Enter a town, city or postcode", type: :search)
+    expect(page).to have_element(:p, text: "Powered by Google", class: "govuk-body-s secondary-text")
+  end
+
+  def when_i_search_for_schools_near_guildford
+    fill_in "Enter a town, city or postcode", with: "Guildford"
+  end
+
+  def and_i_click_on_apply_filters
+    click_on "Apply filters"
+  end
+
+  def then_i_see_the_guildford_school_placement
+    expect(page).to have_h2("Primary with mathematics – Springfield Elementary")
+    expect(page).to have_result_detail_row("Distance", "0.0 mi")
+    expect(page).to have_result_detail_row("Public transport", "42 minutes")
+    expect(page).to have_result_detail_row("Driving", "42 minutes")
+    expect(page).to have_result_detail_row("Walking", "42 minutes")
+  end
+
+  def and_i_do_not_see_the_bath_school_placement
+    expect(page).not_to have_h2("English – Hogwarts")
+  end
+
+  def and_i_see_the_guildford_search_by_location_filter
+    expect(page).to have_filter_tag("Guildford")
+    expect(page).to have_field("Enter a town, city or postcode", type: :search, with: "Guildford")
+  end
+
+  def when_i_search_for_schools_in_a_made_up_location
+    fill_in "Enter a town, city or postcode", with: "Mordor"
+  end
+
+  def then_i_see_no_placements
+    expect(page).to have_h2("No placements")
+    expect(page).to have_element(:p, text: "There are no placements that match your selection. Try searching again, or removing one or more filters.")
+  end
+
+  def and_i_see_my_made_up_location_search_by_location_filter
+    expect(page).to have_filter_tag("Mordor")
+    expect(page).to have_field("Enter a town, city or postcode", type: :search, with: "Mordor")
+  end
+
+  def and_i_do_not_see_my_guildford_search_by_location_filter
+    expect(page).not_to have_filter_tag("Guildford")
+    expect(page).not_to have_field("Enter a town, city or postcode", type: :search, with: "Guildford")
+  end
+
+  def when_i_click_on_the_made_up_location_search_by_location_filter_tag
+    within ".app-filter-tags" do
+      click_on "Mordor"
+    end
+  end
+
+  def and_i_do_not_see_any_selected_search_by_location_filters
+    expect(page).not_to have_filter_tag("Guildford")
+    expect(page).not_to have_field("Enter a town, city or postcode", type: :search, with: "Guildford")
+    expect(page).not_to have_result_detail_row("Distance", "0.0 mi")
+    expect(page).not_to have_result_detail_row("Public transport", "42 minutes")
+    expect(page).not_to have_result_detail_row("Driving", "42 minutes")
+    expect(page).not_to have_result_detail_row("Walking", "42 minutes")
+  end
+
+  def stub_geocoder_results
+    guildford_geocoder_results = instance_double("geocoder_results")
+    guildford_geocoder_result = instance_double("geocoder_result")
+    allow(guildford_geocoder_results).to receive(:first).and_return(guildford_geocoder_result)
+    allow(guildford_geocoder_result).to receive(:coordinates).and_return([51.23622, -0.570409])
+
+    mordor_geocoder_results = instance_double("geocoder_results")
+    mordor_geocoder_result = instance_double("geocoder_result")
+    allow(mordor_geocoder_results).to receive(:first).and_return(mordor_geocoder_result)
+    allow(mordor_geocoder_result).to receive(:coordinates).and_return([55.378051, -3.435973])
+
+    allow(Geocoder).to receive(:search).and_return(guildford_geocoder_results, mordor_geocoder_results)
+  end
+
+  def stub_routes_request
+    body = [
+      {
+        "destinationIndex" => 0,
+        "localizedValues" => {
+          "distance" => { "text" => "20 mi" },
+          "duration" => { "text" => "42 mins" },
+          "staticDuration" => { "text" => "36 mins" },
+        },
+      },
+      {
+        "destinationIndex" => 1,
+        "localizedValues" => {
+          "distance" => { "text" => "20 mi" },
+          "duration" => { "text" => "42 mins" },
+          "staticDuration" => { "text" => "36 mins" },
+        },
+      },
+    ].to_json
+
+    stub_request(:post, "https://routes.googleapis.com/distanceMatrix/v2:computeRouteMatrix")
+      .to_return(status: 200, body:, headers: { "Content-Type" => "application/json" })
+  end
+end

--- a/spec/system/placements/providers/placements/provider_user_filters_placements_by_subject_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_filters_placements_by_subject_spec.rb
@@ -1,0 +1,135 @@
+require "rails_helper"
+
+RSpec.describe "Provider user filters placements by subject", service: :placements, type: :system do
+  scenario do
+    given_that_placements_exist
+    and_i_am_signed_in
+
+    when_i_am_on_the_placements_index_page
+    then_i_see_all_placements
+    and_i_see_the_subject_filter
+
+    when_i_select_primary_with_maths_from_the_subject_filter
+    and_i_click_on_apply_filters
+    then_i_see_the_primary_with_maths_placement
+    and_i_do_not_see_the_primary_with_english_placement
+    and_i_see_my_selected_subject_filter
+
+    when_i_select_primary_with_english_from_the_subject_filter
+    and_i_click_on_apply_filters
+    then_i_see_all_placements
+    and_i_see_my_selected_subject_filters
+
+    when_i_click_on_the_primary_with_maths_subject_filter_tag
+    then_i_see_the_primary_with_english_placement
+    and_i_do_not_see_the_primary_with_maths_placement
+    and_i_do_not_see_the_primary_with_maths_subject_filter
+
+    when_i_click_on_the_primary_with_english_subject_filter_tag
+    then_i_see_all_placements
+    and_i_do_not_see_any_selected_subject_filters
+  end
+
+  private
+
+  def given_that_placements_exist
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+    @primary_school = build(:placements_school, phase: "Primary", name: "Springfield Elementary")
+
+    @primary_maths_subject = build(:subject, name: "Primary with mathematics", subject_area: "primary")
+    _primary_maths_placement = create(:placement, school: @primary_school, subject: @primary_maths_subject)
+
+    @primary_english_subject = build(:subject, name: "Primary with english", subject_area: "primary")
+    _primary_english_placement = create(:placement, school: @primary_school, subject: @primary_english_subject)
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Find placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Find placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def then_i_see_all_placements
+    expect(page).to have_h2("Primary with mathematics – Springfield Elementary")
+    expect(page).to have_h2("Primary with english – Springfield Elementary")
+  end
+
+  def and_i_see_the_subject_filter
+    expect(page).to have_element(:legend, text: "Subject", class: "govuk-fieldset__legend")
+    expect(page).to have_field("Primary with mathematics", type: :checkbox, checked: false)
+    expect(page).to have_field("Primary with english", type: :checkbox, unchecked: true)
+  end
+
+  def when_i_select_primary_with_maths_from_the_subject_filter
+    check "Primary with mathematics"
+  end
+
+  def and_i_click_on_apply_filters
+    click_on "Apply filters"
+  end
+
+  def then_i_see_the_primary_with_maths_placement
+    expect(page).to have_h2("Primary with mathematics – Springfield Elementary")
+  end
+
+  def and_i_do_not_see_the_primary_with_english_placement
+    expect(page).not_to have_h2("Primary with english – Springfield Elementar")
+  end
+
+  def and_i_see_my_selected_subject_filter
+    expect(page).to have_filter_tag("Primary with mathematics")
+    expect(page).to have_checked_field("Primary with mathematics")
+    expect(page).not_to have_filter_tag("Primary with english")
+    expect(page).not_to have_checked_field("Primary with english")
+  end
+
+  def when_i_select_primary_with_english_from_the_subject_filter
+    check "Primary with english"
+  end
+
+  def and_i_see_my_selected_subject_filters
+    expect(page).to have_filter_tag("Primary with mathematics")
+    expect(page).to have_checked_field("Primary with mathematics")
+    expect(page).to have_filter_tag("Primary with english")
+    expect(page).to have_checked_field("Primary with english")
+  end
+
+  def when_i_click_on_the_primary_with_maths_subject_filter_tag
+    within ".app-filter-tags" do
+      click_on "Primary with mathematics"
+    end
+  end
+
+  def then_i_see_the_primary_with_english_placement
+    expect(page).to have_h2("Primary with english – Springfield Elementary")
+  end
+
+  def and_i_do_not_see_the_primary_with_maths_placement
+    expect(page).not_to have_h2("Primary with mathematics – Springfield Elementary")
+  end
+
+  def and_i_do_not_see_the_primary_with_maths_subject_filter
+    expect(page).not_to have_filter_tag("Primary with mathematics")
+    expect(page).not_to have_checked_field("Primary with mathematics")
+    expect(page).to have_filter_tag("Primary with english")
+    expect(page).to have_checked_field("Primary with english")
+  end
+
+  def when_i_click_on_the_primary_with_english_subject_filter_tag
+    within ".app-filter-tags" do
+      click_on "Primary with english"
+    end
+  end
+
+  def and_i_do_not_see_any_selected_subject_filters
+    expect(page).not_to have_filter_tag("Primary with mathematics")
+    expect(page).not_to have_checked_field("Primary with mathematics")
+    expect(page).not_to have_filter_tag("Primary with english")
+    expect(page).not_to have_checked_field("Primary with english")
+  end
+end

--- a/spec/system/placements/providers/placements/provider_user_filters_placements_by_subject_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_filters_placements_by_subject_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Provider user filters placements by subject", service: :placemen
   end
 
   def and_i_do_not_see_the_primary_with_english_placement
-    expect(page).not_to have_h2("Primary with english – Springfield Elementar")
+    expect(page).not_to have_h2("Primary with english – Springfield Elementary")
   end
 
   def and_i_see_my_selected_subject_filter

--- a/spec/system/placements/providers/placements/provider_user_searches_for_school_filter_option_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_searches_for_school_filter_option_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe "Provider user searchers for a school filter option", :js, service: :placements, type: :system do
+  scenario do
+    given_that_school_filter_options_exist
+    and_i_am_signed_in
+
+    when_i_am_on_the_placements_index_page
+    then_i_see_the_school_filter
+
+    when_i_search_for_hogwarts_in_the_school_filter
+    then_i_see_hogwarts_in_the_school_filter
+    and_i_do_not_see_springfield_elementary_in_the_school_filter
+
+    when_i_clear_the_search_in_the_school_filter
+    then_i_see_all_schools_in_the_school_filter
+  end
+
+  private
+
+  def given_that_school_filter_options_exist
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+    @primary_school = create(:placements_school, phase: "Primary", name: "Springfield Elementary")
+    @secondary_school = create(:placements_school, phase: "Secondary", name: "Hogwarts")
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Find placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Find placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def then_i_see_the_school_filter
+    expect(page).to have_element(:legend, text: "School", class: "govuk-fieldset__legend")
+    expect(page).to have_element(:label, text: "Springfield Elementary")
+    expect(page).to have_element(:label, text: "Hogwarts")
+  end
+
+  def when_i_search_for_hogwarts_in_the_school_filter
+    fill_in "Filter School", with: "Hogwarts"
+  end
+
+  def then_i_see_hogwarts_in_the_school_filter
+    expect(page).to have_element(:label, text: "Hogwarts")
+  end
+
+  def and_i_do_not_see_springfield_elementary_in_the_school_filter
+    expect(page).not_to have_element(:label, text: "Springfield Elementary")
+  end
+
+  def when_i_clear_the_search_in_the_school_filter
+    fill_in "Filter School", with: ""
+  end
+
+  def then_i_see_all_schools_in_the_school_filter
+    expect(page).to have_element(:label, text: "Springfield Elementary")
+    expect(page).to have_element(:label, text: "Hogwarts")
+  end
+end

--- a/spec/system/placements/providers/placements/provider_user_searches_for_subject_filter_option_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_searches_for_subject_filter_option_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe "Provider user searchers for a subject filter option", :js, service: :placements, type: :system do
+  scenario do
+    given_that_subject_filter_options_exist
+    and_i_am_signed_in
+
+    when_i_am_on_the_placements_index_page
+    then_i_see_the_subject_filter
+
+    when_i_search_for_primary_with_english_in_the_subject_filter
+    then_i_see_primary_with_english_in_the_subject_filter
+    and_i_do_not_see_primary_with_mathematics_in_the_subject_filter
+
+    when_i_clear_the_search_in_the_subject_filter
+    then_i_see_all_subjects_in_the_subject_filter
+  end
+
+  private
+
+  def given_that_subject_filter_options_exist
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+    @english_subject = create(:subject, name: "Primary with english")
+    @mathematics_subject = create(:subject, name: "Primary with mathematics")
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Find placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Find placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def then_i_see_the_subject_filter
+    expect(page).to have_element(:legend, text: "Subject", class: "govuk-fieldset__legend")
+    expect(page).to have_element(:label, text: "Primary with english")
+    expect(page).to have_element(:label, text: "Primary with mathematics")
+  end
+
+  def when_i_search_for_primary_with_english_in_the_subject_filter
+    fill_in "Filter Subject", with: "Primary with english"
+  end
+
+  def then_i_see_primary_with_english_in_the_subject_filter
+    expect(page).to have_element(:label, text: "Primary with english")
+  end
+
+  def and_i_do_not_see_primary_with_mathematics_in_the_subject_filter
+    expect(page).not_to have_element(:label, text: "Primary with mathematics")
+  end
+
+  def when_i_clear_the_search_in_the_subject_filter
+    fill_in "Filter Subject", with: ""
+  end
+
+  def then_i_see_all_subjects_in_the_subject_filter
+    expect(page).to have_element(:label, text: "Primary with english")
+    expect(page).to have_element(:label, text: "Primary with mathematics")
+  end
+end


### PR DESCRIPTION
## Context

We have collectively decided on a new format for our system specs, as part of switching over to the new format we are picking "tricky" specs to see how they can be adapted. This collection of specs cover the provider user filters on the placements index page.

## Changes proposed in this pull request

- [x] Adds a new `:have_filter_tag` matcher
- [x] Adds a new spec file for each of our 8 placement filters
- [x]  Adds 2 JS specs for testing the search function of the subject and school filters

## Guidance to review

- Purely spec changes, review each file and make sure that nothing has been missed and add any style suggestions whilst we're still exploring exactly how our specs should be created.

## Link to Trello card

[Refactor provider filter system specs to cucumber style](https://trello.com/c/IBTs1FiB/910-refactor-provider-filter-system-specs-to-cucumber-style)
