### PR TITLE
Remove "rspec-retry" gem and remove its use in specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -150,7 +150,6 @@ group :test do
   gem "capybara-screenshot"
   gem "climate_control"
   gem "rails-controller-testing"
-  gem "rspec-retry", git: "https://github.com/DFE-Digital/rspec-retry.git", branch: "main"
   gem "selenium-webdriver"
   gem "shoulda-matchers"
   gem "simplecov", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,14 +10,6 @@ GIT
       request_store_rails (~> 2)
 
 GIT
-  remote: https://github.com/DFE-Digital/rspec-retry.git
-  revision: 306b42b8d5853303982e1a165e82d04744c20ea3
-  branch: main
-  specs:
-    rspec-retry (0.7.0)
-      rspec-core (> 3.3)
-
-GIT
   remote: https://github.com/citizensadvice/capybara_accessible_selectors
   revision: 347bbe06cb420416855e80bb4e3a3016b2d5872c
   branch: main
@@ -740,7 +732,6 @@ DEPENDENCIES
   rladr
   rspec
   rspec-rails
-  rspec-retry!
   rubocop-govuk
   ruby-lsp-rspec
   selenium-webdriver

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,6 @@
 # the additional setup, and require it from the spec files that actually need
 # it.
 
-require "rspec/retry"
 require "pundit/rspec"
 require "audited-rspec"
 require "simplecov"
@@ -128,11 +127,4 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
-
-  # Configuration for re-trying flaky tests.
-  # See https://github.com/DFE-Digital/rspec-retry for documentation
-  # (Optional) show retry status in spec process
-  config.verbose_retry = true
-  # (Optional) show exception that triggers a retry if verbose_retry is set to true
-  config.display_try_failure_messages = true
 end

--- a/spec/system/claims/support/schools/add_a_school_spec.rb
+++ b/spec/system/claims/support/schools/add_a_school_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Support User adds a School", service: :claims, type: :system do
 
   after { Capybara.app_host = nil }
 
-  scenario "Colin adds a new School", :js, retry: 3 do
+  scenario "Colin adds a new School", :js do
     when_i_visit_the_add_school_page
     and_i_enter_a_school_named("School 1")
     then_i_see_a_dropdown_item_for("School 1")
@@ -24,7 +24,7 @@ RSpec.describe "Support User adds a School", service: :claims, type: :system do
     and_i_see_success_message
   end
 
-  scenario "Colin adds a school which already exists", :js, retry: 3 do
+  scenario "Colin adds a school which already exists", :js do
     given_a_school_already_exists_for_claims
     when_i_visit_the_add_school_page
     and_i_enter_a_school_named("Claims School")
@@ -34,13 +34,13 @@ RSpec.describe "Support User adds a School", service: :claims, type: :system do
     then_i_see_an_error("Claims School has already been added. Try another school")
   end
 
-  scenario "Colin submits the search form without selecting a school", :js, retry: 3 do
+  scenario "Colin submits the search form without selecting a school", :js do
     when_i_visit_the_add_school_page
     and_i_click_continue
     then_i_see_an_error("Enter a school name, unique reference number (URN) or postcode")
   end
 
-  scenario "Colin reconsiders onboarding a school", :js, retry: 3 do
+  scenario "Colin reconsiders onboarding a school", :js do
     when_i_visit_the_add_school_page
     and_i_enter_a_school_named("School 1")
     then_i_see_a_dropdown_item_for("School 1")
@@ -81,7 +81,7 @@ RSpec.describe "Support User adds a School", service: :claims, type: :system do
   end
 
   def then_i_see_a_dropdown_item_for(school_name)
-    expect(page).to have_css(".autocomplete__option", text: school_name)
+    expect(page).to have_css(".autocomplete__option", text: school_name, wait: 10)
   end
 
   def when_i_click_the_dropdown_item_for(school_name)

--- a/spec/system/placements/providers/partner_schools/add_a_partner_school_spec.rb
+++ b/spec/system/placements/providers/partner_schools/add_a_partner_school_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Placements / Providers / Partner schools / Add a partner school"
     given_i_am_signed_in_as_a_placements_user(organisations: [provider])
   end
 
-  scenario "User adds a partner school", :js, retry: 3 do
+  scenario "User adds a partner school", :js do
     when_i_view_the_partner_schools_page
     and_i_click_on("Add school")
     and_i_enter_a_school_named("School 1")
