### PR TITLE
Add claims support user sampling approval flow

### DIFF
--- a/app/components/claims/claim/filter_form_component.html.erb
+++ b/app/components/claims/claim/filter_form_component.html.erb
@@ -105,24 +105,24 @@
                   <% if filter_form.submitted_after.present? %>
                     <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t("claims.support.claims.index.submitted_after") %></h3>
                     <ul class="app-filter-tags">
-                    <%= govuk_link_to(
-                      helpers.safe_l(filter_form.submitted_after, format: :short),
-                      filter_form.index_path_without_submitted_dates("submitted_after"),
-                      class: "app-filter__tag",
-                      no_visited_state: true,
-                    ) %>
+                      <%= govuk_link_to(
+                        helpers.safe_l(filter_form.submitted_after, format: :short),
+                        filter_form.index_path_without_submitted_dates("submitted_after"),
+                        class: "app-filter__tag",
+                        no_visited_state: true,
+                      ) %>
                     </ul>
                   <% end %>
 
                   <% if filter_form.submitted_before.present? %>
                     <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t("claims.support.claims.index.submitted_before") %></h3>
                     <ul class="app-filter-tags">
-                    <%= govuk_link_to(
-                      helpers.safe_l(filter_form.submitted_before, format: :short),
-                      filter_form.index_path_without_submitted_dates("submitted_before"),
-                      class: "app-filter__tag",
-                      no_visited_state: true,
-                    ) %>
+                      <%= govuk_link_to(
+                        helpers.safe_l(filter_form.submitted_before, format: :short),
+                        filter_form.index_path_without_submitted_dates("submitted_before"),
+                        class: "app-filter__tag",
+                        no_visited_state: true,
+                      ) %>
                     </ul>
                   <% end %>
                 </div>

--- a/app/controllers/claims/support/claims/samplings_controller.rb
+++ b/app/controllers/claims/support/claims/samplings_controller.rb
@@ -1,6 +1,7 @@
 class Claims::Support::Claims::SamplingsController < Claims::Support::ApplicationController
   before_action :skip_authorization
   before_action :set_filtered_claims, only: %i[index]
+  before_action :set_claim, only: %i[show confirm_approval]
   helper_method :filter_form
 
   def index
@@ -9,10 +10,18 @@ class Claims::Support::Claims::SamplingsController < Claims::Support::Applicatio
     )
   end
 
+  def show; end
+
+  def confirm_approval; end
+
   private
 
   def set_filtered_claims
     @filtered_claims = Claims::ClaimsQuery.call(params: filter_form.query_params)
+  end
+
+  def set_claim
+    @claim = Claims::Claim.find(params.require(:id))
   end
 
   def filter_form

--- a/app/controllers/claims/support/claims/samplings_controller.rb
+++ b/app/controllers/claims/support/claims/samplings_controller.rb
@@ -1,7 +1,7 @@
 class Claims::Support::Claims::SamplingsController < Claims::Support::ApplicationController
   before_action :skip_authorization
   before_action :set_filtered_claims, only: %i[index]
-  before_action :set_claim, only: %i[show confirm_approval]
+  before_action :set_claim, only: %i[show confirm_approval update]
   helper_method :filter_form
 
   def index
@@ -14,6 +14,14 @@ class Claims::Support::Claims::SamplingsController < Claims::Support::Applicatio
 
   def confirm_approval; end
 
+  def update
+    @claim.status = :paid
+    @claim.save!
+    redirect_to claims_support_claims_samplings_path, flash: {
+      heading: t(".success_heading"),
+    }
+  end
+
   private
 
   def set_filtered_claims
@@ -21,7 +29,7 @@ class Claims::Support::Claims::SamplingsController < Claims::Support::Applicatio
   end
 
   def set_claim
-    @claim = Claims::Claim.find(params.require(:id))
+    @claim = Claims::Claim.find_by!(id: params.require(:id))
   end
 
   def filter_form

