### PR TITLE
Revert claims to submitted

### DIFF
--- a/app/controllers/claims/support/databases/claims_controller.rb
+++ b/app/controllers/claims/support/databases/claims_controller.rb
@@ -1,0 +1,12 @@
+class Claims::Support::Databases::ClaimsController < Claims::Support::ApplicationController
+  before_action :skip_authorization
+  def revert_to_submitted; end
+
+  def update_to_submitted
+    Claims::RevertClaimsToSubmitted.call
+
+    redirect_to claims_support_settings_path, flash: {
+      heading: t(".success"),
+    }
+  end
+end

--- a/app/services/claims/revert_claims_to_submitted.rb
+++ b/app/services/claims/revert_claims_to_submitted.rb
@@ -1,0 +1,23 @@
+class Claims::RevertClaimsToSubmitted < ApplicationService
+  def call
+    return if HostingEnvironment.env.production?
+
+    ActiveRecord::Base.transaction do
+      Claims::Claim.not_draft_status.update_all(
+        status: :submitted,
+        unpaid_reason: nil,
+        payment_in_progress_at: nil,
+        sampling_reason: nil,
+      )
+      Claims::MentorTraining.update_all(
+        hours_clawed_back: nil,
+        reason_clawed_back: nil,
+        reason_not_assured: nil,
+        not_assured: false,
+        reason_rejected: nil,
+        rejected: false,
+      )
+      Claims::ClaimActivity.destroy_all
+    end
+  end
+end

--- a/app/views/claims/support/databases/claims/revert_to_submitted.html.erb
+++ b/app/views/claims/support/databases/claims/revert_to_submitted.html.erb
@@ -1,0 +1,39 @@
+<% content_for :page_title, "Reset database" %>
+<% render "claims/support/primary_navigation", current: :settings %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: claims_support_settings_path) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <span class="govuk-caption-l"><%= t(".caption") %></span>
+  <h1 class="govuk-heading-l"><%= t(".title", environment: hosting_environment_phase(current_service).downcase) %></h1>
+
+  <p class="govuk-body"><%= t(".claims_changes", environment: hosting_environment_phase(current_service).downcase) %></p>
+
+  <%= govuk_list type: :bullet do %>
+    <%= tag.li tag.code("claim.status = 'submitted'", class: "inline-code") %>
+    <%= tag.li tag.code("claim.unpaid_reason = nil", class: "inline-code") %>
+    <%= tag.li tag.code("claim.payment_in_progress_at= nil", class: "inline-code") %>
+    <%= tag.li tag.code("claim.sampling_reason= nil", class: "inline-code") %>
+  <% end %>
+
+  <%= govuk_warning_text text: t(".warning"), classes: ["govuk-!-margin-top-4"] %>
+
+  <p class="govuk-body"><%= t(".mentor_trainings_changes", environment: hosting_environment_phase(current_service).downcase) %></p>
+
+  <%= govuk_list type: :bullet do %>
+    <%= tag.li tag.code("mentor_training.hours_clawed_back = nil", class: "inline-code") %>
+    <%= tag.li tag.code("mentor_training.reason_clawed_back = nil", class: "inline-code") %>
+    <%= tag.li tag.code("mentor_training.reason_not_assured = nil", class: "inline-code") %>
+    <%= tag.li tag.code("mentor_training.not_assured = false", class: "inline-code") %>
+    <%= tag.li tag.code("mentor_training.reason_rejected = nil", class: "inline-code") %>
+    <%= tag.li tag.code("mentor_training.rejected = false", class: "inline-code") %>
+  <% end %>
+
+  <p class="govuk-body"><%= t(".claim_activitiy_changes") %></p>
+
+  <%= govuk_button_to "Revert to Submitted", update_to_submitted_claims_support_database_databases_claims_path, warning: true, method: :put, class: "govuk-button--warning" %>
+
+  <%= govuk_link_to "Cancel", claims_support_settings_path, no_visited_state: true %>
+</div>

