### PR TITLE
Download only once

### DIFF
--- a/app/controllers/claims/clawback/claims_controller.rb
+++ b/app/controllers/claims/clawback/claims_controller.rb
@@ -4,6 +4,7 @@ class Claims::Clawback::ClaimsController < Claims::ApplicationController
   before_action :skip_authorization
   before_action :validate_token
   before_action :set_clawback
+  after_action :mark_as_downloaded, only: :download
 
   def download
     send_data @clawback.csv_file.download, filename: "clawback-claims-#{Time.current.iso8601}.csv"
@@ -19,11 +20,18 @@ class Claims::Clawback::ClaimsController < Claims::ApplicationController
 
   def set_clawback
     @clawback = Claims::Clawback.find(@clawback_id)
-  rescue ActiveRecord::RecordNotFound
+    raise CSVPreviouslyDownloadedError if @clawback.downloaded?
+  rescue ActiveRecord::RecordNotFound, CSVPreviouslyDownloadedError
     render "error"
   end
 
   def token_param
     params.fetch(:token, nil)
   end
+
+  def mark_as_downloaded
+    @clawback.update!(downloaded_at: Time.current)
+  end
 end
+
+class CSVPreviouslyDownloadedError < StandardError; end

--- a/app/models/claims/clawback.rb
+++ b/app/models/claims/clawback.rb
@@ -12,4 +12,8 @@ class Claims::Clawback < ApplicationRecord
   has_many :claims, through: :clawback_claims
 
   has_one_attached :csv_file
+
+  def downloaded?
+    downloaded_at.present?
+  end
 end

--- a/app/models/claims/payment.rb
+++ b/app/models/claims/payment.rb
@@ -23,4 +23,8 @@ class Claims::Payment < ApplicationRecord
   has_many :claims, through: :payment_claims, class_name: "Claims::Claim"
 
   has_one_attached :csv_file
+
+  def downloaded?
+    downloaded_at.present?
+  end
 end

--- a/app/models/claims/payment_response.rb
+++ b/app/models/claims/payment_response.rb
@@ -27,4 +27,8 @@ class Claims::PaymentResponse < ApplicationRecord
   def row_count
     @row_count ||= CSV.parse(csv_file.download, headers: true).length
   end
+
+  def downloaded?
+    downloaded_at.present?
+  end
 end

--- a/app/models/claims/provider_sampling.rb
+++ b/app/models/claims/provider_sampling.rb
@@ -31,4 +31,8 @@ class Claims::ProviderSampling < ApplicationRecord
   scope :order_by_provider_name, -> { joins(:provider).order(providers: { name: :asc }) }
 
   delegate :email_address, :name, to: :provider, prefix: true
+
+  def downloaded?
+    downloaded_at.present?
+  end
 end

--- a/spec/models/claims/clawback_spec.rb
+++ b/spec/models/claims/clawback_spec.rb
@@ -18,4 +18,24 @@ RSpec.describe Claims::Clawback, type: :model do
   describe "attachments" do
     it { is_expected.to have_one_attached(:csv_file) }
   end
+
+  describe "#downloaded?" do
+    let(:clawback) { create(:claims_clawback, downloaded_at:) }
+
+    context "when downloaded_at is present" do
+      let(:downloaded_at) { Time.current }
+
+      it "returns true" do
+        expect(clawback.downloaded?).to be(true)
+      end
+    end
+
+    context "when downloaded_at is blank" do
+      let(:downloaded_at) { nil }
+
+      it "returns false" do
+        expect(clawback.downloaded?).to be(false)
+      end
+    end
+  end
 end

--- a/spec/models/claims/payment_response_spec.rb
+++ b/spec/models/claims/payment_response_spec.rb
@@ -24,4 +24,24 @@ RSpec.describe Claims::PaymentResponse, type: :model do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to have_one_attached(:csv_file) }
   end
+
+  describe "#downloaded?" do
+    let(:payment_response) { create(:claims_payment_response, downloaded_at:) }
+
+    context "when downloaded_at is present" do
+      let(:downloaded_at) { Time.current }
+
+      it "returns true" do
+        expect(payment_response.downloaded?).to be(true)
+      end
+    end
+
+    context "when downloaded_at is blank" do
+      let(:downloaded_at) { nil }
+
+      it "returns false" do
+        expect(payment_response.downloaded?).to be(false)
+      end
+    end
+  end
 end

--- a/spec/models/claims/payment_spec.rb
+++ b/spec/models/claims/payment_spec.rb
@@ -25,4 +25,24 @@ RSpec.describe Claims::Payment, type: :model do
     it { is_expected.to have_many(:claims).through(:payment_claims) }
     it { is_expected.to have_one_attached(:csv_file) }
   end
