### PR TITLE
Update status colour tags according to latest designs

### DIFF
--- a/app/components/claim/status_tag_component.rb
+++ b/app/components/claim/status_tag_component.rb
@@ -24,19 +24,19 @@ class Claim::StatusTagComponent < ApplicationComponent
   def status_colours
     {
       internal_draft: "grey",
-      draft: "grey",
-      submitted: "blue",
-      payment_in_progress: "turquoise",
-      payment_information_requested: "light-blue",
+      draft: "yellow",
+      submitted: "turquoise",
+      payment_in_progress: "yellow",
+      payment_information_requested: "turquoise",
       payment_information_sent: "yellow",
-      paid: "green",
-      payment_not_approved: "red",
-      sampling_in_progress: "purple",
-      sampling_provider_not_approved: "pink",
-      sampling_not_approved: "pink",
-      clawback_requested: "orange",
-      clawback_in_progress: "orange",
-      clawback_complete: "red",
+      paid: "blue",
+      payment_not_approved: "orange",
+      sampling_in_progress: "yellow",
+      sampling_provider_not_approved: "turquoise",
+      sampling_not_approved: "turquoise",
+      clawback_requested: "turquoise",
+      clawback_in_progress: "yellow",
+      clawback_complete: "blue",
     }.with_indifferent_access
   end
 end

--- a/spec/components/claim/status_tag_component_spec.rb
+++ b/spec/components/claim/status_tag_component_spec.rb
@@ -18,32 +18,32 @@ RSpec.describe Claim::StatusTagComponent, type: :component do
   context "when the claim's status is 'draft'" do
     let(:claim) { build(:claim, status: :draft) }
 
-    it "renders a grey tag" do
-      expect(page).to have_css(".govuk-tag--grey", text: "Draft")
+    it "renders a yellow tag" do
+      expect(page).to have_css(".govuk-tag--yellow", text: "Draft")
     end
   end
 
   context "when the claim's status is 'submitted'" do
     let(:claim) { build(:claim, status: :submitted) }
 
-    it "renders a blue tag" do
-      expect(page).to have_css(".govuk-tag--blue", text: "Submitted")
+    it "renders a turquoise tag" do
+      expect(page).to have_css(".govuk-tag--turquoise", text: "Submitted")
     end
   end
 
   context "when the claim's status is 'payment_in_progress'" do
     let(:claim) { build(:claim, status: :payment_in_progress) }
 
-    it "renders a turquoise tag" do
-      expect(page).to have_css(".govuk-tag--turquoise", text: "Payment in progress")
+    it "renders a yellow tag" do
+      expect(page).to have_css(".govuk-tag--yellow", text: "Payment in progress")
     end
   end
 
   context "when the claim's status is 'payment_information_requested'" do
     let(:claim) { build(:claim, status: :payment_information_requested) }
 
-    it "renders a light blue tag" do
-      expect(page).to have_css(".govuk-tag--light-blue", text: "Information requested")
+    it "renders a turquoise tag" do
+      expect(page).to have_css(".govuk-tag--turquoise", text: "Information requested")
     end
   end
 
@@ -58,64 +58,64 @@ RSpec.describe Claim::StatusTagComponent, type: :component do
   context "when the claim's status is 'paid'" do
     let(:claim) { build(:claim, status: :paid) }
 
-    it "renders a green tag" do
-      expect(page).to have_css(".govuk-tag--green", text: "Paid")
+    it "renders a blue tag" do
+      expect(page).to have_css(".govuk-tag--blue", text: "Paid")
     end
   end
 
   context "when the claim's status is 'payment_not_approved'" do
     let(:claim) { build(:claim, status: :payment_not_approved) }
 
-    it "renders a red tag" do
-      expect(page).to have_css(".govuk-tag--red", text: "Payment not approved")
+    it "renders a orange tag" do
+      expect(page).to have_css(".govuk-tag--orange", text: "Payment not approved")
     end
   end
 
   context "when the claim's status is 'sampling_in_progress'" do
     let(:claim) { build(:claim, status: :sampling_in_progress) }
 
-    it "renders a purple tag" do
-      expect(page).to have_css(".govuk-tag--purple", text: "Sampling in progress")
+    it "renders a yellow tag" do
+      expect(page).to have_css(".govuk-tag--yellow", text: "Sampling in progress")
     end
   end
 
   context "when the claim's status is 'sampling_provider_not_approved'" do
     let(:claim) { build(:claim, status: :sampling_provider_not_approved) }
 
