### PR TITLE
Remove square brackets from mentor names

### DIFF
--- a/config/locales/en/wizards/claims/provider_rejected_claim_wizard.yml
+++ b/config/locales/en/wizards/claims/provider_rejected_claim_wizard.yml
@@ -14,7 +14,7 @@ en:
           title: What reason has the provider given for rejecting %{mentor_name}?
           caption: Rejected by provider - Claim %{reference}
           mentor_training_assured: Has the provider assured this mentor's training?
-          please_add_reason: Only include details related to [%{mentor_name}].
+          please_add_reason: Only include details related to %{mentor_name}.
           continue: Continue
           hours_completed: 
             one: The school originally claimed %{mentor_name} has completed %{count} hour.

--- a/config/locales/en/wizards/claims/reject_claim_wizard.yml
+++ b/config/locales/en/wizards/claims/reject_claim_wizard.yml
@@ -23,7 +23,7 @@ en:
           hours_completed: 
             one: The school originally claimed %{mentor_name} has completed %{count} hour.
             other: The school originally claimed %{mentor_name} has completed %{count} hours.
-          please_add_reason: Only include details related to [%{mentor_name}].
+          please_add_reason: Only include details related to %{mentor_name}.
           provider_response: Provider response
         check_your_answers_step:
           page_title: Check your answers - Reject - Claim %{reference} - Sampling - Claims

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_mentor_who_is_being_rejected_by_the_provider_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_mentor_who_is_being_rejected_by_the_provider_spec.rb
@@ -145,11 +145,11 @@ RSpec.describe "Support user changes the mentor who is being rejected by the pro
       text: "The school originally claimed John Smith has completed 20 hours.",
       class: "govuk-inset-text",
     )
-    expect(page).to have_element(:label, text: "Only include details related to [John Smith]", class: "govuk-label")
+    expect(page).to have_element(:label, text: "Only include details related to John Smith", class: "govuk-label")
   end
 
   def when_i_enter_a_reason_why_the_provider_rejected_john_smith
-    fill_in "Only include details related to [John Smith]", with: "Provider rejected John Smith"
+    fill_in "Only include details related to John Smith", with: "Provider rejected John Smith"
   end
 
   def then_i_see_the_check_your_answers_page
@@ -210,11 +210,11 @@ RSpec.describe "Support user changes the mentor who is being rejected by the pro
       text: "The school originally claimed Jane Doe has completed 15 hours.",
       class: "govuk-inset-text",
     )
-    expect(page).to have_element(:label, text: "Only include details related to [Jane Doe]", class: "govuk-label")
+    expect(page).to have_element(:label, text: "Only include details related to Jane Doe", class: "govuk-label")
   end
 
   def when_i_enter_a_reason_why_the_provider_rejected_jane_doe
-    fill_in "Only include details related to [Jane Doe]", with: "Provider rejected Jane Doe"
+    fill_in "Only include details related to Jane Doe", with: "Provider rejected Jane Doe"
   end
 
   def and_i_see_the_rejection_details_for_jane_doe

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_reason_the_provider_rejected_the_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_reason_the_provider_rejected_the_mentor_spec.rb
@@ -140,11 +140,11 @@ RSpec.describe "Support user changes the reason the provider rejected the mentor
       text: "The school originally claimed John Smith has completed 20 hours.",
       class: "govuk-inset-text",
     )
-    expect(page).to have_element(:label, text: "Only include details related to [John Smith]", class: "govuk-label")
+    expect(page).to have_element(:label, text: "Only include details related to John Smith", class: "govuk-label")
   end
 
   def when_i_enter_a_reason_why_the_provider_rejected_john_smith
-    fill_in "Only include details related to [John Smith]", with: "Provider rejected John Smith"
+    fill_in "Only include details related to John Smith", with: "Provider rejected John Smith"
   end
 
   def then_i_see_the_check_your_answers_page
@@ -173,7 +173,7 @@ RSpec.describe "Support user changes the reason the provider rejected the mentor
   end
 
   def and_the_reason_why_the_provider_rejected_john_smith_is_prefilled
-    find_field "Only include details related to [John Smith]", with: "Provider rejected John Smith"
+    find_field "Only include details related to John Smith", with: "Provider rejected John Smith"
   end
 
   def when_i_click_on_confirm_and_reject_claim
@@ -185,7 +185,7 @@ RSpec.describe "Support user changes the reason the provider rejected the mentor
   end
 
   def when_i_enter_a_new_reason_why_the_provider_rejected_john_smith