--- a/app/models/claims/claim.rb
+++ b/app/models/claims/claim.rb
@@ -96,6 +96,7 @@ class Claims::Claim < ApplicationRecord
        validate: true
 
   delegate :name, to: :provider, prefix: true, allow_nil: true
+  delegate :name, to: :school, prefix: true, allow_nil: true
   delegate :name, :users, to: :school, prefix: true
   delegate :full_name, to: :submitted_by, prefix: true, allow_nil: true
   delegate :name, to: :academic_year, prefix: true, allow_nil: true

--- a/app/views/claims/support/claims/samplings/confirm_approval.html.erb
+++ b/app/views/claims/support/claims/samplings/confirm_approval.html.erb
@@ -1,0 +1,14 @@
+<%= content_for :page_title, "Are you sure you want to approve the claim?" %>
+<%= render "claims/support/primary_navigation", current: :claims %>
+
+<% content_for(:before_content) do %>
+  <%= govuk_back_link href: claims_support_claims_path %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+    <h1>Hello</h1>
+    </div>
+  </div>
+</div>

--- a/app/views/claims/support/claims/samplings/confirm_approval.html.erb
+++ b/app/views/claims/support/claims/samplings/confirm_approval.html.erb
@@ -1,14 +1,21 @@
-<%= content_for :page_title, "Are you sure you want to approve the claim?" %>
+<%= content_for :page_title, t(".page_title") %>
 <%= render "claims/support/primary_navigation", current: :claims %>
 
 <% content_for(:before_content) do %>
-  <%= govuk_back_link href: claims_support_claims_path %>
+  <%= govuk_back_link href: claims_support_claims_sampling_path(@claim) %>
 <% end %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-    <h1>Hello</h1>
+      <p class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></p>
+          <h1 class="govuk-heading-l"><%= t(".page_title") %></h1>
+            <p class="govuk-body"><%= t(".mark_as_paid") %></p>
+            <%= govuk_button_to t(".approve"), claims_support_claims_sampling_path(@claim), method: :put %>
+
+            <p class="govuk-body">
+              <%= govuk_link_to(t(".cancel"), claims_support_claims_sampling_path(@claim), no_visited_state: true) %>
+            </p>
     </div>
   </div>
 </div>

--- a/app/views/claims/support/claims/samplings/show.html.erb
+++ b/app/views/claims/support/claims/samplings/show.html.erb
@@ -1,0 +1,30 @@
+<%= render "claims/support/primary_navigation", current: :claims %>
+<% content_for(:page_title) { sanitize t(".page_title", school_name: @claim.school.name, reference: @claim.reference) } %>
+
+<% content_for(:before_content) do %>
+  <%= govuk_back_link href: claims_support_claims_path %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></p>
+        <h1 class="govuk-heading-l"><%= @claim.school.name %> <%= render Claim::StatusTagComponent.new(claim: @claim) %></h1>
+
+        <% if @claim.sampling_reason? %>
+          <div class="govuk-inset-text">
+            <h3 class="govuk-heading-s"><%= t(".reason") %></h3>
+              <p class="govuk-body"><%= @claim.sampling_reason %></p>
+          </div>
+        <% end %>
+
+        <%= govuk_button_link_to t(".approve"), confirm_approval_claims_support_claims_sampling_path(@claim), class: "govuk-button" %> <%= govuk_button_link_to t(".confirm_provider_reject"), class: "govuk-button govuk-button--secondary" %>
+
+        <% if @claim.submitted? %>
+          <p class="govuk-body"><%= t(".submitted_by", name: @claim.submitted_by.full_name, date: l(@claim.submitted_on, format: :long)) %></p>
+        <% end %>
+
+        <%= render "claims/support/claims/details", claim: @claim %>
+    </div>
+  </div>
+</div>

--- a/app/views/claims/support/claims/samplings/show.html.erb
+++ b/app/views/claims/support/claims/samplings/show.html.erb
@@ -1,8 +1,8 @@
 <%= render "claims/support/primary_navigation", current: :claims %>
