### PR TITLE
fix host zones to be for each domain environment 

### DIFF
--- a/terraform/domains/environment_domains/output.tf
+++ b/terraform/domains/environment_domains/output.tf
@@ -1,3 +1,10 @@
-output "hosted_zones" {
-  value = keys(var.hosted_zone)
+output "external_urls" {
+  value = flatten([
+    for zone_name, zone_values in var.hosted_zone : [
+      for domain in zone_values["domains"] : (domain == "apex" ?
+        "https://${zone_name}" :
+        "https://${domain}.${zone_name}"
+      )
+    ]
+  ])
 }


### PR DESCRIPTION
## Context

run domain environments always showing production urls

## Changes proposed in this pull request

change to show urls or the environment 

## Guidance to review

tested on workstation 
`make qa domains-plan`
and shows 
Changes to Outputs:
 ```
 ~ external_urls = [
      + "https://qa.claim-funding-for-mentor-training.education.gov.uk",
      + "https://qa.manage-school-placements.education.gov.uk",
    ]
```
## Link to Trello card

[Implement CI/CD for domains on all services](https://trello.com/c/unElJf6I/2168-implement-ci-cd-for-domains-on-all-services)