-    fill_in "Only include details related to [John Smith]",
+    fill_in "Only include details related to John Smith",
             with: "New reason the provider rejected John Smith"
   end
 

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_does_not_enter_a_reason_why_the_provider_rejected_the_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_does_not_enter_a_reason_why_the_provider_rejected_the_mentor_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "Support user does not enter a reason why the provider rejected t
       text: "The school originally claimed John Smith has completed 20 hours.",
       class: "govuk-inset-text",
     )
-    expect(page).to have_element(:label, text: "Only include details related to [John Smith]", class: "govuk-label")
+    expect(page).to have_element(:label, text: "Only include details related to John Smith", class: "govuk-label")
   end
 
   def then_i_see_a_validation_error_for_entering_a_reason_with_john_smith_was_rejected_by_the_provider

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_marks_the_claim_as_provider_not_approved_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_marks_the_claim_as_provider_not_approved_spec.rb
@@ -194,11 +194,11 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
       text: "The school originally claimed John Smith has completed 20 hours.",
       class: "govuk-inset-text",
     )
-    expect(page).to have_element(:label, text: "Only include details related to [John Smith]", class: "govuk-label")
+    expect(page).to have_element(:label, text: "Only include details related to John Smith", class: "govuk-label")
   end
 
   def when_i_enter_a_reason_why_the_provider_rejected_john_smith
-    fill_in "Only include details related to [John Smith]", with: "Provider rejected John Smith"
+    fill_in "Only include details related to John Smith", with: "Provider rejected John Smith"
   end
   alias_method :and_i_enter_a_reason_why_the_provider_rejected_john_smith,
                :when_i_enter_a_reason_why_the_provider_rejected_john_smith
@@ -241,11 +241,11 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
   end
 
   def and_the_reason_why_the_provider_rejected_john_smith_is_prefilled
-    find_field "Only include details related to [John Smith]", with: "Provider rejected John Smith"
+    find_field "Only include details related to John Smith", with: "Provider rejected John Smith"
   end
 
   def and_the_reason_why_the_provider_rejected_jane_doe_is_prefilled
-    find_field "Only include details related to [Jane Doe]", with: "Provider rejected Jane Doe"
+    find_field "Only include details related to Jane Doe", with: "Provider rejected Jane Doe"
   end
 
   def and_john_smith_is_preselected
@@ -275,11 +275,11 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
       text: "The school originally claimed Jane Doe has completed 15 hours.",
       class: "govuk-inset-text",
     )
-    expect(page).to have_element(:label, text: "Only include details related to [Jane Doe]", class: "govuk-label")
+    expect(page).to have_element(:label, text: "Only include details related to Jane Doe", class: "govuk-label")
   end
 
   def when_i_enter_a_reason_why_the_provider_rejected_jane_doe
-    fill_in "Only include details related to [Jane Doe]", with: "Provider rejected Jane Doe"
+    fill_in "Only include details related to Jane Doe", with: "Provider rejected Jane Doe"
   end
   alias_method :and_i_enter_a_reason_why_the_provider_rejected_jane_doe,
                :when_i_enter_a_reason_why_the_provider_rejected_jane_doe

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_changes_the_reason_the_school_rejected_the_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_changes_the_reason_the_school_rejected_the_mentor_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe "Support user changes the reason the school rejected the mentor",
   alias_method :and_i_click_on_continue, :when_i_click_on_continue
 
   def when_i_enter_a_new_reason_why_the_school_rejected_john_smith
-    fill_in "Only include details related to [John Smith]", with: "New reason school rejected John Smith"
+    fill_in "Only include details related to John Smith", with: "New reason school rejected John Smith"
   end
 
   def then_i_see_the_check_your_answers_page
@@ -149,7 +149,7 @@ RSpec.describe "Support user changes the reason the school rejected the mentor",
   end
 
   def and_the_reason_why_the_school_rejected_john_smith_is_prefilled
-    find_field "Only include details related to [John Smith]", with: "School rejected John Smith"
+    find_field "Only include details related to John Smith", with: "School rejected John Smith"
   end
 
   def when_i_click_on_confirm_and_reject_claim
@@ -173,7 +173,7 @@ RSpec.describe "Support user changes the reason the school rejected the mentor",
       text: "The school originally claimed Jane Doe has completed 15 hours.",
       class: "govuk-inset-text",
     )
-    expect(page).to have_element(:label, text: "Only include details related to [Jane Doe]", class: "govuk-label")
+    expect(page).to have_element(:label, text: "Only include details related to Jane Doe", class: "govuk-label")
   end
 
   def then_i_see_the_rejection_reason_page_for_john_smith
@@ -193,11 +193,11 @@ RSpec.describe "Support user changes the reason the school rejected the mentor",
       text: "The school originally claimed John Smith has completed 20 hours.",
       class: "govuk-inset-text",
     )
