### PR TITLE
Upload esfa csv response

### DIFF
--- a/app/controllers/claims/support/claims/clawbacks/upload_esfa_response_controller.rb
+++ b/app/controllers/claims/support/claims/clawbacks/upload_esfa_response_controller.rb
@@ -1,0 +1,37 @@
+class Claims::Support::Claims::Clawbacks::UploadESFAResponseController < Claims::Support::ApplicationController
+  include WizardController
+  before_action :skip_authorization
+
+  before_action :set_wizard
+  helper_method :index_path
+
+  def update
+    if !@wizard.save_step
+      render "edit"
+    elsif @wizard.next_step.present?
+      redirect_to step_path(@wizard.next_step)
+    else
+      @wizard.upload_esfa_responses
+      @wizard.reset_state
+      redirect_to index_path, flash: {
+        heading: t(".success"),
+      }
+    end
+  end
+
+  private
+
+  def set_wizard
+    state = session[state_key] ||= {}
+    current_step = params[:step]&.to_sym
+    @wizard = Claims::UploadESFAClawbackResponseWizard.new(params:, state:, current_step:)
+  end
+
+  def step_path(step)
+    upload_esfa_response_claims_support_claims_clawbacks_path(state_key:, step:)
+  end
+
+  def index_path
+    claims_support_claims_clawbacks_path
+  end
+end

--- a/app/jobs/claims/clawback/update_claim_with_esfa_response_job.rb
+++ b/app/jobs/claims/clawback/update_claim_with_esfa_response_job.rb
@@ -1,0 +1,16 @@
+class Claims::Clawback::UpdateClaimWithESFAResponseJob < ApplicationJob
+  queue_as :default
+
+  def perform(claim_update_details)
+    Claims::Claim::Clawback::Complete.call(
+      claim: claim(claim_update_details.fetch(:id)),
+      esfa_responses: claim_update_details.fetch(:esfa_responses),
+    )
+  end
+
+  private
+
+  def claim(id)
+    Claims::Claim.clawback_in_progress.find(id)
+  end
+end

--- a/app/jobs/claims/clawback/update_collection_with_esfa_response_job.rb
+++ b/app/jobs/claims/clawback/update_collection_with_esfa_response_job.rb
@@ -1,0 +1,18 @@
+class Claims::Clawback::UpdateCollectionWithESFAResponseJob < ApplicationJob
+  queue_as :default
+
+  def perform(claim_update_details)
+    clawback_in_progress_claims(claim_update_details.pluck(:id)).find_in_batches do |batch|
+      batch.each do |claim|
+        updated_details_for_claim = claim_update_details.find { |details| details[:id] == claim.id }
+        Claims::Clawback::UpdateClaimWithESFAResponseJob.perform_later(updated_details_for_claim)
+      end
+    end
+  end
+
+  private
+
+  def clawback_in_progress_claims(ids)
+    Claims::Claim.clawback_in_progress.where(id: ids)
+  end
+end

--- a/app/services/claims/claim/clawback/complete.rb
+++ b/app/services/claims/claim/clawback/complete.rb
@@ -1,0 +1,28 @@
+class Claims::Claim::Clawback::Complete < ApplicationService
+  def initialize(claim:, esfa_responses: [])
+    @claim = claim
+    @esfa_responses = esfa_responses
+  end
+
+  def call
+    claim.transaction do
+      claim.mentor_trainings.not_assured.each do |mentor_training|
+        esfa_mentor_training_response = esfa_responses.find do |esfa_response|
+          esfa_response[:id] == mentor_training.id
+        end
+        next if esfa_mentor_training_response.blank?
+
+        mentor_training.update!(
+          hours_clawed_back: esfa_mentor_training_response[:hours_clawed_back],
+          reason_clawed_back: esfa_mentor_training_response[:reason_clawed_back],
+        )
+      end
+
+      claim.update!(status: :clawback_complete)
+    end
+  end
+
+  private
+
+  attr_reader :claim, :esfa_responses
+end

--- a/app/views/claims/support/claims/clawbacks/index.html.erb
+++ b/app/views/claims/support/claims/clawbacks/index.html.erb
@@ -6,29 +6,28 @@
 
   <%= render "claims/support/claims/secondary_navigation", current: :clawbacks %>
 
-    <% if @claims.any? %>
-    <h2 class="govuk-heading-m"><%= t(".sub_heading", count: @pagy.count) %></h2>
+  <h2 class="govuk-heading-m"><%= t(".sub_heading", count: @pagy.count) %></h2>
 
   <div class="govuk-button-group">
-    <%= govuk_button_link_to t(".buttons.send_claims_to_esfa"), new_claims_support_claims_clawback_path %>
-    <%= govuk_button_link_to t(".buttons.upload_esfa_response"),
+    <%= govuk_button_link_to t(".send_claims_to_esfa"), new_claims_support_claims_clawback_path %>
+    <%= govuk_button_link_to t(".upload_esfa_response"),
       new_upload_esfa_response_claims_support_claims_clawbacks_path,
       secondary: true %>
   </div>
 
-    <%= render Claims::Claim::FilterFormComponent.new(filter_form:, statuses: Claims::Claim::CLAWBACK_STATUSES) do %>
-      <div class="govuk-!-margin-bottom-2">
+  <%= render Claims::Claim::FilterFormComponent.new(filter_form:, statuses: Claims::Claim::CLAWBACK_STATUSES) do %>
+    <div class="govuk-!-margin-bottom-2">
+      <% if @claims.any? %>
         <% @claims.each do |claim| %>
           <%= render Claim::CardComponent.new(claim:, href: claims_support_claims_clawback_path(claim)) %>
         <% end %>
-      </div>
+      <% else %>
+        <p class="govuk-body">
+          <%= t(".no_claims") %>
+        </p>
+      <% end %>
+    </div>
 
-      <%= render PaginationComponent.new(pagy: @pagy) %>
-    <% end %>
-  <% else %>
-    <h2 class="govuk-heading-m"><%= t(".sub_heading_without_count") %></h2>
-    <p class="govuk-body">
-      <%= t(".no_claims") %>
-    </p>
+    <%= render PaginationComponent.new(pagy: @pagy) %>
   <% end %>
 </div>

--- a/app/views/claims/support/claims/clawbacks/index.html.erb
+++ b/app/views/claims/support/claims/clawbacks/index.html.erb
@@ -12,7 +12,7 @@
   <div class="govuk-button-group">
     <%= govuk_button_link_to t(".buttons.send_claims_to_esfa"), new_claims_support_claims_clawback_path %>
     <%= govuk_button_link_to t(".buttons.upload_esfa_response"),
-      "",
+      new_upload_esfa_response_claims_support_claims_clawbacks_path,
       secondary: true %>
   </div>
 

--- a/app/views/claims/support/claims/clawbacks/upload_esfa_response/edit.html.erb
+++ b/app/views/claims/support/claims/clawbacks/upload_esfa_response/edit.html.erb
@@ -1,0 +1,12 @@
+<%= render "claims/support/primary_navigation", current: :claims %>
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: back_link_path) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= render_wizard(@wizard) %>
+
+  <p class="govuk-body">
+    <%= govuk_link_to(t(".cancel"), index_path, no_visited_state: true) %>
+  </p>
+</div>

--- a/app/views/wizards/claims/upload_esfa_clawback_response_wizard/_confirmation_step.html.erb
+++ b/app/views/wizards/claims/upload_esfa_clawback_response_wizard/_confirmation_step.html.erb
@@ -1,0 +1,18 @@
+<% content_for(:page_title) { sanitize t(".page_title") } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= t(".caption") %></span>
+      <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+
+      <%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
+        <%= f.govuk_error_summary %>
+
+        <p class="govuk-body">
+          <%= t(".claims_count", count: current_step.claims_count) %>
+        </p>
+
+        <%= f.govuk_submit(t(".upload_data")) %>
+      <% end %>
+  </div>
+</div>

--- a/app/views/wizards/claims/upload_esfa_clawback_response_wizard/_no_claims_step.html.erb
+++ b/app/views/wizards/claims/upload_esfa_clawback_response_wizard/_no_claims_step.html.erb
@@ -1,0 +1,10 @@
+<% content_for(:page_title) { sanitize t(".page_title") } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= t(".caption") %></span>
+    <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+
+    <p class="govuk-body"><%= t(".you_cannot_upload") %></p>
+  </div>
+</div>

--- a/app/views/wizards/claims/upload_esfa_clawback_response_wizard/_upload_errors_step.html.erb
+++ b/app/views/wizards/claims/upload_esfa_clawback_response_wizard/_upload_errors_step.html.erb
@@ -1,0 +1,119 @@
+<% content_for(:page_title) { sanitize t(".page_title") } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= t(".caption") %></span>
+    <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+    <% if current_step.invalid_claim_references.present? %>
+      <h2 class="govuk-heading-m govuk-!-margin-top-0">
+        <%= t(".incorrect_claim_reference") %>
+      </h2>
+
+      <%= govuk_summary_list(actions: false) do |summary_list| %>
+        <% current_step.invalid_claim_references.each do |invalid_claim_references| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(
+              text: invalid_claim_references,
+            ) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <% if current_step.invalid_status_claims.present? %>
+      <h2 class="govuk-heading-m govuk-!-margin-top-0">
+        <%= t(".incorrect_status") %>
+      </h2>
+
+      <%= govuk_summary_list do |summary_list| %>
+        <% current_step.invalid_status_claims.each do |invalid_claim| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(
+              text: invalid_claim.reference,
+            ) %>
+            <% row.with_action(
+              text: t(".view"),
+              href: claims_support_claim_path(invalid_claim),
+              visually_hidden_text: invalid_claim.reference,
+              html_attributes: {
+                class: "govuk-link--no-visited-state",
+                target: "_blank",
+                new_tab: true,
+              },
+            ) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <% if current_step.missing_mentor_claims.present? %>
+      <h2 class="govuk-heading-m govuk-!-margin-top-0">
+        <%= t(".missing_mentors") %>
+      </h2>
+
+      <%= govuk_summary_list do |summary_list| %>
+        <% current_step.missing_mentor_claims.each do |invalid_claim| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(
+              text: invalid_claim.reference,
+            ) %>
+            <% row.with_action(
+              text: t(".view"),
+              href: claims_support_claim_path(invalid_claim),
+              visually_hidden_text: invalid_claim.reference,
+              html_attributes: { class: "govuk-link--no-visited-state" },
+            ) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <% if current_step.missing_reason_clawed_back_claims.present? %>
+      <h2 class="govuk-heading-m govuk-!-margin-top-0">
+        <%= t(".missing_reason_clawed_back") %>
+      </h2>
+
+      <%= govuk_summary_list do |summary_list| %>
+        <% current_step.missing_reason_clawed_back_claims.each do |invalid_claim| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(
+              text: invalid_claim.reference,
+            ) %>
+            <% row.with_action(
+              text: t(".view"),
+              href: claims_support_claim_path(invalid_claim),
+              visually_hidden_text: invalid_claim.reference,
+              html_attributes: { class: "govuk-link--no-visited-state" },
+            ) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <% if current_step.invalid_hours_clawed_back_claims.present? %>
+      <h2 class="govuk-heading-m govuk-!-margin-top-0">
+        <%= t(".invalid_hours_clawed_back") %>
+      </h2>
+
+      <%= govuk_summary_list do |summary_list| %>
+        <% current_step.invalid_hours_clawed_back_claims.each do |invalid_claim| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(
+              text: invalid_claim.reference,
+            ) %>
+            <% row.with_action(
+              text: t(".view"),
+              href: claims_support_claim_path(invalid_claim),
+              visually_hidden_text: invalid_claim.reference,
+              html_attributes: { class: "govuk-link--no-visited-state" },
+            ) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <%= govuk_warning_text do %>
+      <%= t(".upload_warning_html") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/wizards/claims/upload_esfa_clawback_response_wizard/_upload_step.html.erb
+++ b/app/views/wizards/claims/upload_esfa_clawback_response_wizard/_upload_step.html.erb
@@ -1,0 +1,21 @@
+<% content_for(:page_title) { sanitize t(".page_title") } %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".caption") %></span>
+      <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+
+      <%= form_for(current_step, url: current_step_path, method: :put, multipart: true) do |f| %>
+        <%= f.govuk_error_summary %>
+        <%= f.govuk_file_field :csv_upload, label: { text: t(".upload_csv_file"), size: "s" } %>
+
+        <%= govuk_details(summary_text: t(".csv_help")) do %>
+          <%= render_markdown(t(".csv_help_details")) %>
+        <% end %>
+
+        <%= f.govuk_submit(t(".upload_csv_file")) %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/wizards/claims/upload_esfa_clawback_response_wizard.rb
+++ b/app/wizards/claims/upload_esfa_clawback_response_wizard.rb
@@ -1,0 +1,68 @@
+module Claims
+  class UploadESFAClawbackResponseWizard < BaseWizard
+    def define_steps
+      if clawback_in_progress_claims.present?
+        add_step(UploadStep)
+        if csv_inputs_valid?
+          add_step(ConfirmationStep)
+        else
+          add_step(UploadErrorsStep)
+        end
+      else
+        add_step(NoClaimsStep)
+      end
+    end
+
+    def upload_esfa_responses
+      raise "Invalid wizard state" unless valid? && csv_inputs_valid?
+
+      Claims::Clawback::UpdateCollectionWithESFAResponseJob.perform_later(claim_update_details)
+    end
+
+    def clawback_in_progress_claims
+      @clawback_in_progress_claims ||= Claims::Claim.clawback_in_progress
+    end
+
+    def grouped_csv_rows
+      steps.fetch(:upload).grouped_csv_rows
+    end
+
+    def claim_update_details
+      return [] if steps[:upload].blank?
+
+      update_details = []
+      grouped_csv_rows.each do |claim_reference, esfa_responses|
+        next if claim_reference.nil?
+
+        claim = clawback_in_progress_claims.find_by!(reference: claim_reference)
+
+        update_details << {
+          id: claim.id,
+          status: :clawback_complete,
+          esfa_responses: esfa_responses_for_mentor_trainings(claim, esfa_responses),
+        }
+      end
+      update_details
+    end
+
+    private
+
+    def csv_inputs_valid?
+      @csv_inputs_valid ||= steps.fetch(:upload).csv_inputs_valid?
+    end
+
+    def esfa_responses_for_mentor_trainings(claim, esfa_responses)
+      claim.mentor_trainings.not_assured.map do |mentor_training|
+        esfa_response_for_mentor = esfa_responses.find do |esfa_response|
+          esfa_response["mentor_full_name"] == mentor_training.mentor_full_name
+        end
+
+        {
+          id: mentor_training.id,
+          reason_clawed_back: esfa_response_for_mentor["reason_clawed_back"],
+          hours_clawed_back: esfa_response_for_mentor["hours_clawed_back"],
+        }
+      end
+    end
+  end
+end

