### PR TITLE
Add rejected columns to mentor trainings

### DIFF
--- a/app/models/claims/mentor_training.rb
+++ b/app/models/claims/mentor_training.rb
@@ -5,6 +5,9 @@
 #  id              :uuid             not null, primary key
 #  date_completed  :datetime
 #  hours_completed :integer
+#  hours_rejected  :integer
+#  reason_rejected :text
+#  rejected        :boolean          default(FALSE)
 #  training_type   :enum             default("initial"), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/app/models/claims/mentor_training.rb
+++ b/app/models/claims/mentor_training.rb
@@ -54,6 +54,8 @@ class Claims::MentorTraining < ApplicationRecord
               less_than_or_equal_to: :max_hours,
               only_integer: true,
             }
+  validates :reason_rejected, presence: true, if: -> { rejected }
+  validates :hours_rejected, presence: true, if: -> { rejected }
 
   scope :without_hours, -> { where(hours_completed: nil).order_by_mentor_full_name }
   scope :order_by_mentor_full_name, -> { joins(:mentor).merge(Mentor.order_by_full_name) }

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -16,6 +16,9 @@ shared:
     - provider_id
     - created_at
     - updated_at
+    - rejected
+    - reason_rejected
+    - hours_rejected
   :user_memberships:
     - id
     - user_id

--- a/db/migrate/20241216150808_add_rejected_columns_to_mentor_trainings.rb
+++ b/db/migrate/20241216150808_add_rejected_columns_to_mentor_trainings.rb
@@ -1,0 +1,11 @@
+class AddRejectedColumnsToMentorTrainings < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured do
+      change_table(:mentor_trainings, bulk: true) do |t|
+        t.boolean :rejected, default: false
+        t.text :reason_rejected
+        t.integer :hours_rejected
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+<<<<<<< HEAD
 ActiveRecord::Schema[7.2].define(version: 2024_12_10_120632) do
+=======
+ActiveRecord::Schema[7.2].define(version: 2024_12_16_150808) do
+>>>>>>> bba94a7f (Add rejected columns to mentor trainings)
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -237,6 +241,9 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_10_120632) do
     t.uuid "provider_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "rejected", default: false
+    t.text "reason_rejected"
+    t.integer "hours_rejected"
     t.index ["claim_id"], name: "index_mentor_trainings_on_claim_id"
     t.index ["mentor_id"], name: "index_mentor_trainings_on_mentor_id"
     t.index ["provider_id"], name: "index_mentor_trainings_on_provider_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-<<<<<<< HEAD
-ActiveRecord::Schema[7.2].define(version: 2024_12_10_120632) do
-=======
 ActiveRecord::Schema[7.2].define(version: 2024_12_16_150808) do
->>>>>>> bba94a7f (Add rejected columns to mentor trainings)
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"

--- a/spec/factories/mentor_trainings.rb
+++ b/spec/factories/mentor_trainings.rb
@@ -5,6 +5,9 @@
 #  id              :uuid             not null, primary key
 #  date_completed  :datetime
 #  hours_completed :integer
+#  hours_rejected  :integer
+#  reason_rejected :text
+#  rejected        :boolean          default(FALSE)
 #  training_type   :enum             default("initial"), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/spec/models/claims/mentor_training_spec.rb
+++ b/spec/models/claims/mentor_training_spec.rb
@@ -40,6 +40,28 @@ RSpec.describe Claims::MentorTraining, type: :model do
     it { is_expected.to belong_to(:provider) }
   end
 
+  describe "validations" do
+    context "when rejected is true" do
+      let(:mentor_training) { build(:mentor_training, rejected: true) }
+
+      it "validates that the rejected reason is present" do
+        expect(mentor_training.valid?).to be(false)
+        expect(mentor_training.errors["reason_rejected"]).to include("can't be blank")
+      end
+
+      it "validates that the rejected hours is present" do
+        expect(mentor_training.valid?).to be(false)
+        expect(mentor_training.errors["hours_rejected"]).to include("can't be blank")
+      end
+    end
+
+    context "when rejected is false" do
+      it "confirms the mentor training is valid" do
+        expect(mentor_training.valid?).to be(true)
+      end
+    end
+  end
+
   describe "auditing" do
     it { is_expected.to be_audited.associated_with(:claim) }
   end

--- a/spec/models/claims/mentor_training_spec.rb
+++ b/spec/models/claims/mentor_training_spec.rb
@@ -5,6 +5,9 @@
 #  id              :uuid             not null, primary key
 #  date_completed  :datetime
 #  hours_completed :integer
+#  hours_rejected  :integer
+#  reason_rejected :text
+#  rejected        :boolean          default(FALSE)
 #  training_type   :enum             default("initial"), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null


### PR DESCRIPTION
## Context

- Add the following columns to the `mentor_trainings` table:
  - rejected (Boolean)
  - rejected_reason (Text)
  - rejected_hours (Integer)

![image](https://github.com/user-attachments/assets/e09ad8e8-2889-4c40-bc5b-af117f6a72a2)


## Link to Trello card

- https://trello.com/c/O19JNLcS/1001-add-rejected-columns-to-the-mentor-trainings-table
