### PR TITLE
Add manual workflow buttons to payments flow

### DIFF
--- a/app/controllers/claims/support/claims/payments/claims_controller.rb
+++ b/app/controllers/claims/support/claims/payments/claims_controller.rb
@@ -1,10 +1,33 @@
 class Claims::Support::Claims::Payments::ClaimsController < Claims::Support::ApplicationController
   append_pundit_namespace :claims, :payments
 
-  before_action :set_claim, only: %i[show]
+  before_action :set_claim, only: %i[show confirm_information_sent information_sent confirm_paid paid confirm_reject reject]
   before_action :authorize_claim
 
   def show; end
+  def confirm_information_sent; end
+
+  def information_sent
+    @claim.payment_information_sent!
+
+    redirect_to claims_support_claims_payments_claim_path(@claim), flash: { success: true, heading: t(".success") }
+  end
+
+  def confirm_paid; end
+
+  def paid
+    @claim.paid!
+
+    redirect_to claims_support_claims_payments_claim_path(@claim), flash: { success: true, heading: t(".success") }
+  end
+
+  def confirm_reject; end
+
+  def reject
+    @claim.payment_not_approved!
+
+    redirect_to claims_support_claims_payments_claim_path(@claim), flash: { success: true, heading: t(".success") }
+  end
 
   private
 

--- a/app/policies/claims/support/claims/payments/claim_policy.rb
+++ b/app/policies/claims/support/claims/payments/claim_policy.rb
@@ -2,4 +2,28 @@ class Claims::Support::Claims::Payments::ClaimPolicy < Claims::ApplicationPolicy
   def update?
     false
   end
+
+  def confirm_information_sent?
+    information_sent?
+  end
+
+  def information_sent?
+    record.payment_information_requested?
+  end
+
+  def confirm_paid?
+    paid?
+  end
+
+  def paid?
+    record.payment_information_sent?
+  end
+
+  def confirm_reject?
+    reject?
+  end
+
+  def reject?
+    record.payment_information_requested? || record.payment_information_sent?
+  end
 end

--- a/app/views/claims/support/claims/payments/claims/confirm_information_sent.html.erb
+++ b/app/views/claims/support/claims/payments/claims/confirm_information_sent.html.erb
@@ -1,0 +1,21 @@
+<%= render "claims/support/primary_navigation", current: :claims %>
+<% content_for(:page_title) { sanitize t(".page_title") } %>
+
+<% content_for(:before_content) do %>
+  <%= govuk_back_link href: claims_support_claims_payments_path %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></p>
+      <h1 class="govuk-heading-l"><%= t(".page_title") %></h1>
+
+      <p class="govuk-body"><%= t(".description") %></p>
+
+      <%= govuk_button_to t(".submit"), information_sent_claims_support_claims_payments_claim_path(@claim), method: :put %>
+
+      <p class="govuk-body"><%= govuk_link_to t(".cancel"), claims_support_claims_payments_path %></p>
+    </div>
+  </div>
+</div>

--- a/app/views/claims/support/claims/payments/claims/confirm_paid.html.erb
+++ b/app/views/claims/support/claims/payments/claims/confirm_paid.html.erb
@@ -1,0 +1,21 @@
+<%= render "claims/support/primary_navigation", current: :claims %>
+<% content_for(:page_title) { sanitize t(".page_title") } %>
+
+<% content_for(:before_content) do %>
+  <%= govuk_back_link href: claims_support_claims_payments_path %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></p>
+      <h1 class="govuk-heading-l"><%= t(".page_title") %></h1>
+
+      <p class="govuk-body"><%= t(".description") %></p>
+
+      <%= govuk_button_to t(".submit"), paid_claims_support_claims_payments_claim_path(@claim), method: :put %>
+
+      <p class="govuk-body"><%= govuk_link_to t(".cancel"), claims_support_claims_payments_path %></p>
+    </div>
+  </div>
+</div>

--- a/app/views/claims/support/claims/payments/claims/confirm_reject.html.erb
+++ b/app/views/claims/support/claims/payments/claims/confirm_reject.html.erb
@@ -1,0 +1,21 @@
+<%= render "claims/support/primary_navigation", current: :claims %>
+<% content_for(:page_title) { sanitize t(".page_title") } %>
+
+<% content_for(:before_content) do %>
+  <%= govuk_back_link href: claims_support_claims_payments_path %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></p>
+      <h1 class="govuk-heading-l"><%= t(".page_title") %></h1>
+
+      <p class="govuk-body"><%= t(".description") %></p>
+
+      <%= govuk_button_to t(".submit"), reject_claims_support_claims_payments_claim_path(@claim), method: :put %>
+
+      <p class="govuk-body"><%= govuk_link_to t(".cancel"), claims_support_claims_payments_path %></p>
+    </div>
+  </div>
+</div>

