### PR TITLE
Create sampling send and deliver

### DIFF
--- a/app/controllers/claims/sampling/claims_controller.rb
+++ b/app/controllers/claims/sampling/claims_controller.rb
@@ -6,7 +6,8 @@ class Claims::Sampling::ClaimsController < Claims::ApplicationController
   before_action :set_provider_sampling
 
   def download
-    send_data @provider_sampling.csv_file.download, filename: "sampling-claims-#{Time.current.iso8601}.csv"
+    provider_name = @provider_sampling.provider_name.parameterize
+    send_data @provider_sampling.csv_file.download, filename: "sampling-claims-#{provider_name}-#{Time.current.iso8601}.csv"
   end
 
   private

--- a/app/controllers/claims/support/claims/samplings/upload_data_controller.rb
+++ b/app/controllers/claims/support/claims/samplings/upload_data_controller.rb
@@ -24,7 +24,7 @@ class Claims::Support::Claims::Samplings::UploadDataController < Claims::Support
   def set_wizard
     state = session[state_key] ||= {}
     current_step = params[:step]&.to_sym
-    @wizard = Claims::UploadSamplingDataWizard.new(params:, state:, current_step:)
+    @wizard = Claims::UploadSamplingDataWizard.new(params:, state:, current_step:, current_user:)
   end
 
   def step_path(step)

--- a/app/jobs/claims/sampling/create_and_deliver_job.rb
+++ b/app/jobs/claims/sampling/create_and_deliver_job.rb
@@ -1,0 +1,22 @@
+class Claims::Sampling::CreateAndDeliverJob < ApplicationJob
+  queue_as :default
+
+  def perform(current_user_id:, claim_ids:)
+    @current_user_id = current_user_id
+    @claim_ids = claim_ids
+
+    Claims::Sampling::CreateAndDeliver.call(current_user:, claims:)
+  end
+
+  private
+
+  attr_reader :current_user_id, :claim_ids
+
+  def claims
+    @claims ||= Claims::Claim.find(claim_ids)
+  end
+
+  def current_user
+    @current_user ||= User.find(current_user_id)
+  end
+end

--- a/app/mailers/claims/provider_mailer.rb
+++ b/app/mailers/claims/provider_mailer.rb
@@ -1,7 +1,22 @@
 class Claims::ProviderMailer < Claims::ApplicationMailer
-  def sampling_checks_required(provider, url_for_csv)
-    notify_email to: provider.email_address,
+  def sampling_checks_required(provider_sampling)
+    @provider_sampling = provider_sampling
+
+    notify_email to: @provider_sampling.provider_email_address,
                  subject: t(".subject"),
-                 body: t(".body", provider_name: provider.name, url_for_csv:, support_email:, service_name:)
+                 body: t(
+                   ".body",
+                   provider_name: @provider_sampling.provider_name,
+                   download_csv_url: claims_sampling_claims_url(token:),
+                   support_email:, service_name:
+                 )
+  end
+
+  private
+
+  attr_reader :provider_sampling
+
+  def token
+    Rails.application.message_verifier(:sampling).generate(provider_sampling.id, expires_in: 7.days)
   end
 end

--- a/app/models/claims/claim_activity.rb
+++ b/app/models/claims/claim_activity.rb
@@ -23,5 +23,8 @@ class Claims::ClaimActivity < ApplicationRecord
   belongs_to :user
   belongs_to :record, polymorphic: true
 
-  enum :action, { payment_delivered: "payment_delivered" }
+  enum :action, {
+    payment_delivered: "payment_delivered",
+    sampling_in_progress: "sampling_in_progress",
+  }
 end

--- a/app/models/claims/provider_sampling.rb
+++ b/app/models/claims/provider_sampling.rb
@@ -26,4 +26,6 @@ class Claims::ProviderSampling < ApplicationRecord
   has_many :claims, through: :provider_sampling_claims
 
   has_one_attached :csv_file
+
+  delegate :email_address, :name, to: :provider, prefix: true
 end

