### PR TITLE
Amend show and index route for sampling claims

### DIFF
--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -77,7 +77,7 @@ scope module: :claims, as: :claims, constraints: {
       end
 
       resources :payments, only: %i[index]
-      resources :samplings, path: "sampling", only: %i[index show] do
+      resources :samplings, path: "sampling/claims", only: %i[index show] do
         member do
           get :confirm_approval
           put :update

--- a/spec/system/claims/support/claims/sampling/support_user_approves_a_claim_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_approves_a_claim_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe "Support user approves a claim", service: :claims, type: :system 
       expect(page).to have_element(:p, text: "Randomly selected for audit", class: "govuk-body")
     end
 
-    expect(page).to have_link("Approve claim", href: "/support/claims/sampling/#{@sampling_claim.id}/confirm_approval")
+    expect(page).to have_link("Approve claim", href: "/support/claims/sampling/claims/#{@sampling_claim.id}/confirm_approval")
   end
 
   def when_i_click_on_approve_claim
@@ -131,7 +131,7 @@ RSpec.describe "Support user approves a claim", service: :claims, type: :system 
     expect(page).to have_h1("Are you sure you want to approve the claim?")
     expect(page).to have_element(:p, text: "This will mark the claim as 'Paid'.", class: "govuk-body")
     expect(page).to have_button("Approve claim")
-    expect(page).to have_link("Cancel", href: "/support/claims/sampling/#{@sampling_claim.id}")
+    expect(page).to have_link("Cancel", href: "/support/claims/sampling/claims/#{@sampling_claim.id}")
   end
 
   def when_i_click_on_cancel

--- a/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_by_academic_year_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_by_academic_year_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe "Support user filters sampled claims by academic year", service: 
   def and_i_see_the_sampled_claim_for_the_current_academic_year
     expect(page).to have_claim_card({
       "title" => "#{@current_claim.reference} - #{@current_claim.school.name}",
-      "url" => "/support/claims/sampling/#{@current_claim.id}",
+      "url" => "/support/claims/sampling/claims/#{@current_claim.id}",
       "status" => "Sampling in progress",
       "academic_year" => @current_claim.academic_year.name,
       "provider_name" => @current_claim.provider.name,
@@ -135,7 +135,7 @@ RSpec.describe "Support user filters sampled claims by academic year", service: 
   def and_i_see_the_sampled_claim_for_the_previous_academic_year
     expect(page).to have_claim_card({
       "title" => "#{@previous_claim.reference} - #{@previous_claim.school.name}",
-      "url" => "/support/claims/sampling/#{@previous_claim.id}",
+      "url" => "/support/claims/sampling/claims/#{@previous_claim.id}",
       "status" => "Sampling in progress",
       "academic_year" => @previous_claim.academic_year.name,
       "provider_name" => @previous_claim.provider.name,

--- a/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_by_provider_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_by_provider_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe "Support user filters sampled claims by provider", service: :clai
   def and_i_see_the_sampled_claim_for_provider_niot
     expect(page).to have_claim_card({
       "title" => "#{@niot_claim.reference} - #{@niot_claim.school.name}",
-      "url" => "/support/claims/sampling/#{@niot_claim.id}",
+      "url" => "/support/claims/sampling/claims/#{@niot_claim.id}",
       "status" => "Sampling in progress",
       "academic_year" => @niot_claim.academic_year.name,
       "provider_name" => @niot_claim.provider.name,
@@ -123,7 +123,7 @@ RSpec.describe "Support user filters sampled claims by provider", service: :clai
   def and_i_see_the_sampled_claim_for_provider_bpn
     expect(page).to have_claim_card({
       "title" => "#{@bpn_claim.reference} - #{@bpn_claim.school.name}",
-      "url" => "/support/claims/sampling/#{@bpn_claim.id}",
+      "url" => "/support/claims/sampling/claims/#{@bpn_claim.id}",
       "status" => "Sampling in progress",
       "academic_year" => @bpn_claim.academic_year.name,
       "provider_name" => @bpn_claim.provider.name,

--- a/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_by_school_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_by_school_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe "Support user filters sampled claims by school", service: :claims
   def and_i_see_the_sampled_claim_for_springfield_elementary
     expect(page).to have_claim_card({
       "title" => "#{@springfield_claim.reference} - #{@springfield_claim.school.name}",
-      "url" => "/support/claims/sampling/#{@springfield_claim.id}",
+      "url" => "/support/claims/sampling/claims/#{@springfield_claim.id}",
       "status" => "Sampling in progress",
       "academic_year" => @springfield_claim.academic_year.name,
       "provider_name" => @springfield_claim.provider.name,
@@ -123,7 +123,7 @@ RSpec.describe "Support user filters sampled claims by school", service: :claims
   def and_i_see_the_sampled_claim_for_hogwarts
     expect(page).to have_claim_card({
       "title" => "#{@hogwarts_claim.reference} - #{@hogwarts_claim.school.name}",
-      "url" => "/support/claims/sampling/#{@hogwarts_claim.id}",
+      "url" => "/support/claims/sampling/claims/#{@hogwarts_claim.id}",
       "status" => "Sampling in progress",
       "academic_year" => @hogwarts_claim.academic_year.name,
       "provider_name" => @hogwarts_claim.provider.name,

--- a/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_by_status_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_by_status_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "Support user filters sampled claims by status", service: :claims
   def and_i_see_claims_with_a_sampling_in_progress_status
     expect(page).to have_claim_card({
       "title" => "#{@sampling_in_progress_claim.reference} - #{@sampling_in_progress_claim.school.name}",
-      "url" => "/support/claims/sampling/#{@sampling_in_progress_claim.id}",
+      "url" => "/support/claims/sampling/claims/#{@sampling_in_progress_claim.id}",
       "status" => "Sampling in progress",
       "academic_year" => @sampling_in_progress_claim.academic_year.name,
       "provider_name" => @sampling_in_progress_claim.provider.name,
@@ -114,7 +114,7 @@ RSpec.describe "Support user filters sampled claims by status", service: :claims
   def and_i_see_claims_with_a_sampling_provider_not_approved_status
     expect(page).to have_claim_card({
       "title" => "#{@sampling_provider_not_approved_claim.reference} - #{@sampling_provider_not_approved_claim.school.name}",
-      "url" => "/support/claims/sampling/#{@sampling_provider_not_approved_claim.id}",
+      "url" => "/support/claims/sampling/claims/#{@sampling_provider_not_approved_claim.id}",
       "status" => "Sampling in progress",
       "academic_year" => @sampling_provider_not_approved_claim.academic_year.name,
       "provider_name" => @sampling_provider_not_approved_claim.provider.name,

--- a/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_submitted_after_a_date_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_submitted_after_a_date_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "Support user filters sampled claims submitted after a date", ser
   def and_i_see_the_sampled_claim_submitted_in_may
     expect(page).to have_claim_card({
       "title" => "#{@may_claim.reference} - #{@may_claim.school.name}",
-      "url" => "/support/claims/sampling/#{@may_claim.id}",
+      "url" => "/support/claims/sampling/claims/#{@may_claim.id}",
       "status" => "Sampling in progress",
       "academic_year" => @may_claim.academic_year.name,
       "provider_name" => @may_claim.provider.name,
@@ -99,7 +99,7 @@ RSpec.describe "Support user filters sampled claims submitted after a date", ser
   def and_i_see_the_sampled_claim_submitted_in_july
     expect(page).to have_claim_card({
       "title" => "#{@july_claim.reference} - #{@july_claim.school.name}",
-      "url" => "/support/claims/sampling/#{@july_claim.id}",
+      "url" => "/support/claims/sampling/claims/#{@july_claim.id}",
       "status" => "Sampling in progress",
       "academic_year" => @july_claim.academic_year.name,
       "provider_name" => @july_claim.provider.name,

--- a/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_submitted_before_a_date_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_submitted_before_a_date_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "Support user filters sampled claims submitted before a date", se
   def and_i_see_the_sampled_claim_submitted_in_may
     expect(page).to have_claim_card({
       "title" => "#{@may_claim.reference} - #{@may_claim.school.name}",
-      "url" => "/support/claims/sampling/#{@may_claim.id}",
+      "url" => "/support/claims/sampling/claims/#{@may_claim.id}",
       "status" => "Sampling in progress",
       "academic_year" => @may_claim.academic_year.name,
       "provider_name" => @may_claim.provider.name,
@@ -99,7 +99,7 @@ RSpec.describe "Support user filters sampled claims submitted before a date", se
   def and_i_see_the_sampled_claim_submitted_in_july
     expect(page).to have_claim_card({
       "title" => "#{@july_claim.reference} - #{@july_claim.school.name}",
-      "url" => "/support/claims/sampling/#{@july_claim.id}",
+      "url" => "/support/claims/sampling/claims/#{@july_claim.id}",
       "status" => "Sampling in progress",
       "academic_year" => @july_claim.academic_year.name,
       "provider_name" => @july_claim.provider.name,

--- a/spec/system/claims/support/claims/sampling/support_user_searches_for_a_sampled_claim_using_a_reference_number_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_searches_for_a_sampled_claim_using_a_reference_number_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "Support user searches for a sampled claim using a reference numb
   def and_i_see_the_sampled_claim_with_reference_11111111
     expect(page).to have_claim_card({
       "title" => "#{@claim_11111111.reference} - #{@claim_11111111.school.name}",
-      "url" => "/support/claims/sampling/#{@claim_11111111.id}",
+      "url" => "/support/claims/sampling/claims/#{@claim_11111111.id}",
       "status" => "Sampling in progress",
       "academic_year" => @claim_11111111.academic_year.name,
       "provider_name" => @claim_11111111.provider.name,
@@ -97,7 +97,7 @@ RSpec.describe "Support user searches for a sampled claim using a reference numb
   def and_i_see_the_sampled_claim_with_reference_22222222
     expect(page).to have_claim_card({
       "title" => "#{@claim_22222222.reference} - #{@claim_22222222.school.name}",
-      "url" => "/support/claims/sampling/#{@claim_22222222.id}",
+      "url" => "/support/claims/sampling/claims/#{@claim_22222222.id}",
       "status" => "Sampling in progress",
       "academic_year" => @claim_22222222.academic_year.name,
       "provider_name" => @claim_22222222.provider.name,

--- a/spec/system/claims/support/claims/sampling/support_user_views_sampled_claims_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_views_sampled_claims_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "Support user views sampled claims", service: :claims, type: :sys
   def and_i_see_claims_with_a_sampling_in_progress_status
     expect(page).to have_claim_card({
       "title" => "#{@sampling_in_progress_claim.reference} - #{@sampling_in_progress_claim.school.name}",
-      "url" => "/support/claims/sampling/#{@sampling_in_progress_claim.id}",
+      "url" => "/support/claims/sampling/claims/#{@sampling_in_progress_claim.id}",
       "status" => "Sampling in progress",
       "academic_year" => @sampling_in_progress_claim.academic_year.name,
       "provider_name" => @sampling_in_progress_claim.provider.name,
@@ -80,7 +80,7 @@ RSpec.describe "Support user views sampled claims", service: :claims, type: :sys
   def and_i_see_claims_with_a_sampling_provider_not_approved_status
     expect(page).to have_claim_card({
       "title" => "#{@sampling_provider_not_approved_claim.reference} - #{@sampling_provider_not_approved_claim.school.name}",
-      "url" => "/support/claims/sampling/#{@sampling_provider_not_approved_claim.id}",
+      "url" => "/support/claims/sampling/claims/#{@sampling_provider_not_approved_claim.id}",
       "status" => "Sampling in progress",
       "academic_year" => @sampling_provider_not_approved_claim.academic_year.name,
       "provider_name" => @sampling_provider_not_approved_claim.provider.name,

--- a/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_sampling_data_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_sampling_data_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe "Support user uploads sampling data", service: :claims, type: :sy
     expect(page).to have_h2("Sampling (1)")
     expect(page).to have_claim_card({
       "title" => "#{@current_claim.reference} - #{@current_claim.school.name}",
-      "url" => "/support/claims/sampling/#{@current_claim.id}",
+      "url" => "/support/claims/sampling/claims/#{@current_claim.id}",
       "status" => "Sampling in progress",
       "academic_year" => @current_claim.academic_year.name,
       "provider_name" => @current_claim.provider.name,

--- a/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_does_not_upload_a_file_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_does_not_upload_a_file_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "Support user does not upload a file",
     expect(page).to have_h2("Sampling (1)")
     expect(page).to have_claim_card({
       "title" => "11111111 - #{@claim.school_name}",
-      "url" => "/support/claims/sampling/#{@claim.id}",
+      "url" => "/support/claims/sampling/claims/#{@claim.id}",
       "status" => "Sampling in progress",
       "academic_year" => @claim.academic_year.name,
       "provider_name" => @claim.provider.name,

--- a/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_containing_claims_not_with_the_status_sampling_in_progress_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_containing_claims_not_with_the_status_sampling_in_progress_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "Support user uploads a CSV containing claims not with the status
     expect(page).to have_h2("Sampling (1)")
     expect(page).to have_claim_card({
       "title" => "11111111 - #{@sampling_in_progress_claim.school_name}",
-      "url" => "/support/claims/sampling/#{@sampling_in_progress_claim.id}",
+      "url" => "/support/claims/sampling/claims/#{@sampling_in_progress_claim.id}",
       "status" => "Sampling in progress",
       "academic_year" => @sampling_in_progress_claim.academic_year.name,
       "provider_name" => @sampling_in_progress_claim.provider.name,

--- a/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_containing_invalid_references_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_containing_invalid_references_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "Support user uploads a CSV not containing invalid references",
     expect(page).to have_h2("Sampling (2)")
     expect(page).to have_claim_card({
       "title" => "33333333 - #{@sampling_in_progress_claim_1.school_name}",
-      "url" => "/support/claims/sampling/#{@sampling_in_progress_claim_1.id}",
+      "url" => "/support/claims/sampling/claims/#{@sampling_in_progress_claim_1.id}",
       "status" => "Sampling in progress",
       "academic_year" => @sampling_in_progress_claim_1.academic_year.name,
       "provider_name" => @sampling_in_progress_claim_1.provider.name,
@@ -91,7 +91,7 @@ RSpec.describe "Support user uploads a CSV not containing invalid references",
     })
     expect(page).to have_claim_card({
       "title" => "22222222 - #{@sampling_in_progress_claim_2.school_name}",
-      "url" => "/support/claims/sampling/#{@sampling_in_progress_claim_2.id}",
+      "url" => "/support/claims/sampling/claims/#{@sampling_in_progress_claim_2.id}",
       "status" => "Sampling in progress",
       "academic_year" => @sampling_in_progress_claim_2.academic_year.name,
       "provider_name" => @sampling_in_progress_claim_2.provider.name,

--- a/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_not_containing_a_not_assured_reason_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_not_containing_a_not_assured_reason_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "Support user uploads a CSV not containing a not assured reason",
     expect(page).to have_h2("Sampling (2)")
     expect(page).to have_claim_card({
       "title" => "11111111 - #{@sampling_in_progress_claim_1.school_name}",
-      "url" => "/support/claims/sampling/#{@sampling_in_progress_claim_1.id}",
+      "url" => "/support/claims/sampling/claims/#{@sampling_in_progress_claim_1.id}",
       "status" => "Sampling in progress",
       "academic_year" => @sampling_in_progress_claim_1.academic_year.name,
       "provider_name" => @sampling_in_progress_claim_1.provider.name,
@@ -91,7 +91,7 @@ RSpec.describe "Support user uploads a CSV not containing a not assured reason",
     })
     expect(page).to have_claim_card({
       "title" => "22222222 - #{@sampling_in_progress_claim_2.school_name}",
-      "url" => "/support/claims/sampling/#{@sampling_in_progress_claim_2.id}",
+      "url" => "/support/claims/sampling/claims/#{@sampling_in_progress_claim_2.id}",
       "status" => "Sampling in progress",
       "academic_year" => @sampling_in_progress_claim_2.academic_year.name,
       "provider_name" => @sampling_in_progress_claim_2.provider.name,

--- a/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_not_containing_all_the_mentors_associated_with_a_claim_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_not_containing_all_the_mentors_associated_with_a_claim_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Support user uploads a CSV not containing all the mentors associ
     expect(page).to have_h2("Sampling (2)")
     expect(page).to have_claim_card({
       "title" => "11111111 - #{@sampling_in_progress_claim_1.school_name}",
-      "url" => "/support/claims/sampling/#{@sampling_in_progress_claim_1.id}",
+      "url" => "/support/claims/sampling/claims/#{@sampling_in_progress_claim_1.id}",
       "status" => "Sampling in progress",
       "academic_year" => @sampling_in_progress_claim_1.academic_year.name,
       "provider_name" => @sampling_in_progress_claim_1.provider.name,
@@ -98,7 +98,7 @@ RSpec.describe "Support user uploads a CSV not containing all the mentors associ
     })
     expect(page).to have_claim_card({
       "title" => "22222222 - #{@sampling_in_progress_claim_2.school_name}",
-      "url" => "/support/claims/sampling/#{@sampling_in_progress_claim_2.id}",
+      "url" => "/support/claims/sampling/claims/#{@sampling_in_progress_claim_2.id}",
       "status" => "Sampling in progress",
       "academic_year" => @sampling_in_progress_claim_2.academic_year.name,
       "provider_name" => @sampling_in_progress_claim_2.provider.name,

--- a/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_not_containing_an_assured_status_for_each_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_not_containing_an_assured_status_for_each_mentor_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "Support user uploads a CSV not containing an assured status for 
     expect(page).to have_h2("Sampling (2)")
     expect(page).to have_claim_card({
       "title" => "11111111 - #{@sampling_in_progress_claim_1.school_name}",
-      "url" => "/support/claims/sampling/#{@sampling_in_progress_claim_1.id}",
+      "url" => "/support/claims/sampling/claims/#{@sampling_in_progress_claim_1.id}",
       "status" => "Sampling in progress",
       "academic_year" => @sampling_in_progress_claim_1.academic_year.name,
       "provider_name" => @sampling_in_progress_claim_1.provider.name,
@@ -91,7 +91,7 @@ RSpec.describe "Support user uploads a CSV not containing an assured status for 
     })
     expect(page).to have_claim_card({
       "title" => "22222222 - #{@sampling_in_progress_claim_2.school_name}",
-      "url" => "/support/claims/sampling/#{@sampling_in_progress_claim_2.id}",
+      "url" => "/support/claims/sampling/claims/#{@sampling_in_progress_claim_2.id}",
       "status" => "Sampling in progress",
       "academic_year" => @sampling_in_progress_claim_2.academic_year.name,
       "provider_name" => @sampling_in_progress_claim_2.provider.name,

--- a/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_provider_responses_for_claims_with_the_status_sampling_in_progress_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_provider_responses_for_claims_with_the_status_sampling_in_progress_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe "Support user uploads provider responses for claims with the stat
     expect(page).to have_h2("Sampling (2)")
     expect(page).to have_claim_card({
       "title" => "11111111 - #{@sampling_in_progress_claim_1.school_name}",
-      "url" => "/support/claims/sampling/#{@sampling_in_progress_claim_1.id}",
+      "url" => "/support/claims/sampling/claims/#{@sampling_in_progress_claim_1.id}",
       "status" => "Sampling in progress",
       "academic_year" => @sampling_in_progress_claim_1.academic_year.name,
       "provider_name" => @sampling_in_progress_claim_1.provider.name,
@@ -128,7 +128,7 @@ RSpec.describe "Support user uploads provider responses for claims with the stat
     })
     expect(page).to have_claim_card({
       "title" => "22222222 - #{@sampling_in_progress_claim_2.school_name}",
-      "url" => "/support/claims/sampling/#{@sampling_in_progress_claim_2.id}",
+      "url" => "/support/claims/sampling/claims/#{@sampling_in_progress_claim_2.id}",
       "status" => "Sampling in progress",
       "academic_year" => @sampling_in_progress_claim_2.academic_year.name,
       "provider_name" => @sampling_in_progress_claim_2.provider.name,
@@ -182,7 +182,7 @@ RSpec.describe "Support user uploads provider responses for claims with the stat
   def then_i_can_see_claim_11111111_has_the_status_provider_not_approved
     expect(page).to have_claim_card({
       "title" => "11111111 - #{@sampling_in_progress_claim_1.school_name}",
-      "url" => "/support/claims/sampling/#{@sampling_in_progress_claim_1.id}",
+      "url" => "/support/claims/sampling/claims/#{@sampling_in_progress_claim_1.id}",
       "status" => "Provider not approved",
       "academic_year" => @sampling_in_progress_claim_1.academic_year.name,
       "provider_name" => @sampling_in_progress_claim_1.provider.name,

--- a/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_the_wrong_file_type_as_provider_responses_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_the_wrong_file_type_as_provider_responses_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "Support user uploads the wrong file type as provider responses",
     expect(page).to have_h2("Sampling (1)")
     expect(page).to have_claim_card({
       "title" => "11111111 - #{@claim.school_name}",
-      "url" => "/support/claims/sampling/#{@claim.id}",
+      "url" => "/support/claims/sampling/claims/#{@claim.id}",
       "status" => "Sampling in progress",
       "academic_year" => @claim.academic_year.name,
       "provider_name" => @claim.provider.name,


### PR DESCRIPTION
## Context

We are making progressive enhancements to the support console to assist in the processing of Claims.

## Changes proposed in this pull request

- Update index page and show routes to match those for clawbacks:

Index:

`/support/claims/sampling/claims`

Show:

`/support/claims/sampling/claims/:claim_id`

## Guidance to review

- Sign in as Colin
- Visit the Sampling index and check that the URL matches the pattern above
- Visit a Sampling show page and check that the URL matches the pattern above
- Compare with clawback claims

## Link to Trello card

https://trello.com/c/FA4AmkYg/1005-wire-up-remaining-sampling-logic