-    it "renders a pink tag" do
-      expect(page).to have_css(".govuk-tag--pink", text: "Provider not approved")
+    it "renders a turquoise tag" do
+      expect(page).to have_css(".govuk-tag--turquoise", text: "Provider not approved")
     end
   end
 
   context "when the claim's status is 'sampling_not_approved'" do
     let(:claim) { build(:claim, status: :sampling_not_approved) }
 
-    it "renders a pink tag" do
-      expect(page).to have_css(".govuk-tag--pink", text: "Claim not approved")
+    it "renders a turquoise tag" do
+      expect(page).to have_css(".govuk-tag--turquoise", text: "Claim not approved")
     end
   end
 
   context "when the claim's status is 'clawback_requested'" do
     let(:claim) { build(:claim, status: :clawback_requested) }
 
-    it "renders a orange tag" do
-      expect(page).to have_css(".govuk-tag--orange", text: "Clawback requested")
+    it "renders a turquoise tag" do
+      expect(page).to have_css(".govuk-tag--turquoise", text: "Clawback requested")
     end
   end
 
   context "when the claim's status is 'clawback_in_progress'" do
     let(:claim) { build(:claim, status: :clawback_in_progress) }
 
-    it "renders a orange tag" do
-      expect(page).to have_css(".govuk-tag--orange", text: "Clawback in progress")
+    it "renders a yellow tag" do
+      expect(page).to have_css(".govuk-tag--yellow", text: "Clawback in progress")
     end
   end
 
   context "when the claim's status is 'clawback_complete'" do
     let(:claim) { build(:claim, status: :clawback_complete) }
 
-    it "renders a red tag" do
-      expect(page).to have_css(".govuk-tag--red", text: "Clawback complete")
+    it "renders a blue tag" do
+      expect(page).to have_css(".govuk-tag--blue", text: "Clawback complete")
     end
   end
 

--- a/spec/system/claims/support/claims/clawbacks/support_user_requests_a_clawback_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/support_user_requests_a_clawback_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "Support user requests a clawback on a claim", service: :claims, 
     expect(primary_navigation).to have_current_item("Claims")
     expect(page).to have_element(:span, text: "Clawbacks - Claim 11111111", class: "govuk-caption-l")
     expect(page).to have_h1(@claim_one.school_name)
-    expect(page).to have_element(:strong, text: "Claim not approved", class: "govuk-tag govuk-tag--pink")
+    expect(page).to have_element(:strong, text: "Claim not approved", class: "govuk-tag govuk-tag--turquoise")
     expect(page).to have_link("Request clawback", href: "/support/claims/clawbacks/claims/new/#{@claim_one.id}")
     expect(page).to have_summary_list_row("School", @claim_one.school_name)
     expect(page).to have_summary_list_row("Academic year", @claim_one.academic_year_name)

--- a/spec/system/claims/support/claims/clawbacks/support_user_views_clawbacks_index_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/support_user_views_clawbacks_index_spec.rb
@@ -180,6 +180,6 @@ RSpec.describe "Support user views clawbacks index", service: :claims, type: :sy
     )
     expect(page).to have_element(:span, text: "Clawbacks - Claim #{@clawback_requested_claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@clawback_requested_claim.school.name)
-    expect(page).to have_element(:strong, text: "Clawback requested", class: "govuk-tag govuk-tag--orange")
+    expect(page).to have_element(:strong, text: "Clawback requested", class: "govuk-tag govuk-tag--turquoise")
   end
 end

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_mentor_who_is_being_rejected_by_the_provider_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_mentor_who_is_being_rejected_by_the_provider_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Support user changes the mentor who is being rejected by the pro
     )
     expect(page).to have_element(:p, text: "Sampling - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@claim.school.name)
-    expect(page).to have_element(:strong, text: "Sampling in progress", class: "govuk-tag govuk-tag--purple")
+    expect(page).to have_element(:strong, text: "Sampling in progress", class: "govuk-tag govuk-tag--yellow")
   end
 
   def when_i_click_on_confirm_provider_rejected_claim
@@ -108,7 +108,7 @@ RSpec.describe "Support user changes the mentor who is being rejected by the pro
     )
     expect(page).to have_h1(@claim.school.name)
 