--- a/app/services/claims/sampling/create_and_deliver.rb
+++ b/app/services/claims/sampling/create_and_deliver.rb
@@ -1,0 +1,36 @@
+class Claims::Sampling::CreateAndDeliver < ApplicationService
+  def initialize(current_user:, claims:)
+    @current_user = current_user
+    @claims = claims
+  end
+
+  attr_reader :current_user, :claims
+
+  def call
+    claims.group_by(&:provider).each do |provider, provider_claims|
+      ActiveRecord::Base.transaction do |transaction|
+        provider_claims.each do |claim|
+          Claims::Sampling::FlagForSamplingJob.perform_now(claim)
+        end
+
+        provider_sampling = Claims::ProviderSampling.create!(provider:, claims: provider_claims, sampling:, csv_file: File.open(csv_for_provider.to_io))
+
+        transaction.after_commit do
+          Claims::ProviderMailer.sampling_checks_required(provider_sampling).deliver_later
+        end
+      end
+    end
+
+    Claims::ClaimActivity.create!(action: :sampling_in_progress, user: current_user, record: sampling)
+  end
+
+  private
+
+  def csv_for_provider
+    Claims::Sampling::GenerateCSVFile.call(claims:)
+  end
+
+  def sampling
+    @sampling ||= Claims::Sampling.new
+  end
+end

--- a/app/services/claims/sampling/generate_csv_file.rb
+++ b/app/services/claims/sampling/generate_csv_file.rb
@@ -1,0 +1,35 @@
+require "csv"
+
+class Claims::Sampling::GenerateCSVFile < ApplicationService
+  HEADERS = %w[
+    claim_reference
+    sampling_reason
+  ].freeze
+
+  def initialize(claims:)
+    @claims = claims
+  end
+
+  def call
+    CSV.open(file_name, "w", headers: true) do |csv|
+      csv << HEADERS
+
+      claims.each do |claim|
+        csv << [
+          claim.reference,
+          claim.sampling_reason,
+        ]
+      end
+
+      csv
+    end
+  end
+
+  private
+
+  attr_reader :claims
+
+  def file_name
+    Rails.root.join("tmp/sampling-claims-#{Time.current}.csv")
+  end
+end

--- a/app/views/claims/sampling/claims/error.html.erb
+++ b/app/views/claims/sampling/claims/error.html.erb
@@ -1,0 +1,11 @@
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= t(".page_title") %></h1>
+
+      <p class="govuk-body"><%= t(".description") %></p>
+
+      <p class="govuk-body"><%= t(".support_html", mail_to: govuk_mail_to(t("claims.support_email"), t("claims.support_email_html"))) %></p>
+    </div>
+  </div>
+</div>

--- a/app/views/claims/sampling/claims/error.html.erb
+++ b/app/views/claims/sampling/claims/error.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, t(".page_title") %>
+
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/sampling/claims/index.html.erb
+++ b/app/views/claims/sampling/claims/index.html.erb
@@ -1,0 +1,13 @@
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= t(".page_title") %></h1>
+
+      <p class="govuk-body"><%= t(".description_html") %></p>
+
+      <p class="govuk-body"><%= t(".support_html", mail_to: govuk_mail_to(t("claims.support_email"), t("claims.support_email_html"))) %></p>
+
+      <%= govuk_button_link_to t(".submit"), download_claims_sampling_claims_path(token: params[:token]) %>
+    </div>
+  </div>
+</div>

--- a/app/views/claims/sampling/claims/index.html.erb
+++ b/app/views/claims/sampling/claims/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, t(".page_title") %>
+
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/wizards/claims/upload_sampling_data_wizard.rb
+++ b/app/wizards/claims/upload_sampling_data_wizard.rb
@@ -1,5 +1,13 @@
 module Claims
   class UploadSamplingDataWizard < BaseWizard
