### PR TITLE
Add 'storage' to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ log/*
 tmp/*
 !tmp/.keep
 
+storage/*
+!storage/.keep
+
 tmp/pids/*
 !tmp/pids/
 !tmp/pids/.keep


### PR DESCRIPTION
## Context

Local active storage files should be ignored.

## Changes proposed in this pull request

- Add `storage/*` to `.gitignore`.

## Guidance to review

\-