-    expect(page).to have_element(:strong, text: "Provider not approved", class: "govuk-tag govuk-tag--pink")
+    expect(page).to have_element(:strong, text: "Provider not approved", class: "govuk-tag govuk-tag--turquoise")
     expect(page).to have_success_banner("Claim updated")
   end
 

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_reason_the_provider_rejected_the_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_reason_the_provider_rejected_the_mentor_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "Support user changes the reason the provider rejected the mentor
     )
     expect(page).to have_element(:p, text: "Sampling - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@claim.school.name)
-    expect(page).to have_element(:strong, text: "Sampling in progress", class: "govuk-tag govuk-tag--purple")
+    expect(page).to have_element(:strong, text: "Sampling in progress", class: "govuk-tag govuk-tag--yellow")
   end
 
   def when_i_click_on_confirm_provider_rejected_claim
@@ -103,7 +103,7 @@ RSpec.describe "Support user changes the reason the provider rejected the mentor
     )
     expect(page).to have_h1(@claim.school.name)
 
-    expect(page).to have_element(:strong, text: "Provider not approved", class: "govuk-tag govuk-tag--pink")
+    expect(page).to have_element(:strong, text: "Provider not approved", class: "govuk-tag govuk-tag--turquoise")
     expect(page).to have_success_banner("Claim updated")
   end
 

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_does_not_enter_a_reason_why_the_provider_rejected_the_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_does_not_enter_a_reason_why_the_provider_rejected_the_mentor_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Support user does not enter a reason why the provider rejected t
     )
     expect(page).to have_element(:p, text: "Sampling - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@claim.school.name)
-    expect(page).to have_element(:strong, text: "Sampling in progress", class: "govuk-tag govuk-tag--purple")
+    expect(page).to have_element(:strong, text: "Sampling in progress", class: "govuk-tag govuk-tag--yellow")
   end
 
   def when_i_click_on_confirm_provider_rejected_claim

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_does_not_select_any_mentors_rejected_by_the_provider_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_does_not_select_any_mentors_rejected_by_the_provider_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Support user does not select any mentors rejected by the provide
     )
     expect(page).to have_element(:p, text: "Sampling - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@claim.school.name)
-    expect(page).to have_element(:strong, text: "Sampling in progress", class: "govuk-tag govuk-tag--purple")
+    expect(page).to have_element(:strong, text: "Sampling in progress", class: "govuk-tag govuk-tag--yellow")
   end
 
   def when_i_click_on_confirm_provider_rejected_claim

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_marks_the_claim_as_provider_not_approved_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_marks_the_claim_as_provider_not_approved_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
     )
     expect(page).to have_element(:p, text: "Sampling - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@claim.school.name)
-    expect(page).to have_element(:strong, text: "Sampling in progress", class: "govuk-tag govuk-tag--purple")
+    expect(page).to have_element(:strong, text: "Sampling in progress", class: "govuk-tag govuk-tag--yellow")
   end
 
   def when_i_click_on_confirm_provider_rejected_claim
@@ -152,7 +152,7 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
     )
     expect(page).to have_h1(@claim.school.name)
 
-    expect(page).to have_element(:strong, text: "Provider not approved", class: "govuk-tag govuk-tag--pink")
+    expect(page).to have_element(:strong, text: "Provider not approved", class: "govuk-tag govuk-tag--turquoise")
     expect(page).to have_success_banner("Claim updated")
   end
 

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_changes_the_reason_the_school_rejected_the_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_changes_the_reason_the_school_rejected_the_mentor_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "Support user changes the reason the school rejected the mentor",
     )
     expect(page).to have_element(:p, text: "Sampling - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@claim.school.name)
-    expect(page).to have_element(:strong, text: "Provider not approved", class: "govuk-tag govuk-tag--pink")
+    expect(page).to have_element(:strong, text: "Provider not approved", class: "govuk-tag govuk-tag--turquoise")
   end
 
   def when_i_click_on_reject_claim
@@ -102,7 +102,7 @@ RSpec.describe "Support user changes the reason the school rejected the mentor",
     )
     expect(page).to have_h1(@claim.school.name)
 
