### PR TITLE
Prefactor specs ahead of refresher training changes

### DIFF
--- a/app/models/claims/mentor_training.rb
+++ b/app/models/claims/mentor_training.rb
@@ -26,8 +26,8 @@
 #
 class Claims::MentorTraining < ApplicationRecord
   belongs_to :claim
-  belongs_to :mentor, optional: true
-  belongs_to :provider, optional: true
+  belongs_to :mentor
+  belongs_to :provider
 
   audited associated_with: :claim
 

--- a/spec/forms/claims/claim/mentors_form_spec.rb
+++ b/spec/forms/claims/claim/mentors_form_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 describe Claims::Claim::MentorsForm, type: :model do
   let!(:claim) { create(:claim) }
-  let!(:mentor1) { create(:mentor) }
-  let!(:mentor2) { create(:mentor) }
+  let!(:mentor1) { create(:claims_mentor) }
+  let!(:mentor2) { create(:claims_mentor) }
 
   describe "validations" do
     context "when mentors is blank" do

--- a/spec/forms/claims/support/claim/mentors_form_spec.rb
+++ b/spec/forms/claims/support/claim/mentors_form_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 describe Claims::Support::Claim::MentorsForm, type: :model do
   let!(:claim) { create(:claim) }
-  let!(:mentor1) { create(:mentor) }
-  let!(:mentor2) { create(:mentor) }
+  let!(:mentor1) { create(:claims_mentor) }
+  let!(:mentor2) { create(:claims_mentor) }
 
   describe "validations" do
     context "when mentors is blank" do

--- a/spec/models/claims/claim_spec.rb
+++ b/spec/models/claims/claim_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Claims::Claim, type: :model do
     end
 
     it "returns false when a mentor has more hours than maximum allocated per provider" do
-      provider = create(:provider)
+      provider = create(:claims_provider)
       claim = create(:claim, :submitted, provider:)
       mentor = create(:claims_mentor)
       create(:mentor_training, claim:, hours_completed: 20, mentor:, provider:)

--- a/spec/models/claims/mentor_training_spec.rb
+++ b/spec/models/claims/mentor_training_spec.rb
@@ -29,7 +29,7 @@ require "rails_helper"
 RSpec.describe Claims::MentorTraining, type: :model do
   subject(:mentor_training) { described_class.new }
 
-  context "with associations" do
+  describe "associations" do
     it { is_expected.to belong_to(:claim) }
     it { is_expected.to belong_to(:mentor).optional }
     it { is_expected.to belong_to(:provider).optional }
@@ -40,27 +40,25 @@ RSpec.describe Claims::MentorTraining, type: :model do
   end
 
   describe "enums" do
-    subject(:mentor_training) { described_class.new }
-
     it "defines the expected values for training_type" do
       expect(mentor_training).to define_enum_for(:training_type)
-                         .with_values(initial: "initial", refresher: "refresher")
-                         .backed_by_column_of_type(:enum)
-                         .with_default(:initial)
+        .with_values(initial: "initial", refresher: "refresher")
+        .backed_by_column_of_type(:enum)
+        .with_default(:initial)
     end
   end
 
-  context "with validations" do
+  describe "validations" do
     it {
       expect(mentor_training).to validate_numericality_of(:hours_completed)
-      .only_integer
-      .is_greater_than(0)
-      .is_less_than_or_equal_to(20)
-      .allow_nil
+        .only_integer
+        .is_greater_than(0)
+        .is_less_than_or_equal_to(20)
+        .allow_nil
     }
   end
 
-  context "with scopes" do
+  describe "scopes" do
     describe "#without_hours" do
       it "returns mentor_trainings without completed hours ordered by mentor first nameand last name" do
         mentor1 = create(:mentor, first_name: "Anne", last_name: "Doe")
@@ -91,7 +89,7 @@ RSpec.describe Claims::MentorTraining, type: :model do
     end
   end
 
-  context "with delegations" do
+  describe "#full_name" do
     it { is_expected.to delegate_method(:full_name).to(:mentor).with_prefix.allow_nil }
   end
 end

--- a/spec/models/claims/mentor_training_spec.rb
+++ b/spec/models/claims/mentor_training_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe Claims::MentorTraining, type: :model do
 
   describe "associations" do
     it { is_expected.to belong_to(:claim) }
