### PR TITLE
Add `sampling_reason` to Claim

### DIFF
--- a/app/models/claims/claim.rb
+++ b/app/models/claims/claim.rb
@@ -6,6 +6,7 @@
 #  created_by_type      :string
 #  reference            :string
 #  reviewed             :boolean          default(FALSE)
+#  sampling_reason      :text
 #  status               :enum
 #  submitted_at         :datetime
 #  submitted_by_type    :string

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -81,6 +81,7 @@ shared:
     - reviewed
     - previous_revision_id
     - claim_window_id
+    - sampling_reason
   :schools:
     - id
     - urn

--- a/db/migrate/20241202160112_add_sampling_reason_to_claim.rb
+++ b/db/migrate/20241202160112_add_sampling_reason_to_claim.rb
@@ -1,0 +1,5 @@
+class AddSamplingReasonToClaim < ActiveRecord::Migration[7.2]
+  def change
+    add_column :claims, :sampling_reason, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_20_213146) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_02_160112) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -109,6 +109,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_20_213146) do
     t.uuid "previous_revision_id"
     t.boolean "reviewed", default: false
     t.uuid "claim_window_id"
+    t.text "sampling_reason"
     t.index ["claim_window_id"], name: "index_claims_on_claim_window_id"
     t.index ["created_by_type", "created_by_id"], name: "index_claims_on_created_by"
     t.index ["previous_revision_id"], name: "index_claims_on_previous_revision_id"

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -6,6 +6,7 @@
 #  created_by_type      :string
 #  reference            :string
 #  reviewed             :boolean          default(FALSE)
+#  sampling_reason      :text
 #  status               :enum
 #  submitted_at         :datetime
 #  submitted_by_type    :string

--- a/spec/models/claims/claim_spec.rb
+++ b/spec/models/claims/claim_spec.rb
@@ -6,6 +6,7 @@
 #  created_by_type      :string
 #  reference            :string
 #  reviewed             :boolean          default(FALSE)
+#  sampling_reason      :text
 #  status               :enum
 #  submitted_at         :datetime
 #  submitted_by_type    :string


### PR DESCRIPTION
## Context

The claims support console is being enhanced for claim management, as part of those changes a claim can be sampled and a sampling reason can be optionally provided. We need a place to store this sampling reason.

## Changes proposed in this pull request

- [x] Adds `sampling_reason` to the `claims` table

## Guidance to review

No UI elements included in this PR, a review of the files should be adequate.

## Link to Trello card

[[Sampling] Add sampling_reason to claims table](https://trello.com/c/cw5vBlt2/971-sampling-add-samplingreason-to-claims-table)
