### PR TITLE
Add downloaded_at to models with csv_file attachments

### DIFF
--- a/app/models/claims/clawback.rb
+++ b/app/models/claims/clawback.rb
@@ -2,9 +2,10 @@
 #
 # Table name: clawbacks
 #
-#  id         :uuid             not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id            :uuid             not null, primary key
+#  downloaded_at :datetime
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
 #
 class Claims::Clawback < ApplicationRecord
   has_many :clawback_claims

--- a/app/models/claims/payment.rb
+++ b/app/models/claims/payment.rb
@@ -2,10 +2,11 @@
 #
 # Table name: payments
 #
-#  id         :uuid             not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  sent_by_id :uuid             not null
+#  id            :uuid             not null, primary key
+#  downloaded_at :datetime
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  sent_by_id    :uuid             not null
 #
 # Indexes
 #

--- a/app/models/claims/payment_response.rb
+++ b/app/models/claims/payment_response.rb
@@ -2,11 +2,12 @@
 #
 # Table name: payment_responses
 #
-#  id         :uuid             not null, primary key
-#  processed  :boolean          default(FALSE)
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  user_id    :uuid             not null
+#  id            :uuid             not null, primary key
+#  downloaded_at :datetime
+#  processed     :boolean          default(FALSE)
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  user_id       :uuid             not null
 #
 # Indexes
 #

--- a/app/models/claims/provider_sampling.rb
+++ b/app/models/claims/provider_sampling.rb
@@ -2,11 +2,12 @@
 #
 # Table name: provider_samplings
 #
-#  id          :uuid             not null, primary key
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  provider_id :uuid             not null
-#  sampling_id :uuid             not null
+#  id            :uuid             not null, primary key
+#  downloaded_at :datetime
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  provider_id   :uuid             not null
+#  sampling_id   :uuid             not null
 #
 # Indexes
 #

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -100,6 +100,7 @@ shared:
     - provider_id
     - created_at
     - updated_at
+    - downloaded_at
   :provider_sampling_claims:
     - id
     - claim_id
@@ -110,6 +111,7 @@ shared:
     - id
     - created_at
     - updated_at
+    - downloaded_at
   :clawback_claims:
     - id
     - claim_id
@@ -231,6 +233,7 @@ shared:
     - sent_by_id
     - created_at
     - updated_at
+    - downloaded_at
   :payment_claims:
     - id
     - payment_id
@@ -243,6 +246,7 @@ shared:
     - processed
     - created_at
     - updated_at
+    - downloaded_at
   :claim_activities:
     - id
     - action

--- a/db/migrate/20250108210737_add_downloaded_at_to_clawbacks.rb
+++ b/db/migrate/20250108210737_add_downloaded_at_to_clawbacks.rb
@@ -1,0 +1,5 @@
+class AddDownloadedAtToClawbacks < ActiveRecord::Migration[7.2]
+  def change
+    add_column :clawbacks, :downloaded_at, :datetime
+  end
+end

--- a/db/migrate/20250108211108_add_downloaded_at_to_payment_responses.rb
+++ b/db/migrate/20250108211108_add_downloaded_at_to_payment_responses.rb
@@ -1,0 +1,5 @@
+class AddDownloadedAtToPaymentResponses < ActiveRecord::Migration[7.2]
+  def change
+    add_column :payment_responses, :downloaded_at, :datetime
+  end
+end

--- a/db/migrate/20250108211304_add_downloaded_at_to_payments.rb
+++ b/db/migrate/20250108211304_add_downloaded_at_to_payments.rb
@@ -1,0 +1,5 @@
+class AddDownloadedAtToPayments < ActiveRecord::Migration[7.2]
+  def change
+    add_column :payments, :downloaded_at, :datetime
+  end
+end

--- a/db/migrate/20250108211418_add_downloaded_at_to_provider_samplings.rb
+++ b/db/migrate/20250108211418_add_downloaded_at_to_provider_samplings.rb
@@ -1,0 +1,5 @@
+class AddDownloadedAtToProviderSamplings < ActiveRecord::Migration[7.2]
+  def change
+    add_column :provider_samplings, :downloaded_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_02_102324) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_08_211418) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -144,6 +144,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_02_102324) do
   create_table "clawbacks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "downloaded_at"
   end
 
   create_table "flipflop_features", force: :cascade do |t|
@@ -307,6 +308,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_02_102324) do
     t.boolean "processed", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "downloaded_at"
     t.index ["user_id"], name: "index_payment_responses_on_user_id"
   end
 
