### PR TITLE
Improve policies to prevent claims being changed after being submitted

### DIFF
--- a/app/models/claims/claim.rb
+++ b/app/models/claims/claim.rb
@@ -144,6 +144,10 @@ class Claims::Claim < ApplicationRecord
     mentor_trainings.not_assured.sum { |mt| mt.hours_clawed_back * school.region_funding_available_per_hour }
   end
 
+  def in_draft?
+    DRAFT_STATUSES.include?(status.to_sym)
+  end
+
   private
 
   def has_revision?

--- a/app/policies/claims/claim_policy.rb
+++ b/app/policies/claims/claim_policy.rb
@@ -4,7 +4,7 @@ class Claims::ClaimPolicy < Claims::ApplicationPolicy
   end
 
   def edit?
-    claim_claim_window_current? && !record.submitted?
+    claim_claim_window_current? && record.in_draft?
   end
 
   def update?
@@ -16,7 +16,7 @@ class Claims::ClaimPolicy < Claims::ApplicationPolicy
   end
 
   def submit?
-    current_claim_window? && !record.submitted?
+    current_claim_window? && record.in_draft?
   end
 
   def rejected?
@@ -32,7 +32,7 @@ class Claims::ClaimPolicy < Claims::ApplicationPolicy
   end
 
   def check?
-    record.draft? || record.internal_draft?
+    record.in_draft?
   end
 
   private

--- a/app/policies/claims/support/claim_policy.rb
+++ b/app/policies/claims/support/claim_policy.rb
@@ -4,7 +4,7 @@ class Claims::Support::ClaimPolicy < Claims::ApplicationPolicy
   end
 
   def edit?
-    claim_claim_window_current? && !record.submitted?
+    claim_claim_window_current? && record.in_draft?
   end
 
   def update?
@@ -16,7 +16,7 @@ class Claims::Support::ClaimPolicy < Claims::ApplicationPolicy
   end
 
   def submit?
-    current_claim_window? && !user.support_user? && !record.submitted?
+    current_claim_window? && !user.support_user? && record.in_draft?
   end
 
   def rejected?
@@ -29,11 +29,11 @@ class Claims::Support::ClaimPolicy < Claims::ApplicationPolicy
 
   # TODO: Remove record.draft? and not create drafts for existing drafts
   def draft?
-    current_claim_window? && user.support_user? && (record.internal_draft? || record.draft?)
+    current_claim_window? && user.support_user? && record.in_draft?
   end
 
   def check?
-    record.draft? || record.internal_draft?
+    record.in_draft?
   end
 
   def download_csv?

--- a/spec/models/claims/claim_spec.rb
+++ b/spec/models/claims/claim_spec.rb
@@ -298,4 +298,120 @@ RSpec.describe Claims::Claim, type: :model do
       end
     end
   end
