### PR TITLE
Add conditional clawback details on show page

### DIFF
--- a/app/views/claims/support/claims/_details.html.erb
+++ b/app/views/claims/support/claims/_details.html.erb
@@ -86,7 +86,7 @@
   <% end %>
 <% end %>
 
-  <% if claim.status == "clawback_requested" || claim.status == "clawback_in_progress" %>
+  <% if claim.clawback_requested? || claim.clawback_in_progress? %>
     <h2 class="govuk-heading-m"><%= t(".clawback_details") %></h2>
     <%= govuk_summary_list do |summary_list| %>
       <% summary_list.with_row do |row| %>

--- a/app/views/claims/support/claims/_details.html.erb
+++ b/app/views/claims/support/claims/_details.html.erb
@@ -85,3 +85,41 @@
     <% row.with_value(text: humanized_money_with_symbol(claim.amount)) %>
   <% end %>
 <% end %>
+
+  <% if claim.status == "clawback_requested" || claim.status == "clawback_in_progress" %>
+    <h2 class="govuk-heading-m"><%= t(".clawback_details") %></h2>
+    <%= govuk_summary_list do |summary_list| %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: t(".hours")) %>
+        <% row.with_value %>
+        <% if claim.status == "clawback_requested" %>
+          <% row.with_action(text: t(".change"),
+                             href: request_clawback_claims_support_claims_clawbacks_path(claim_id: claim.id, step: :clawback),
+                             visually_hidden_text: t(".hours"),
+                             classes: ["govuk-link--no-visited-state"]) %>
+        <% end %>
+      <% end %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: t(".rate")) %>
+        <% row.with_value(text: humanized_money_with_symbol(claim.school.region.funding_available_per_hour)) %>
+      <% end %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: t(".amount")) %>
+        <% row.with_value %>
+      <% end %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: t(".reason")) %>
+        <% row.with_value %>
+        <% if claim.status == "clawback_requested" %>
+          <% row.with_action(text: t(".change"),
+                             href: request_clawback_claims_support_claims_clawbacks_path(claim_id: claim.id, step: :clawback),
+                             visually_hidden_text: t(".reason"),
+                             classes: ["govuk-link--no-visited-state"]) %>
+        <% end %>
+      <% end %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: t(".revised")) %>
+        <% row.with_value %>
+      <% end %>
+    <% end %>
+  <% end %>

--- a/config/locales/en/claims/support/claims.yml
+++ b/config/locales/en/claims/support/claims.yml
@@ -42,3 +42,10 @@ en:
           mentors: Mentors
           hours_of_training: Hours of training
           grant_funding: Grant funding
+          clawback_details: Clawback details
+          hours: Number of hours
+          rate: Hourly rate
+          amount: Clawback amount
+          reason: Reason for clawback
+          change: Change
+          revised: Revised claim amount

--- a/spec/system/claims/support/claims/clawbacks/support_user_requests_a_clawback_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/support_user_requests_a_clawback_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe "Support user requests a clawback on a claim", service: :claims, 
 
     when_i_enter_fifty_hours
     and_i_click_on_continue
-    # then_i_see_a_validation_error_for_entering_too_many_hours
+    # TODO: then_i_see_a_validation_error_for_entering_too_many_hours
 
     when_i_leave_all_fields_blank
     and_i_click_on_continue
-    # then_i_see_validation_errors_for_not_providing_required_data
+    # TODO: then_i_see_validation_errors_for_not_providing_required_data
 
     when_i_enter_valid_data
     and_i_click_on_continue
@@ -39,10 +39,10 @@ RSpec.describe "Support user requests a clawback on a claim", service: :claims, 
   private
 
   def given_claims_exist