+    def initialize(current_user:, params:, state:, current_step: nil)
+      @current_user = current_user
+
+      super(state:, params:, current_step:)
+    end
+
+    attr_reader :current_user
+
     def define_steps
       if paid_claims.present?
         add_step(UploadStep)
@@ -12,7 +20,7 @@ module Claims
     def upload_data
       raise "Invalid wizard state" unless valid?
 
-      Claims::Sampling::FlagCollectionForSamplingJob.perform_later(uploaded_claim_ids)
+      Claims::Sampling::CreateAndDeliverJob.perform_later(current_user_id: current_user.id, claim_ids: uploaded_claim_ids)
     end
 
     def paid_claims

--- a/config/locales/en/claims/provider_mailer.yml
+++ b/config/locales/en/claims/provider_mailer.yml
@@ -8,7 +8,7 @@ en:
           
           These claims from the Claim funding for mentor training service (Claim) are ready for post-payment assurance. The link to the latest CSV file is valid for 7 days.
           
-          %{url_for_csv}
+          %{download_csv_url}
         
           What you need to do:
         

--- a/config/locales/en/claims/sampling/claims.yml
+++ b/config/locales/en/claims/sampling/claims.yml
@@ -1,0 +1,13 @@
+en:
+  claims:
+    sampling:
+      claims:
+        index:
+          page_title: Download the sampling CSV
+          description_html: Download the Claim funding for mentor training sampling <span title="Comma separated values">CSV</span> file.
+          support_html: If you have any questions, email %{mail_to}.
+          submit: Download CSV file
+        error:
+          page_title: Sorry, there is a problem with the download link
+          description: You are seeing this page because the download link is not working. It may have timed out or contained an invalid security token.
+          support_html: Email %{mail_to} to request a new download link.

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -19,6 +19,12 @@ scope module: :claims, as: :claims, constraints: {
     end
   end
 
+  namespace :sampling do
+    resources :claims, only: %i[index] do
+      get :download, on: :collection
+    end
+  end
+
   resources :schools, only: %i[index show] do
     scope module: :schools do
       resources :claims do

--- a/spec/jobs/claims/sampling/create_and_deliver_job_spec.rb
+++ b/spec/jobs/claims/sampling/create_and_deliver_job_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Claims::Sampling::CreateAndDeliverJob, type: :job do
+  let(:current_user) { create(:claims_user) }
+  let(:claims) { create_list(:claim, 3) }
+
+  describe "#perform" do
+    before do
+      allow(Claims::Sampling::CreateAndDeliver).to receive(:call).and_return(true)
+    end
+
+    it "calls the Claims::Sampling::CreateAndDeliver service" do
+      described_class.perform_now(current_user_id: current_user.id, claim_ids: claims.map(&:id))
+      expect(Claims::Sampling::CreateAndDeliver).to have_received(:call).with(current_user:, claims:).once
+    end
+
+    it "enqueues the job in the default queue" do
+      expect {
+        described_class.perform_later(current_user_id: current_user.id, claim_ids: claims.map(&:id))
+      }.to have_enqueued_job(described_class).on_queue("default")
+    end
+  end
+end

--- a/spec/mailers/claims/provider_mailer_spec.rb
+++ b/spec/mailers/claims/provider_mailer_spec.rb
@@ -2,12 +2,17 @@ require "rails_helper"
 
 RSpec.describe Claims::ProviderMailer, type: :mailer do
   describe "#sampling_checks_required" do
-    subject(:sampling_checks_required_email) { described_class.sampling_checks_required(provider, url_for_csv) }
+    subject(:sampling_checks_required_email) { described_class.sampling_checks_required(provider_sampling) }
 
-    let(:provider) { create(:claims_provider, email_address: "aes_sedai_trust@example.com") }
+    let(:provider) { build(:claims_provider, email_address: "aes_sedai_trust@example.com") }
+    let(:provider_sampling) { create(:provider_sampling, provider:) }
     let(:url_for_csv) { "https://example.com" }
     let(:service_name) { "Claim funding for mentor training" }
     let(:support_email) { "ittmentor.funding@education.gov.uk" }
+
+    before do
+      allow(Rails.application.message_verifier(:sampling)).to receive(:generate).and_return("token")
+    end
 
     it "sends the sampling checks required email" do
       expect(sampling_checks_required_email.to).to contain_exactly(provider.email_address)
@@ -17,7 +22,7 @@ RSpec.describe Claims::ProviderMailer, type: :mailer do
 
         These claims from the Claim funding for mentor training service (Claim) are ready for post-payment assurance. The link to the latest CSV file is valid for 7 days.
 
-        #{url_for_csv}
+        http://claims.localhost/sampling/claims?token=token
 
         What you need to do:
 

--- a/spec/models/claims/provider_sampling_spec.rb
+++ b/spec/models/claims/provider_sampling_spec.rb
@@ -31,4 +31,9 @@ RSpec.describe Claims::ProviderSampling, type: :model do
   describe "attachments" do
     it { is_expected.to have_one_attached(:csv_file) }
   end
+
+  describe "delegations" do
+    it { is_expected.to delegate_method(:email_address).to(:provider).with_prefix }
+    it { is_expected.to delegate_method(:name).to(:provider).with_prefix }
+  end
 end

--- a/spec/services/claims/sampling/create_and_deliver_spec.rb
+++ b/spec/services/claims/sampling/create_and_deliver_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe Claims::Sampling::CreateAndDeliver do
+  subject(:create_and_deliver) { described_class.call(current_user:, claims:) }
+
+  let(:current_user) { create(:claims_support_user) }
+  let!(:claims) { [create(:claim, :paid)] }
+
+  describe "#call" do
+    context "when there are submitted claims" do
+      it "does a thing" do
+        expect { create_and_deliver }.to change(Claims::Sampling, :count).by(1)
+        .and change(Claims::ClaimActivity, :count).by(1)
+        .and change { Claims::Claim.pluck(:status).uniq }.from(%w[paid]).to(%w[sampling_in_progress])
+        .and enqueue_mail(Claims::ProviderMailer, :sampling_checks_required)
+      end
+    end
+  end
+end

--- a/spec/services/claims/sampling/generate_csv_file_spec.rb
+++ b/spec/services/claims/sampling/generate_csv_file_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe Claims::Sampling::GenerateCSVFile do
+  subject(:generate_csv_file) { described_class.call(claims:) }
+
+  let(:claims) { create_list(:claim, 3) }
+
+  describe "#call" do
+    it "generates a CSV file of claims" do
+      expect(generate_csv_file).to be_a(CSV)
+      expect(generate_csv_file).to be_closed
+
+      csv = CSV.read(generate_csv_file.path)
+
+      expect(csv.first).to eq(%w[claim_reference sampling_reason])
+
+      claims.each_with_index do |claim, index|
+        expect(csv[index + 1]).to eq([
+          claim.reference,
+          claim.sampling_reason,
+        ])
+      end
+    end
+  end
+end

--- a/spec/system/claims/sampling/claims/provider_user_downloads_sampling_csv_with_expired_token_spec.rb
+++ b/spec/system/claims/sampling/claims/provider_user_downloads_sampling_csv_with_expired_token_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "Provider user downloads a sampling CSV with expired token", service: :claims, type: :system do
+  scenario do
+    given_one_of_my_claims_has_been_sampled
+    and_the_token_has_expired
+
+    when_i_visit_the_download_link_in_the_email
+    then_i_see_the_error_page
+  end
+
+  private
+
+  def given_one_of_my_claims_has_been_sampled
+    @provider_sampling = create(:provider_sampling)
+  end
+
+  def and_the_token_has_expired
+    @token = Rails.application.message_verifier(:sampling).generate(@provider_sampling.id, expires_at: 1.day.ago)
+  end
+
+  def when_i_visit_the_download_link_in_the_email
+    visit claims_sampling_claims_path(token: @token)
+  end
+
+  def then_i_see_the_error_page
+    expect(page).to have_h1("Sorry, there is a problem with the download link")
+    expect(page).to have_element(:p, text: "You are seeing this page because the download link is not working. It may have timed out or contained an invalid security token.", class: "govuk-body")
+    expect(page).to have_element(:p, text: "Email ittmentor.funding@education.gov.uk to request a new download link.", class: "govuk-body")
+  end
+end

--- a/spec/system/claims/sampling/claims/provider_user_downloads_sampling_csv_with_expired_token_spec.rb
+++ b/spec/system/claims/sampling/claims/provider_user_downloads_sampling_csv_with_expired_token_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe "Provider user downloads a sampling CSV with expired token", serv
   end
 
   def then_i_see_the_error_page
+    expect(page).to have_title("Sorry, there is a problem with the download link - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Sorry, there is a problem with the download link")
     expect(page).to have_element(:p, text: "You are seeing this page because the download link is not working. It may have timed out or contained an invalid security token.", class: "govuk-body")
     expect(page).to have_element(:p, text: "Email ittmentor.funding@education.gov.uk to request a new download link.", class: "govuk-body")

--- a/spec/system/claims/sampling/claims/provider_user_downloads_sampling_csv_with_invalid_record_token_spec.rb
+++ b/spec/system/claims/sampling/claims/provider_user_downloads_sampling_csv_with_invalid_record_token_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "Provider user downloads a sampling CSV with invalid record token", service: :claims, type: :system do
+  scenario do
+    given_one_of_my_claims_has_been_sampled
+    and_the_token_has_expired
+
+    when_i_visit_the_download_link_in_the_email
+    then_i_see_the_error_page
+  end
+
+  private
+
+  def given_one_of_my_claims_has_been_sampled
+    @provider_sampling = create(:provider_sampling)
+  end
+
+  def and_the_token_has_expired
+    @token = Rails.application.message_verifier(:sampling).generate("invalid_token", expires_in: 7.days)
+  end
+
+  def when_i_visit_the_download_link_in_the_email
+    visit claims_sampling_claims_path(token: @token)
+  end
+
+  def then_i_see_the_error_page
+    expect(page).to have_h1("Sorry, there is a problem with the download link")
+    expect(page).to have_element(:p, text: "You are seeing this page because the download link is not working. It may have timed out or contained an invalid security token.", class: "govuk-body")
+    expect(page).to have_element(:p, text: "Email ittmentor.funding@education.gov.uk to request a new download link.", class: "govuk-body")
+  end
+end

--- a/spec/system/claims/sampling/claims/provider_user_downloads_sampling_csv_with_invalid_record_token_spec.rb
+++ b/spec/system/claims/sampling/claims/provider_user_downloads_sampling_csv_with_invalid_record_token_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe "Provider user downloads a sampling CSV with invalid record token
   end
 
   def then_i_see_the_error_page
+    expect(page).to have_title("Sorry, there is a problem with the download link - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Sorry, there is a problem with the download link")
     expect(page).to have_element(:p, text: "You are seeing this page because the download link is not working. It may have timed out or contained an invalid security token.", class: "govuk-body")
     expect(page).to have_element(:p, text: "Email ittmentor.funding@education.gov.uk to request a new download link.", class: "govuk-body")

--- a/spec/system/claims/sampling/claims/provider_user_downloads_sampling_csv_with_invalid_token_spec.rb
+++ b/spec/system/claims/sampling/claims/provider_user_downloads_sampling_csv_with_invalid_token_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "Provider user downloads a sampling CSV with invalid token", service: :claims, type: :system do
+  scenario do
+    given_one_of_my_claims_has_been_sampled
+    and_the_token_is_invalid
+
+    when_i_visit_the_download_link_in_the_email
+    then_i_see_the_error_page
+  end
+
+  private
+
+  def given_one_of_my_claims_has_been_sampled
+    @provider_sampling = create(:provider_sampling)
+  end
+
+  def and_the_token_is_invalid
+    @token = Rails.application.message_verifier(:bobs_burgers).generate(@provider_sampling.id, expires_in: 7.days)
+  end
+
+  def when_i_visit_the_download_link_in_the_email
+    visit claims_sampling_claims_path(token: @token)
+  end
+
+  def then_i_see_the_error_page
+    expect(page).to have_h1("Sorry, there is a problem with the download link")
+    expect(page).to have_element(:p, text: "You are seeing this page because the download link is not working. It may have timed out or contained an invalid security token.", class: "govuk-body")
+    expect(page).to have_element(:p, text: "Email ittmentor.funding@education.gov.uk to request a new download link.", class: "govuk-body")
+  end
+end

--- a/spec/system/claims/sampling/claims/provider_user_downloads_sampling_csv_with_invalid_token_spec.rb
+++ b/spec/system/claims/sampling/claims/provider_user_downloads_sampling_csv_with_invalid_token_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe "Provider user downloads a sampling CSV with invalid token", serv
   end
 
   def then_i_see_the_error_page
+    expect(page).to have_title("Sorry, there is a problem with the download link - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Sorry, there is a problem with the download link")
     expect(page).to have_element(:p, text: "You are seeing this page because the download link is not working. It may have timed out or contained an invalid security token.", class: "govuk-body")
     expect(page).to have_element(:p, text: "Email ittmentor.funding@education.gov.uk to request a new download link.", class: "govuk-body")

--- a/spec/system/claims/sampling/claims/provider_user_downloads_sampling_csv_with_valid_token_spec.rb
+++ b/spec/system/claims/sampling/claims/provider_user_downloads_sampling_csv_with_valid_token_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe "Provider user downloads sampling CSV with valid token", service: :claims, type: :system do
+  scenario do
+    given_one_of_my_claims_has_been_sampled
+    and_the_token_is_valid
+
+    when_i_visit_the_download_link_in_the_email
+    then_i_see_the_download_page
+
+    when_i_click_on_the_download_button
+    then_the_csv_is_downloaded
+  end
+
+  private
+
+  def given_one_of_my_claims_has_been_sampled
+    @provider_sampling = create(:provider_sampling)
+  end
+
+  def and_the_token_is_valid
+    @token = Rails.application.message_verifier(:sampling).generate(@provider_sampling.id, expires_in: 7.days)
+  end
+
+  def when_i_visit_the_download_link_in_the_email
+    visit claims_sampling_claims_path(token: @token)
+  end
+
+  def then_i_see_the_download_page
+    expect(page).to have_h1("Download the sampling CSV")
+    expect(page).to have_element(:p, text: "Download the Claim funding for mentor training sampling CSV file.", class: "govuk-body")
+    expect(page).to have_element(:p, text: "If you have any questions, email ittmentor.funding@education.gov.uk", class: "govuk-body")
+    expect(page).to have_element(:a, text: "Download", class: "govuk-button")
+  end
+
+  def when_i_click_on_the_download_button
+    click_on "Download"
+  end
+
+  def then_the_csv_is_downloaded
+    current_time = Time.zone.now.utc.strftime("%Y-%m-%dT%H%%3A%M%%3A%SZ")
+    expect(page.response_headers["Content-Type"]).to eq("text/csv")
+    expect(page.response_headers["Content-Disposition"]).to eq("attachment; filename=\"sampling-claims-#{current_time}.csv\"; filename*=UTF-8''sampling-claims-#{current_time}.csv")
+  end
+end

--- a/spec/system/claims/sampling/claims/provider_user_downloads_sampling_csv_with_valid_token_spec.rb
+++ b/spec/system/claims/sampling/claims/provider_user_downloads_sampling_csv_with_valid_token_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe "Provider user downloads sampling CSV with valid token", service:
   end
 
   def then_i_see_the_download_page
+    expect(page).to have_title("Download the sampling CSV - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Download the sampling CSV")
     expect(page).to have_element(:p, text: "Download the Claim funding for mentor training sampling CSV file.", class: "govuk-body")
     expect(page).to have_element(:p, text: "If you have any questions, email ittmentor.funding@education.gov.uk", class: "govuk-body")
@@ -39,7 +40,8 @@ RSpec.describe "Provider user downloads sampling CSV with valid token", service:
 
   def then_the_csv_is_downloaded
     current_time = Time.zone.now.utc.strftime("%Y-%m-%dT%H%%3A%M%%3A%SZ")
+    provider_name = @provider_sampling.provider_name.parameterize
     expect(page.response_headers["Content-Type"]).to eq("text/csv")
-    expect(page.response_headers["Content-Disposition"]).to eq("attachment; filename=\"sampling-claims-#{current_time}.csv\"; filename*=UTF-8''sampling-claims-#{current_time}.csv")
+    expect(page.response_headers["Content-Disposition"]).to eq("attachment; filename=\"sampling-claims-#{provider_name}-#{current_time}.csv\"; filename*=UTF-8''sampling-claims-#{provider_name}-#{current_time}.csv")
   end
 end

--- a/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_sampling_data_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_sampling_data_spec.rb
@@ -57,11 +57,15 @@ RSpec.describe "Support user uploads sampling data", service: :claims, type: :sy
     current_claim_window = create(:claim_window, academic_year: @current_academic_year,
                                                  starts_on: @current_academic_year.starts_on,
                                                  ends_on: @current_academic_year.starts_on + 2.days)
+
+    provider = create(:claims_provider, email_address: "provider@example.com")
+
     @current_claim = create(:claim,
                             :submitted,
                             status: :paid,
                             claim_window: current_claim_window,
-                            reference: 11_111_111)
+                            reference: 11_111_111,
+                            provider:)
   end
 
   def and_i_am_signed_in