+
+  describe "#in_draft?" do
+    subject(:in_draft) { claim.in_draft? }
+
+    context "when the claim has the status internal draft" do
+      let(:claim) { create(:claim) }
+
+      it "returns true" do
+        expect(in_draft).to be(true)
+      end
+    end
+
+    context "when the claim has the status draft" do
+      let(:claim) { create(:claim, :draft) }
+
+      it "returns true" do
+        expect(in_draft).to be(true)
+      end
+    end
+
+    context "when the claim has status submitted" do
+      let(:claim) { create(:claim, :submitted) }
+
+      it "returns false" do
+        expect(in_draft).to be(false)
+      end
+    end
+
+    context "when the claim has status payment in progress" do
+      let(:claim) { create(:claim, :submitted, status: :payment_in_progress) }
+
+      it "returns false" do
+        expect(in_draft).to be(false)
+      end
+    end
+
+    context "when the claim has status payment information requested" do
+      let(:claim) { create(:claim, :submitted, status: :payment_information_requested) }
+
+      it "returns false" do
+        expect(in_draft).to be(false)
+      end
+    end
+
+    context "when the claim has status payment information sent" do
+      let(:claim) { create(:claim, :submitted, status: :payment_information_sent) }
+
+      it "returns false" do
+        expect(in_draft).to be(false)
+      end
+    end
+
+    context "when the claim has status paid" do
+      let(:claim) { create(:claim, :submitted, status: :paid) }
+
+      it "returns false" do
+        expect(in_draft).to be(false)
+      end
+    end
+
+    context "when the claim has status payment not approved" do
+      let(:claim) { create(:claim, :submitted, status: :payment_not_approved) }
+
+      it "returns false" do
+        expect(in_draft).to be(false)
+      end
+    end
+
+    context "when the claim has status sampling in progress" do
+      let(:claim) { create(:claim, :submitted, status: :sampling_in_progress) }
+
+      it "returns false" do
+        expect(in_draft).to be(false)
+      end
+    end
+
+    context "when the claim has status sampling provider not approved" do
+      let(:claim) { create(:claim, :submitted, status: :sampling_provider_not_approved) }
+
+      it "returns false" do
+        expect(in_draft).to be(false)
+      end
+    end
+
+    context "when the claim has status sampling not approved" do
+      let(:claim) { create(:claim, :submitted, status: :sampling_not_approved) }
+
+      it "returns false" do
+        expect(in_draft).to be(false)
+      end
+    end
+
+    context "when the claim has status clawback requested" do
+      let(:claim) { create(:claim, :submitted, status: :clawback_requested) }
+
+      it "returns false" do
+        expect(in_draft).to be(false)
+      end
+    end
+
+    context "when the claim has status clawback in progress" do
+      let(:claim) { create(:claim, :submitted, status: :clawback_in_progress) }
+
+      it "returns false" do
+        expect(in_draft).to be(false)
+      end
+    end
+
+    context "when the claim has status clawback complete" do
+      let(:claim) { create(:claim, :submitted, status: :clawback_complete) }
+
+      it "returns false" do
+        expect(in_draft).to be(false)
+      end
+    end
+  end
 end

--- a/spec/policies/claims/claim_policy_spec.rb
+++ b/spec/policies/claims/claim_policy_spec.rb
@@ -8,6 +8,24 @@ describe Claims::ClaimPolicy do
   let(:draft_claim) { build(:claim, :draft) }
   let(:submitted_claim) { build(:claim, :submitted) }
 
+  let(:payment_in_progress_claim) { create(:claim, :submitted, status: :payment_in_progress) }
+  let(:payment_information_requested_claim) do
+    create(:claim, :submitted, status: :payment_information_requested)
+  end
+  let(:payment_information_sent_claim) { create(:claim, :submitted, status: :payment_information_sent) }
+  let(:paid_claim) { create(:claim, :submitted, status: :paid) }
+  let(:payment_not_approved_claim) { create(:claim, :submitted, status: :payment_not_approved) }
+
+  let(:sampling_in_progress_claim) { create(:claim, :submitted, status: :sampling_in_progress) }
+  let(:sampling_provider_not_approved_claim) do
+    create(:claim, :submitted, status: :sampling_provider_not_approved)
+  end
+  let(:sampling_not_approved_claim) { create(:claim, :submitted, status: :sampling_not_approved) }
+
+  let(:clawback_requested_claim) { create(:claim, :submitted, status: :clawback_requested) }
+  let(:clawback_in_progress_claim) { create(:claim, :submitted, status: :clawback_in_progress) }
+  let(:clawback_complete_claim) { create(:claim, :submitted, status: :clawback_complete) }
+
   before do
     Claims::ClaimWindow::Build.call(claim_window_params: { starts_on: 2.days.ago, ends_on: 2.days.from_now }).save!(validate: false)
   end
@@ -30,6 +48,72 @@ describe Claims::ClaimPolicy do
         expect(claim_policy).not_to permit(user, submitted_claim)
       end
     end
