### PR TITLE
Migrate provider emails to ProviderEmailAddress records

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -40,6 +40,7 @@ class Provider < ApplicationRecord
 
   has_many :user_memberships, as: :organisation
   has_many :users, through: :user_memberships
+  has_many :provider_email_addresses, dependent: :destroy
 
   enum :provider_type,
        { scitt: "scitt", lead_school: "lead_school", university: "university" },
@@ -59,4 +60,10 @@ class Provider < ApplicationRecord
   pg_search_scope :search_name_urn_ukprn_postcode,
                   against: %i[name postcode urn ukprn],
                   using: { trigram: { word_similarity: true } }
+
+  accepts_nested_attributes_for :provider_email_addresses, allow_destroy: true
+
+  def email_addresses
+    provider_email_addresses.pluck(:email_address).uniq
+  end
 end

--- a/app/models/provider_email_address.rb
+++ b/app/models/provider_email_address.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: provider_email_addresses
+#
+#  id            :uuid             not null, primary key
+#  email_address :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  provider_id   :uuid             not null
+#
+# Indexes
+#
+#  index_provider_email_addresses_on_provider_id  (provider_id)
+#  unique_provider_email                          (email_address,provider_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (provider_id => providers.id)
+#
+class ProviderEmailAddress < ApplicationRecord
+  belongs_to :provider
+
+  validates :email_address, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :email_address, uniqueness: { scope: :provider_id, case_sensitive: false }
+end

--- a/app/services/publish_teacher_training/provider/importer.rb
+++ b/app/services/publish_teacher_training/provider/importer.rb
@@ -71,8 +71,6 @@ module PublishTeacherTraining
       def upsert_emails_attributes
         emails_attributes = []
         @email_details.each do |record|
-          next if record[:email_address].blank?
-
           emails_attributes << {
             email_address: record[:email_address],
             provider_id: provider_by_code(record[:code]).id,

--- a/app/services/publish_teacher_training/provider/importer.rb
+++ b/app/services/publish_teacher_training/provider/importer.rb
@@ -4,6 +4,7 @@ module PublishTeacherTraining
       def call
         @invalid_records = []
         @records = []
+        @email_details = []
 
         fetch_providers
 
@@ -13,6 +14,10 @@ module PublishTeacherTraining
 
         Rails.logger.silence do
           ::Provider.upsert_all(@records, unique_by: :code)
+          ::ProviderEmailAddress.upsert_all(
+            upsert_emails_attributes,
+            unique_by: :unique_provider_email,
+          )
         end
 
         Rails.logger.info "Done!"
@@ -38,7 +43,7 @@ module PublishTeacherTraining
             provider_type: provider_attributes["provider_type"],
             ukprn: provider_attributes["ukprn"],
             urn: provider_attributes["urn"],
-            email_address: provider_attributes["email"],
+            email_address: provider_attributes["email"], # TODO: Remove once 'email_address' is removed from providers tables
             telephone: provider_attributes["telephone"],
             website: provider_attributes["website"],
             address1: provider_attributes["street_address_1"],
@@ -49,11 +54,35 @@ module PublishTeacherTraining
             postcode: provider_attributes["postcode"],
             accredited: provider_attributes["accredited_body"],
           }
+
+          next if provider_attributes["email"].blank?
+
+          @email_details << {
+            email_address: provider_attributes["email"],
+            code: provider_attributes["code"],
+          }
         end
 
         if providers.dig("links", "next").present?
           fetch_providers(providers.dig("links", "next"))
         end
+      end
+
+      def upsert_emails_attributes
+        emails_attributes = []
+        @email_details.each do |record|
+          next if record[:email_address].blank?
+
+          emails_attributes << {
+            email_address: record[:email_address],
+            provider_id: provider_by_code(record[:code]).id,
+          }
+        end
+        emails_attributes
+      end
+
+      def provider_by_code(code)
+        ::Provider.find_by(code:)
       end
     end
   end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -255,3 +255,9 @@ shared:
     - record_id
     - created_at
     - updated_at
+  :provider_email_addresses:
+    - id
+    - email_address
+    - provider_id
+    - created_at
+    - updated_at

--- a/db/migrate/20250114120009_create_provider_email_addresses.rb
+++ b/db/migrate/20250114120009_create_provider_email_addresses.rb
@@ -1,0 +1,11 @@
+class CreateProviderEmailAddresses < ActiveRecord::Migration[7.2]
+  def change
+    create_table :provider_email_addresses, id: :uuid do |t|
+      t.string :email_address
+      t.references :provider, null: false, foreign_key: true, type: :uuid
+      t.timestamps
+
+      t.index %i[email_address provider_id], unique: true, name: "unique_provider_email"
+    end
+  end
+end