--- a/app/wizards/claims/upload_esfa_clawback_response_wizard/confirmation_step.rb
+++ b/app/wizards/claims/upload_esfa_clawback_response_wizard/confirmation_step.rb
@@ -1,0 +1,7 @@
+class Claims::UploadESFAClawbackResponseWizard::ConfirmationStep < BaseStep
+  delegate :grouped_csv_rows, to: :wizard
+
+  def claims_count
+    grouped_csv_rows.keys.compact.count
+  end
+end

--- a/app/wizards/claims/upload_esfa_clawback_response_wizard/no_claims_step.rb
+++ b/app/wizards/claims/upload_esfa_clawback_response_wizard/no_claims_step.rb
@@ -1,0 +1,2 @@
+class Claims::UploadESFAClawbackResponseWizard::NoClaimsStep < BaseStep
+end

--- a/app/wizards/claims/upload_esfa_clawback_response_wizard/upload_errors_step.rb
+++ b/app/wizards/claims/upload_esfa_clawback_response_wizard/upload_errors_step.rb
@@ -1,0 +1,38 @@
+class Claims::UploadESFAClawbackResponseWizard::UploadErrorsStep < BaseStep
+  delegate :invalid_claim_references,
+           :invalid_status_claim_references,
+           :missing_mentor_training_claim_references,
+           :missing_reason_clawed_back_claim_references,
+           :invalid_hours_clawed_back_claim_references,
+           to: :upload_step
+
+  def invalid_status_claims
+    return [] if invalid_status_claim_references.blank?
+
+    Claims::Claim.where(reference: invalid_status_claim_references)
+  end
+
+  def missing_mentor_claims
+    return [] if missing_mentor_training_claim_references.blank?
+
+    Claims::Claim.where(reference: missing_mentor_training_claim_references)
+  end
+
+  def missing_reason_clawed_back_claims
+    return [] if missing_reason_clawed_back_claim_references.blank?
+
+    Claims::Claim.where(reference: missing_reason_clawed_back_claim_references)
+  end
+
+  def invalid_hours_clawed_back_claims
+    return [] if invalid_hours_clawed_back_claim_references.blank?
+
+    Claims::Claim.where(reference: invalid_hours_clawed_back_claim_references)
+  end
+
+  private
+
+  def upload_step
+    @upload_step ||= wizard.steps.fetch(:upload)
+  end
+end

--- a/app/wizards/claims/upload_esfa_clawback_response_wizard/upload_step.rb
+++ b/app/wizards/claims/upload_esfa_clawback_response_wizard/upload_step.rb
@@ -1,0 +1,135 @@
+class Claims::UploadESFAClawbackResponseWizard::UploadStep < BaseStep
+  attribute :csv_upload
+  attribute :csv_content
+  # input validation attributes
+  attribute :invalid_claim_references, default: []
+  attribute :invalid_status_claim_references, default: []
+  attribute :missing_mentor_training_claim_references, default: []
+  attribute :missing_reason_clawed_back_claim_references, default: []
+  attribute :invalid_hours_clawed_back_claim_references, default: []
+
+  validates :csv_upload, presence: true, if: -> { csv_content.blank? }
+  validate :validate_csv_file, if: -> { csv_upload.present? }
+
+  delegate :clawback_in_progress_claims, to: :wizard
+
+  def initialize(wizard:, attributes:)
+    super(wizard:, attributes:)
+
+    process_csv if csv_upload.present?
+  end
+
+  def validate_csv_file
+    errors.add(:csv_upload, :invalid) unless csv_format
+  end
+
+  def process_csv
+    validate_csv_file
+    return if errors.present?
+
+    assign_csv_content
+
+    self.csv_upload = nil
+  end
+
+  def grouped_csv_rows
+    @grouped_csv_rows ||= CSV.parse(read_csv, headers: true)
+      .group_by { |row| row["claim_reference"] }
+  end
+
+  def csv_inputs_valid?
+    return true if csv_content.blank?
+
+    reset_input_attributes
+
+    all_claims_valid_status?
+    grouped_csv_rows.each do |claim_reference, esfa_responses|
+      next if claim_reference.nil?
+
+      claim = Claims::Claim.find_by(reference: claim_reference)
+      if claim.present?
+        row_for_each_mentor?(claim, esfa_responses)
+        reason_clawed_back_for_each_mentor?(claim_reference, esfa_responses)
+        hours_clawed_back_for_each_mentor?(claim, esfa_responses)
+      else
+        invalid_claim_references << claim_reference
+      end
+    end
+
+    invalid_claim_references &&
+      invalid_status_claim_references.blank? &&
+      missing_mentor_training_claim_references.blank? &&
+      missing_reason_clawed_back_claim_references.blank? &&
+      invalid_hours_clawed_back_claim_references.blank?
+  end
+
+  private
+
+  def csv_format
+    csv_upload.content_type == "text/csv"
+  end
+
+  def assign_csv_content
+    self.csv_content = read_csv
+  end
+
+  def read_csv
+    @read_csv ||= csv_content || csv_upload.read
+  end
+
+  def reset_input_attributes
+    self.invalid_claim_references = []
+    self.invalid_status_claim_references = []
+    self.missing_mentor_training_claim_references = []
+    self.missing_reason_clawed_back_claim_references = []
+    self.invalid_hours_clawed_back_claim_references = []
+  end
+
+  ### CSV input valiations
+
+  def all_claims_valid_status?
+    claim_references = grouped_csv_rows.keys.compact
+    valid_references = clawback_in_progress_claims.where(reference: claim_references).pluck(:reference)
+    return true if valid_references.sort == claim_references.sort
+
+    self.invalid_status_claim_references = claim_references - valid_references
+  end
+
+  def row_for_each_mentor?(claim, esfa_responses)
+    claim_mentor_names = claim.mentors.map(&:full_name)
+    esfa_responses_mentor_names = esfa_responses.pluck("mentor_full_name")
+    return if claim_mentor_names.sort == esfa_responses_mentor_names.sort
+
+    missing_mentor_training_claim_references << claim.reference
+  end
+
+  def reason_clawed_back_for_each_mentor?(claim_reference, esfa_responses)
+    reasons_clawed_back = esfa_responses.pluck("reason_clawed_back")
+    return unless reasons_clawed_back.any?(&:blank?)
+
+    missing_reason_clawed_back_claim_references << claim_reference
+  end
+
+  def hours_clawed_back_for_each_mentor?(claim, esfa_responses)
+    hours_clawed_back = esfa_responses.pluck("hours_clawed_back")
+    if hours_clawed_back.any?(&:blank?) || invalid_clawback_hours?(claim, esfa_responses)
+      invalid_hours_clawed_back_claim_references << claim.reference
+    end
+  end
+
+  def invalid_clawback_hours?(claim, esfa_responses)
+    invalid_hours = false
+    mentor_trainings = claim.mentor_trainings.not_assured
+    mentor_trainings.each do |mentor_training|
+      esfa_response_for_mentor = esfa_responses.find do |esfa_response|
+        esfa_response["mentor_full_name"] == mentor_training.mentor_full_name
+      end
+      next if esfa_response_for_mentor.blank? ||
+        esfa_response_for_mentor["hours_clawed_back"].to_i <= mentor_training.hours_completed
+
+      invalid_hours = true
+      break
+    end
+    invalid_hours
+  end
+end

--- a/app/wizards/claims/upload_esfa_clawback_response_wizard/upload_step.rb
+++ b/app/wizards/claims/upload_esfa_clawback_response_wizard/upload_step.rb
@@ -34,7 +34,9 @@ class Claims::UploadESFAClawbackResponseWizard::UploadStep < BaseStep
 
   def grouped_csv_rows
     @grouped_csv_rows ||= CSV.parse(read_csv, headers: true)
-      .group_by { |row| row["claim_reference"] }
+      .group_by do |row|
+        row["claim_reference"]
+      end
   end
 
   def csv_inputs_valid?

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -227,3 +227,9 @@ en:
               blank: Enter the number of hours to clawback.
             reason_for_clawback:
               blank: Enter the details about your decision.
+        claims/upload_esfa_clawback_response_wizard/upload_step:
+          attributes:
+            csv_upload:
+              blank: Select a CSV file to upload
+              invalid: The selected file must be a CSV
+              invalid_data: The selected CSV file contains invalid data

--- a/config/locales/en/claims/support/claims/clawbacks.yml
+++ b/config/locales/en/claims/support/claims/clawbacks.yml
@@ -5,12 +5,13 @@ en:
         clawbacks:
           index:
             heading: Claims
-            sub_heading: Clawbacks (%{count})
-            sub_heading_without_count: Clawbacks
+            sub_heading: 
+              zero: Clawbacks
+              one: Clawbacks (%{count})
+              other: Clawbacks (%{count})
             no_claims: There are no claims waiting to be processed.
-            buttons:
-              send_claims_to_esfa: Send claims to ESFA
-              upload_esfa_response: Upload ESFA response
+            send_claims_to_esfa: Send claims to ESFA
+            upload_esfa_response: Upload ESFA response
           show:
             page_caption: Clawbacks - Claim %{reference}
             page_title: "Clawbacks - %{school_name} - Claim %{reference}"

--- a/config/locales/en/claims/support/claims/clawbacks/upload_esfa_response.yml
+++ b/config/locales/en/claims/support/claims/clawbacks/upload_esfa_response.yml
@@ -1,0 +1,10 @@
+en:
+  claims:
+    support:
+      claims:
+        clawbacks:
+          upload_esfa_response:
+            edit:
+              cancel: Cancel
+            update: 
+              success: ESFA response uploaded

--- a/config/locales/en/wizards/claims/upload_esfa_clawback_response_wizard.yml
+++ b/config/locales/en/wizards/claims/upload_esfa_clawback_response_wizard.yml
@@ -1,0 +1,54 @@
+en:
+  wizards:
+    claims:
+      upload_esfa_clawback_response_wizard:
+        upload_step:
+          page_title: Upload ESFA response - Claims
+          title: Upload ESFA response
+          caption: Clawbacks
+          upload_csv_file: Upload CSV file
+          csv_help: Help with the CSV file
+          csv_help_details: |
+            Use this form to upload the CSV file sent by the ESFA.
+
+            The CSV file must contain the following headers in the first row:
+
+              - claim_reference
+              - school_urn
+              - school_name
+              - school_local_authority
+              - school_type_of_establishment
+              - school_group
+              - claim_submission_date
+              - mentor_full_name
+              - reason_clawed_back
+              - hours_clawed_back
+        confirmation_step:
+          page_title: Are you sure you want to upload the ESFA response? - Clawbacks - Claims
+          title: Are you sure you want to upload the ESFA response?
+          caption: Clawbacks
+          claims_count: 
+            one: There is %{count} claim included in this upload.
+            other: There are %{count} claims included in this upload.
+          upload_data: Upload responses
+        no_claims_step:
+          title: You cannot upload an ESFA response
+          page_title: You cannot upload an ESFA response - Clawbacks - Claims
+          caption: Clawbacks
+          you_cannot_upload: You cannot upload an ESFA response as there are no claims waiting for a response.
+        upload_errors_step:
+          title: There is a problem with the CSV file
+          caption: Clawbacks
+          page_title: There is a problem with the CSV file - Clawbacks - Claims
+          status: Status
+          claim_reference: Claim reference
+          view: View (opens in new tab)
+          incorrect_claim_reference: There are no claims associated with the following references:-
+          incorrect_status: The following claims do not have the status 'Clawback in progress':-
+          missing_mentors: The following claims are missing mentors from the uploaded CSV:-
+          missing_reason_clawed_back: The following claims are missing a missing a reason why the claim was clawed back:-
+          invalid_hours_clawed_back: The following claims have either no hours or an invalid amount of hours clawed back:-
+          upload_warning_html: |
+            You can only upload the ESFA's CSV once they have completed all rows.
+            <br><br>
+            Email the ESFA and ask them to complete the CSV with the missing information.

--- a/config/locales/en/wizards/claims/upload_esfa_clawback_response_wizard.yml
+++ b/config/locales/en/wizards/claims/upload_esfa_clawback_response_wizard.yml
@@ -46,7 +46,7 @@ en:
           incorrect_claim_reference: There are no claims associated with the following references:-
           incorrect_status: The following claims do not have the status 'Clawback in progress':-
           missing_mentors: The following claims are missing mentors from the uploaded CSV:-