+
+    context "when the user has a payment in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_in_progress_claim)
+      end
+    end
+
+    context "when the user has a payment information requested claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_information_requested_claim)
+      end
+    end
+
+    context "when the user has a payment information sent claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_information_sent_claim)
+      end
+    end
+
+    context "when the user has a paid claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, paid_claim)
+      end
+    end
+
+    context "when the user has a payment not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_not_approved_claim)
+      end
+    end
+
+    context "when the user has a sampling in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_in_progress_claim)
+      end
+    end
+
+    context "when the user has a sampling provider not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_provider_not_approved_claim)
+      end
+    end
+
+    context "when the user has a sampling not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_not_approved_claim)
+      end
+    end
+
+    context "when the user has a clawback requested claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_requested_claim)
+      end
+    end
+
+    context "when the user has a clawback in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_in_progress_claim)
+      end
+    end
+
+    context "when the user has a clawback complete claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_complete_claim)
+      end
+    end
   end
 
   permissions :update?, :rejected?, :submit? do
@@ -50,6 +134,72 @@ describe Claims::ClaimPolicy do
         expect(claim_policy).not_to permit(user, submitted_claim)
       end
     end
+
+    context "when the user has a payment in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_in_progress_claim)
+      end
+    end
+
+    context "when the user has a payment information requested claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_information_requested_claim)
+      end
+    end
+
+    context "when the user has a payment information sent claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_information_sent_claim)
+      end
+    end
+
+    context "when the user has a paid claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, paid_claim)
+      end
+    end
+
+    context "when the user has a payment not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_not_approved_claim)
+      end
+    end
+
+    context "when the user has a sampling in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_in_progress_claim)
+      end
+    end
+
+    context "when the user has a sampling provider not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_provider_not_approved_claim)
+      end
+    end
+
+    context "when the user has a sampling not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_not_approved_claim)
+      end
+    end
+
+    context "when the user has a clawback requested claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_requested_claim)
+      end
+    end
+
+    context "when the user has a clawback in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_in_progress_claim)
+      end
+    end
+
+    context "when the user has a clawback complete claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_complete_claim)
+      end
+    end
   end
 
   permissions :confirmation? do
@@ -60,7 +210,7 @@ describe Claims::ClaimPolicy do
     end
 
     context "when user has an internal draft claim" do
-      it "grants access" do
+      it "denies access" do
         expect(claim_policy).not_to permit(user, internal_draft_claim)
       end
     end
@@ -68,6 +218,72 @@ describe Claims::ClaimPolicy do
     context "when user has a draft claim" do
       it "denies access" do
         expect(claim_policy).not_to permit(user, draft_claim)
+      end
+    end
+
+    context "when the user has a payment in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_in_progress_claim)
+      end
+    end
+
+    context "when the user has a payment information requested claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_information_requested_claim)
+      end
+    end
+
+    context "when the user has a payment information sent claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_information_sent_claim)
+      end
+    end
+
+    context "when the user has a paid claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, paid_claim)
+      end
+    end
+
+    context "when the user has a payment not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_not_approved_claim)
+      end
+    end
+
+    context "when the user has a sampling in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_in_progress_claim)
+      end
+    end
+
+    context "when the user has a sampling provider not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_provider_not_approved_claim)
+      end
+    end
+
+    context "when the user has a sampling not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_not_approved_claim)
+      end
+    end
+
+    context "when the user has a clawback requested claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_requested_claim)
+      end
+    end
+
+    context "when the user has a clawback in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_in_progress_claim)
+      end
+    end
+
+    context "when the user has a clawback complete claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_complete_claim)
       end
     end
   end
@@ -88,6 +304,72 @@ describe Claims::ClaimPolicy do
     context "when user has a submitted claim" do
       it "denies access" do
         expect(claim_policy).not_to permit(user, submitted_claim)
+      end
+    end
+
+    context "when the user has a payment in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_in_progress_claim)
+      end
+    end
+
+    context "when the user has a payment information requested claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_information_requested_claim)
+      end
+    end
+
+    context "when the user has a payment information sent claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_information_sent_claim)
+      end
+    end
+
+    context "when the user has a paid claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, paid_claim)
+      end
+    end
+
+    context "when the user has a payment not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_not_approved_claim)
+      end
+    end
+
+    context "when the user has a sampling in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_in_progress_claim)
+      end
+    end
+
+    context "when the user has a sampling provider not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_provider_not_approved_claim)
+      end
+    end
+
+    context "when the user has a sampling not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_not_approved_claim)
+      end
+    end
+
+    context "when the user has a clawback requested claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_requested_claim)
+      end
+    end
+
+    context "when the user has a clawback in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_in_progress_claim)
+      end
+    end
+
+    context "when the user has a clawback complete claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_complete_claim)
       end
     end
   end

