### PR TITLE
Improve validation for claims to be audited upload 

### DIFF
--- a/app/controllers/claims/support/claims/samplings/upload_data_controller.rb
+++ b/app/controllers/claims/support/claims/samplings/upload_data_controller.rb
@@ -14,7 +14,8 @@ class Claims::Support::Claims::Samplings::UploadDataController < Claims::Support
       @wizard.upload_data
       @wizard.reset_state
       redirect_to index_path, flash: {
-        heading: t(".success"),
+        heading: t(".heading"),
+        body: t(".body"),
       }
     end
   end

--- a/app/jobs/claims/sampling/create_and_deliver_job.rb
+++ b/app/jobs/claims/sampling/create_and_deliver_job.rb
@@ -1,9 +1,8 @@
 class Claims::Sampling::CreateAndDeliverJob < ApplicationJob
   queue_as :default
 
-  def perform(current_user_id:, claim_ids:, csv_data:)
+  def perform(current_user_id:, csv_data:)
     @current_user_id = current_user_id
-    @claim_ids = claim_ids
     @csv_data = csv_data
 
     Claims::Sampling::CreateAndDeliver.call(current_user:, claims:, csv_data:)
@@ -11,10 +10,14 @@ class Claims::Sampling::CreateAndDeliverJob < ApplicationJob
 
   private
 
-  attr_reader :current_user_id, :claim_ids, :csv_data
+  attr_reader :current_user_id, :csv_data
+
+  def claim_ids
+    @claim_ids ||= csv_data.map { |claim| claim[:id] }.compact
+  end
 
   def claims
-    @claims ||= Claims::Claim.find(claim_ids)
+    @claims ||= Claims::Claim.where(id: claim_ids)
   end
 
   def current_user

--- a/app/services/claims/sampling/create_and_deliver.rb
+++ b/app/services/claims/sampling/create_and_deliver.rb
@@ -38,6 +38,6 @@ class Claims::Sampling::CreateAndDeliver < ApplicationService
   end
 
   def sampling_reason(claim)
-    csv_data.find { |csv_data| csv_data["claim_reference"] == claim.reference }["sample_reason"]
+    csv_data.find { |csv_data| csv_data[:id] == claim.id }[:sample_reason]
   end
 end

--- a/app/views/wizards/claims/upload_sampling_data_wizard/_confirmation_step.html.erb
+++ b/app/views/wizards/claims/upload_sampling_data_wizard/_confirmation_step.html.erb
@@ -8,13 +8,43 @@
       <%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
         <%= f.govuk_error_summary %>
 
-        <p class="govuk-body">
-          <%= t(".claims_count", count: current_step.uploaded_claim_ids.count) %>
+        <h2 class="govuk-heading-m"><%= current_step.file_name %></h2>
+
+        <div class="horizontal-scrollable">
+          <%= govuk_table do |table| %>
+            <% table.with_head do |head| %>
+              <% head.with_row do |row| %>
+                <% row.with_cell text: 1 %>
+                <% current_step.csv_headers.each do |header| %>
+                  <% row.with_cell text: header %>
+                <% end %>
+              <% end %>
+            <% end %>
+
+            <% table.with_body do |body| %>
+              <% current_step.csv.each_with_index do |csv_row, index| %>
+                <% if csv_row["claim_reference"].present? %>
+                  <% body.with_row do |row| %>
+                    <% row.with_cell text: index + 2 %>
+                    <% current_step.csv_headers.each do |header| %>
+                      <%= row.with_cell text: csv_row[header] %>
+                    <% end %>
+                  <% end %>
+                <% end %>
+              <% end %>
+            <% end %>
+          <% end %>
+        </div>
+
+        <p class="govuk_body govuk-!-text-align-centre secondary-text">
+          <% if current_step.csv.count > 5 %>
+            <%= t(".only_showing_first_rows", row_count: current_step.csv.count) %>
+          <% else %>
+            <%= t(".showing_all_rows") %>
+          <% end %>
         </p>
 
-        <%= f.govuk_submit(t(".upload_data")) %>
+        <%= f.govuk_submit(t(".confirm_upload")) %>
       <% end %>
-
-      <%= govuk_warning_text(text: t(".providers_will_be_emailed")) %>
   </div>
 </div>

--- a/app/views/wizards/claims/upload_sampling_data_wizard/_confirmation_step.html.erb
+++ b/app/views/wizards/claims/upload_sampling_data_wizard/_confirmation_step.html.erb
@@ -8,7 +8,7 @@
       <%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
         <%= f.govuk_error_summary %>
 
-        <h2 class="govuk-heading-m"><%= current_step.file_name %></h2>
+        <h2 class="govuk-heading-m"><%= t(".preview_file_name", file_name: current_step.file_name) %></h2>
 
         <div class="horizontal-scrollable">
           <%= govuk_table do |table| %>

--- a/app/views/wizards/claims/upload_sampling_data_wizard/_confirmation_step.html.erb
+++ b/app/views/wizards/claims/upload_sampling_data_wizard/_confirmation_step.html.erb
@@ -22,7 +22,7 @@
             <% end %>
 
             <% table.with_body do |body| %>
-              <% current_step.csv.each_with_index do |csv_row, index| %>
+              <% current_step.csv.first(5).each_with_index do |csv_row, index| %>
                 <% if csv_row["claim_reference"].present? %>
                   <% body.with_row do |row| %>
                     <% row.with_cell text: index + 2 %>

--- a/app/views/wizards/claims/upload_sampling_data_wizard/_upload_errors_step.html.erb
+++ b/app/views/wizards/claims/upload_sampling_data_wizard/_upload_errors_step.html.erb
@@ -24,7 +24,7 @@
 
     <h2 class="govuk-heading-m"><%= current_step.file_name %></h2>
 
-        <%= govuk_table do |table| %>
+    <%= govuk_table do |table| %>
       <% table.with_head do |head| %>
         <% head.with_row do |row| %>
           <% row.with_cell text: 1 %>
@@ -59,7 +59,7 @@
     <% end %>
   <% end %>
 
-  <p class="govuk_body govuk-!-text-align-centre">
+  <p class="govuk_body govuk-!-text-align-centre secondary-text">
     <%= t(".only_showing_rows_with_errors") %>
   </p>
 

--- a/app/views/wizards/claims/upload_sampling_data_wizard/_upload_errors_step.html.erb
+++ b/app/views/wizards/claims/upload_sampling_data_wizard/_upload_errors_step.html.erb
@@ -46,6 +46,14 @@
               <%= csv_row["claim_reference"] %>
             </p>
           <% end %>
+          <% row.with_cell do %>
+              <p>
+                <% if current_step.missing_sampling_reason_rows.include?(csv_row_index) %>
+                  <strong class="error-text"><%= t(".csv_table.errors.reason_needed") %></strong><br>
+                <% end %>
+                <%= csv_row["sampling_reason"] %>
+              </p>
+            <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/wizards/claims/upload_sampling_data_wizard/_upload_errors_step.html.erb
+++ b/app/views/wizards/claims/upload_sampling_data_wizard/_upload_errors_step.html.erb
@@ -20,7 +20,7 @@
       </div>
     </div>
 
-    <h2 class="govuk-heading-m">preview of <%= current_step.file_name %></h2>
+    <h2 class="govuk-heading-m"><%= current_step.file_name %></h2>
 
     <%= govuk_table do |table| %>
       <% table.with_head do |head| %>

--- a/app/views/wizards/claims/upload_sampling_data_wizard/_upload_errors_step.html.erb
+++ b/app/views/wizards/claims/upload_sampling_data_wizard/_upload_errors_step.html.erb
@@ -1,10 +1,61 @@
-<% content_for(:page_title) { sanitize t(".page_title") } %>
+<% content_for(:page_title) { sanitize title_with_error_prefix(t(".page_title"), error: true) } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l"><%= t(".caption") %></span>
     <h1 class="govuk-heading-l"><%= t(".title") %></h1>
 
-    <p class="govuk-body"><%= t(".you_cannot_upload") %></p>
+    <div class="govuk-error-summary" data-module="govuk-error-summary">
+      <div role="alert">
+        <h2 class="govuk-error-summary__title">
+          <%= t(".error_summary.title") %>
+        </h2>
+        <div class="govuk-error-summary__body">
+          <div class="govuk-list govuk-error-summary__list">
+            <% if current_step.error_count > 0 %>
+              <p class="govuk-heading-s">
+                <%= t(".error_summary.errors_to_fix", count: current_step.error_count) %>
+              </p>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <h2 class="govuk-heading-m"><%= current_step.file_name %></h2>
+
+        <%= govuk_table do |table| %>
+      <% table.with_head do |head| %>
+        <% head.with_row do |row| %>
+          <% row.with_cell text: 1 %>
+          <% row.with_cell text: t(".csv_table.headers.claim_reference") %>
+          <% row.with_cell text: t(".csv_table.headers.sampling_reason") %>
+        <% end %>
+      <% end %>
+
+    <% table.with_body do |body| %>
+      <% current_step.row_indexes_with_errors.each do |csv_row_index| %>
+        <% csv_row = current_step.csv[csv_row_index] %>
+        <% body.with_row do |row| %>
+          <% row.with_cell(text: csv_row_index + 2) %>
+          <% row.with_cell do %>
+            <p>
+              <% if current_step.invalid_claim_rows.include?(csv_row_index) %>
+                <strong class="error-text"><%= t(".csv_table.errors.invalid_claim_reference") %></strong><br>
+              <% end %>
+              <%= csv_row["claim_reference"] %>
+            </p>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <p class="govuk_body govuk-!-text-align-centre">
+    <%= t(".only_showing_rows_with_errors") %>
+  </p>
+
+  <%= govuk_button_link_to t(".upload_your_file_again"), step_path(:upload) %>
+
   </div>
 </div>