@@ -314,6 +316,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_02_102324) do
     t.uuid "sent_by_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "downloaded_at"
     t.index ["sent_by_id"], name: "index_payments_on_sent_by_id"
   end
 
@@ -383,6 +386,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_02_102324) do
     t.uuid "provider_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "downloaded_at"
     t.index ["provider_id"], name: "index_provider_samplings_on_provider_id"
     t.index ["sampling_id"], name: "index_provider_samplings_on_sampling_id"
   end

--- a/spec/factories/claims/payment_responses.rb
+++ b/spec/factories/claims/payment_responses.rb
@@ -2,11 +2,12 @@
 #
 # Table name: payment_responses
 #
-#  id         :uuid             not null, primary key
-#  processed  :boolean          default(FALSE)
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  user_id    :uuid             not null
+#  id            :uuid             not null, primary key
+#  downloaded_at :datetime
+#  processed     :boolean          default(FALSE)
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  user_id       :uuid             not null
 #
 # Indexes
 #

--- a/spec/factories/claims/payments.rb
+++ b/spec/factories/claims/payments.rb
@@ -2,10 +2,11 @@
 #
 # Table name: payments
 #
-#  id         :uuid             not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  sent_by_id :uuid             not null
+#  id            :uuid             not null, primary key
+#  downloaded_at :datetime
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  sent_by_id    :uuid             not null
 #
 # Indexes
 #

--- a/spec/factories/claims/provider_samplings.rb
+++ b/spec/factories/claims/provider_samplings.rb
@@ -2,11 +2,12 @@
 #
 # Table name: provider_samplings
 #
-#  id          :uuid             not null, primary key
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  provider_id :uuid             not null
-#  sampling_id :uuid             not null
+#  id            :uuid             not null, primary key
+#  downloaded_at :datetime
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  provider_id   :uuid             not null
+#  sampling_id   :uuid             not null
 #
 # Indexes
 #

--- a/spec/factories/clawbacks.rb
+++ b/spec/factories/clawbacks.rb
@@ -2,9 +2,10 @@
 #
 # Table name: clawbacks
 #
-#  id         :uuid             not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id            :uuid             not null, primary key
+#  downloaded_at :datetime
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
 #
 FactoryBot.define do
   factory :clawback do

--- a/spec/models/claims/clawback_spec.rb
+++ b/spec/models/claims/clawback_spec.rb
@@ -2,9 +2,10 @@
 #
 # Table name: clawbacks
 #
-#  id         :uuid             not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id            :uuid             not null, primary key
+#  downloaded_at :datetime
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
 #
 require "rails_helper"
 

--- a/spec/models/claims/payment_response_spec.rb
+++ b/spec/models/claims/payment_response_spec.rb
@@ -2,11 +2,12 @@
 #
 # Table name: payment_responses
 #
-#  id         :uuid             not null, primary key
-#  processed  :boolean          default(FALSE)
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  user_id    :uuid             not null
+#  id            :uuid             not null, primary key
+#  downloaded_at :datetime
+#  processed     :boolean          default(FALSE)
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  user_id       :uuid             not null
 #
 # Indexes
 #

--- a/spec/models/claims/payment_spec.rb
+++ b/spec/models/claims/payment_spec.rb
@@ -2,10 +2,11 @@
 #
 # Table name: payments
 #
-#  id         :uuid             not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  sent_by_id :uuid             not null
+#  id            :uuid             not null, primary key
+#  downloaded_at :datetime
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  sent_by_id    :uuid             not null
 #
 # Indexes
 #

--- a/spec/models/claims/provider_sampling_spec.rb
+++ b/spec/models/claims/provider_sampling_spec.rb
@@ -2,11 +2,12 @@
 #
 # Table name: provider_samplings
 #
-#  id          :uuid             not null, primary key
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  provider_id :uuid             not null
-#  sampling_id :uuid             not null
+#  id            :uuid             not null, primary key
+#  downloaded_at :datetime
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  provider_id   :uuid             not null
+#  sampling_id   :uuid             not null
 #
 # Indexes
 #


### PR DESCRIPTION
## Context

- Add `downloaded_at` to models containing `csv_file` attachments.

## Changes proposed in this pull request

- Add `downloaded_at` columns to:
  - Claims::Clawback
  - Claims::Payment
  - Claims::PaymentResponse
  - Claims::ProviderSampling

## Link to Trello card

https://trello.com/c/pzSI6C8H/343-add-downloadedat-column-to-tables-with-csv-files