-          missing_reason_clawed_back: The following claims are missing a missing a reason why the claim was clawed back:-
+          missing_reason_clawed_back: The following claims are missing a reason why the claim was clawed back:-
           invalid_hours_clawed_back: The following claims have either no hours or an invalid amount of hours clawed back:-
           upload_warning_html: |
             You can only upload the ESFA's CSV once they have completed all rows.

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -142,6 +142,10 @@ scope module: :claims, as: :claims, constraints: {
           get "new/:claim_id", to: "request_clawback#new", as: :new_request_clawback
           get "new/:claim_id/:step", to: "request_clawback#edit", as: :request_clawback
           put "new/:claim_id/:step", to: "request_clawback#update"
+
+          get "upload_esfa_response/new", to: "clawbacks/upload_esfa_response#new", as: :new_upload_esfa_response
+          get "upload_esfa_response/new/:state_key/:step", to: "clawbacks/upload_esfa_response#edit", as: :upload_esfa_response
+          put "upload_esfa_response/new/:state_key/:step", to: "clawbacks/upload_esfa_response#update"
         end
       end
 

--- a/spec/factories/mentor_trainings.rb
+++ b/spec/factories/mentor_trainings.rb
@@ -39,5 +39,17 @@ FactoryBot.define do
     trait :submitted do
       claim { create(:claim, :submitted) }
     end
+
+    trait :not_assured do
+      submitted
+      not_assured { true }
+      reason_not_assured { "Not assured" }
+    end
+
+    trait :rejected do
+      not_assured
+      rejected { true }
+      reason_rejected { "Rejected" }
+    end
   end
 end

--- a/spec/fixtures/claims/clawback/esfa_responses/example_esfa_clawback_response_upload.csv
+++ b/spec/fixtures/claims/clawback/esfa_responses/example_esfa_clawback_response_upload.csv
@@ -1,0 +1,5 @@
+claim_reference,mentor_full_name,reason_clawed_back,hours_clawed_back
+11111111,John Smith,Some reason,10
+11111111,Jane Doe,Another reason,5
+22222222,Joe Bloggs,Yet another reason,2
+,,,

--- a/spec/fixtures/claims/clawback/esfa_responses/invalid_esfa_clawback_response_upload_missing_hours_clawed_back.csv
+++ b/spec/fixtures/claims/clawback/esfa_responses/invalid_esfa_clawback_response_upload_missing_hours_clawed_back.csv
@@ -1,0 +1,5 @@
+claim_reference,mentor_full_name,reason_clawed_back,hours_clawed_back
+11111111,John Smith,Some reason,10
+11111111,Jane Doe,Another reason,
+22222222,Joe Bloggs,Yet another reason,2
+,,,

--- a/spec/fixtures/claims/clawback/esfa_responses/invalid_esfa_clawback_response_upload_missing_reason_clawed_back.csv
+++ b/spec/fixtures/claims/clawback/esfa_responses/invalid_esfa_clawback_response_upload_missing_reason_clawed_back.csv
@@ -1,0 +1,5 @@
+claim_reference,mentor_full_name,reason_clawed_back,hours_clawed_back
+11111111,John Smith,Some reason,10
+11111111,Jane Doe,,5
+22222222,Joe Bloggs,Yet another reason,2
+,,,

--- a/spec/jobs/claims/clawback/update_claim_with_esfa_response_job_spec.rb
+++ b/spec/jobs/claims/clawback/update_claim_with_esfa_response_job_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe Claims::Clawback::UpdateClaimWithESFAResponseJob, type: :job do
+  let(:claim) { create(:claim, :submitted, status: :clawback_in_progress) }
+  let(:claim_update_details) { { id: claim.id, status:, esfa_responses: } }
+  let(:status) { :clawback_complete }
+  let(:esfa_responses) { [] }
+
+  describe "#perform" do
+    subject(:perform) { described_class.perform_now(claim_update_details) }
+
+    it "changes the status of the claim to sampling_provider_not_approved" do
+      perform
+      expect(claim.reload.status).to eq("clawback_complete")
+    end
+
+    context "when the claim has associated mentor trainings" do
+      let(:mentor_john_smith) { create(:claims_mentor, first_name: "John", last_name: "Smith") }
+      let(:john_smith_mentor_training) do
+        create(:mentor_training,
+               :rejected,
+               claim:,
+               mentor: mentor_john_smith,
+               hours_completed: 20)
+      end
+      let(:mentor_jane_doe) { create(:claims_mentor, first_name: "Jane", last_name: "Doe") }
+      let(:jane_doe_mentor_training) do
+        create(:mentor_training,
+               :rejected,
+               claim:,
+               mentor: mentor_jane_doe,
+               hours_completed: 10)
+      end
+
+      let(:esfa_responses) do
+        [
+          { id: john_smith_mentor_training.id, hours_clawed_back: 10, reason_clawed_back: "Some reason" },
+          { id: jane_doe_mentor_training.id, hours_clawed_back: 5, reason_clawed_back: "Another reason" },
+        ]
+      end
+
+      it "updates the clawed back hours and reason for mentors" do
+        perform
+        expect(claim.reload.status).to eq("clawback_complete")
+        expect(john_smith_mentor_training.reload.hours_clawed_back).to eq(10)
+        expect(john_smith_mentor_training.reload.reason_clawed_back).to eq("Some reason")
+        expect(jane_doe_mentor_training.reload.hours_clawed_back).to be(5)
+        expect(jane_doe_mentor_training.reload.reason_clawed_back).to eq("Another reason")
+      end
+    end
+
+    it "enqueues the job in the default queue" do
+      expect {
+        described_class.perform_later(claim_update_details)
+      }.to have_enqueued_job(described_class).on_queue("default")
+    end
+  end
+end

--- a/spec/jobs/claims/clawback/update_collection_with_esfa_response_job_spec.rb
+++ b/spec/jobs/claims/clawback/update_collection_with_esfa_response_job_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe Claims::Clawback::UpdateCollectionWithESFAResponseJob, type: :job do
+  let(:claims) { create_list(:claim, 2, :submitted, status: :clawback_in_progress) }
+  let(:claim_update_details) do
+    [
+      { id: claims[0].id, status: :clawback_complete, not_assured_reason: nil },
+      { id: claims[1].id, status: :clawback_complete, not_assured_reason: nil },
+    ]
+  end
+
+  describe "#perform" do
+    subject(:perform) { described_class.perform_now(claim_update_details) }
+
+    it "enqueues a Claims::Clawback::UpdateClaimWithESFAResponseJob per claim" do
+      expect { described_class.perform_now(claim_update_details) }.to have_enqueued_job(
+        Claims::Clawback::UpdateClaimWithESFAResponseJob,
+      ).exactly(:twice)
+    end
+
+    it "enqueues the job in the default queue" do
+      expect {
+        described_class.perform_later(claim_update_details)
+      }.to have_enqueued_job(described_class).on_queue("default")
+    end
+  end
+end

--- a/spec/services/claims/claim/clawback/complete_spec.rb
+++ b/spec/services/claims/claim/clawback/complete_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+describe Claims::Claim::Clawback::Complete do
+  let!(:claim) { create(:claim, :submitted, status: :clawback_in_progress) }
+
+  describe "#call" do
+    subject(:call) { described_class.call(claim:, esfa_responses:) }
+
+    context "when given no esfa responses" do
+      let(:esfa_responses) { [] }
+
+      it "changes to status of the claim to clawback requested" do
+        expect { call }.to change(claim, :status)
+          .from("clawback_in_progress")
+          .to("clawback_complete")
+      end
+    end
+
+    context "when given an esfa responses" do
+      let(:mentor_training_1) do
+        create(:mentor_training,
+               :rejected,
+               claim:,
+               hours_completed: 20)
+      end
+      let(:mentor_training_2) do
+        create(:mentor_training,
+               :rejected,
+               claim:,
+               hours_completed: 10)
+      end
+      let(:esfa_responses) do
+        [
+          { id: mentor_training_1.id, hours_clawed_back: 10, reason_clawed_back: "Some reason" },
+          { id: mentor_training_2.id, hours_clawed_back: 5, reason_clawed_back: "Another reason" },
+        ]
+      end
+
+      it "updates the mentor trainings with the given response" do
+        expect { call }.to change(claim, :status)
+          .from("clawback_in_progress")
+          .to("clawback_complete")
+
+        mentor_training_1.reload
+        mentor_training_2.reload
+
+        expect(mentor_training_1.hours_clawed_back).to be(10)
+        expect(mentor_training_1.reason_clawed_back).to eq("Some reason")
+        expect(mentor_training_2.hours_clawed_back).to be(5)
+        expect(mentor_training_2.reason_clawed_back).to eq("Another reason")
+      end
+
+      context "when an esfa response is not given for a mentor training associated with this claim" do
+        let(:esfa_responses) do
+          [
+            { id: mentor_training_1.id, number_of_hours: 20, reason_for_clawback: "Some reason" },
+          ]
+        end
+
+        before do
+          mentor_training_1
+          mentor_training_2
+        end
+
+        it "skips the mentor training not associated with the claim" do
+          expect { call }.not_to change(mentor_training_2, :hours_clawed_back).from(nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_can_not_upload_esfa_clawback_responses_when_there_are_no_claims_with_the_status_clawback_in_progress_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_can_not_upload_esfa_clawback_responses_when_there_are_no_claims_with_the_status_clawback_in_progress_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe "Support user can not upload ESFA clawback responses when there are no claims with the status 'clawback_in_progress'",
+               service: :claims,
+               type: :system do
+  scenario do
+    given_i_am_signed_in
+
+    when_i_navigate_to_the_clawback_claims_index_page
+    then_i_see_the_clawback_claims_index_page
+    and_i_see_no_clawback_claims_have_been_uploaded
+
+    when_i_click_on_upload_esfa_response
+    then_i_see_there_are_no_claims_waiting_for_a_response
+  end
+
+  private
+
+  def given_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_clawback_claims_index_page
+    within primary_navigation do
+      click_on "Claims"
+    end
+
+    within secondary_navigation do
+      click_on "Clawbacks"
+    end
+  end
+
+  def then_i_see_the_clawback_claims_index_page
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Claims")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(secondary_navigation).to have_current_item("Clawbacks")
+    expect(page).to have_current_path(claims_support_claims_clawbacks_path, ignore_query: true)
+  end
+
+  def and_i_see_no_clawback_claims_have_been_uploaded
+    expect(page).to have_h2("Clawbacks")
+    expect(page).to have_element(:p, text: "There are no claims waiting to be processed.")
+  end
+
+  def when_i_click_on_upload_esfa_response
+    click_on "Upload ESFA response"
+  end
+
+  def then_i_see_there_are_no_claims_waiting_for_a_response
+    expect(page).to have_title("You cannot upload an ESFA response - Clawbacks - Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("You cannot upload an ESFA response")
+    expect(page).to have_element(:span, text: "Clawback")
+    expect(page).to have_element(
+      :p,
+      text: "You cannot upload an ESFA response as there are no claims waiting for a response.",
+      class: "govuk-body",
+    )
+  end
+end

--- a/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_does_not_upload_a_file_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_does_not_upload_a_file_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe "Support user does not upload a file",
+               service: :claims,
+               type: :system do
+  scenario do
+    given_claims_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_clawback_claims_index_page
+    then_i_see_the_clawback_claims_index_page
+    and_i_see_a_claim_with_the_status_clawback_in_progress
+
+    when_i_click_on_upload_esfa_response
+    then_i_see_the_upload_csv_page
+
+    when_i_click_on_upload_csv_file
+    then_i_see_validation_error_regarding_invalid_data
+  end
+
+  private
+
+  def given_claims_exist
+    @claim = create(:claim,
+                    :submitted,
+                    status: :clawback_in_progress,
+                    reference: 11_111_111)
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_clawback_claims_index_page
+    within primary_navigation do
+      click_on "Claims"
+    end
+
+    within secondary_navigation do
+      click_on "Clawbacks"
+    end
+  end
+
+  def then_i_see_the_clawback_claims_index_page
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Claims")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(secondary_navigation).to have_current_item("Clawbacks")
+    expect(page).to have_current_path(claims_support_claims_clawbacks_path, ignore_query: true)
+  end
+
+  def then_i_see_the_upload_csv_page
+    expect(page).to have_h1("Upload ESFA response")
+    have_element(:span, text: "Sampling", class: "govuk-caption-l")
+    expect(page).to have_element(:label, text: "Upload CSV file")
+  end
+
+  def and_i_see_a_claim_with_the_status_clawback_in_progress
+    expect(page).to have_h2("Clawbacks (1)")
+    expect(page).to have_claim_card({
+      "title" => "11111111 - #{@claim.school_name}",
+      "url" => "/support/claims/clawbacks/claims/#{@claim.id}",
+      "status" => "Clawback in progress",
+      "academic_year" => @claim.academic_year.name,
+      "provider_name" => @claim.provider.name,
+      "submitted_at" => I18n.l(@claim.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+  end
+
+  def when_i_click_on_upload_esfa_response
+    click_on "Upload ESFA response"
+  end
+
+  def when_i_click_on_upload_csv_file
+    click_on "Upload CSV file"
+  end
+
+  def then_i_see_validation_error_regarding_invalid_data
+    expect(page).to have_validation_error("Select a CSV file to upload")
+  end
+end

--- a/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_a_csv_containing_claims_not_with_the_status_clawback_in_progress_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_a_csv_containing_claims_not_with_the_status_clawback_in_progress_spec.rb
@@ -1,0 +1,132 @@
+require "rails_helper"
+
+RSpec.describe "Support user uploads a CSV containing claims not with the status 'clawback in progress'",
+               service: :claims,
+               type: :system do
+  scenario do
+    given_claims_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_clawback_claims_index_page
+    then_i_see_the_clawback_claims_index_page
+    and_i_see_a_claim_with_the_status_clawback_in_progress
+    and_i_do_not_see_a_claim_with_the_status_paid
+
+    when_i_click_on_upload_esfa_response
+    then_i_see_the_upload_csv_page
+
+    when_i_upload_a_csv_containing_a_claim_not_with_the_status_clawback_in_progress
+    and_i_click_on_upload_csv_file
+    then_i_see_the_errors_page
+    and_i_see_the_csv_contained_claims_not_with_the_status_clawback_in_progress
+  end
+
+  private
+
+  def given_claims_exist
+    @clawback_in_progress_claim = create(:claim, :submitted, status: :clawback_in_progress, reference: 11_111_111)
+    @paid_claim = create(:claim, :submitted, status: :paid, reference: 22_222_222)
+
+    mentor_john_smith = create(:claims_mentor, first_name: "John", last_name: "Smith")
+    mentor_jane_doe = create(:claims_mentor, first_name: "Jane", last_name: "Doe")
+    mentor_joe_bloggs = create(:claims_mentor, first_name: "Joe", last_name: "Bloggs")
+
+    _john_smith_mentor_training = create(
+      :mentor_training,
+      :rejected,
+      mentor: mentor_john_smith,
+      claim: @clawback_in_progress_claim,
+      hours_completed: 20,
+    )
+    _jane_doe_mentor_training = create(
+      :mentor_training,
+      :rejected,
+      mentor: mentor_jane_doe,
+      claim: @clawback_in_progress_claim,
+      hours_completed: 20,
+    )
+    _joe_bloggs_mentor_training = create(
+      :mentor_training,
+      mentor: mentor_joe_bloggs,
+      claim: @paid_claim,
+      hours_completed: 20,
+    )
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_clawback_claims_index_page
+    within primary_navigation do
+      click_on "Claims"
+    end
+
+    within secondary_navigation do
+      click_on "Clawbacks"
+    end
+  end
+
+  def then_i_see_the_clawback_claims_index_page
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Claims")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(secondary_navigation).to have_current_item("Clawbacks")
+    expect(page).to have_current_path(claims_support_claims_clawbacks_path, ignore_query: true)
+  end
+
+  def then_i_see_the_upload_csv_page
+    expect(page).to have_h1("Upload ESFA response")
+    have_element(:span, text: "Clawback", class: "govuk-caption-l")
+    expect(page).to have_element(:label, text: "Upload CSV file")
+  end
+
+  def and_i_see_a_claim_with_the_status_clawback_in_progress
+    expect(page).to have_h2("Clawbacks (1)")
+    expect(page).to have_claim_card({
+      "title" => "11111111 - #{@clawback_in_progress_claim.school_name}",
+      "url" => "/support/claims/clawbacks/claims/#{@clawback_in_progress_claim.id}",
+      "status" => "Clawback in progress",
+      "academic_year" => @clawback_in_progress_claim.academic_year.name,
+      "provider_name" => @clawback_in_progress_claim.provider.name,
+      "submitted_at" => I18n.l(@clawback_in_progress_claim.submitted_at.to_date, format: :long),
+      "amount" => @clawback_in_progress_claim.amount.format(symbol: true, decimal_mark: ".", no_cents: true),
+    })
+  end
+
+  def and_i_do_not_see_a_claim_with_the_status_paid
+    expect(page).not_to have_claim_card({
+      "title" => "22222222 - #{@paid_claim.school_name}",
+    })
+  end
+
+  def when_i_click_on_upload_esfa_response
+    click_on "Upload ESFA response"
+  end
+
+  def and_i_click_on_upload_csv_file
+    click_on "Upload CSV file"
+  end
+
+  def when_i_upload_a_csv_containing_a_claim_not_with_the_status_clawback_in_progress
+    attach_file "Upload CSV file",
+                "spec/fixtures/claims/clawback/esfa_responses/example_esfa_clawback_response_upload.csv"
+  end
+
+  def then_i_see_the_errors_page
+    expect(page).to have_title(
+      "There is a problem with the CSV file - Clawbacks - Claims - Claim funding for mentor training - GOV.UK",
+    )
+    expect(page).to have_h1("There is a problem with the CSV file")
+  end
+
+  def and_i_see_the_csv_contained_claims_not_with_the_status_clawback_in_progress
+    expect(page).to have_h2("The following claims do not have the status 'Clawback in progress':-")
+    expect(page).to have_element(:dl, text: "22222222", class: "govuk-summary-list")
+    expect(page).to have_link(text: "View (opens in new tab)", href: "/support/claims/#{@paid_claim.id}")
+    expect(page).to have_warning_text(
+      "You can only upload the ESFA's CSV once they have completed all rows." \
+        " Email the ESFA and ask them to complete the CSV with the missing information.",
+    )
+  end
+end

--- a/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_a_csv_containing_hours_greater_than_the_hours_completed_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_a_csv_containing_hours_greater_than_the_hours_completed_spec.rb
@@ -1,0 +1,135 @@
+require "rails_helper"
+
+RSpec.describe "Support user uploads a CSV not containing hours greater than the hours completed",
+               service: :claims,
+               type: :system do
+  scenario do
+    given_claims_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_clawback_claims_index_page
+    then_i_see_the_clawback_claims_index_page
+    and_i_see_two_claims_with_the_status_clawback_in_progress
+
+    when_i_click_on_upload_esfa_response
+    then_i_see_the_upload_csv_page
+
+    when_i_upload_a_file_not_containing_hours_clawed_back_for_each_mentor
+    and_i_click_on_upload_csv_file
+    then_i_see_the_errors_page
+    and_i_see_the_csv_contained_claims_without_a_not_assured_reason
+  end
+
+  private
+
+  def given_claims_exist
+    @clawback_in_progress_claim_1 = create(:claim, :submitted, status: :clawback_in_progress, reference: 11_111_111)
+    @clawback_in_progress_claim_2 = create(:claim, :submitted, status: :clawback_in_progress, reference: 22_222_222)
+
+    mentor_john_smith = create(:claims_mentor, first_name: "John", last_name: "Smith")
+    mentor_jane_doe = create(:claims_mentor, first_name: "Jane", last_name: "Doe")
+    mentor_joe_bloggs = create(:claims_mentor, first_name: "Joe", last_name: "Bloggs")
+
+    _john_smith_mentor_training = create(
+      :mentor_training,
+      :rejected,
+      mentor: mentor_john_smith,
+      claim: @clawback_in_progress_claim_1,
+      hours_completed: 20,
+    )
+    _jane_doe_mentor_training = create(
+      :mentor_training,
+      :rejected,
+      mentor: mentor_jane_doe,
+      claim: @clawback_in_progress_claim_1,
+      hours_completed: 2,
+    )
+    _joe_bloggs_mentor_training = create(
+      :mentor_training,
+      :rejected,
+      mentor: mentor_joe_bloggs,
+      claim: @clawback_in_progress_claim_2,
+      hours_completed: 20,
+    )
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_clawback_claims_index_page
+    within primary_navigation do
+      click_on "Claims"
+    end
+
+    within secondary_navigation do
+      click_on "Clawbacks"
+    end
+  end
+
+  def then_i_see_the_clawback_claims_index_page
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Claims")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(secondary_navigation).to have_current_item("Clawbacks")
+    expect(page).to have_current_path(claims_support_claims_clawbacks_path, ignore_query: true)
+  end
+
+  def then_i_see_the_upload_csv_page
+    expect(page).to have_h1("Upload ESFA response")
+    have_element(:span, text: "Clawbacks", class: "govuk-caption-l")
+    expect(page).to have_element(:label, text: "Upload CSV file")
+  end
+
+  def and_i_see_two_claims_with_the_status_clawback_in_progress
+    expect(page).to have_h2("Clawbacks (2)")
+    expect(page).to have_claim_card({
+      "title" => "11111111 - #{@clawback_in_progress_claim_1.school_name}",
+      "url" => "/support/claims/clawbacks/claims/#{@clawback_in_progress_claim_1.id}",
+      "status" => "Clawback in progress",
+      "academic_year" => @clawback_in_progress_claim_1.academic_year.name,
+      "provider_name" => @clawback_in_progress_claim_1.provider.name,
+      "submitted_at" => I18n.l(@clawback_in_progress_claim_1.submitted_at.to_date, format: :long),
+      "amount" => @clawback_in_progress_claim_1.amount.format(symbol: true, decimal_mark: ".", no_cents: true),
+    })
+    expect(page).to have_claim_card({
+      "title" => "22222222 - #{@clawback_in_progress_claim_2.school_name}",
+      "url" => "/support/claims/clawbacks/claims/#{@clawback_in_progress_claim_2.id}",
+      "status" => "Clawback in progress",
+      "academic_year" => @clawback_in_progress_claim_2.academic_year.name,
+      "provider_name" => @clawback_in_progress_claim_2.provider.name,
+      "submitted_at" => I18n.l(@clawback_in_progress_claim_2.submitted_at.to_date, format: :long),
+      "amount" => @clawback_in_progress_claim_2.amount.format(symbol: true, decimal_mark: ".", no_cents: true),
+    })
+  end
+
+  def when_i_click_on_upload_esfa_response
+    click_on "Upload ESFA response"
+  end
+
+  def and_i_click_on_upload_csv_file
+    click_on "Upload CSV file"
+  end
+
+  def when_i_upload_a_file_not_containing_hours_clawed_back_for_each_mentor
+    attach_file "Upload CSV file",
+                "spec/fixtures/claims/clawback/esfa_responses/example_esfa_clawback_response_upload.csv"
+  end
+
+  def then_i_see_the_errors_page
+    expect(page).to have_title(
+      "There is a problem with the CSV file - Clawbacks - Claims - Claim funding for mentor training - GOV.UK",
+    )
+    expect(page).to have_h1("There is a problem with the CSV file")
+  end
+
+  def and_i_see_the_csv_contained_claims_without_a_not_assured_reason
+    expect(page).to have_h2("The following claims have either no hours or an invalid amount of hours clawed back:-")
+    expect(page).to have_element(:dl, text: "11111111", class: "govuk-summary-list")
+    expect(page).to have_link(text: "View (opens in new tab)", href: "/support/claims/#{@clawback_in_progress_claim_1.id}")
+    expect(page).to have_warning_text(
+      "You can only upload the ESFA's CSV once they have completed all rows." \
+        " Email the ESFA and ask them to complete the CSV with the missing information.",
+    )
+  end
+end

--- a/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_a_csv_containing_invalid_references_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_a_csv_containing_invalid_references_spec.rb
@@ -1,0 +1,134 @@
+require "rails_helper"
+
+RSpec.describe "Support user uploads a CSV not containing invalid references",
+               service: :claims,
+               type: :system do
+  scenario do
+    given_claims_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_clawback_claims_index_page
+    then_i_see_the_clawback_claims_index_page
+    and_i_see_two_claims_with_the_status_clawback_in_progress
+
+    when_i_click_on_upload_esfa_response
+    then_i_see_the_upload_csv_page
+
+    when_i_upload_a_file_not_containing_an_assured_status_for_each_mentor
+    and_i_click_on_upload_csv_file
+    then_i_see_the_errors_page
+    and_i_see_the_csv_contained_claims_without_an_assured_status_for_each_mentor
+  end
+
+  private
+
+  def given_claims_exist
+    @clawback_in_progress_claim_1 = create(:claim, :submitted, status: :clawback_in_progress, reference: 33_333_333)
+    @clawback_in_progress_claim_2 = create(:claim, :submitted, status: :clawback_in_progress, reference: 22_222_222)
+
+    mentor_john_smith = create(:claims_mentor, first_name: "John", last_name: "Smith")
+    mentor_jane_doe = create(:claims_mentor, first_name: "Jane", last_name: "Doe")
+    mentor_joe_bloggs = create(:claims_mentor, first_name: "Joe", last_name: "Bloggs")
+
+    _john_smith_mentor_training = create(
+      :mentor_training,
+      :rejected,
+      mentor: mentor_john_smith,
+      claim: @clawback_in_progress_claim_1,
+      hours_completed: 20,
+    )
+    _jane_doe_mentor_training = create(
+      :mentor_training,
+      :rejected,
+      mentor: mentor_jane_doe,
+      claim: @clawback_in_progress_claim_1,
+      hours_completed: 20,
+    )
+    _joe_bloggs_mentor_training = create(
+      :mentor_training,
+      :rejected,
+      mentor: mentor_joe_bloggs,
+      claim: @clawback_in_progress_claim_2,
+      hours_completed: 20,
+    )
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_clawback_claims_index_page
+    within primary_navigation do
+      click_on "Claims"
+    end
+
+    within secondary_navigation do
+      click_on "Clawbacks"
+    end
+  end
+
+  def then_i_see_the_clawback_claims_index_page
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Claims")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(secondary_navigation).to have_current_item("Clawbacks")
+    expect(page).to have_current_path(claims_support_claims_clawbacks_path, ignore_query: true)
+  end
+
+  def then_i_see_the_upload_csv_page
+    expect(page).to have_h1("Upload ESFA response")
+    have_element(:span, text: "Clawbacks", class: "govuk-caption-l")
+    expect(page).to have_element(:label, text: "Upload CSV file")
+  end
+
+  def and_i_see_two_claims_with_the_status_clawback_in_progress
+    expect(page).to have_h2("Clawbacks (2)")
+    expect(page).to have_claim_card({
+      "title" => "33333333 - #{@clawback_in_progress_claim_1.school_name}",
+      "url" => "/support/claims/clawbacks/claims/#{@clawback_in_progress_claim_1.id}",
+      "status" => "Clawback in progress",
+      "academic_year" => @clawback_in_progress_claim_1.academic_year.name,
+      "provider_name" => @clawback_in_progress_claim_1.provider.name,
+      "submitted_at" => I18n.l(@clawback_in_progress_claim_1.submitted_at.to_date, format: :long),
+      "amount" => @clawback_in_progress_claim_1.amount.format(symbol: true, decimal_mark: ".", no_cents: true),
+    })
+    expect(page).to have_claim_card({
+      "title" => "22222222 - #{@clawback_in_progress_claim_2.school_name}",
+      "url" => "/support/claims/clawbacks/claims/#{@clawback_in_progress_claim_2.id}",
+      "status" => "Clawback in progress",
+      "academic_year" => @clawback_in_progress_claim_2.academic_year.name,
+      "provider_name" => @clawback_in_progress_claim_2.provider.name,
+      "submitted_at" => I18n.l(@clawback_in_progress_claim_2.submitted_at.to_date, format: :long),
+      "amount" => @clawback_in_progress_claim_2.amount.format(symbol: true, decimal_mark: ".", no_cents: true),
+    })
+  end
+
+  def when_i_click_on_upload_esfa_response
+    click_on "Upload ESFA response"
+  end
+
+  def and_i_click_on_upload_csv_file
+    click_on "Upload CSV file"
+  end
+
+  def when_i_upload_a_file_not_containing_an_assured_status_for_each_mentor
+    attach_file "Upload CSV file",
+                "spec/fixtures/claims/clawback/esfa_responses/example_esfa_clawback_response_upload.csv"
+  end
+
+  def then_i_see_the_errors_page
+    expect(page).to have_title(
+      "There is a problem with the CSV file - Clawbacks - Claims - Claim funding for mentor training - GOV.UK",
+    )
+    expect(page).to have_h1("There is a problem with the CSV file")
+  end
+
+  def and_i_see_the_csv_contained_claims_without_an_assured_status_for_each_mentor
+    expect(page).to have_h2("There are no claims associated with the following references:-")
+    expect(page).to have_element(:dl, text: "11111111", class: "govuk-summary-list")
+    expect(page).to have_warning_text(
+      "You can only upload the ESFA's CSV once they have completed all rows." \
+        " Email the ESFA and ask them to complete the CSV with the missing information.",
+    )
+  end
+end

--- a/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_a_csv_not_containing_a_reason_clawed_back_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_a_csv_not_containing_a_reason_clawed_back_spec.rb
@@ -1,0 +1,135 @@
+require "rails_helper"
+
+RSpec.describe "Support user uploads a CSV not containing a reason clawed back",
+               service: :claims,
+               type: :system do
+  scenario do
+    given_claims_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_clawback_claims_index_page
+    then_i_see_the_clawback_claims_index_page
+    and_i_see_two_claims_with_the_status_clawback_in_progress
+
+    when_i_click_on_upload_esfa_response
+    then_i_see_the_upload_csv_page
+
+    when_i_upload_a_file_not_containing_a_reason_clawed_back_for_each_mentor
+    and_i_click_on_upload_csv_file
+    then_i_see_the_errors_page
+    and_i_see_the_csv_contained_claims_without_a_not_assured_reason
+  end
+
+  private
+
+  def given_claims_exist
+    @clawback_in_progress_claim_1 = create(:claim, :submitted, status: :clawback_in_progress, reference: 11_111_111)
+    @clawback_in_progress_claim_2 = create(:claim, :submitted, status: :clawback_in_progress, reference: 22_222_222)
+
+    mentor_john_smith = create(:claims_mentor, first_name: "John", last_name: "Smith")
+    mentor_jane_doe = create(:claims_mentor, first_name: "Jane", last_name: "Doe")
+    mentor_joe_bloggs = create(:claims_mentor, first_name: "Joe", last_name: "Bloggs")
+
+    _john_smith_mentor_training = create(
+      :mentor_training,
+      :rejected,
+      mentor: mentor_john_smith,
+      claim: @clawback_in_progress_claim_1,
+      hours_completed: 20,
+    )
+    _jane_doe_mentor_training = create(
+      :mentor_training,
+      :rejected,
+      mentor: mentor_jane_doe,
+      claim: @clawback_in_progress_claim_1,
+      hours_completed: 20,
+    )
+    _joe_bloggs_mentor_training = create(
+      :mentor_training,
+      :rejected,
+      mentor: mentor_joe_bloggs,
+      claim: @clawback_in_progress_claim_2,
+      hours_completed: 20,
+    )
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_clawback_claims_index_page
+    within primary_navigation do
+      click_on "Claims"
+    end
+
+    within secondary_navigation do
+      click_on "Clawbacks"
+    end
+  end
+
+  def then_i_see_the_clawback_claims_index_page
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Claims")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(secondary_navigation).to have_current_item("Clawbacks")
+    expect(page).to have_current_path(claims_support_claims_clawbacks_path, ignore_query: true)
+  end
+
+  def then_i_see_the_upload_csv_page
+    expect(page).to have_h1("Upload ESFA response")
+    have_element(:span, text: "Clawbacks", class: "govuk-caption-l")
+    expect(page).to have_element(:label, text: "Upload CSV file")
+  end
+
+  def and_i_see_two_claims_with_the_status_clawback_in_progress
+    expect(page).to have_h2("Clawbacks (2)")
+    expect(page).to have_claim_card({
+      "title" => "11111111 - #{@clawback_in_progress_claim_1.school_name}",
+      "url" => "/support/claims/clawbacks/claims/#{@clawback_in_progress_claim_1.id}",
+      "status" => "Clawback in progress",
+      "academic_year" => @clawback_in_progress_claim_1.academic_year.name,
+      "provider_name" => @clawback_in_progress_claim_1.provider.name,
+      "submitted_at" => I18n.l(@clawback_in_progress_claim_1.submitted_at.to_date, format: :long),
+      "amount" => @clawback_in_progress_claim_1.amount.format(symbol: true, decimal_mark: ".", no_cents: true),
+    })
+    expect(page).to have_claim_card({
+      "title" => "22222222 - #{@clawback_in_progress_claim_2.school_name}",
+      "url" => "/support/claims/clawbacks/claims/#{@clawback_in_progress_claim_2.id}",
+      "status" => "Clawback in progress",
+      "academic_year" => @clawback_in_progress_claim_2.academic_year.name,
+      "provider_name" => @clawback_in_progress_claim_2.provider.name,
+      "submitted_at" => I18n.l(@clawback_in_progress_claim_2.submitted_at.to_date, format: :long),
+      "amount" => @clawback_in_progress_claim_2.amount.format(symbol: true, decimal_mark: ".", no_cents: true),
+    })
+  end
+
+  def when_i_click_on_upload_esfa_response
+    click_on "Upload ESFA response"
+  end
+
+  def and_i_click_on_upload_csv_file
+    click_on "Upload CSV file"
+  end
+
+  def when_i_upload_a_file_not_containing_a_reason_clawed_back_for_each_mentor
+    attach_file "Upload CSV file",
+                "spec/fixtures/claims/clawback/esfa_responses/invalid_esfa_clawback_response_upload_missing_reason_clawed_back.csv"
+  end
+
+  def then_i_see_the_errors_page
+    expect(page).to have_title(
+      "There is a problem with the CSV file - Clawbacks - Claims - Claim funding for mentor training - GOV.UK",
+    )
+    expect(page).to have_h1("There is a problem with the CSV file")
+  end
+
+  def and_i_see_the_csv_contained_claims_without_a_not_assured_reason
+    expect(page).to have_h2("The following claims are missing a reason why the claim was clawed back:-")
+    expect(page).to have_element(:dl, text: "11111111", class: "govuk-summary-list")
+    expect(page).to have_link(text: "View (opens in new tab)", href: "/support/claims/#{@clawback_in_progress_claim_1.id}")
+    expect(page).to have_warning_text(
+      "You can only upload the ESFA's CSV once they have completed all rows." \
+        " Email the ESFA and ask them to complete the CSV with the missing information.",
+    )
+  end
+end

--- a/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_a_csv_not_containing_all_the_rejected_mentors_associated_with_a_claim_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_a_csv_not_containing_all_the_rejected_mentors_associated_with_a_claim_spec.rb
@@ -1,0 +1,143 @@
+require "rails_helper"
+
+RSpec.describe "Support user uploads a CSV not containing all the rejected mentors associated with a claim",
+               service: :claims,
+               type: :system do
+  scenario do
+    given_claims_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_clawback_claims_index_page
+    then_i_see_the_clawback_claims_index_page
+    and_i_see_two_claims_with_the_status_clawback_in_progress
+
+    when_i_click_on_upload_esfa_response
+    then_i_see_the_upload_csv_page
+
+    when_i_upload_a_file_not_containing_an_assured_status_for_each_mentor
+    and_i_click_on_upload_csv_file
+    then_i_see_the_errors_page
+    and_i_see_the_csv_contained_claims_without_a_not_assured_reason
+  end
+
+  private
+
+  def given_claims_exist
+    @clawback_in_progress_claim_1 = create(:claim, :submitted, status: :clawback_in_progress, reference: 11_111_111)
+    @clawback_in_progress_claim_2 = create(:claim, :submitted, status: :clawback_in_progress, reference: 22_222_222)
+
+    mentor_john_smith = create(:claims_mentor, first_name: "John", last_name: "Smith")
+    mentor_jane_doe = create(:claims_mentor, first_name: "Jane", last_name: "Doe")
+    mentor_joe_bloggs = create(:claims_mentor, first_name: "Joe", last_name: "Bloggs")
+    mentor_james_bay = create(:claims_mentor, first_name: "James", last_name: "Bay")
+
+    _john_smith_mentor_training = create(
+      :mentor_training,
+      :rejected,
+      mentor: mentor_john_smith,
+      claim: @clawback_in_progress_claim_1,
+      hours_completed: 20,
+    )
+    _jane_doe_mentor_training = create(
+      :mentor_training,
+      :rejected,
+      mentor: mentor_jane_doe,
+      claim: @clawback_in_progress_claim_1,
+      hours_completed: 20,
+    )
+    _james_bay_mentor_training = create(
+      :mentor_training,
+      :rejected,
+      mentor: mentor_james_bay,
+      claim: @clawback_in_progress_claim_1,
+      hours_completed: 20,
+    )
+    _joe_bloggs_mentor_training = create(
+      :mentor_training,
+      :rejected,
+      mentor: mentor_joe_bloggs,
+      claim: @clawback_in_progress_claim_2,
+      hours_completed: 20,
+    )
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_clawback_claims_index_page
+    within primary_navigation do
+      click_on "Claims"
+    end
+
+    within secondary_navigation do
+      click_on "Clawbacks"
+    end
+  end
+
+  def then_i_see_the_clawback_claims_index_page
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Claims")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(secondary_navigation).to have_current_item("Clawbacks")
+    expect(page).to have_current_path(claims_support_claims_clawbacks_path, ignore_query: true)
+  end
+
+  def then_i_see_the_upload_csv_page
+    expect(page).to have_h1("Upload ESFA response")
+    have_element(:span, text: "Clawbacks", class: "govuk-caption-l")
+    expect(page).to have_element(:label, text: "Upload CSV file")
+  end
+
+  def and_i_see_two_claims_with_the_status_clawback_in_progress
+    expect(page).to have_h2("Clawbacks (2)")
+    expect(page).to have_claim_card({
+      "title" => "11111111 - #{@clawback_in_progress_claim_1.school_name}",
+      "url" => "/support/claims/clawbacks/claims/#{@clawback_in_progress_claim_1.id}",
+      "status" => "Clawback in progress",
+      "academic_year" => @clawback_in_progress_claim_1.academic_year.name,
+      "provider_name" => @clawback_in_progress_claim_1.provider.name,
+      "submitted_at" => I18n.l(@clawback_in_progress_claim_1.submitted_at.to_date, format: :long),
+      "amount" => @clawback_in_progress_claim_1.amount.format(symbol: true, decimal_mark: ".", no_cents: true),
+    })
+    expect(page).to have_claim_card({
+      "title" => "22222222 - #{@clawback_in_progress_claim_2.school_name}",
+      "url" => "/support/claims/clawbacks/claims/#{@clawback_in_progress_claim_2.id}",
+      "status" => "Clawback in progress",
+      "academic_year" => @clawback_in_progress_claim_2.academic_year.name,
+      "provider_name" => @clawback_in_progress_claim_2.provider.name,
+      "submitted_at" => I18n.l(@clawback_in_progress_claim_2.submitted_at.to_date, format: :long),
+      "amount" => @clawback_in_progress_claim_2.amount.format(symbol: true, decimal_mark: ".", no_cents: true),
+    })
+  end
+
+  def when_i_click_on_upload_esfa_response
+    click_on "Upload ESFA response"
+  end
+
+  def and_i_click_on_upload_csv_file
+    click_on "Upload CSV file"
+  end
+
+  def when_i_upload_a_file_not_containing_an_assured_status_for_each_mentor
+    attach_file "Upload CSV file",
+                "spec/fixtures/claims/clawback/esfa_responses/example_esfa_clawback_response_upload.csv"
+  end
+
+  def then_i_see_the_errors_page
+    expect(page).to have_title(
+      "There is a problem with the CSV file - Clawbacks - Claims - Claim funding for mentor training - GOV.UK",
+    )
+    expect(page).to have_h1("There is a problem with the CSV file")
+  end
+
+  def and_i_see_the_csv_contained_claims_without_a_not_assured_reason
+    expect(page).to have_h2("The following claims are missing mentors from the uploaded CSV:-")
+    expect(page).to have_element(:dl, text: "11111111", class: "govuk-summary-list")
+    expect(page).to have_link(text: "View (opens in new tab)", href: "/support/claims/#{@clawback_in_progress_claim_1.id}")
+    expect(page).to have_warning_text(
+      "You can only upload the ESFA's CSV once they have completed all rows." \
+        " Email the ESFA and ask them to complete the CSV with the missing information.",
+    )
+  end
+end

--- a/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_a_csv_not_containing_hours_clawed_back_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_a_csv_not_containing_hours_clawed_back_spec.rb
@@ -1,0 +1,135 @@
+require "rails_helper"
+
+RSpec.describe "Support user uploads a CSV not containing hours clawed back",
+               service: :claims,
+               type: :system do
+  scenario do
+    given_claims_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_clawback_claims_index_page
+    then_i_see_the_clawback_claims_index_page
+    and_i_see_two_claims_with_the_status_clawback_in_progress
+
+    when_i_click_on_upload_esfa_response
+    then_i_see_the_upload_csv_page
+
+    when_i_upload_a_file_not_containing_hours_clawed_back_for_each_mentor
+    and_i_click_on_upload_csv_file
+    then_i_see_the_errors_page
+    and_i_see_the_csv_contained_claims_without_a_not_assured_reason
+  end
+
+  private
+
+  def given_claims_exist
+    @clawback_in_progress_claim_1 = create(:claim, :submitted, status: :clawback_in_progress, reference: 11_111_111)
+    @clawback_in_progress_claim_2 = create(:claim, :submitted, status: :clawback_in_progress, reference: 22_222_222)
+
+    mentor_john_smith = create(:claims_mentor, first_name: "John", last_name: "Smith")
+    mentor_jane_doe = create(:claims_mentor, first_name: "Jane", last_name: "Doe")
+    mentor_joe_bloggs = create(:claims_mentor, first_name: "Joe", last_name: "Bloggs")
+
+    _john_smith_mentor_training = create(
+      :mentor_training,
+      :rejected,
+      mentor: mentor_john_smith,
+      claim: @clawback_in_progress_claim_1,
+      hours_completed: 20,
+    )
+    _jane_doe_mentor_training = create(
+      :mentor_training,
+      :rejected,
+      mentor: mentor_jane_doe,
+      claim: @clawback_in_progress_claim_1,
+      hours_completed: 20,
+    )
+    _joe_bloggs_mentor_training = create(
+      :mentor_training,
+      :rejected,
+      mentor: mentor_joe_bloggs,
+      claim: @clawback_in_progress_claim_2,
+      hours_completed: 20,
+    )
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_clawback_claims_index_page
+    within primary_navigation do
+      click_on "Claims"
+    end
+
+    within secondary_navigation do
+      click_on "Clawbacks"
+    end
+  end
+
+  def then_i_see_the_clawback_claims_index_page
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Claims")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(secondary_navigation).to have_current_item("Clawbacks")
+    expect(page).to have_current_path(claims_support_claims_clawbacks_path, ignore_query: true)
+  end
+
+  def then_i_see_the_upload_csv_page
+    expect(page).to have_h1("Upload ESFA response")
+    have_element(:span, text: "Clawbacks", class: "govuk-caption-l")
+    expect(page).to have_element(:label, text: "Upload CSV file")
+  end
+
+  def and_i_see_two_claims_with_the_status_clawback_in_progress
+    expect(page).to have_h2("Clawbacks (2)")
+    expect(page).to have_claim_card({
+      "title" => "11111111 - #{@clawback_in_progress_claim_1.school_name}",
+      "url" => "/support/claims/clawbacks/claims/#{@clawback_in_progress_claim_1.id}",
+      "status" => "Clawback in progress",
+      "academic_year" => @clawback_in_progress_claim_1.academic_year.name,
+      "provider_name" => @clawback_in_progress_claim_1.provider.name,
+      "submitted_at" => I18n.l(@clawback_in_progress_claim_1.submitted_at.to_date, format: :long),
+      "amount" => @clawback_in_progress_claim_1.amount.format(symbol: true, decimal_mark: ".", no_cents: true),
+    })
+    expect(page).to have_claim_card({
+      "title" => "22222222 - #{@clawback_in_progress_claim_2.school_name}",
+      "url" => "/support/claims/clawbacks/claims/#{@clawback_in_progress_claim_2.id}",
+      "status" => "Clawback in progress",
+      "academic_year" => @clawback_in_progress_claim_2.academic_year.name,
+      "provider_name" => @clawback_in_progress_claim_2.provider.name,
+      "submitted_at" => I18n.l(@clawback_in_progress_claim_2.submitted_at.to_date, format: :long),
+      "amount" => @clawback_in_progress_claim_2.amount.format(symbol: true, decimal_mark: ".", no_cents: true),
+    })
+  end
+
+  def when_i_click_on_upload_esfa_response
+    click_on "Upload ESFA response"
+  end
+
+  def and_i_click_on_upload_csv_file
+    click_on "Upload CSV file"
+  end
+
+  def when_i_upload_a_file_not_containing_hours_clawed_back_for_each_mentor
+    attach_file "Upload CSV file",
+                "spec/fixtures/claims/clawback/esfa_responses/invalid_esfa_clawback_response_upload_missing_hours_clawed_back.csv"
+  end
+
+  def then_i_see_the_errors_page
+    expect(page).to have_title(
+      "There is a problem with the CSV file - Clawbacks - Claims - Claim funding for mentor training - GOV.UK",
+    )
+    expect(page).to have_h1("There is a problem with the CSV file")
+  end
+
+  def and_i_see_the_csv_contained_claims_without_a_not_assured_reason
+    expect(page).to have_h2("The following claims have either no hours or an invalid amount of hours clawed back:-")
+    expect(page).to have_element(:dl, text: "11111111", class: "govuk-summary-list")
+    expect(page).to have_link(text: "View (opens in new tab)", href: "/support/claims/#{@clawback_in_progress_claim_1.id}")
+    expect(page).to have_warning_text(
+      "You can only upload the ESFA's CSV once they have completed all rows." \
+        " Email the ESFA and ask them to complete the CSV with the missing information.",
+    )
+  end
+end

--- a/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_esfa_responses_for_claims_with_the_status_clawback_in_progress_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_esfa_responses_for_claims_with_the_status_clawback_in_progress_spec.rb
@@ -1,0 +1,226 @@
+require "rails_helper"
+
+RSpec.describe "Support user uploads ESFA responses for claims with the status 'clawback in progress'",
+               service: :claims,
+               type: :system do
+  include ActiveJob::TestHelper
+
+  around do |example|
+    perform_enqueued_jobs { example.run }
+  end
+
+  scenario do
+    given_claims_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_clawback_claims_index_page
+    then_i_see_the_clawback_claims_index_page
+    and_i_see_two_claims_with_the_status_clawback_in_progress
+
+    when_i_click_on_upload_esfa_response
+    then_i_see_the_upload_csv_page
+
+    when_i_upload_a_csv_containing_esfa_responses_for_all_claims_with_the_status_clawback_in_progress
+    and_i_click_on_upload_csv_file
+    then_i_see_the_confirmation_page_for_uploading_esfa_responses
+
+    when_i_click_on_cancel
+    then_i_see_the_clawback_claims_index_page
+
+    when_i_click_on_upload_esfa_response
+    and_i_click_on_cancel
+    then_i_see_the_clawback_claims_index_page
+
+    when_i_click_on_upload_esfa_response
+    and_i_click_on_back
+    then_i_see_the_clawback_claims_index_page
+
+    when_i_click_on_upload_esfa_response
+    and_i_upload_a_csv_containing_esfa_responses_for_all_claims_with_the_status_clawback_in_progress
+    and_i_click_on_upload_csv_file
+    then_i_see_the_confirmation_page_for_uploading_esfa_responses
+
+    when_i_click_on_back
+    then_i_see_the_upload_csv_page
+
+    when_i_upload_a_csv_containing_esfa_responses_for_all_claims_with_the_status_clawback_in_progress
+    and_i_click_on_upload_csv_file
+    then_i_see_the_confirmation_page_for_uploading_esfa_responses
+
+    when_i_click_upload_responses
+    then_i_see_the_upload_has_been_successful
+    and_i_can_not_see_claim_11111111
+    and_i_can_not_see_claim_22222222
+
+    when_i_navigate_to_the_all_claims_index_page
+    then_i_can_see_claim_11111111_has_the_status_clawback_complete
+    and_i_can_see_claim_22222222_has_the_status_clawback_complete
+  end
+
+  private
+
+  def given_claims_exist
+    @clawback_in_progress_claim_1 = create(:claim, :submitted, status: :clawback_in_progress, reference: 11_111_111)
+    @clawback_in_progress_claim_2 = create(:claim, :submitted, status: :clawback_in_progress, reference: 22_222_222)
+
+    mentor_john_smith = create(:claims_mentor, first_name: "John", last_name: "Smith")
+    mentor_jane_doe = create(:claims_mentor, first_name: "Jane", last_name: "Doe")
+    mentor_joe_bloggs = create(:claims_mentor, first_name: "Joe", last_name: "Bloggs")
+
+    _john_smith_mentor_training = create(
+      :mentor_training,
+      :rejected,
+      mentor: mentor_john_smith,
+      claim: @clawback_in_progress_claim_1,
+      hours_completed: 20,
+    )
+    _jane_doe_mentor_training = create(
+      :mentor_training,
+      :rejected,
+      mentor: mentor_jane_doe,
+      claim: @clawback_in_progress_claim_1,
+      hours_completed: 20,
+    )
+    _joe_bloggs_mentor_training = create(
+      :mentor_training,
+      :rejected,
+      mentor: mentor_joe_bloggs,
+      claim: @clawback_in_progress_claim_2,
+      hours_completed: 20,
+    )
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_clawback_claims_index_page
+    within primary_navigation do
+      click_on "Claims"
+    end
+
+    within secondary_navigation do
+      click_on "Clawbacks"
+    end
+  end
+
+  def then_i_see_the_clawback_claims_index_page
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Claims")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(secondary_navigation).to have_current_item("Clawbacks")
+    expect(page).to have_current_path(claims_support_claims_clawbacks_path, ignore_query: true)
+  end
+
+  def then_i_see_the_upload_csv_page
+    expect(page).to have_h1("Upload ESFA response")
+    have_element(:span, text: "Clawbacks", class: "govuk-caption-l")
+    expect(page).to have_element(:label, text: "Upload CSV file")
+  end
+
+  def and_i_see_two_claims_with_the_status_clawback_in_progress
+    expect(page).to have_h2("Clawbacks (2)")
+    expect(page).to have_claim_card({
+      "title" => "11111111 - #{@clawback_in_progress_claim_1.school_name}",
+      "url" => "/support/claims/clawbacks/claims/#{@clawback_in_progress_claim_1.id}",
+      "status" => "Clawback in progress",
+      "academic_year" => @clawback_in_progress_claim_1.academic_year.name,
+      "provider_name" => @clawback_in_progress_claim_1.provider.name,
+      "submitted_at" => I18n.l(@clawback_in_progress_claim_1.submitted_at.to_date, format: :long),
+      "amount" => @clawback_in_progress_claim_1.amount.format(symbol: true, decimal_mark: ".", no_cents: true),
+    })
+    expect(page).to have_claim_card({
+      "title" => "22222222 - #{@clawback_in_progress_claim_2.school_name}",
+      "url" => "/support/claims/clawbacks/claims/#{@clawback_in_progress_claim_2.id}",
+      "status" => "Clawback in progress",
+      "academic_year" => @clawback_in_progress_claim_2.academic_year.name,
+      "provider_name" => @clawback_in_progress_claim_2.provider.name,
+      "submitted_at" => I18n.l(@clawback_in_progress_claim_2.submitted_at.to_date, format: :long),
+      "amount" => @clawback_in_progress_claim_2.amount.format(symbol: true, decimal_mark: ".", no_cents: true),
+    })
+  end
+
+  def when_i_click_on_upload_esfa_response
+    click_on "Upload ESFA response"
+  end
+
+  def and_i_click_on_upload_csv_file
+    click_on "Upload CSV file"
+  end
+
+  def when_i_upload_a_csv_containing_esfa_responses_for_all_claims_with_the_status_clawback_in_progress
+    attach_file "Upload CSV file",
+                "spec/fixtures/claims/clawback/esfa_responses/example_esfa_clawback_response_upload.csv"
+  end
+  alias_method :and_i_upload_a_csv_containing_esfa_responses_for_all_claims_with_the_status_clawback_in_progress,
+               :when_i_upload_a_csv_containing_esfa_responses_for_all_claims_with_the_status_clawback_in_progress
+
+  def then_i_see_the_confirmation_page_for_uploading_esfa_responses
+    expect(page).to have_title(
+      "Are you sure you want to upload the ESFA response? - Clawbacks - Claims - Claim funding for mentor training - GOV.UK",
+    )
+    expect(page).to have_h1("Are you sure you want to upload the ESFA response?")
+    have_element(:span, text: "Clawbacks", class: "govuk-caption-l")
+    expect(page).to have_element(:p, text: "There are 2 claims included in this upload.", class: "govuk-body")
+  end
+
+  def when_i_click_on_cancel
+    click_on "Cancel"
+  end
+  alias_method :and_i_click_on_cancel, :when_i_click_on_cancel
+
+  def when_i_click_on_back
+    click_on "Back"
+  end
+  alias_method :and_i_click_on_back, :when_i_click_on_back
+
+  def when_i_click_upload_responses
+    click_on "Upload responses"
+  end
+
+  def then_i_see_the_upload_has_been_successful
+    expect(page).to have_success_banner("ESFA response uploaded")
+  end
+
+  def and_i_can_not_see_claim_11111111
+    expect(page).not_to have_claim_card({
+      "title" => "11111111 - #{@clawback_in_progress_claim_1.school_name}",
+    })
+  end
+
+  def and_i_can_not_see_claim_22222222
+    expect(page).not_to have_claim_card({
+      "title" => "22222222 - #{@clawback_in_progress_claim_2.school_name}",
+    })
+  end
+
+  def when_i_navigate_to_the_all_claims_index_page
+    within secondary_navigation do
+      click_on "All claims"
+    end
+  end
+
+  def then_i_can_see_claim_11111111_has_the_status_clawback_complete
+    expect(page).to have_claim_card({
+      "title" => "11111111 - #{@clawback_in_progress_claim_1.school_name}",
+      "url" => "/support/claims/#{@clawback_in_progress_claim_1.id}",
+      "status" => "Clawback complete",
+      "academic_year" => @clawback_in_progress_claim_1.academic_year.name,
+      "provider_name" => @clawback_in_progress_claim_1.provider.name,
+      "submitted_at" => I18n.l(@clawback_in_progress_claim_1.submitted_at.to_date, format: :long),
+      "amount" => @clawback_in_progress_claim_1.amount.format(symbol: true, decimal_mark: ".", no_cents: true),
+    })
+  end
+
+  def and_i_can_see_claim_22222222_has_the_status_clawback_complete
+    expect(page).to have_claim_card({
+      "title" => "22222222 - #{@clawback_in_progress_claim_2.school_name}",
+      "url" => "/support/claims/#{@clawback_in_progress_claim_2.id}",
+      "status" => "Clawback complete",
+      "academic_year" => @clawback_in_progress_claim_2.academic_year.name,
+      "provider_name" => @clawback_in_progress_claim_2.provider.name,
+      "submitted_at" => I18n.l(@clawback_in_progress_claim_2.submitted_at.to_date, format: :long),
+      "amount" => @clawback_in_progress_claim_2.amount.format(symbol: true, decimal_mark: ".", no_cents: true),
+    })
+  end
+end

--- a/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_the_wrong_file_type_as_esfa_responses_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_the_wrong_file_type_as_esfa_responses_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+RSpec.describe "Support user uploads the wrong file type as ESFA responses",
+               service: :claims,
+               type: :system do
+  scenario do
+    given_claims_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_clawback_claims_index_page
+    then_i_see_the_clawback_claims_index_page
+    and_i_see_a_claim_with_the_status_clawback_in_progress
+
+    when_i_click_on_upload_esfa_response
+    then_i_see_the_upload_csv_page
+
+    when_i_upload_an_invalid_file_type
+    and_i_click_on_upload_csv_file
+    then_i_see_validation_error_regarding_invalid_file_type
+  end
+
+  private
+
+  def given_claims_exist
+    @claim = create(:claim, :submitted, status: :clawback_in_progress, reference: 11_111_111)
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_clawback_claims_index_page
+    within primary_navigation do
+      click_on "Claims"
+    end
+
+    within secondary_navigation do
+      click_on "Clawbacks"
+    end
+  end
+
+  def then_i_see_the_clawback_claims_index_page
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Claims")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(secondary_navigation).to have_current_item("Clawbacks")
+    expect(page).to have_current_path(claims_support_claims_clawbacks_path, ignore_query: true)
+  end
+
+  def then_i_see_the_upload_csv_page
+    expect(page).to have_h1("Upload ESFA response")
+    have_element(:span, text: "Clawbacks", class: "govuk-caption-l")
+    expect(page).to have_element(:label, text: "Upload CSV file")
+  end
+
+  def and_i_see_a_claim_with_the_status_clawback_in_progress
+    expect(page).to have_h2("Clawbacks (1)")
+    expect(page).to have_claim_card({
+      "title" => "11111111 - #{@claim.school_name}",
+      "url" => "/support/claims/clawbacks/claims/#{@claim.id}",
+      "status" => "Clawback in progress",
+      "academic_year" => @claim.academic_year.name,
+      "provider_name" => @claim.provider.name,
+      "submitted_at" => I18n.l(@claim.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+  end
+
+  def when_i_click_on_upload_esfa_response
+    click_on "Upload ESFA response"
+  end
+
+  def and_i_click_on_upload_csv_file
+    click_on "Upload CSV file"
+  end
+
+  def then_i_see_validation_error_regarding_invalid_file_type
+    expect(page).to have_validation_error("The selected file must be a CSV")
+  end
+
+  def when_i_upload_an_invalid_file_type
+    tmp = Tempfile.new("invalid_upload.txt")
+    attach_file "Upload CSV file", tmp.path
+  end
+end

--- a/spec/wizards/claims/upload_esfa_clawback_response_wizard/confirmation_step_spec.rb
+++ b/spec/wizards/claims/upload_esfa_clawback_response_wizard/confirmation_step_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe Claims::UploadESFAClawbackResponseWizard::ConfirmationStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Claims::UploadESFAClawbackResponseWizard).tap do |mock_wizard|
+      allow(mock_wizard).to receive(:grouped_csv_rows).and_return({ "11111111" => [], "22222222" => [] })
+    end
+  end
+  let(:attributes) { nil }
+
+  describe "delegations" do
+    it { is_expected.to delegate_method(:grouped_csv_rows).to(:wizard) }
+  end
+
+  describe "#claims_count" do
+    it "returns the number of keys returned by the upload steps grouping of claims references" do
+      expect(step.claims_count).to eq(2)
+    end
+  end
+end

--- a/spec/wizards/claims/upload_esfa_clawback_response_wizard/upload_errors_step_spec.rb
+++ b/spec/wizards/claims/upload_esfa_clawback_response_wizard/upload_errors_step_spec.rb
@@ -1,0 +1,109 @@
+require "rails_helper"
+
+RSpec.describe Claims::UploadESFAClawbackResponseWizard::UploadErrorsStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Claims::UploadESFAClawbackResponseWizard).tap do |mock_wizard|
+      allow(mock_wizard).to receive_messages(clawback_in_progress_claims: Claims::Claim.clawback_in_progress, steps: { upload: mock_upload_step })
+    end
+  end
+  let(:mock_upload_step) do
+    instance_double(Claims::UploadESFAClawbackResponseWizard::UploadStep).tap do |mock_upload_step|
+      allow(mock_upload_step).to receive_messages(
+        invalid_claim_references:,
+        invalid_status_claim_references:,
+        missing_mentor_training_claim_references:,
+        missing_reason_clawed_back_claim_references:,
+        invalid_hours_clawed_back_claim_references:,
+      )
+    end
+  end
+  let(:attributes) { nil }
+  let(:invalid_claim_references) { nil }
+  let(:invalid_status_claim_references) { nil }
+  let(:missing_mentor_training_claim_references) { nil }
+  let(:missing_reason_clawed_back_claim_references) { nil }
+  let(:invalid_hours_clawed_back_claim_references) { nil }
+  let(:claim_1) { create(:claim, :submitted, status: :clawback_in_progress, reference: 11_111_111) }
+  let(:claim_2) { create(:claim, :submitted, status: :clawback_in_progress, reference: 22_222_222) }
+  let(:claim_3) { create(:claim, :submitted, status: :clawback_in_progress, reference: 33_333_333) }
+
+  before do
+    claim_1
+    claim_2
+    claim_3
+  end
+
+  describe "#invalid_status_claims" do
+    subject(:invalid_status_claims) { step.invalid_status_claims }
+
+    context "when the upload step invalid_claim_references attribute is nil" do
+      it "returns an empty array" do
+        expect(invalid_status_claims).to eq([])
+      end
+    end
+
+    context "when the upload step invalid_claim_references attribute contains a reference" do
+      let(:invalid_status_claim_references) { %w[11111111 22222222] }
+
+      it "returns a list of claims with the references in the invalid_claim_references attribute" do
+        expect(invalid_status_claims).to contain_exactly(claim_1, claim_2)
+      end
+    end
+  end
+
+  describe "#missing_mentor_claims" do
+    subject(:missing_mentor_claims) { step.missing_mentor_claims }
+
+    context "when the upload step missing_mentor_training_claim_references attribute is nil" do
+      it "returns an empty array" do
+        expect(missing_mentor_claims).to eq([])
+      end
+    end
+
+    context "when the upload step missing_mentor_training_claim_references attribute contains a reference" do
+      let(:missing_mentor_training_claim_references) { %w[11111111 22222222] }
+
+      it "returns a list of claims with the references in the missing_mentor_training_claim_references attribute" do
+        expect(missing_mentor_claims).to contain_exactly(claim_1, claim_2)
+      end
+    end
+  end
+
+  describe "#missing_reason_clawed_back_claims" do
+    subject(:missing_reason_clawed_back_claims) { step.missing_reason_clawed_back_claims }
+
+    context "when the upload step missing_reason_clawed_back_claim_references attribute is nil" do
+      it "returns an empty array" do
+        expect(missing_reason_clawed_back_claims).to eq([])
+      end
+    end
+
+    context "when the upload step missing_reason_clawed_back_claim_references attribute contains a reference" do
+      let(:missing_reason_clawed_back_claim_references) { %w[11111111 22222222] }
+
+      it "returns a list of claims with the references in the missing_reason_clawed_back_claim_references attribute" do
+        expect(missing_reason_clawed_back_claims).to contain_exactly(claim_1, claim_2)
+      end
+    end
+  end
+
+  describe "#invalid_hours_clawed_back_claims" do
+    subject(:invalid_hours_clawed_back_claims) { step.invalid_hours_clawed_back_claims }
+
+    context "when the upload step invalid_hours_clawed_back_claim_references attribute is nil" do
+      it "returns an empty array" do
+        expect(invalid_hours_clawed_back_claims).to eq([])
+      end
+    end
+
+    context "when the upload step invalid_hours_clawed_back_claim_references attribute contains a reference" do
+      let(:invalid_hours_clawed_back_claim_references) { %w[11111111 22222222] }
+
+      it "returns a list of claims with the references in the invalid_hours_clawed_back_claim_references attribute" do
+        expect(invalid_hours_clawed_back_claims).to contain_exactly(claim_1, claim_2)
+      end
+    end
+  end
+end

--- a/spec/wizards/claims/upload_esfa_clawback_response_wizard/upload_step_spec.rb
+++ b/spec/wizards/claims/upload_esfa_clawback_response_wizard/upload_step_spec.rb
@@ -1,0 +1,371 @@
+require "rails_helper"
+
+RSpec.describe Claims::UploadESFAClawbackResponseWizard::UploadStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Claims::UploadESFAClawbackResponseWizard).tap do |mock_wizard|
+      allow(mock_wizard).to receive(:clawback_in_progress_claims).and_return(Claims::Claim.clawback_in_progress)
+    end
+  end
+  let(:attributes) { nil }
+
+  describe "attributes" do
+    it {
+      expect(step).to have_attributes(
+        csv_upload: nil,
+        csv_content: nil,
+        invalid_claim_references: [],
+        invalid_status_claim_references: [],
+        missing_mentor_training_claim_references: [],
+        missing_reason_clawed_back_claim_references: [],
+        invalid_hours_clawed_back_claim_references: [],
+      )
+    }
+  end
+
+  describe "delegations" do
+    it { is_expected.to delegate_method(:clawback_in_progress_claims).to(:wizard) }
+  end
+
+  describe "validations" do
+    describe "#csv_upload" do
+      context "when the csv_content is blank" do
+        it { is_expected.to validate_presence_of(:csv_upload) }
+      end
+
+      context "when the csv_content is present" do
+        let(:csv_content) do
+          "claim_reference,mentor_full_name,reason_clawed_back,hours_clawed_back\r\n" \
+          "11111111,John Smith,Some reason,10\r\n"
+        end
+        let(:attributes) { { csv_content: } }
+
+        it { is_expected.not_to validate_presence_of(:csv_upload) }
+      end
+    end
+
+    describe "#validate_csv_file" do
+      context "when the csv_upload is present" do
+        context "when the csv_upload is not a CSV" do
+          let(:attributes) { { csv_upload: invalid_file } }
+          let(:invalid_file) do
+            ActionDispatch::Http::UploadedFile.new({
+              filename: "invalid.jpg",
+              type: "image/jpeg",
+              tempfile: Tempfile.new("invalid.jpg"),
+            })
+          end
+
+          it "validates that the file is the incorrect format" do
+            expect(step.valid?).to be(false)
+            expect(step.errors.messages[:csv_upload]).to include("The selected file must be a CSV")
+          end
+        end
+
+        context "when the csv_upload is a CSV file" do
+          let(:clawback_in_progress_claim_1) do
+            create(:claim, :submitted, status: :clawback_in_progress, reference: 11_111_111)
+          end
+          let(:clawback_in_progress_claim_2) do
+            create(:claim, :submitted, status: :clawback_in_progress, reference: 22_222_222)
+          end
+          let(:mentor_john_smith) { create(:claims_mentor, first_name: "John", last_name: "Smith") }
+          let(:mentor_jane_doe) { create(:claims_mentor, first_name: "Jane", last_name: "Doe") }
+          let(:mentor_joe_bloggs) { create(:claims_mentor, first_name: "Joe", last_name: "Bloggs") }
+          let(:attributes) { { csv_upload: valid_file } }
+          let(:valid_file) do
+            ActionDispatch::Http::UploadedFile.new({
+              filename: "valid.csv",
+              type: "text/csv",
+              tempfile: File.open(
+                "spec/fixtures/claims/clawback/esfa_responses/example_esfa_clawback_response_upload.csv",
+              ),
+            })
+          end
+
+          before do
+            create(:mentor_training,
+                   :rejected,
+                   hours_completed: 20,
+                   mentor: mentor_john_smith,
+                   claim: clawback_in_progress_claim_1)
+            create(:mentor_training,
+                   :rejected,
+                   hours_completed: 10,
+                   mentor: mentor_jane_doe,
+                   claim: clawback_in_progress_claim_1)
+            create(:mentor_training,
+                   :rejected,
+                   hours_completed: 2,
+                   mentor: mentor_joe_bloggs,
+                   claim: clawback_in_progress_claim_2)
+          end
+
+          it "validates that the file is the correct format" do
+            expect(step.valid?).to be(true)
+          end
+        end
+      end
+    end
+  end
+
+  describe "#csv_inputs_valid?" do
+    subject(:csv_inputs_valid) { step.csv_inputs_valid? }
+
+    context "when the csv_content is blank" do
+      it "returns true" do
+        expect(csv_inputs_valid).to be(true)
+      end
+    end
+
+    context "when csv_content contains invalid references" do
+      let(:csv_content) do
+        "claim_reference,mentor_full_name,reason_clawed_back,hours_clawed_back\r\n" \
+        "11111111,John Smith,Some reason,10\r\n" \
+      end
+      let(:attributes) { { csv_content: } }
+
+      before { create(:claim, :submitted, status: :paid, reference: 22_222_222) }
+
+      it "returns false and assigns the reference to the 'invalid_claim_references' attribute" do
+        expect(csv_inputs_valid).to be(false)
+        expect(step.invalid_claim_references).to contain_exactly("11111111")
+      end
+    end
+
+    context "when csv_content contains claims not with the status 'clawback_in_progress" do
+      let(:csv_content) do
+        "claim_reference,mentor_full_name,reason_clawed_back,hours_clawed_back\r\n" \
+        "11111111,John Smith,Some reason,10"
+      end
+      let(:attributes) { { csv_content: } }
+
+      before { create(:claim, :submitted, status: :paid, reference: 11_111_111) }
+
+      it "returns false and assigns the reference to the 'invalid_status_claim_references' attribute" do
+        expect(csv_inputs_valid).to be(false)
+        expect(step.invalid_status_claim_references).to contain_exactly("11111111")
+      end
+    end
+
+    context "when csv_content does not contains all the not assured mentors associated with the claims" do
+      let(:csv_content) do
+        "claim_reference,mentor_full_name,reason_clawed_back,hours_clawed_back\r\n" \
+        "11111111,John Smith,Some reason,10"
+      end
+      let(:attributes) { { csv_content: } }
+
+      let(:sampling_in_progress_claim) do
+        create(:claim, :submitted, status: :sampling_in_progress, reference: 11_111_111)
+      end
+      let(:mentor_john_smith) { create(:claims_mentor, first_name: "John", last_name: "Smith") }
+      let(:mentor_jane_doe) { create(:claims_mentor, first_name: "Jane", last_name: "Doe") }
+
+      before do
+        create(:mentor_training,
+               :rejected,
+               hours_completed: 20,
+               mentor: mentor_john_smith,
+               claim: sampling_in_progress_claim)
+        create(:mentor_training,
+               :rejected,
+               hours_completed: 10,
+               mentor: mentor_jane_doe,
+               claim: sampling_in_progress_claim)
+      end
+
+      it "returns false and assigns the reference to the 'missing_mentor_training_claim_references' attribute" do
+        expect(csv_inputs_valid).to be(false)
+        expect(step.missing_mentor_training_claim_references).to contain_exactly("11111111")
+      end
+    end
+
+    context "when the csv_content does not contain a reason clawed back for each mentor" do
+      let(:csv_content) do
+        "claim_reference,mentor_full_name,reason_clawed_back,hours_clawed_back\r\n" \
+        "11111111,John Smith,,10"
+      end
+      let(:attributes) { { csv_content: } }
+      let(:clawback_in_progress_claim) do
+        create(:claim, :submitted, status: :clawback_in_progress, reference: 11_111_111)
+      end
+      let(:mentor_john_smith) { create(:claims_mentor, first_name: "John", last_name: "Smith") }
+
+      before do
+        create(:mentor_training,
+               :rejected,
+               hours_completed: 20,
+               mentor: mentor_john_smith,
+               claim: clawback_in_progress_claim)
+      end
+
+      it "returns false and assigns the reference to the 'missing_reason_clawed_back_claim_references' attribute" do
+        expect(csv_inputs_valid).to be(false)
+        expect(step.missing_reason_clawed_back_claim_references).to contain_exactly("11111111")
+      end
+    end
+
+    context "when the csv_content does not contain hours clawed back for each mentor" do
+      let(:csv_content) do
+        "claim_reference,mentor_full_name,reason_clawed_back,hours_clawed_back\r\n" \
+        "11111111,John Smith,Some reason,"
+      end
+      let(:attributes) { { csv_content: } }
+      let(:clawback_in_progress_claim) do
+        create(:claim, :submitted, status: :clawback_in_progress, reference: 11_111_111)
+      end
+      let(:mentor_john_smith) { create(:claims_mentor, first_name: "John", last_name: "Smith") }
+
+      before do
+        create(:mentor_training,
+               :rejected,
+               hours_completed: 20,
+               mentor: mentor_john_smith,
+               claim: clawback_in_progress_claim)
+      end
+
+      it "returns false and assigns the reference to the 'invalid_clawed_back_claim_references' attribute" do
+        expect(csv_inputs_valid).to be(false)
+        expect(step.invalid_hours_clawed_back_claim_references).to contain_exactly("11111111")
+      end
+    end
+
+    context "when the csv_content contain hours clawed back greater than the hours completed" do
+      let(:csv_content) do
+        "claim_reference,mentor_full_name,reason_clawed_back,hours_clawed_back\r\n" \
+        "11111111,John Smith,Some reason,20"
+      end
+      let(:attributes) { { csv_content: } }
+      let(:clawback_in_progress_claim) do
+        create(:claim, :submitted, status: :clawback_in_progress, reference: 11_111_111)
+      end
+      let(:mentor_john_smith) { create(:claims_mentor, first_name: "John", last_name: "Smith") }
+
+      before do
+        create(:mentor_training,
+               :rejected,
+               hours_completed: 5,
+               mentor: mentor_john_smith,
+               claim: clawback_in_progress_claim)
+      end
+
+      it "returns false and assigns the reference to the 'invalid_clawed_back_claim_references' attribute" do
+        expect(csv_inputs_valid).to be(false)
+        expect(step.invalid_hours_clawed_back_claim_references).to contain_exactly("11111111")
+      end
+    end
+
+    context "when the csv_content contains valid claim references and all necessary valid attributes" do
+      let(:csv_content) do
+        "claim_reference,mentor_full_name,reason_clawed_back,hours_clawed_back\r\n" \
+        "11111111,John Smith,Some reason,10"
+      end
+      let(:attributes) { { csv_content: } }
+      let(:clawback_in_progress_claim) do
+        create(:claim, :submitted, status: :clawback_in_progress, reference: 11_111_111)
+      end
+      let(:mentor_john_smith) { create(:claims_mentor, first_name: "John", last_name: "Smith") }
+
+      before do
+        create(:mentor_training,
+               :rejected,
+               hours_completed: 20,
+               mentor: mentor_john_smith,
+               claim: clawback_in_progress_claim)
+      end
+
+      it "returns true" do
+        expect(csv_inputs_valid).to be(true)
+      end
+    end
+  end
+
+  describe "#process_csv" do
+    let(:clawback_in_progress_claim_1) do
+      create(:claim, :submitted, status: :clawback_in_progress, reference: 11_111_111)
+    end
+    let(:clawback_in_progress_claim_2) do
+      create(:claim, :submitted, status: :clawback_in_progress, reference: 22_222_222)
+    end
+    let(:mentor_john_smith) { create(:claims_mentor, first_name: "John", last_name: "Smith") }
+    let(:mentor_jane_doe) { create(:claims_mentor, first_name: "Jane", last_name: "Doe") }
+    let(:mentor_joe_bloggs) { create(:claims_mentor, first_name: "Joe", last_name: "Bloggs") }
+    let(:attributes) { { csv_upload: valid_file } }
+    let(:valid_file) do
+      ActionDispatch::Http::UploadedFile.new({
+        filename: "valid.csv",
+        type: "text/csv",
+        tempfile: File.open(
+          "spec/fixtures/claims/clawback/esfa_responses/example_esfa_clawback_response_upload.csv",
+        ),
+      })
+    end
+
+    before do
+      create(:mentor_training,
+             :rejected,
+             hours_completed: 20,
+             mentor: mentor_john_smith,
+             claim: clawback_in_progress_claim_1)
+      create(:mentor_training,
+             :rejected,
+             hours_completed: 10,
+             mentor: mentor_jane_doe,
+             claim: clawback_in_progress_claim_1)
+      create(:mentor_training,
+             :rejected,
+             hours_completed: 5,
+             mentor: mentor_joe_bloggs,
+             claim: clawback_in_progress_claim_2)
+    end
+
+    it "reads a given CSV and assigns the content to the csv_content attribute,
+        and assigns the associated claim IDs to the claim_ids attribute" do
+      expect(step.csv_content).to eq(
+        "claim_reference,mentor_full_name,reason_clawed_back,hours_clawed_back\n" \
+        "11111111,John Smith,Some reason,10\n" \
+        "11111111,Jane Doe,Another reason,5\n" \
+        "22222222,Joe Bloggs,Yet another reason,2\n" \
+        ",,,\n",
+      )
+    end
+  end
+
+  describe "#grouped_csv_rows" do
+    subject(:grouped_csv_rows) { step.grouped_csv_rows }
+
+    let(:csv_content) do
+      "claim_reference,mentor_full_name,reason_clawed_back,hours_clawed_back\n" \
+        "11111111,John Smith,Some reason,10\n" \
+        "11111111,Jane Doe,Another reason,5\n" \
+        "22222222,Joe Bloggs,Yet another reason,2"
+    end
+    let(:attributes) { { csv_content: } }
+
+    it "returns the rows of the CSV grouped by references" do
+      expect(grouped_csv_rows["11111111"].map(&:to_hash)).to contain_exactly(
+        {
+          "claim_reference" => "11111111",
+          "mentor_full_name" => "John Smith",
+          "reason_clawed_back" => "Some reason",
+          "hours_clawed_back" => "10",
+        },
+        {
+          "claim_reference" => "11111111",
+          "mentor_full_name" => "Jane Doe",
+          "reason_clawed_back" => "Another reason",
+          "hours_clawed_back" => "5",
+        },
+      )
+      expect(grouped_csv_rows["22222222"].map(&:to_hash)).to contain_exactly(
+        {
+          "claim_reference" => "22222222",
+          "mentor_full_name" => "Joe Bloggs",
+          "reason_clawed_back" => "Yet another reason",
+          "hours_clawed_back" => "2",
+        },
+      )
+    end
+  end
+end

--- a/spec/wizards/claims/upload_esfa_clawback_response_wizard_spec.rb
+++ b/spec/wizards/claims/upload_esfa_clawback_response_wizard_spec.rb
@@ -1,0 +1,251 @@
+require "rails_helper"
+
+RSpec.describe Claims::UploadESFAClawbackResponseWizard do
+  subject(:wizard) { described_class.new(state:, params:, current_step: nil) }
+
+  let(:state) { {} }
+  let(:params_data) { {} }
+  let(:params) { ActionController::Parameters.new(params_data) }
+
+  describe "#steps" do
+    subject { wizard.steps.keys }
+
+    context "when no clawback in progress claims exist" do
+      it { is_expected.to contain_exactly(:no_claims) }
+    end
+
+    context "when clawback in progress claims exist" do
+      before { create(:claim, :submitted, status: :clawback_in_progress) }
+
+      it { is_expected.to eq(%i[upload confirmation]) }
+    end
+
+    context "when the csv contains invalid inputs" do
+      let(:csv_content) do
+        "claim_reference,mentor_full_name,reason_clawed_back,hours_clawed_back\r\n" \
+        "22222222,John Smith,Some reason,2"
+      end
+      let(:state) do
+        {
+          "upload" => {
+            "csv_upload" => nil,
+            "csv_content" => csv_content,
+          },
+        }
+      end
+
+      before do
+        create(:claim, :submitted, status: :clawback_in_progress, reference: 11_111_111)
+      end
+
+      it { is_expected.to eq(%i[upload upload_errors]) }
+    end
+  end
+
+  describe "#upload_esfa_responses" do\
+    let(:clawback_in_progress_claim) do
+      create(:claim, :submitted, status: :clawback_in_progress, reference: 11_111_111)
+    end
+    let(:mentor) { create(:claims_mentor, first_name: "John", last_name: "Smith") }
+    let(:state) do
+      {
+        "upload" => {
+          "csv_upload" => nil,
+          "csv_content" => csv_content,
+        },
+      }
+    end
+
+    before do
+      create(
+        :mentor_training,
+        :rejected,
+        mentor:,
+        claim: clawback_in_progress_claim,
+        hours_completed: 20,
+      )
+    end
+
+    context "when the steps are valid" do
+      let(:csv_content) do
+        "claim_reference,mentor_full_name,reason_clawed_back,hours_clawed_back\r\n" \
+        "11111111,John Smith,Some reason,10"
+      end
+
+      it "queues a job to update the claim with the ESFA response" do
+        expect { wizard.upload_esfa_responses }.to have_enqueued_job(
+          Claims::Clawback::UpdateCollectionWithESFAResponseJob,
+        ).exactly(:once)
+      end
+    end
+
+    context "when a step is invalid" do
+      context "when the a step is valid" do
+        let(:csv_content) { nil }
+
+        it "returns an invalid wizard error" do
+          expect { wizard.upload_esfa_responses }.to raise_error("Invalid wizard state")
+        end
+      end
+
+      context "when the uploaded content includes an invalid input" do
+        let(:csv_content) do
+          "claim_reference,mentor_full_name,reason_clawed_back,hours_clawed_back\r\n" \
+          "11111111,John Smith,Some reason,10\r\n" \
+          "22222222,Maggie Smith,Another reason,2"
+        end
+
+        it "returns an invalid wizard error" do
+          expect { wizard.upload_esfa_responses }.to raise_error("Invalid wizard state")
+        end
+      end
+    end
+  end
+
+  describe "#clawback_in_progress_claims" do
+    subject(:clawback_in_progress_claims) { wizard.clawback_in_progress_claims }
+
+    let(:submitted_claim) { create(:claim, :submitted) }
+    let!(:clawback_in_progress_claim) { create(:claim, :submitted, status: :clawback_in_progress) }
+    let(:sampling_in_progress_claim) { create(:claim, :submitted, status: :sampling_in_progress) }
+    let(:draft_claim) { create(:claim) }
+
+    before do
+      submitted_claim
+      sampling_in_progress_claim
+      draft_claim
+    end
+
+    it "returns all claims with the status 'sampling_in_progress" do
+      expect(clawback_in_progress_claims).to contain_exactly(clawback_in_progress_claim)
+    end
+  end
+
+  describe "#claim_update_details" do
+    subject(:claim_update_details) { wizard.claim_update_details }
+
+    context "when the upload step is blank" do
+      it "returns an empty array" do
+        expect(claim_update_details).to eq([])
+      end
+    end
+
+    context "when the upload step is present" do
+      let(:clawback_in_progress_claim_1) do
+        create(:claim, :submitted, status: :clawback_in_progress, reference: 11_111_111)
+      end
+      let(:mentor_john_smith) { create(:claims_mentor, first_name: "John", last_name: "Smith") }
+      let(:clawback_in_progress_claim_2) do
+        create(:claim, :submitted, status: :clawback_in_progress, reference: 22_222_222)
+      end
+      let(:mentor_jane_doe) { create(:claims_mentor, first_name: "Jane", last_name: "Doe") }
+      let(:csv_content) do
+        "claim_reference,mentor_full_name,reason_clawed_back,hours_clawed_back\r\n" \
+        "11111111,John Smith,Some reason,10\r\n" \
+        "22222222,Jane Doe,Another reason,4,"
+      end
+      let(:state) do
+        {
+          "upload" => {
+            "csv_upload" => nil,
+            "csv_content" => csv_content,
+          },
+        }
+      end
+      let(:john_smith_mentor_training) do
+        create(:mentor_training,
+               :rejected,
+               hours_completed: 20,
+               mentor: mentor_john_smith,
+               claim: clawback_in_progress_claim_1)
+      end
+      let(:jane_doe_mentor_training) do
+        create(:mentor_training,
+               :rejected,
+               hours_completed: 10,
+               mentor: mentor_jane_doe,
+               claim: clawback_in_progress_claim_2)
+      end
+
+      before do
+        john_smith_mentor_training
+        jane_doe_mentor_training
+      end
+
+      it "returns the claim_update_details from the upload step" do
+        expect(claim_update_details).to contain_exactly(
+          {
+            id: clawback_in_progress_claim_1.id,
+            status: :clawback_complete,
+            esfa_responses: [
+              { id: john_smith_mentor_training.id, reason_clawed_back: "Some reason", hours_clawed_back: "10" },
+            ],
+          },
+          {
+            id: clawback_in_progress_claim_2.id,
+            status: :clawback_complete,
+            esfa_responses: [
+              { id: jane_doe_mentor_training.id, reason_clawed_back: "Another reason", hours_clawed_back: "4" },
+            ],
+          },
+        )
+      end
+    end
+  end
+
+  describe "#grouped_csv_rows" do
+    let(:clawback_in_progress_claim_1) do
+      create(:claim, :submitted, status: :clawback_in_progress, reference: 11_111_111)
+    end
+    let(:mentor_john_smith) { create(:claims_mentor, first_name: "John", last_name: "Smith") }
+    let(:clawback_in_progress_claim_2) do
+      create(:claim, :submitted, status: :clawback_in_progress, reference: 22_222_222)
+    end
+    let(:mentor_jane_doe) { create(:claims_mentor, first_name: "Jane", last_name: "Doe") }
+    let(:csv_content) do
+      "claim_reference,mentor_full_name,reason_clawed_back,hours_clawed_back\r\n" \
+      "11111111,John Smith,Some reason,10\r\n" \
+      "22222222,Jane Doe,Another reason,4"
+    end
+    let(:state) do
+      {
+        "upload" => {
+          "csv_upload" => nil,
+          "csv_content" => csv_content,
+        },
+      }
+    end
+
+    before do
+      create(:mentor_training,
+             :rejected,
+             hours_completed: 20,
+             mentor: mentor_john_smith,
+             claim: clawback_in_progress_claim_1)
+      create(:mentor_training,
+             :rejected,
+             hours_completed: 10,
+             mentor: mentor_jane_doe,
+             claim: clawback_in_progress_claim_2)
+    end
+
+    it "returns the groups rows from the CSV uploaded to the upload step" do
+      expect(wizard.grouped_csv_rows["11111111"][0].to_h).to eq(
+        {
+          "claim_reference" => "11111111",
+          "mentor_full_name" => "John Smith",
+          "reason_clawed_back" => "Some reason",
+          "hours_clawed_back" => "10",
+        },
+      )
+      expect(wizard.grouped_csv_rows["22222222"][0].to_h).to eq(
+        {
+          "claim_reference" => "22222222",
+          "mentor_full_name" => "Jane Doe",
+          "reason_clawed_back" => "Another reason",
+          "hours_clawed_back" => "4",
+        },
+      )
+    end
+  end
+end

--- a/spec/wizards/claims/upload_provider_response_wizard_spec.rb
+++ b/spec/wizards/claims/upload_provider_response_wizard_spec.rb
@@ -103,6 +103,11 @@ RSpec.describe Claims::UploadProviderResponseWizard do
     let!(:sampling_in_progress_claim) { create(:claim, :submitted, status: :sampling_in_progress) }
     let(:draft_claim) { create(:claim) }
 
+    before do
+      submitted_claim
+      draft_claim
+    end
+
     it "returns all claims with the status 'sampling_in_progress" do
       expect(sampled_claims).to contain_exactly(sampling_in_progress_claim)
     end


### PR DESCRIPTION
## Context

- Allow Support users the ability to upload a CSV, which will change claims in the "Clawback in progress" status to "Clawback complete", and assign a reason and hours clawed back to each rejected mentor training.

## Changes proposed in this pull request

- Add interface for Support Users to upload a CSV of claims/mentors they wish to change the status of (and provide ESFA reponses.
Add Wizard and related Steps for Uploading ESFA responses.
Add Jobs to run in the background, which will change the status of the uploaded claims from "Clawback in progress" to "Clawback complete"

## Guidance to review

Sign in as Colin
Navigate to Claims -> Clawback
(Assuming you have claims with the "clawback in progress" status for the current academic year)
Click "Upload ESFA responses"
Upload the CSV containing the claim_reference, mentor_full_name, reason_clawed_back ,hours_clawed_back
Click "Upload data"
You will be informed that the upload was success
(after a few mins) The claim/s related to your CSV be updated to "Clawback complete"
## Link to Trello card

https://trello.com/c/3FWgTzJ4/329-clawbacks-upload-esfa-response-functionality

## Screenshots

https://github.com/user-attachments/assets/c0f5ad63-fcc8-464f-97b5-7d1e2235021a