--- a/app/views/wizards/claims/upload_sampling_data_wizard/_upload_errors_step.html.erb
+++ b/app/views/wizards/claims/upload_sampling_data_wizard/_upload_errors_step.html.erb
@@ -48,10 +48,10 @@
           <% end %>
           <% row.with_cell do %>
               <p>
-                <% if current_step.missing_sampling_reason_rows.include?(csv_row_index) %>
+                <% if current_step.missing_sample_reason_rows.include?(csv_row_index) %>
                   <strong class="error-text"><%= t(".csv_table.errors.reason_needed") %></strong><br>
                 <% end %>
-                <%= csv_row["sampling_reason"] %>
+                <%= csv_row["sample_reason"] %>
               </p>
             <% end %>
         <% end %>

--- a/app/views/wizards/claims/upload_sampling_data_wizard/_upload_errors_step.html.erb
+++ b/app/views/wizards/claims/upload_sampling_data_wizard/_upload_errors_step.html.erb
@@ -12,11 +12,9 @@
         </h2>
         <div class="govuk-error-summary__body">
           <div class="govuk-list govuk-error-summary__list">
-            <% if current_step.error_count > 0 %>
               <p class="govuk-heading-s">
                 <%= t(".error_summary.errors_to_fix", count: current_step.error_count) %>
               </p>
-            <% end %>
           </div>
         </div>
       </div>

--- a/app/views/wizards/claims/upload_sampling_data_wizard/_upload_errors_step.html.erb
+++ b/app/views/wizards/claims/upload_sampling_data_wizard/_upload_errors_step.html.erb
@@ -22,7 +22,7 @@
       </div>
     </div>
 
-    <h2 class="govuk-heading-m"><%= current_step.file_name %></h2>
+    <h2 class="govuk-heading-m">preview of <%= current_step.file_name %></h2>
 
     <%= govuk_table do |table| %>
       <% table.with_head do |head| %>

--- a/app/views/wizards/claims/upload_sampling_data_wizard/_upload_errors_step.html.erb
+++ b/app/views/wizards/claims/upload_sampling_data_wizard/_upload_errors_step.html.erb
@@ -1,0 +1,10 @@
+<% content_for(:page_title) { sanitize t(".page_title") } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= t(".caption") %></span>
+    <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+
+    <p class="govuk-body"><%= t(".you_cannot_upload") %></p>
+  </div>
+</div>

--- a/app/views/wizards/claims/upload_sampling_data_wizard/_upload_step.html.erb
+++ b/app/views/wizards/claims/upload_sampling_data_wizard/_upload_step.html.erb
@@ -12,9 +12,8 @@
 
       <%= form_for(current_step, url: current_step_path, method: :put, multipart: true) do |f| %>
         <%= f.govuk_error_summary(presenter: DetailedErrorSummaryPresenter) %>
-        <%= f.govuk_file_field :csv_upload, label: nil %>
-
-        <%= f.govuk_submit(t(".upload_csv_file")) %>
+        <%= f.govuk_file_field :csv_upload, label: { text: t(".upload_csv_file"), hidden: true } %>
+        <%= f.govuk_submit(t(".upload")) %>
       <% end %>
     </div>
   </div>

--- a/app/views/wizards/claims/upload_sampling_data_wizard/_upload_step.html.erb
+++ b/app/views/wizards/claims/upload_sampling_data_wizard/_upload_step.html.erb
@@ -6,13 +6,13 @@
       <span class="govuk-caption-l"><%= t(".caption") %></span>
       <h1 class="govuk-heading-l"><%= t(".title") %></h1>
 
+      <p class="govuk-body"><%= t(".upload_text") %></p>
+
+      <p class="govuk-body"><%= t(".file_must_contain") %></p>
+
       <%= form_for(current_step, url: current_step_path, method: :put, multipart: true) do |f| %>
         <%= f.govuk_error_summary(presenter: DetailedErrorSummaryPresenter) %>
-        <%= f.govuk_file_field :csv_upload, label: { text: t(".upload_csv_file"), size: "s" } %>
-
-        <%= govuk_details(summary_text: t(".csv_help")) do %>
-          <%= render_markdown(t(".csv_help_details")) %>
-        <% end %>
+        <%= f.govuk_file_field :csv_upload, label: nil %>
 
         <%= f.govuk_submit(t(".upload_csv_file")) %>
       <% end %>

--- a/app/views/wizards/claims/upload_sampling_data_wizard/_upload_step.html.erb
+++ b/app/views/wizards/claims/upload_sampling_data_wizard/_upload_step.html.erb
@@ -7,7 +7,7 @@
       <h1 class="govuk-heading-l"><%= t(".title") %></h1>
 
       <%= form_for(current_step, url: current_step_path, method: :put, multipart: true) do |f| %>
-        <%= f.govuk_error_summary %>
+        <%= f.govuk_error_summary(presenter: DetailedErrorSummaryPresenter) %>
         <%= f.govuk_file_field :csv_upload, label: { text: t(".upload_csv_file"), size: "s" } %>
 
         <%= govuk_details(summary_text: t(".csv_help")) do %>

--- a/app/wizards/claims/upload_provider_response_wizard/upload_step.rb
+++ b/app/wizards/claims/upload_provider_response_wizard/upload_step.rb
@@ -119,7 +119,7 @@ class Claims::UploadProviderResponseWizard::UploadStep < BaseStep
     self.missing_rejection_reason_rows = []
   end
 
-  ### CSV input valiations
+  ### CSV input validations
 
   def validate_claim_reference(row, row_number)
     return if sampled_claims.find_by(reference: row["claim_reference"]).present?

--- a/app/wizards/claims/upload_sampling_data_wizard/confirmation_step.rb
+++ b/app/wizards/claims/upload_sampling_data_wizard/confirmation_step.rb
@@ -1,3 +1,14 @@
 class Claims::UploadSamplingDataWizard::ConfirmationStep < BaseStep
+  delegate :file_name, :csv, to: :upload_step
   delegate :uploaded_claim_ids, to: :wizard
+
+  def csv_headers
+    @csv_headers ||= csv.headers
+  end
+
+  private
+
+  def upload_step
+    @upload_step ||= wizard.steps.fetch(:upload)
+  end
 end

--- a/app/wizards/claims/upload_sampling_data_wizard/confirmation_step.rb
+++ b/app/wizards/claims/upload_sampling_data_wizard/confirmation_step.rb
@@ -1,6 +1,5 @@
 class Claims::UploadSamplingDataWizard::ConfirmationStep < BaseStep
   delegate :file_name, :csv, to: :upload_step
-  delegate :uploaded_claim_ids, to: :wizard
 
   def csv_headers
     @csv_headers ||= csv.headers

--- a/app/wizards/claims/upload_sampling_data_wizard/upload_errors_step.rb
+++ b/app/wizards/claims/upload_sampling_data_wizard/upload_errors_step.rb
@@ -1,6 +1,6 @@
 class Claims::UploadSamplingDataWizard::UploadErrorsStep < BaseStep
   delegate :invalid_claim_rows,
-           :missing_sampling_reason_rows,
+           :missing_sample_reason_rows,
            :file_name,
            :csv,
            to: :upload_step
@@ -17,7 +17,7 @@ class Claims::UploadSamplingDataWizard::UploadErrorsStep < BaseStep
 
   def combined_errors
     invalid_claim_rows +
-      missing_sampling_reason_rows
+      missing_sample_reason_rows
   end
 
   def upload_step

--- a/app/wizards/claims/upload_sampling_data_wizard/upload_errors_step.rb
+++ b/app/wizards/claims/upload_sampling_data_wizard/upload_errors_step.rb
@@ -1,0 +1,2 @@
+class Claims::UploadSamplingDataWizard::UploadErrorsStep < BaseStep
+end

--- a/app/wizards/claims/upload_sampling_data_wizard/upload_errors_step.rb
+++ b/app/wizards/claims/upload_sampling_data_wizard/upload_errors_step.rb
@@ -1,2 +1,20 @@
 class Claims::UploadSamplingDataWizard::UploadErrorsStep < BaseStep
