### PR TITLE
Pin ubuntu-22.04 for github workflows

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       docker-image-tag: ${{ steps.build-image.outputs.tag }}
 
@@ -33,7 +33,7 @@ jobs:
   deploy_review:
     name: Deploy to review environment
     concurrency: deploy_review_${{ github.event.pull_request.number }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy') }}
     needs: [build]
     environment:
@@ -66,7 +66,7 @@ jobs:
 
   deploy_nonprod:
     name: Deploy to ${{ matrix.environment }} environment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     concurrency: deploy_${{ matrix.environment }}
     needs: [build]
@@ -115,7 +115,7 @@ jobs:
 
   deploy_prod:
     name: Deploy to production environment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     concurrency: deploy_production
     needs: [build, deploy_nonprod]

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -6,7 +6,7 @@ on: push
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -29,7 +29,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgres:16

--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -33,7 +33,7 @@ env:
 jobs:
   backup:
     name: Backup AKS Database
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment:
       name: ${{ inputs.environment || 'production' }}
     env:

--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -18,7 +18,7 @@ jobs:
   delete-review-app:
     name: Delete Review App ${{ github.event.pull_request.number }}
     concurrency: deploy_review_${{ github.event.pull_request.number }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy') || github.event_name == 'workflow_dispatch' }}
     environment: review
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
     environment:
       name: ${{ github.event.inputs.environment }}
     concurrency: deploy_all
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/disable-maintenance.yml
+++ b/.github/workflows/disable-maintenance.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   disable-maintenance:
     name: Disable maintenance app
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: ${{ inputs.environment }}
 
     steps:

--- a/.github/workflows/enable-maintenance.yml
+++ b/.github/workflows/enable-maintenance.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   enable-maintenance:
     name: Enable maintenance app
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: ${{ inputs.environment }}
 
     steps:

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   set-maintenance-mode:
     name: Set maintenance mode
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: ${{ inputs.environment }}
 
     steps:

--- a/.github/workflows/postgres-ptr.yml
+++ b/.github/workflows/postgres-ptr.yml
@@ -36,7 +36,7 @@ jobs:
   ptr-restore:
     name: PTR Restore AKS Database
     if: ${{ inputs.environment != 'production' || (inputs.environment == 'production' && github.event.inputs.confirm-production == 'true' )  }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: ${{ inputs.environment }}
     concurrency: deploy_${{ inputs.environment }}
 

--- a/.github/workflows/postgres-restore.yml
+++ b/.github/workflows/postgres-restore.yml
@@ -34,7 +34,7 @@ jobs:
   restore:
     name: Restore AKS Database
     if: ${{ inputs.environment != 'production' || (inputs.environment == 'production' && github.event.inputs.confirm-production == 'true' )  }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: ${{ inputs.environment }}
 
     steps:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   block-fixup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
     steps:


### PR DESCRIPTION
## Context

We've been having an array of failures related to our build pipelines and deployments. @saliceti has identified that the latest version of ubuntu is likely the culprit.

## Changes proposed in this pull request

- [x] Pin the ubuntu version to the previous version
