### PR TITLE
Add validation for number of hours - must be greater than 0

### DIFF
--- a/app/wizards/claims/request_clawback_wizard/mentor_training_clawback_step.rb
+++ b/app/wizards/claims/request_clawback_wizard/mentor_training_clawback_step.rb
@@ -4,7 +4,7 @@ class Claims::RequestClawbackWizard::MentorTrainingClawbackStep < BaseStep
   attribute :reason_for_clawback
 
   validates :mentor_training_id, presence: true
-  validates :number_of_hours, presence: true, numericality: { only_integer: true, less_than_or_equal_to: proc { |step| step.mentor_training.hours_completed } }
+  validates :number_of_hours, presence: true, numericality: { only_integer: true, less_than_or_equal_to: proc { |step| step.mentor_training.hours_completed }, greater_than: 0 }
   validates :reason_for_clawback, presence: true
 
   delegate :mentor_trainings, to: :wizard

--- a/spec/wizards/claims/request_clawback_wizard/mentor_training_clawback_step_spec.rb
+++ b/spec/wizards/claims/request_clawback_wizard/mentor_training_clawback_step_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe Claims::RequestClawbackWizard::MentorTrainingClawbackStep, type: 
 
       it { is_expected.to be_valid }
     end
+
+    context "when the number of hours is less than 1" do
+      let(:attributes) { { mentor_training_id: mentor_training.id, number_of_hours: 0, reason_for_clawback: "reason" } }
+
+      it { is_expected.not_to be_valid }
+    end
   end
 
   describe "delegations" do


### PR DESCRIPTION
## Context

The number of hours for clawbacks must be greater than 0

## Changes proposed in this pull request

- [x] Add validation to ensure number of hours is greater than 0

## Guidance to review

- Log in as Colin
- Request a clawback
- Enter 0 in Number of hours
- See the validation error

## Link to Trello card

[Request clawback accepts 0 hours](https://trello.com/c/BaJbe25Q/348-request-clawback-accepts-0-hours)

## Screenshots

![image](https://github.com/user-attachments/assets/943b6f5c-476e-449e-922e-df6c1bd539ad)

