### PR TITLE
Add claim activity model

### DIFF
--- a/app/models/claims/claim_activity.rb
+++ b/app/models/claims/claim_activity.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: claim_activities
+#
+#  id          :uuid             not null, primary key
+#  action      :string
+#  record_type :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  record_id   :uuid             not null
+#  user_id     :uuid             not null
+#
+# Indexes
+#
+#  index_claim_activities_on_record   (record_type,record_id)
+#  index_claim_activities_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class Claims::ClaimActivity < ApplicationRecord
+  belongs_to :user
+  belongs_to :record, polymorphic: true
+
+  enum :action, { payment_delivered: "payment_delivered" }
+end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -225,3 +225,11 @@ shared:
     - claim_id
     - created_at
     - updated_at
+  :claim_activities:
+    - id
+    - action
+    - user_id
+    - record_type
+    - record_id
+    - created_at
+    - updated_at

--- a/db/migrate/20241217132410_create_claims_claim_activities.rb
+++ b/db/migrate/20241217132410_create_claims_claim_activities.rb
@@ -1,0 +1,11 @@
+class CreateClaimsClaimActivities < ActiveRecord::Migration[7.2]
+  def change
+    create_table :claim_activities, id: :uuid do |t|
+      t.string :action
+      t.references :user, null: false, foreign_key: true, type: :uuid
+      t.references :record, null: false, polymorphic: true, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_16_161048) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_17_132410) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -81,6 +81,17 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_16_161048) do
     t.index ["created_at"], name: "index_audits_on_created_at"
     t.index ["request_uuid"], name: "index_audits_on_request_uuid"
     t.index ["user_id", "user_type"], name: "user_index"
+  end
+
+  create_table "claim_activities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "action"
+    t.uuid "user_id", null: false
+    t.string "record_type", null: false
+    t.uuid "record_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["record_type", "record_id"], name: "index_claim_activities_on_record"
+    t.index ["user_id"], name: "index_claim_activities_on_user_id"
   end
 
   create_table "claim_windows", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -523,6 +534,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_16_161048) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "claim_activities", "users"
   add_foreign_key "claim_windows", "academic_years"
   add_foreign_key "claims", "providers"
   add_foreign_key "claims", "schools"

--- a/spec/factories/claims/claim_activities.rb
+++ b/spec/factories/claims/claim_activities.rb
@@ -1,0 +1,32 @@
+# == Schema Information
+#
+# Table name: claim_activities
+#
+#  id          :uuid             not null, primary key
+#  action      :string
+#  record_type :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  record_id   :uuid             not null
+#  user_id     :uuid             not null
+#
+# Indexes
+#
+#  index_claim_activities_on_record   (record_type,record_id)
+#  index_claim_activities_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+FactoryBot.define do
+  factory :claim_activity, class: "Claims::ClaimActivity" do
+    association :user, factory: :claims_support_user
+
+    trait :payment_delivered do
+      action { "payment_delivered" }
+
+      association :record, factory: :claims_payment
+    end
+  end
+end

--- a/spec/models/claims/claim_activity_spec.rb
+++ b/spec/models/claims/claim_activity_spec.rb
@@ -1,0 +1,29 @@
+# == Schema Information
+#
+# Table name: claim_activities
+#
+#  id          :uuid             not null, primary key
+#  action      :string
+#  record_type :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  record_id   :uuid             not null
+#  user_id     :uuid             not null
+#
+# Indexes
+#
+#  index_claim_activities_on_record   (record_type,record_id)
+#  index_claim_activities_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+require "rails_helper"
+
+RSpec.describe Claims::ClaimActivity, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:record) }
+  end
+end


### PR DESCRIPTION
## Context

We need to be able to track when claim processing activity is performed, who performed them, and associate the activity to the artifacts created.

## Changes proposed in this pull request

- Add the `Claims::ClaimsActivity` model.

## Guidance to review

