### PR TITLE
Fix a flaky system spec

### DIFF
--- a/spec/system/claims/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/schools/claims/create_claim_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Create claim", service: :claims, type: :system do
     when_i_click("Continue")
     then_i_check_my_answers
     when_i_click("Submit claim")
-    then_i_get_a_claim_reference_and_see_next_steps(Claims::Claim.submitted.first)
+    then_i_get_a_claim_reference_and_see_next_steps
   end
 
   scenario "Anne attempts to create a claim but backs off before the check page" do
@@ -117,8 +117,8 @@ RSpec.describe "Create claim", service: :claims, type: :system do
     when_i_add_training_hours("20 hours")
     when_i_click("Continue")
     when_i_click("Submit claim")
-    then_i_get_a_claim_reference_and_see_next_steps(Claims::Claim.submitted.last)
-    given_i_visit_claim_check_page_after_submitting(Claims::Claim.submitted.last)
+    then_i_get_a_claim_reference_and_see_next_steps
+    given_i_visit_claim_check_page_after_submitting
     then_i_am_redirected_to_root_path_with_alert
   end
 
@@ -258,7 +258,9 @@ RSpec.describe "Create claim", service: :claims, type: :system do
     end
   end
 
-  def then_i_get_a_claim_reference_and_see_next_steps(claim)
+  def then_i_get_a_claim_reference_and_see_next_steps
+    claim = Claims::Claim.submitted.order(:submitted_at).last
+
     within(".govuk-panel") do
       expect(page).to have_content("Claim submitted\nYour reference number\n#{claim.reference}")
     end
@@ -284,7 +286,9 @@ RSpec.describe "Create claim", service: :claims, type: :system do
     end
   end
 
-  def given_i_visit_claim_check_page_after_submitting(claim)
+  def given_i_visit_claim_check_page_after_submitting
+    claim = Claims::Claim.submitted.order(:submitted_at).last
+
     Capybara.current_session.driver.header(
       "Referer",
       check_claims_school_claim_url(school, claim),


### PR DESCRIPTION
## Context

This system spec was unpredictably passing and failing.

It looks like this was caused by pulling the 'last' record from the database, but not providing a sort order. You can't rely on the order of records in the database unless you specify one – especially since we use UUID strings as our primary keys.

In this case, there are two claims in the database which means sort order is important.

## Changes proposed in this pull request

Sort records before retrieving the 'last' one.

## Guidance to review

Do the tests pass?

## Link to Trello card

Done as part of this card: https://trello.com/c/TUWOipzZ/824-add-test-coverage-for-refresher-training-and-remove-some-hardcoded-training-allowance-limits

I've cherry-picked this fix into its own standalone PR.