+  delegate :invalid_claim_rows,
+           :file_name,
+           :csv,
+           to: :upload_step
+
+  def row_indexes_with_errors
+    invalid_claim_rows.uniq.sort
+  end
+
+  def error_count
+    invalid_claim_rows.count
+  end
+
+  private
+
+  def upload_step
+    @upload_step ||= wizard.steps.fetch(:upload)
+  end
 end

--- a/app/wizards/claims/upload_sampling_data_wizard/upload_errors_step.rb
+++ b/app/wizards/claims/upload_sampling_data_wizard/upload_errors_step.rb
@@ -1,18 +1,24 @@
 class Claims::UploadSamplingDataWizard::UploadErrorsStep < BaseStep
   delegate :invalid_claim_rows,
+           :missing_sampling_reason_rows,
            :file_name,
            :csv,
            to: :upload_step
 
   def row_indexes_with_errors
-    invalid_claim_rows.uniq.sort
+    combined_errors.uniq.sort
   end
 
   def error_count
-    invalid_claim_rows.count
+    combined_errors.count
   end
 
   private
+
+  def combined_errors
+    invalid_claim_rows +
+      missing_sampling_reason_rows
+  end
 
   def upload_step
     @upload_step ||= wizard.steps.fetch(:upload)

--- a/app/wizards/claims/upload_sampling_data_wizard/upload_step.rb
+++ b/app/wizards/claims/upload_sampling_data_wizard/upload_step.rb
@@ -4,6 +4,7 @@ class Claims::UploadSamplingDataWizard::UploadStep < BaseStep
   attribute :file_name
   attribute :claim_ids, default: []
   attribute :invalid_claim_rows, default: []
+  attribute :missing_sampling_reason_rows, default: []
 
   delegate :paid_claims, to: :wizard
 
@@ -31,7 +32,8 @@ class Claims::UploadSamplingDataWizard::UploadStep < BaseStep
       validate_claim_reference(row, i)
     end
 
-    invalid_claim_rows.blank?
+    invalid_claim_rows.blank? &&
+      missing_sampling_reason_rows.blank?
   end
 
   def process_csv
@@ -68,11 +70,18 @@ class Claims::UploadSamplingDataWizard::UploadStep < BaseStep
 
   def reset_input_attributes
     self.invalid_claim_rows = []
+    self.missing_sampling_reason_rows = []
   end
 
   def validate_claim_reference(row, row_number)
     return if paid_claims.find_by(reference: row["claim_reference"]).present?
 
     invalid_claim_rows << row_number
+  end
+
+  def validate_sampling_reason(row, row_number)
+    return if row["sampling_reason"].present?
+
+    missing_sampling_reason_rows << row_number
   end
 end

--- a/app/wizards/claims/upload_sampling_data_wizard/upload_step.rb
+++ b/app/wizards/claims/upload_sampling_data_wizard/upload_step.rb
@@ -4,7 +4,7 @@ class Claims::UploadSamplingDataWizard::UploadStep < BaseStep
   attribute :file_name
   attribute :claim_ids, default: []
   attribute :invalid_claim_rows, default: []
-  attribute :missing_sampling_reason_rows, default: []
+  attribute :missing_sample_reason_rows, default: []
 
   delegate :paid_claims, to: :wizard
 
@@ -12,7 +12,7 @@ class Claims::UploadSamplingDataWizard::UploadStep < BaseStep
   validate :validate_csv_file, if: -> { csv_upload.present? }
   validate :validate_csv_headers, if: -> { csv_content.present? }
 
-  REQUIRED_HEADERS = %w[claim_reference sampling_reason].freeze
+  REQUIRED_HEADERS = %w[claim_reference sample_reason].freeze
 
   def initialize(wizard:, attributes:)
     super(wizard:, attributes:)
@@ -50,10 +50,11 @@ class Claims::UploadSamplingDataWizard::UploadStep < BaseStep
       next if row["claim_reference"].blank?
 
       validate_claim_reference(row, i)
+      validate_sample_reason(row, i)
     end
 
     invalid_claim_rows.blank? &&
-      missing_sampling_reason_rows.blank?
+      missing_sample_reason_rows.blank?
   end
 
   def process_csv
@@ -98,7 +99,7 @@ class Claims::UploadSamplingDataWizard::UploadStep < BaseStep
 
   def reset_input_attributes
     self.invalid_claim_rows = []
-    self.missing_sampling_reason_rows = []
+    self.missing_sample_reason_rows = []
   end
 
   def validate_claim_reference(row, row_number)
@@ -107,9 +108,9 @@ class Claims::UploadSamplingDataWizard::UploadStep < BaseStep
     invalid_claim_rows << row_number
   end
 
-  def validate_sampling_reason(row, row_number)
-    return if row["sampling_reason"].present?
+  def validate_sample_reason(row, row_number)
+    return if row["sample_reason"].present?
 
-    missing_sampling_reason_rows << row_number
+    missing_sample_reason_rows << row_number
   end
 end

--- a/app/wizards/claims/upload_sampling_data_wizard/upload_step.rb
+++ b/app/wizards/claims/upload_sampling_data_wizard/upload_step.rb
@@ -60,8 +60,16 @@ class Claims::UploadSamplingDataWizard::UploadStep < BaseStep
     validate_csv_file
     return if errors.present?
 
+    reset_claim_ids
+
+    CSV.parse(read_csv, headers: true) do |row|
+      claim = paid_claims.find_by(reference: row["claim_reference"])
+      break if claim.blank?
+
+      claim_ids << claim.id
+    end
+
     assign_csv_content
-    self.file_name = csv_upload.original_filename
 
     self.csv_upload = nil
   end

--- a/app/wizards/claims/upload_sampling_data_wizard/upload_step.rb
+++ b/app/wizards/claims/upload_sampling_data_wizard/upload_step.rb
@@ -24,7 +24,7 @@ class Claims::UploadSamplingDataWizard::UploadStep < BaseStep
   end
 
   def validate_csv_headers
-    csv_headers = CSV.parse(read_csv, headers: true).headers
+    csv_headers = csv.headers
     missing_columns = REQUIRED_HEADERS - csv_headers
     return if missing_columns.empty?
 
@@ -67,7 +67,7 @@ class Claims::UploadSamplingDataWizard::UploadStep < BaseStep
   end
 
   def csv
-    @csv ||= CSV.parse(csv_content, headers: true)
+    @csv ||= CSV.parse(read_csv, headers: true, skip_blanks: true)
   end
 
   private

--- a/app/wizards/claims/upload_sampling_data_wizard/upload_step.rb
+++ b/app/wizards/claims/upload_sampling_data_wizard/upload_step.rb
@@ -61,7 +61,9 @@ class Claims::UploadSamplingDataWizard::UploadStep < BaseStep
     validate_csv_file
     return if errors.present?
 
-    reset_claim_ids
+    reset_input_attributes
+
+    self.file_name = csv_upload.original_filename
 
     CSV.parse(read_csv, headers: true) do |row|
       claim = paid_claims.find_by(reference: row["claim_reference"])
@@ -91,10 +93,6 @@ class Claims::UploadSamplingDataWizard::UploadStep < BaseStep
 
   def read_csv
     @read_csv ||= csv_content || csv_upload.read
-  end
-
-  def reset_claim_ids
-    self.claim_ids = []
   end
 
   def reset_input_attributes

--- a/app/wizards/claims/upload_sampling_data_wizard/upload_step.rb
+++ b/app/wizards/claims/upload_sampling_data_wizard/upload_step.rb
@@ -2,7 +2,6 @@ class Claims::UploadSamplingDataWizard::UploadStep < BaseStep
   attribute :csv_upload
   attribute :csv_content
   attribute :file_name
-  attribute :claim_ids, default: []
   attribute :invalid_claim_rows, default: []
   attribute :missing_sample_reason_rows, default: []
 
@@ -61,18 +60,8 @@ class Claims::UploadSamplingDataWizard::UploadStep < BaseStep
     validate_csv_file
     return if errors.present?
 
-    reset_input_attributes
-
-    self.file_name = csv_upload.original_filename
-
-    CSV.parse(read_csv, headers: true) do |row|
-      claim = paid_claims.find_by(reference: row["claim_reference"])
-      break if claim.blank?
-
-      claim_ids << claim.id
-    end
-
     assign_csv_content
+    self.file_name = csv_upload.original_filename
 
     self.csv_upload = nil
   end

--- a/app/wizards/claims/upload_sampling_data_wizard/upload_step.rb
+++ b/app/wizards/claims/upload_sampling_data_wizard/upload_step.rb
@@ -9,8 +9,8 @@ class Claims::UploadSamplingDataWizard::UploadStep < BaseStep
   delegate :paid_claims, to: :wizard
 
   validates :csv_upload, presence: true, if: -> { csv_content.blank? }
-  validate :validate_csv_headers, if: -> { csv_content.present? }
   validate :validate_csv_file, if: -> { csv_upload.present? }
