### PR TITLE
Add helper for showing provider rejection reason

### DIFF
--- a/app/helpers/claims/claim_helper.rb
+++ b/app/helpers/claims/claim_helper.rb
@@ -4,4 +4,20 @@ module Claims::ClaimHelper
       Claims::Claim::DRAFT_STATUSES.map(&:to_s).include?(status)
     }.sort
   end
+
+  def claim_provider_response(claim)
+    not_assured_mentor_trainings = claim.mentor_trainings.not_assured
+    return "" if not_assured_mentor_trainings.blank?
+
+    content_tag(:ul, class: "govuk-list") do
+      not_assured_mentor_trainings.order_by_mentor_full_name.each do |mentor_training|
+        concat(
+          content_tag(
+            :li,
+            "#{mentor_training.mentor_full_name}: #{mentor_training.reason_not_assured}",
+          ),
+        )
+      end
+    end
+  end
 end

--- a/app/views/claims/support/claims/samplings/show.html.erb
+++ b/app/views/claims/support/claims/samplings/show.html.erb
@@ -18,6 +18,13 @@
           </div>
         <% end %>
 
+        <% if @claim.sampling_provider_not_approved? && @claim.mentor_trainings.not_assured.present? %>
+          <div class="govuk-inset-text">
+            <h3 class="govuk-heading-s"><%= t(".provider_response") %></h3>
+              <p class="govuk-body"><%= claim_provider_response(@claim) %></p>
+          </div>
+        <% end %>
+
         <% if @claim.sampling_in_progress? %>
           <div class="govuk-button-group">
             <%= govuk_button_link_to t(".approve"), confirm_approval_claims_support_claims_sampling_path(@claim) %>

--- a/config/locales/en/claims/support/claims/samplings.yml
+++ b/config/locales/en/claims/support/claims/samplings.yml
@@ -23,6 +23,7 @@ en:
             mentor_with_index: Mentor %{index}
             mentor: Mentor
             submitted_by: Submitted by %{name} on %{date}.
+            provider_response: Provider response
           confirm_approval:
             page_caption: Sampling - Claim %{reference}
             page_title: Are you sure you want to approve the claim?

--- a/spec/helpers/claims/claim_helper_spec.rb
+++ b/spec/helpers/claims/claim_helper_spec.rb
@@ -19,4 +19,61 @@ RSpec.describe Claims::ClaimHelper do
       )
     end
   end
+
+  describe "#claim_provider_response" do
+    let(:claim) { create(:claim, :submitted, status: :sampling_provider_not_approved) }
+
+    context "when the claim has no 'not_assured' mentor trainings" do
+      it "returns an empty string" do
+        expect(claim_provider_response(claim)).to eq("")
+      end
+    end
+
+    context "when the claim has 'not_assured' mentor trainings" do
+      let(:mentor_john_smith) { create(:claims_mentor, first_name: "John", last_name: "Smith") }
+      let(:mentor_jane_doe) { create(:claims_mentor, first_name: "Jane", last_name: "Doe") }
+      let(:mentor_joe_bloggs) { create(:claims_mentor, first_name: "Joe", last_name: "Bloggs") }
+      let(:john_smith_mentor_training) do
+        create(
+          :mentor_training,
+          mentor: mentor_john_smith,
+          claim:,
+          hours_completed: 20,
+          not_assured: true,
+          reason_not_assured: "Some reason",
+        )
+      end
+
+      let(:jane_doe_mentor_training) do
+        create(
+          :mentor_training,
+          mentor: mentor_jane_doe,
+          claim:,
+          hours_completed: 20,
+          not_assured: true,
+          reason_not_assured: "Another reason",
+        )
+      end
+      let(:joe_bloggs_mentor_training) do
+        create(
+          :mentor_training,
+          mentor: mentor_joe_bloggs,
+          claim:,
+          hours_completed: 20,
+        )
+      end
+
+      before do
+        john_smith_mentor_training
+        jane_doe_mentor_training
+        joe_bloggs_mentor_training
+      end
+
+      it "returns a list of the not assured mentors and the providers reason" do
+        expect(claim_provider_response(claim)).to eq(
+          "<ul class=\"govuk-list\"><li>Jane Doe: Another reason</li><li>John Smith: Some reason</li></ul>",
+        )
+      end
+    end
+  end
 end

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_reason_the_provider_rejected_the_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_reason_the_provider_rejected_the_mentor_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe "Support user changes the reason the provider rejected the mentor
 
     when_i_click_on_confirm_and_reject_claim
     then_i_see_that_the_claim_has_been_updated_to_provider_not_approved
+    and_i_see_the_providers_response
   end
 
   private
@@ -194,5 +195,13 @@ RSpec.describe "Support user changes the reason the provider rejected the mentor
       expect(page).to have_summary_list_row("Original number of hours claimed", "20")
       expect(page).to have_summary_list_row("Reason for rejection", "New reason the provider rejected John Smith")
     end
+  end
+
+  def and_i_see_the_providers_response
+    expect(page).to have_element(
+      :div,
+      text: "Provider response\nJohn Smith: New reason the provider rejected John Smith",
+      class: "govuk-inset-text",
+    )
   end
 end

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_marks_the_claim_as_provider_not_approved_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_marks_the_claim_as_provider_not_approved_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
 
     when_i_click_on_confirm_and_reject_claim
     then_i_see_that_the_claim_has_been_updated_to_provider_not_approved
+    and_i_see_the_providers_response
   end
 
   private
@@ -282,4 +283,12 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
   end
   alias_method :and_i_enter_a_reason_why_the_provider_rejected_jane_doe,
                :when_i_enter_a_reason_why_the_provider_rejected_jane_doe
+
+  def and_i_see_the_providers_response
+    expect(page).to have_element(
+      :div,
+      text: "Provider response\nJane Doe: Provider rejected Jane DoeJohn Smith: Provider rejected John Smith",
+      class: "govuk-inset-text",
+    )
+  end
 end


### PR DESCRIPTION
## Context

- Add helper method to display the provider response on a provider rejected claim

## Link to Trello card

https://trello.com/c/quUmLvF4/970-sampling-confirm-provider-rejected-claim-flow

## Screenshots

![Screenshot 2024-12-24 at 11 31 35](https://github.com/user-attachments/assets/40b99440-ac49-4685-aa9f-d5dd55fc3e72)