-<% content_for(:page_title) { sanitize t(".page_title", school_name: @claim.school.name, reference: @claim.reference) } %>
+<% content_for(:page_title) { sanitize t(".page_title", school_name: @claim.school_name, reference: @claim.reference) } %>
 
 <% content_for(:before_content) do %>
-  <%= govuk_back_link href: claims_support_claims_path %>
+  <%= govuk_back_link href: claims_support_claims_samplings_path %>
 <% end %>
 
 <div class="govuk-width-container">
@@ -11,16 +11,21 @@
       <p class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></p>
         <h1 class="govuk-heading-l"><%= @claim.school.name %> <%= render Claim::StatusTagComponent.new(claim: @claim) %></h1>
 
-        <% if @claim.sampling_reason? %>
+        <% if @claim.sampling_in_progress? && @claim.sampling_reason? %>
           <div class="govuk-inset-text">
             <h3 class="govuk-heading-s"><%= t(".reason") %></h3>
               <p class="govuk-body"><%= @claim.sampling_reason %></p>
           </div>
         <% end %>
 
-        <%= govuk_button_link_to t(".approve"), confirm_approval_claims_support_claims_sampling_path(@claim), class: "govuk-button" %> <%= govuk_button_link_to t(".confirm_provider_reject"), class: "govuk-button govuk-button--secondary" %>
+        <% if @claim.sampling_in_progress? %>
+          <div class="govuk-button-group">
+            <%= govuk_button_link_to t(".approve"), confirm_approval_claims_support_claims_sampling_path(@claim) %>
+            <%= govuk_button_link_to t(".confirm_provider_reject"), "", secondary: true %>
+          </div>
+        <% end %>
 
-        <% if @claim.submitted? %>
+        <% if @claim.submitted_by.present? %>
           <p class="govuk-body"><%= t(".submitted_by", name: @claim.submitted_by.full_name, date: l(@claim.submitted_on, format: :long)) %></p>
         <% end %>
 

--- a/config/locales/en/claims/support/claims.yml
+++ b/config/locales/en/claims/support/claims.yml
@@ -23,6 +23,9 @@ en:
         show:
           page_caption: Claim %{reference}
           page_title: "%{school_name} - Claim %{reference}"
+          reason: Reason claim is being sampled
+          approve: Approve claim
+          confirm_provider_reject: Confirm provider rejected claim
           status: Status
           provider: Accredited provider
           mentor_with_index: Mentor %{index}

--- a/config/locales/en/claims/support/claims/samplings.yml
+++ b/config/locales/en/claims/support/claims/samplings.yml
@@ -13,7 +13,7 @@ en:
             upload_provider_response: Upload provider response
           show:
             page_caption: Sampling - Claim %{reference}
-            page_title: "%{school_name} - Claim %{reference}"
+            page_title: "%{school_name} - Sampling - Claim %{reference}"
             reason: Reason claim is being sampled
             approve: Approve claim
             confirm_provider_reject: Confirm provider rejected claim

--- a/config/locales/en/claims/support/claims/samplings.yml
+++ b/config/locales/en/claims/support/claims/samplings.yml
@@ -11,3 +11,22 @@ en:
           upload_buttons:
             upload_claims: Upload claims to be sampled
             upload_provider_response: Upload provider response
