### PR TITLE
Update status labels in line with latest designs

### DIFF
--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -14,16 +14,16 @@ en:
         internal_draft: Internal draft
         draft: Draft
         submitted: Submitted
-        payment_in_progress: Payment in progress
-        payment_information_requested: Information requested
-        payment_information_sent: Information sent
+        payment_in_progress: Payer payment review
+        payment_information_requested: Payer needs information
+        payment_information_sent: Information sent to payer
         paid: Paid
-        payment_not_approved: Payment not approved
-        sampling_in_progress: Sampling in progress
-        sampling_provider_not_approved: Provider not approved
-        sampling_not_approved: Claim not approved
-        clawback_requested: Clawback requested
-        clawback_in_progress: Clawback in progress
+        payment_not_approved: Rejected by payer
+        sampling_in_progress: Audit requested
+        sampling_provider_not_approved: Rejected by provider
+        sampling_not_approved: Rejected by school
+        clawback_requested: Ready for clawback
+        clawback_in_progress: Sent to payer for clawback
         clawback_complete: Clawback complete
       claims/claim_activity/action:
         payment_request_delivered: Claims sent to ESFA for payment

--- a/spec/components/claim/status_tag_component_spec.rb
+++ b/spec/components/claim/status_tag_component_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Claim::StatusTagComponent, type: :component do
     let(:claim) { build(:claim, status: :payment_in_progress) }
 
     it "renders a yellow tag" do
-      expect(page).to have_css(".govuk-tag--yellow", text: "Payment in progress")
+      expect(page).to have_css(".govuk-tag--yellow", text: "Payer payment review")
     end
   end
 
@@ -43,7 +43,7 @@ RSpec.describe Claim::StatusTagComponent, type: :component do
     let(:claim) { build(:claim, status: :payment_information_requested) }
 
     it "renders a turquoise tag" do
-      expect(page).to have_css(".govuk-tag--turquoise", text: "Information requested")
+      expect(page).to have_css(".govuk-tag--turquoise", text: "Payer needs information")
     end
   end
 
@@ -51,7 +51,7 @@ RSpec.describe Claim::StatusTagComponent, type: :component do
     let(:claim) { build(:claim, status: :payment_information_sent) }
 
     it "renders a yellow tag" do
-      expect(page).to have_css(".govuk-tag--yellow", text: "Information sent")
+      expect(page).to have_css(".govuk-tag--yellow", text: "Information sent to payer")
     end
   end
 
@@ -67,7 +67,7 @@ RSpec.describe Claim::StatusTagComponent, type: :component do
     let(:claim) { build(:claim, status: :payment_not_approved) }
 
     it "renders a orange tag" do
-      expect(page).to have_css(".govuk-tag--orange", text: "Payment not approved")
+      expect(page).to have_css(".govuk-tag--orange", text: "Rejected by payer")
     end
   end
 
@@ -75,7 +75,7 @@ RSpec.describe Claim::StatusTagComponent, type: :component do
     let(:claim) { build(:claim, status: :sampling_in_progress) }
 
     it "renders a yellow tag" do
-      expect(page).to have_css(".govuk-tag--yellow", text: "Sampling in progress")
+      expect(page).to have_css(".govuk-tag--yellow", text: "Audit requested")
     end
   end
 
@@ -83,7 +83,7 @@ RSpec.describe Claim::StatusTagComponent, type: :component do
     let(:claim) { build(:claim, status: :sampling_provider_not_approved) }
 
     it "renders a turquoise tag" do
-      expect(page).to have_css(".govuk-tag--turquoise", text: "Provider not approved")
+      expect(page).to have_css(".govuk-tag--turquoise", text: "Rejected by provider")
     end
   end
 
@@ -91,7 +91,7 @@ RSpec.describe Claim::StatusTagComponent, type: :component do
     let(:claim) { build(:claim, status: :sampling_not_approved) }
 
     it "renders a turquoise tag" do
