### PR TITLE
Update copy on provider user ->  download sampling  CSV page

### DIFF
--- a/app/views/claims/sampling/claims/index.html.erb
+++ b/app/views/claims/sampling/claims/index.html.erb
@@ -5,9 +5,11 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l"><%= t(".page_title") %></h1>
 
-      <p class="govuk-body"><%= t(".description_html") %></p>
+      <p class="govuk-body"><%= t(".description") %></p>
 
       <p class="govuk-body"><%= t(".support_html", mail_to: govuk_mail_to(t("claims.support_email"), t("claims.support_email_html"))) %></p>
+
+      <p class="govuk-body"><%= t(".expire") %></p>
 
       <%= govuk_button_link_to t(".submit"), download_claims_sampling_claims_path(token: params[:token]) %>
     </div>

--- a/config/locales/en/claims/sampling/claims.yml
+++ b/config/locales/en/claims/sampling/claims.yml
@@ -3,9 +3,13 @@ en:
     sampling:
       claims:
         index:
-          page_title: Download the sampling CSV
-          description_html: Download the Claim funding for mentor training sampling <span title="Comma separated values">CSV</span> file.
-          support_html: If you have any questions, email %{mail_to}.
+          page_title: Download the CSV file
+          description: |
+            Download the file to complete quality assurance on mentor funding claims associated with you.
+
+            Instructions on how to complete the CSV file have been sent to you by email.
+          support_html: If you need help, contact the team at %{mail_to}.
+          expire: The ability to download will expire 7 days after receiving the instructions via email. This is due to data security.
           submit: Download CSV file
         error:
           page_title: Sorry, there is a problem with the download link

--- a/spec/system/claims/sampling/claims/provider_user_downloads_sampling_csv_with_valid_token_spec.rb
+++ b/spec/system/claims/sampling/claims/provider_user_downloads_sampling_csv_with_valid_token_spec.rb
@@ -28,15 +28,16 @@ RSpec.describe "Provider user downloads sampling CSV with valid token", service:
   end
 
   def then_i_see_the_download_page
-    expect(page).to have_title("Download the sampling CSV - Claim funding for mentor training - GOV.UK")
-    expect(page).to have_h1("Download the sampling CSV")
-    expect(page).to have_element(:p, text: "Download the Claim funding for mentor training sampling CSV file.", class: "govuk-body")
-    expect(page).to have_element(:p, text: "If you have any questions, email ittmentor.funding@education.gov.uk", class: "govuk-body")
-    expect(page).to have_element(:a, text: "Download", class: "govuk-button")
+    expect(page).to have_title("Download the CSV file - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Download the CSV file")
+    expect(page).to have_element(:p, text: "Download the file to complete quality assurance on mentor funding claims associated with you. Instructions on how to complete the CSV file have been sent to you by email.", class: "govuk-body")
+    expect(page).to have_element(:p, text: "If you need help, contact the team at ittmentor.funding@education.gov.uk", class: "govuk-body")
+    expect(page).to have_element(:p, text: "The ability to download will expire 7 days after receiving the instructions via email. This is due to data security.", class: "govuk-body")
+    expect(page).to have_element(:a, text: "Download CSV file", class: "govuk-button")
   end
 
   def when_i_click_on_the_download_button
-    click_on "Download"
+    click_on "Download CSV file"
   end
 
   def then_the_csv_is_downloaded


### PR DESCRIPTION
## Context

We are making progressive enhancements to the support console to assist in the processing of Claims.

## Changes proposed in this pull request

- Update copy on the "Download sampling CSV" page (provider user) to match latest content designs.

## Guidance to review

- Please compare the design (screenshot on trello card) with the updated page.

## Link to Trello card

https://trello.com/c/vNoGL0OF/376-change-copy-on-the-screen-where-providers-go-to-download-the-sampling-csv