-    it { is_expected.to belong_to(:mentor).optional }
-    it { is_expected.to belong_to(:provider).optional }
+    it { is_expected.to belong_to(:mentor) }
+    it { is_expected.to belong_to(:provider) }
   end
 
   describe "auditing" do

--- a/spec/models/claims/training_allowance_spec.rb
+++ b/spec/models/claims/training_allowance_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Claims::TrainingAllowance, type: :model do
       end
 
       context "when the mentor has completed 3 hours of training in the current academic year and 20 hours in the previous academic year for a claim they want to exclude" do
-        let(:hours_completed) { 6 }
+        let(:hours_completed) { 3 }
         let(:claim_to_exclude) { claim }
 
         it "excludes the excluded claim" do

--- a/spec/services/claims/provider/generate_csv_spec.rb
+++ b/spec/services/claims/provider/generate_csv_spec.rb
@@ -3,12 +3,12 @@ require "rails_helper"
 RSpec.describe Claims::Provider::GenerateCSV do
   subject(:generate_csv) { described_class.call(provider:, academic_year:) }
 
-  let!(:provider) { create(:provider) }
+  let!(:provider) { create(:claims_provider) }
   let!(:academic_year) { create(:academic_year, :current) }
 
   it_behaves_like "a service object" do
     let(:params) do
-      { provider: create(:provider), academic_year: create(:academic_year, :current) }
+      { provider: create(:claims_provider), academic_year: create(:academic_year, :current) }
     end
   end
 
@@ -32,7 +32,7 @@ RSpec.describe Claims::Provider::GenerateCSV do
              ends_on: Date.parse("19 July 2025"))
     end
 
-    let(:another_provider) { create(:provider) }
+    let(:another_provider) { create(:claims_provider) }
 
     let(:school_a) { create(:claims_school, name: "School A", postcode: "AAA AAA", urn: "1111111") }
     let(:school_b) { create(:claims_school, name: "School B", postcode: "BBB BBB", urn: "2222222") }

--- a/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
       user_memberships: [create(:user_membership, organisation: school)],
     )
   end
-  let!(:provider1) { create(:provider, :best_practice_network) }
-  let!(:provider2) { create(:provider, :niot) }
+  let!(:provider1) { create(:claims_provider, :best_practice_network) }
+  let!(:provider2) { create(:claims_provider, :niot) }
 
   let(:mentor1) { create(:mentor, first_name: "Anne") }
   let(:mentor2) { create(:mentor, first_name: "Joe") }

--- a/spec/system/claims/schools/claims/view_claims_spec.rb
+++ b/spec/system/claims/schools/claims/view_claims_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe "View claims", service: :claims, type: :system do
       :claim,
       :draft,
       school: school_with_mentors,
-      provider: create(:claims_provider),
-      mentors: [school_with_mentors.mentors.first],
+      provider: build(:claims_provider),
+      mentor_trainings: [build(:mentor_training, mentor: school_with_mentors.mentors.first)],
     )
   end
   let!(:submitted_claim) do
@@ -31,7 +31,7 @@ RSpec.describe "View claims", service: :claims, type: :system do
       :submitted,
       school: school_with_mentors,
       provider: create(:claims_provider),
-      mentors: [school_with_mentors.mentors.first],
+      mentor_trainings: [build(:mentor_training, mentor: school_with_mentors.mentors.first)],
       submitted_at: Time.new(2024, 3, 5, 12, 31, 52, "+00:00"),
     )
   end

--- a/spec/system/claims/schools/mentors/mentor_associated_to_active_claim_spec.rb
+++ b/spec/system/claims/schools/mentors/mentor_associated_to_active_claim_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe "When removing a mentor", service: :claims, type: :system do
   end
 
   scenario "When I try and remove a mentor who is already part of a submitted claim" do
-    create(:claim, school_id: school.id, reference: "12345678", status: :submitted, mentors: [mentor1])
+    mentor_trainings = [build(:mentor_training, mentor: mentor1)]
+    create(:claim, school_id: school.id, reference: "12345678", status: :submitted, mentor_trainings:)
 
     user_exists_in_dfe_sign_in(user: anne)
     given_i_sign_in
@@ -26,7 +27,8 @@ RSpec.describe "When removing a mentor", service: :claims, type: :system do
   end
 
   scenario "When I try and remove a mentor who is already part of a draft claim" do
