### PR TITLE
Update colour tags in failing specs

### DIFF
--- a/spec/system/claims/support/claims/sampling/mark_provider_rejected_claim_as_approved/support_user_approves_a_provider_rejected_sampling_claim_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_provider_rejected_claim_as_approved/support_user_approves_a_provider_rejected_sampling_claim_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe "Support user approves a provider rejected sampling claim", servi
     )
     expect(page).to have_element(:p, text: "Sampling - Claim #{@provider_rejected_sampling_claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@provider_rejected_sampling_claim.school.name)
-    expect(page).to have_element(:strong, text: "Provider not approved", class: "govuk-tag govuk-tag--pink")
+    expect(page).to have_element(:strong, text: "Provider not approved", class: "govuk-tag govuk-tag--turquoise")
   end
 
   def when_i_click_on_back
@@ -140,6 +140,6 @@ RSpec.describe "Support user approves a provider rejected sampling claim", servi
     expect(page).to have_h2("Claims (2)")
     expect(page).to have_link("#{@provider_rejected_sampling_claim.reference} - #{@provider_rejected_sampling_claim.school.name}", href: "/support/claims/#{@provider_rejected_sampling_claim.id}")
     expect(page).to have_link("#{@paid_claim.reference} - #{@paid_claim.school.name}", href: "/support/claims/#{@paid_claim.id}")
-    expect(page).to have_element(:strong, text: "Paid", class: "govuk-tag govuk-tag--green", count: 2)
+    expect(page).to have_element(:strong, text: "Paid", class: "govuk-tag govuk-tag--blue", count: 2)
   end
 end

--- a/spec/system/claims/support/claims/sampling/support_user_approves_a_claim_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_approves_a_claim_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe "Support user approves a claim", service: :claims, type: :system 
     )
     expect(page).to have_element(:p, text: "Claim #{@paid_claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@paid_claim.school.name)
-    expect(page).to have_element(:strong, text: "Paid", class: "govuk-tag govuk-tag--green")
+    expect(page).to have_element(:strong, text: "Paid", class: "govuk-tag govuk-tag--blue")
   end
 
   def then_i_see_the_details_of_the_sampling_claim


### PR DESCRIPTION
## Context

Update failing tests to match recent merged changes to status tag designs.

## Changes proposed in this pull request

- Update specs expecting `provider_not_approved` to be pink. This is now turquoise.
- Update specs expecting `paid` to be green. This is now blue.

## Guidance to review

- Check that all specs are passing.
