### PR TITLE
Replace sampling with auditing

### DIFF
--- a/app/controllers/claims/sampling/claims_controller.rb
+++ b/app/controllers/claims/sampling/claims_controller.rb
@@ -7,7 +7,7 @@ class Claims::Sampling::ClaimsController < Claims::ApplicationController
 
   def download
     provider_name = @provider_sampling.provider_name.parameterize
-    send_data @provider_sampling.csv_file.download, filename: "sampling-claims-#{provider_name}-#{Time.current.iso8601}.csv"
+    send_data @provider_sampling.csv_file.download, filename: "quality_assurance_for_#{provider_name.parameterize(separator: "_")}_response.csv"
   end
 
   private

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -28,14 +28,14 @@ en:
       claims/claim_activity/action:
         payment_request_delivered: Claims sent to payer for payment
         payment_response_uploaded: Payer payment response uploaded
-        sampling_uploaded: Sampling data uploaded
-        sampling_response_uploaded: Provider sampling response uploaded
+        sampling_uploaded: Audit data uploaded
+        sampling_response_uploaded: Provider audit response uploaded
         clawback_request_delivered: Claims sent to payer for clawback
         clawback_response_uploaded: Payer clawback response uploaded
       claims/claim_activity/document:
         payment_request_delivered: Claims sent to payer
         payment_response_uploaded: Payer payment response
-        sampling_response_uploaded: Provider sampling response
+        sampling_response_uploaded: Provider audit response
         clawback_request_delivered: Claims sent to payer
         clawback_response_uploaded: Payer clawback response
       claims/claim_window:

--- a/config/locales/en/claims/support/claims.yml
+++ b/config/locales/en/claims/support/claims.yml
@@ -27,7 +27,7 @@ en:
         show:
           page_caption: Claim %{reference}
           page_title: "%{school_name} - Claim %{reference}"
-          reason: Reason claim is being sampled
+          reason: Reason claim is being audited
           approve: Approve claim
           confirm_provider_reject: Confirm provider rejected claim
           status: Status

--- a/config/locales/en/claims/support/claims/samplings.yml
+++ b/config/locales/en/claims/support/claims/samplings.yml
@@ -6,16 +6,16 @@ en:
           index:
             heading: Claims
             sub_heading:
-              zero: Sampling
-              one: Sampling (%{count})
-              other: Sampling (%{count})
+              zero: Auditing
+              one: Auditing (%{count})
+              other: Auditing (%{count})
             no_claims: There are no claims waiting to be processed.
-            upload_claims: Upload claims to be sampled
+            upload_claims: Upload claims to be audited
             upload_provider_response: Upload provider response
           show:
-            page_caption: Sampling - Claim %{reference}
-            page_title: "%{school_name} - Sampling - Claim %{reference}"
-            reason: Reason claim is being sampled
+            page_caption: Auditing - Claim %{reference}
+            page_title: "%{school_name} - Auditing - Claim %{reference}"
+            reason: Reason claim is being audited
             approve: Approve claim
             confirm_provider_reject: Confirm provider rejected claim
             reject_claim: Reject claim
@@ -26,7 +26,7 @@ en:
             submitted_by: Submitted by %{name} on %{date}.
             provider_response: Provider response
           confirm_approval:
-            page_caption: Sampling - Claim %{reference}
+            page_caption: Auditing - Claim %{reference}
             page_title: Are you sure you want to approve the claim?
             mark_as_paid: This will mark the claim as 'Paid'.
             approve: Approve claim
@@ -34,8 +34,8 @@ en:
           update:
             success_heading: Claim updated
           confirm_provider_rejected:
-            page_title: Are you sure you want to confirm the provider has rejected the claim? - Sampling - Claim %{reference}
-            caption: Sampling - Claim %{reference}
+            page_title: Are you sure you want to confirm the provider has rejected the claim? - Auditing - Claim %{reference}
+            caption: Auditing - Claim %{reference}
             title: Are you sure you want to confirm the provider has rejected the claim?
             cancel: Cancel
             provider_has_rejected: You confirm you have spoken to the provider and they have rejected the claim.
@@ -44,8 +44,8 @@ en:
           provider_rejected:
             success: Claim updated
           confirm_rejection:
-            page_title: Are you sure you want to reject the claim? - Sampling - Claim %{reference}
-            caption: Sampling - Claim %{reference}
+            page_title: Are you sure you want to reject the claim? - Auditing - Claim %{reference}
+            caption: Auditing - Claim %{reference}
             title: Are you sure you want to reject the claim?
             cancel: Cancel
             mark_as_claim_not_approved: | 

--- a/config/locales/en/claims/support/claims/samplings/upload_data.yml
+++ b/config/locales/en/claims/support/claims/samplings/upload_data.yml
@@ -7,4 +7,4 @@ en:
             edit:
               cancel: Cancel
             update: 
-              success: Sampling data uploaded
+              success: Auditing data uploaded

--- a/config/locales/en/claims/support/claims/secondary_navigation.yml
+++ b/config/locales/en/claims/support/claims/secondary_navigation.yml
@@ -5,6 +5,6 @@ en:
         secondary_navigation:
           all_claims: All claims
           payments: Payments
-          sampling: Sampling
+          sampling: Auditing
           clawbacks: Clawbacks
           activity_log: Activity log

--- a/config/locales/en/wizards/claims/provider_rejected_claim_wizard.yml
+++ b/config/locales/en/wizards/claims/provider_rejected_claim_wizard.yml
@@ -3,14 +3,14 @@ en:
     claims:
       provider_rejected_claim_wizard:
         mentor_training_step:
-          page_title: Select a mentor - Rejected by provider - Claim %{reference} - Sampling - Claims
+          page_title: Select a mentor - Rejected by provider - Claim %{reference} - Auditing - Claims
           title: Rejection details from the provider
           caption: Rejected by provider - Claim %{reference}
           continue: Continue
           which_mentors: Which mentors are being rejected?
           include_partial_or_whole_clawback: Include mentors which need partial or whole clawback.
         provider_response_step:
-          page_title:  What reason has the provider given for rejecting %{mentor_name}? - Rejected by provider - Claim %{reference} - Sampling - Claims
+          page_title:  What reason has the provider given for rejecting %{mentor_name}? - Rejected by provider - Claim %{reference} - Auditing - Claims
           title: What reason has the provider given for rejecting %{mentor_name}?
           caption: Rejected by provider - Claim %{reference}
           mentor_training_assured: Has the provider assured this mentor's training?
@@ -20,7 +20,7 @@ en:
             one: The school originally claimed %{mentor_name} has completed %{count} hour.
             other: The school originally claimed %{mentor_name} has completed %{count} hours.
         check_your_answers_step:
-          page_title: Check your answers - Rejected by provider - Claim %{reference} - Sampling - Claims
+          page_title: Check your answers - Rejected by provider - Claim %{reference} - Auditing - Claims
           title: Check your answers
           caption: Rejected by provider - Claim %{reference}
           reason_for_rejection: Reason for rejection

--- a/config/locales/en/wizards/claims/reject_claim_wizard.yml
+++ b/config/locales/en/wizards/claims/reject_claim_wizard.yml
@@ -3,7 +3,7 @@ en:
     claims:
       reject_claim_wizard:
         confirmation_step:
-          page_title:  Are you sure you want to reject the claim? - Reject - Claim %{reference} - Sampling - Claims
+          page_title:  Are you sure you want to reject the claim? - Reject - Claim %{reference} - Auditing - Claims
           title: Are you sure you want to reject the claim?
           caption: Reject - Claim %{reference}
           continue: Continue
@@ -16,7 +16,7 @@ en:
               <li>told the school which claims you are rejecting and how much will be clawed back</li>
             </ol>
         school_response_step:
-          page_title:  What is the schools response to the claim about %{mentor_name}? - Reject - Claim %{reference} - Sampling - Claims
+          page_title:  What is the schools response to the claim about %{mentor_name}? - Reject - Claim %{reference} - Auditing - Claims
           title: What is the schools response to the claim about %{mentor_name}?
           caption: Reject - Claim %{reference}
           continue: Continue
