### PR TITLE
CI-CD for domains

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -169,3 +169,81 @@ jobs:
           SLACK_TITLE: Failure deploying release to production
           SLACK_MESSAGE: Failure deploying release to production - Docker tag ${{ needs.build.outputs.docker-image-tag }}
           SLACK_WEBHOOK: ${{ steps.keyvault-yaml-secret.outputs.SLACK_WEBHOOK }}
+
+  deploy_domains_infra:
+    name: Deploy Domains Infrastructure
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    concurrency: deploy_production
+    needs: [deploy_prod]
+    environment:
+      name: production
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: azure/login@v2
+        with:
+          client-id:  ${{ secrets.AZURE_CLIENT_ID  }}
+          tenant-id:  ${{ secrets.AZURE_TENANT_ID   }}
+          subscription-id:  ${{ secrets.AZURE_SUBSCRIPTION_ID   }}
+
+      - name: Fetch secrets from key vault
+        uses: azure/CLI@v2
+        id: keyvault-secret
+        with:
+          inlineScript: |
+            SLACK_WEBHOOK=$(az keyvault secret show --name "SLACK-WEBHOOK" --vault-name "${{ secrets.INF_KEY_VAULT }}" --query "value" -o tsv)
+            echo "::add-mask::$SLACK_WEBHOOK"
+            echo "SLACK_WEBHOOK=$SLACK_WEBHOOK" >> $GITHUB_OUTPUT
+
+      - name: Deploy Domains Infrastructure
+        id: deploy_domains_infra
+        uses: DFE-Digital/github-actions/deploy-domains-infra@master
+        with:
+          azure-client-id:  ${{ secrets.AZURE_CLIENT_ID  }}
+          azure-tenant-id:  ${{ secrets.AZURE_TENANT_ID   }}
+          azure-subscription-id:  ${{ secrets.AZURE_SUBSCRIPTION_ID   }}
+          slack-webhook: ${{ steps.keyvault-secret.outputs.SLACK_WEBHOOK }}
+
+  deploy_domains_env:
+    name: Deploy Domains to ${{ matrix.domain_environment }} environment
+    runs-on: ubuntu-22.04
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    concurrency: deploy_${{ matrix.domain_environment }}
+    needs: [deploy_domains_infra]
+    strategy:
+      max-parallel: 1
+      matrix:
+        domain_environment: [qa, staging, sandbox, production]
+    environment:
+      name: production
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: azure/login@v2
+        with:
+          client-id:  ${{ secrets.AZURE_CLIENT_ID  }}
+          tenant-id:  ${{ secrets.AZURE_TENANT_ID   }}
+          subscription-id:  ${{ secrets.AZURE_SUBSCRIPTION_ID   }}
+
+      - name: Fetch secrets from key vault
+        uses: azure/CLI@v2
+        id: keyvault-secret
+        with:
+          inlineScript: |
+            SLACK_WEBHOOK=$(az keyvault secret show --name "SLACK-WEBHOOK" --vault-name "${{ secrets.INF_KEY_VAULT }}" --query "value" -o tsv)
+            echo "::add-mask::$SLACK_WEBHOOK"
+            echo "SLACK_WEBHOOK=$SLACK_WEBHOOK" >> $GITHUB_OUTPUT
+
+      - name: Deploy Domains Environment
+        id: deploy_domains_env
+        uses: DFE-Digital/github-actions/deploy-domains-env@master
+        with:
+          azure-client-id:  ${{ secrets.AZURE_CLIENT_ID  }}
+          azure-tenant-id:  ${{ secrets.AZURE_TENANT_ID   }}
+          azure-subscription-id:  ${{ secrets.AZURE_SUBSCRIPTION_ID   }}
+          environment: ${{ matrix.domain_environment }}
+          healthcheck: healthcheck/all
+          slack-webhook: ${{ steps.keyvault-secret.outputs.SLACK_WEBHOOK }}


### PR DESCRIPTION
## Context

adding workflows for domain deployment to build workflows 

## Changes proposed in this pull request

this is the updated build_and_deploy.yml adding calls to the deploy domains github actions. 

## Guidance to review

review the actions to see the workflows being running. 
review code and decide on best architecture

can see test runs for jobs added to  build_and_deploy.yml  run as separate test runs but doing plan not apply
https://github.com/DFE-Digital/itt-mentor-services/actions/runs/12829975027
https://github.com/DFE-Digital/itt-mentor-services/actions/runs/12829975022 (this only fails because plan doesn't see output variable like apply so will success for appply)

## Link to Trello card

[Implement CI/CD for domains on all services](https://trello.com/c/unElJf6I/2168-implement-ci-cd-for-domains-on-all-services)