@@ -31,7 +31,7 @@ RSpec.describe "Placements / Providers / Partner schools / Add a partner school"
     and_a_notification_email_is_sent_to(school_user)
   end
 
-  scenario "User adds a partner school which already exists", :js, retry: 3 do
+  scenario "User adds a partner school which already exists", :js do
     given_a_partnership_exists_between(school, provider)
     when_i_view_the_partner_schools_page
     and_i_click_on("Add school")
@@ -42,13 +42,13 @@ RSpec.describe "Placements / Providers / Partner schools / Add a partner school"
     then_i_see_an_error("School 1 has already been added. Try another school")
   end
 
-  scenario "User submits the search form without selecting a school", :js, retry: 3 do
+  scenario "User submits the search form without selecting a school", :js do
     when_i_visit_the_add_partner_school_page
     and_i_click_on("Continue")
     then_i_see_an_error("Enter a school name, unique reference number (URN) or postcode")
   end
 
-  scenario "User reconsiders selecting a school using back link", :js, retry: 3 do
+  scenario "User reconsiders selecting a school using back link", :js do
     when_i_view_the_partner_schools_page
     and_i_click_on("Add school")
     and_i_enter_a_school_named("School 1")
@@ -62,7 +62,7 @@ RSpec.describe "Placements / Providers / Partner schools / Add a partner school"
     then_i_see_the_check_details_page_for_school("School 1")
   end
 
-  scenario "User reconsiders selecting a school using change link", :js, retry: 3 do
+  scenario "User reconsiders selecting a school using change link", :js do
     when_i_view_the_partner_schools_page
     and_i_click_on("Add school")
     and_i_enter_a_school_named("School 1")
@@ -76,7 +76,7 @@ RSpec.describe "Placements / Providers / Partner schools / Add a partner school"
     then_i_see_the_check_details_page_for_school("School 1")
   end
 
-  scenario "User adds a partner school, which is not onboarded on the placements service", :js, retry: 3 do
+  scenario "User adds a partner school, which is not onboarded on the placements service", :js do
     given_the_school_is_not_onboarded_on_placements_service(school)
     when_i_view_the_partner_schools_page
     and_i_click_on("Add school")
@@ -151,7 +151,7 @@ RSpec.describe "Placements / Providers / Partner schools / Add a partner school"
   end
 
   def then_i_see_a_dropdown_item_for(school_name)
-    expect(page).to have_css(".autocomplete__option", text: school_name)
+    expect(page).to have_css(".autocomplete__option", text: school_name, wait: 10)
   end
 
   def when_i_click_the_dropdown_item_for(school_name)

--- a/spec/system/placements/schools/partner_providers/add_a_partner_provider_spec.rb
+++ b/spec/system/placements/schools/partner_providers/add_a_partner_provider_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Placements / Schools / Partner providers / Add a partner provide
     given_i_am_signed_in_as_a_placements_user(organisations: [school])
   end
 
-  scenario "User adds a partner provider", :js, retry: 3 do
+  scenario "User adds a partner provider", :js do
     when_i_view_the_partner_providers_page
     and_i_click_on("Add provider")
     and_i_enter_a_provider_named("Provider 1")
@@ -31,7 +31,7 @@ RSpec.describe "Placements / Schools / Partner providers / Add a partner provide
     and_a_notification_email_is_sent_to(provider_user)
   end
 
-  scenario "User adds a partner provider which already exists", :js, retry: 3 do
+  scenario "User adds a partner provider which already exists", :js do
     given_a_partnership_exists_between(school, provider)
     when_i_view_the_partner_providers_page
     and_i_click_on("Add provider")
@@ -42,13 +42,13 @@ RSpec.describe "Placements / Schools / Partner providers / Add a partner provide
     then_i_see_an_error("Provider 1 has already been added. Try another provider")
   end
 
-  scenario "User submits the search form without selecting a provider", :js, retry: 3 do
+  scenario "User submits the search form without selecting a provider", :js do
     when_i_visit_the_add_partner_provider_page
     and_i_click_on("Continue")
     then_i_see_an_error("Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode")
   end
 
-  scenario "User reconsiders selecting a provider using back link", :js, retry: 3 do
+  scenario "User reconsiders selecting a provider using back link", :js do
     when_i_view_the_partner_providers_page
     and_i_click_on("Add provider")
     and_i_enter_a_provider_named("Provider 1")