--- a/spec/policies/claims/support/claim_policy_spec.rb
+++ b/spec/policies/claims/support/claim_policy_spec.rb
@@ -9,6 +9,24 @@ describe Claims::Support::ClaimPolicy do
   let(:draft_claim) { build(:claim, :draft) }
   let(:submitted_claim) { build(:claim, :submitted) }
 
+  let(:payment_in_progress_claim) { create(:claim, :submitted, status: :payment_in_progress) }
+  let(:payment_information_requested_claim) do
+    create(:claim, :submitted, status: :payment_information_requested)
+  end
+  let(:payment_information_sent_claim) { create(:claim, :submitted, status: :payment_information_sent) }
+  let(:paid_claim) { create(:claim, :submitted, status: :paid) }
+  let(:payment_not_approved_claim) { create(:claim, :submitted, status: :payment_not_approved) }
+
+  let(:sampling_in_progress_claim) { create(:claim, :submitted, status: :sampling_in_progress) }
+  let(:sampling_provider_not_approved_claim) do
+    create(:claim, :submitted, status: :sampling_provider_not_approved)
+  end
+  let(:sampling_not_approved_claim) { create(:claim, :submitted, status: :sampling_not_approved) }
+
+  let(:clawback_requested_claim) { create(:claim, :submitted, status: :clawback_requested) }
+  let(:clawback_in_progress_claim) { create(:claim, :submitted, status: :clawback_in_progress) }
+  let(:clawback_complete_claim) { create(:claim, :submitted, status: :clawback_complete) }
+
   before do
     Claims::ClaimWindow::Build.call(claim_window_params: { starts_on: 2.days.ago, ends_on: 2.days.from_now }).save!(validate: false)
   end
@@ -31,6 +49,72 @@ describe Claims::Support::ClaimPolicy do
         expect(claim_policy).not_to permit(user, submitted_claim)
       end
     end
+
+    context "when the user has a payment in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_in_progress_claim)
+      end
+    end
+
+    context "when the user has a payment information requested claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_information_requested_claim)
+      end
+    end
+
+    context "when the user has a payment information sent claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_information_sent_claim)
+      end
+    end
+
+    context "when the user has a paid claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, paid_claim)
+      end
+    end
+
+    context "when the user has a payment not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_not_approved_claim)
+      end
+    end
+
+    context "when the user has a sampling in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_in_progress_claim)
+      end
+    end
+
+    context "when the user has a sampling provider not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_provider_not_approved_claim)
+      end
+    end
+
+    context "when the user has a sampling not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_not_approved_claim)
+      end
+    end
+
+    context "when the user has a clawback requested claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_requested_claim)
+      end
+    end
+
+    context "when the user has a clawback in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_in_progress_claim)
+      end
+    end
+
+    context "when the user has a clawback complete claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_complete_claim)
+      end
+    end
   end
 
   permissions :update? do
@@ -49,6 +133,72 @@ describe Claims::Support::ClaimPolicy do
     context "when user has a submitted claim" do
       it "denies access" do
         expect(claim_policy).not_to permit(user, submitted_claim)
+      end
+    end
+
+    context "when the user has a payment in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_in_progress_claim)
+      end
+    end
+
+    context "when the user has a payment information requested claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_information_requested_claim)
+      end
+    end
+
+    context "when the user has a payment information sent claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_information_sent_claim)
+      end
+    end
+
+    context "when the user has a paid claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, paid_claim)
+      end
+    end
+
+    context "when the user has a payment not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_not_approved_claim)
+      end
+    end
+
+    context "when the user has a sampling in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_in_progress_claim)
+      end
+    end
+
+    context "when the user has a sampling provider not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_provider_not_approved_claim)
+      end
+    end
+
+    context "when the user has a sampling not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_not_approved_claim)
+      end
+    end
+
+    context "when the user has a clawback requested claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_requested_claim)
+      end
+    end
+
+    context "when the user has a clawback in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_in_progress_claim)
+      end
+    end
+
+    context "when the user has a clawback complete claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_complete_claim)
       end
     end
   end