+  validate :validate_csv_headers, if: -> { csv_content.present? }
 
   REQUIRED_HEADERS = %w[claim_reference sampling_reason].freeze
 

--- a/app/wizards/claims/upload_sampling_data_wizard/upload_step.rb
+++ b/app/wizards/claims/upload_sampling_data_wizard/upload_step.rb
@@ -1,6 +1,7 @@
 class Claims::UploadSamplingDataWizard::UploadStep < BaseStep
   attribute :csv_upload
   attribute :csv_content
+  attribute :file_name
   attribute :claim_ids, default: []
   attribute :invalid_claim_rows, default: []
 
@@ -37,16 +38,8 @@ class Claims::UploadSamplingDataWizard::UploadStep < BaseStep
     validate_csv_file
     return if errors.present?
 
-    reset_claim_ids
-
-    CSV.parse(read_csv, headers: true) do |row|
-      claim = paid_claims.find_by(reference: row["claim_reference"])
-      break if claim.blank?
-
-      claim_ids << claim.id
-    end
-
     assign_csv_content
+    self.file_name = csv_upload.original_filename
 
     self.csv_upload = nil
   end

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -203,7 +203,10 @@ en:
             csv_upload:
               blank: Select a CSV file to upload
               invalid: The selected file must be a CSV
-              invalid_data: The selected CSV file contains invalid data
+              invalid_headers:
+                Your file needs a column called %{missing_columns}.
+              uploaded_headers:
+                Right now it has columns called %{uploaded_headers}.
         claims/upload_provider_response_wizard/upload_step:
           attributes:
             csv_upload:
@@ -211,7 +214,7 @@ en:
               invalid: The selected file must be a CSV
               invalid_headers:
                 Your file needs a column called %{missing_columns}.
-              uploaded_headers: 
+              uploaded_headers:
                 Right now it has columns called %{uploaded_headers}.
         claims/provider_rejected_claim_wizard/mentor_training_step:
           attributes:
@@ -238,7 +241,7 @@ en:
               invalid: The selected file must be a CSV
               invalid_headers:
                 Your file needs a column called %{missing_columns}.
-              uploaded_headers: 
+              uploaded_headers:
                 Right now it has columns called %{uploaded_headers}.
         claims/upload_payer_payment_response_wizard/upload_step:
           attributes:

--- a/config/locales/en/claims/support/claims/samplings.yml
+++ b/config/locales/en/claims/support/claims/samplings.yml
@@ -33,6 +33,10 @@ en:
             cancel: Cancel
           update:
             success_heading: Claim updated
+          upload_data:
+            update:
+              heading: Sampling data uploaded
+              body: It may take a moment for the uploaded claims to update
           confirm_provider_rejected:
             page_title: Are you sure you want to confirm the provider has rejected the claim? - Auditing - Claim %{reference}
             caption: Auditing - Claim %{reference}
@@ -48,7 +52,7 @@ en:
             caption: Auditing - Claim %{reference}
             title: Are you sure you want to reject the claim?
             cancel: Cancel
-            mark_as_claim_not_approved: | 
+            mark_as_claim_not_approved: |
               This will mark the claim as 'Claim not approved' and move it into the clawbacks queue.
             reject_claim: Reject claim
           reject:

--- a/config/locales/en/claims/support/claims/samplings.yml
+++ b/config/locales/en/claims/support/claims/samplings.yml
@@ -35,7 +35,7 @@ en:
             success_heading: Claim updated
           upload_data:
             update:
-              heading: Sampling data uploaded
+              heading: Auditing data uploaded
               body: It may take a moment for the uploaded claims to update
           confirm_provider_rejected:
             page_title: Are you sure you want to confirm the provider has rejected the claim? - Auditing - Claim %{reference}

--- a/config/locales/en/wizards/claims/upload_provider_response_wizard.yml
+++ b/config/locales/en/wizards/claims/upload_provider_response_wizard.yml
@@ -14,7 +14,7 @@ en:
             Use this form to upload the CSV file sent by the provider.
 
             The CSV file must contain the following headers in the first row:
-            
+
               - claim_reference
               - school_urn
               - school_name
@@ -45,11 +45,11 @@ en:
           page_title: Upload provider response - Auditing - Claims
           error_summary:
             title: There is a problem
-            missing_mentors: 
+            missing_mentors:
               one: Mentors are missing from the claim with the reference %{references}
               other: Mentors are missing from claims with the reference %{references}
             errors_to_fix:
-              one: You need to fix %{count} error related to specific rows
+              one: You need to fix %{count} error related to a specific row
               other: You need to fix %{count} errors related to specific rows
           csv_table:
             headers:

--- a/config/locales/en/wizards/claims/upload_sampling_data_wizard.yml
+++ b/config/locales/en/wizards/claims/upload_sampling_data_wizard.yml
@@ -9,6 +9,7 @@ en:
           upload_text: Upload the CSV file sent to you by DfE
           file_must_contain: The file must contain the headers 'claim_reference' and 'sample_reason'
           upload_csv_file: Upload CSV file
+          upload: Upload
           already_been_claimed: Test
         confirmation_step:
           page_title: Are you sure you want to upload the auditing data? - Auditing - Claims

--- a/config/locales/en/wizards/claims/upload_sampling_data_wizard.yml
+++ b/config/locales/en/wizards/claims/upload_sampling_data_wizard.yml
@@ -19,12 +19,17 @@ en:
           page_title: Are you sure you want to upload the auditing data? - Auditing - Claims
           title: Are you sure you want to upload the auditing data?
           caption: Auditing
-          claims_count: 
+          claims_count:
             one: There is %{count} claim included in this upload.
             other: There are %{count} claims included in this upload.
-          providers_will_be_emailed: 
+          providers_will_be_emailed:
             Each accredited provider will receive an email instructing them to assure their partner schools' claim.
           upload_data: Upload data
+        upload_errors_step:
+          title: TEST Validation errors
+          page_title: TEST Validation errors
+          caption: Auditing
+          you_cannot_upload: TEST Validation errors
         no_claims_step:
           title: You cannot upload any claims to be audited
           page_title: You cannot upload any claims to be audited - Auditing - Claims

--- a/config/locales/en/wizards/claims/upload_sampling_data_wizard.yml
+++ b/config/locales/en/wizards/claims/upload_sampling_data_wizard.yml
@@ -26,10 +26,24 @@ en:
             Each accredited provider will receive an email instructing them to assure their partner schools' claim.
           upload_data: Upload data
         upload_errors_step:
-          title: TEST Validation errors
-          page_title: TEST Validation errors
+          page_title: Upload claims to be audited - Auditing - Claims
+          title: Upload claims to be audited
           caption: Auditing
-          you_cannot_upload: TEST Validation errors
+          error_summary:
+            title: There is a problem
+            errors_to_fix:
+                one: You need to fix %{count} error related to specific rows
+                other: You need to fix %{count} errors related to specific rows
+          csv_table:
+            headers:
+              claim_reference: claim_reference
+              sampling_reason: sampling_reason
+            errors:
+              invalid_claim_reference: Not a valid claim reference
+              invalid_input: Not a valid input
+              reason_needed: Reason needed
+          only_showing_rows_with_errors: Only showing rows with errors
+          upload_your_file_again: Upload your file again
         no_claims_step:
           title: You cannot upload any claims to be audited
           page_title: You cannot upload any claims to be audited - Auditing - Claims

--- a/config/locales/en/wizards/claims/upload_sampling_data_wizard.yml
+++ b/config/locales/en/wizards/claims/upload_sampling_data_wizard.yml
@@ -6,18 +6,13 @@ en:
           page_title: Upload claims to be audited - Auditing - Claims
           title: Upload claims to be audited
           caption: Auditing
+          upload_text: Upload the CSV file sent to you by DfE
+          file_must_contain: The file must contain the headers 'claim_reference' and 'sample_reason'
           upload_csv_file: Upload CSV file
-          csv_help: Help with the CSV file
-          csv_help_details: |
-            Use this form to upload the CSV file sent by the data and insights team.
-
-            The CSV file must contain the following headers in the first row:
-
-            - claim_reference
-            - sample_reason
+          already_been_claimed: Test
         confirmation_step:
           page_title: Are you sure you want to upload the auditing data? - Auditing - Claims
-          title: Confirm you want to upload claims to be sampled
+          title: Confirm you want to upload claims to be audited
           caption: Auditing
           confirm_upload: Confirm upload
           only_showing_first_rows: Only showing the first %{row_count} rows
@@ -36,9 +31,8 @@ en:
               claim_reference: claim_reference
               sampling_reason: sample_reason
             errors:
-              invalid_claim_reference: Not a valid claim reference
-              invalid_input: Not a valid input
-              reason_needed: Reason needed
+              invalid_claim_reference: Enter a valid claim reference
+              reason_needed: Enter a valid sample reason
           only_showing_rows_with_errors: Only showing rows with errors
           upload_your_file_again: Upload your file again
         no_claims_step:

--- a/config/locales/en/wizards/claims/upload_sampling_data_wizard.yml
+++ b/config/locales/en/wizards/claims/upload_sampling_data_wizard.yml
@@ -17,14 +17,11 @@ en:
             - sampling_reason
         confirmation_step:
           page_title: Are you sure you want to upload the auditing data? - Auditing - Claims
-          title: Are you sure you want to upload the auditing data?
+          title: Confirm you want to upload claims to be sampled
           caption: Auditing
-          claims_count:
-            one: There is %{count} claim included in this upload.
-            other: There are %{count} claims included in this upload.
-          providers_will_be_emailed:
-            Each accredited provider will receive an email instructing them to assure their partner schools' claim.
-          upload_data: Upload data
+          confirm_upload: Confirm upload
+          only_showing_first_rows: Only showing the first %{row_count} rows
+          showing_all_rows: Showing all rows
         upload_errors_step:
           page_title: Upload claims to be audited - Auditing - Claims
           title: Upload claims to be audited

--- a/config/locales/en/wizards/claims/upload_sampling_data_wizard.yml
+++ b/config/locales/en/wizards/claims/upload_sampling_data_wizard.yml
@@ -4,8 +4,8 @@ en:
       upload_sampling_data_wizard:
         upload_step:
           page_title: Upload claims to be audited - Auditing - Claims
-          caption: Auditing
           title: Upload claims to be audited
+          caption: Auditing
           upload_csv_file: Upload CSV file
           csv_help: Help with the CSV file
           csv_help_details: |
@@ -14,7 +14,7 @@ en:
             The CSV file must contain the following headers in the first row:
 
             - claim_reference
-            - sample_reason
+            - sampling_reason
         confirmation_step:
           page_title: Are you sure you want to upload the auditing data? - Auditing - Claims
           title: Are you sure you want to upload the auditing data?
@@ -32,7 +32,7 @@ en:
           error_summary:
             title: There is a problem
             errors_to_fix:
-                one: You need to fix %{count} error related to specific rows
+                one: You need to fix %{count} error related to a specific row
                 other: You need to fix %{count} errors related to specific rows
           csv_table:
             headers:

--- a/config/locales/en/wizards/claims/upload_sampling_data_wizard.yml
+++ b/config/locales/en/wizards/claims/upload_sampling_data_wizard.yml
@@ -13,6 +13,7 @@ en:
         confirmation_step:
           page_title: Are you sure you want to upload the auditing data? - Auditing - Claims
           title: Confirm you want to upload claims to be audited
+          preview_file_name: Preview of %{file_name}
           caption: Auditing
           confirm_upload: Confirm upload
           only_showing_first_rows: Only showing the first %{row_count} rows

--- a/config/locales/en/wizards/claims/upload_sampling_data_wizard.yml
+++ b/config/locales/en/wizards/claims/upload_sampling_data_wizard.yml
@@ -14,7 +14,7 @@ en:
             The CSV file must contain the following headers in the first row:
 
             - claim_reference
-            - sampling_reason
+            - sample_reason
         confirmation_step:
           page_title: Are you sure you want to upload the auditing data? - Auditing - Claims
           title: Confirm you want to upload claims to be sampled
@@ -34,7 +34,7 @@ en:
           csv_table:
             headers:
               claim_reference: claim_reference
-              sampling_reason: sampling_reason
+              sampling_reason: sample_reason
             errors:
               invalid_claim_reference: Not a valid claim reference
               invalid_input: Not a valid input

--- a/spec/fixtures/claims/sampling/invalid_example_sampling_upload.csv
+++ b/spec/fixtures/claims/sampling/invalid_example_sampling_upload.csv
@@ -1,3 +1,3 @@
 claim_reference,sample_reason
-11111111,Valid paid claim
-22222222,Invalid claim
+88888888,Valid reason
+11111111,

--- a/spec/fixtures/claims/sampling/invalid_headers_sampling_upload.csv
+++ b/spec/fixtures/claims/sampling/invalid_headers_sampling_upload.csv
@@ -1,0 +1,2 @@
+claim_refrence,sampl_reason
+11111111,Random audit

--- a/spec/services/claims/sampling/create_and_deliver_spec.rb
+++ b/spec/services/claims/sampling/create_and_deliver_spec.rb
@@ -5,7 +5,7 @@ describe Claims::Sampling::CreateAndDeliver do
 
   let(:current_user) { create(:claims_support_user) }
   let!(:claims) { [create(:claim, :paid)] }
-  let(:csv_data) { [{ "claim_reference" => claims.first.reference, "sample_reason" => "ABCD" }] }
+  let(:csv_data) { [{ id: claims.first.id, sample_reason: "ABCD" }] }
 
   describe "#call" do
     context "when there are submitted claims" do

--- a/spec/system/claims/support/claims/sampling/upload_data/support_user_does_not_upload_a_file_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_data/support_user_does_not_upload_a_file_spec.rb
@@ -58,7 +58,6 @@ RSpec.describe "Support user does not upload a file",
   def then_i_see_the_upload_csv_page
     expect(page).to have_h1("Upload claims to be audited")
     have_element(:span, text: "Auditing", class: "govuk-caption-l")
-    expect(page).to have_element(:label, text: "Upload CSV file")
   end
 
   def and_i_see_no_sampling_claims_have_been_uploaded

--- a/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_a_csv_containing_invalid_sampling_data_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_a_csv_containing_invalid_sampling_data_spec.rb
@@ -14,9 +14,14 @@ RSpec.describe "Support user uploads a CSV containing invalid sampling data",
     when_i_click_on_upload_claims_to_be_sampled
     then_i_see_the_upload_csv_page
 
-    when_i_upload_a_csv_containing_invalid_sampling_data
-    and_i_click_on_upload_csv_file
-    then_i_see_validation_error_regarding_invalid_data
+    # when_i_upload_a_csv_containing_invalid_headers
+    # and_i_click_on_upload_csv_file
+    # then_i_see_validation_errors_regarding_invalid_headers
+
+    # when_i_click_on_upload_again
+    # and_i_upload_a_csv_containing_invalid_sampling_data
+    # and_i_click_on_upload_csv_file
+    # then_i_see_validation_errors_regarding_invalid_data
   end
 
   private
@@ -69,7 +74,7 @@ RSpec.describe "Support user uploads a CSV containing invalid sampling data",
   end
 
   def when_i_upload_a_csv_containing_invalid_sampling_data
-    attach_file "Upload CSV file", "spec/fixtures/claims/sampling/example_sampling_upload.csv"
+    attach_file "Upload CSV file", "spec/fixtures/claims/sampling/invalid_example_sampling_upload.csv"
   end
 
   def and_i_click_on_upload_csv_file

--- a/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_a_csv_containing_invalid_sampling_data_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_a_csv_containing_invalid_sampling_data_spec.rb
@@ -14,32 +14,16 @@ RSpec.describe "Support user uploads a CSV containing invalid sampling data",
     when_i_click_on_upload_claims_to_be_sampled
     then_i_see_the_upload_csv_page
 
-    # when_i_upload_a_csv_containing_invalid_headers
-    # and_i_click_on_upload_csv_file
-    # then_i_see_validation_errors_regarding_invalid_headers
-
-    # when_i_click_on_upload_again
-    # and_i_upload_a_csv_containing_invalid_sampling_data
-    # and_i_click_on_upload_csv_file
-    # then_i_see_validation_errors_regarding_invalid_data
+    when_i_upload_a_csv_containing_invalid_sampling_data
+    and_i_click_on_upload_csv_file
+    then_i_see_validation_errors_regarding_invalid_data
   end
 
   private
 
   def given_claims_exist
-    @current_academic_year = AcademicYear.for_date(Time.current) || create(:academic_year, :current)
-
-    current_claim_window = create(:claim_window, academic_year: @current_academic_year,
-                                                 starts_on: @current_academic_year.starts_on,
-                                                 ends_on: @current_academic_year.starts_on + 2.days)
-    @current_claim = create(:claim,
-                            :submitted,
-                            claim_window: current_claim_window,
-                            reference: 11_111_111)
-    @another_paid_claim = create(:claim,
-                                 :submitted,
-                                 status: :paid,
-                                 claim_window: current_claim_window)
+    @paid_claim_1 = create(:claim, :submitted, status: :paid, reference: 11_111_111)
+    @paid_claim_2 = create(:claim, :submitted, status: :paid, reference: 22_222_222)
   end
 
   def and_i_am_signed_in
@@ -74,20 +58,24 @@ RSpec.describe "Support user uploads a CSV containing invalid sampling data",
   end
 
   def when_i_upload_a_csv_containing_invalid_sampling_data
-    attach_file "Upload CSV file", "spec/fixtures/claims/sampling/invalid_example_sampling_upload.csv"
+    attach_file nil,
+                "spec/fixtures/claims/sampling/invalid_example_sampling_upload.csv"
   end
 
   def and_i_click_on_upload_csv_file
     click_on "Upload"
   end
 