@@ -26,7 +26,7 @@ en:
           please_add_reason: Only include details related to %{mentor_name}.
           provider_response: Provider response
         check_your_answers_step:
-          page_title: Check your answers - Reject - Claim %{reference} - Sampling - Claims
+          page_title: Check your answers - Reject - Claim %{reference} - Auditing - Claims
           title: Check your answers
           caption: Reject - Claim %{reference}
           reason_for_rejection: Reason for rejection

--- a/config/locales/en/wizards/claims/upload_provider_response_wizard.yml
+++ b/config/locales/en/wizards/claims/upload_provider_response_wizard.yml
@@ -3,9 +3,9 @@ en:
     claims:
       upload_provider_response_wizard:
         upload_step:
-          page_title: Sampling - Claims
+          page_title: Auditing - Claims
           title: Upload provider response
-          caption: Sampling
+          caption: Auditing
           upload_csv_file: Upload CSV file
           csv_help: Help with the CSV file
           csv_help_details: |
@@ -25,27 +25,27 @@ en:
               - claim_accepted
               - rejection_reason
         confirmation_step:
-          page_title: Are you sure you want to upload the provider's response? - Sampling - Claims
+          page_title: Are you sure you want to upload the provider's response? - Auditing - Claims
           title: Are you sure you want to upload the provider's response?
-          caption: Sampling
+          caption: Auditing
           claims_count: 
             one: There is %{count} claim included in this upload.
             other: There are %{count} claims included in this upload.
           upload_data: Upload responses
         no_claims_step:
           title: You cannot upload a provider response
-          page_title: You cannot upload a provider response - Sampling - Claims
-          caption: Sampling
+          page_title: You cannot upload a provider response - Auditing - Claims
+          caption: Auditing
           you_cannot_upload: You cannot upload a provider response as there are no claims waiting for a response.
         upload_errors_step:
           title: There is a problem with the CSV file
-          caption: Sampling
-          page_title: There is a problem with the CSV file - Sampling - Claims
+          caption: Auditing
+          page_title: There is a problem with the CSV file - Auditing - Claims
           status: Status
           claim_reference: Claim reference
           view: View (opens in new tab)
           incorrect_claim_reference: There are no claims associated with the following references:-
-          incorrect_status: The following claims do not have the status 'Sampling in progress':-
+          incorrect_status: The following claims do not have the status 'Audit in progress':-
           missing_mentors: The following claims are missing mentors from the uploaded CSV:-
           invalid_assured_status: The following claims are missing a claim assured status:-
           missing_not_assured_message: The following claims are missing a claim not assured reason:-

--- a/config/locales/en/wizards/claims/upload_sampling_data_wizard.yml
+++ b/config/locales/en/wizards/claims/upload_sampling_data_wizard.yml
@@ -3,9 +3,9 @@ en:
     claims:
       upload_sampling_data_wizard:
         upload_step:
-          page_title: Upload claims to be sampled - Sampling - Claims
-          caption: Sampling
-          title: Upload claims to be sampled
+          page_title: Upload claims to be audited - Auditing - Claims
+          caption: Auditing
+          title: Upload claims to be audited
           upload_csv_file: Upload CSV file
           csv_help: Help with the CSV file
           csv_help_details: |
@@ -16,18 +16,17 @@ en:
             - claim_reference
             - sample_reason
         confirmation_step:
-          page_title: Are you sure you want to upload the sampling data? - Sampling - Claims
-          title: Are you sure you want to upload the sampling data?
-          caption: Sampling
+          page_title: Are you sure you want to upload the auditing data? - Auditing - Claims
+          title: Are you sure you want to upload the auditing data?
+          caption: Auditing
           claims_count: 
             one: There is %{count} claim included in this upload.
             other: There are %{count} claims included in this upload.
           providers_will_be_emailed: 
-            Each accredited provider included in the sample data will receive an email
-            instructing them to assure their partner schools' claim.
+            Each accredited provider will receive an email instructing them to assure their partner schools' claim.
           upload_data: Upload data
         no_claims_step:
-          title: You cannot upload any claims to be sampled
-          page_title: You cannot upload any claims to be sampled - Sampling - Claims
-          caption: Sampling
-          you_cannot_upload: You cannot upload a sampling file as there are no claims that have been paid.
+          title: You cannot upload any claims to be audited
+          page_title: You cannot upload any claims to be audited - Auditing - Claims
+          caption: Auditing
+          you_cannot_upload: You cannot upload an auditing file as there are no claims that have been paid.

--- a/spec/system/claims/sampling/claims/provider_user_downloads_sampling_csv_with_valid_token_spec.rb
+++ b/spec/system/claims/sampling/claims/provider_user_downloads_sampling_csv_with_valid_token_spec.rb
@@ -42,10 +42,9 @@ RSpec.describe "Provider user downloads sampling CSV with valid token", service:
   end
 
   def then_the_csv_is_downloaded
-    current_time = Time.zone.now.utc.strftime("%Y-%m-%dT%H%%3A%M%%3A%SZ")
     provider_name = @provider_sampling.provider_name.parameterize
     expect(page.response_headers["Content-Type"]).to eq("text/csv")
-    expect(page.response_headers["Content-Disposition"]).to eq("attachment; filename=\"sampling-claims-#{provider_name}-#{current_time}.csv\"; filename*=UTF-8''sampling-claims-#{provider_name}-#{current_time}.csv")
+    expect(page.response_headers["Content-Disposition"]).to eq("attachment; filename=\"quality_assurance_for_#{provider_name}_response.csv\"; filename*=UTF-8''quality_assurance_for_#{provider_name}_response.csv")
   end
 
   def and_the_sampling_is_marked_as_downloaded

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_mentor_who_is_being_rejected_by_the_provider_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_mentor_who_is_being_rejected_by_the_provider_spec.rb
@@ -66,16 +66,16 @@ RSpec.describe "Support user changes the mentor who is being rejected by the pro
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
   def then_i_see_the_sampling_claims_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
-    expect(page).to have_h2("Sampling (1)")
+    expect(page).to have_h2("Auditing (1)")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 
@@ -85,9 +85,9 @@ RSpec.describe "Support user changes the mentor who is being rejected by the pro
 
   def then_i_see_the_details_of_the_claim
     expect(page).to have_title(
-      "#{@claim.school.name} - Sampling - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+      "#{@claim.school.name} - Auditing - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
     )
-    expect(page).to have_element(:p, text: "Sampling - Claim #{@claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_element(:p, text: "Auditing - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@claim.school.name)
     expect(page).to have_element(:strong, text: "Audit requested", class: "govuk-tag govuk-tag--yellow")
   end
