### PR TITLE
Bug fixes for things seen in user guide screenshot creation

### DIFF
--- a/app/views/wizards/claims/upload_esfa_clawback_response_wizard/_confirmation_step.html.erb
+++ b/app/views/wizards/claims/upload_esfa_clawback_response_wizard/_confirmation_step.html.erb
@@ -22,7 +22,7 @@
             <% end %>
 
             <% table.with_body do |body| %>
-              <% current_step.csv.each_with_index do |csv_row, index| %>
+              <% current_step.csv.first(5).each_with_index do |csv_row, index| %>
                 <% if csv_row["claim_reference"].present? %>
                   <% body.with_row do |row| %>
                     <% row.with_cell text: index + 2 %>

--- a/app/views/wizards/claims/upload_payer_payment_response_wizard/_confirmation_step.html.erb
+++ b/app/views/wizards/claims/upload_payer_payment_response_wizard/_confirmation_step.html.erb
@@ -22,7 +22,7 @@
             <% end %>
 
             <% table.with_body do |body| %>
-              <% current_step.csv.each_with_index do |csv_row, index| %>
+              <% current_step.csv.first(5).each_with_index do |csv_row, index| %>
                 <% if csv_row["claim_reference"].present? %>
                   <% body.with_row do |row| %>
                     <% row.with_cell text: index + 2 %>

--- a/app/views/wizards/claims/upload_provider_response_wizard/_confirmation_step.html.erb
+++ b/app/views/wizards/claims/upload_provider_response_wizard/_confirmation_step.html.erb
@@ -25,7 +25,7 @@
             <% end %>
 
             <% table.with_body do |body| %>
-              <% current_step.csv.each_with_index do |csv_row, index| %>
+              <% current_step.csv.first(5).each_with_index do |csv_row, index| %>
                 <% if csv_row["claim_reference"].present? %>
                   <% body.with_row do |row| %>
                     <% row.with_cell text: index + 2 %>

--- a/config/locales/en/wizards/claims/reject_claim_wizard.yml
+++ b/config/locales/en/wizards/claims/reject_claim_wizard.yml
@@ -36,7 +36,7 @@ en:
           change: Change
           original_number_of_hours_claimed: Original hours claimed
           rejecting_these_mentors_will_update_status: |
-            Rejecting these mentors will update the claim status to ‘claim not approved’ and move it to the clawback queue.
+            This will update the claim status to ‘rejected by school’ and move it to the clawback queue.
           hours:
             one: "%{count} hour"
             other: "%{count} hours"

--- a/config/locales/en/wizards/claims/upload_provider_response_wizard.yml
+++ b/config/locales/en/wizards/claims/upload_provider_response_wizard.yml
@@ -57,7 +57,7 @@ en:
               claim_accepted: claim_accepted
               rejection_reason: rejection_reason
             errors:
-              invalid_claim_reference: Not a valid claim reference
+              invalid_claim_reference: Enter a valid claim reference
               invalid_mentor: Enter a valid mentor name
               invalid_input: Enter a valid input
               reason_needed: Enter a reason

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_changes_the_reason_the_school_rejected_the_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_changes_the_reason_the_school_rejected_the_mentor_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe "Support user changes the reason the school rejected the mentor",
     expect(page).to have_h1("Check your answers")
     expect(page).to have_element(
       :div,
-      text: "Rejecting these mentors will update the claim status to ‘claim not approved’ and move it to the clawback queue.",
+      text: "This will update the claim status to ‘rejected by school’ and move it to the clawback queue.",
       class: "govuk-warning-text",
     )
   end

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_marks_the_claim_as_rejected_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_rejected/support_user_marks_the_claim_as_rejected_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe "Support user marks a claim as rejected", service: :claims, type:
     expect(page).to have_h1("Check your answers")
     expect(page).to have_element(
       :div,
-      text: "Rejecting these mentors will update the claim status to ‘claim not approved’ and move it to the clawback queue.",
+      text: "This will update the claim status to ‘rejected by school’ and move it to the clawback queue.",
       class: "govuk-warning-text",
     )
   end

--- a/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_containing_claims_not_with_the_status_sampling_in_progress_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_containing_claims_not_with_the_status_sampling_in_progress_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe "Support user uploads a CSV containing claims not with the status
   def and_i_see_the_csv_contained_claims_not_with_the_status_sampling_in_progress
     expect(page).to have_h1("Upload provider response")
     expect(page).to have_element(:div, text: "You need to fix 1 error related to specific rows", class: "govuk-error-summary")
-    expect(page).to have_element(:td, text: "Not a valid claim reference 22222222", class: "govuk-table__cell")
+    expect(page).to have_element(:td, text: "Enter a valid claim reference 22222222", class: "govuk-table__cell")
     expect(page).to have_element(:p, text: "Only showing rows with errors", class: "govuk-!-text-align-centre")
   end
 end

--- a/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_containing_invalid_references_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_a_csv_containing_invalid_references_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe "Support user uploads a CSV not containing invalid references",
   def and_i_see_the_csv_contained_invalid_claim_references
     expect(page).to have_h1("Upload provider response")
     expect(page).to have_element(:div, text: "You need to fix 2 errors related to specific rows", class: "govuk-error-summary")
-    expect(page).to have_element(:td, text: "Not a valid claim reference 11111111", class: "govuk-table__cell", count: 2)
+    expect(page).to have_element(:td, text: "Enter a valid claim reference 11111111", class: "govuk-table__cell", count: 2)
     expect(page).to have_element(:p, text: "Only showing rows with errors", class: "govuk-!-text-align-centre")
   end
 end


### PR DESCRIPTION
## Context

- Small text changes and limit CSV display to 5 rows.


## Link to Trello card

https://trello.com/c/j4OHflJa/395-limit-number-of-csv-rows-when-uploading

## Screenshots
https://www.figma.com/design/2dHqnhuBuiUNO4LNAGK5UG/Track-and-pay---Claim-funding-for-mentor-training?t=lf7E0BZN7BVSGH07-0