-  def then_i_see_validation_error_regarding_invalid_data
-    expect(page).to have_validation_error("The selected CSV file contains invalid data")
-  end
-
   def then_i_see_the_upload_csv_page
     expect(page).to have_h1("Upload claims to be audited")
     have_element(:span, text: "Auditing", class: "govuk-caption-l")
-    expect(page).to have_element(:label, text: "Upload CSV file")
+  end
+
+  def then_i_see_validation_errors_regarding_invalid_data
+    expect(page).to have_h1("Upload claims to be audited")
+    expect(page).to have_element(:div, text: "You need to fix 2 errors related to specific rows", class: "govuk-error-summary")
+    expect(page).to have_element(:td, text: "Enter a valid claim reference", class: "govuk-table__cell")
+    expect(page).to have_element(:td, text: "Enter a valid sample reason", class: "govuk-table__cell")
+    expect(page).to have_element(:p, text: "Only showing rows with errors", class: "govuk-!-text-align-centre")
   end
 end

--- a/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_a_csv_containing_invalid_sampling_data_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_a_csv_containing_invalid_sampling_data_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Support user uploads a CSV containing invalid sampling data",
   end
 
   def when_i_upload_a_csv_containing_invalid_sampling_data
-    attach_file nil,
+    attach_file "Upload CSV file",
                 "spec/fixtures/claims/sampling/invalid_example_sampling_upload.csv"
   end
 

--- a/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_a_csv_file_with_wrong_headers_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_a_csv_file_with_wrong_headers_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Support user uploads a CSV file with the wrong headers",
   end
 
   def when_i_upload_a_csv_file_not_containing_invalid_headers
-    attach_file nil,
+    attach_file "Upload CSV file",
                 "spec/fixtures/claims/sampling/invalid_headers_sampling_upload.csv"
   end
 

--- a/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_a_csv_file_with_wrong_headers_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_a_csv_file_with_wrong_headers_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe "Support user uploads a CSV file with the wrong headers",
+               service: :claims,
+               type: :system do
+  scenario do
+    given_claims_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_sampling_claims_index_page
+    then_i_see_the_sampling_claims_index_page
+
+    when_i_click_on_upload_claims_to_be_audited
+    then_i_see_the_upload_csv_page
+
+    when_i_upload_a_csv_file_not_containing_invalid_headers
+    and_i_click_on_upload_csv_file
+    then_i_see_validation_error_regarding_invalid_headers
+  end
+
+  private
+
+  def given_claims_exist
+    @paid_claim_1 = create(:claim, :submitted, status: :paid, reference: 11_111_111)
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_sampling_claims_index_page
+    within primary_navigation do
+      click_on "Claims"
+    end
+
+    within secondary_navigation do
+      click_on "Auditing"
+    end
+  end
+
+  def then_i_see_the_sampling_claims_index_page
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Claims")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(secondary_navigation).to have_current_item("Auditing")
+    expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
+  end
+
+  def then_i_see_the_upload_csv_page
+    expect(page).to have_h1("Upload claims to be audited")
+    have_element(:span, text: "Auditing", class: "govuk-caption-l")
+  end
+
+  def when_i_click_on_upload_claims_to_be_audited
+    click_on "Upload claims to be audited"
+  end
+
+  def and_i_click_on_upload_csv_file
+    click_on "Upload"
+  end
+
+  def when_i_upload_a_csv_file_not_containing_invalid_headers
+    attach_file nil,
+                "spec/fixtures/claims/sampling/invalid_headers_sampling_upload.csv"
+  end
+
+  def then_i_see_validation_error_regarding_invalid_headers
+    expect(page).to have_css(".govuk-error-summary__list", text: "Your file needs a column called ‘claim_reference’ and ‘sample_reason’")
+    expect(page).to have_css(".govuk-error-summary__list", text: "Right now it has columns called ‘claim_refrence’ and ‘sampl_reason’.")
+  end
+end

--- a/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_sampling_data_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_sampling_data_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "Support user uploads sampling data", service: :claims, type: :sy
   end
 
   def when_i_upload_a_csv_containing_a_valid_sampling_data
-    attach_file "Upload CSV file", "spec/fixtures/claims/sampling/example_sampling_upload.csv"
+    attach_file nil, "spec/fixtures/claims/sampling/example_sampling_upload.csv"
   end
   alias_method :and_i_upload_a_csv_containing_a_valid_sampling_data,
                :when_i_upload_a_csv_containing_a_valid_sampling_data
@@ -110,13 +110,12 @@ RSpec.describe "Support user uploads sampling data", service: :claims, type: :sy
   end
 
   def then_i_see_the_confirmation_page_for_uploading_the_sampling_data
-    expect(page).to have_h1("Are you sure you want to upload the auditing data?")
+    expect(page).to have_h1("Confirm you want to upload claims to be audited")
     have_element(:span, text: "Auditing", class: "govuk-caption-l")
