### PR TITLE
Make database creation optional

### DIFF
--- a/terraform/application/config/dv_review.tfvars.json
+++ b/terraform/application/config/dv_review.tfvars.json
@@ -1,5 +1,6 @@
 {
   "namespace": "development",
   "deploy_azure_backing_services": false,
-  "enable_postgres_ssl": false
+  "enable_postgres_ssl": false,
+  "create_database": false
 }

--- a/terraform/application/config/pt_review.tfvars.json
+++ b/terraform/application/config/pt_review.tfvars.json
@@ -2,5 +2,6 @@
   "cluster": "platform-test",
   "namespace": "development",
   "deploy_azure_backing_services": false,
-  "enable_postgres_ssl": false
+  "enable_postgres_ssl": false,
+  "create_database": false
 }

--- a/terraform/application/config/review.tfvars.json
+++ b/terraform/application/config/review.tfvars.json
@@ -2,5 +2,6 @@
   "cluster": "test",
   "namespace": "bat-qa",
   "deploy_azure_backing_services": false,
-  "enable_postgres_ssl": false
+  "enable_postgres_ssl": false,
+  "create_database": false
 }

--- a/terraform/application/database.tf
+++ b/terraform/application/database.tf
@@ -16,4 +16,5 @@ module "postgres" {
   azure_sku_name          = var.postgres_flexible_server_sku
   azure_enable_high_availability = var.postgres_enable_high_availability
   azure_maintenance_window       = var.azure_maintenance_window
+  create_database = var.create_database
 }

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -84,6 +84,11 @@ variable "statuscake_alerts" {
   default = {}
 }
 
+variable "create_database" {
+  description = "Create the postgres database. If false, rails must create it."
+  default     = true
+}
+
 locals {
   postgres_ssl_mode       = var.enable_postgres_ssl ? "require" : "disable"
   app_env_values_from_yml = yamldecode(file("${path.module}/config/${var.config}_app_env.yml"))


### PR DESCRIPTION
## Context
Allow db schema load on review apps instead of running all migrations

## Changes proposed in this pull request
Do not create the database in review to force rails to create it and load schema via db:prepare

## Guidance to review
Check review app
