### PR TITLE
Update payer information from "ESFA" to "payer"

### DIFF
--- a/app/controllers/claims/support/claims/payments_controller.rb
+++ b/app/controllers/claims/support/claims/payments_controller.rb
@@ -20,7 +20,7 @@ class Claims::Support::Claims::PaymentsController < Claims::Support::Application
   def create
     Claims::Payment::CreateAndDeliver.call(current_user:)
 
-    redirect_to claims_support_claims_payments_path, flash: { success: true, heading: "Claims sent to ESFA" }
+    redirect_to claims_support_claims_payments_path, flash: { success: true, heading: "Claims sent to payer" }
   end
 
   private

--- a/app/views/claims/schools/_grant_conditions.html.erb
+++ b/app/views/claims/schools/_grant_conditions.html.erb
@@ -143,7 +143,7 @@
 
       <h2 class="govuk-heading-m" id="payments">6. Payments</h2>
       <p class="govuk-body">Payments will be made in arrears from September 2025. Schools will be able to submit a claim via a new GOV.UK service. The service will open in May 2025 and schools will be able to submit their claims once their mentors have completed their training.</p>
-      <p class="govuk-body">Schools must complete their claims by the end of July to receive payment from the Educational and Skills Funding Agency (ESFA) in late September/early October. If schools miss the payment window, they will be able to submit a claim in September, with payment being made in December 2025.</p>
+      <p class="govuk-body">Schools must complete their claims by the end of July to receive payment from the payer in late September/early October. If schools miss the payment window, they will be able to submit a claim in September, with payment being made in December 2025.</p>
       <p class="govuk-body">DfE will begin communicating details of this new service to schools and providers from September 2024.</p>
       <p class="govuk-body">If you would like additional information about the payments email <%= govuk_mail_to(t("claims.support_email")) %>.</p>
 

--- a/app/views/claims/service_updates/content/payment-of-your-funding-claim-2023-to-2024.md
+++ b/app/views/claims/service_updates/content/payment-of-your-funding-claim-2023-to-2024.md
@@ -4,4 +4,4 @@ date: 2024-08-26
 start_page: true
 ---
 
-Claims submitted before 20 July are being reviewed and processed by the Education and Skills Funding Agency (ESFA). Payments are due before the end of October 2024. Depending on the type of your educational organisation, you will either be paid directly by ESFA, or your local authority.
+Claims submitted before 20 July are being reviewed and processed by the payer. Payments are due before the end of October 2024. Depending on the type of your educational organisation, you will either be paid directly by the payer, or your local authority.

--- a/app/views/claims/support/claims/claim_activities/show.html.erb
+++ b/app/views/claims/support/claims/claim_activities/show.html.erb
@@ -16,7 +16,7 @@
   <%= govuk_list type: :bullet do %>
     <% case @claim_activity.action %>
     <% when "payment_request_delivered", "clawback_request_delivered" %>
-      <li><%= govuk_link_to "Claims sent to ESFA", @claim_activity.record.csv_file %></li>
+      <li><%= govuk_link_to "Claims sent to payer", @claim_activity.record.csv_file %></li>
     <% when "sampling_uploaded" %>
       <% @provider_samplings.each do |provider_sampling| %>
         <li><%= govuk_link_to provider_sampling.provider.name, provider_sampling.csv_file %></li>

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -26,18 +26,18 @@ en:
         clawback_in_progress: Sent to payer for clawback
         clawback_complete: Clawback complete
       claims/claim_activity/action:
-        payment_request_delivered: Claims sent to ESFA for payment
-        payment_response_uploaded: ESFA payment response uploaded
+        payment_request_delivered: Claims sent to payer for payment
+        payment_response_uploaded: Payer payment response uploaded
         sampling_uploaded: Sampling data uploaded
         sampling_response_uploaded: Provider sampling response uploaded
-        clawback_request_delivered: Claims sent to ESFA for clawback
-        clawback_response_uploaded: ESFA clawback response uploaded
+        clawback_request_delivered: Claims sent to payer for clawback
+        clawback_response_uploaded: Payer clawback response uploaded
       claims/claim_activity/document:
-        payment_request_delivered: Claims sent to ESFA
-        payment_response_uploaded: ESFA payment response
+        payment_request_delivered: Claims sent to payer
+        payment_response_uploaded: Payer payment response
         sampling_response_uploaded: Provider sampling response
-        clawback_request_delivered: Claims sent to ESFA
-        clawback_response_uploaded: ESFA clawback response
+        clawback_request_delivered: Claims sent to payer
+        clawback_response_uploaded: Payer clawback response
       claims/claim_window:
         academic_year: Academic year
         window: Claim window

--- a/config/locales/en/claims/esfa_mailer.yml
+++ b/config/locales/en/claims/esfa_mailer.yml
@@ -4,7 +4,7 @@ en:
       claims_require_clawback:
         subject: Claims requiring clawback - Claim funding for mentor training
         body: |
-          To ESFA,
+          To the payer,
     
           The claims in the CSV file link are ready for clawback— the link to the latest CSV file is valid for 7 days:
             

--- a/config/locales/en/claims/payment_mailer.yml
+++ b/config/locales/en/claims/payment_mailer.yml
@@ -4,7 +4,7 @@ en:
       payment_created_notification:
         subject: Claims ready for payment - Claim funding for mentor training
         body: |
-          To ESFA,
+          To the payer,
 
           These claims from the Claim funding for mentor training service (Claim) are ready for payment — the link to the latest CSV file is valid for 7 days:
 

--- a/config/locales/en/claims/support/claims/clawbacks.yml
+++ b/config/locales/en/claims/support/claims/clawbacks.yml
@@ -10,8 +10,8 @@ en:
               one: Clawbacks (%{count})
               other: Clawbacks (%{count})
             no_claims: There are no claims waiting to be processed.
-            send_claims_to_esfa: Send claims to ESFA
-            upload_esfa_response: Upload ESFA response
+            send_claims_to_esfa: Send claims to payer
+            upload_esfa_response: Upload payer response
           show:
             page_caption: Clawbacks - Claim %{reference}
             page_title: "Clawbacks - %{school_name} - Claim %{reference}"
@@ -21,9 +21,9 @@ en:
             mentor: Mentor
             submitted_by: Submitted by %{name} on %{date}.
           new: 
-            page_title: Send claims to ESFA - Clawbacks
+            page_title: Send claims to payer - Clawbacks
             caption: Clawbacks
-            title: Send claims to ESFA
+            title: Send claims to payer
             description:
               one: There is %{count} claim included in this submission.
               other: There are %{count} claims included in this submission.
@@ -31,18 +31,17 @@ en:
               <p>Selecting ‘Send claims’ will:</p>
               <ul class="govuk-list govuk-list--bullet">
                 <li>create a CSV containing a list of all claims marked as ‘Clawback requested’</li>
-                <li>send an email to the ESFA containing a link to the generated CSV - this link expires after 7 days</li>
+                <li>send an email to the payer containing a link to the generated CSV - this link expires after 7 days</li>
                 <li>update the claim status from ‘Clawback requested’ to ‘Clawback in progress’</li>
               </ul>
             warning: This action cannot be undone.
             submit: Send claims
             cancel: Cancel
           create:
-            success: Claims sent to ESFA
+            success: Claims sent to payer
           new_not_permitted:
             page_title: There are no claims to send for clawback - Clawbacks
             title: There are no claims to send for clawback
             caption: Clawbacks
             cancel: Cancel
-            description: You cannot send any claims to the ESFA because there are no claims with a clawback requested.
-
+            description: You cannot send any claims to the payer because there are no claims with a clawback requested.

--- a/config/locales/en/claims/support/claims/payment_responses.yml
+++ b/config/locales/en/claims/support/claims/payment_responses.yml
@@ -5,11 +5,11 @@ en:
         payment_responses:
           new:
             page_caption: Payments
-            page_title: Upload ESFA response
+            page_title: Upload payer response
             label: Upload CSV file
             help:
               label: Help with the CSV file