-      expect(page).to have_css(".govuk-tag--turquoise", text: "Claim not approved")
+      expect(page).to have_css(".govuk-tag--turquoise", text: "Rejected by school")
     end
   end
 
@@ -99,7 +99,7 @@ RSpec.describe Claim::StatusTagComponent, type: :component do
     let(:claim) { build(:claim, status: :clawback_requested) }
 
     it "renders a turquoise tag" do
-      expect(page).to have_css(".govuk-tag--turquoise", text: "Clawback requested")
+      expect(page).to have_css(".govuk-tag--turquoise", text: "Ready for clawback")
     end
   end
 
@@ -107,7 +107,7 @@ RSpec.describe Claim::StatusTagComponent, type: :component do
     let(:claim) { build(:claim, status: :clawback_in_progress) }
 
     it "renders a yellow tag" do
-      expect(page).to have_css(".govuk-tag--yellow", text: "Clawback in progress")
+      expect(page).to have_css(".govuk-tag--yellow", text: "Sent to payer for clawback")
     end
   end
 

--- a/spec/system/claims/support/claims/clawbacks/support_user_filters_clawback_claims_by_status_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/support_user_filters_clawback_claims_by_status_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe "Support user filters clawback claims by status", service: :claim
     expect(page).to have_claim_card({
       "title" => "#{@sampling_not_approved_claim.reference} - #{@sampling_not_approved_claim.school.name}",
       "url" => "/support/claims/clawbacks/claims/#{@sampling_not_approved_claim.id}",
-      "status" => "Clawback in progress",
+      "status" => "Sent to payer for clawback",
       "academic_year" => @sampling_not_approved_claim.academic_year.name,
       "provider_name" => @sampling_not_approved_claim.provider.name,
       "submitted_at" => I18n.l(@sampling_not_approved_claim.submitted_at.to_date, format: :long),
@@ -156,23 +156,23 @@ RSpec.describe "Support user filters clawback claims by status", service: :claim
   end
 
   def when_i_select_the_clawback_in_progress_filter
-    check "Clawback in progress"
+    check "Sent to payer for clawback"
   end
   alias_method :and_i_select_the_clawback_in_progress_filter,
                :when_i_select_the_clawback_in_progress_filter
 
   def when_i_select_the_clawback_requested_filter
-    check "Clawback requested"
+    check "Ready for clawback"
   end
   alias_method :and_i_select_the_clawback_requested_filter,
                :when_i_select_the_clawback_requested_filter
 
   def when_i_unselect_the_clawback_in_progress_filter
-    uncheck "Clawback in progress"
+    uncheck "Sent to payer for clawback"
   end
 
   def and_i_select_the_sampling_not_approved_filter
-    check "Claim not approved"
+    check "Rejected by school"
   end
 
   def and_i_do_not_see_claims_with_a_clawback_requested_status
@@ -195,25 +195,25 @@ RSpec.describe "Support user filters clawback claims by status", service: :claim
 
   def and_i_see_clawback_in_progress_selected_from_the_status_filter
     expect(page).to have_element(:legend, text: "Status", class: "govuk-fieldset__legend")
-    expect(page).to have_checked_field("Clawback in progress")
-    expect(page).to have_filter_tag("Clawback in progress")
+    expect(page).to have_checked_field("Sent to payer for clawback")
+    expect(page).to have_filter_tag("Sent to payer for clawback")
   end
 
   def and_i_see_clawback_requested_selected_from_the_status_filter
     expect(page).to have_element(:legend, text: "Status", class: "govuk-fieldset__legend")
-    expect(page).to have_checked_field("Clawback requested")
-    expect(page).to have_filter_tag("Clawback requested")
+    expect(page).to have_checked_field("Ready for clawback")
+    expect(page).to have_filter_tag("Ready for clawback")
   end
 
   def and_i_see_sampling_not_approved_selected_from_the_status_filter
     expect(page).to have_element(:legend, text: "Status", class: "govuk-fieldset__legend")
-    expect(page).to have_checked_field("Claim not approved")
-    expect(page).to have_filter_tag("Claim not approved")
+    expect(page).to have_checked_field("Rejected by school")
+    expect(page).to have_filter_tag("Rejected by school")
   end
 
   def and_i_do_not_see_clawback_requested_selected_from_the_status_filter
-    expect(page).not_to have_checked_field("Clawback requested")
-    expect(page).not_to have_filter_tag("Clawback requested")
+    expect(page).not_to have_checked_field("Ready for clawback")
+    expect(page).not_to have_filter_tag("Ready for clawback")
   end
 
   def and_i_do_not_see_sampling_not_approved_selected_from_the_status_filter
@@ -222,13 +222,13 @@ RSpec.describe "Support user filters clawback claims by status", service: :claim
   end
 
   def and_i_do_not_see_clawback_in_progress_selected_from_the_status_filter
-    expect(page).not_to have_checked_field("Clawback in progress")
-    expect(page).not_to have_filter_tag("Clawback in progress")
+    expect(page).not_to have_checked_field("Sent to payer for clawback")
+    expect(page).not_to have_filter_tag("Sent to payer for clawback")
   end
 
   def when_i_click_on_the_clawback_requested_filter_tag
     within ".app-filter-tags" do
-      click_on "Clawback requested"
+      click_on "Ready for clawback"
     end
   end
 

--- a/spec/system/claims/support/claims/clawbacks/support_user_requests_a_clawback_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/support_user_requests_a_clawback_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "Support user requests a clawback on a claim", service: :claims, 
     expect(primary_navigation).to have_current_item("Claims")
     expect(page).to have_element(:span, text: "Clawbacks - Claim 11111111", class: "govuk-caption-l")
     expect(page).to have_h1(@claim_one.school_name)
-    expect(page).to have_element(:strong, text: "Claim not approved", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_element(:strong, text: "Rejected by school", class: "govuk-tag govuk-tag--turquoise")
     expect(page).to have_link("Request clawback", href: "/support/claims/clawbacks/claims/new/#{@claim_one.id}")
     expect(page).to have_summary_list_row("School", @claim_one.school_name)
     expect(page).to have_summary_list_row("Academic year", @claim_one.academic_year_name)

--- a/spec/system/claims/support/claims/clawbacks/support_user_views_clawbacks_index_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/support_user_views_clawbacks_index_spec.rb
@@ -180,6 +180,6 @@ RSpec.describe "Support user views clawbacks index", service: :claims, type: :sy
     )
     expect(page).to have_element(:span, text: "Clawbacks - Claim #{@clawback_requested_claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@clawback_requested_claim.school.name)
-    expect(page).to have_element(:strong, text: "Clawback requested", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_element(:strong, text: "Ready for clawback", class: "govuk-tag govuk-tag--turquoise")
   end
 end

--- a/spec/system/claims/support/claims/payments/reject_claim_payment_spec.rb
+++ b/spec/system/claims/support/claims/payments/reject_claim_payment_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Reject claim payment", service: :claims, type: :system do
     expect(page).to have_content("Claim rejected")
 
     within("h1.govuk-heading-l .govuk-tag") do
-      expect(page).to have_content("Payment not approved")
+      expect(page).to have_content("Rejected by payer")
     end
   end
 end

--- a/spec/system/claims/support/claims/payments/view_a_claim_spec.rb
+++ b/spec/system/claims/support/claims/payments/view_a_claim_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "View claims", service: :claims, type: :system do
 
   def then_i_can_see_the_details_of_claim(claim)
     expect(page).to have_content("Claim #{claim.reference}")
-    expect(page).to have_content("Information requested")
+    expect(page).to have_content("Payer needs information")
     expect(page).to have_content("School#{claim.school_name}")
     expect(page).to have_content("Academic year#{claim.academic_year_name}")
     expect(page).to have_content("Accredited provider#{claim.provider.name}")

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_mentor_who_is_being_rejected_by_the_provider_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_mentor_who_is_being_rejected_by_the_provider_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Support user changes the mentor who is being rejected by the pro
     )
     expect(page).to have_element(:p, text: "Sampling - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@claim.school.name)
-    expect(page).to have_element(:strong, text: "Sampling in progress", class: "govuk-tag govuk-tag--yellow")
+    expect(page).to have_element(:strong, text: "Audit requested", class: "govuk-tag govuk-tag--yellow")
   end
 
   def when_i_click_on_confirm_provider_rejected_claim
@@ -108,7 +108,7 @@ RSpec.describe "Support user changes the mentor who is being rejected by the pro
     )
     expect(page).to have_h1(@claim.school.name)
 
-    expect(page).to have_element(:strong, text: "Provider not approved", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_element(:strong, text: "Rejected by provider", class: "govuk-tag govuk-tag--turquoise")
     expect(page).to have_success_banner("Claim updated")
   end
 

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_reason_the_provider_rejected_the_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_reason_the_provider_rejected_the_mentor_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "Support user changes the reason the provider rejected the mentor
     )
     expect(page).to have_element(:p, text: "Sampling - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@claim.school.name)
-    expect(page).to have_element(:strong, text: "Sampling in progress", class: "govuk-tag govuk-tag--yellow")
+    expect(page).to have_element(:strong, text: "Audit requested", class: "govuk-tag govuk-tag--yellow")
   end
 
   def when_i_click_on_confirm_provider_rejected_claim
@@ -103,7 +103,7 @@ RSpec.describe "Support user changes the reason the provider rejected the mentor
     )
     expect(page).to have_h1(@claim.school.name)
 
-    expect(page).to have_element(:strong, text: "Provider not approved", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_element(:strong, text: "Rejected by provider", class: "govuk-tag govuk-tag--turquoise")
     expect(page).to have_success_banner("Claim updated")
   end
 

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_does_not_enter_a_reason_why_the_provider_rejected_the_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_does_not_enter_a_reason_why_the_provider_rejected_the_mentor_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Support user does not enter a reason why the provider rejected t
     )
     expect(page).to have_element(:p, text: "Sampling - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@claim.school.name)
-    expect(page).to have_element(:strong, text: "Sampling in progress", class: "govuk-tag govuk-tag--yellow")
+    expect(page).to have_element(:strong, text: "Audit requested", class: "govuk-tag govuk-tag--yellow")
   end
 
   def when_i_click_on_confirm_provider_rejected_claim

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_does_not_select_any_mentors_rejected_by_the_provider_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_does_not_select_any_mentors_rejected_by_the_provider_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Support user does not select any mentors rejected by the provide
     )
     expect(page).to have_element(:p, text: "Sampling - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@claim.school.name)
-    expect(page).to have_element(:strong, text: "Sampling in progress", class: "govuk-tag govuk-tag--yellow")
+    expect(page).to have_element(:strong, text: "Audit requested", class: "govuk-tag govuk-tag--yellow")
   end
 
   def when_i_click_on_confirm_provider_rejected_claim

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_marks_the_claim_as_provider_not_approved_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_marks_the_claim_as_provider_not_approved_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
     )
     expect(page).to have_element(:p, text: "Sampling - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@claim.school.name)
-    expect(page).to have_element(:strong, text: "Sampling in progress", class: "govuk-tag govuk-tag--yellow")
+    expect(page).to have_element(:strong, text: "Audit requested", class: "govuk-tag govuk-tag--yellow")
   end
 
   def when_i_click_on_confirm_provider_rejected_claim
@@ -152,7 +152,7 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
     )
     expect(page).to have_h1(@claim.school.name)
 
-    expect(page).to have_element(:strong, text: "Provider not approved", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_element(:strong, text: "Rejected by provider", class: "govuk-tag govuk-tag--turquoise")
     expect(page).to have_success_banner("Claim updated")
   end
 

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_changes_the_reason_the_school_rejected_the_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_changes_the_reason_the_school_rejected_the_mentor_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "Support user changes the reason the school rejected the mentor",
     )
     expect(page).to have_element(:p, text: "Sampling - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@claim.school.name)
-    expect(page).to have_element(:strong, text: "Provider not approved", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_element(:strong, text: "Rejected by provider", class: "govuk-tag govuk-tag--turquoise")
   end
 
   def when_i_click_on_reject_claim
@@ -102,7 +102,7 @@ RSpec.describe "Support user changes the reason the school rejected the mentor",
     )
     expect(page).to have_h1(@claim.school.name)
 
-    expect(page).to have_element(:strong, text: "Claim not approved", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_element(:strong, text: "Rejected by school", class: "govuk-tag govuk-tag--turquoise")
     expect(page).to have_success_banner("Claim updated")
   end
 

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_does_not_enter_a_reason_why_the_school_rejected_the_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_does_not_enter_a_reason_why_the_school_rejected_the_mentor_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Support user does not enter a reason why the school rejected the
     )
     expect(page).to have_element(:p, text: "Sampling - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@claim.school.name)
-    expect(page).to have_element(:strong, text: "Provider not approved", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_element(:strong, text: "Rejected by provider", class: "govuk-tag govuk-tag--turquoise")
   end
 
   def when_i_click_on_reject_claim

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_marks_the_claim_as_rejected_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_marks_the_claim_as_rejected_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe "Support user marks a claim as rejected", service: :claims, type:
     )
     expect(page).to have_element(:p, text: "Sampling - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@claim.school.name)
-    expect(page).to have_element(:strong, text: "Provider not approved", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_element(:strong, text: "Rejected by provider", class: "govuk-tag govuk-tag--turquoise")
   end
 
   def when_i_click_on_reject_claim
@@ -160,7 +160,7 @@ RSpec.describe "Support user marks a claim as rejected", service: :claims, type:
     )
     expect(page).to have_h1(@claim.school.name)
 
-    expect(page).to have_element(:strong, text: "Claim not approved", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_element(:strong, text: "Rejected by school", class: "govuk-tag govuk-tag--turquoise")
     expect(page).to have_success_banner("Claim updated")
   end
 

--- a/spec/system/claims/support/claims/sampling/mark_provider_rejected_claim_as_approved/support_user_approves_a_provider_rejected_sampling_claim_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_provider_rejected_claim_as_approved/support_user_approves_a_provider_rejected_sampling_claim_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe "Support user approves a provider rejected sampling claim", servi
     )
     expect(page).to have_element(:p, text: "Sampling - Claim #{@provider_rejected_sampling_claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@provider_rejected_sampling_claim.school.name)
-    expect(page).to have_element(:strong, text: "Provider not approved", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_element(:strong, text: "Rejected by provider", class: "govuk-tag govuk-tag--turquoise")
   end
 
   def when_i_click_on_back

--- a/spec/system/claims/support/claims/sampling/support_user_approves_a_claim_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_approves_a_claim_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "Support user approves a claim", service: :claims, type: :system 
     )
     expect(page).to have_element(:p, text: "Sampling - Claim #{@sampling_claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@sampling_claim.school.name)
-    expect(page).to have_element(:strong, text: "Sampling in progress", class: "govuk-tag govuk-tag--yellow")
+    expect(page).to have_element(:strong, text: "Audit requested", class: "govuk-tag govuk-tag--yellow")
   end
 
   def when_i_click_on_back

--- a/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_by_status_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_by_status_spec.rb
@@ -128,19 +128,19 @@ RSpec.describe "Support user filters sampled claims by status", service: :claims
   end
 
   def when_i_select_the_sampling_in_progress_filter
-    check "Sampling in progress"
+    check "Audit requested"
   end
   alias_method :and_i_select_the_sampling_in_progress_filter,
                :when_i_select_the_sampling_in_progress_filter
 
   def when_i_select_the_sampling_provider_not_approved_filter
-    check "Provider not approved"
+    check "Rejected by provider"
   end
   alias_method :and_i_select_the_sampling_provider_not_approved_filter,
                :when_i_select_the_sampling_provider_not_approved_filter
 
   def when_i_unselect_the_sampling_in_progress_filter
-    uncheck "Sampling in progress"
+    uncheck "Audit requested"
   end
 
   def and_i_do_not_see_claims_with_a_sampling_provider_not_approved_status
@@ -157,29 +157,29 @@ RSpec.describe "Support user filters sampled claims by status", service: :claims
 
   def and_i_see_sampling_in_progress_selected_from_the_status_filter
     expect(page).to have_element(:legend, text: "Status", class: "govuk-fieldset__legend")
-    expect(page).to have_checked_field("Sampling in progress")
-    expect(page).to have_filter_tag("Sampling in progress")
+    expect(page).to have_checked_field("Audit requested")
+    expect(page).to have_filter_tag("Audit requested")
   end
 
   def and_i_see_sampling_provider_not_approved_selected_from_the_status_filter
     expect(page).to have_element(:legend, text: "Status", class: "govuk-fieldset__legend")
-    expect(page).to have_checked_field("Provider not approved")
-    expect(page).to have_filter_tag("Provider not approved")
+    expect(page).to have_checked_field("Rejected by provider")
+    expect(page).to have_filter_tag("Rejected by provider")
   end
 
   def and_i_do_not_see_sampling_provider_not_approved_selected_from_the_status_filter
-    expect(page).not_to have_checked_field("Provider not approved")
-    expect(page).not_to have_filter_tag("Provider not approved")
+    expect(page).not_to have_checked_field("Rejected by provider")
+    expect(page).not_to have_filter_tag("Rejected by provider")
   end
 
   def and_i_do_not_see_sampling_in_progress_selected_from_the_status_filter
-    expect(page).not_to have_checked_field("Sampling in progress")
-    expect(page).not_to have_filter_tag("Sampling in progress")
+    expect(page).not_to have_checked_field("Audit requested")
+    expect(page).not_to have_filter_tag("Audit requested")
   end
 
   def when_i_click_on_the_sampling_provider_not_approved_filter_tag
     within ".app-filter-tags" do
-      click_on "Provider not approved"
+      click_on "Rejected by provider"
     end
   end
 


### PR DESCRIPTION
## Context

Update status label names in line with latest designs.

## Changes proposed in this pull request

Status labels updated to reflect new wording:

### Draft
Status: draft
Label: “Draft”

### Submitted
status: submitted
Label “Submitted”

### Paid
status: paid
Label “Paid”

### Payer payment review
status: payment_in_progress
Label “Payer payment review”

### Payer needs information
status: payment_information_requested
Label “Payer needs information”

### Information sent to payer
status: payment_information_sent
Label “Information sent to payer”

### Rejected by payer
status: payment_not_approved
Label “Rejected by payer”

### Audit requested
status: sampling_in_progress
Label "Audit requested"

### Rejected by provider
status: sampling_provider_not_approved
Label "Rejected by provider"

### Rejected by school
status: sampling_not_approved
Label "Rejected by school"

### Ready for clawback
status: clawback_requested
Label "Ready for clawback"

### Sent to payer for clawback
status: clawback_in_progress
Label "Sent to payer for clawback"

### Clawback complete
status: clawback_complete
Label "Clawback complete"

## Guidance to review

Please review status labels and verify that they are in line with those set out above.

## Link to Trello card

https://trello.com/c/HMzyPzQX/368-update-claims-status-labels