### PR TITLE
Extend seed data

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -155,7 +155,7 @@ reference = 12_345_678
 created_by = Claims::SupportUser.last
 Claims::School.all.find_each do |school|
   Claims::Provider.private_beta_providers.each do |claim_provider|
-    claim = Claims::Claim.create!(
+    claim_paid = Claims::Claim.create!(
       claim_window: Claims::ClaimWindow.current,
       school:,
       provider: claim_provider,
@@ -165,16 +165,37 @@ Claims::School.all.find_each do |school|
       submitted_at: Time.current,
       submitted_by: created_by,
     )
+
+    reference += 1
+
+    claim_submitted = Claims::Claim.create!(
+      claim_window: Claims::ClaimWindow.current,
+      school: school,
+      provider: claim_provider,
+      reference:,
+      created_by: created_by,
+      status: :submitted,
+      submitted_at: Time.current,
+      submitted_by: created_by,
+    )
+
+    reference += 1
+
     school.mentors.find_each do |mentor|
       Claims::MentorTraining.create!(
         mentor:,
-        claim:,
+        claim: claim_paid,
+        provider: claim_provider,
+        hours_completed: rand(1..20),
+        date_completed: Time.current,
+      )
+      Claims::MentorTraining.create!(
+        mentor:,
+        claim: claim_submitted,
         provider: claim_provider,
         hours_completed: rand(1..20),
         date_completed: Time.current,
       )
     end
-
-    reference += 1
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,6 @@
 # Don't run seeds in test or production environments
 return unless Rails.env.development? || HostingEnvironment.env.review?
 
-### DEFINE METHODS HERE
-
-# Methods for making claims
 def create_claim(school:, provider:, created_by:, reference:, status:)
   return unless mentor_remaining_hours(school:, provider:).any?
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -170,7 +170,7 @@ Claims::School.all.find_each do |school|
         mentor:,
         claim:,
         provider: claim_provider,
-        hours_completed: rand(20),
+        hours_completed: rand(1..20),
         date_completed: Time.current,
       )
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -148,3 +148,33 @@ Placements::School.find_each do |school|
 
   PlacementMentorJoin.create!(placement:, mentor: Placements::Mentor.first)
 end
+
+# Generate claims
+
+reference = 12_345_678
+created_by = Claims::SupportUser.last
+Claims::School.all.find_each do |school|
+  Claims::Provider.private_beta_providers.each do |claim_provider|
+    claim = Claims::Claim.create!(
+      claim_window: Claims::ClaimWindow.current,
+      school:,
+      provider: claim_provider,
+      reference:,
+      created_by:,
+      status: :paid,
+      submitted_at: Time.current,
+      submitted_by: created_by,
+    )
+    school.mentors.find_each do |mentor|
+      Claims::MentorTraining.create!(
+        mentor:,
+        claim:,
+        provider: claim_provider,
+        hours_completed: rand(20),
+        date_completed: Time.current,
+      )
+    end
+
+    reference += 1
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,11 +27,6 @@ def assign_mentors(claim:, school:)
     next if hours_completed.zero?
 
     create_mentor_training(mentor:, claim:, hours_completed:)
-
-    remaining_hours = hours_completed(mentor:, provider: claim.provider)
-    next if remaining_hours.zero?
-
-    create_mentor_training(mentor:, claim:, hours_completed: remaining_hours)
   end
 end
 


### PR DESCRIPTION
## Context

- Add `submitted` and `paid` claims to seed data

## Changes proposed in this pull request

- Add code and methods to create `submitted` and `paid` claims for each school ( and provider ) within the seed data.

## Guidance to review

- run `bundle exec rake db:drop db:create db:setup`
- This should result in creating both `submitted` and `paid` claims.

## Link to Trello card

https://trello.com/c/Tlf4e2qH/365-add-seeds-to-populate-claims-in-staging-and-local-environments

## Screenshots

![screencapture-claims-localhost-3000-support-claims-2025-01-17-11_56_38](https://github.com/user-attachments/assets/07beba0e-22c2-4ae1-897c-4c6af202675b)