@@ -77,6 +227,72 @@ describe Claims::Support::ClaimPolicy do
         expect(claim_policy).not_to permit(support_user, submitted_claim)
       end
     end
+
+    context "when the user has a payment in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_in_progress_claim)
+      end
+    end
+
+    context "when the user has a payment information requested claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_information_requested_claim)
+      end
+    end
+
+    context "when the user has a payment information sent claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_information_sent_claim)
+      end
+    end
+
+    context "when the user has a paid claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, paid_claim)
+      end
+    end
+
+    context "when the user has a payment not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_not_approved_claim)
+      end
+    end
+
+    context "when the user has a sampling in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_in_progress_claim)
+      end
+    end
+
+    context "when the user has a sampling provider not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_provider_not_approved_claim)
+      end
+    end
+
+    context "when the user has a sampling not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_not_approved_claim)
+      end
+    end
+
+    context "when the user has a clawback requested claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_requested_claim)
+      end
+    end
+
+    context "when the user has a clawback in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_in_progress_claim)
+      end
+    end
+
+    context "when the user has a clawback complete claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_complete_claim)
+      end
+    end
   end
 
   permissions :rejected? do
@@ -103,6 +319,72 @@ describe Claims::Support::ClaimPolicy do
         expect(claim_policy).not_to permit(user, submitted_claim)
       end
     end
+
+    context "when the user has a payment in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_in_progress_claim)
+      end
+    end
+
+    context "when the user has a payment information requested claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_information_requested_claim)
+      end
+    end
+
+    context "when the user has a payment information sent claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_information_sent_claim)
+      end
+    end
+
+    context "when the user has a paid claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, paid_claim)
+      end
+    end
+
+    context "when the user has a payment not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_not_approved_claim)
+      end
+    end
+
+    context "when the user has a sampling in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_in_progress_claim)
+      end
+    end
+
+    context "when the user has a sampling provider not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_provider_not_approved_claim)
+      end
+    end
+
+    context "when the user has a sampling not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_not_approved_claim)
+      end
+    end
+
+    context "when the user has a clawback requested claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_requested_claim)
+      end
+    end
+
+    context "when the user has a clawback in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_in_progress_claim)
+      end
+    end
+
+    context "when the user has a clawback complete claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_complete_claim)
+      end
+    end
   end
 
   permissions :draft? do
@@ -127,6 +409,72 @@ describe Claims::Support::ClaimPolicy do
     context "when user is not a support user" do
       it "denies access" do
         expect(claim_policy).not_to permit(user, submitted_claim)
+      end
+    end
+
+    context "when the user has a payment in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_in_progress_claim)
+      end
+    end
+
+    context "when the user has a payment information requested claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_information_requested_claim)
+      end
+    end
+
+    context "when the user has a payment information sent claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_information_sent_claim)
+      end
+    end
+
+    context "when the user has a paid claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, paid_claim)
+      end
+    end
+
+    context "when the user has a payment not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, payment_not_approved_claim)
+      end
+    end
+
+    context "when the user has a sampling in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_in_progress_claim)
+      end
+    end
+
+    context "when the user has a sampling provider not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_provider_not_approved_claim)
+      end
+    end
+
+    context "when the user has a sampling not approved claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, sampling_not_approved_claim)
+      end
+    end
+
+    context "when the user has a clawback requested claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_requested_claim)
+      end
+    end
+
+    context "when the user has a clawback in progress claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_in_progress_claim)
+      end
+    end
+
+    context "when the user has a clawback complete claim" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, clawback_complete_claim)
       end
     end
   end


### PR DESCRIPTION
## Context

- Improve claims policies to prevent `Claims` being changed after they have been submitted.

## Changes proposed in this pull request

- Add a `in_draft?` method to determine whether or not a claim is in `draft` or `internal_draft` status.
- Amend polices to use the `in_draft?` method.

## Guidance to review

- View the show page for claims in each status to make sure the change links only show for claims in the `draft` or `internal draft` status.

## Link to Trello card

