### PR TITLE
Fix for organisation options step

### DIFF
--- a/app/wizards/placements/add_organisation_wizard/organisation_options_step.rb
+++ b/app/wizards/placements/add_organisation_wizard/organisation_options_step.rb
@@ -8,7 +8,7 @@ class Placements::AddOrganisationWizard::OrganisationOptionsStep < Placements::A
   end
 
   def organisations
-    return if wizard.organisation_model.blank?
+    return [] if wizard.organisation_model.blank?
 
     @organisations ||= if wizard.steps[:organisation_type].provider?
                          wizard.organisation_model.search_name_urn_ukprn_postcode(

--- a/spec/wizards/placements/add_organisation_wizard/organisation_options_step_spec.rb
+++ b/spec/wizards/placements/add_organisation_wizard/organisation_options_step_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe Placements::AddOrganisationWizard::OrganisationOptionsStep, type:
       let(:is_provider) { false }
 
       it "returns nil" do
-        expect(step.organisations).to be_nil
+        expect(step.organisations).to eq([])
       end
     end
   end


### PR DESCRIPTION
## Context

- When the session expires, the `organisations` on the `organisation_options_step` returns `nil` which breaks `.count`

## Changes proposed in this pull request

- Change to the `organisations` method to return an empty array `[]` if `wizard.organisation_model.blank?`

## Link to Trello card

https://trello.com/c/YXrsqbXO/955-fix-organisation-count-bug
