### PR TITLE
Show request clawback button conditionally

### DIFF
--- a/app/views/claims/support/claims/clawbacks/show.html.erb
+++ b/app/views/claims/support/claims/clawbacks/show.html.erb
@@ -11,7 +11,9 @@
       <span class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></span>
       <h1 class="govuk-heading-l"><%= @claim.school_name %> <%= render Claim::StatusTagComponent.new(claim: @claim) %></h1>
 
-      <%= govuk_button_link_to("Request clawback", new_request_clawback_claims_support_claims_clawbacks_path(@claim)) %>
+      <% if @claim.sampling_not_approved? %>
+        <%= govuk_button_link_to("Request clawback", new_request_clawback_claims_support_claims_clawbacks_path(@claim)) %>
+      <% end %>
 
       <% if @claim.submitted? %>
         <p class="govuk-body"><%= t(".submitted_by", name: @claim.submitted_by.full_name, date: l(@claim.submitted_on, format: :long)) %></p>

--- a/spec/system/claims/support/claims/clawbacks/support_user_requests_a_clawback_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/support_user_requests_a_clawback_spec.rb
@@ -41,6 +41,9 @@ RSpec.describe "Support user requests a clawback on a claim", service: :claims, 
     then_i_see_a_success_message
     and_i_see_the_clawbacks_index_page
     and_i_see_the_claim_status_is_clawback_requested
+
+    when_i_click_on_claim_one
+    then_i_do_not_see_the_request_clawback_button
   end
 
   private
@@ -215,5 +218,13 @@ RSpec.describe "Support user requests a clawback on a claim", service: :claims, 
       "submitted_at" => I18n.l(@claim_one.submitted_at.to_date, format: :long),
       "amount" => @claim_one.amount.format(symbol: true, decimal_mark: ".", no_cents: true),
     })
+  end
+
+  def when_i_click_on_claim_one
+    click_on "11111111 - #{@claim_one.school_name}"
+  end
+
+  def then_i_do_not_see_the_request_clawback_button
+    expect(page).not_to have_link("Request clawback")
   end
 end


### PR DESCRIPTION
## Context

When requesting a clawback the "Request clawback" button was still visible, this is unintended behaviour.

## Changes proposed in this pull request

- [x] Only show the "Request clawback" button when the claim status is `"sampling_not_approved"`

## Guidance to review

- [x] Log in as Colin
- [x] Request a clawback
- [x] View the claim again and note the button is no longer visible

## Link to Trello card

[A clawback can be requested on a claim that has the status "Clawback requested"
](https://trello.com/c/Y14jBkwL/352-a-clawback-can-be-requested-on-a-claim-that-has-the-status-clawback-requested)

## Screenshots

![image](https://github.com/user-attachments/assets/5b852d2f-52a0-437f-87db-bb03bc23620b)