+          show:
+            page_caption: Sampling - Claim %{reference}
+            page_title: "%{school_name} - Claim %{reference}"
+            reason: Reason claim is being sampled
+            approve: Approve claim
+            confirm_provider_reject: Confirm provider rejected claim
+            status: Status
+            provider: Accredited provider
+            mentor_with_index: Mentor %{index}
+            mentor: Mentor
+            submitted_by: Submitted by %{name} on %{date}.
+          confirm_approval:
+            page_caption: Sampling - Claim %{reference}
+            page_title: Are you sure you want to approve the claim?
+            mark_as_paid: This will mark the claim as 'Paid'.
+            approve: Approve claim
+            cancel: Cancel
+          update:
+            success_heading: Claim updated

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -80,6 +80,7 @@ scope module: :claims, as: :claims, constraints: {
       resources :samplings, path: "sampling", only: %i[index show] do
         member do
           get :confirm_approval
+          put :update
         end
         collection do
           get "new", to: "samplings/upload_data#new", as: :new_upload_data

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -78,12 +78,16 @@ scope module: :claims, as: :claims, constraints: {
 
       resources :payments, only: %i[index]
       resources :samplings, path: "sampling", only: %i[index show] do
+        member do
+          get :confirm_approval
+        end
         collection do
           get "new", to: "samplings/upload_data#new", as: :new_upload_data
           get "new/:state_key/:step", to: "samplings/upload_data#edit", as: :upload_data
           put "new/:state_key/:step", to: "samplings/upload_data#update"
         end
       end
+
       resources :clawbacks, path: "clawbacks/claims", only: %i[index show]
       resources :activity_logs, path: "activity", only: %i[index]
     end

--- a/spec/system/claims/support/claims/sampling/support_user_approves_a_claim_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_approves_a_claim_spec.rb
@@ -1,0 +1,156 @@
+require "rails_helper"
+
+RSpec.describe "Support user approves a claim", service: :claims, type: :system do
+  scenario do
+    given_claims_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_sampling_claims_index_page
+    when_i_click_to_view_the_sampling_claim
+    then_i_see_the_details_of_the_sampling_claim
+
+    when_i_click_on_back
+    then_i_see_the_sampling_claims_index_page
+
+    when_i_click_to_view_the_sampling_claim
+    then_i_see_the_sampling_reason
+
+    when_i_click_on_approve_claim
+    then_i_see_the_confirm_approval_page
+
+    when_i_click_on_back
+    then_i_see_the_details_of_the_sampling_claim
+
+    when_i_click_on_approve_claim
+    then_i_see_the_confirm_approval_page
+
+    when_i_click_on_cancel
+    then_i_see_the_details_of_the_sampling_claim
+
+    when_i_click_on_approve_claim
+    and_i_click_approve_claim_on_the_confirm_approval_page
+    then_i_see_the_sampling_claims_index_page
+    and_i_see_a_success_message_for_updating_claim
+    and_i_see_sampling_claim_is_no_longer_listed
+
+    when_i_navigate_to_the_claims_index_page
+    then_i_see_there_are_two_paid_claims
+  end
+
+  private
+
+  def given_claims_exist
+    @sampling_claim = create(:claim,
+                             :submitted,
+                             status: :sampling_in_progress,
+                             sampling_reason: "Randomly selected for audit")
+
+    @paid_claim = create(:claim,
+                         :submitted,
+                         status: :paid)
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_claims_index_page
+    within primary_navigation do
+      click_on "Claims"
+    end
+  end
+
+  def when_i_navigate_to_the_sampling_claims_index_page
+    within primary_navigation do
+      click_on "Claims"
+    end
+
+    within secondary_navigation do
+      click_on "Sampling"
+    end
+  end
+
+  def then_i_see_the_sampling_claims_index_page
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Claims")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(secondary_navigation).to have_current_item("Sampling")
+  end
+
+  def when_i_click_to_view_the_paid_claim
+    click_on "#{@paid_claim.reference} - #{@paid_claim.school.name}"
+  end
+
+  def when_i_click_to_view_the_sampling_claim
+    click_on "#{@sampling_claim.reference} - #{@sampling_claim.school.name}"
+  end
+
+  def then_i_see_the_details_of_the_paid_claim
+    expect(page).to have_title(
+      "#{@paid_claim.school.name} - Claim #{@paid_claim.reference} - Claim funding for mentor training - GOV.UK",
+    )
+    expect(page).to have_element(:p, text: "Claim #{@paid_claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_h1(@paid_claim.school.name)
+    expect(page).to have_element(:strong, text: "Paid", class: "govuk-tag govuk-tag--green")
+  end
+
+  def then_i_see_the_details_of_the_sampling_claim
+    expect(page).to have_title(
+      "#{@sampling_claim.school.name} - Sampling - Claim #{@sampling_claim.reference} - Claim funding for mentor training - GOV.UK",
+    )
+    expect(page).to have_element(:p, text: "Sampling - Claim #{@sampling_claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_h1(@sampling_claim.school.name)
+    expect(page).to have_element(:strong, text: "Sampling in progress", class: "govuk-tag govuk-tag--purple")
+  end
+
+  def when_i_click_on_back
+    click_on "Back"
+  end
+
+  def then_i_see_the_sampling_reason
+    inset_text = page.find("div.govuk-inset-text")
+
+    within(inset_text) do
+      expect(page).to have_h3("Reason claim is being sampled")
+      expect(page).to have_element(:p, text: "Randomly selected for audit", class: "govuk-body")
+    end
+
+    expect(page).to have_link("Approve claim", href: "/support/claims/sampling/#{@sampling_claim.id}/confirm_approval")
+  end
+
+  def when_i_click_on_approve_claim
+    click_on "Approve claim"
+  end
+  alias_method :and_i_click_approve_claim_on_the_confirm_approval_page, :when_i_click_on_approve_claim
+
+  def then_i_see_the_confirm_approval_page
+    expect(page).to have_title("Are you sure you want to approve the claim? - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Claims")
+
+    expect(page).to have_element(:p, text: "Sampling - Claim #{@sampling_claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_h1("Are you sure you want to approve the claim?")
+    expect(page).to have_element(:p, text: "This will mark the claim as 'Paid'.", class: "govuk-body")
+    expect(page).to have_button("Approve claim")
+    expect(page).to have_link("Cancel", href: "/support/claims/sampling/#{@sampling_claim.id}")
+  end
+
+  def when_i_click_on_cancel
+    click_on "Cancel"
+  end
+
+  def and_i_see_a_success_message_for_updating_claim
+    expect(page).to have_success_banner("Claim updated")
+  end
+
+  def and_i_see_sampling_claim_is_no_longer_listed
+    expect(page).to have_h2("Sampling")
+    expect(page).not_to have_link("#{@sampling_claim.reference} - #{@sampling_claim.school.name}", href: "/support/claims/sampling/#{@sampling_claim.id}")
+  end
+
+  def then_i_see_there_are_two_paid_claims
+    expect(page).to have_h2("Claims (2)")
+    expect(page).to have_link("#{@sampling_claim.reference} - #{@sampling_claim.school.name}", href: "/support/claims/#{@sampling_claim.id}")
+    expect(page).to have_link("#{@paid_claim.reference} - #{@paid_claim.school.name}", href: "/support/claims/#{@paid_claim.id}")
+    expect(page).to have_element(:strong, text: "Paid", class: "govuk-tag govuk-tag--green", count: 2)
+  end
+end


### PR DESCRIPTION
## Context

We are making progressive enhancements to the support console to assist in the processing of Claims.

## Changes proposed in this pull request

- Create new show page for sampling claims: `app/views/claims/support/claims/samplings/show.html.erb`
- Add UI to display `claim_reason` if present
-  Add "Approve claim" button
- Add approval confirmation page
-  Add approval logic to update claim `status` from `sampling_in_progress` or `sampling_provider_not_approved` to `paid`
- Add success banner and return support user to the sampling index following an approval

## Guidance to review

- Use the review app to navigate through the flow
- Run the sampling system tests `spec/system/claims/support/claims/sampling`
- Review `spec/system/claims/support/claims/sampling/support_user_approves_a_claim_spec.rb` to check that it covers all aspects of the scenario and no checks are missing

## Link to Trello card

https://trello.com/c/3YZqpb8s/972-sampling-approve-button-sampling-details

## Screenshot

https://github.com/user-attachments/assets/7331464d-7a6a-4ae8-9f3f-0705e5e4a1d2
