### PR TITLE
Fix filters show on claims index pages

### DIFF
--- a/app/views/claims/support/claims/payments/index.html.erb
+++ b/app/views/claims/support/claims/payments/index.html.erb
@@ -13,19 +13,19 @@
     <%= govuk_button_link_to t(".buttons.upload_esfa_response"), new_claims_support_claims_payment_response_path, secondary: true %>
   </div>
 
-  <% if @claims.any? %>
-    <h3 class="govuk-heading-s"><%= t(".description", count: @pagy.count) %></h3>
+  <h3 class="govuk-heading-s"><%= t(".description", count: @pagy.count) %></h3>
 
-    <%= render Claims::Claim::FilterFormComponent.new(filter_form:, statuses: Claims::Claim::PAYMENT_ACTIONABLE_STATUSES) do %>
-      <div class="govuk-!-margin-bottom-2">
+  <%= render Claims::Claim::FilterFormComponent.new(filter_form:, statuses: Claims::Claim::PAYMENT_ACTIONABLE_STATUSES) do %>
+    <div class="govuk-!-margin-bottom-2">
+      <% if @claims.any? %>
         <% @claims.each do |claim| %>
           <%= render Claim::CardComponent.new(claim:, href: claims_support_claims_payments_claim_path(claim)) %>
         <% end %>
-      </div>
+      <% else %>
+        <p class="govuk-body"><%= t(".no_claims") %></p>
+      <% end %>
+    </div>
 
-      <%= render PaginationComponent.new(pagy: @pagy) %>
-    <% end %>
-  <% else %>
-    <p class="govuk-body"><%= t(".no_claims") %></p>
+    <%= render PaginationComponent.new(pagy: @pagy) %>
   <% end %>
 </div>

--- a/app/views/claims/support/claims/samplings/_upload_buttons.html.erb
+++ b/app/views/claims/support/claims/samplings/_upload_buttons.html.erb
@@ -1,7 +1,0 @@
-<div class="govuk-button-group">
-  <%= govuk_button_link_to t(".upload_claims"),
-    new_upload_data_claims_support_claims_samplings_path %>
-  <%= govuk_button_link_to t(".upload_provider_response"),
-    new_upload_provider_response_claims_support_claims_samplings_path,
-    secondary: true %>
-</div>

--- a/app/views/claims/support/claims/samplings/index.html.erb
+++ b/app/views/claims/support/claims/samplings/index.html.erb
@@ -6,25 +6,29 @@
 
   <%= render "claims/support/claims/secondary_navigation", current: :sampling %>
 
-  <% if @claims.any? %>
-    <h2 class="govuk-heading-m"><%= t(".sub_heading", count: @pagy.count) %></h2>
-    <%= render "upload_buttons" %>
+  <h2 class="govuk-heading-m"><%= t(".sub_heading", count: @pagy.count) %></h2>
 
-    <%= render Claims::Claim::FilterFormComponent.new(filter_form:, statuses: Claims::Claim::SAMPLING_STATUSES) do %>
-      <div class="govuk-!-margin-bottom-2">
+  <div class="govuk-button-group">
+    <%= govuk_button_link_to t(".upload_claims"),
+      new_upload_data_claims_support_claims_samplings_path %>
+    <%= govuk_button_link_to t(".upload_provider_response"),
+      new_upload_provider_response_claims_support_claims_samplings_path,
+      secondary: true %>
+  </div>
+
+  <%= render Claims::Claim::FilterFormComponent.new(filter_form:, statuses: Claims::Claim::SAMPLING_STATUSES) do %>
+    <div class="govuk-!-margin-bottom-2">
+      <% if @claims.any? %>
         <% @claims.each do |claim| %>
           <%= render Claim::CardComponent.new(claim:, href: claims_support_claims_sampling_path(claim)) %>
         <% end %>
-      </div>
+      <% else %>
+        <p class="govuk-body">
+        <%= t(".no_claims") %>
+      </p>
+      <% end %>
+    </div>
 
-      <%= render PaginationComponent.new(pagy: @pagy) %>
-    <% end %>
-  <% else %>
-    <h2 class="govuk-heading-m"><%= t(".sub_heading_without_count") %></h2>
-    <%= render "upload_buttons" %>
-
-    <p class="govuk-body">
-      <%= t(".no_claims") %>
-    </p>
+    <%= render PaginationComponent.new(pagy: @pagy) %>
   <% end %>
 </div>

--- a/config/locales/en/claims/support/claims/samplings.yml
+++ b/config/locales/en/claims/support/claims/samplings.yml
@@ -5,10 +5,11 @@ en:
         samplings:
           index:
             heading: Claims
-            sub_heading: Sampling (%{count})
-            sub_heading_without_count: Sampling
+            sub_heading:
+              zero: Sampling
+              one: Sampling (%{count})
+              other: Sampling (%{count})
             no_claims: There are no claims waiting to be processed.
-          upload_buttons:
             upload_claims: Upload claims to be sampled
             upload_provider_response: Upload provider response
           show:


### PR DESCRIPTION
## Context

- Fix issue with filters not appearing on the claims index pages when there are no results.

## Changes proposed in this pull request

- Refactor code so that the filters still show, even when no results are found.

## Guidance to review

- Sign in as Colin (Support user)
- Navigate to Claims using the Navbar
- Check each index sub page with no claims.
- The filters should appear on each page, despite there not being any claim results.

## Link to Trello card

https://trello.com/c/D0Tj7nGT/335-show-filters-when-there-are-no-search-results

## Screenshots

![screencapture-claims-localhost-3000-support-claims-clawbacks-claims-2025-01-08-10_29_21](https://github.com/user-attachments/assets/b53b15db-5714-4c18-892d-40f732a12e84)
![screencapture-claims-localhost-3000-support-claims-sampling-claims-2025-01-08-10_29_04](https://github.com/user-attachments/assets/62b3a94c-199b-4c8a-8dec-d51feb7c2cad)
![screencapture-claims-localhost-3000-support-claims-payments-2025-01-08-10_28_38](https://github.com/user-attachments/assets/b8526266-d012-42b5-a65b-354ea8f894a5)

