### PR TITLE
Validate presence of action in activity log and conditionally show CSV

### DIFF
--- a/app/models/claims/claim_activity.rb
+++ b/app/models/claims/claim_activity.rb
@@ -32,7 +32,7 @@ class Claims::ClaimActivity < ApplicationRecord
     sampling_response_uploaded: "sampling_response_uploaded",
     clawback_request_delivered: "clawback_request_delivered",
     clawback_response_uploaded: "clawback_response_uploaded",
-  }
+  }, validate: true
 
   delegate :full_name, to: :user, prefix: true, allow_nil: true
 end

--- a/app/models/claims/claim_activity.rb
+++ b/app/models/claims/claim_activity.rb
@@ -23,8 +23,6 @@ class Claims::ClaimActivity < ApplicationRecord
   belongs_to :user, class_name: "Claims::SupportUser"
   belongs_to :record, polymorphic: true
 
-  validates :action, presence: true
-
   enum :action, {
     payment_request_delivered: "payment_request_delivered",
     payment_response_uploaded: "payment_response_uploaded",

--- a/app/models/claims/claim_activity.rb
+++ b/app/models/claims/claim_activity.rb
@@ -23,6 +23,8 @@ class Claims::ClaimActivity < ApplicationRecord
   belongs_to :user, class_name: "Claims::SupportUser"
   belongs_to :record, polymorphic: true
 
+  validates :action, presence: true
+
   enum :action, {
     payment_request_delivered: "payment_request_delivered",
     payment_response_uploaded: "payment_response_uploaded",

--- a/app/views/claims/support/claims/claim_activities/index.html.erb
+++ b/app/views/claims/support/claims/claim_activities/index.html.erb
@@ -27,25 +27,29 @@
               <div class="app-timeline__description">
                 <% case claim_activity.action %>
                 <% when "payment_request_delivered", "clawback_request_delivered", "payment_response_uploaded" %>
-                  <ul class="app-timeline__documents">
-                    <li class="app-timeline__document-item">
-                      <%= govuk_link_to claim_activity.record.csv_file, class: "app-timeline__document-link" do %>
-                        <%= image_tag "icon-document.svg", class: "app-timeline__document-link__icon" %>
+                  <% if claim_activity.record.csv_file.present? %>
+                    <ul class="app-timeline__documents">
+                      <li class="app-timeline__document-item">
+                        <%= govuk_link_to claim_activity.record.csv_file, class: "app-timeline__document-link" do %>
+                          <%= image_tag "icon-document.svg", class: "app-timeline__document-link__icon" %>
 
-                        <%= Claims::ClaimActivity.human_attribute_name("document.#{claim_activity.action}") %>
-                      <% end %>
-                    </li>
-                  </ul>
+                          <%= Claims::ClaimActivity.human_attribute_name("document.#{claim_activity.action}") %>
+                        <% end %>
+                      </li>
+                    </ul>
+                  <% end %>
                 <% when "sampling_uploaded" %>
                   <% provider_samplings = claim_activity.record.provider_samplings %>
 
                   <ul class="app-timeline__documents">
                     <% provider_samplings.limit(5).each do |provider_sampling| %>
-                      <li class="app-timeline__document-item">
-                        <%= govuk_link_to provider_sampling.csv_file, class: "app-timeline__document-link" do %>
-                          <%= image_tag "icon-document.svg", class: "app-timeline__document-link__icon" %> <%= provider_sampling.provider.name %>
-                        <% end %>
-                      </li>
+                      <% if provider_sampling.csv_file.present? %>
+                        <li class="app-timeline__document-item">
+                          <%= govuk_link_to provider_sampling.csv_file, class: "app-timeline__document-link" do %>
+                            <%= image_tag "icon-document.svg", class: "app-timeline__document-link__icon" %> <%= provider_sampling.provider.name %>
+                          <% end %>
+                        </li>
+                      <% end %>
                     <% end %>
                   </ul>
 

--- a/spec/models/claims/claim_activity_spec.rb
+++ b/spec/models/claims/claim_activity_spec.rb
@@ -22,6 +22,10 @@
 require "rails_helper"
 
 RSpec.describe Claims::ClaimActivity, type: :model do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:action) }
+  end
+
   describe "associations" do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:record) }

--- a/spec/models/claims/claim_activity_spec.rb
+++ b/spec/models/claims/claim_activity_spec.rb
@@ -23,7 +23,7 @@ require "rails_helper"
 
 RSpec.describe Claims::ClaimActivity, type: :model do
   describe "validations" do
-    it { is_expected.to validate_presence_of(:action) }
+    it { is_expected.to validate_inclusion_of(:action).in_array(described_class.actions.keys) }
   end
 
   describe "associations" do


### PR DESCRIPTION
## Context

- Claim Activity records require an action, otherwise the activity log page breaks. Currently this is not validated.

## Changes proposed in this pull request

- Add validation to `Claims::ClaimActivity` to ensure `action` is present.

## Guidance to review

(Assuming you have a number of `Claims::ClaimActivity` records in your database.
- Sign in as Colin (Support user)
- Navigate to Claims -> Activity log in the nav bar.
- The page should not break whether or not you have a `csv_file` attached to the record.

_In the rails console_
- Try to create a `Claims::ClaimActivity` record without an `action`
- It should error due to the validation.

## Link to Trello card

https://trello.com/c/viXc3m6A/338-fix-activity-log-when-csv-files-are-not-present

## Screenshots
![screencapture-claims-localhost-3000-support-claims-activity-2025-01-08-13_33_41](https://github.com/user-attachments/assets/d72b11fa-a066-4240-a303-86fce11d2c07)