-    expect(page).to have_element(:p, text: "There is 1 claim included in this upload.", class: "govuk-body")
-    expect(page).to have_element(
-      :strong,
-      text: "WarningEach accredited provider will receive an email instructing them to assure their partner schools' claim.",
-      class: "govuk-warning-text__text",
+    expect(page).to have_table_row(
+      "1" => "2",
+      "claim_reference" => "11111111",
+      "sample_reason" => "Some Reason",
     )
   end
 
@@ -133,11 +132,10 @@ RSpec.describe "Support user uploads sampling data", service: :claims, type: :sy
   def then_i_see_the_upload_csv_page
     expect(page).to have_h1("Upload claims to be audited")
     have_element(:span, text: "Auditing", class: "govuk-caption-l")
-    expect(page).to have_element(:label, text: "Upload CSV file")
   end
 
   def when_i_click_upload_data
-    click_on "Upload data"
+    click_on "Confirm upload"
   end
 
   def then_i_see_the_upload_has_been_successful

--- a/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_sampling_data_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_sampling_data_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "Support user uploads sampling data", service: :claims, type: :sy
   end
 
   def when_i_upload_a_csv_containing_a_valid_sampling_data
-    attach_file nil, "spec/fixtures/claims/sampling/example_sampling_upload.csv"
+    attach_file "Upload CSV file", "spec/fixtures/claims/sampling/example_sampling_upload.csv"
   end
   alias_method :and_i_upload_a_csv_containing_a_valid_sampling_data,
                :when_i_upload_a_csv_containing_a_valid_sampling_data

--- a/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_the_wrong_file_type_as_sampling_data_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_the_wrong_file_type_as_sampling_data_spec.rb
@@ -66,12 +66,11 @@ RSpec.describe "Support user uploads the wrong file type as sampling data", serv
   def then_i_see_the_upload_csv_page
     expect(page).to have_h1("Upload claims to be audited")
     have_element(:span, text: "Auditing", class: "govuk-caption-l")
-    expect(page).to have_element(:label, text: "Upload CSV file")
   end
 
   def when_i_upload_an_invalid_file_type
     tmp = Tempfile.new("invalid_upload.txt")
-    attach_file "Upload CSV file", tmp.path
+    attach_file nil, tmp.path
   end
 
   def and_i_click_on_upload_csv_file

--- a/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_the_wrong_file_type_as_sampling_data_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_data/support_user_uploads_the_wrong_file_type_as_sampling_data_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Support user uploads the wrong file type as sampling data", serv
 
   def when_i_upload_an_invalid_file_type
     tmp = Tempfile.new("invalid_upload.txt")
-    attach_file nil, tmp.path
+    attach_file "Upload CSV file", tmp.path
   end
 
   def and_i_click_on_upload_csv_file

--- a/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_containing_a_mentor_not_associated_with_the_claims_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_containing_a_mentor_not_associated_with_the_claims_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe "Support user uploads a CSV containing a mentor not associated wi
 
   def and_i_see_the_csv_contained_claims_not_with_the_status_sampling_in_progress
     expect(page).to have_h1("Upload provider response")
-    expect(page).to have_element(:div, text: "You need to fix 1 error related to specific rows", class: "govuk-error-summary")
+    expect(page).to have_element(:div, text: "You need to fix 1 error related to a specific row", class: "govuk-error-summary")
     expect(page).to have_element(:td, text: "Enter a valid mentor name Jane Doe", class: "govuk-table__cell")
     expect(page).to have_element(:p, text: "Only showing rows with errors", class: "govuk-!-text-align-centre")
   end

--- a/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_containing_claims_not_with_the_status_sampling_in_progress_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_containing_claims_not_with_the_status_sampling_in_progress_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe "Support user uploads a CSV containing claims not with the status
 
   def and_i_see_the_csv_contained_claims_not_with_the_status_sampling_in_progress
     expect(page).to have_h1("Upload provider response")
-    expect(page).to have_element(:div, text: "You need to fix 1 error related to specific rows", class: "govuk-error-summary")
+    expect(page).to have_element(:div, text: "You need to fix 1 error related to a specific row", class: "govuk-error-summary")
     expect(page).to have_element(:td, text: "Enter a valid claim reference 22222222", class: "govuk-table__cell")
     expect(page).to have_element(:p, text: "Only showing rows with errors", class: "govuk-!-text-align-centre")
   end

--- a/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_not_containing_a_rejection_reason_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_not_containing_a_rejection_reason_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe "Support user uploads a CSV not containing a rejection reason",
 
   def and_i_see_the_csv_contained_claims_without_a_rejection_reason
     expect(page).to have_h1("Upload provider response")
-    expect(page).to have_element(:div, text: "You need to fix 1 error related to specific rows", class: "govuk-error-summary")
+    expect(page).to have_element(:div, text: "You need to fix 1 error related to a specific row", class: "govuk-error-summary")
     expect(page).to have_element(:td, text: "Enter a reason", class: "govuk-table__cell")
     expect(page).to have_element(:p, text: "Only showing rows with errors", class: "govuk-!-text-align-centre")
   end

--- a/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_not_containing_an_assured_status_for_each_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_not_containing_an_assured_status_for_each_mentor_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe "Support user uploads a CSV not containing a claim accepted input
 
   def and_i_see_the_csv_contained_claims_without_a_claim_accepted_input_for_each_mentor
     expect(page).to have_h1("Upload provider response")
-    expect(page).to have_element(:div, text: "You need to fix 1 error related to specific rows", class: "govuk-error-summary")
+    expect(page).to have_element(:div, text: "You need to fix 1 error related to a specific row", class: "govuk-error-summary")
     expect(page).to have_element(:td, text: "Enter a valid input", class: "govuk-table__cell")
     expect(page).to have_element(:p, text: "Only showing rows with errors", class: "govuk-!-text-align-centre")
   end

--- a/spec/wizards/claims/upload_sampling_data_wizard/confirmation_step_spec.rb
+++ b/spec/wizards/claims/upload_sampling_data_wizard/confirmation_step_spec.rb
@@ -4,11 +4,42 @@ RSpec.describe Claims::UploadSamplingDataWizard::ConfirmationStep, type: :model 
   subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
 
   let(:mock_wizard) do
-    instance_double(Claims::UploadSamplingDataWizard)
+    instance_double(Claims::UploadSamplingDataWizard).tap do |mock_wizard|
+      allow(mock_wizard).to receive_messages(paid_claims: Claims::Claim.paid, steps: { upload: mock_upload_step })
+    end
+  end
+  let(:mock_upload_step) do
+    instance_double(Claims::UploadSamplingDataWizard::UploadStep).tap do |mock_upload_step|
+      allow(mock_upload_step).to receive_messages(
+        invalid_claim_rows:,
+        missing_sample_reason_rows:,
+        file_name:,
+        csv:,
+      )
+    end
   end
   let(:attributes) { nil }
+  let(:invalid_claim_rows) { nil }
+  let(:missing_sample_reason_rows) { nil }
+  let(:file_name) { "uploaded.csv" }
+  let(:csv) { CSV.parse(csv_content, headers: true, skip_blanks: true) }
+  let(:csv_content) do
+    "claim_reference,sample_reason\r\n" \
+    "11111111,Some reason\r\n" \
+    "22222222,Another reason"
+  end
 
   describe "delegations" do
+    it { is_expected.to delegate_method(:csv).to(:upload_step) }
+    it { is_expected.to delegate_method(:file_name).to(:upload_step) }
     it { is_expected.to delegate_method(:uploaded_claim_ids).to(:wizard) }
+  end
+
+  describe "#csv_headers" do
+    it "returns the headers of the CSV file" do
+      expect(step.csv_headers).to match_array(
+        %w[claim_reference sample_reason],
+      )
+    end
   end
 end

--- a/spec/wizards/claims/upload_sampling_data_wizard/confirmation_step_spec.rb
+++ b/spec/wizards/claims/upload_sampling_data_wizard/confirmation_step_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe Claims::UploadSamplingDataWizard::ConfirmationStep, type: :model 
   describe "delegations" do
     it { is_expected.to delegate_method(:csv).to(:upload_step) }
     it { is_expected.to delegate_method(:file_name).to(:upload_step) }
-    it { is_expected.to delegate_method(:uploaded_claim_ids).to(:wizard) }
   end
 
   describe "#csv_headers" do

--- a/spec/wizards/claims/upload_sampling_data_wizard/upload_errors_step_spec.rb
+++ b/spec/wizards/claims/upload_sampling_data_wizard/upload_errors_step_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe Claims::UploadSamplingDataWizard::UploadErrorsStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Claims::UploadSamplingDataWizard).tap do |mock_wizard|
+      allow(mock_wizard).to receive_messages(paid_claims: Claims::Claim.paid, steps: { upload: mock_upload_step })
+    end
+  end
+  let(:mock_upload_step) do
+    instance_double(Claims::UploadSamplingDataWizard::UploadStep).tap do |mock_upload_step|
+      allow(mock_upload_step).to receive_messages(
+        invalid_claim_rows:,
+        missing_sample_reason_rows:,
+        file_name:,
+        csv:,
+      )
+    end
+  end
+  let(:attributes) { nil }
+  let(:invalid_claim_rows) { nil }
+  let(:missing_sample_reason_rows) { nil }
+  let(:file_name) { "uploaded.csv" }
+  let(:csv) { CSV.parse(csv_content, headers: true, skip_blanks: true) }
+  let(:csv_content) do
+    "claim_reference,sample_reason\r\n" \
+    "11111111,Some reason\r\n" \
+  end
+
+  let(:claim_1) { create(:claim, :submitted, status: :paid, reference: 11_111_111) }
+  let(:claim_2) { create(:claim, :submitted, status: :paid, reference: 22_222_222) }
+  let(:claim_3) { create(:claim, :submitted, status: :paid, reference: 33_333_333) }
+
+  before do
+    claim_1
+    claim_2
+    claim_3
+  end
+
+  describe "delegations" do
+    it { is_expected.to delegate_method(:invalid_claim_rows).to(:upload_step) }
+    it { is_expected.to delegate_method(:missing_sample_reason_rows).to(:upload_step) }
+    it { is_expected.to delegate_method(:file_name).to(:upload_step) }
+    it { is_expected.to delegate_method(:csv).to(:upload_step) }
+  end
+
+  describe "#row_indexes_with_errors" do
+    subject(:row_indexes_with_errors) { step.row_indexes_with_errors }
+
+    let(:invalid_claim_rows) { [1] }
+    let(:missing_sample_reason_rows) { [1, 5] }
+
+    it "merges all the validation attributes containing row numbers together (removing duplicates)" do
+      expect(row_indexes_with_errors).to contain_exactly(1, 5)
+    end
+  end
+
+  describe "#error_count" do
+    subject(:error_count) { step.error_count }
+
+    let(:invalid_claim_rows) { [1] }
+    let(:missing_sample_reason_rows) { [1, 2, 3, 4, 5] }
+
+    it "adds together the number of elements in validation attribute" do
+      expect(error_count).to eq(6)
+    end
+  end
+end

--- a/spec/wizards/claims/upload_sampling_data_wizard/upload_step_spec.rb
+++ b/spec/wizards/claims/upload_sampling_data_wizard/upload_step_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe Claims::UploadSamplingDataWizard::UploadStep, type: :model do
       expect(step).to have_attributes(csv_upload: nil,
                                       csv_content: nil,
                                       file_name: nil,
-                                      claim_ids: [],
                                       invalid_claim_rows: [],
                                       missing_sample_reason_rows: [])
     }

--- a/spec/wizards/claims/upload_sampling_data_wizard/upload_step_spec.rb
+++ b/spec/wizards/claims/upload_sampling_data_wizard/upload_step_spec.rb
@@ -12,7 +12,14 @@ RSpec.describe Claims::UploadSamplingDataWizard::UploadStep, type: :model do
   let(:attributes) { nil }
 
   describe "attributes" do
-    it { is_expected.to have_attributes(csv_upload: nil, csv_content: nil, claim_ids: []) }
+    it {
+      expect(step).to have_attributes(csv_upload: nil,
+                                      csv_content: nil,
+                                      file_name: nil,
+                                      claim_ids: [],
+                                      invalid_claim_rows: [],
+                                      missing_sample_reason_rows: [])
+    }
   end
 
   describe "delegations" do
@@ -71,68 +78,153 @@ RSpec.describe Claims::UploadSamplingDataWizard::UploadStep, type: :model do
       end
     end
 