+
+  describe "#downloaded?" do
+    let(:payment) { create(:claims_payment, downloaded_at:) }
+
+    context "when downloaded_at is present" do
+      let(:downloaded_at) { Time.current }
+
+      it "returns true" do
+        expect(payment.downloaded?).to be(true)
+      end
+    end
+
+    context "when downloaded_at is blank" do
+      let(:downloaded_at) { nil }
+
+      it "returns false" do
+        expect(payment.downloaded?).to be(false)
+      end
+    end
+  end
 end

--- a/spec/models/claims/provider_sampling_spec.rb
+++ b/spec/models/claims/provider_sampling_spec.rb
@@ -37,4 +37,24 @@ RSpec.describe Claims::ProviderSampling, type: :model do
     it { is_expected.to delegate_method(:email_address).to(:provider).with_prefix }
     it { is_expected.to delegate_method(:name).to(:provider).with_prefix }
   end
+
+  describe "#downloaded?" do
+    let(:provider_sampling) { create(:provider_sampling, downloaded_at:) }
+
+    context "when downloaded_at is present" do
+      let(:downloaded_at) { Time.current }
+
+      it "returns true" do
+        expect(provider_sampling.downloaded?).to be(true)
+      end
+    end
+
+    context "when downloaded_at is blank" do
+      let(:downloaded_at) { nil }
+
+      it "returns false" do
+        expect(provider_sampling.downloaded?).to be(false)
+      end
+    end
+  end
 end

--- a/spec/system/claims/clawback/claims/esfa_user_downloads_a_clawback_which_has_already_been_downloaded_spec.rb
+++ b/spec/system/claims/clawback/claims/esfa_user_downloads_a_clawback_which_has_already_been_downloaded_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe "ESFA user downloads a clawback CSV which has already been downloaded", service: :claims, type: :system do
+  scenario do
+    given_one_of_my_claims_have_been_clawed_back
+    and_the_token_is_invalid
+
+    when_i_visit_the_download_link_in_the_email
+    then_i_see_the_error_page
+  end
+
+  private
+
+  def given_one_of_my_claims_have_been_clawed_back
+    @clawback = create(:claims_clawback, downloaded_at: Time.current)
+  end
+
+  def and_the_token_is_invalid
+    @token = Rails.application.message_verifier(:clawback).generate(@clawback.id, expires_in: 7.days)
+  end
+
+  def when_i_visit_the_download_link_in_the_email
+    visit claims_clawback_claims_path(token: @token)
+  end
+
+  def then_i_see_the_error_page
+    expect(page).to have_title("Sorry, there is a problem with the download link - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Sorry, there is a problem with the download link")
+    expect(page).to have_element(:p, text: "You are seeing this page because the download link is not working. It may have timed out or contained an invalid security token.", class: "govuk-body")
+    expect(page).to have_element(:p, text: "Email ittmentor.funding@education.gov.uk to request a new download link.", class: "govuk-body")
+  end
+end

--- a/spec/system/claims/clawback/claims/esfa_user_downloads_clawback_csv_with_valid_token_spec.rb
+++ b/spec/system/claims/clawback/claims/esfa_user_downloads_clawback_csv_with_valid_token_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "ESFA user downloads clawback CSV with valid token", service: :cl
 
     when_i_click_on_the_download_button
     then_the_csv_is_downloaded
+    and_the_clawback_is_marked_as_downloaded
   end
 
   private
@@ -42,5 +43,9 @@ RSpec.describe "ESFA user downloads clawback CSV with valid token", service: :cl
     current_time = Time.zone.now.utc.strftime("%Y-%m-%dT%H%%3A%M%%3A%SZ")
     expect(page.response_headers["Content-Type"]).to eq("text/csv")
     expect(page.response_headers["Content-Disposition"]).to eq("attachment; filename=\"clawback-claims-#{current_time}.csv\"; filename*=UTF-8''clawback-claims-#{current_time}.csv")
+  end
+
+  def and_the_clawback_is_marked_as_downloaded
+    expect(@clawback.reload.downloaded?).to be(true)
   end
 end

--- a/spec/system/claims/payments/claims/download_claims_spec.rb
+++ b/spec/system/claims/payments/claims/download_claims_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "Download payment claims", service: :claims, type: :system do
 
     when_i_click_on_the_download_button
     then_a_csv_file_is_downloaded
+    and_the_payment_is_marked_as_downloaded
   end
 
   scenario "ESFA user clicks on an expired link in their email inbox" do