-    expect(page).to have_element(:strong, text: "Claim not approved", class: "govuk-tag govuk-tag--pink")
+    expect(page).to have_element(:strong, text: "Claim not approved", class: "govuk-tag govuk-tag--turquoise")
     expect(page).to have_success_banner("Claim updated")
   end
 

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_does_not_enter_a_reason_why_the_school_rejected_the_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_does_not_enter_a_reason_why_the_school_rejected_the_mentor_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Support user does not enter a reason why the school rejected the
     )
     expect(page).to have_element(:p, text: "Sampling - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@claim.school.name)
-    expect(page).to have_element(:strong, text: "Provider not approved", class: "govuk-tag govuk-tag--pink")
+    expect(page).to have_element(:strong, text: "Provider not approved", class: "govuk-tag govuk-tag--turquoise")
   end
 
   def when_i_click_on_reject_claim

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_marks_the_claim_as_rejected_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_marks_the_claim_as_rejected_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe "Support user marks a claim as rejected", service: :claims, type:
     )
     expect(page).to have_element(:p, text: "Sampling - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@claim.school.name)
-    expect(page).to have_element(:strong, text: "Provider not approved", class: "govuk-tag govuk-tag--pink")
+    expect(page).to have_element(:strong, text: "Provider not approved", class: "govuk-tag govuk-tag--turquoise")
   end
 
   def when_i_click_on_reject_claim
@@ -160,7 +160,7 @@ RSpec.describe "Support user marks a claim as rejected", service: :claims, type:
     )
     expect(page).to have_h1(@claim.school.name)
 
-    expect(page).to have_element(:strong, text: "Claim not approved", class: "govuk-tag govuk-tag--pink")
+    expect(page).to have_element(:strong, text: "Claim not approved", class: "govuk-tag govuk-tag--turquoise")
     expect(page).to have_success_banner("Claim updated")
   end
 

--- a/spec/system/claims/support/claims/sampling/support_user_approves_a_claim_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_approves_a_claim_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "Support user approves a claim", service: :claims, type: :system 
     )
     expect(page).to have_element(:p, text: "Sampling - Claim #{@sampling_claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@sampling_claim.school.name)
-    expect(page).to have_element(:strong, text: "Sampling in progress", class: "govuk-tag govuk-tag--purple")
+    expect(page).to have_element(:strong, text: "Sampling in progress", class: "govuk-tag govuk-tag--yellow")
   end
 
   def when_i_click_on_back
@@ -151,6 +151,6 @@ RSpec.describe "Support user approves a claim", service: :claims, type: :system 
     expect(page).to have_h2("Claims (2)")
     expect(page).to have_link("#{@sampling_claim.reference} - #{@sampling_claim.school.name}", href: "/support/claims/#{@sampling_claim.id}")
     expect(page).to have_link("#{@paid_claim.reference} - #{@paid_claim.school.name}", href: "/support/claims/#{@paid_claim.id}")
-    expect(page).to have_element(:strong, text: "Paid", class: "govuk-tag govuk-tag--green", count: 2)
+    expect(page).to have_element(:strong, text: "Paid", class: "govuk-tag govuk-tag--blue", count: 2)
   end
 end


### PR DESCRIPTION
## Context

We have decided to update the status labels to improve the understanding for support users

## Changes proposed in this pull request

Update the Claim status labels to match the latest content changes:

#### Draft

Status: draft
Label: “Draft”
Tag colour: govuk-tag--yellow

#### Submitted

status: submitted
Label “Submitted”
Tag colour: govuk-tag--turquoise

#### Paid

status: paid
Label “Paid”
Tag colour: govuk-tag--blue

#### Payer payment review

status: payment_in_progress
Label “Payer payment review”
Tag colour: govuk-tag--yellow

#### Payer needs information

status: payment_information_requested
Label “Payer needs information”
Tag colour: govuk-tag--turquoise

#### Information sent to payer

status: payment_information_sent
Label “Information sent to payer”
Tag colour: govuk-tag--yellow

#### Rejected by payer

status: payment_not_approved
Label “Rejected by payer”
Tag colour: govuk-tag--orange

#### Audit requested

status: sampling_in_progress
Label "Audit requested"
Tag colour: govuk-tag--yellow

#### Rejected by provider

status: sampling_provider_not_approved
Label "Rejected by provider"
Tag colour: govuk-tag--turquoise

#### Rejected by school

status: sampling_not_approved
Label "Rejected by school"
Tag colour: govuk-tag--turquoise

#### Ready for clawback

status: clawback_requested
Label "Ready for clawback"
Tag colour: govuk-tag--turquoise

#### Sent to payer for clawback

status: clawback_in_progress
Label "Sent to payer for clawback"
Tag colour: govuk-tag--yellow

#### Clawback complete

status: clawback_complete
Label "Clawback complete"
Tag colour: govuk-tag--blue

## Guidance to review

- Log in as Colin.
- Navigate to Claims > All claims.
- Review the existing tags and compare with the mapping above.

## Link to Trello card

https://trello.com/c/HMzyPzQX/368-update-claims-status-labels

## Screenshots

<img width="1005" alt="Screenshot 2025-01-16 at 11 19 15" src="https://github.com/user-attachments/assets/6448e260-e83e-434e-9687-795fb13c1aaa" />