-              description: Use this form to upload the CSV file sent by the ESFA.
+              description: Use this form to upload the CSV file sent by the payer.
               csv_instructions: "The CSV file must contain the following headers in the first row:"
               csv_headers:
                 - claim_reference
@@ -26,16 +26,16 @@ en:
             cancel: Cancel
           new_not_permitted:
             page_caption: Payments
-            page_title: You cannot upload a response from the ESFA
-            description: You cannot upload a response from the ESFA as there are no claims waiting for a response.
+            page_title: You cannot upload a response from the payer
+            description: You cannot upload a response from the payer as there are no claims waiting for a response.
             cancel: Cancel
           check:
             page_caption: Payments
-            page_title: Are you sure you want to upload the ESFA response?
+            page_title: Are you sure you want to upload the payer response?
             description:
               one: There is %{count} claim included in this upload.
               other: There are %{count} claims included in this upload.
             submit: Upload response
             cancel: Cancel
           update:
-            success: ESFA response uploaded
+            success: Payer response uploaded

--- a/config/locales/en/claims/support/claims/payments.yml
+++ b/config/locales/en/claims/support/claims/payments.yml
@@ -10,15 +10,15 @@ en:
               one: Payments (%{count})
               other: Payments (%{count})
             buttons:
-              send_claims_to_esfa: Send claims to ESFA
-              upload_esfa_response: Upload ESFA response
+              send_claims_to_esfa: Send claims to payer
+              upload_esfa_response: Upload payer response
             description:
               one: "%{count} claim needs processing"
               other: "%{count} claims need processing"
             no_claims: There are no claims waiting to be processed.
           new:
             page_caption: Payments
-            page_title: Send claims to ESFA
+            page_title: Send claims to payer
             description:
               one: There is %{count} claim included in this submission.
               other: There are %{count} claims included in this submission.
@@ -26,7 +26,7 @@ en:
               heading: "Selecting ‘Send claims’ will:"
               list:
                 - create a CSV containing a list of all ‘Submitted’ claims
-                - send an email to the ESFA containing a link to the generated CSV - this link expires after 7 days
+                - send an email to the payer containing a link to the generated CSV - this link expires after 7 days
                 - update the claim status from ‘Submitted’ to ‘Payment in progress’
             warning: This action cannot be undone.
             submit: Send claims
@@ -34,5 +34,5 @@ en:
           new_not_permitted:
             page_caption: Payments
             page_title: There are no claims to send for payment
-            description: You cannot send any claims to the ESFA because there are no claims pending payment.
+            description: You cannot send any claims to the payer because there are no claims pending payment.
             cancel: Cancel

--- a/config/locales/en/claims/support/claims/payments/claims.yml
+++ b/config/locales/en/claims/support/claims/payments/claims.yml
@@ -20,7 +20,7 @@ en:
             confirm_information_sent:
               page_caption: Payments - Claim %{reference}
               page_title: Are you sure you want to update the claim?
-              description: You confirm that you have sent the ESFA the information they requested so they can pay the claim.
+              description: You confirm that you have sent the payer the information they requested so they can pay the claim.
               submit: Update claim
               cancel: Cancel
             information_sent:

--- a/config/locales/en/claims/user_mailer.yml
+++ b/config/locales/en/claims/user_mailer.yml
@@ -87,7 +87,7 @@ en:
         body: |
           Dear %{user_name},
   
-          We have amended your claim to reflect the amount being clawed back by the Education and Skills Funding Agency (ESFA). They will contact you to discuss how they will claim this money from you.
+          We have amended your claim to reflect the amount being clawed back by the payer. They will contact you to discuss how they will claim this money from you.
         
           The affected claim reference is: %{reference}
           

--- a/config/locales/en/wizards/claims/upload_esfa_clawback_response_wizard.yml
+++ b/config/locales/en/wizards/claims/upload_esfa_clawback_response_wizard.yml
@@ -3,8 +3,8 @@ en:
     claims:
       upload_esfa_clawback_response_wizard:
         upload_step:
-          page_title: Upload ESFA response - Claims
-          title: Upload ESFA response
+          page_title: Upload payer response - Claims
+          title: Upload payer response
           caption: Clawbacks
           upload_csv_file: Upload CSV file
           csv_help: Help with the CSV file
@@ -32,10 +32,10 @@ en:
             other: There are %{count} claims included in this upload.
           upload_data: Upload responses
         no_claims_step:
-          title: You cannot upload an ESFA response
-          page_title: You cannot upload an ESFA response - Clawbacks - Claims
+          title: You cannot upload a payer response
+          page_title: You cannot upload a payer response - Clawbacks - Claims
           caption: Clawbacks
-          you_cannot_upload: You cannot upload an ESFA response as there are no claims waiting for a response.
+          you_cannot_upload: You cannot upload a payer response as there are no claims waiting for a response.
         upload_errors_step:
           title: There is a problem with the CSV file
           caption: Clawbacks

--- a/spec/mailers/claims/esfa_mailer_spec.rb
+++ b/spec/mailers/claims/esfa_mailer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Claims::ESFAMailer, type: :mailer do
         expect(claims_require_clawback_email.to).to match_array(esfa_emails)
         expect(claims_require_clawback_email.subject).to eq("Claims requiring clawback - Claim funding for mentor training")
         expect(claims_require_clawback_email.body.to_s.squish).to eq(<<~EMAIL.squish)
-          To ESFA,
+          To the payer,
 
           The claims in the CSV file link are ready for clawback— the link to the latest CSV file is valid for 7 days:
 

--- a/spec/mailers/claims/payment_mailer_spec.rb
+++ b/spec/mailers/claims/payment_mailer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Claims::PaymentMailer, freeze: "20 December 2024", type: :mailer 
       expect(email.to).to contain_exactly("esfa@example.com")
       expect(email.subject).to eq("Claims ready for payment - Claim funding for mentor training")
       expect(email.body.to_s.squish).to eq(<<~EMAIL.squish)
-        To ESFA,
+        To the payer,
 
         These claims from the Claim funding for mentor training service (Claim) are ready for payment — the link to the latest CSV file is valid for 7 days:
 

--- a/spec/mailers/claims/user_mailer_spec.rb
+++ b/spec/mailers/claims/user_mailer_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe Claims::UserMailer, type: :mailer do
       expect(clawback_email.body.to_s.strip).to eq(<<~EMAIL.strip)
         Dear #{user.first_name},
 
-        We have amended your claim to reflect the amount being clawed back by the Education and Skills Funding Agency (ESFA). They will contact you to discuss how they will claim this money from you.
+        We have amended your claim to reflect the amount being clawed back by the payer. They will contact you to discuss how they will claim this money from you.
 
         The affected claim reference is: #{claim.reference}
 

--- a/spec/system/claims/support/claims/clawbacks/send_to_esfa/support_user_can_not_send_claims_to_esfa_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/send_to_esfa/support_user_can_not_send_claims_to_esfa_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Support user can not send claims to ESFA", service: :claims, typ
   end
 
   def when_i_click_on_send_claims_to_esfa
-    click_on "Send claims to ESFA"
+    click_on "Send claims to payer"
   end
 
   def and_i_see_the_details_of_the_clawback_in_progress_claim
@@ -68,7 +68,7 @@ RSpec.describe "Support user can not send claims to ESFA", service: :claims, typ
     expect(page).to have_element(:p, text: "Clawbacks", class: "govuk-caption-l")
     expect(page).to have_element(
       :p,
-      text: "You cannot send any claims to the ESFA because there are no claims with a clawback requested.",
+      text: "You cannot send any claims to the payer because there are no claims with a clawback requested.",
     )
   end
 end

--- a/spec/system/claims/support/claims/clawbacks/send_to_esfa/support_user_sends_claims_to_esfa_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/send_to_esfa/support_user_sends_claims_to_esfa_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Support user sends claims to ESFA", service: :claims, type: :system do
+RSpec.describe "Support user sends claims to payer", service: :claims, type: :system do
   scenario do
     given_claims_exist
     and_i_am_signed_in