--- a/app/views/claims/support/settings/index.html.erb
+++ b/app/views/claims/support/settings/index.html.erb
@@ -11,6 +11,7 @@
         govuk_link_to(t(".claim_windows"), claims_support_claim_windows_path, no_visited_state: true),
         govuk_link_to(t(".emails"), claims_support_mailers_path, no_visited_state: true),
         (govuk_link_to(t(".reset_database"), reset_claims_support_database_path, no_visited_state: true) unless HostingEnvironment.env.production?),
+        (govuk_link_to(t(".revert_claims_to_submitted"), revert_to_submitted_claims_support_database_databases_claims_path, no_visited_state: true) unless HostingEnvironment.env.production?),
       ], spaced: true %>
     </div>
   </div>

--- a/config/locales/en/claims/support/databases.yml
+++ b/config/locales/en/claims/support/databases.yml
@@ -4,3 +4,14 @@ en:
       databases:
         destroy:
           success: Database has been reset
+        claims:
+          update_to_submitted:
+            success: Claims have been reverted to 'Submitted'
+          revert_to_submitted:
+            title: Are you sure you want to revert all claims in the %{environment} environment database to 'Submitted'?
+            caption: Revert all claims to 'Submitted'
+            warning: This action will not affect claims with the status 'draft' or 'internal_draft'.
+            claims_changes: "This action will perform the following changes to the `claims` table in the %{environment} database:"
+            mentor_trainings_changes: "This action will perform the following changes to the `mentor_trainings` table in the %{environment} database:"
+            claim_activitiy_changes: All `Claims::ClaimActivity` records will be destroyed.
+

--- a/config/locales/en/claims/support/settings.yml
+++ b/config/locales/en/claims/support/settings.yml
@@ -8,3 +8,4 @@ en:
           claim_windows: Claim windows
           emails: Emails
           reset_database: Reset database
