### PR TITLE
[2151] Output terraform external urls

### DIFF
--- a/terraform/application/outputs.tf
+++ b/terraform/application/outputs.tf
@@ -1,3 +1,7 @@
 output "ingress_hostnames" {
   value = [local.ingress_domain_map["INGRESS_CLAIMS_HOST"], local.ingress_domain_map["INGRESS_PLACEMENTS_HOST"]]
 }
+
+output "external_urls" {
+  value = [for domain in ["CLAIMS_HOST", "PLACEMENTS_HOST"] : "https://${local.app_env_values[domain]}/"]
+}


### PR DESCRIPTION
## Context
Use ittms deployments as smoke test for the AKS platform deployment.
Currently failing: https://github.com/DFE-Digital/teacher-services-cloud/actions/runs/12890121135/job/35938967409

## Changes proposed in this pull request
Use the new URL output format defined in the template

## Guidance to review
- make review terraform-init PR_NUMBER=1335
- terraform -chdir=terraform/application output external_urls

## Link to Trello card
https://trello.com/c/F9hmE3if