@@ -62,7 +62,7 @@ RSpec.describe "Placements / Schools / Partner providers / Add a partner provide
     then_i_see_the_check_details_page_for_provider("Provider 1")
   end
 
-  scenario "User reconsiders selecting a provider using change link", :js, retry: 3 do
+  scenario "User reconsiders selecting a provider using change link", :js do
     when_i_view_the_partner_providers_page
     and_i_click_on("Add provider")
     and_i_enter_a_provider_named("Provider 1")
@@ -76,7 +76,7 @@ RSpec.describe "Placements / Schools / Partner providers / Add a partner provide
     then_i_see_the_check_details_page_for_provider("Provider 1")
   end
 
-  scenario "User adds a partner provider, which is not onboarded on the placements service", :js, retry: 3 do
+  scenario "User adds a partner provider, which is not onboarded on the placements service", :js do
     given_the_provider_is_not_onboarded_on_placements_service(provider)
     when_i_view_the_partner_providers_page
     and_i_click_on("Add provider")
@@ -151,7 +151,7 @@ RSpec.describe "Placements / Schools / Partner providers / Add a partner provide
   end
 
   def then_i_see_a_dropdown_item_for(provider_name)
-    expect(page).to have_css(".autocomplete__option", text: provider_name)
+    expect(page).to have_css(".autocomplete__option", text: provider_name, wait: 10)
   end
 
   def when_i_click_the_dropdown_item_for(provider_name)

--- a/spec/system/placements/support/providers/partner_schools/support_user_adds_a_partner_school_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/support_user_adds_a_partner_school_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
     given_i_am_signed_in_as_a_placements_support_user
   end
 
-  scenario "Support user adds a partner school", :js, retry: 3 do
+  scenario "Support user adds a partner school", :js do
     when_i_visit_the_partner_schools_page_for(provider)
     and_i_click_on("Add school")
     and_i_enter_a_school_named("School 1")
@@ -31,7 +31,7 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
     and_a_notification_email_is_sent_to(school_user)
   end
 
-  scenario "Support user adds a partner school which already exists", :js, retry: 3 do
+  scenario "Support user adds a partner school which already exists", :js do
     given_a_partnership_exists_between(school, provider)
     when_i_visit_the_partner_schools_page_for(provider)
     and_i_click_on("Add school")
@@ -42,13 +42,13 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
     then_i_see_an_error("School 1 has already been added. Try another school")
   end
 
-  scenario "Support user submits the search form without selecting a school", :js, retry: 3 do
+  scenario "Support user submits the search form without selecting a school", :js do
     when_i_visit_the_add_partner_school_page_for(provider)
     and_i_click_on("Continue")
     then_i_see_an_error("Enter a school name, unique reference number (URN) or postcode")
   end
 
-  scenario "Support user reconsiders selecting a school", :js, retry: 3 do
+  scenario "Support user reconsiders selecting a school", :js do
     when_i_visit_the_partner_schools_page_for(provider)
     and_i_click_on("Add school")
     and_i_enter_a_school_named("School 1")
@@ -62,7 +62,7 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
     then_i_see_the_check_details_page_for_school("School 1")
   end
 
-  scenario "Support user adds a partner school, which is not onboarded on the placements service", :js, retry: 3 do
+  scenario "Support user adds a partner school, which is not onboarded on the placements service", :js do
     given_the_school_is_not_onboarded_on_placements_service(school)
     when_i_visit_the_partner_schools_page_for(provider)
     and_i_click_on("Add school")
@@ -153,7 +153,7 @@ RSpec.describe "Placements / Support / Providers / Partner schools / Support use
   end
 
   def then_i_see_a_dropdown_item_for(school_name)
-    expect(page).to have_css(".autocomplete__option", text: school_name)
+    expect(page).to have_css(".autocomplete__option", text: school_name, wait: 10)
   end
 
   def when_i_click_the_dropdown_item_for(school_name)

--- a/spec/system/placements/support/providers/support_user_adds_a_provider_spec.rb
+++ b/spec/system/placements/support/providers/support_user_adds_a_provider_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Placements / Support / Providers / Support User adds a Provider"
 
   after { Capybara.app_host = nil }
 