-    @claim_one = create(:claim,
-                        :submitted,
-                        status: :sampling_not_approved,
-                        reference: 11_111_111)
+    @claim_not_approved_claim = create(:claim,
+                                       :submitted,
+                                       status: :sampling_not_approved,
+                                       reference: 11_111_111)
     @claim_two = create(:claim,
                         :submitted,
                         status: :sampling_not_approved,
@@ -64,32 +64,13 @@ RSpec.describe "Support user requests a clawback on a claim", service: :claims, 
   end
 
   def and_i_click_on_claim_one
-    click_on "11111111 - #{@claim_one.school_name}"
+    click_on "11111111 - #{@claim_not_approved_claim.school_name}"
   end
 
   def then_i_see_the_show_page_for_claim_one
-    expect(page).to have_title("Clawbacks - #{@claim_one.school_name} - Claim 11111111 - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_title("Clawbacks - #{@claim_not_approved_claim.school_name} - Claim 11111111 - Claim funding for mentor training - GOV.UK")
     expect(primary_navigation).to have_current_item("Claims")
     expect(page).to have_element(:span, text: "Clawbacks - Claim 11111111", class: "govuk-caption-l")
-    expect(page).to have_h1(@claim_one.school_name)
-    expect(page).to have_element(:strong, text: "Claim not approved", class: "govuk-tag govuk-tag--pink")
-    expect(page).to have_link("Request clawback", href: "/support/claims/clawbacks/claims/new/#{@claim_one.id}")
-    expect(page).to have_summary_list_row("School", @claim_one.school_name)
-    expect(page).to have_summary_list_row("Academic year", @claim_one.academic_year_name)
-    expect(page).to have_summary_list_row("Accredited provider", @claim_one.provider.name)
-    expect(page).to have_summary_list_row("Mentors") do |row|
-      @claim_one.mentors.each do |mentor|
-        expect(row).to have_css("ul.govuk-list li", text: mentor.full_name)
-      end
-    end
-    expect(page).to have_h2("Hours of training")
-    @claim_one.mentor_trainings.order_by_mentor_full_name.each do |mentor_training|
-      expect(page).to have_summary_list_row(mentor_training.mentor.full_name, "#{mentor_training.hours_completed} hours")
-    end
-    expect(page).to have_h2("Grant funding")
-    expect(page).to have_summary_list_row("Total hours", "#{@claim_one.mentor_trainings.sum(:hours_completed)} hours")
-    expect(page).to have_summary_list_row("Hourly rate", @claim_one.school.region.funding_available_per_hour)
-    expect(page).to have_summary_list_row("Claim amount", @claim_one.amount)
   end
 
   def when_i_click_on_request_clawback
@@ -97,7 +78,7 @@ RSpec.describe "Support user requests a clawback on a claim", service: :claims, 
   end
 
   def then_i_see_the_clawback_details_page
-    expect(page).to have_title("Clawback details - #{@claim_one.school_name} - Claim 11111111 - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_title("Clawback details - #{@claim_not_approved_claim.school_name} - Claim 11111111 - Claim funding for mentor training - GOV.UK")
     expect(primary_navigation).to have_current_item("Claims")
 
     expect(page).to have_element(:span, text: "Clawbacks - Claim 11111111", class: "govuk-caption-l")
@@ -119,13 +100,13 @@ RSpec.describe "Support user requests a clawback on a claim", service: :claims, 
   end
   alias_method :when_i_click_on_continue, :and_i_click_on_continue
 
-  # def then_i_see_a_validation_error_for_entering_too_many_hours; end
+  # TODO: def then_i_see_a_validation_error_for_entering_too_many_hours; end
 
   def when_i_leave_all_fields_blank
     fill_in "claims_request_clawback_wizard_clawback_step[number_of_hours]", with: ""
   end
 
-  # def then_i_see_validation_errors_for_not_providing_required_data; end
+  # TODO: def then_i_see_validation_errors_for_not_providing_required_data; end
 
   def when_i_enter_valid_data
     fill_in "claims_request_clawback_wizard_clawback_step[number_of_hours]", with: "8"
@@ -133,12 +114,12 @@ RSpec.describe "Support user requests a clawback on a claim", service: :claims, 
   end
 
   def then_i_see_the_check_your_answers_page
-    expect(page).to have_title("Check your answers - #{@claim_one.school_name} - Claim 11111111 - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_title("Check your answers - #{@claim_not_approved_claim.school_name} - Claim 11111111 - Claim funding for mentor training - GOV.UK")
     expect(primary_navigation).to have_current_item("Claims")
     expect(page).to have_element(:span, text: "Clawbacks - Claim 11111111", class: "govuk-caption-l")
     expect(page).to have_h1("Check your answers")
     expect(page).to have_summary_list_row("Number of hours", "")
-    expect(page).to have_summary_list_row("Hourly rate", @claim_one.school.region.funding_available_per_hour)
+    expect(page).to have_summary_list_row("Hourly rate", @claim_not_approved_claim.school.region.funding_available_per_hour)
     expect(page).to have_summary_list_row("Clawback amount", "")
     expect(page).to have_summary_list_row("Reason for clawback", "")
     expect(page).to have_element(:strong, text: "We will show clawback details to the school.", class: "govuk-warning-text__text")
@@ -162,13 +143,13 @@ RSpec.describe "Support user requests a clawback on a claim", service: :claims, 
 
   def and_i_see_the_claim_status_is_clawback_requested
     expect(page).to have_claim_card({
-      "title" => "#{@claim_one.reference} - #{@claim_one.school_name}",
-      "url" => "/support/claims/clawbacks/claims/#{@claim_one.id}",
+      "title" => "#{@claim_not_approved_claim.reference} - #{@claim_not_approved_claim.school_name}",
+      "url" => "/support/claims/clawbacks/claims/#{@claim_not_approved_claim.id}",
       "status" => "Clawback requested",
-      "academic_year" => @claim_one.academic_year.name,
-      "provider_name" => @claim_one.provider.name,
-      "submitted_at" => I18n.l(@claim_one.submitted_at.to_date, format: :long),
-      "amount" => @claim_one.amount,
+      "academic_year" => @claim_not_approved_claim.academic_year.name,
+      "provider_name" => @claim_not_approved_claim.provider.name,
+      "submitted_at" => I18n.l(@claim_not_approved_claim.submitted_at.to_date, format: :long),
+      "amount" => @claim_not_approved_claim.amount,
     })
   end
 end

--- a/spec/system/claims/support/claims/clawbacks/support_user_views_clawbacks_show_page_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/support_user_views_clawbacks_show_page_spec.rb
@@ -1,0 +1,191 @@
+require "rails_helper"
+
+RSpec.describe "Support user requests a clawback on a claim", service: :claims, type: :system do
+  scenario do
+    given_claims_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_clawbacks_index_page
+    and_i_click_on_claim_with_status_of_claim_not_approved
+    then_i_see_the_show_page_for_the_claim_not_approved_claim
+    and_i_do_not_see_the_clawback_details_section
+
+    # support user clicks back on show page
+    when_i_click_on_back
+    then_i_see_the_claims_index_page
+
+    when_i_navigate_to_the_clawbacks_index_page
+    and_i_click_on_claim_with_status_of_clawback_requested
+    then_i_see_the_show_page_for_the_clawback_requested_claim
+    and_i_see_the_clawback_details_section
+
+    when_i_click_on_change
+    then_i_see_the_clawback_step_for_the_clawback_requested_claim
+
+    # support user clicks back on wizard step
+    when_i_click_on_back
+    then_i_see_the_clawbacks_index_page
+
+    and_i_click_on_claim_with_status_of_clawback_in_progress
+    then_i_see_the_show_page_for_the_clawback_in_progress_claim
+    and_i_see_the_clawback_details_section
+  end
+
+  private
+
+  def given_claims_exist
+    @claim_not_approved_claim = create(:claim,
+                                       :submitted,
+                                       status: :sampling_not_approved,
+                                       reference: 11_111_111)
+    @clawback_requested_claim = create(:claim,
+                                       :submitted,
+                                       status: :clawback_requested,
+                                       reference: 22_222_222)
+    @clawback_in_progress_claim = create(:claim,
+                                         :submitted,
+                                         status: :clawback_in_progress,
+                                         reference: 33_333_333)
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_clawbacks_index_page
+    within primary_navigation do
+      click_on "Claims"
+    end
+
+    within secondary_navigation do
+      click_on "Clawbacks"
+    end
+  end
+
+  def and_i_click_on_claim_with_status_of_claim_not_approved
+    click_on "11111111 - #{@claim_not_approved_claim.school_name}"
+  end
+
+  def then_i_see_the_show_page_for_the_claim_not_approved_claim
+    expect(page).to have_title("Clawbacks - #{@claim_not_approved_claim.school_name} - Claim 11111111 - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(page).to have_element(:span, text: "Clawbacks - Claim 11111111", class: "govuk-caption-l")
+    expect(page).to have_h1(@claim_not_approved_claim.school_name)
+    expect(page).to have_element(:strong, text: "Claim not approved", class: "govuk-tag govuk-tag--pink")
+    expect(page).to have_link("Request clawback", href: "/support/claims/clawbacks/claims/new/#{@claim_not_approved_claim.id}")
+    expect(page).to have_summary_list_row("School", @claim_not_approved_claim.school_name)
+    expect(page).to have_summary_list_row("Academic year", @claim_not_approved_claim.academic_year_name)
+    expect(page).to have_summary_list_row("Accredited provider", @claim_not_approved_claim.provider.name)
+    expect(page).to have_summary_list_row("Mentors") do |row|
+      @claim_not_approved_claim.mentors.each do |mentor|
+        expect(row).to have_css("ul.govuk-list li", text: mentor.full_name)
+      end
+    end
+    expect(page).to have_h2("Hours of training")
+    @claim_not_approved_claim.mentor_trainings.order_by_mentor_full_name.each do |mentor_training|
+      expect(page).to have_summary_list_row(mentor_training.mentor.full_name, "#{mentor_training.hours_completed} hours")
+    end
+    expect(page).to have_h2("Grant funding")
+    expect(page).to have_summary_list_row("Total hours", "#{@claim_not_approved_claim.mentor_trainings.sum(:hours_completed)} hours")
+    expect(page).to have_summary_list_row("Claim amount", @claim_not_approved_claim.amount)
+  end
+
+  def and_i_see_the_clawback_details_section
+    expect(page).to have_h2("Clawback details")
+    expect(page).to have_element(:dt, text: "Number of hours", class: "govuk-summary-list__key")
+    expect(page).to have_element(:dt, text: "Hourly rate", class: "govuk-summary-list__key")
+    expect(page).to have_element(:dt, text: "Clawback amount", class: "govuk-summary-list__key")
+    expect(page).to have_element(:dt, text: "Reason for clawback", class: "govuk-summary-list__key")
+    expect(page).to have_element(:dt, text: "Revised claim amount", class: "govuk-summary-list__key")
+  end
+
+  def and_i_do_not_see_the_clawback_details_section
+    expect(page).not_to have_h2("Clawback details")
+    expect(page).not_to have_element(:dt, text: "Reason for clawback", class: "govuk-summary-list__key")
+    expect(page).not_to have_element(:dt, text: "Revised claim amount", class: "govuk-summary-list__key")
+  end
+
+  def when_i_click_on_back
+    click_on "Back"
+  end
+
+  def then_i_see_the_claims_index_page
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(secondary_navigation).to have_current_item("All claims")
+  end
+
+  def and_i_click_on_claim_with_status_of_clawback_requested
+    click_on "22222222 - #{@clawback_requested_claim.school_name}"
+  end
+
+  def then_i_see_the_show_page_for_the_clawback_requested_claim
+    expect(page).to have_title("Clawbacks - #{@clawback_requested_claim.school_name} - Claim 22222222 - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(page).to have_element(:span, text: "Clawbacks - Claim 22222222", class: "govuk-caption-l")
+    expect(page).to have_h1(@clawback_requested_claim.school_name)
+    expect(page).to have_element(:strong, text: "Clawback requested", class: "govuk-tag govuk-tag--orange")
+    expect(page).not_to have_link("Request clawback", href: "/support/claims/clawbacks/claims/new/#{@clawback_requested_claim.id}", class: "govuk-link govuk-button")
+    expect(page).to have_summary_list_row("School", @clawback_requested_claim.school_name)
+    expect(page).to have_summary_list_row("Academic year", @clawback_requested_claim.academic_year_name)
+    expect(page).to have_summary_list_row("Accredited provider", @clawback_requested_claim.provider.name)
+    expect(page).to have_summary_list_row("Mentors") do |row|
+      @clawback_requested_claim.mentors.each do |mentor|
+        expect(row).to have_css("ul.govuk-list li", text: mentor.full_name)
+      end
+    end
+    expect(page).to have_h2("Hours of training")
+    @clawback_requested_claim.mentor_trainings.order_by_mentor_full_name.each do |mentor_training|
+      expect(page).to have_summary_list_row(mentor_training.mentor.full_name, "#{mentor_training.hours_completed} hours")
+    end
+    expect(page).to have_h2("Grant funding")
+    expect(page).to have_summary_list_row("Total hours", "#{@clawback_requested_claim.mentor_trainings.sum(:hours_completed)} hours")
+    expect(page).to have_summary_list_row("Claim amount", @clawback_requested_claim.amount)
+  end
+
+  def when_i_click_on_change
+    all("a", text: "Change").last.click
+  end
+
+  def then_i_see_the_clawback_step_for_the_clawback_requested_claim
+    # TODO: Add expectation for prepopulated fields with expected values.
+    expect(page).to have_title("Clawback details - #{@clawback_requested_claim.school_name} - Claim 22222222 - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Claims")
+
+    expect(page).to have_element(:span, text: "Clawbacks - Claim 22222222", class: "govuk-caption-l")
+    expect(page).to have_h1("Clawback details")
+    expect(page).to have_element(:label, text: "Number of hours to clawback", class: "govuk-label")
+    expect(page).to have_element(:div, text: "Enter whole numbers up to a maximum of 40 hours", class: "govuk-hint")
+    expect(page).to have_element(:label, text: "Reason for clawback", class: "govuk-label")
+    expect(page).to have_element(:div, text: "Explain why the clawback is being requested. For example, include details of which mentor has received a deduction.", class: "govuk-hint")
+    expect(page).to have_button("Continue")
+    expect(page).to have_link("Cancel", href: "/support/claims/clawbacks/claims")
+  end
+
+  def then_i_see_the_clawbacks_index_page
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(secondary_navigation).to have_current_item("Clawbacks")
+  end
+
+  def and_i_click_on_claim_with_status_of_clawback_in_progress
+    click_on "33333333 - #{@clawback_in_progress_claim.school_name}"
+  end
+
+  def then_i_see_the_show_page_for_the_clawback_in_progress_claim
+    expect(page).to have_title("Clawbacks - #{@clawback_in_progress_claim.school_name} - Claim 33333333 - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(page).to have_element(:span, text: "Clawbacks - Claim 33333333", class: "govuk-caption-l")
+    expect(page).to have_h1(@clawback_in_progress_claim.school_name)
+    expect(page).to have_element(:strong, text: "Clawback in progress", class: "govuk-tag govuk-tag--orange")
+    expect(page).not_to have_link("Request clawback", href: "/support/claims/clawbacks/claims/new/#{@clawback_in_progress_claim.id}", class: "govuk-link govuk-button")
+    expect(page).to have_summary_list_row("School", @clawback_in_progress_claim.school_name)
+    expect(page).to have_summary_list_row("Academic year", @clawback_in_progress_claim.academic_year_name)
+    expect(page).to have_summary_list_row("Accredited provider", @clawback_in_progress_claim.provider.name)
+    expect(page).to have_summary_list_row("Mentors") do |row|
+      @clawback_in_progress_claim.mentors.each do |mentor|
+        expect(row).to have_css("ul.govuk-list li", text: mentor.full_name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We are making progressive enhancements to the support console to assist in the processing of Claims.

## Changes proposed in this pull request

- Add the Clawback details to the clawbacks show page (an initial show page was added in `dpd/request-clawback-wizard`)
- Use change links on 'number of hours' and 'reason for clawback' which link to the edit request clawback wizard. This section should only be visible if a clawback has been requested. 
- If the clawback is in progress the Clawback details should be visible, but the change links should not be available.

## Guidance to review

- Navigate to the show page of claims with all three clawback statuses (`sampling_not_approved`, `clawback_requested`, and `clawback_in_progress`.
- Check them against the logic outlined above.
- Note that the values for clawback hours and reason are not yet in place. Changes to the Claims table have been postponed until a further design iteration has been approved and handed over.

## Link to Trello card

https://trello.com/c/eyaECIcP/999-clawbacks-add-clawback-show-page