+          revert_claims_to_submitted: Revert all claims to 'Submitted'

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -85,6 +85,14 @@ scope module: :claims, as: :claims, constraints: {
 
     unless HostingEnvironment.env.production?
       resource :database, only: %i[destroy] do
+        namespace :databases do
+          resources :claims, only: [] do
+            collection do
+              get :revert_to_submitted
+              put :update_to_submitted
+            end
+          end
+        end
         get :reset
       end
     end

--- a/spec/services/claims/revert_claims_to_submitted_spec.rb
+++ b/spec/services/claims/revert_claims_to_submitted_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe Claims::RevertClaimsToSubmitted do
+  describe "#call" do
+    before do
+      create(:claim)
+      create(:claim, :draft)
+      create(:claim, :submitted)
+      create(:claim, :submitted, status: :paid)
+      create(:claim, :payment_in_progress)
+      create(:claim, :payment_information_requested)
+      create(:claim, :payment_information_sent)
+      create(:claim, :submitted, status: :payment_not_approved, unpaid_reason: "Unpaid")
+      create(:claim, :submitted, status: :sampling_in_progress, sampling_reason: "Sampled")
+      create(:claim, :submitted, status: :sampling_provider_not_approved, sampling_reason: "Sampled")
+      create(:claim, :submitted, status: :sampling_not_approved, sampling_reason: "Sampled")
+      create(:claim, :submitted, status: :clawback_requested)
+      create(:claim, :submitted, status: :clawback_in_progress)
+      create(:claim, :submitted, status: :clawback_complete)
+
+      create_list(:claim_activity, 5, :sampling_uploaded)
+    end
+
+    context "when the environment is not Production" do
+      it "reverts the status of all non-draft claims to submitted" do
+        expect { described_class.call }.to change(Claims::Claim.submitted, :count).from(1).to(12)
+          .and not_change(Claims::Claim.draft, :count)
+          .and not_change(Claims::Claim.internal_draft, :count)
+          .and change(Claims::ClaimActivity, :count).from(5).to(0)
+      end
+
+      it "updates all sampling_reasons, unpaid_reasons and payment_in_progress_at attributes to nil" do
+        described_class.call
+        expect(Claims::Claim.distinct.pluck(:sampling_reason)).to contain_exactly(nil)
+        expect(Claims::Claim.distinct.pluck(:unpaid_reason)).to contain_exactly(nil)
+        expect(Claims::Claim.distinct.pluck(:payment_in_progress_at)).to contain_exactly(nil)
+      end
+
+      context "when the claim has mentor trainings" do
+        before do
+          create(:mentor_training, :submitted)
+          create(:mentor_training, :not_assured)
+          create(:mentor_training, :rejected)
+          create(:mentor_training, :rejected, hours_clawed_back: 20, reason_clawed_back: "Reason")
+        end
+
+        it "updates the hours_clawed_back, reason_clawed_back, reason_not_assured,
+          not_assured, reason_rejected, rejected attributes to nil (or false if boolean)" do
+          described_class.call
+          expect(Claims::MentorTraining.distinct.pluck(:hours_clawed_back)).to contain_exactly(nil)
+          expect(Claims::MentorTraining.distinct.pluck(:reason_clawed_back)).to contain_exactly(nil)
+          expect(Claims::MentorTraining.distinct.pluck(:reason_not_assured)).to contain_exactly(nil)
+          expect(Claims::MentorTraining.distinct.pluck(:not_assured)).to contain_exactly(false)
+          expect(Claims::MentorTraining.distinct.pluck(:reason_rejected)).to contain_exactly(nil)
+          expect(Claims::MentorTraining.distinct.pluck(:rejected)).to contain_exactly(false)
+        end
+      end
+    end
+
+    context "when the environment is Production" do
+      it "does nothing in Production" do
+        allow(HostingEnvironment).to receive(:env).and_return(ActiveSupport::EnvironmentInquirer.new("production"))
+
+        expect { described_class.call }.to not_change(Claims::Claim.submitted, :count)
+          .and not_change(Claims::ClaimActivity, :count)
+      end
+    end
+  end
+end

--- a/spec/system/claims/support/revert_claims_to_submitted/support_user_reverts_claims_to_submitted_spec.rb
+++ b/spec/system/claims/support/revert_claims_to_submitted/support_user_reverts_claims_to_submitted_spec.rb
@@ -1,0 +1,147 @@
+require "rails_helper"
+
+RSpec.describe "Support user reverts claims to submitted", service: :claims, type: :system do
+  scenario do
+    given_claims_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_claims_index_page
+    then_i_can_see_a_paid_claim
+    and_i_can_see_a_sampled_claim
+    and_i_can_see_a_clawed_back_claim
+
+    when_i_navigate_to_the_settings_page
+    and_i_click_on_revert_all_claims_to_submitted
+    then_i_see_the_page_to_review_all_claims_to_submitted
+
+    when_i_click_revert_to_submitted
+    then_i_see_a_success_message
+
+    when_i_navigate_to_the_claims_index_page
+    then_i_see_the_paid_claim_is_now_in_the_submitted_state
+    and_i_see_the_sampled_claim_is_now_in_the_submitted_state
+    and_i_see_the_clawed_back_claim_is_now_in_the_submitted_state
+  end
+
+  private
+
+  def given_claims_exist
+    @sampling_claim = create(:claim,
+                             :submitted,
+                             status: :sampling_in_progress,
+                             sampling_reason: "Randomly selected for audit")
+
+    @paid_claim = create(:claim,
+                         :submitted,
+                         status: :paid)
+
+    @clawed_back_claim = create(:claim, :submitted, status: :clawback_complete)
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_claims_index_page
+    within primary_navigation do
+      click_on "Claims"
+    end
+  end
+
+  def then_i_can_see_a_paid_claim
+    expect(page).to have_claim_card({
+      "title" => "#{@paid_claim.reference} - #{@paid_claim.school.name}",
+      "url" => "/support/claims/#{@paid_claim.id}",
+      "status" => "Paid",
+      "academic_year" => @paid_claim.academic_year.name,
+      "provider_name" => @paid_claim.provider.name,
+      "submitted_at" => I18n.l(@paid_claim.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+  end
+
+  def and_i_can_see_a_sampled_claim
+    expect(page).to have_claim_card({
+      "title" => "#{@sampling_claim.reference} - #{@sampling_claim.school.name}",
+      "url" => "/support/claims/#{@sampling_claim.id}",
+      "status" => "Sampling in progress",
+      "academic_year" => @sampling_claim.academic_year.name,
+      "provider_name" => @sampling_claim.provider.name,
+      "submitted_at" => I18n.l(@sampling_claim.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+  end
+
+  def and_i_can_see_a_clawed_back_claim
+    expect(page).to have_claim_card({
+      "title" => "#{@clawed_back_claim.reference} - #{@clawed_back_claim.school.name}",
+      "url" => "/support/claims/#{@clawed_back_claim.id}",
+      "status" => "Sampling in progress",
+      "academic_year" => @clawed_back_claim.academic_year.name,
+      "provider_name" => @clawed_back_claim.provider.name,
+      "submitted_at" => I18n.l(@clawed_back_claim.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+  end
+
+  def when_i_navigate_to_the_settings_page
+    within primary_navigation do
+      click_on "Settings"
+    end
+  end
+
+  def and_i_click_on_revert_all_claims_to_submitted
+    click_on "Revert all claims to 'Submitted'"
+  end
+
+  def then_i_see_the_page_to_review_all_claims_to_submitted
+    expect(page).to have_h1(
+      "Are you sure you want to revert all claims in the test environment database to 'Submitted'?",
+    )
+    expect(page).to have_element(:span, text: "Revert all claims to 'Submitted'", class: "govuk-caption-l")
+  end
+
+  def when_i_click_revert_to_submitted
+    click_on "Revert to Submitted"
+  end
+
+  def then_i_see_a_success_message
+    expect(page).to have_success_banner("Claims have been reverted to 'Submitted'")
+  end
+
+  def then_i_see_the_paid_claim_is_now_in_the_submitted_state
+    expect(page).to have_claim_card({
+      "title" => "#{@paid_claim.reference} - #{@paid_claim.school.name}",
+      "url" => "/support/claims/#{@paid_claim.id}",
+      "status" => "Submitted",
+      "academic_year" => @paid_claim.academic_year.name,
+      "provider_name" => @paid_claim.provider.name,
+      "submitted_at" => I18n.l(@paid_claim.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+  end
+
+  def and_i_see_the_sampled_claim_is_now_in_the_submitted_state
+    expect(page).to have_claim_card({
+      "title" => "#{@sampling_claim.reference} - #{@sampling_claim.school.name}",
+      "url" => "/support/claims/#{@sampling_claim.id}",
+      "status" => "Submitted",
+      "academic_year" => @sampling_claim.academic_year.name,
+      "provider_name" => @sampling_claim.provider.name,
+      "submitted_at" => I18n.l(@sampling_claim.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+  end
+
+  def and_i_see_the_clawed_back_claim_is_now_in_the_submitted_state
+    expect(page).to have_claim_card({
+      "title" => "#{@clawed_back_claim.reference} - #{@clawed_back_claim.school.name}",
+      "url" => "/support/claims/#{@clawed_back_claim.id}",
+      "status" => "Submitted",
+      "academic_year" => @clawed_back_claim.academic_year.name,
+      "provider_name" => @clawed_back_claim.provider.name,
+      "submitted_at" => I18n.l(@clawed_back_claim.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+  end
+end


### PR DESCRIPTION
## Context

- Allow Support Users the ability to revert claims to a "Submitted" state

## Changes proposed in this pull request

- Add a service and interface for Support users to revert claims back to a "Submitted" state

## Guidance to review

- Sign in as Colin (Support User)
- Navigate to Claims, to see all of your claims (hopefully in different states)
- Navigate to Settings
- Click "Revert all claims to 'Submitted'"
- Click "Revert to submitted"
- Navigate to Claims, to see all of your claims are now in a "Submitted" state.

## Link to Trello card

https://trello.com/c/Vr7bt1xZ/360-add-set-all-claims-to-submitted-feature-to-support-user-setting-page

## Screenshots

https://github.com/user-attachments/assets/613da761-133f-46b9-8ffc-cffff9a089d1