@@ -58,5 +59,9 @@ RSpec.describe "Download payment claims", service: :claims, type: :system do
 
   def then_a_csv_file_is_downloaded
     expect(response_headers["Content-Type"]).to eq "text/csv"
+  end
+
+  def and_the_payment_is_marked_as_downloaded
+    expect(payment.reload.downloaded?).to be(true)
   end
 end

--- a/spec/system/claims/payments/claims/esfa_user_downloads_a_payment_spec.rb
+++ b/spec/system/claims/payments/claims/esfa_user_downloads_a_payment_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe "ESFA user downloads a payment CSV which has already been downloaded", service: :claims, type: :system do
+  scenario do
+    given_one_of_my_claims_have_been_paid
+    and_the_token_is_invalid
+
+    when_i_visit_the_download_link_in_the_email
+    then_i_see_the_error_page
+  end
+
+  private
+
+  def given_one_of_my_claims_have_been_paid
+    @payment = create(:claims_payment, downloaded_at: Time.current)
+  end
+
+  def and_the_token_is_invalid
+    @token = Rails.application.message_verifier(:payments).generate(@payment.id, expires_in: 7.days)
+  end
+
+  def when_i_visit_the_download_link_in_the_email
+    visit claims_payments_claims_path(token: @token)
+  end
+
+  def then_i_see_the_error_page
+    expect(page).to have_title("Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Sorry, there is a problem with the download link")
+    expect(page).to have_element(:p, text: "You are seeing this page because the download link is not working. It may have timed out or contained an invalid security token.", class: "govuk-body")
+    expect(page).to have_element(:p, text: "Email ittmentor.funding@education.gov.uk to request a new download link.", class: "govuk-body")
+  end
+end

--- a/spec/system/claims/sampling/claims/provider_user_downloads_sampling_csv_which_has_already_been_downloaded_spec.rb
+++ b/spec/system/claims/sampling/claims/provider_user_downloads_sampling_csv_which_has_already_been_downloaded_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe "Provider user downloads a sampling CSV with expired token", service: :claims, type: :system do
+  scenario do
+    given_one_of_my_claims_has_been_sampled
+    and_the_token_has_expired
+
+    when_i_visit_the_download_link_in_the_email
+    then_i_see_the_error_page
+  end
+
+  private
+
+  def given_one_of_my_claims_has_been_sampled
+    @provider_sampling = create(:provider_sampling, downloaded_at: Time.current)
+  end
+
+  def and_the_token_has_expired
+    @token = Rails.application.message_verifier(:sampling).generate(@provider_sampling.id, expires_in: 7.days)
+  end
+
+  def when_i_visit_the_download_link_in_the_email
+    visit claims_sampling_claims_path(token: @token)
+  end
+
+  def then_i_see_the_error_page
+    expect(page).to have_title("Sorry, there is a problem with the download link - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Sorry, there is a problem with the download link")
+    expect(page).to have_element(:p, text: "You are seeing this page because the download link is not working. It may have timed out or contained an invalid security token.", class: "govuk-body")
+    expect(page).to have_element(:p, text: "Email ittmentor.funding@education.gov.uk to request a new download link.", class: "govuk-body")
+  end
+end

--- a/spec/system/claims/sampling/claims/provider_user_downloads_sampling_csv_with_valid_token_spec.rb
+++ b/spec/system/claims/sampling/claims/provider_user_downloads_sampling_csv_with_valid_token_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "Provider user downloads sampling CSV with valid token", service:
 
     when_i_click_on_the_download_button
     then_the_csv_is_downloaded
+    and_the_sampling_is_marked_as_downloaded
   end
 
   private
@@ -43,5 +44,9 @@ RSpec.describe "Provider user downloads sampling CSV with valid token", service:
     provider_name = @provider_sampling.provider_name.parameterize
     expect(page.response_headers["Content-Type"]).to eq("text/csv")
     expect(page.response_headers["Content-Disposition"]).to eq("attachment; filename=\"sampling-claims-#{provider_name}-#{current_time}.csv\"; filename*=UTF-8''sampling-claims-#{provider_name}-#{current_time}.csv")
+  end
+
+  def and_the_sampling_is_marked_as_downloaded
+    expect(@provider_sampling.reload.downloaded?).to be(true)
   end
 end


### PR DESCRIPTION
## Context

- Users can only download CSV files once.

## Changes proposed in this pull request

- When a user downloads a CSV, it assigns the time to the downloaded attribute.

## Guidance to review

- Test that the CSV links with tokens can only be downloaded once.

## Link to Trello card

https://trello.com/c/6s7As2KA/346-only-allow-csvs-to-be-downloaded-once