-    expect(page).to have_element(:label, text: "Only include details related to [John Smith]", class: "govuk-label")
+    expect(page).to have_element(:label, text: "Only include details related to John Smith", class: "govuk-label")
   end
 
   def when_i_enter_a_reason_why_the_school_rejected_john_smith
-    fill_in "Only include details related to [John Smith]", with: "School rejected John Smith"
+    fill_in "Only include details related to John Smith", with: "School rejected John Smith"
   end
 
   def then_i_see_the_confirmation_page

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_does_not_enter_a_reason_why_the_school_rejected_the_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_does_not_enter_a_reason_why_the_school_rejected_the_mentor_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe "Support user does not enter a reason why the school rejected the
       text: "The school originally claimed John Smith has completed 20 hours.",
       class: "govuk-inset-text",
     )
-    expect(page).to have_element(:label, text: "Only include details related to [John Smith]", class: "govuk-label")
+    expect(page).to have_element(:label, text: "Only include details related to John Smith", class: "govuk-label")
   end
 
   def then_i_see_a_validation_error_for_entering_a_reason_with_john_smith_was_rejected_by_the_provider

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_marks_the_claim_as_rejected_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_marks_the_claim_as_rejected_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe "Support user marks a claim as rejected", service: :claims, type:
   alias_method :and_i_click_on_continue, :when_i_click_on_continue
 
   def when_i_enter_a_reason_why_the_school_rejected_john_smith
-    fill_in "Only include details related to [John Smith]", with: "School rejected John Smith"
+    fill_in "Only include details related to John Smith", with: "School rejected John Smith"
   end
   alias_method :and_i_enter_a_reason_why_the_school_rejected_john_smith,
                :when_i_enter_a_reason_why_the_school_rejected_john_smith
@@ -213,11 +213,11 @@ RSpec.describe "Support user marks a claim as rejected", service: :claims, type:
   end
 
   def and_the_reason_why_the_school_rejected_john_smith_is_prefilled
-    find_field "Only include details related to [John Smith]", with: "School rejected John Smith"
+    find_field "Only include details related to John Smith", with: "School rejected John Smith"
   end
 
   def and_the_reason_why_the_school_rejected_jane_doe_is_prefilled
-    find_field "Only include details related to [Jane Doe]", with: "School rejected Jane Doe"
+    find_field "Only include details related to Jane Doe", with: "School rejected Jane Doe"
   end
 
   def when_i_click_on_confirm_and_reject_claim
@@ -241,7 +241,7 @@ RSpec.describe "Support user marks a claim as rejected", service: :claims, type:
       text: "The school originally claimed Jane Doe has completed 15 hours.",
       class: "govuk-inset-text",
     )
-    expect(page).to have_element(:label, text: "Only include details related to [Jane Doe]", class: "govuk-label")
+    expect(page).to have_element(:label, text: "Only include details related to Jane Doe", class: "govuk-label")
   end
 
   def then_i_see_the_rejection_reason_page_for_john_smith
@@ -261,11 +261,11 @@ RSpec.describe "Support user marks a claim as rejected", service: :claims, type:
       text: "The school originally claimed John Smith has completed 20 hours.",
       class: "govuk-inset-text",
     )
-    expect(page).to have_element(:label, text: "Only include details related to [John Smith]", class: "govuk-label")
+    expect(page).to have_element(:label, text: "Only include details related to John Smith", class: "govuk-label")
   end
 
   def when_i_enter_a_reason_why_the_school_rejected_jane_doe
-    fill_in "Only include details related to [Jane Doe]", with: "School rejected Jane Doe"
+    fill_in "Only include details related to Jane Doe", with: "School rejected Jane Doe"
   end
   alias_method :and_i_enter_a_reason_why_the_school_rejected_jane_doe,
                :when_i_enter_a_reason_why_the_school_rejected_jane_doe


### PR DESCRIPTION
## Context

The [square brackets] from the copy were mistakenly copied into the build.

## Changes proposed in this pull request

- [x] Remove the square brackets from mentor names

## Guidance to review

- Log in as Colin
- Manually reject a claim from a provider that has been requested for sampling
- Check for any instances of square brackets
- Manually reject a claim from a school that has been requested for sampling
- Check for any instances of square brackets


## Link to Trello card

[Remove [square brackets] from mentor name
](https://trello.com/c/CR53Q1fB/350-remove-square-brackets-from-mentor-name)

## Screenshots

![image](https://github.com/user-attachments/assets/c28adecb-d3b3-443a-92c5-87a03938a617)
![image](https://github.com/user-attachments/assets/e7a0030a-ce1d-433f-9467-44d2ffdc90fb)
