### PR TITLE
Silence all sass warnings by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "sass": "^1.81.0"
   },
   "scripts": {
-    "build:css": "sass ./app/assets/stylesheets/application.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules --quiet-deps",
+    "build:css": "sass ./app/assets/stylesheets/application.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules --quiet",
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=/assets"
   }
 }


### PR DESCRIPTION
## Context

The various warnings when running `yarn build:css` clutter the important logs. Let's remove warnings from logs by default to highlight actual issues within our CI.

## Changes proposed in this pull request

- Change the `--quiet-deps` flag to `--quiet` to silence all warnings.

## Guidance to review

- Run `yarn build:css`

## Screenshots

| Before | After |
| ------ | ----- |
| ![CleanShot 2024-11-25 at 11 24 24](https://github.com/user-attachments/assets/15de400d-b71e-4fb9-a0b4-a4af19df7c44) | ![CleanShot 2024-11-25 at 11 24 56](https://github.com/user-attachments/assets/6151f6bf-1818-4c59-831b-42d1ada846f6) |