### PR TITLE
Separate maintenance messages

### DIFF
--- a/maintenance_page/html/index2.html
+++ b/maintenance_page/html/index2.html
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>This service is currently unavailable - Claim funding for mentor training - GOV.UK</title>
+    <title>This service is currently unavailable - Manage school placements - GOV.UK</title>
     <meta name="robots" content="noindex, nofollow">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
@@ -45,7 +45,7 @@
           </a>
         </div>
         <div class="govuk-header__content">
-          <a class="govuk-header__link govuk-header__service-name" href="/">Claim funding for mentor</a>
+          <a class="govuk-header__link govuk-header__service-name" href="/">Manage school placements</a>
         </div>
       </div>
     </header>

--- a/maintenance_page/nginx.conf
+++ b/maintenance_page/nginx.conf
@@ -12,6 +12,8 @@ events {
 
 
 http {
+    server_names_hash_bucket_size 256;
+
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
@@ -29,7 +31,7 @@ http {
 
     server {
         listen       8080;
-        server_name  localhost;
+        server_name  track-and-pay-staging.test.teacherservices.cloud track-and-pay-production.teacherservices.cloud;
 
         root /usr/share/nginx/html;
 
@@ -41,6 +43,28 @@ http {
         # And the response code is changed to 500
         # The user is not redirected and if they keep refreshing, the URL remains the same
         error_page 403 404 =500 /index.html;
+
+        # Assets are relative to the URL. We capture the prefix and filename
+        # and serve them from the right files
+        location ~ /(stylesheets|assets|javascript)/(.*)$ {
+            alias /usr/share/nginx/html/$1/$2;
+        }
+    }
+
+    server {
+        listen       8080;
+        server_name  manage-school-placements-staging.test.teacherservices.cloud manage-school-placements-production.teacherservices.cloud;
+
+        root /usr/share/nginx/html;
+
+        # Request to / returns 200
+        index  /index2.html;
+
+        # Request to anything else than /index2.html returns 404 not found
+        # The maintenance page is served as error page
+        # And the response code is changed to 500
+        # The user is not redirected and if they keep refreshing, the URL remains the same
+        error_page 403 404 =500 /index2.html;
 
         # Assets are relative to the URL. We capture the prefix and filename
         # and serve them from the right files


### PR DESCRIPTION
## Context

ittms has two services and we want to display a different maintenance message depending on which service is being used.

## Changes proposed in this pull request

configure the nginx.conf to go to different index pages based on the different server names of the two services

## Guidance to review

i applied a temporary commit to support running in review 
make review terraform-apply PR_NUMBER=1234
make review enable-maintenance GITHUB_TOKEN=ghp_xxxxxxxxx PR_NUMBER=1234

you can see it running in test at 

https://manage-school-placements-1234.test.teacherservices.cloud/

https://track-and-pay-1234.test.teacherservices.cloud/

and the title at the top is now the correct service 

also review code changes

running 
make review disable-maintenance GITHUB_TOKEN=ghp_xxxxxxxxx PR_NUMBER=1234

would switch back out of maintenance page mode

## Link to Trello card

[Separate maintenance message for ittms services](https://trello.com/c/r79S0SLz/2112-separate-maintenance-message-for-ittms-services)