--- a/app/views/claims/support/claims/payments/claims/show.html.erb
+++ b/app/views/claims/support/claims/payments/claims/show.html.erb
@@ -11,6 +11,20 @@
       <p class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></p>
       <h1 class="govuk-heading-l"><%= @claim.school_name %> <%= render Claim::StatusTagComponent.new(claim: @claim) %></h1>
 
+      <% if @claim.payment_information_requested? %>
+        <div class="govuk-button-group">
+          <%= govuk_button_link_to t(".buttons.information_sent"), confirm_information_sent_claims_support_claims_payments_claim_path(@claim) %>
+          <%= govuk_button_link_to t(".buttons.reject"), confirm_reject_claims_support_claims_payments_claim_path(@claim), secondary: true %>
+        </div>
+      <% end %>
+
+      <% if @claim.payment_information_sent? %>
+        <div class="govuk-button-group">
+          <%= govuk_button_link_to t(".buttons.paid"), confirm_paid_claims_support_claims_payments_claim_path(@claim) %>
+          <%= govuk_button_link_to t(".buttons.reject"), confirm_reject_claims_support_claims_payments_claim_path(@claim), secondary: true %>
+        </div>
+      <% end %>
+
       <% if @claim.submitted_by_id? %>
         <p class="govuk-body"><%= t(".submitted_by", name: @claim.submitted_by.full_name, date: l(@claim.submitted_on, format: :long)) %></p>
       <% end %>

--- a/config/locales/en/claims/support/claims/payments/claims.yml
+++ b/config/locales/en/claims/support/claims/payments/claims.yml
@@ -12,3 +12,31 @@ en:
               mentor_with_index: Mentor %{index}
               mentor: Mentor
               submitted_by: Submitted by %{name} on %{date}.