-  scenario "Colin adds a new Provider", :js, retry: 3 do
+  scenario "Colin adds a new Provider", :js do
     when_i_visit_the_add_organisation_page
     and_choose_to_add_a_provider
     and_i_click_continue
@@ -25,7 +25,7 @@ RSpec.describe "Placements / Support / Providers / Support User adds a Provider"
     and_i_see_success_message
   end
 
-  scenario "Colin adds a Provider which already exists", :js, retry: 3 do
+  scenario "Colin adds a Provider which already exists", :js do
     given_a_provider_already_as_already_been_onboarded
     when_i_visit_the_add_organisation_page
     and_choose_to_add_a_provider
@@ -37,7 +37,7 @@ RSpec.describe "Placements / Support / Providers / Support User adds a Provider"
     then_i_see_an_error("Provider 1 has already been added. Try another provider")
   end
 
-  scenario "Colin submits the search form without selecting a provider", :js, retry: 3 do
+  scenario "Colin submits the search form without selecting a provider", :js do
     when_i_visit_the_add_organisation_page
     and_choose_to_add_a_provider
     and_i_click_continue
@@ -48,7 +48,7 @@ RSpec.describe "Placements / Support / Providers / Support User adds a Provider"
     )
   end
 
-  scenario "Colin reconsiders onboarding a provider", :js, retry: 3 do
+  scenario "Colin reconsiders onboarding a provider", :js do
     when_i_visit_the_add_organisation_page
     and_choose_to_add_a_provider
     and_i_click_continue
@@ -89,7 +89,7 @@ RSpec.describe "Placements / Support / Providers / Support User adds a Provider"
   end
 
   def then_i_see_a_dropdown_item_for(provider_name)
-    expect(page).to have_css(".autocomplete__option", text: provider_name)
+    expect(page).to have_css(".autocomplete__option", text: provider_name, wait: 10)
   end
 
   def when_i_click_the_dropdown_item_for(provider_name)

--- a/spec/system/placements/support/schools/partner_providers/support_user_adds_a_partner_provider_spec.rb
+++ b/spec/system/placements/support/schools/partner_providers/support_user_adds_a_partner_provider_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Placements / Support / Schools / Partner providers / Support use
     given_i_am_signed_in_as_a_placements_support_user
   end
 
-  scenario "Support user adds a partner provider", :js, retry: 3 do
+  scenario "Support user adds a partner provider", :js do
     when_i_visit_the_partner_providers_page_for(school)
     and_i_click_on("Add provider")
     and_i_enter_a_provider_named("Provider 1")
@@ -31,7 +31,7 @@ RSpec.describe "Placements / Support / Schools / Partner providers / Support use
     and_a_notification_email_is_sent_to(provider_user)
   end
 
-  scenario "Support user adds a partner provider which already exists", :js, retry: 3 do
+  scenario "Support user adds a partner provider which already exists", :js do
     given_a_partnership_exists_between(school, provider)
     when_i_visit_the_partner_providers_page_for(school)
     and_i_click_on("Add provider")
@@ -42,13 +42,13 @@ RSpec.describe "Placements / Support / Schools / Partner providers / Support use
     then_i_see_an_error("Provider 1 has already been added. Try another provider")
   end
 
-  scenario "Support user submits the search form without selecting a provider", :js, retry: 3 do
+  scenario "Support user submits the search form without selecting a provider", :js do
     when_i_visit_the_add_partner_provider_page
     and_i_click_on("Continue")
     then_i_see_an_error("Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode")
   end
 
-  scenario "Support user reconsiders selecting a provider", :js, retry: 3 do
+  scenario "Support user reconsiders selecting a provider", :js do
     when_i_visit_the_partner_providers_page_for(school)
     and_i_click_on("Add provider")
     and_i_enter_a_provider_named("Provider 1")
@@ -62,7 +62,7 @@ RSpec.describe "Placements / Support / Schools / Partner providers / Support use
     then_i_see_the_check_details_page_for_provider("Provider 1")
   end
 
-  scenario "Support user adds a partner provider, which is not onboarded on the placements service", :js, retry: 3 do
+  scenario "Support user adds a partner provider, which is not onboarded on the placements service", :js do
     given_the_provider_is_not_onboarded_on_placements_service(provider)
     when_i_visit_the_partner_providers_page_for(school)
     and_i_click_on("Add provider")
