### PR TITLE
Update inset text

### DIFF
--- a/app/components/claims/claim/mentors_form/disclaimer_component.rb
+++ b/app/components/claims/claim/mentors_form/disclaimer_component.rb
@@ -8,7 +8,7 @@ class Claims::Claim::MentorsForm::DisclaimerComponent < ApplicationComponent
   end
 
   def call
-    govuk_inset_text do
+    govuk_details summary_text: t(".mentor_not_listed") do
       tag.p(sanitize(t(".disclaimer", provider_name:))) +
         tag.p(sanitize(t(".disclaimer_contact", email_link:)))
     end

--- a/app/views/claims/schools/claims/index.html.erb
+++ b/app/views/claims/schools/claims/index.html.erb
@@ -6,9 +6,8 @@
 
   <% if policy(Claims::Claim).create? %>
     <% if @school.mentors.any? %>
-      <%= govuk_inset_text do %>
-        <p class="govuk-body"><%= t(".guidance") %></p>
-        <p class="govuk-body"><%= sanitize t(".closing_date_disclaimer", time: l(Claims::ClaimWindow.current.ends_on.end_of_day, format: :time_on_date)) %></p>
+      <%= govuk_warning_text do %>
+        <p class="govuk-body"><%= t(".guidance", end_date: l(Claims::ClaimWindow.current.ends_on, format: :long_with_day), start_year: Claims::ClaimWindow.current.starts_on.year, end_year: Claims::ClaimWindow.current.ends_on.year) %></p>
       <% end %>
 
       <%= govuk_link_to t(".add_claim"), new_claims_school_claim_path, class: "govuk-button" %>

--- a/app/views/claims/schools/claims/mentors/_form.html.erb
+++ b/app/views/claims/schools/claims/mentors/_form.html.erb
@@ -8,8 +8,6 @@
       <% if claim_mentors_form.mentors_with_claimable_hours.any? %>
         <h1 class="govuk-heading-l"><%= t(".heading", provider_name: claim_mentors_form.claim.provider_name) %></h1>
 
-        <%= render Claims::Claim::MentorsForm::DisclaimerComponent.new(mentors_form: claim_mentors_form) %>
-
         <%= f.govuk_collection_check_boxes(
           :mentor_ids,
           claim_mentors_form.mentors_with_claimable_hours,
@@ -19,6 +17,8 @@
           legend: { text: t(".label"), size: "s" },
           hint: { text: t(".select_all_that_apply") },
         ) %>
+
+        <%= render Claims::Claim::MentorsForm::DisclaimerComponent.new(mentors_form: claim_mentors_form) %>
 
         <%= f.govuk_submit t("continue") %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
     formats:
       month: "%B"
       long: "%-d %B %Y"
+      long_with_day: "%A %-d %B %Y"
       short: "%d/%m/%Y"
   time:
     formats:

--- a/config/locales/en/claims/schools/claims.yml
+++ b/config/locales/en/claims/schools/claims.yml
@@ -47,9 +47,7 @@ en:
         index:
           heading: Claims
           add_claim: Add claim
-          guidance: Claims can only be made for the school year September 2023 to July 2024.
-          closing_date_disclaimer_title: Important
-          closing_date_disclaimer: You must submit a claim by <strong>%{time}</strong>.
+          guidance: You have until 11:59pm on %{end_date} to submit claims for the school year September %{start_year} to July %{end_year}.
           add_mentor_guidance_html: Before you can start a claim you will need to %{link_to}.
           add_a_mentor: add a mentor
           window_closed: Claims can no longer be submitted for school year September %{start_year} to July %{end_year}.

--- a/config/locales/en/components/claims/claim/mentors_form/disclaimer_component.yml
+++ b/config/locales/en/components/claims/claim/mentors_form/disclaimer_component.yml
@@ -4,5 +4,6 @@ en:
       claim:
         mentors_form:
           disclaimer_component:
-            disclaimer: This list includes all mentors who can be included on a claim. If a mentor you have added is not showing in this list, that is because they have already had 20 hours of training claimed for with %{provider_name}.
-            disclaimer_contact: Contact %{email_link} if you think there is a problem.
+            disclaimer: If a mentor you have added is not showing in the list, they have already claimed 20 hours with %{provider_name}.
+            disclaimer_contact: If you think this is a mistake, contact %{email_link}.
+            mentor_not_listed: My mentor is not listed

--- a/spec/components/claims/claim/mentors_form/disclaimer_component_spec.rb
+++ b/spec/components/claims/claim/mentors_form/disclaimer_component_spec.rb
@@ -24,12 +24,12 @@ RSpec.describe Claims::Claim::MentorsForm::DisclaimerComponent, type: :component
       create(:mentor_training, claim: create(:claim, :submitted, school:), mentor: school.mentors.first, provider: claim.provider, hours_completed: 20)
     end
 
-    it "renders an inset text block with information about why a mentor is missing from the list" do
+    it "renders a details block with information about why a mentor is missing from the list" do
       render_inline described_class.new(mentors_form:)
 
-      expect(page).to have_css(".govuk-inset-text")
-      expect(page).to have_content "This list includes all mentors who can be included on a claim. If a mentor you have added is not showing in this list, that is because they have already had 20 hours of training claimed for with #{claim.provider.name}."
-      expect(page).to have_content "Contact ittmentor.funding@education.gov.uk if you think there is a problem."
+      expect(page).to have_css(".govuk-details")
+      expect(page).to have_content "If a mentor you have added is not showing in the list, they have already claimed 20 hours with #{claim.provider.name}."
+      expect(page).to have_content "If you think this is a mistake, contact ittmentor.funding@education.gov.uk."
     end
   end
 end

--- a/spec/system/claims/schools/claims/view_claims_spec.rb
+++ b/spec/system/claims/schools/claims/view_claims_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe "View claims", service: :claims, type: :system do
     )
   end
 
+  let(:claim_window) { Claims::ClaimWindow.current }
+
   before do
     create(:claim, status: :internal_draft, school:)
     given_there_is_a_current_claim_window
@@ -102,7 +104,7 @@ RSpec.describe "View claims", service: :claims, type: :system do
   def i_can_see_the_claim_guidance
     within(first(".govuk-body")) do
       expect(page).to have_content(
-        "Claims can only be made for the school year September 2023 to July 2024.",
+        "You have until 11:59pm on #{I18n.l(claim_window.ends_on, format: :long_with_day)} to submit claims for the school year September #{claim_window.starts_on.year} to July #{claim_window.ends_on.year}.",
       )
     end
   end


### PR DESCRIPTION
## Context

The inset text was use incorrectly under the design system guidelines, we have updated to the text be in more semantically correct containers.

## Changes proposed in this pull request

- [x] Updates the inset text for the claims index page
- [x] Updates the inset text for the mentors page when adding a claim

## Guidance to review

- Log in as Anne
- Review the guidance on the claims index page
- Add a claim for a mentor with 20 hours
- Add a second claim and review details text

## Link to Trello card

[Change inset text on claims homepage school user](https://trello.com/c/BmbYCCqx/384-change-inset-text-on-claims-homepage-school-user)
[Change inset text on Mentors page during add claim flow (school user)
](https://trello.com/c/vkRmDeDF/383-change-inset-text-on-mentors-page-during-add-claim-flow-school-user)

## Screenshots

![image](https://github.com/user-attachments/assets/f2c057bd-3fe2-4e5d-9a9c-20ef60593089)
![image](https://github.com/user-attachments/assets/b9ec6ba9-4480-42fc-b590-a99919ed57b1)

