### PR TITLE
Adds validation to the `not_assured_reason`

### DIFF
--- a/app/models/claims/mentor_training.rb
+++ b/app/models/claims/mentor_training.rb
@@ -58,7 +58,7 @@ class Claims::MentorTraining < ApplicationRecord
             }
   validates :reason_rejected, presence: true, if: -> { rejected }
   validates :hours_rejected, presence: true, if: -> { rejected }
-  # validates :reason_not_assured, presence: true, if: -> { not_assured } TODO: Undercover is failing for some reason even when tested.
+  validates :reason_not_assured, presence: true, if: -> { not_assured }
 
   scope :without_hours, -> { where(hours_completed: nil).order_by_mentor_full_name }
   scope :order_by_mentor_full_name, -> { joins(:mentor).merge(Mentor.order_by_full_name) }

--- a/spec/models/claims/mentor_training_spec.rb
+++ b/spec/models/claims/mentor_training_spec.rb
@@ -43,6 +43,25 @@ RSpec.describe Claims::MentorTraining, type: :model do
   end
 
   describe "validations" do
+    describe "reason_not_assured" do
+      context "when not_assured is true" do
+        let(:mentor_training) { build(:mentor_training, not_assured: true) }
+
+        it "validates that the reason not assured is present" do
+          expect(mentor_training.valid?).to be(false)
+          expect(mentor_training.errors["reason_not_assured"]).to include("can't be blank")
+        end
+      end
+
+      context "when not_assured is false" do
+        let(:mentor_training) { build(:mentor_training, not_assured: false) }
+
+        it "confirms the mentor training is valid" do
+          expect(mentor_training.valid?).to be(true)
+        end
+      end
+    end
+
     describe "rejected" do
       context "when rejected is true" do
         let(:mentor_training) { build(:mentor_training, rejected: true) }


### PR DESCRIPTION
## Context

When this was implemented it undercover was failing and blocking the pipeline, now that it has been reverted we can re-add this validation.

## Changes proposed in this pull request

- [x] Adds validation for `reason_not_assured`
- [x] Adds test coverage for this change

## Guidance to review

- [x] Review file changes and CI

## Link to Trello card

[Add reason not assured validation](https://trello.com/c/ABxOVrK9/1009-add-reason-not-assured-validation)