@@ -49,12 +49,12 @@ RSpec.describe "Support user sends claims to ESFA", service: :claims, type: :sys
   end
 
   def when_i_click_on_send_claims_to_esfa
-    click_on "Send claims to ESFA"
+    click_on "Send claims to payer"
   end
 
   def then_i_can_see_a_confirmation_page
     expect(page).to have_element(:p, text: "Clawbacks", class: "govuk-caption-l")
-    expect(page).to have_h1("Send claims to ESFA")
+    expect(page).to have_h1("Send claims to payer")
     expect(page).to have_element(:p, text: "There is 1 claim included in this submission.", class: "govuk-body")
     expect(page).to have_element(:div, text: "Selecting ‘Send claims’ will:", class: "govuk-body")
     expect(page).to have_element(
@@ -63,7 +63,7 @@ RSpec.describe "Support user sends claims to ESFA", service: :claims, type: :sys
     )
     expect(page).to have_element(
       :li,
-      text: "send an email to the ESFA containing a link to the generated CSV - this link expires after 7 days",
+      text: "send an email to the payer containing a link to the generated CSV - this link expires after 7 days",
     )
     expect(page).to have_element(
       :li,
@@ -77,7 +77,7 @@ RSpec.describe "Support user sends claims to ESFA", service: :claims, type: :sys
   end
 
   def then_i_see_a_success_message
-    expect(page).to have_success_banner("Claims sent to ESFA")
+    expect(page).to have_success_banner("Claims sent to payer")
   end
 
   def and_i_see_the_details_of_the_clawback_requested_claim

--- a/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_can_not_upload_esfa_clawback_responses_when_there_are_no_claims_with_the_status_clawback_in_progress_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_can_not_upload_esfa_clawback_responses_when_there_are_no_claims_with_the_status_clawback_in_progress_spec.rb
@@ -44,16 +44,16 @@ RSpec.describe "Support user can not upload ESFA clawback responses when there a
   end
 
   def when_i_click_on_upload_esfa_response
-    click_on "Upload ESFA response"
+    click_on "Upload payer response"
   end
 
   def then_i_see_there_are_no_claims_waiting_for_a_response
-    expect(page).to have_title("You cannot upload an ESFA response - Clawbacks - Claims - Claim funding for mentor training - GOV.UK")
-    expect(page).to have_h1("You cannot upload an ESFA response")
+    expect(page).to have_title("You cannot upload a payer response - Clawbacks - Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("You cannot upload a payer response")
     expect(page).to have_element(:span, text: "Clawback")
     expect(page).to have_element(
       :p,
-      text: "You cannot upload an ESFA response as there are no claims waiting for a response.",
+      text: "You cannot upload a payer response as there are no claims waiting for a response.",
       class: "govuk-body",
     )
   end

--- a/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_does_not_upload_a_file_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_does_not_upload_a_file_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Support user does not upload a file",
   end
 
   def then_i_see_the_upload_csv_page
-    expect(page).to have_h1("Upload ESFA response")
+    expect(page).to have_h1("Upload payer response")
     have_element(:span, text: "Sampling", class: "govuk-caption-l")
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
@@ -69,7 +69,7 @@ RSpec.describe "Support user does not upload a file",
   end
 
   def when_i_click_on_upload_esfa_response
-    click_on "Upload ESFA response"
+    click_on "Upload payer response"
   end
 
   def when_i_click_on_upload_csv_file

--- a/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_a_csv_containing_an_invalid_claim_status_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_a_csv_containing_an_invalid_claim_status_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Support user uploads a CSV containing an invalid claim status",
   end
 
   def then_i_see_the_upload_csv_page
-    expect(page).to have_h1("Upload ESFA response")
+    expect(page).to have_h1("Upload payer response")
     have_element(:span, text: "Clawbacks", class: "govuk-caption-l")
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
@@ -104,7 +104,7 @@ RSpec.describe "Support user uploads a CSV containing an invalid claim status",
   end
 
   def when_i_click_on_upload_esfa_response
-    click_on "Upload ESFA response"
+    click_on "Upload payer response"
   end
 
   def and_i_click_on_upload_csv_file

--- a/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_a_csv_containing_claims_not_with_the_status_clawback_in_progress_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_a_csv_containing_claims_not_with_the_status_clawback_in_progress_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Support user uploads a CSV containing claims not with the status
   end
 
   def then_i_see_the_upload_csv_page
-    expect(page).to have_h1("Upload ESFA response")
+    expect(page).to have_h1("Upload payer response")
     have_element(:span, text: "Clawback", class: "govuk-caption-l")
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
@@ -101,7 +101,7 @@ RSpec.describe "Support user uploads a CSV containing claims not with the status
   end
 
   def when_i_click_on_upload_esfa_response
-    click_on "Upload ESFA response"
+    click_on "Upload payer response"
   end
 
   def and_i_click_on_upload_csv_file

--- a/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_a_csv_containing_invalid_references_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_a_csv_containing_invalid_references_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Support user uploads a CSV containing invalid references",
   end
 
   def then_i_see_the_upload_csv_page
-    expect(page).to have_h1("Upload ESFA response")
+    expect(page).to have_h1("Upload payer response")
     have_element(:span, text: "Clawbacks", class: "govuk-caption-l")
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
@@ -104,7 +104,7 @@ RSpec.describe "Support user uploads a CSV containing invalid references",
   end
 
   def when_i_click_on_upload_esfa_response
-    click_on "Upload ESFA response"
+    click_on "Upload payer response"
   end
 
   def and_i_click_on_upload_csv_file

--- a/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_esfa_responses_for_claims_with_the_status_clawback_in_progress_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_esfa_responses_for_claims_with_the_status_clawback_in_progress_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe "Support user uploads ESFA responses for claims with the status '
   end
 
   def then_i_see_the_upload_csv_page
-    expect(page).to have_h1("Upload ESFA response")
+    expect(page).to have_h1("Upload payer response")
     have_element(:span, text: "Clawbacks", class: "govuk-caption-l")
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
@@ -141,7 +141,7 @@ RSpec.describe "Support user uploads ESFA responses for claims with the status '
   end
 
   def when_i_click_on_upload_esfa_response
-    click_on "Upload ESFA response"
+    click_on "Upload payer response"
   end
 
   def and_i_click_on_upload_csv_file

--- a/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_the_wrong_file_type_as_esfa_responses_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_the_wrong_file_type_as_esfa_responses_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Support user uploads the wrong file type as ESFA responses",
   end
 
   def then_i_see_the_upload_csv_page
-    expect(page).to have_h1("Upload ESFA response")
+    expect(page).to have_h1("Upload payer response")
     have_element(:span, text: "Clawbacks", class: "govuk-caption-l")
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
@@ -67,7 +67,7 @@ RSpec.describe "Support user uploads the wrong file type as ESFA responses",
   end
 
   def when_i_click_on_upload_esfa_response
-    click_on "Upload ESFA response"
+    click_on "Upload payer response"
   end
 
   def and_i_click_on_upload_csv_file

--- a/spec/system/claims/support/claims/payments/confirm_claim_payment_information_sent_spec.rb
+++ b/spec/system/claims/support/claims/payments/confirm_claim_payment_information_sent_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Confirm claim payment information sent", service: :claims, type:
 
   def then_i_see_a_confirmation_page
     expect(page).to have_content("Are you sure you want to update the claim?")
-    expect(page).to have_content("You confirm that you have sent the ESFA the information they requested so they can pay the claim.")
+    expect(page).to have_content("You confirm that you have sent the payer the information they requested so they can pay the claim.")
   end
 
   def when_i_click_on_update_claim

--- a/spec/system/claims/support/claims/payments/send_claims_to_esfa_spec.rb
+++ b/spec/system/claims/support/claims/payments/send_claims_to_esfa_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
-RSpec.describe "Send claims to ESFA", service: :claims, type: :system do
+RSpec.describe "Send claims to payer", service: :claims, type: :system do
   let(:support_user) { create(:claims_support_user) }
 
   before do
     user_exists_in_dfe_sign_in(user: support_user)
   end
 
-  scenario "Support user attempts to send claims to ESFA, but there are no 'submitted' claims" do
+  scenario "Support user attempts to send claims to payer, but there are no 'submitted' claims" do
     given_i_sign_in
     when_i_visit_claims_payments_index_page
     when_i_click_on_send_claims_to_esfa
@@ -19,7 +19,7 @@ RSpec.describe "Send claims to ESFA", service: :claims, type: :system do
       create_list(:claim, 3, :submitted)
     end
 
-    scenario "Support user sends claims to ESFA" do
+    scenario "Support user sends claims to payer" do
       given_i_sign_in
       when_i_visit_claims_payments_index_page
       when_i_click_on_send_claims_to_esfa
@@ -44,23 +44,23 @@ RSpec.describe "Send claims to ESFA", service: :claims, type: :system do
   end
 
   def when_i_click_on_send_claims_to_esfa
-    click_on("Send claims to ESFA")
+    click_on("Send claims to payer")
   end
 
   def then_i_can_see_an_error_page
     expect(page).to have_css("p.govuk-caption-l", text: "Payments")
     expect(page).to have_css("h1.govuk-heading-l", text: "There are no claims to send for payment")
-    expect(page).to have_css("p.govuk-body", text: "You cannot send any claims to the ESFA because there are no claims pending payment.")
+    expect(page).to have_css("p.govuk-body", text: "You cannot send any claims to the payer because there are no claims pending payment.")
     expect(page).to have_link("Cancel", href: claims_support_claims_payments_path)
   end
 
   def then_i_can_see_a_confirmation_page
     expect(page).to have_css("p.govuk-caption-l", text: "Payments")
-    expect(page).to have_css("h1.govuk-heading-l", text: "Send claims to ESFA")
+    expect(page).to have_css("h1.govuk-heading-l", text: "Send claims to payer")
     expect(page).to have_css("p.govuk-body", text: "There are 3 claims included in this submission.")
     expect(page).to have_css("p.govuk-body", text: "Selecting ‘Send claims’ will:")
     expect(page).to have_css("li", text: "create a CSV containing a list of all ‘Submitted’ claims")
-    expect(page).to have_css("li", text: "send an email to the ESFA containing a link to the generated CSV - this link expires after 7 days")
+    expect(page).to have_css("li", text: "send an email to the payer containing a link to the generated CSV - this link expires after 7 days")
     expect(page).to have_css("li", text: "update the claim status from ‘Submitted’ to ‘Payment in progress’")
     expect(page).to have_css("div.govuk-warning-text", text: "This action cannot be undone.")
   end
@@ -70,7 +70,7 @@ RSpec.describe "Send claims to ESFA", service: :claims, type: :system do
   end
 
   def then_i_see_a_success_flash_message
-    expect(page).to have_content("Claims sent to ESFA")
+    expect(page).to have_content("Claims sent to payer")
   end
 
   def and_claims_have_been_sent_to_esfa

--- a/spec/system/claims/support/claims/payments/upload_esfa_response_spec.rb
+++ b/spec/system/claims/support/claims/payments/upload_esfa_response_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
-RSpec.describe "Upload ESFA response CSV", service: :claims, type: :system do
+RSpec.describe "Upload payer response CSV", service: :claims, type: :system do
   let(:support_user) { create(:claims_support_user) }
 
-  scenario "Support user attempts to upload ESFA response, but there are no 'payment_in_progress' claims" do
+  scenario "Support user attempts to upload payer response, but there are no 'payment_in_progress' claims" do
     given_i_sign_in
     when_i_visit_claims_payments_index_page
     when_i_click_on_upload_esfa_response
@@ -31,7 +31,7 @@ RSpec.describe "Upload ESFA response CSV", service: :claims, type: :system do
       and_claims_have_been_paid_and_payment_information_requested
     end
 
-    scenario "Support user attempts to upload ESFA response without attaching a file" do
+    scenario "Support user attempts to upload payer response without attaching a file" do
       given_i_sign_in
       when_i_visit_claims_payments_index_page
       when_i_click_on_upload_esfa_response
@@ -54,7 +54,7 @@ RSpec.describe "Upload ESFA response CSV", service: :claims, type: :system do
   end
 
   def when_i_click_on_upload_esfa_response
-    click_on("Upload ESFA response")
+    click_on("Upload payer response")
   end
 
   def then_i_can_see_an_upload_form
@@ -63,8 +63,8 @@ RSpec.describe "Upload ESFA response CSV", service: :claims, type: :system do
 
   def then_i_can_see_an_error_page
     expect(page).to have_css("p.govuk-caption-l", text: "Payments")
-    expect(page).to have_css("h1.govuk-heading-l", text: "You cannot upload a response from the ESFA")
-    expect(page).to have_css("p.govuk-body", text: "You cannot upload a response from the ESFA as there are no claims waiting for a response.")
+    expect(page).to have_css("h1.govuk-heading-l", text: "You cannot upload a response from the payer")
+    expect(page).to have_css("p.govuk-body", text: "You cannot upload a response from the payer as there are no claims waiting for a response.")
     expect(page).to have_link("Cancel", href: claims_support_claims_payments_path)
   end
 
@@ -79,7 +79,7 @@ RSpec.describe "Upload ESFA response CSV", service: :claims, type: :system do
 
   def then_i_can_see_a_confirmation_page
     expect(page).to have_css("p.govuk-caption-l", text: "Payments")
-    expect(page).to have_css("h1.govuk-heading-l", text: "Are you sure you want to upload the ESFA response?")
+    expect(page).to have_css("h1.govuk-heading-l", text: "Are you sure you want to upload the payer response?")
     expect(page).to have_css("p.govuk-body", text: "There are 5 claims included in this upload.")
   end
 
@@ -88,7 +88,7 @@ RSpec.describe "Upload ESFA response CSV", service: :claims, type: :system do
   end
 
   def then_i_see_a_success_flash_message
-    expect(page).to have_content("ESFA response uploaded")
+    expect(page).to have_content("Payer response uploaded")
   end
 
   def then_i_see_the_error_message(message)

--- a/spec/system/claims/support/claims/view_a_claims_activity_spec.rb
+++ b/spec/system/claims/support/claims/view_a_claims_activity_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "View a claims activity", service: :claims, type: :system do
   end
 
   def then_i_can_see_the_claims_activity_payment_request_delivered_details
-    expect(page).to have_css("h1.govuk-heading-l", text: "Claims sent to ESFA")
+    expect(page).to have_css("h1.govuk-heading-l", text: "Claims sent to payer")
     expect(page).to have_content("Colin Chapman on 20 December 2024 at 4:00pm")
   end
 

--- a/spec/system/claims/support/claims/view_claims_activity_log_spec.rb
+++ b/spec/system/claims/support/claims/view_claims_activity_log_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "View claims activity log", service: :claims, type: :system do
     end
 
     within(".app-timeline__item:nth-child(2)") do
-      expect(page).to have_content("Claims sent to ESFA for payment")
+      expect(page).to have_content("Claims sent to payer for payment")
       expect(page).to have_content("Colin Chapman on 20 December 2024 at 4:00pm")
     end
   end

--- a/spec/wizards/claims/request_clawback_wizard_spec.rb
+++ b/spec/wizards/claims/request_clawback_wizard_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Claims::RequestClawbackWizard do
         }
       end
 
-      it "calls the ClawbackRequested service with the claim and esfa responses" do
+      it "calls the ClawbackRequested service with the claim and payer responses" do
         wizard.submit_esfa_responses
         expect(Claims::Claim::Clawback::ClawbackRequested).to have_received(:call).with(claim:, esfa_responses:)
       end


### PR DESCRIPTION
## Context

Update all references to the "ESFA" in the application to instead be "Payer"

## Changes proposed in this pull request

- [x] Replace "ESFA" with "payer"

## Guidance to review

- Work through the new support screens and check for any references to ESFA.

## Link to Trello card

[Replace ESFA with payer](https://trello.com/c/2xzPWFRC/386-replace-esfa-with-payer)