https://trello.com/c/Sl3Sqzod/351-claims-should-not-be-editable-after-being-submitted

## Screenshots
_Internal draft_
![screencapture-claims-localhost-3000-support-schools-000fa70e-dac1-4c30-bb75-f7af840f6ae5-claims-c114e06b-07cf-4006-a783-aa812a2de0fd-check-2025-01-16-16_38_37](https://github.com/user-attachments/assets/c62dd8c0-384a-4285-956c-abb82971e5a6)

_Draft_
![screencapture-claims-localhost-3000-support-schools-000fa70e-dac1-4c30-bb75-f7af840f6ae5-claims-c114e06b-07cf-4006-a783-aa812a2de0fd-2025-01-16-16_39_29](https://github.com/user-attachments/assets/73e6899e-0f24-48cb-a96d-87255dd35234)

![screencapture-claims-localhost-3000-schools-000fa70e-dac1-4c30-bb75-f7af840f6ae5-claims-c114e06b-07cf-4006-a783-aa812a2de0fd-2025-01-16-16_40_10](https://github.com/user-attachments/assets/a85964a1-624c-497c-b0b9-c3f82f0429b8)


_Submitted_
![screencapture-claims-localhost-3000-schools-000fa70e-dac1-4c30-bb75-f7af840f6ae5-claims-c114e06b-07cf-4006-a783-aa812a2de0fd-2025-01-16-16_41_00](https://github.com/user-attachments/assets/5bfcc6fe-1334-453b-8f42-5a9b5b0ad48c)

![screencapture-claims-localhost-3000-support-claims-c114e06b-07cf-4006-a783-aa812a2de0fd-2025-01-16-16_41_26](https://github.com/user-attachments/assets/765c11b1-2c10-4f9c-a654-9704e88b6a34)

_Payment in progress_
![screencapture-claims-localhost-3000-support-claims-c114e06b-07cf-4006-a783-aa812a2de0fd-2025-01-16-16_42_04](https://github.com/user-attachments/assets/490c34ef-8e93-4056-8ef3-6787614fca40)

_Paid_
![screencapture-claims-localhost-3000-support-claims-c114e06b-07cf-4006-a783-aa812a2de0fd-2025-01-16-16_47_22](https://github.com/user-attachments/assets/c81e81f8-8a0d-4951-bc9e-3dd0d18c52bb)

_Sampling in progress_
![screencapture-claims-localhost-3000-support-claims-sampling-claims-c114e06b-07cf-4006-a783-aa812a2de0fd-2025-01-16-16_50_23](https://github.com/user-attachments/assets/a4285517-7c25-440b-8460-42577bdb7716)

_Provider not approved_
![screencapture-claims-localhost-3000-support-claims-sampling-claims-c114e06b-07cf-4006-a783-aa812a2de0fd-2025-01-16-16_51_07](https://github.com/user-attachments/assets/f03c5de1-b5f8-4cdb-9d25-e10b65008e30)

_Claim not approved_
![screencapture-claims-localhost-3000-support-claims-sampling-claims-c114e06b-07cf-4006-a783-aa812a2de0fd-2025-01-16-16_51_39](https://github.com/user-attachments/assets/bfb0ac9b-0737-4d8f-ae6b-90d802473b0c)

_Clawback requested_
![screencapture-claims-localhost-3000-support-claims-clawbacks-claims-c114e06b-07cf-4006-a783-aa812a2de0fd-2025-01-16-16_52_49](https://github.com/user-attachments/assets/b14b7efe-cb93-436b-95c1-51eea6c7bf36)

_Clawback in progress_
![screencapture-claims-localhost-3000-support-claims-clawbacks-claims-c114e06b-07cf-4006-a783-aa812a2de0fd-2025-01-16-16_53_41](https://github.com/user-attachments/assets/628aa88c-4998-4e56-93ba-8ffc29450b7e)

_Clawback complete_
![screencapture-claims-localhost-3000-support-claims-c114e06b-07cf-4006-a783-aa812a2de0fd-2025-01-16-16_56_03](https://github.com/user-attachments/assets/688a8dd4-8fda-4c1e-8028-461c53508d85)