--- a/spec/wizards/claims/upload_sampling_data_wizard_spec.rb
+++ b/spec/wizards/claims/upload_sampling_data_wizard_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Claims::UploadSamplingDataWizard do
-  subject(:wizard) { described_class.new(state:, params:, current_step: nil) }
+  subject(:wizard) { described_class.new(current_user:, state:, params:, current_step: nil) }
 
   let(:state) { {} }
   let(:params_data) { {} }
@@ -21,6 +21,8 @@ RSpec.describe Claims::UploadSamplingDataWizard do
            claim_window: current_claim_window,
            reference: "11111111")
   end
+
+  let(:current_user) { create(:claims_user) }
 
   describe "#steps" do
     subject { wizard.steps.keys }
@@ -53,7 +55,7 @@ RSpec.describe Claims::UploadSamplingDataWizard do
 
       it "queues a job to flag the claim for sampling" do
         expect { wizard.upload_data }.to have_enqueued_job(
-          Claims::Sampling::FlagCollectionForSamplingJob,
+          Claims::Sampling::CreateAndDeliverJob,
         ).exactly(:once)
       end
     end


### PR DESCRIPTION
## Context

Now that all of the individual functionality of the sampling flow have been implemented we needed to tie them all together so that the correct processes happen after a support user has uploaded the sampling CSV.

## Changes proposed in this pull request

- [x] Adds the `CreateAndDeliver` service to group the logic together
- [x] Adds the `CreateAndDeliverJob` to call the `CreateAndDeliver` service asynchronously
- [x] Adds the provider views for downloading their CSV containing the claims that require checking
- [x] Adds a `GenerateCSVFile` service that creates the provider CSV
- [x] Alters the upload wizard to accept current user
- [x] Adds some useful delegations to the provider sampling model.

## Guidance to review

- [x] Log in as Colin
- [x] Upload a CSV for claims that need to be sampled
- [x] Check the email that has been sent to the provider
- [x] Click on the download link
- [x] Verify the CSV is correct

## Link to Trello card

[[Sampling] Create CreateAndDeliver service
](https://trello.com/c/7A8uP8OT/987-sampling-create-createanddeliver-service)