-    create(:claim, school_id: school.id, reference: "12345671", status: :draft, mentors: [mentor2])
+    mentor_trainings = [build(:mentor_training, mentor: mentor2)]
+    create(:claim, school_id: school.id, reference: "12345671", status: :draft, mentor_trainings:)
 
     user_exists_in_dfe_sign_in(user: anne)
     given_i_sign_in

--- a/spec/system/claims/support/claims/view_a_claim_spec.rb
+++ b/spec/system/claims/support/claims/view_a_claim_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "View claims", service: :claims, type: :system do
       :submitted,
       provider:,
       school: create(:claims_school, region: regions(:inner_london)),
-      mentors: [mentor],
+      mentor_trainings: [build(:mentor_training, mentor:)],
       submitted_by: user,
       submitted_at: Time.zone.parse("2024-03-05 12:31:52"),
     )

--- a/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
       user_memberships: [create(:user_membership, organisation: school)],
     )
   end
-  let!(:provider1) { create(:provider, :best_practice_network) }
-  let!(:provider2) { create(:provider, :niot) }
+  let!(:provider1) { create(:claims_provider, :best_practice_network) }
+  let!(:provider2) { create(:claims_provider, :niot) }
 
   let(:mentor1) { create(:mentor, first_name: "Anne") }
   let(:mentor2) { create(:mentor, first_name: "Joe") }

--- a/spec/system/claims/support/schools/mentors/mentor_associated_to_active_claim_spec.rb
+++ b/spec/system/claims/support/schools/mentors/mentor_associated_to_active_claim_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe "When removing a mentor", service: :claims, type: :system do
   let!(:colin) { create(:claims_support_user, :colin) }
 
   scenario "When I try and remove a mentor who is already part of a submitted claim" do
-    create(:claim, school_id: school.id, reference: "12345678", status: :submitted, mentors: [mentor1])
+    mentor_trainings = [build(:mentor_training, mentor: mentor1)]
+    create(:claim, school_id: school.id, reference: "12345678", status: :submitted, mentor_trainings:)
 
     user_exists_in_dfe_sign_in(user: colin)
     given_i_sign_in


### PR DESCRIPTION
## Context

While working to [add refresher training to the Claims service](https://trello.com/c/TUWOipzZ/824-add-test-coverage-for-refresher-training-and-remove-some-hardcoded-training-allowance-limits), I stumbled across a few specs which needed refactoring before I could easily implement the feature.

## Changes proposed in this pull request

Some of the changes I've made here are cosmetic – for example, I've reformatted a spec to improve readability.

Other changes are more functional and far reaching in nature. For example, I've updated the associations on the Claim model so that Provider and Mentor are required. They were previously optional, but on closer inspection it only seemed to be required by the test suite, and was not actually a requirement of the app itself. In particular this seemed to be due to the way Claim records were created during tests, so I tweaked them to remove that need. This tightens up the data model and reduces the likelihood of unexpected data being persisted to the database.

I also found a bunch of specs where the wrong factory was used – for example, `build(:provider)` instead of `build(:claims_provider)`. These needed to be fixed ahead of the upcoming changes, where it becomes more important for us to have the correct type of object in our hands.

## Guidance to review

These changes are easiest reviewed commit-by-commit. I've tried to include meaningful commit messages throughout.

1. [Tidy up formatting of the Mentor Training spec](https://github.com/DFE-Digital/itt-mentor-services/commit/3d5a2defc8546a0215901871c0d85674a1049370)
2. [Fix a logic error in the Training Allowance spec](https://github.com/DFE-Digital/itt-mentor-services/commit/44f8abaf622e4e5c2ca6038090121f731e5b4906)
3. [Fix incorrect usage of test factories](https://github.com/DFE-Digital/itt-mentor-services/commit/0125d0447b85e1c8087ea6e2aeb320bdbc63c5b1)
4. [Require Provider and Mentor associations](https://github.com/DFE-Digital/itt-mentor-services/commit/2976b4be5bff4e15774ff2e058c47e5d8f5a8c71)

## Link to Trello card

This is a [preparatory refactor](url) (a 'prefactor'), being done as part of this card: https://trello.com/c/TUWOipzZ/824-add-test-coverage-for-refresher-training-and-remove-some-hardcoded-training-allowance-limits