-    describe "#csv_contains_valid_claims" do
-      context "when the CSV contains claims which are not in the paid status" do
-        let(:paid_claims) { [create(:claim, :submitted, status: :paid, reference: 11_111_111)] }
-        let(:submitted_claim) { create(:claim, :submitted, reference: 22_222_222) }
-        let(:attributes) { { csv_upload: invalid_file } }
-        let(:invalid_file) do
-          ActionDispatch::Http::UploadedFile.new({
-            filename: "invalid.csv",
-            type: "text/csv",
-            tempfile: File.open("spec/fixtures/claims/sampling/invalid_example_sampling_upload.csv"),
-          })
-        end
+    describe "#validate_csv_headers" do
+      context "when csv_content is present" do
+        context "when the csv content is missing valid headers" do
+          let(:csv_content) do
+            "sampling_reason\r\n"
+          end
+          let(:attributes) { { csv_content: } }
 
-        before do
-          paid_claims
-          submitted_claim
+          it "returns errors for missing headers" do
+            expect(step.valid?).to be(false)
+            expect(step.errors.messages[:csv_upload]).to include(
+              "Your file needs a column called ‘claim_reference’ and ‘sample_reason’.",
+            )
+            expect(step.errors.messages[:csv_upload]).to include(
+              "Right now it has columns called ‘sampling_reason’.",
+            )
+          end
         end
+      end
+    end
 
-        it "validates that the file is the correct format" do
-          expect(step.valid?).to be(false)
-          expect(step.errors.messages[:csv_upload]).to include("The selected CSV file contains invalid data")
+    describe "#csv_inputs_valid?" do
+      subject(:csv_inputs_valid) { step.csv_inputs_valid? }
+
+      context "when the csv_content is blank" do
+        it "returns true" do
+          expect(csv_inputs_valid).to be(true)
         end
       end
 
-      context "when the CSV contains only claims which are in the paid status" do
-        let(:paid_claims) { [create(:claim, :submitted, status: :paid, reference: 11_111_111)] }
-        let(:submitted_claim) { create(:claim, :submitted, reference: 22_222_222) }
-        let(:attributes) { { csv_upload: valid_file } }
-        let(:valid_file) do
-          ActionDispatch::Http::UploadedFile.new({
-            filename: "valid.csv",
-            type: "text/csv",
-            tempfile: File.open("spec/fixtures/claims/sampling/example_sampling_upload.csv"),
-          })
+      context "when csv_content contains invalid references" do
+        let(:csv_content) do
+          "claim_reference,sample_reason\r\n" \
+          "11111111,Random auditing"
         end
+        let(:attributes) { { csv_content: } }
 
-        before { paid_claims }
+        before { create(:claim, :submitted, status: :paid, reference: 22_222_222) }
 
-        it "validates that the file is the correct format" do
-          expect(step.valid?).to be(true)
+        it "returns false and assigns the csv row to the 'invalid_claim_rows' attribute" do
+          expect(csv_inputs_valid).to be(false)
+          expect(step.invalid_claim_rows).to contain_exactly(0)
         end
+      end
+
+      context "when csv_content contains claims not with the status 'paid" do
+        let(:csv_content) do
+          "claim_reference,sampling_reason\r\n" \
+          "11111111,Large provider"
+        end
+        let(:attributes) { { csv_content: } }
+
+        before { create(:claim, :submitted, status: :sampling_in_progress, reference: 11_111_111) }
+
+        it "returns false and assigns the csv row to the 'invalid_claim_rows' attribute" do
+          expect(csv_inputs_valid).to be(false)
+          expect(step.invalid_claim_rows).to contain_exactly(0)
+        end
+      end
+
+      context "when the csv_content does not contain a sample reason" do
+        let(:csv_content) do
+          "claim_reference,sample_reason\r\n" \
+          "33333333,"
+        end
+        let(:attributes) { { csv_content: } }
+
+        before { create(:claim, :submitted, status: :paid, sampling_reason: nil, reference: 33_333_333) }
+
+        it "returns false and assigns the reference to the 'missing_sample_reason_rows' attribute" do
+          expect(csv_inputs_valid).to be(false)
+          expect(step.missing_sample_reason_rows).to contain_exactly(0)
+        end
+      end
+
+      context "when the csv_content contains valid claim references and all necessary attributes" do
+        let(:csv_content) do
+          "claim_reference,sample_reason\r\n" \
+          "11111111,Routine audit"
+        end
+        let(:attributes) { { csv_content: } }
+
+        before { create(:claim, :submitted, status: :paid, sampling_reason: "Routine audit", reference: 11_111_111) }
+
+        it "returns true" do
+          expect(csv_inputs_valid).to be(true)
+        end
+      end
+    end
+
+    describe "#process_csv" do
+      let(:paid_claims) { [create(:claim, :submitted, status: :paid, reference: 11_111_111)] }
+      let(:submitted_claim) { create(:claim, :submitted, reference: 22_222_222) }
+      let(:attributes) { { csv_upload: valid_file } }
+      let(:valid_file) do
+        ActionDispatch::Http::UploadedFile.new({
+          filename: "valid.csv",
+          type: "text/csv",
+          tempfile: File.open("spec/fixtures/claims/sampling/example_sampling_upload.csv"),
+        })
+      end
+
+      before { paid_claims }
+
+      it "reads a given CSV and assigns the content to the csv_content attribute,
+        and assigns the associated claim IDs to the claim_ids attribute" do
+        expect(step.csv_content).to eq("claim_reference,sample_reason\n11111111,Some Reason\n")
       end
     end
   end
 
-  describe "#process_csv" do
-    let(:paid_claims) { [create(:claim, :submitted, status: :paid, reference: 11_111_111)] }
-    let(:submitted_claim) { create(:claim, :submitted, reference: 22_222_222) }
-    let(:attributes) { { csv_upload: valid_file } }
-    let(:valid_file) do
-      ActionDispatch::Http::UploadedFile.new({
-        filename: "valid.csv",
-        type: "text/csv",
-        tempfile: File.open("spec/fixtures/claims/sampling/example_sampling_upload.csv"),
-      })
+  describe "#csv" do
+    subject(:csv) { step.csv }
+
+    let(:csv_content) do
+      "claim_reference,sample_reason\r\n" \
+      "11111111,Some reason\r\n" \
+      "11111111,Another reason\r\n" \
+      "22222222,A reason\r\n" \
+      ""
     end
+    let(:attributes) { { csv_content: } }
 
-    before { paid_claims }
+    it "converts the csv content into a CSV record" do
+      expect(csv).to be_a(CSV::Table)
+      expect(csv.headers).to match_array(
+        %w[claim_reference sample_reason],
+      )
+      expect(csv.count).to eq(3)
 
-    it "reads a given CSV and assigns the content to the csv_content attribute,
-      and assigns the associated claim IDs to the claim_ids attribute" do
-      expect(step.csv_content).to eq("claim_reference,sample_reason\n11111111,Some Reason\n")
+      expect(csv[0]).to be_a(CSV::Row)
+      expect(csv[0].to_h).to eq({
+        "claim_reference" => "11111111",
+        "sample_reason" => "Some reason",
+      })
+
+      expect(csv[1]).to be_a(CSV::Row)
+      expect(csv[1].to_h).to eq({
+        "claim_reference" => "11111111",
+        "sample_reason" => "Another reason",
+      })
+
+      expect(csv[2]).to be_a(CSV::Row)
+      expect(csv[2].to_h).to eq({
+        "claim_reference" => "22222222",
+        "sample_reason" => "A reason",
+      })
     end
   end
 end


### PR DESCRIPTION
## Context

Improve validation for "claims to be audited" upload 

## Changes proposed in this pull request

- Changes to Claims::UploadSamplingClaimsWizard and related steps to validate rows, headers and inputs of the uploaded CSV.

## Guidance to review

- Sign in as Colin (Support user)
- Navigate to Claims -> Auditing (assuming you have claims in the `paid` status)
- Click "Upload claims to be audited"
- Upload a CSV with valid headers and inputs
- You should see the CSV shown on the confirmation page
- Click "Confirm upload"
- You should see a success message
- Next, trigger validation errors by uploading a CSV with missing or misspelt headers
- Trigger an "invalid claim reference" validation error by uploading a CSV with a reference number which does not belong to a Claim with a status of "paid"
- Trigger a "missing sample reason error" by uploading a CSV with a valid reference number which does not have a sample reason

## Link to Trello card

https://trello.com/c/QTrfQQDW/377-csv-uploads-upload-claims-to-be-sampled

## Screenshots

<img width="713" alt="Screenshot 2025-01-31 at 17 36 04" src="https://github.com/user-attachments/assets/dacdec96-c3ea-4ba4-b2ba-ce00dddef430" />
<img width="725" alt="Screenshot 2025-01-31 at 17 36 18" src="https://github.com/user-attachments/assets/cd3055e1-01bb-4e64-9b88-9e58808b5650" />
<img width="761" alt="Screenshot 2025-01-31 at 17 38 22" src="https://github.com/user-attachments/assets/97ac03c5-0589-45bd-984f-0a26149c0da6" />
<img width="1035" alt="Screenshot 2025-01-31 at 17 38 31" src="https://github.com/user-attachments/assets/6e46fa5a-4afa-4d56-b614-1003890935da" />