--- a/db/migrate/20250114161953_migrate_provider_email_addresses.rb
+++ b/db/migrate/20250114161953_migrate_provider_email_addresses.rb
@@ -1,5 +1,7 @@
 class MigrateProviderEmailAddresses < ActiveRecord::Migration[7.2]
   def up
+    return unless Provider.column_names.include?("email_address")
+
     email_attributes = Provider.select(:email_address, :id)
       .map do |provider|
         { provider_id: provider.id, email_address: provider.email_address }
@@ -11,6 +13,6 @@ class MigrateProviderEmailAddresses < ActiveRecord::Migration[7.2]
   end
 
   def down
-    ProviderEmailAddress.destroy_all
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20250114161953_migrate_provider_email_addresses.rb
+++ b/db/migrate/20250114161953_migrate_provider_email_addresses.rb
@@ -1,0 +1,16 @@
+class MigrateProviderEmailAddresses < ActiveRecord::Migration[7.2]
+  def up
+    email_attributes = Provider.select(:email_address, :id)
+      .map do |provider|
+        { provider_id: provider.id, email_address: provider.email_address }
+      end
+    ProviderEmailAddress.upsert_all(
+      email_attributes,
+      unique_by: :unique_provider_email,
+    )
+  end
+
+  def down
+    ProviderEmailAddress.destroy_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_08_211418) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_14_161953) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -372,6 +372,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_08_211418) do
     t.index ["year_group"], name: "index_placements_on_year_group"
   end
 
+  create_table "provider_email_addresses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "email_address"
+    t.uuid "provider_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email_address", "provider_id"], name: "unique_provider_email", unique: true
+    t.index ["provider_id"], name: "index_provider_email_addresses_on_provider_id"
+  end
+
   create_table "provider_sampling_claims", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "claim_id", null: false
     t.uuid "provider_sampling_id", null: false
@@ -589,6 +598,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_08_211418) do
   add_foreign_key "placements", "providers"
   add_foreign_key "placements", "schools"
   add_foreign_key "placements", "subjects"
+  add_foreign_key "provider_email_addresses", "providers"
   add_foreign_key "provider_sampling_claims", "claims"
   add_foreign_key "provider_sampling_claims", "provider_samplings"
   add_foreign_key "provider_samplings", "providers"

--- a/spec/factories/provider_email_addresses.rb
+++ b/spec/factories/provider_email_addresses.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: provider_email_addresses
+#
+#  id            :uuid             not null, primary key
+#  email_address :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  provider_id   :uuid             not null
+#
+# Indexes
+#
+#  index_provider_email_addresses_on_provider_id  (provider_id)
+#  unique_provider_email                          (email_address,provider_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (provider_id => providers.id)
+#
+FactoryBot.define do
+  factory :provider_email_address do
+    association :provider
+    sequence(:email_address) { |n| "provider_email#{n}@example.com" }
+  end
+end

--- a/spec/models/provider_email_address_spec.rb
+++ b/spec/models/provider_email_address_spec.rb
@@ -1,0 +1,33 @@
+# == Schema Information
+#
+# Table name: provider_email_addresses
+#
+#  id            :uuid             not null, primary key
+#  email_address :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  provider_id   :uuid             not null
+#
+# Indexes
+#
+#  index_provider_email_addresses_on_provider_id  (provider_id)
+#  unique_provider_email                          (email_address,provider_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (provider_id => providers.id)
+#
+require "rails_helper"
+
+RSpec.describe ProviderEmailAddress, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:provider) }
+  end
+
+  describe "validations" do
+    subject(:test_provider_email_address) { build(:provider_email_address) }
+
+    it { is_expected.to validate_presence_of(:email_address) }
+    it { is_expected.to validate_uniqueness_of(:email_address).scoped_to(:provider_id).case_insensitive }
+  end
+end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Provider, type: :model do
   context "with associations" do
     it { is_expected.to have_many(:user_memberships) }
     it { is_expected.to have_many(:users).through(:user_memberships) }
+    it { is_expected.to have_many(:provider_email_addresses) }
   end
 
   describe "enums" do


### PR DESCRIPTION
## Context

- Migrate provider emails to new ProviderEmailAddress records

## Changes proposed in this pull request

- Add model ProviderEmailAddress
- Change provider importer to create ProviderEmailAddress records

## Guidance to review

- run migrations
- ProviderEmailAddress table is added
- Provider emails are migrated to ProviderEmailAddress records

-------

- run `bundle exec rake db:drop db:create db:setup`
- Seed should use the import and create ProviderEmailAddress records

## Link to Trello card

https://trello.com/c/FbmyXt7z/345-allow-providers-to-have-multiple-email-addresses