@@ -138,7 +138,7 @@ RSpec.describe "Placements / Support / Schools / Partner providers / Support use
   end
 
   def then_i_see_a_dropdown_item_for(provider_name)
-    expect(page).to have_css(".autocomplete__option", text: provider_name)
+    expect(page).to have_css(".autocomplete__option", text: provider_name, wait: 10)
   end
 
   def when_i_click_the_dropdown_item_for(provider_name)

--- a/spec/system/placements/support/schools/support_user_adds_a_school_spec.rb
+++ b/spec/system/placements/support/schools/support_user_adds_a_school_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Placements / Support / Schools / Support User adds a School",
 
   after { Capybara.app_host = nil }
 
-  scenario "Colin adds a new School", :js, retry: 3 do
+  scenario "Colin adds a new School", :js do
     when_i_visit_the_add_organisation_page
     and_choose_to_add_a_school
     and_i_click_continue
@@ -26,7 +26,7 @@ RSpec.describe "Placements / Support / Schools / Support User adds a School",
     and_i_see_success_message
   end
 
-  scenario "Colin adds a school which already exists", :js, retry: 3 do
+  scenario "Colin adds a school which already exists", :js do
     given_a_school_already_exists_for_placements
     when_i_visit_the_add_organisation_page
     and_choose_to_add_a_school
@@ -38,7 +38,7 @@ RSpec.describe "Placements / Support / Schools / Support User adds a School",
     then_i_see_an_error("Placements School has already been added. Try another school")
   end
 
-  scenario "Colin submits the search form without selecting a school", :js, retry: 3 do
+  scenario "Colin submits the search form without selecting a school", :js do
     when_i_visit_the_add_organisation_page
     and_choose_to_add_a_school
     and_i_click_continue
@@ -47,7 +47,7 @@ RSpec.describe "Placements / Support / Schools / Support User adds a School",
     then_i_see_an_error("Enter a school name, unique reference number (URN) or postcode")
   end
 
-  scenario "Colin reconsiders onboarding a school", :js, retry: 3 do
+  scenario "Colin reconsiders onboarding a school", :js do
     when_i_visit_the_add_organisation_page
     and_choose_to_add_a_school
     and_i_click_continue
@@ -82,7 +82,7 @@ RSpec.describe "Placements / Support / Schools / Support User adds a School",
   end
 
   def then_i_see_a_dropdown_item_for(school_name)
-    expect(page).to have_css(".autocomplete__option", text: school_name)
+    expect(page).to have_css(".autocomplete__option", text: school_name, wait: 10)
   end
 
   def when_i_click_the_dropdown_item_for(school_name)


### PR DESCRIPTION
## Context

The rspec-retry gem was added to the codebase in [PR#223](https://github.com/DFE-Digital/itt-mentor-services/pull/223).

The original intent behind this PR was to reduce the flakiness of JS-enabled system specs. In particular, it seems like the autocomplete component used on some pages (for example, when adding a provider) was resulting in intermittent test failures.

However brute-force retrying failed tests is a [code smell](https://en.wikipedia.org/wiki/Code_smell). The gem serves as a sticking plaster to cover over the underlying issue. In this case, the underlying issue is that Capybara isn’t waiting long enough for JS-enabled features to appear asynchronously on the page.

Rather than addressing the symptom, we should fix the underlying problem. This will remove our reliance on the "rspec-retry "gem and resolve the core issue.

## Changes proposed in this pull request

Refactor the JS-enabled system specs to replace the third-party rspec-retry gem with built-in Capybara functionality:
- Remove the rspec-retry gem
- Remove [configuration associated with the gem](https://github.com/DFE-Digital/itt-mentor-services/blob/0e3c0c7c893a604f4ce2ade3876a8ee01d5e6f81/spec/spec_helper.rb#L132-L137)
- Remove the retry: tag [from system specs](https://github.com/search?q=repo:DFE-Digital/itt-mentor-services%20%22retry:%22&type=code)
- Add wait: times to individual selectors which we know to be slow

## Guidance to review

- Run `bundle install` to update gems
- Run`rails parallel:spec` to test that all specs still work without the retry gem

## Link to Trello card

https://trello.com/c/grkKmMAM/932-refactor-system-specs-to-remove-their-dependency-on-the-rspec-retry-gem
