### PR TITLE
Fix the nginx config for maintenance pages

### DIFF
--- a/maintenance_page/nginx.conf
+++ b/maintenance_page/nginx.conf
@@ -29,9 +29,10 @@ http {
 
     gzip  on;
 
+    # Service: Claim funding for mentor training
     server {
         listen       8080;
-        server_name  track-and-pay-staging.test.teacherservices.cloud track-and-pay-production.teacherservices.cloud;
+        server_name  .claim-funding-for-mentor-training.education.gov.uk ~^track-and-pay-.+\.teacherservices\.cloud$;
 
         root /usr/share/nginx/html;
 
@@ -51,9 +52,10 @@ http {
         }
     }
 
+    # Service: Manage school placements
     server {
         listen       8080;
-        server_name  manage-school-placements-staging.test.teacherservices.cloud manage-school-placements-production.teacherservices.cloud;
+        server_name  .manage-school-placements.education.gov.uk ~^manage-school-placements-.+\.teacherservices\.cloud$;
 
         root /usr/share/nginx/html;
 


### PR DESCRIPTION
The nginx server was configured incorrectly.

This updates the config so the expected pages are rendered at the expected hostnames.

## Context

For context, see the Slack thread: https://ukgovernmentdfe.slack.com/archives/C011EM7HU85/p1732032598405959

## URLs to test

- https://staging.claim-funding-for-mentor-training.education.gov.uk
- https://track-and-pay-staging.test.teacherservices.cloud
- https://staging.manage-school-placements.education.gov.uk
- https://manage-school-placements-staging.test.teacherservices.cloud