@@ -99,11 +99,11 @@ RSpec.describe "Support user changes the mentor who is being rejected by the pro
   def then_i_see_that_the_claim_has_been_updated_to_provider_not_approved
     expect(page).to have_current_path(claims_support_claims_sampling_path(@claim), ignore_query: true)
     expect(page).to have_title(
-      "#{@claim.school.name} - Sampling - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+      "#{@claim.school.name} - Auditing - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :p,
-      text: "Sampling - Claim #{@claim.reference}",
+      text: "Auditing - Claim #{@claim.reference}",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1(@claim.school.name)
@@ -114,7 +114,7 @@ RSpec.describe "Support user changes the mentor who is being rejected by the pro
 
   def then_i_see_the_mentor_selection_page
     expect(page).to have_title(
-      "Select a mentor - Rejected by provider - Claim #{@claim.reference} - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "Select a mentor - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(:span, text: "Rejected by provider - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1("Rejection details from the provider")
@@ -132,7 +132,7 @@ RSpec.describe "Support user changes the mentor who is being rejected by the pro
 
   def then_i_see_the_rejection_reason_page_for_john_smith
     expect(page).to have_title(
-      "What reason has the provider given for rejecting John Smith? - Rejected by provider - Claim #{@claim.reference} - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "What reason has the provider given for rejecting John Smith? - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
@@ -154,7 +154,7 @@ RSpec.describe "Support user changes the mentor who is being rejected by the pro
 
   def then_i_see_the_check_your_answers_page
     expect(page).to have_title(
-      "Check your answers - Rejected by provider - Claim #{@claim.reference} - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "Check your answers - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
@@ -197,7 +197,7 @@ RSpec.describe "Support user changes the mentor who is being rejected by the pro
 
   def then_i_see_the_rejection_reason_page_for_jane_doe
     expect(page).to have_title(
-      "What reason has the provider given for rejecting Jane Doe? - Rejected by provider - Claim #{@claim.reference} - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "What reason has the provider given for rejecting Jane Doe? - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_reason_the_provider_rejected_the_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_reason_the_provider_rejected_the_mentor_spec.rb
@@ -61,16 +61,16 @@ RSpec.describe "Support user changes the reason the provider rejected the mentor
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
   def then_i_see_the_sampling_claims_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
-    expect(page).to have_h2("Sampling (1)")
+    expect(page).to have_h2("Auditing (1)")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 
@@ -80,9 +80,9 @@ RSpec.describe "Support user changes the reason the provider rejected the mentor
 
   def then_i_see_the_details_of_the_claim
     expect(page).to have_title(
-      "#{@claim.school.name} - Sampling - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+      "#{@claim.school.name} - Auditing - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
     )
-    expect(page).to have_element(:p, text: "Sampling - Claim #{@claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_element(:p, text: "Auditing - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@claim.school.name)
     expect(page).to have_element(:strong, text: "Audit requested", class: "govuk-tag govuk-tag--yellow")
   end
@@ -94,11 +94,11 @@ RSpec.describe "Support user changes the reason the provider rejected the mentor
   def then_i_see_that_the_claim_has_been_updated_to_provider_not_approved
     expect(page).to have_current_path(claims_support_claims_sampling_path(@claim), ignore_query: true)
     expect(page).to have_title(
-      "#{@claim.school.name} - Sampling - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+      "#{@claim.school.name} - Auditing - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :p,
-      text: "Sampling - Claim #{@claim.reference}",
+      text: "Auditing - Claim #{@claim.reference}",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1(@claim.school.name)
@@ -109,7 +109,7 @@ RSpec.describe "Support user changes the reason the provider rejected the mentor
 
   def then_i_see_the_mentor_selection_page
     expect(page).to have_title(
-      "Select a mentor - Rejected by provider - Claim #{@claim.reference} - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "Select a mentor - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(:span, text: "Rejected by provider - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1("Rejection details from the provider")
@@ -127,7 +127,7 @@ RSpec.describe "Support user changes the reason the provider rejected the mentor
 
   def then_i_see_the_rejection_reason_page_for_john_smith
     expect(page).to have_title(
-      "What reason has the provider given for rejecting John Smith? - Rejected by provider - Claim #{@claim.reference} - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "What reason has the provider given for rejecting John Smith? - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
@@ -149,7 +149,7 @@ RSpec.describe "Support user changes the reason the provider rejected the mentor
 
   def then_i_see_the_check_your_answers_page
     expect(page).to have_title(
-      "Check your answers - Rejected by provider - Claim #{@claim.reference} - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "Check your answers - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_does_not_enter_a_reason_why_the_provider_rejected_the_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_does_not_enter_a_reason_why_the_provider_rejected_the_mentor_spec.rb
@@ -46,16 +46,16 @@ RSpec.describe "Support user does not enter a reason why the provider rejected t
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
   def then_i_see_the_sampling_claims_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
-    expect(page).to have_h2("Sampling (1)")
+    expect(page).to have_h2("Auditing (1)")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 
@@ -65,9 +65,9 @@ RSpec.describe "Support user does not enter a reason why the provider rejected t
 
   def then_i_see_the_details_of_the_claim
     expect(page).to have_title(
-      "#{@claim.school.name} - Sampling - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+      "#{@claim.school.name} - Auditing - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
     )
-    expect(page).to have_element(:p, text: "Sampling - Claim #{@claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_element(:p, text: "Auditing - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@claim.school.name)
     expect(page).to have_element(:strong, text: "Audit requested", class: "govuk-tag govuk-tag--yellow")
   end
@@ -78,7 +78,7 @@ RSpec.describe "Support user does not enter a reason why the provider rejected t
 
   def then_i_see_the_mentor_selection_page
     expect(page).to have_title(
-      "Select a mentor - Rejected by provider - Claim #{@claim.reference} - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "Select a mentor - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(:span, text: "Rejected by provider - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1("Rejection details from the provider")
@@ -97,7 +97,7 @@ RSpec.describe "Support user does not enter a reason why the provider rejected t
 
   def then_i_see_the_rejection_reason_page_for_john_smith
     expect(page).to have_title(
-      "What reason has the provider given for rejecting John Smith? - Rejected by provider - Claim #{@claim.reference} - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "What reason has the provider given for rejecting John Smith? - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_does_not_select_any_mentors_rejected_by_the_provider_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_does_not_select_any_mentors_rejected_by_the_provider_spec.rb
@@ -40,16 +40,16 @@ RSpec.describe "Support user does not select any mentors rejected by the provide
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
   def then_i_see_the_sampling_claims_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
-    expect(page).to have_h2("Sampling (1)")
+    expect(page).to have_h2("Auditing (1)")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 
@@ -59,9 +59,9 @@ RSpec.describe "Support user does not select any mentors rejected by the provide
 
   def then_i_see_the_details_of_the_claim
     expect(page).to have_title(
-      "#{@claim.school.name} - Sampling - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+      "#{@claim.school.name} - Auditing - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
     )
-    expect(page).to have_element(:p, text: "Sampling - Claim #{@claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_element(:p, text: "Auditing - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@claim.school.name)
     expect(page).to have_element(:strong, text: "Audit requested", class: "govuk-tag govuk-tag--yellow")
   end
@@ -72,7 +72,7 @@ RSpec.describe "Support user does not select any mentors rejected by the provide
 
   def then_i_see_the_mentor_selection_page
     expect(page).to have_title(
-      "Select a mentor - Rejected by provider - Claim #{@claim.reference} - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "Select a mentor - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(:span, text: "Rejected by provider - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1("Rejection details from the provider")

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_marks_the_claim_as_provider_not_approved_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_marks_the_claim_as_provider_not_approved_spec.rb
@@ -103,16 +103,16 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
   def then_i_see_the_sampling_claims_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
-    expect(page).to have_h2("Sampling (1)")
+    expect(page).to have_h2("Auditing (1)")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 
@@ -122,9 +122,9 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
 
   def then_i_see_the_details_of_the_claim
     expect(page).to have_title(
-      "#{@claim.school.name} - Sampling - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+      "#{@claim.school.name} - Auditing - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
     )
-    expect(page).to have_element(:p, text: "Sampling - Claim #{@claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_element(:p, text: "Auditing - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@claim.school.name)
     expect(page).to have_element(:strong, text: "Audit requested", class: "govuk-tag govuk-tag--yellow")
   end
@@ -143,11 +143,11 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
   def then_i_see_that_the_claim_has_been_updated_to_provider_not_approved
     expect(page).to have_current_path(claims_support_claims_sampling_path(@claim), ignore_query: true)
     expect(page).to have_title(
-      "#{@claim.school.name} - Sampling - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+      "#{@claim.school.name} - Auditing - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :p,
-      text: "Sampling - Claim #{@claim.reference}",
+      text: "Auditing - Claim #{@claim.reference}",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1(@claim.school.name)
@@ -158,7 +158,7 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
 
   def then_i_see_the_mentor_selection_page
     expect(page).to have_title(
-      "Select a mentor - Rejected by provider - Claim #{@claim.reference} - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "Select a mentor - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(:span, text: "Rejected by provider - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1("Rejection details from the provider")
@@ -181,7 +181,7 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
 
   def then_i_see_the_rejection_reason_page_for_john_smith
     expect(page).to have_title(
-      "What reason has the provider given for rejecting John Smith? - Rejected by provider - Claim #{@claim.reference} - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "What reason has the provider given for rejecting John Smith? - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
@@ -205,7 +205,7 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
 
   def then_i_see_the_check_your_answers_page
     expect(page).to have_title(
-      "Check your answers - Rejected by provider - Claim #{@claim.reference} - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "Check your answers - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
@@ -262,7 +262,7 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
 
   def then_i_see_the_rejection_reason_page_for_jane_doe
     expect(page).to have_title(
-      "What reason has the provider given for rejecting Jane Doe? - Rejected by provider - Claim #{@claim.reference} - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "What reason has the provider given for rejecting Jane Doe? - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_changes_the_reason_the_school_rejected_the_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_changes_the_reason_the_school_rejected_the_mentor_spec.rb
@@ -60,16 +60,16 @@ RSpec.describe "Support user changes the reason the school rejected the mentor",
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
   def then_i_see_the_sampling_claims_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
-    expect(page).to have_h2("Sampling (1)")
+    expect(page).to have_h2("Auditing (1)")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 
@@ -79,9 +79,9 @@ RSpec.describe "Support user changes the reason the school rejected the mentor",
 
   def then_i_see_the_details_of_the_claim
     expect(page).to have_title(
-      "#{@claim.school.name} - Sampling - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+      "#{@claim.school.name} - Auditing - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
     )
-    expect(page).to have_element(:p, text: "Sampling - Claim #{@claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_element(:p, text: "Auditing - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@claim.school.name)
     expect(page).to have_element(:strong, text: "Rejected by provider", class: "govuk-tag govuk-tag--turquoise")
   end
@@ -93,11 +93,11 @@ RSpec.describe "Support user changes the reason the school rejected the mentor",
   def then_i_see_that_the_claim_has_been_updated_to_not_approved
     expect(page).to have_current_path(claims_support_claims_sampling_path(@claim), ignore_query: true)
     expect(page).to have_title(
-      "#{@claim.school.name} - Sampling - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+      "#{@claim.school.name} - Auditing - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :p,
-      text: "Sampling - Claim #{@claim.reference}",
+      text: "Auditing - Claim #{@claim.reference}",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1(@claim.school.name)
@@ -117,7 +117,7 @@ RSpec.describe "Support user changes the reason the school rejected the mentor",
 
   def then_i_see_the_check_your_answers_page
     expect(page).to have_title(
-      "Check your answers - Reject - Claim #{@claim.reference} - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "Check your answers - Reject - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
@@ -158,7 +158,7 @@ RSpec.describe "Support user changes the reason the school rejected the mentor",
 
   def then_i_see_the_rejection_reason_page_for_jane_doe
     expect(page).to have_title(
-      "What is the schools response to the claim about Jane Doe? - Reject - Claim #{@claim.reference} - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "What is the schools response to the claim about Jane Doe? - Reject - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
@@ -178,7 +178,7 @@ RSpec.describe "Support user changes the reason the school rejected the mentor",
 
   def then_i_see_the_rejection_reason_page_for_john_smith
     expect(page).to have_title(
-      "What is the schools response to the claim about John Smith? - Reject - Claim #{@claim.reference} - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "What is the schools response to the claim about John Smith? - Reject - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
@@ -202,7 +202,7 @@ RSpec.describe "Support user changes the reason the school rejected the mentor",
 
   def then_i_see_the_confirmation_page
     expect(page).to have_title(
-      "Are you sure you want to reject the claim? - Reject - Claim #{@claim.reference} - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "Are you sure you want to reject the claim? - Reject - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_does_not_enter_a_reason_why_the_school_rejected_the_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_does_not_enter_a_reason_why_the_school_rejected_the_mentor_spec.rb
@@ -48,16 +48,16 @@ RSpec.describe "Support user does not enter a reason why the school rejected the
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
   def then_i_see_the_sampling_claims_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
-    expect(page).to have_h2("Sampling (1)")
+    expect(page).to have_h2("Auditing (1)")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 
@@ -67,9 +67,9 @@ RSpec.describe "Support user does not enter a reason why the school rejected the
 
   def then_i_see_the_details_of_the_claim
     expect(page).to have_title(
-      "#{@claim.school.name} - Sampling - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+      "#{@claim.school.name} - Auditing - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
     )
-    expect(page).to have_element(:p, text: "Sampling - Claim #{@claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_element(:p, text: "Auditing - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@claim.school.name)
     expect(page).to have_element(:strong, text: "Rejected by provider", class: "govuk-tag govuk-tag--turquoise")
   end
@@ -84,7 +84,7 @@ RSpec.describe "Support user does not enter a reason why the school rejected the
 
   def then_i_see_the_rejection_reason_page_for_john_smith
     expect(page).to have_title(
-      "What is the schools response to the claim about John Smith? - Reject - Claim #{@claim.reference} - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "What is the schools response to the claim about John Smith? - Reject - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
@@ -108,7 +108,7 @@ RSpec.describe "Support user does not enter a reason why the school rejected the
 
   def then_i_see_the_confirmation_page
     expect(page).to have_title(
-      "Are you sure you want to reject the claim? - Reject - Claim #{@claim.reference} - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "Are you sure you want to reject the claim? - Reject - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_marks_the_claim_as_rejected_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_marks_the_claim_as_rejected_spec.rb
@@ -111,16 +111,16 @@ RSpec.describe "Support user marks a claim as rejected", service: :claims, type:
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
   def then_i_see_the_sampling_claims_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
-    expect(page).to have_h2("Sampling (1)")
+    expect(page).to have_h2("Auditing (1)")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 
@@ -130,9 +130,9 @@ RSpec.describe "Support user marks a claim as rejected", service: :claims, type:
 
   def then_i_see_the_details_of_the_claim
     expect(page).to have_title(
-      "#{@claim.school.name} - Sampling - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+      "#{@claim.school.name} - Auditing - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
     )
-    expect(page).to have_element(:p, text: "Sampling - Claim #{@claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_element(:p, text: "Auditing - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@claim.school.name)
     expect(page).to have_element(:strong, text: "Rejected by provider", class: "govuk-tag govuk-tag--turquoise")
   end
@@ -151,11 +151,11 @@ RSpec.describe "Support user marks a claim as rejected", service: :claims, type:
   def then_i_see_that_the_claim_has_been_updated_to_not_approved
     expect(page).to have_current_path(claims_support_claims_sampling_path(@claim), ignore_query: true)
     expect(page).to have_title(
-      "#{@claim.school.name} - Sampling - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+      "#{@claim.school.name} - Auditing - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :p,
-      text: "Sampling - Claim #{@claim.reference}",
+      text: "Auditing - Claim #{@claim.reference}",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1(@claim.school.name)
@@ -177,7 +177,7 @@ RSpec.describe "Support user marks a claim as rejected", service: :claims, type:
 
   def then_i_see_the_check_your_answers_page
     expect(page).to have_title(
-      "Check your answers - Reject - Claim #{@claim.reference} - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "Check your answers - Reject - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
@@ -226,7 +226,7 @@ RSpec.describe "Support user marks a claim as rejected", service: :claims, type:
 
   def then_i_see_the_rejection_reason_page_for_jane_doe
     expect(page).to have_title(
-      "What is the schools response to the claim about Jane Doe? - Reject - Claim #{@claim.reference} - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "What is the schools response to the claim about Jane Doe? - Reject - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
@@ -246,7 +246,7 @@ RSpec.describe "Support user marks a claim as rejected", service: :claims, type:
 
   def then_i_see_the_rejection_reason_page_for_john_smith
     expect(page).to have_title(
-      "What is the schools response to the claim about John Smith? - Reject - Claim #{@claim.reference} - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "What is the schools response to the claim about John Smith? - Reject - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
@@ -272,7 +272,7 @@ RSpec.describe "Support user marks a claim as rejected", service: :claims, type:
 
   def then_i_see_the_confirmation_page
     expect(page).to have_title(
-      "Are you sure you want to reject the claim? - Reject - Claim #{@claim.reference} - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "Are you sure you want to reject the claim? - Reject - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,

--- a/spec/system/claims/support/claims/sampling/mark_provider_rejected_claim_as_approved/support_user_approves_a_provider_rejected_sampling_claim_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_provider_rejected_claim_as_approved/support_user_approves_a_provider_rejected_sampling_claim_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Support user approves a provider rejected sampling claim", servi
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
@@ -72,7 +72,7 @@ RSpec.describe "Support user approves a provider rejected sampling claim", servi
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
   end
 
   def when_i_click_to_view_the_paid_claim
@@ -95,9 +95,9 @@ RSpec.describe "Support user approves a provider rejected sampling claim", servi
 
   def then_i_see_the_details_of_the_provider_rejected_sampling_claim
     expect(page).to have_title(
-      "#{@provider_rejected_sampling_claim.school.name} - Sampling - Claim #{@provider_rejected_sampling_claim.reference} - Claim funding for mentor training - GOV.UK",
+      "#{@provider_rejected_sampling_claim.school.name} - Auditing - Claim #{@provider_rejected_sampling_claim.reference} - Claim funding for mentor training - GOV.UK",
     )
-    expect(page).to have_element(:p, text: "Sampling - Claim #{@provider_rejected_sampling_claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_element(:p, text: "Auditing - Claim #{@provider_rejected_sampling_claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@provider_rejected_sampling_claim.school.name)
     expect(page).to have_element(:strong, text: "Rejected by provider", class: "govuk-tag govuk-tag--turquoise")
   end
@@ -116,7 +116,7 @@ RSpec.describe "Support user approves a provider rejected sampling claim", servi
     expect(page).to have_title("Are you sure you want to approve the claim? - Claim funding for mentor training - GOV.UK")
     expect(primary_navigation).to have_current_item("Claims")
 
-    expect(page).to have_element(:p, text: "Sampling - Claim #{@provider_rejected_sampling_claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_element(:p, text: "Auditing - Claim #{@provider_rejected_sampling_claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1("Are you sure you want to approve the claim?")
     expect(page).to have_element(:p, text: "This will mark the claim as 'Paid'.", class: "govuk-body")
     expect(page).to have_button("Approve claim")
@@ -132,7 +132,7 @@ RSpec.describe "Support user approves a provider rejected sampling claim", servi
   end
 
   def and_i_see_provider_rejected_sampling_claim_is_no_longer_listed
-    expect(page).to have_h2("Sampling")
+    expect(page).to have_h2("Auditing")
     expect(page).not_to have_link("#{@provider_rejected_sampling_claim.reference} - #{@provider_rejected_sampling_claim.school.name}", href: "/support/claims/sampling/#{@provider_rejected_sampling_claim.id}")
   end
 

--- a/spec/system/claims/support/claims/sampling/support_user_approves_a_claim_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_approves_a_claim_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Support user approves a claim", service: :claims, type: :system 
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
@@ -74,7 +74,7 @@ RSpec.describe "Support user approves a claim", service: :claims, type: :system 
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
   end
 
   def when_i_click_to_view_the_paid_claim
@@ -96,9 +96,9 @@ RSpec.describe "Support user approves a claim", service: :claims, type: :system 
 
   def then_i_see_the_details_of_the_sampling_claim
     expect(page).to have_title(
-      "#{@sampling_claim.school.name} - Sampling - Claim #{@sampling_claim.reference} - Claim funding for mentor training - GOV.UK",
+      "#{@sampling_claim.school.name} - Auditing - Claim #{@sampling_claim.reference} - Claim funding for mentor training - GOV.UK",
     )
-    expect(page).to have_element(:p, text: "Sampling - Claim #{@sampling_claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_element(:p, text: "Auditing - Claim #{@sampling_claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1(@sampling_claim.school.name)
     expect(page).to have_element(:strong, text: "Audit requested", class: "govuk-tag govuk-tag--yellow")
   end
@@ -111,7 +111,7 @@ RSpec.describe "Support user approves a claim", service: :claims, type: :system 
     inset_text = page.find("div.govuk-inset-text")
 
     within(inset_text) do
-      expect(page).to have_h3("Reason claim is being sampled")
+      expect(page).to have_h3("Reason claim is being audited")
       expect(page).to have_element(:p, text: "Randomly selected for audit", class: "govuk-body")
     end
 
@@ -127,7 +127,7 @@ RSpec.describe "Support user approves a claim", service: :claims, type: :system 
     expect(page).to have_title("Are you sure you want to approve the claim? - Claim funding for mentor training - GOV.UK")
     expect(primary_navigation).to have_current_item("Claims")
 
-    expect(page).to have_element(:p, text: "Sampling - Claim #{@sampling_claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_element(:p, text: "Auditing - Claim #{@sampling_claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1("Are you sure you want to approve the claim?")
     expect(page).to have_element(:p, text: "This will mark the claim as 'Paid'.", class: "govuk-body")
     expect(page).to have_button("Approve claim")
@@ -143,7 +143,7 @@ RSpec.describe "Support user approves a claim", service: :claims, type: :system 
   end
 
   def and_i_see_sampling_claim_is_no_longer_listed
-    expect(page).to have_h2("Sampling")
+    expect(page).to have_h2("Auditing")
     expect(page).not_to have_link("#{@sampling_claim.reference} - #{@sampling_claim.school.name}", href: "/support/claims/sampling/#{@sampling_claim.id}")
   end
 

--- a/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_by_academic_year_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_by_academic_year_spec.rb
@@ -96,27 +96,27 @@ RSpec.describe "Support user filters sampled claims by academic year", service: 
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
   def then_i_see_the_sampling_claims_index_page
     i_see_the_sampling_index_page
-    expect(page).to have_h2("Sampling (2)")
+    expect(page).to have_h2("Auditing (2)")
   end
   alias_method :then_i_see_all_claims_on_the_claims_sampling_index_page,
                :then_i_see_the_sampling_claims_index_page
 
   def then_i_see_only_filtered_claims_on_the_sampling_claims_index_page
     i_see_the_sampling_index_page
-    expect(page).to have_h2("Sampling (1)")
+    expect(page).to have_h2("Auditing (1)")
   end
 
   def i_see_the_sampling_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 

--- a/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_by_provider_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_by_provider_spec.rb
@@ -84,27 +84,27 @@ RSpec.describe "Support user filters sampled claims by provider", service: :clai
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
   def then_i_see_the_sampling_claims_index_page
     i_see_the_sampling_index_page
-    expect(page).to have_h2("Sampling (2)")
+    expect(page).to have_h2("Auditing (2)")
   end
   alias_method :then_i_see_all_claims_on_the_claims_sampling_index_page,
                :then_i_see_the_sampling_claims_index_page
 
   def then_i_see_only_filtered_claims_on_the_sampling_claims_index_page
     i_see_the_sampling_index_page
-    expect(page).to have_h2("Sampling (1)")
+    expect(page).to have_h2("Auditing (1)")
   end
 
   def i_see_the_sampling_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 

--- a/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_by_school_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_by_school_spec.rb
@@ -84,27 +84,27 @@ RSpec.describe "Support user filters sampled claims by school", service: :claims
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
   def then_i_see_the_sampling_claims_index_page
     i_see_the_sampling_index_page
-    expect(page).to have_h2("Sampling (2)")
+    expect(page).to have_h2("Auditing (2)")
   end
   alias_method :then_i_see_all_claims_on_the_claims_sampling_index_page,
                :then_i_see_the_sampling_claims_index_page
 
   def then_i_see_only_filtered_claims_on_the_sampling_claims_index_page
     i_see_the_sampling_index_page
-    expect(page).to have_h2("Sampling (1)")
+    expect(page).to have_h2("Auditing (1)")
   end
 
   def i_see_the_sampling_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 

--- a/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_by_status_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_by_status_spec.rb
@@ -75,27 +75,27 @@ RSpec.describe "Support user filters sampled claims by status", service: :claims
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
   def then_i_see_the_sampling_claims_index_page
     i_see_the_sampling_index_page
-    expect(page).to have_h2("Sampling (2)")
+    expect(page).to have_h2("Auditing (2)")
   end
   alias_method :then_i_see_all_claims_on_the_claims_sampling_index_page,
                :then_i_see_the_sampling_claims_index_page
 
   def then_i_see_only_filtered_claims_on_the_sampling_claims_index_page
     i_see_the_sampling_index_page
-    expect(page).to have_h2("Sampling (1)")
+    expect(page).to have_h2("Auditing (1)")
   end
 
   def i_see_the_sampling_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 

--- a/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_submitted_after_a_date_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_submitted_after_a_date_spec.rb
@@ -60,27 +60,27 @@ RSpec.describe "Support user filters sampled claims submitted after a date", ser
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
   def then_i_see_the_sampling_claims_index_page
     i_see_the_sampling_index_page
-    expect(page).to have_h2("Sampling (2)")
+    expect(page).to have_h2("Auditing (2)")
   end
   alias_method :then_i_see_all_claims_on_the_claims_sampling_index_page,
                :then_i_see_the_sampling_claims_index_page
 
   def then_i_see_only_filtered_claims_on_the_sampling_claims_index_page
     i_see_the_sampling_index_page
-    expect(page).to have_h2("Sampling (1)")
+    expect(page).to have_h2("Auditing (1)")
   end
 
   def i_see_the_sampling_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 

--- a/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_submitted_before_a_date_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_submitted_before_a_date_spec.rb
@@ -60,27 +60,27 @@ RSpec.describe "Support user filters sampled claims submitted before a date", se
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
   def then_i_see_the_sampling_claims_index_page
     i_see_the_sampling_index_page
-    expect(page).to have_h2("Sampling (2)")
+    expect(page).to have_h2("Auditing (2)")
   end
   alias_method :then_i_see_all_claims_on_the_claims_sampling_index_page,
                :then_i_see_the_sampling_claims_index_page
 
   def then_i_see_only_filtered_claims_on_the_sampling_claims_index_page
     i_see_the_sampling_index_page
-    expect(page).to have_h2("Sampling (1)")
+    expect(page).to have_h2("Auditing (1)")
   end
 
   def i_see_the_sampling_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 

--- a/spec/system/claims/support/claims/sampling/support_user_searches_for_a_sampled_claim_using_a_reference_number_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_searches_for_a_sampled_claim_using_a_reference_number_spec.rb
@@ -58,27 +58,27 @@ RSpec.describe "Support user searches for a sampled claim using a reference numb
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
   def then_i_see_the_sampling_claims_index_page
     i_see_the_sampling_index_page
-    expect(page).to have_h2("Sampling (2)")
+    expect(page).to have_h2("Auditing (2)")
   end
   alias_method :then_i_see_all_claims_on_the_claims_sampling_index_page,
                :then_i_see_the_sampling_claims_index_page
 
   def then_i_see_only_filtered_claims_on_the_sampling_claims_index_page
     i_see_the_sampling_index_page
-    expect(page).to have_h2("Sampling (1)")
+    expect(page).to have_h2("Auditing (1)")
   end
 
   def i_see_the_sampling_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 

--- a/spec/system/claims/support/claims/sampling/support_user_views_sampled_claims_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_views_sampled_claims_spec.rb
@@ -53,16 +53,16 @@ RSpec.describe "Support user views sampled claims", service: :claims, type: :sys
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
   def then_i_see_the_claims_sampling_claims_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
-    expect(page).to have_h2("Sampling (2)")
+    expect(page).to have_h2("Auditing (2)")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
   end
 
   def and_i_see_claims_with_a_sampling_in_progress_status

--- a/spec/system/claims/support/claims/sampling/support_user_views_there_are_no_sampled_claims_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_views_there_are_no_sampled_claims_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Support user views there are no sampled sampled claims", service: :claims, type: :system do
+RSpec.describe "Support user views there are no sampled claims", service: :claims, type: :system do
   scenario do
     when_i_am_signed_in
 
@@ -21,16 +21,16 @@ RSpec.describe "Support user views there are no sampled sampled claims", service
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
   def then_i_see_the_claims_sampling_claims_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
-    expect(page).to have_h2("Sampling")
+    expect(page).to have_h2("Auditing")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
   end
 
   def and_i_see_there_are_no_claims_waiting_to_be_processed

--- a/spec/system/claims/support/claims/sampling/upload_data/support_user_does_not_upload_a_file_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_data/support_user_does_not_upload_a_file_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Support user does not upload a file",
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
@@ -51,23 +51,23 @@ RSpec.describe "Support user does not upload a file",
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 
   def then_i_see_the_upload_csv_page
-    expect(page).to have_h1("Upload claims to be sampled")
-    have_element(:span, text: "Sampling", class: "govuk-caption-l")
+    expect(page).to have_h1("Upload claims to be audited")
+    have_element(:span, text: "Auditing", class: "govuk-caption-l")
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
 
   def and_i_see_no_sampling_claims_have_been_uploaded
-    expect(page).to have_h2("Sampling")
+    expect(page).to have_h2("Auditing")
     expect(page).to have_element(:p, text: "There are no claims waiting to be processed.")
   end
 
   def when_i_click_on_upload_claims_to_be_sampled
-    click_on "Upload claims to be sampled"
+    click_on "Upload claims to be audited"
   end
 
   def when_i_click_on_upload_csv_file

--- a/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_a_csv_containing_invalid_sampling_data_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_a_csv_containing_invalid_sampling_data_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Support user uploads a CSV containing invalid sampling data",
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
@@ -55,17 +55,17 @@ RSpec.describe "Support user uploads a CSV containing invalid sampling data",
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 
   def and_i_see_no_sampling_claims_have_been_uploaded
-    expect(page).to have_h2("Sampling")
+    expect(page).to have_h2("Auditing")
     expect(page).to have_element(:p, text: "There are no claims waiting to be processed.")
   end
 
   def when_i_click_on_upload_claims_to_be_sampled
-    click_on "Upload claims to be sampled"
+    click_on "Upload claims to be audited"
   end
 
   def when_i_upload_a_csv_containing_invalid_sampling_data
@@ -81,8 +81,8 @@ RSpec.describe "Support user uploads a CSV containing invalid sampling data",
   end
 
   def then_i_see_the_upload_csv_page
-    expect(page).to have_h1("Upload claims to be sampled")
-    have_element(:span, text: "Sampling", class: "govuk-caption-l")
+    expect(page).to have_h1("Upload claims to be audited")
+    have_element(:span, text: "Auditing", class: "govuk-caption-l")
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
 end

--- a/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_sampling_data_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_sampling_data_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Support user uploads sampling data", service: :claims, type: :sy
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
@@ -86,17 +86,17 @@ RSpec.describe "Support user uploads sampling data", service: :claims, type: :sy
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 
   def and_i_see_no_sampling_claims_have_been_uploaded
-    expect(page).to have_h2("Sampling")
+    expect(page).to have_h2("Auditing")
     expect(page).to have_element(:p, text: "There are no claims waiting to be processed.")
   end
 
   def when_i_click_on_upload_claims_to_be_sampled
-    click_on "Upload claims to be sampled"
+    click_on "Upload claims to be audited"
   end
 
   def when_i_upload_a_csv_containing_a_valid_sampling_data
@@ -110,12 +110,12 @@ RSpec.describe "Support user uploads sampling data", service: :claims, type: :sy
   end
 
   def then_i_see_the_confirmation_page_for_uploading_the_sampling_data
-    expect(page).to have_h1("Are you sure you want to upload the sampling data?")
-    have_element(:span, text: "Sampling", class: "govuk-caption-l")
+    expect(page).to have_h1("Are you sure you want to upload the auditing data?")
+    have_element(:span, text: "Auditing", class: "govuk-caption-l")
     expect(page).to have_element(:p, text: "There is 1 claim included in this upload.", class: "govuk-body")
     expect(page).to have_element(
       :strong,
-      text: "WarningEach accredited provider included in the sample data will receive an email instructing them to assure their partner schools' claim.",
+      text: "WarningEach accredited provider will receive an email instructing them to assure their partner schools' claim.",
       class: "govuk-warning-text__text",
     )
   end
@@ -131,8 +131,8 @@ RSpec.describe "Support user uploads sampling data", service: :claims, type: :sy
   alias_method :and_i_click_on_back, :when_i_click_on_back
 
   def then_i_see_the_upload_csv_page
-    expect(page).to have_h1("Upload claims to be sampled")
-    have_element(:span, text: "Sampling", class: "govuk-caption-l")
+    expect(page).to have_h1("Upload claims to be audited")
+    have_element(:span, text: "Auditing", class: "govuk-caption-l")
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
 
@@ -141,8 +141,8 @@ RSpec.describe "Support user uploads sampling data", service: :claims, type: :sy
   end
 
   def then_i_see_the_upload_has_been_successful
-    expect(page).to have_success_banner("Sampling data uploaded")
-    expect(page).to have_h2("Sampling (1)")
+    expect(page).to have_success_banner("Auditing data uploaded")
+    expect(page).to have_h2("Auditing (1)")
     expect(page).to have_claim_card({
       "title" => "#{@current_claim.reference} - #{@current_claim.school.name}",
       "url" => "/support/claims/sampling/claims/#{@current_claim.id}",

--- a/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_the_wrong_file_type_as_sampling_data_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_the_wrong_file_type_as_sampling_data_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Support user uploads the wrong file type as sampling data", serv
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
@@ -50,22 +50,22 @@ RSpec.describe "Support user uploads the wrong file type as sampling data", serv
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 
   def and_i_see_no_sampling_claims_have_been_uploaded
-    expect(page).to have_h2("Sampling")
+    expect(page).to have_h2("Auditing")
     expect(page).to have_element(:p, text: "There are no claims waiting to be processed.")
   end
 
   def when_i_click_on_upload_claims_to_be_sampled
-    click_on "Upload claims to be sampled"
+    click_on "Upload claims to be audited"
   end
 
   def then_i_see_the_upload_csv_page
-    expect(page).to have_h1("Upload claims to be sampled")
-    have_element(:span, text: "Sampling", class: "govuk-caption-l")
+    expect(page).to have_h1("Upload claims to be audited")
+    have_element(:span, text: "Auditing", class: "govuk-caption-l")
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
 

--- a/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_can_not_upload_provider_responses_when_there_are_no_claims_with_the_status_sampling_in_progress_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_can_not_upload_provider_responses_when_there_are_no_claims_with_the_status_sampling_in_progress_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Support user can not upload provider responses when there are no
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
@@ -34,12 +34,12 @@ RSpec.describe "Support user can not upload provider responses when there are no
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 
   def and_i_see_no_sampling_claims_have_been_uploaded
-    expect(page).to have_h2("Sampling")
+    expect(page).to have_h2("Auditing")
     expect(page).to have_element(:p, text: "There are no claims waiting to be processed.")
   end
 
@@ -48,9 +48,9 @@ RSpec.describe "Support user can not upload provider responses when there are no
   end
 
   def then_i_see_there_are_no_claims_waiting_for_a_response
-    expect(page).to have_title("You cannot upload a provider response - Sampling - Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_title("You cannot upload a provider response - Auditing - Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("You cannot upload a provider response")
-    expect(page).to have_element(:span, text: "Sampling")
+    expect(page).to have_element(:span, text: "Auditing")
     expect(page).to have_element(
       :p,
       text: "You cannot upload a provider response as there are no claims waiting for a response.",

--- a/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_does_not_upload_a_file_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_does_not_upload_a_file_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Support user does not upload a file",
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
@@ -45,18 +45,18 @@ RSpec.describe "Support user does not upload a file",
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 
   def then_i_see_the_upload_csv_page
     expect(page).to have_h1("Upload provider response")
-    have_element(:span, text: "Sampling", class: "govuk-caption-l")
+    have_element(:span, text: "Auditing", class: "govuk-caption-l")
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
 
   def and_i_see_a_claim_with_the_status_sampling_in_progress
-    expect(page).to have_h2("Sampling (1)")
+    expect(page).to have_h2("Auditing (1)")
     expect(page).to have_claim_card({
       "title" => "11111111 - #{@claim.school_name}",
       "url" => "/support/claims/sampling/claims/#{@claim.id}",

--- a/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_containing_claims_not_with_the_status_sampling_in_progress_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_containing_claims_not_with_the_status_sampling_in_progress_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Support user uploads a CSV containing claims not with the status
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
@@ -69,18 +69,18 @@ RSpec.describe "Support user uploads a CSV containing claims not with the status
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 
   def then_i_see_the_upload_csv_page
     expect(page).to have_h1("Upload provider response")
-    have_element(:span, text: "Sampling", class: "govuk-caption-l")
+    have_element(:span, text: "Auditing", class: "govuk-caption-l")
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
 
   def and_i_see_a_claim_with_the_status_sampling_in_progress
-    expect(page).to have_h2("Sampling (1)")
+    expect(page).to have_h2("Auditing (1)")
     expect(page).to have_claim_card({
       "title" => "11111111 - #{@sampling_in_progress_claim.school_name}",
       "url" => "/support/claims/sampling/claims/#{@sampling_in_progress_claim.id}",
@@ -113,13 +113,13 @@ RSpec.describe "Support user uploads a CSV containing claims not with the status
 
   def then_i_see_the_errors_page
     expect(page).to have_title(
-      "There is a problem with the CSV file - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "There is a problem with the CSV file - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_h1("There is a problem with the CSV file")
   end
 
   def and_i_see_the_csv_contained_claims_not_with_the_status_sampling_in_progress
-    expect(page).to have_h2("The following claims do not have the status 'Sampling in progress':-")
+    expect(page).to have_h2("The following claims do not have the status 'Audit in progress':-")
     expect(page).to have_element(:dl, text: "22222222", class: "govuk-summary-list")
     expect(page).to have_link(text: "View (opens in new tab)", href: "/support/claims/#{@paid_claim.id}")
     expect(page).to have_warning_text(

--- a/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_containing_invalid_references_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_containing_invalid_references_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Support user uploads a CSV not containing invalid references",
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
@@ -68,18 +68,18 @@ RSpec.describe "Support user uploads a CSV not containing invalid references",
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 
   def then_i_see_the_upload_csv_page
     expect(page).to have_h1("Upload provider response")
-    have_element(:span, text: "Sampling", class: "govuk-caption-l")
+    have_element(:span, text: "Auditing", class: "govuk-caption-l")
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
 
   def and_i_see_two_claims_with_the_status_sampling_in_progress
-    expect(page).to have_h2("Sampling (2)")
+    expect(page).to have_h2("Auditing (2)")
     expect(page).to have_claim_card({
       "title" => "33333333 - #{@sampling_in_progress_claim_1.school_name}",
       "url" => "/support/claims/sampling/claims/#{@sampling_in_progress_claim_1.id}",
@@ -115,7 +115,7 @@ RSpec.describe "Support user uploads a CSV not containing invalid references",
 
   def then_i_see_the_errors_page
     expect(page).to have_title(
-      "There is a problem with the CSV file - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "There is a problem with the CSV file - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_h1("There is a problem with the CSV file")
   end

--- a/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_not_containing_a_not_assured_reason_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_not_containing_a_not_assured_reason_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Support user uploads a CSV not containing a not assured reason",
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
@@ -68,18 +68,18 @@ RSpec.describe "Support user uploads a CSV not containing a not assured reason",
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 
   def then_i_see_the_upload_csv_page
     expect(page).to have_h1("Upload provider response")
-    have_element(:span, text: "Sampling", class: "govuk-caption-l")
+    have_element(:span, text: "Auditing", class: "govuk-caption-l")
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
 
   def and_i_see_two_claims_with_the_status_sampling_in_progress
-    expect(page).to have_h2("Sampling (2)")
+    expect(page).to have_h2("Auditing (2)")
     expect(page).to have_claim_card({
       "title" => "11111111 - #{@sampling_in_progress_claim_1.school_name}",
       "url" => "/support/claims/sampling/claims/#{@sampling_in_progress_claim_1.id}",
@@ -115,7 +115,7 @@ RSpec.describe "Support user uploads a CSV not containing a not assured reason",
 
   def then_i_see_the_errors_page
     expect(page).to have_title(
-      "There is a problem with the CSV file - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "There is a problem with the CSV file - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_h1("There is a problem with the CSV file")
   end

--- a/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_not_containing_all_the_mentors_associated_with_a_claim_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_not_containing_all_the_mentors_associated_with_a_claim_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Support user uploads a CSV not containing all the mentors associ
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
@@ -75,18 +75,18 @@ RSpec.describe "Support user uploads a CSV not containing all the mentors associ
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 
   def then_i_see_the_upload_csv_page
     expect(page).to have_h1("Upload provider response")
-    have_element(:span, text: "Sampling", class: "govuk-caption-l")
+    have_element(:span, text: "Auditing", class: "govuk-caption-l")
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
 
   def and_i_see_two_claims_with_the_status_sampling_in_progress
-    expect(page).to have_h2("Sampling (2)")
+    expect(page).to have_h2("Auditing (2)")
     expect(page).to have_claim_card({
       "title" => "11111111 - #{@sampling_in_progress_claim_1.school_name}",
       "url" => "/support/claims/sampling/claims/#{@sampling_in_progress_claim_1.id}",
@@ -126,7 +126,7 @@ RSpec.describe "Support user uploads a CSV not containing all the mentors associ
 
   def then_i_see_the_errors_page
     expect(page).to have_title(
-      "There is a problem with the CSV file - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "There is a problem with the CSV file - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_h1("There is a problem with the CSV file")
   end

--- a/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_not_containing_an_assured_status_for_each_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_not_containing_an_assured_status_for_each_mentor_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Support user uploads a CSV not containing an assured status for 
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
@@ -68,18 +68,18 @@ RSpec.describe "Support user uploads a CSV not containing an assured status for 
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 
   def then_i_see_the_upload_csv_page
     expect(page).to have_h1("Upload provider response")
-    have_element(:span, text: "Sampling", class: "govuk-caption-l")
+    have_element(:span, text: "Auditing", class: "govuk-caption-l")
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
 
   def and_i_see_two_claims_with_the_status_sampling_in_progress
-    expect(page).to have_h2("Sampling (2)")
+    expect(page).to have_h2("Auditing (2)")
     expect(page).to have_claim_card({
       "title" => "11111111 - #{@sampling_in_progress_claim_1.school_name}",
       "url" => "/support/claims/sampling/claims/#{@sampling_in_progress_claim_1.id}",
@@ -115,7 +115,7 @@ RSpec.describe "Support user uploads a CSV not containing an assured status for 
 
   def then_i_see_the_errors_page
     expect(page).to have_title(
-      "There is a problem with the CSV file - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "There is a problem with the CSV file - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_h1("There is a problem with the CSV file")
   end

--- a/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_provider_responses_for_claims_with_the_status_sampling_in_progress_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_provider_responses_for_claims_with_the_status_sampling_in_progress_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe "Support user uploads provider responses for claims with the stat
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
@@ -105,18 +105,18 @@ RSpec.describe "Support user uploads provider responses for claims with the stat
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 
   def then_i_see_the_upload_csv_page
     expect(page).to have_h1("Upload provider response")
-    have_element(:span, text: "Sampling", class: "govuk-caption-l")
+    have_element(:span, text: "Auditing", class: "govuk-caption-l")
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
 
   def and_i_see_two_claims_with_the_status_sampling_in_progress
-    expect(page).to have_h2("Sampling (2)")
+    expect(page).to have_h2("Auditing (2)")
     expect(page).to have_claim_card({
       "title" => "11111111 - #{@sampling_in_progress_claim_1.school_name}",
       "url" => "/support/claims/sampling/claims/#{@sampling_in_progress_claim_1.id}",
@@ -154,10 +154,10 @@ RSpec.describe "Support user uploads provider responses for claims with the stat
 
   def then_i_see_the_confirmation_page_for_uploading_provider_responses
     expect(page).to have_title(
-      "Are you sure you want to upload the provider's response? - Sampling - Claims - Claim funding for mentor training - GOV.UK",
+      "Are you sure you want to upload the provider's response? - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_h1("Are you sure you want to upload the provider's response?")
-    have_element(:span, text: "Sampling", class: "govuk-caption-l")
+    have_element(:span, text: "Auditing", class: "govuk-caption-l")
     expect(page).to have_element(:p, text: "There are 2 claims included in this upload.", class: "govuk-body")
   end
 

--- a/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_the_wrong_file_type_as_provider_responses_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_the_wrong_file_type_as_provider_responses_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Support user uploads the wrong file type as provider responses",
     end
 
     within secondary_navigation do
-      click_on "Sampling"
+      click_on "Auditing"
     end
   end
 
@@ -43,18 +43,18 @@ RSpec.describe "Support user uploads the wrong file type as provider responses",
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(secondary_navigation).to have_current_item("Sampling")
+    expect(secondary_navigation).to have_current_item("Auditing")
     expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
   end
 
   def then_i_see_the_upload_csv_page
     expect(page).to have_h1("Upload provider response")
-    have_element(:span, text: "Sampling", class: "govuk-caption-l")
+    have_element(:span, text: "Auditing", class: "govuk-caption-l")
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
 
   def and_i_see_a_claim_with_the_status_sampling_in_progress
-    expect(page).to have_h2("Sampling (1)")
+    expect(page).to have_h2("Auditing (1)")
     expect(page).to have_claim_card({
       "title" => "11111111 - #{@claim.school_name}",
       "url" => "/support/claims/sampling/claims/#{@claim.id}",

--- a/spec/system/claims/support/claims/view_a_claims_activity_spec.rb
+++ b/spec/system/claims/support/claims/view_a_claims_activity_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "View a claims activity", service: :claims, type: :system do
   end
 
   def then_i_can_see_the_claims_activity_sampling_uploaded_details
-    expect(page).to have_css("h1.govuk-heading-l", text: "Sampling data uploaded")
+    expect(page).to have_css("h1.govuk-heading-l", text: "Audit data uploaded")
     expect(page).to have_content("Colin Chapman on 21 December 2024 at 4:00pm")
   end
 end

--- a/spec/system/claims/support/claims/view_claims_activity_log_spec.rb
+++ b/spec/system/claims/support/claims/view_claims_activity_log_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "View claims activity log", service: :claims, type: :system do
 
   def then_i_can_see_the_claims_activities
     within(".app-timeline__item:nth-child(1)") do
-      expect(page).to have_content("Sampling data uploaded")
+      expect(page).to have_content("Audit data uploaded")
       expect(page).to have_content("Colin Chapman on 21 December 2024 at 4:00pm")
     end
 


### PR DESCRIPTION
## Context

- Replace "Sampling" with "Auditing"

## Changes proposed in this pull request

- Replace all text showing "Sampling" with "Auditing"

## Guidance to review

- Sign in as Colin (Support user)
- Navigate to Claims -> Auditing (once Sampling)
- Check all instances of the "Sampling" have been replaced with "Auditing"

## Link to Trello card

https://trello.com/b/3vEr3mS1/manage-school-placements

## Screenshots


