### PR TITLE
Fix training allowance to include more than just draft and submitted claims

### DIFF
--- a/app/models/claims/training_allowance.rb
+++ b/app/models/claims/training_allowance.rb
@@ -51,7 +51,7 @@ class Claims::TrainingAllowance
     mentor_training_scope
       .where(claims: { claim_windows: { academic_year: } })
       .where.not(claim_id: [claim_to_exclude&.id, claim_to_exclude&.previous_revision_id])
-      .merge(Claims::Claim.not_internal_draft)
+      .merge(Claims::Claim.not_internal_draft.not_payment_not_approved)
       .sum(:hours_completed)
   end
 end

--- a/app/models/claims/training_allowance.rb
+++ b/app/models/claims/training_allowance.rb
@@ -51,7 +51,7 @@ class Claims::TrainingAllowance
     mentor_training_scope
       .where(claims: { claim_windows: { academic_year: } })
       .where.not(claim_id: [claim_to_exclude&.id, claim_to_exclude&.previous_revision_id])
-      .merge(Claims::Claim.active)
+      .merge(Claims::Claim.not_internal_draft)
       .sum(:hours_completed)
   end
 end

--- a/spec/models/claims/training_allowance_spec.rb
+++ b/spec/models/claims/training_allowance_spec.rb
@@ -99,6 +99,22 @@ RSpec.describe Claims::TrainingAllowance, type: :model do
             expect(training_allowance).to be_available
           end
         end
+
+        context "when a second claim has been paid whilst excluding a previous claim" do
+          let(:second_claim) { build(:claim, :paid, claim_window:, provider:) }
+          let(:second_mentor_training) { create(:mentor_training, mentor:, provider:, claim: second_claim, hours_completed: 3) }
+
+          before do
+            second_mentor_training
+          end
+
+          it "does not exclude other claims" do
+            expect(training_allowance.training_type).to eq(:initial)
+            expect(training_allowance.total_hours).to eq(20)
+            expect(training_allowance.remaining_hours).to eq(17)
+            expect(training_allowance).to be_available
+          end
+        end
       end
     end
   end
@@ -180,6 +196,22 @@ RSpec.describe Claims::TrainingAllowance, type: :model do
 
         context "when a second claim has been made whilst excluding a previous claim" do
           let(:second_claim) { build(:claim, :submitted, claim_window:, provider:) }
+          let(:second_mentor_training) { create(:mentor_training, mentor:, provider:, claim: second_claim, hours_completed: 3) }
+
+          before do
+            second_mentor_training
+          end
+
+          it "does not exclude other claims" do
+            expect(training_allowance.training_type).to eq(:refresher)
+            expect(training_allowance.total_hours).to eq(6)
+            expect(training_allowance.remaining_hours).to eq(3)
+            expect(training_allowance).to be_available
+          end
+        end
+
+        context "when a second claim has been paid whilst excluding a previous claim" do
+          let(:second_claim) { build(:claim, :paid, claim_window:, provider:) }
           let(:second_mentor_training) { create(:mentor_training, mentor:, provider:, claim: second_claim, hours_completed: 3) }
 
           before do


### PR DESCRIPTION
## Context

- Fix issue with Training Allowance only considering "Draft" and "Submitted" claims

## Changes proposed in this pull request

- Change Training Allowance only considering "Draft" and "Submitted" claims
