### PR TITLE
Fix issue when not selecting any filters on the placements filter

### DIFF
--- a/app/forms/placements/placements/filter_form.rb
+++ b/app/forms/placements/placements/filter_form.rb
@@ -18,7 +18,13 @@ class Placements::Placements::FilterForm < ApplicationForm
   end
 
   def filters_selected?
-    attributes.except("placements_to_show", "academic_year_id").values.compact.flatten.any?
+    attributes
+      .except("placements_to_show", "academic_year_id")
+      .values
+      .compact
+      .flatten
+      .select(&:present?)
+      .any?
   end
 
   def clear_filters_path

--- a/spec/forms/placements/placements/filter_form_spec.rb
+++ b/spec/forms/placements/placements/filter_form_spec.rb
@@ -42,10 +42,38 @@ describe Placements::Placements::FilterForm, type: :model do
     end
 
     context "when given partner school params" do
-      let(:params) { { only_partner_schools: true } }
+      context "when only partner schools is true" do
+        let(:params) { { only_partner_schools: true } }
 
-      it "returns true" do
-        expect(filter_form).to be(true)
+        it "returns true" do
+          expect(filter_form).to be(true)
+        end
+      end
+
+      context "when only partner schools is false" do
+        let(:params) { { only_partner_schools: false } }
+
+        it "returns true" do
+          expect(filter_form).to be(false)
+        end
+      end
+    end
+
+    context "when given search location params" do
+      context "when search location an empty string" do
+        let(:params) { { search_location: "" } }
+
+        it "return false" do
+          expect(filter_form).to be(false)
+        end
+      end
+
+      context "when search location not an empty string" do
+        let(:params) { { search_location: "London" } }
+
+        it "return true" do
+          expect(filter_form).to be(true)
+        end
       end
     end
 


### PR DESCRIPTION
## Context

- Currently when clicking "Apply filters" (without selecting anything to filter) it still shows "Clean filters".
- This is now fixed.

## Changes proposed in this pull request

- Add `.select(&:present?)` to remove `false` and `""` from the array of applied filters in `filters_selected?`

## Guidance to review

- Sign in as Patricia (Provider user)
- Navigate to the Placements page
- Click "Apply filters"
- The "Clear filters" link show no longer appear.

## Link to Trello card

https://trello.com/c/zucVbw7D/960-selected-filters-section-appears-when-using-placements-to-show-and-academic-year-filters

## Screenshots

https://github.com/user-attachments/assets/44713363-29a9-410c-a7d5-36c69ceb8c25