+              buttons:
+                information_sent: Confirm information sent
+                paid: Confirm claim paid
+                reject: Reject claim
+            confirm_information_sent:
+              page_caption: Payments - Claim %{reference}
+              page_title: Are you sure you want to update the claim?
+              description: You confirm that you have sent the ESFA the information they requested so they can pay the claim.
+              submit: Update claim
+              cancel: Cancel
+            information_sent:
+              success: Claim updated
+            confirm_paid:
+              page_caption: Payments - Claim %{reference}
+              page_title: Are you sure you want to update the claim?
+              description: This will mark the claim as ‘Paid’.
+              submit: Update claim
+              cancel: Cancel
+            paid:
+              success: Claim updated
+            confirm_reject:
+              page_caption: Payments - Claim %{reference}
+              page_title: Are you sure you want to reject the claim?
+              description: This will result in this claim not being paid.
+              submit: Reject claim
+              cancel: Cancel
+            reject:
+              success: Claim rejected

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -85,7 +85,18 @@ scope module: :claims, as: :claims, constraints: {
 
     namespace :claims do
       namespace :payments do
-        resources :claims, only: %i[show]
+        resources :claims, only: %i[show] do
+          member do
+            get :confirm_information_sent, path: "information-sent"
+            put :information_sent, path: "information-sent"
+
+            get :confirm_paid, path: "paid"
+            put :paid, path: "paid"
+
+            get :confirm_reject, path: "reject"
+            put :reject, path: "reject"
+          end
+        end
       end
 
       resources :payments, only: %i[index new create]

--- a/spec/system/claims/support/claims/payments/confirm_claim_payment_information_sent_spec.rb
+++ b/spec/system/claims/support/claims/payments/confirm_claim_payment_information_sent_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe "Confirm claim payment information sent", service: :claims, type: :system do
+  let(:support_user) { create(:claims_support_user) }
+
+  let!(:claim) { create(:claim, :payment_information_requested) }
+
+  scenario "Support user confirms claim payment information sent" do
+    given_i_sign_in_as(support_user)
+
+    given_i_visit_a_claim_show_page(claim)
+    when_i_click_on_confirm_information_sent
+    then_i_see_a_confirmation_page
+
+    when_i_click_on_update_claim
+    then_i_see_the_claim_updated
+  end
+
+  private
+
+  def given_i_visit_a_claim_show_page(claim)
+    click_on("Claims")
+    click_on("Payments")
+    click_on(claim.school_name)
+  end
+
+  def when_i_click_on_confirm_information_sent
+    click_on("Confirm information sent")
+  end
+
+  def then_i_see_a_confirmation_page
+    expect(page).to have_content("Are you sure you want to update the claim?")
+    expect(page).to have_content("You confirm that you have sent the ESFA the information they requested so they can pay the claim.")
+  end
+
+  def when_i_click_on_update_claim
+    click_on("Update claim")
+  end
+
+  def then_i_see_the_claim_updated
+    expect(page).to have_content("Claim updated")
+
+    within("h1.govuk-heading-l .govuk-tag") do
+      expect(page).to have_content("Information sent")
+    end
+  end
+end

--- a/spec/system/claims/support/claims/payments/confirm_claim_payment_paid_spec.rb
+++ b/spec/system/claims/support/claims/payments/confirm_claim_payment_paid_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe "Confirm claim payment paid", service: :claims, type: :system do
+  let(:support_user) { create(:claims_support_user) }
+
+  let!(:claim) { create(:claim, :payment_information_sent) }
+
+  scenario "Support user confirms claim payment paid" do
+    given_i_sign_in_as(support_user)
+
+    given_i_visit_a_claim_show_page(claim)
+    when_i_click_on_confirm_paid
+    then_i_see_a_confirmation_page
+
+    when_i_click_on_update_claim
+    then_i_see_the_claim_updated
+  end
+
+  private
+
+  def given_i_visit_a_claim_show_page(claim)
+    click_on("Claims")
+    click_on("Payments")
+    click_on(claim.school_name)
+  end
+
+  def when_i_click_on_confirm_paid
+    click_on("Confirm claim paid")
+  end
+
+  def then_i_see_a_confirmation_page
+    expect(page).to have_content("Are you sure you want to update the claim?")
+    expect(page).to have_content("This will mark the claim as ‘Paid’.")
+  end
+
+  def when_i_click_on_update_claim
+    click_on("Update claim")
+  end
+
+  def then_i_see_the_claim_updated
+    expect(page).to have_content("Claim updated")
+
+    within("h1.govuk-heading-l .govuk-tag") do
+      expect(page).to have_content("Paid")
+    end
+  end
+end

--- a/spec/system/claims/support/claims/payments/reject_claim_payment_spec.rb
+++ b/spec/system/claims/support/claims/payments/reject_claim_payment_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe "Reject claim payment", service: :claims, type: :system do
+  let(:support_user) { create(:claims_support_user) }
+
+  let!(:claim) { create(:claim, :payment_information_sent) }
+
+  scenario "Support user rejects claim payment" do
+    given_i_sign_in_as(support_user)
+
+    given_i_visit_a_claim_show_page(claim)
+    when_i_click_on_reject
+    then_i_see_a_confirmation_page
+
+    when_i_click_on_reject_claim
+    then_i_see_the_claim_rejected
+  end
+
+  private
+
+  def given_i_visit_a_claim_show_page(claim)
+    click_on("Claims")
+    click_on("Payments")
+    click_on(claim.school_name)
+  end
+
+  def when_i_click_on_reject
+    click_on("Reject claim")
+  end
+
+  def then_i_see_a_confirmation_page
+    expect(page).to have_content("Are you sure you want to reject the claim?")
+    expect(page).to have_content("This will result in this claim not being paid.")
+  end
+
+  def when_i_click_on_reject_claim
+    click_on("Reject claim")
+  end
+
+  def then_i_see_the_claim_rejected
+    expect(page).to have_content("Claim rejected")
+
+    within("h1.govuk-heading-l .govuk-tag") do
+      expect(page).to have_content("Payment not approved")
+    end
+  end
+end


### PR DESCRIPTION
## Context

We need to also be able to process payments of claims without the use of CSV files. This is exceptionally convenient for testing purposes and working with small amounts of claims.

## Changes proposed in this pull request

- Add 3 manual workflow pages to the support payments claims.

## Guidance to review

- Send submitted claims to ESFA.
- Download associated file in activity log.
- Update status to "unpaid".
- Visit payments page.
- Click on claim.
- Interact with buttons.

## Screenshots

### Claim - payment information requested

![CleanShot 2025-01-02 at 12 43 55@2x](https://github.com/user-attachments/assets/87fe58b4-2473-4a52-b90d-469f0451fa54)

### Claim - Confirmation information sent

![CleanShot 2025-01-02 at 12 44 32@2x](https://github.com/user-attachments/assets/ed6dd8f3-ebae-4e66-aebf-352ca7509fc0)

### Claim - payment information sent

![CleanShot 2025-01-02 at 12 44 46@2x](https://github.com/user-attachments/assets/9bbce499-5d02-4b81-9b53-9b32fee379ba)

### Claim - confirm paid

![CleanShot 2025-01-02 at 12 45 23@2x](https://github.com/user-attachments/assets/2a763338-abac-46ba-b264-c208dccf594f)

### Claim - confirm reject

![CleanShot 2025-01-02 at 12 45 46@2x](https://github.com/user-attachments/assets/1799b61c-32ac-4744-ad4f-1bfdeee103ed)

