### PR TITLE
Set claim card header css align-items to flex-start

### DIFF
--- a/app/assets/stylesheets/components/claim/card.scss
+++ b/app/assets/stylesheets/components/claim/card.scss
@@ -10,6 +10,7 @@
     display: flex;
     flex-direction: row;
     justify-content: space-between;
+    align-items: flex-start;
     gap: govuk-spacing(1) govuk-spacing(2);
 
     @include govuk-media-query($until: desktop) {


### PR DESCRIPTION
## Context

The status tag of claims in claim cards are being stretched.

## Changes proposed in this pull request

- Set `align-items` of the card header to `flex-start`.

## Guidance to review

- See screenshots.

## Screenshots

| Before | After |
| ------ | ----- |
| ![CleanShot 2024-12-23 at 11 04 48@2x](https://github.com/user-attachments/assets/d6556df9-9859-4dda-abe8-80c31005f5bc) | ![CleanShot 2024-12-23 at 11 05 21@2x](https://github.com/user-attachments/assets/d2de69c3-1eb8-4226-8dea-6f9ae7403a74) |
