### PR TITLE
Add mentor columns to analytics

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -69,6 +69,9 @@ shared:
   :mentors:
     - first_name
     - last_name
+    - id
+    - created_at
+    - updated_at
   :mentor_memberships:
     - id
     - type

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -122,10 +122,7 @@ shared:
   :users:
     - email
   :mentors:
-    - id
     - trn
-    - created_at
-    - updated_at
   :providers:
     - telephone
   :provider_email_addresses:


### PR DESCRIPTION
## Context

We require these fields for tracking purposes

## Changes proposed in this pull request

- Remove `mentors` table `id`, `created_at` and `updated` at from blocklist.
-  Add `mentors` table `id`, `created_at` and `updated` to analytics

## Guidance to review

Ensure that the added fields match the listed fields and that tests pass.