### PR TITLE
Support details for claims

### DIFF
--- a/app/controllers/claims/support/claims/support_details_controller.rb
+++ b/app/controllers/claims/support/claims/support_details_controller.rb
@@ -1,0 +1,46 @@
+class Claims::Support::Claims::SupportDetailsController < Claims::Support::ApplicationController
+  include WizardController
+  before_action :skip_authorization
+
+  before_action :set_wizard
+  helper_method :index_path
+
+  def new
+    @wizard.setup_state
+    redirect_to step_path(@wizard.first_step)
+  end
+
+  def update
+    if !@wizard.save_step
+      render "edit"
+    elsif @wizard.next_step.present?
+      redirect_to step_path(@wizard.next_step)
+    else
+      @wizard.update_support_details
+      @wizard.reset_state
+      redirect_to index_path, flash: {
+        heading: @wizard.success_message,
+      }
+    end
+  end
+
+  private
+
+  def set_wizard
+    state = session[state_key] ||= {}
+    current_step = params[:step]&.to_sym
+    @wizard = Claims::SupportDetailsWizard.new(params:, claim:, state:, current_step:)
+  end
+
+  def step_path(step)
+    support_details_claims_support_claim_path(state_key:, step:)
+  end
+
+  def claim
+    @claim ||= Claims::Claim.find(params.require(:id))
+  end
+
+  def index_path
+    claims_support_claim_path(claim)
+  end
+end

--- a/app/controllers/claims/support/claims/support_details_controller.rb
+++ b/app/controllers/claims/support/claims/support_details_controller.rb
@@ -13,8 +13,6 @@ class Claims::Support::Claims::SupportDetailsController < Claims::Support::Appli
   def update
     if !@wizard.save_step
       render "edit"
-    elsif @wizard.next_step.present?
-      redirect_to step_path(@wizard.next_step)
     else
       @wizard.update_support_details
       @wizard.reset_state
@@ -28,7 +26,7 @@ class Claims::Support::Claims::SupportDetailsController < Claims::Support::Appli
 
   def set_wizard
     state = session[state_key] ||= {}
-    current_step = params[:step]&.to_sym
+    current_step = params.fetch(:step).to_sym
     @wizard = Claims::SupportDetailsWizard.new(params:, claim:, state:, current_step:)
   end
 

--- a/app/models/claims/claim.rb
+++ b/app/models/claims/claim.rb
@@ -12,6 +12,7 @@
 #  submitted_at           :datetime
 #  submitted_by_type      :string
 #  unpaid_reason          :text
+#  zendesk_url            :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  claim_window_id        :uuid
@@ -20,6 +21,7 @@
 #  provider_id            :uuid
 #  school_id              :uuid             not null
 #  submitted_by_id        :uuid
+#  support_user_id        :uuid
 #
 # Indexes
 #
@@ -30,6 +32,7 @@
 #  index_claims_on_reference             (reference)
 #  index_claims_on_school_id             (school_id)
 #  index_claims_on_submitted_by          (submitted_by_type,submitted_by_id)
+#  index_claims_on_support_user_id       (support_user_id)
 #
 # Foreign Keys
 #
@@ -46,6 +49,7 @@ class Claims::Claim < ApplicationRecord
   belongs_to :created_by, polymorphic: true
   belongs_to :submitted_by, polymorphic: true, optional: true
   belongs_to :previous_revision, class_name: "Claims::Claim", optional: true
+  belongs_to :support_user, class_name: "Claims::SupportUser", optional: true
 
   has_one :academic_year, through: :claim_window
 

--- a/app/models/claims/support_user.rb
+++ b/app/models/claims/support_user.rb
@@ -20,4 +20,6 @@
 #
 class Claims::SupportUser < User
   include ActsAsSupportUser
+
+  has_many :claims
 end

--- a/app/models/claims/support_user.rb
+++ b/app/models/claims/support_user.rb
@@ -21,5 +21,5 @@
 class Claims::SupportUser < User
   include ActsAsSupportUser
 
-  has_many :claims
+  has_many :assigned_claims, class_name: "Claims::Claim"
 end

--- a/app/views/claims/support/claims/_details.html.erb
+++ b/app/views/claims/support/claims/_details.html.erb
@@ -1,3 +1,39 @@
+<h2 class="govuk-heading-m"><%= t(".support_details") %></h2>
+<%= govuk_summary_list(actions: claim.zendesk_url.present? || claim.support_user.present?) do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t(".support_ticket")) %>
+    <% if claim.zendesk_url.present? %>
+      <% row.with_value(text: govuk_link_to(t(".zendesk_support_ticket"), claim.zendesk_url, new_tab: true)) %>
+    <% else %>
+      <% row.with_value(text: govuk_link_to(t(".add_zendesk_link"), new_support_details_claims_support_claim_path(step: :zendesk))) %>
+    <% end %>
+    <% if claim.zendesk_url.present? %>
+      <% row.with_action(
+        text: t("change"),
+        visually_hidden_text: t(".support_ticket"),
+        href: new_support_details_claims_support_claim_path(step: :zendesk),
+      ) %>
+    <% end %>
+  <% end %>
+
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t(".assigned_user")) %>
+    <% if claim.support_user.present? %>
+      <% row.with_value(text: claim.support_user.full_name) %>
+    <% else %>
+      <% row.with_value(text: govuk_link_to(t(".assign_support_user"), new_support_details_claims_support_claim_path(step: :support_user))) %>
+    <% end %>
+    <% if claim.support_user.present? %>
+      <% row.with_action(
+        text: t("change"),
+        visually_hidden_text: t(".assigned_user"),
+        href: new_support_details_claims_support_claim_path(step: :support_user),
+      ) %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<h2 class="govuk-heading-m"><%= t(".claim_details") %></h2>
 <%= govuk_summary_list(actions: policy(claim).edit?) do |summary_list| %>
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: Claims::Claim.human_attribute_name(:school)) %>

--- a/app/views/claims/support/claims/_details.html.erb
+++ b/app/views/claims/support/claims/_details.html.erb
@@ -4,15 +4,13 @@
     <% row.with_key(text: t(".support_ticket")) %>
     <% if claim.zendesk_url.present? %>
       <% row.with_value(text: govuk_link_to(t(".zendesk_support_ticket"), claim.zendesk_url, new_tab: true)) %>
-    <% else %>
-      <% row.with_value(text: govuk_link_to(t(".add_zendesk_link"), new_support_details_claims_support_claim_path(step: :zendesk))) %>
-    <% end %>
-    <% if claim.zendesk_url.present? %>
       <% row.with_action(
         text: t("change"),
         visually_hidden_text: t(".support_ticket"),
         href: new_support_details_claims_support_claim_path(step: :zendesk),
       ) %>
+    <% else %>
+      <% row.with_value(text: govuk_link_to(t(".add_zendesk_link"), new_support_details_claims_support_claim_path(step: :zendesk))) %>
     <% end %>
   <% end %>
 
@@ -20,15 +18,13 @@
     <% row.with_key(text: t(".assigned_user")) %>
     <% if claim.support_user.present? %>
       <% row.with_value(text: claim.support_user.full_name) %>
-    <% else %>
-      <% row.with_value(text: govuk_link_to(t(".assign_support_user"), new_support_details_claims_support_claim_path(step: :support_user))) %>
-    <% end %>
-    <% if claim.support_user.present? %>
       <% row.with_action(
         text: t("change"),
         visually_hidden_text: t(".assigned_user"),
         href: new_support_details_claims_support_claim_path(step: :support_user),
       ) %>
+    <% else %>
+      <% row.with_value(text: govuk_link_to(t(".assign_support_user"), new_support_details_claims_support_claim_path(step: :support_user))) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/claims/support/claims/support_details/edit.html.erb
+++ b/app/views/claims/support/claims/support_details/edit.html.erb
@@ -1,0 +1,12 @@
+<%= render "claims/support/primary_navigation", current: :claims %>
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: back_link_path) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= render_wizard(@wizard) %>
+
+  <p class="govuk-body">
+    <%= govuk_link_to(t(".cancel"), index_path, no_visited_state: true) %>
+  </p>
+</div>

--- a/app/views/wizards/claims/support_details_wizard/_support_user_step.html.erb
+++ b/app/views/wizards/claims/support_details_wizard/_support_user_step.html.erb
@@ -1,0 +1,21 @@
+<% content_for(:page_title) { sanitize title_with_error_prefix(t(".page_title", reference: @claim.reference), error: current_step.errors.any?) } %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".caption", reference: @claim.reference) %></span>
+      <%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
+        <%= f.govuk_error_summary %>
+
+        <%= f.govuk_collection_radio_buttons(
+          :support_user_id,
+          current_step.support_users,
+          :id, :full_name,
+          legend: { size: "l", text: t(".title"), tag: "h1" }
+        ) %>
+
+         <%= f.govuk_submit(t(".continue")) %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/wizards/claims/support_details_wizard/_zendesk_step.html.erb
+++ b/app/views/wizards/claims/support_details_wizard/_zendesk_step.html.erb
@@ -1,0 +1,17 @@
+<% content_for(:page_title) { sanitize title_with_error_prefix(t(".page_title", reference: @claim.reference), error: current_step.errors.any?) } %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".caption", reference: @claim.reference) %></span>
+
+      <%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
+        <%= f.govuk_error_summary %>
+
+        <%= f.govuk_text_field :zendesk_url, label: { text: t(".title"), size: "l", tag: "h1" } %>
+
+        <%= f.govuk_submit(t(".continue")) %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/wizards/claims/support_details_wizard.rb
+++ b/app/wizards/claims/support_details_wizard.rb
@@ -1,0 +1,46 @@
+module Claims
+  class SupportDetailsWizard < BaseWizard
+    attr_reader :claim
+
+    def initialize(claim:, params:, state:, current_step: nil)
+      @claim = claim
+
+      super(state:, params:, current_step:)
+    end
+
+    def define_steps
+      # Define the wizard steps here
+      add_step(ZendeskStep) if current_step == :zendesk
+      add_step(SupportUserStep) if current_step == :support_user
+    end
+
+    def update_support_details
+      raise "Invalid wizard state" unless valid?
+
+      if steps[:zendesk].present?
+        claim.zendesk_url = steps[:zendesk].zendesk_url
+      elsif steps[:support_user].present?
+        claim.support_user_id = steps[:support_user].support_user_id
+      end
+
+      claim.save!
+    end
+
+    def setup_state
+      if steps[:zendesk].present?
+        state["zendesk"] = { "zendesk_url" => claim.zendesk_url }
+
+      elsif steps[:support_user].present?
+        state["support_user"] = { "support_user_id" => claim.support_user_id }
+      end
+    end
+
+    def success_message
+      if steps[:zendesk].present?
+        I18n.t(".wizards.claims.support_details_wizard.success.zendesk")
+      elsif steps[:support_user].present?
+        I18n.t(".wizards.claims.support_details_wizard.success.support_user")
+      end
+    end
+  end
+end

--- a/app/wizards/claims/support_details_wizard.rb
+++ b/app/wizards/claims/support_details_wizard.rb
@@ -19,7 +19,7 @@ module Claims
 
       if steps[:zendesk].present?
         claim.zendesk_url = steps[:zendesk].zendesk_url
-      elsif steps[:support_user].present?
+      else
         claim.support_user_id = steps[:support_user].support_user_id
       end
 
@@ -29,18 +29,15 @@ module Claims
     def setup_state
       if steps[:zendesk].present?
         state["zendesk"] = { "zendesk_url" => claim.zendesk_url }
-
-      elsif steps[:support_user].present?
+      else
         state["support_user"] = { "support_user_id" => claim.support_user_id }
       end
     end
 
     def success_message
-      if steps[:zendesk].present?
-        I18n.t(".wizards.claims.support_details_wizard.success.zendesk")
-      elsif steps[:support_user].present?
-        I18n.t(".wizards.claims.support_details_wizard.success.support_user")
-      end
+      return I18n.t(".wizards.claims.support_details_wizard.success.zendesk") if steps[:zendesk].present?
+
+      I18n.t(".wizards.claims.support_details_wizard.success.support_user")
     end
   end
 end

--- a/app/wizards/claims/support_details_wizard/support_user_step.rb
+++ b/app/wizards/claims/support_details_wizard/support_user_step.rb
@@ -1,0 +1,9 @@
+class Claims::SupportDetailsWizard::SupportUserStep < BaseStep
+  attribute :support_user_id
+
+  validates :support_user_id, presence: true, inclusion: { in: ->(step) { step.support_users.ids } }
+
+  def support_users
+    Claims::SupportUser.all
+  end
+end

--- a/app/wizards/claims/support_details_wizard/zendesk_step.rb
+++ b/app/wizards/claims/support_details_wizard/zendesk_step.rb
@@ -1,0 +1,5 @@
+class Claims::SupportDetailsWizard::ZendeskStep < BaseStep
+  attribute :zendesk_url
+
+  validates :zendesk_url, presence: true
+end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -98,6 +98,8 @@ shared:
     - sampling_reason
     - payment_in_progress_at
     - unpaid_reason
+    - zendesk_url
+    - support_user_id
   :samplings:
     - id
     - created_at

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -98,8 +98,6 @@ shared:
     - sampling_reason
     - payment_in_progress_at
     - unpaid_reason
-    - zendesk_url
-    - support_user_id
   :samplings:
     - id
     - created_at

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -43,6 +43,9 @@ shared:
     - record_id
     - blob_id
     - created_at
+  :claims:
+    - zendesk_url
+    - support_user_id
   :download_access_tokens:
     - id
     - email_address

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -249,3 +249,12 @@ en:
                 Your file needs a column called %{missing_columns}.
               uploaded_headers: 
                 Right now it has columns called %{uploaded_headers}.
+        claims/support_details_wizard/zendesk_step:
+          attributes:
+            zendesk_url: 
+              blank: Please enter a zendesk URL
+        claims/support_details_wizard/support_user_step:
+          attributes:
+            support_user_id: 
+              blank: Please select a support agent
+              inclusion: Please select a support agent

--- a/config/locales/en/claims/support/claims.yml
+++ b/config/locales/en/claims/support/claims.yml
@@ -42,3 +42,11 @@ en:
           mentors: Mentors
           hours_of_training: Hours of training
           grant_funding: Grant funding
+          claim_details: Claim details
+          support_details: Support details
+          support_ticket: Support ticket
+          assigned_user: Assigned user
+          zendesk_support_ticket: Zendesk ticket
+          add_zendesk_link: Add link to Zendesk ticket
+          assign_support_user: Assign a support agent
+          change: Change

--- a/config/locales/en/claims/support/claims/support_details.yml
+++ b/config/locales/en/claims/support/claims/support_details.yml
@@ -1,0 +1,7 @@
+en:
+  claims:
+    support:
+      claims:
+        support_details:
+          edit:
+            cancel: Cancel

--- a/config/locales/en/wizards/claims/support_details_wizard.yml
+++ b/config/locales/en/wizards/claims/support_details_wizard.yml
@@ -1,0 +1,17 @@
+en:
+  wizards:
+    claims:
+      support_details_wizard:
+        zendesk_step:
+          page_title: "Enter a URL for the associated Zendesk ticket - Claim %{reference}"
+          caption: Claim %{reference}
+          title: Enter a URL for the associated Zendesk ticket
+          continue: Continue
+        support_user_step:
+          page_title: "Assign a support agent - Claim %{reference}"
+          caption: Claim %{reference}
+          title: Assign a support agent
+          continue: Continue
+        success:
+          zendesk: Link to Zendesk ticket added
+          support_user: Support agent assigned

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -173,6 +173,12 @@ scope module: :claims, as: :claims, constraints: {
 
     resources :claims, only: %i[index show] do
       get :download_csv, on: :collection
+
+      member do
+        get "support_details/new", to: "claims/support_details#new", as: :new_support_details
+        get "support_details/new/:state_key/:step", to: "claims/support_details#edit", as: :support_details
+        put "support_details/new/:state_key/:step", to: "claims/support_details#update"
+      end
     end
 
     resources :support_users, path: "support-users", only: %i[index show destroy] do

--- a/db/migrate/20250207155250_add_zendesk_url_to_claims.rb
+++ b/db/migrate/20250207155250_add_zendesk_url_to_claims.rb
@@ -1,0 +1,5 @@
+class AddZendeskUrlToClaims < ActiveRecord::Migration[7.2]
+  def change
+    add_column :claims, :zendesk_url, :string
+  end
+end

--- a/db/migrate/20250207155319_add_support_user_to_claims.rb
+++ b/db/migrate/20250207155319_add_support_user_to_claims.rb
@@ -1,0 +1,7 @@
+class AddSupportUserToClaims < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :claims, :support_user, type: :uuid, index: { algorithm: :concurrently }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_24_105642) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_07_155319) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -123,6 +123,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_24_105642) do
     t.text "sampling_reason"
     t.datetime "payment_in_progress_at"
     t.text "unpaid_reason"
+    t.string "zendesk_url"
+    t.uuid "support_user_id"
     t.index ["claim_window_id"], name: "index_claims_on_claim_window_id"
     t.index ["created_by_type", "created_by_id"], name: "index_claims_on_created_by"
     t.index ["previous_revision_id"], name: "index_claims_on_previous_revision_id"
@@ -130,6 +132,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_24_105642) do
     t.index ["reference"], name: "index_claims_on_reference"
     t.index ["school_id"], name: "index_claims_on_school_id"
     t.index ["submitted_by_type", "submitted_by_id"], name: "index_claims_on_submitted_by"
+    t.index ["support_user_id"], name: "index_claims_on_support_user_id"
   end
 
   create_table "clawback_claims", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -12,6 +12,7 @@
 #  submitted_at           :datetime
 #  submitted_by_type      :string
 #  unpaid_reason          :text
+#  zendesk_url            :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  claim_window_id        :uuid
@@ -20,6 +21,7 @@
 #  provider_id            :uuid
 #  school_id              :uuid             not null
 #  submitted_by_id        :uuid
+#  support_user_id        :uuid
 #
 # Indexes
 #
@@ -30,6 +32,7 @@
 #  index_claims_on_reference             (reference)
 #  index_claims_on_school_id             (school_id)
 #  index_claims_on_submitted_by          (submitted_by_type,submitted_by_id)
+#  index_claims_on_support_user_id       (support_user_id)
 #
 # Foreign Keys
 #

--- a/spec/models/claims/claim_spec.rb
+++ b/spec/models/claims/claim_spec.rb
@@ -12,6 +12,7 @@
 #  submitted_at           :datetime
 #  submitted_by_type      :string
 #  unpaid_reason          :text
+#  zendesk_url            :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  claim_window_id        :uuid
@@ -20,6 +21,7 @@
 #  provider_id            :uuid
 #  school_id              :uuid             not null
 #  submitted_by_id        :uuid
+#  support_user_id        :uuid
 #
 # Indexes
 #
@@ -30,6 +32,7 @@
 #  index_claims_on_reference             (reference)
 #  index_claims_on_school_id             (school_id)
 #  index_claims_on_submitted_by          (submitted_by_type,submitted_by_id)
+#  index_claims_on_support_user_id       (support_user_id)
 #
 # Foreign Keys
 #
@@ -44,6 +47,7 @@ RSpec.describe Claims::Claim, type: :model do
     it { is_expected.to belong_to(:provider) }
     it { is_expected.to belong_to(:created_by) }
     it { is_expected.to belong_to(:claim_window) }
+    it { is_expected.to belong_to(:support_user).class_name("Claims::SupportUser").optional }
     it { is_expected.to belong_to(:previous_revision).class_name("Claims::Claim").optional }
     it { is_expected.to belong_to(:submitted_by).optional }
     it { is_expected.to have_many(:mentor_trainings).dependent(:destroy) }

--- a/spec/models/claims/support_user_spec.rb
+++ b/spec/models/claims/support_user_spec.rb
@@ -22,7 +22,7 @@ require "rails_helper"
 
 RSpec.describe Claims::SupportUser do
   describe "associations" do
-    it { is_expected.to have_many(:claims) }
+    it { is_expected.to have_many(:assigned_claims).class_name("Claims::Claim") }
   end
 
   context "with validations" do

--- a/spec/models/claims/support_user_spec.rb
+++ b/spec/models/claims/support_user_spec.rb
@@ -21,6 +21,10 @@
 require "rails_helper"
 
 RSpec.describe Claims::SupportUser do
+  describe "associations" do
+    it { is_expected.to have_many(:claims) }
+  end
+
   context "with validations" do
     subject { build(:claims_support_user) }
 

--- a/spec/system/claims/support/claims/support_details/support_user/support_user_assigns_a_support_user_to_a_claim_spec.rb
+++ b/spec/system/claims/support/claims/support_details/support_user/support_user_assigns_a_support_user_to_a_claim_spec.rb
@@ -1,0 +1,131 @@
+require "rails_helper"
+
+RSpec.describe "Support user assigns a support user to a claim", service: :claims, type: :system do
+  scenario do
+    given_claims_exist
+    and_a_support_user_exists
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_claims_index_page
+    then_i_see_the_claims_index_page
+    and_i_see_a_claim_with_the_status_submitted
+
+    when_i_click_to_view_the_claim
+    then_i_see_the_details_of_the_claim
+    and_i_can_see_a_support_user_has_not_been_assigned
+
+    when_i_click_assign_a_support_agent
+    then_i_see_the_select_a_support_user_page
+
+    when_i_click_back
+    then_i_see_the_details_of_the_claim
+
+    when_i_click_assign_a_support_agent
+    then_i_see_the_select_a_support_user_page
+
+    when_i_click_cancel
+    then_i_see_the_details_of_the_claim
+
+    when_i_click_assign_a_support_agent
+    and_i_select_a_support_user
+    and_i_click_continue
+    then_i_see_the_details_of_the_claim
+    and_i_see_the_support_user_has_been_assigned
+  end
+
+  private
+
+  def given_claims_exist
+    @claim = create(:claim, :submitted, reference: 11_111_111)
+  end
+
+  def and_a_support_user_exists
+    @support_user = create(:claims_support_user, first_name: "Joe", last_name: "Bloggs")
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_claims_index_page
+    within primary_navigation do
+      click_on "Claims"
+    end
+  end
+
+  def then_i_see_the_claims_index_page
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Claims")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(secondary_navigation).to have_current_item("All claims")
+    expect(page).to have_current_path(claims_support_claims_path, ignore_query: true)
+  end
+
+  def and_i_see_a_claim_with_the_status_submitted
+    expect(page).to have_h2("Claims (1)")
+    expect(page).to have_claim_card({
+      "title" => "11111111 - #{@claim.school_name}",
+      "url" => "/support/claims/#{@claim.id}",
+      "status" => "Submitted",
+      "academic_year" => @claim.academic_year.name,
+      "provider_name" => @claim.provider.name,
+      "submitted_at" => I18n.l(@claim.submitted_at.to_date, format: :long),
+      "amount" => "0.00",
+    })
+  end
+
+  def when_i_click_to_view_the_claim
+    click_on "#{@claim.reference} - #{@claim.school.name}"
+  end
+
+  def then_i_see_the_details_of_the_claim
+    expect(page).to have_title(
+      "#{@claim.school.name} - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+    )
+    expect(page).to have_element(:p, text: "Claim #{@claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_h1(@claim.school.name)
+    expect(page).to have_element(:strong, text: "Submitted", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_current_path(claims_support_claim_path(@claim), ignore_query: true)
+  end
+
+  def and_i_can_see_a_support_user_has_not_been_assigned
+    expect(page).to have_link("Assign a support agent")
+  end
+
+  def when_i_click_assign_a_support_agent
+    click_on "Assign a support agent"
+  end
+
+  def then_i_see_the_select_a_support_user_page
+    expect(page).to have_title(
+      "Assign a support agent - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+    )
+    expect(page).to have_element(
+      :legend,
+      text: "Assign a support agent",
+      class: "govuk-fieldset__legend govuk-fieldset__legend--l",
+    )
+  end
+
+  def when_i_click_back
+    click_on "Back"
+  end
+
+  def when_i_click_cancel
+    click_on "Cancel"
+  end
+
+  def and_i_select_a_support_user
+    choose "Joe Bloggs"
+  end
+
+  def and_i_click_continue
+    click_on "Continue"
+  end
+
+  def and_i_see_the_support_user_has_been_assigned
+    expect(page).to have_success_banner("Support agent assigned")
+    expect(page).not_to have_link("Assign a support agent")
+    expect(page).to have_summary_list_row("Assigned user", "Joe Bloggs")
+  end
+end

--- a/spec/system/claims/support/claims/support_details/support_user/support_user_changes_the_assigned_support_user_on_a_claim_spec.rb
+++ b/spec/system/claims/support/claims/support_details/support_user/support_user_changes_the_assigned_support_user_on_a_claim_spec.rb
@@ -1,0 +1,122 @@
+require "rails_helper"
+
+RSpec.describe "Support user changes the assigned support user on a claim",
+               service: :claims,
+               type: :system do
+  scenario do
+    given_support_users_exists
+    and_claims_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_claims_index_page
+    then_i_see_the_claims_index_page
+    and_i_see_a_claim_with_the_status_submitted
+
+    when_i_click_to_view_the_claim
+    then_i_see_the_details_of_the_claim
+    and_i_can_see_a_support_user_has_already_been_assigned
+
+    when_i_click_change_assigned_user
+    then_i_see_the_select_a_support_user_page
+    and_see_the_support_user_has_been_preselected
+
+    and_i_select_a_support_user
+    and_i_click_continue
+    then_i_see_the_details_of_the_claim
+    and_i_see_the_support_user_has_been_assigned
+  end
+
+  private
+
+  def and_claims_exist
+    @claim = create(:claim, :submitted, reference: 11_111_111, support_user: @support_user_1)
+  end
+
+  def given_support_users_exists
+    @support_user_1 = create(:claims_support_user, first_name: "Joe", last_name: "Bloggs")
+    @support_user_2 = create(:claims_support_user, first_name: "Sarah", last_name: "Doe")
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_claims_index_page
+    within primary_navigation do
+      click_on "Claims"
+    end
+  end
+
+  def then_i_see_the_claims_index_page
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Claims")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(secondary_navigation).to have_current_item("All claims")
+    expect(page).to have_current_path(claims_support_claims_path, ignore_query: true)
+  end
+
+  def and_i_see_a_claim_with_the_status_submitted
+    expect(page).to have_h2("Claims (1)")
+    expect(page).to have_claim_card({
+      "title" => "11111111 - #{@claim.school_name}",
+      "url" => "/support/claims/#{@claim.id}",
+      "status" => "Submitted",
+      "academic_year" => @claim.academic_year.name,
+      "provider_name" => @claim.provider.name,
+      "submitted_at" => I18n.l(@claim.submitted_at.to_date, format: :long),
+      "amount" => "0.00",
+    })
+  end
+
+  def when_i_click_to_view_the_claim
+    click_on "#{@claim.reference} - #{@claim.school.name}"
+  end
+
+  def then_i_see_the_details_of_the_claim
+    expect(page).to have_title(
+      "#{@claim.school.name} - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+    )
+    expect(page).to have_element(:p, text: "Claim #{@claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_h1(@claim.school.name)
+    expect(page).to have_element(:strong, text: "Submitted", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_current_path(claims_support_claim_path(@claim), ignore_query: true)
+  end
+
+  def and_i_can_see_a_support_user_has_already_been_assigned
+    expect(page).to have_link("Change Assigned user")
+    expect(page).to have_summary_list_row("Assigned user", "Joe Bloggs")
+  end
+
+  def when_i_click_change_assigned_user
+    click_on "Change Assigned user"
+  end
+
+  def then_i_see_the_select_a_support_user_page
+    expect(page).to have_title(
+      "Assign a support agent - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+    )
+    expect(page).to have_element(
+      :legend,
+      text: "Assign a support agent",
+      class: "govuk-fieldset__legend govuk-fieldset__legend--l",
+    )
+  end
+
+  def and_see_the_support_user_has_been_preselected
+    expect(page).to have_checked_field("Joe Bloggs")
+  end
+
+  def and_i_select_a_support_user
+    choose "Joe Bloggs"
+  end
+
+  def and_i_click_continue
+    click_on "Continue"
+  end
+
+  def and_i_see_the_support_user_has_been_assigned
+    expect(page).to have_success_banner("Support agent assigned")
+    expect(page).not_to have_link("Assign a support agent")
+    expect(page).to have_summary_list_row("Assigned user", "Joe Bloggs")
+  end
+end

--- a/spec/system/claims/support/claims/support_details/support_user/support_user_does_not_assign_a_support_user_to_a_claim_spec.rb
+++ b/spec/system/claims/support/claims/support_details/support_user/support_user_does_not_assign_a_support_user_to_a_claim_spec.rb
@@ -1,0 +1,105 @@
+require "rails_helper"
+
+RSpec.describe "Support user does not assign a support user to a claim", service: :claims, type: :system do
+  scenario do
+    given_claims_exist
+    and_a_support_user_exists
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_claims_index_page
+    then_i_see_the_claims_index_page
+    and_i_see_a_claim_with_the_status_submitted
+
+    when_i_click_to_view_the_claim
+    then_i_see_the_details_of_the_claim
+    and_i_can_see_a_support_user_has_not_been_assigned
+
+    when_i_click_assign_a_support_agent
+    then_i_see_the_select_a_support_user_page
+
+    when_i_click_continue
+    then_i_see_validation_error_regarding_the_support_user
+  end
+
+  private
+
+  def given_claims_exist
+    @claim = create(:claim, :submitted, reference: 11_111_111)
+  end
+
+  def and_a_support_user_exists
+    @support_user = create(:claims_support_user, first_name: "Joe", last_name: "Bloggs")
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_claims_index_page
+    within primary_navigation do
+      click_on "Claims"
+    end
+  end
+
+  def then_i_see_the_claims_index_page
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Claims")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(secondary_navigation).to have_current_item("All claims")
+    expect(page).to have_current_path(claims_support_claims_path, ignore_query: true)
+  end
+
+  def and_i_see_a_claim_with_the_status_submitted
+    expect(page).to have_h2("Claims (1)")
+    expect(page).to have_claim_card({
+      "title" => "11111111 - #{@claim.school_name}",
+      "url" => "/support/claims/#{@claim.id}",
+      "status" => "Submitted",
+      "academic_year" => @claim.academic_year.name,
+      "provider_name" => @claim.provider.name,
+      "submitted_at" => I18n.l(@claim.submitted_at.to_date, format: :long),
+      "amount" => "0.00",
+    })
+  end
+
+  def when_i_click_to_view_the_claim
+    click_on "#{@claim.reference} - #{@claim.school.name}"
+  end
+
+  def then_i_see_the_details_of_the_claim
+    expect(page).to have_title(
+      "#{@claim.school.name} - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+    )
+    expect(page).to have_element(:p, text: "Claim #{@claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_h1(@claim.school.name)
+    expect(page).to have_element(:strong, text: "Submitted", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_current_path(claims_support_claim_path(@claim), ignore_query: true)
+  end
+
+  def and_i_can_see_a_support_user_has_not_been_assigned
+    expect(page).to have_link("Assign a support agent")
+  end
+
+  def when_i_click_assign_a_support_agent
+    click_on "Assign a support agent"
+  end
+
+  def then_i_see_the_select_a_support_user_page
+    expect(page).to have_title(
+      "Assign a support agent - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+    )
+    expect(page).to have_element(
+      :legend,
+      text: "Assign a support agent",
+      class: "govuk-fieldset__legend govuk-fieldset__legend--l",
+    )
+  end
+
+  def when_i_click_continue
+    click_on "Continue"
+  end
+
+  def then_i_see_validation_error_regarding_the_support_user
+    expect(page).to have_validation_error("Please select a support agent")
+  end
+end

--- a/spec/system/claims/support/claims/support_details/zendesk_ticket/support_user_does_not_add_a_link_to_a_support_ticket_spec.rb
+++ b/spec/system/claims/support/claims/support_details/zendesk_ticket/support_user_does_not_add_a_link_to_a_support_ticket_spec.rb
@@ -1,0 +1,100 @@
+require "rails_helper"
+
+RSpec.describe "Support user does not add a link to a support ticket", service: :claims, type: :system do
+  scenario do
+    given_claims_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_claims_index_page
+    then_i_see_the_claims_index_page
+    and_i_see_a_claim_with_the_status_submitted
+
+    when_i_click_to_view_the_claim
+    then_i_see_the_details_of_the_claim
+    and_i_can_see_a_support_ticket_has_not_been_assigned
+
+    when_i_click_add_link_to_zendesk_ticket
+    then_i_see_the_zendesk_url_input_page
+
+    when_i_click_continue
+    then_i_see_validation_error_regarding_the_zendesk_url
+  end
+
+  private
+
+  def given_claims_exist
+    @claim = create(:claim, :submitted, reference: 11_111_111)
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_claims_index_page
+    within primary_navigation do
+      click_on "Claims"
+    end
+  end
+
+  def then_i_see_the_claims_index_page
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Claims")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(secondary_navigation).to have_current_item("All claims")
+    expect(page).to have_current_path(claims_support_claims_path, ignore_query: true)
+  end
+
+  def and_i_see_a_claim_with_the_status_submitted
+    expect(page).to have_h2("Claims (1)")
+    expect(page).to have_claim_card({
+      "title" => "11111111 - #{@claim.school_name}",
+      "url" => "/support/claims/#{@claim.id}",
+      "status" => "Submitted",
+      "academic_year" => @claim.academic_year.name,
+      "provider_name" => @claim.provider.name,
+      "submitted_at" => I18n.l(@claim.submitted_at.to_date, format: :long),
+      "amount" => "0.00",
+    })
+  end
+
+  def when_i_click_to_view_the_claim
+    click_on "#{@claim.reference} - #{@claim.school.name}"
+  end
+
+  def then_i_see_the_details_of_the_claim
+    expect(page).to have_title(
+      "#{@claim.school.name} - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+    )
+    expect(page).to have_element(:p, text: "Claim #{@claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_h1(@claim.school.name)
+    expect(page).to have_element(:strong, text: "Submitted", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_current_path(claims_support_claim_path(@claim), ignore_query: true)
+  end
+
+  def and_i_can_see_a_support_ticket_has_not_been_assigned
+    expect(page).to have_link("Add link to Zendesk ticket")
+  end
+
+  def when_i_click_add_link_to_zendesk_ticket
+    click_on "Add link to Zendesk ticket"
+  end
+
+  def then_i_see_the_zendesk_url_input_page
+    expect(page).to have_title(
+      "Enter a URL for the associated Zendesk ticket - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+    )
+    expect(page).to have_element(
+      :label,
+      text: "Enter a URL for the associated Zendesk ticket",
+      class: "govuk-label govuk-label--l",
+    )
+  end
+
+  def when_i_click_continue
+    click_on "Continue"
+  end
+
+  def then_i_see_validation_error_regarding_the_zendesk_url
+    expect(page).to have_validation_error("Please enter a zendesk URL")
+  end
+end

--- a/spec/system/claims/support/claims/support_details/zendesk_ticket/support_user_links_a_claim_to_a_support_ticket_spec.rb
+++ b/spec/system/claims/support/claims/support_details/zendesk_ticket/support_user_links_a_claim_to_a_support_ticket_spec.rb
@@ -1,0 +1,126 @@
+require "rails_helper"
+
+RSpec.describe "Support user links a claim to a support ticket", service: :claims, type: :system do
+  scenario do
+    given_claims_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_claims_index_page
+    then_i_see_the_claims_index_page
+    and_i_see_a_claim_with_the_status_submitted
+
+    when_i_click_to_view_the_claim
+    then_i_see_the_details_of_the_claim
+    and_i_can_see_a_support_ticket_has_not_been_assigned
+
+    when_i_click_add_link_to_zendesk_ticket
+    then_i_see_the_zendesk_url_input_page
+
+    when_i_click_back
+    then_i_see_the_details_of_the_claim
+
+    when_i_click_add_link_to_zendesk_ticket
+    then_i_see_the_zendesk_url_input_page
+
+    when_i_click_cancel
+    then_i_see_the_details_of_the_claim
+
+    when_i_click_add_link_to_zendesk_ticket
+    and_i_enter_a_zendesk_ticket_url
+    and_i_click_continue
+    then_i_see_the_details_of_the_claim
+    and_i_see_the_zendesk_ticket_url_has_been_added
+  end
+
+  private
+
+  def given_claims_exist
+    @claim = create(:claim, :submitted, reference: 11_111_111)
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_claims_index_page
+    within primary_navigation do
+      click_on "Claims"
+    end
+  end
+
+  def then_i_see_the_claims_index_page
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Claims")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(secondary_navigation).to have_current_item("All claims")
+    expect(page).to have_current_path(claims_support_claims_path, ignore_query: true)
+  end
+
+  def and_i_see_a_claim_with_the_status_submitted
+    expect(page).to have_h2("Claims (1)")
+    expect(page).to have_claim_card({
+      "title" => "11111111 - #{@claim.school_name}",
+      "url" => "/support/claims/#{@claim.id}",
+      "status" => "Submitted",
+      "academic_year" => @claim.academic_year.name,
+      "provider_name" => @claim.provider.name,
+      "submitted_at" => I18n.l(@claim.submitted_at.to_date, format: :long),
+      "amount" => "0.00",
+    })
+  end
+
+  def when_i_click_to_view_the_claim
+    click_on "#{@claim.reference} - #{@claim.school.name}"
+  end
+
+  def then_i_see_the_details_of_the_claim
+    expect(page).to have_title(
+      "#{@claim.school.name} - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+    )
+    expect(page).to have_element(:p, text: "Claim #{@claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_h1(@claim.school.name)
+    expect(page).to have_element(:strong, text: "Submitted", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_current_path(claims_support_claim_path(@claim), ignore_query: true)
+  end
+
+  def and_i_can_see_a_support_ticket_has_not_been_assigned
+    expect(page).to have_link("Add link to Zendesk ticket")
+  end
+
+  def when_i_click_add_link_to_zendesk_ticket
+    click_on "Add link to Zendesk ticket"
+  end
+
+  def then_i_see_the_zendesk_url_input_page
+    expect(page).to have_title(
+      "Enter a URL for the associated Zendesk ticket - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+    )
+    expect(page).to have_element(
+      :label,
+      text: "Enter a URL for the associated Zendesk ticket",
+      class: "govuk-label govuk-label--l",
+    )
+  end
+
+  def when_i_click_back
+    click_on "Back"
+  end
+
+  def when_i_click_cancel
+    click_on "Cancel"
+  end
+
+  def and_i_enter_a_zendesk_ticket_url
+    fill_in "Enter a URL for the associated Zendesk ticket", with: "example.zendesk.com"
+  end
+
+  def and_i_click_continue
+    click_on "Continue"
+  end
+
+  def and_i_see_the_zendesk_ticket_url_has_been_added
+    expect(page).to have_success_banner("Link to Zendesk ticket added")
+    expect(page).not_to have_link("Add link to Zendesk ticket")
+    expect(page).to have_link("Zendesk ticket (opens in new tab)", href: "example.zendesk.com")
+  end
+end

--- a/spec/system/claims/support/claims/support_details/zendesk_ticket/support_user_updates_the_zendesk_ticket_linked_to_a_claim_spec.rb
+++ b/spec/system/claims/support/claims/support_details/zendesk_ticket/support_user_updates_the_zendesk_ticket_linked_to_a_claim_spec.rb
@@ -1,0 +1,116 @@
+require "rails_helper"
+
+RSpec.describe "Support user updates the zendesk ticket linked to claim", service: :claims, type: :system do
+  scenario do
+    given_claims_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_claims_index_page
+    then_i_see_the_claims_index_page
+    and_i_see_a_claim_with_the_status_submitted
+
+    when_i_click_to_view_the_claim
+    then_i_see_the_details_of_the_claim
+    and_i_can_see_a_support_ticket_has_been_assigned
+
+    when_i_click_change_zendesk_ticket
+    then_i_see_the_zendesk_url_input_page
+    and_see_the_input_pre_fiiled_with_the_zendesk_link
+
+    when_i_enter_a_zendesk_ticket_url
+    and_i_click_continue
+    then_i_see_the_details_of_the_claim
+    and_i_see_the_zendesk_ticket_url_has_been_added
+  end
+
+  private
+
+  def given_claims_exist
+    @claim = create(:claim,
+                    :submitted,
+                    reference: 11_111_111,
+                    zendesk_url: "example.zendesk.com")
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_claims_index_page
+    within primary_navigation do
+      click_on "Claims"
+    end
+  end
+
+  def then_i_see_the_claims_index_page
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Claims")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(secondary_navigation).to have_current_item("All claims")
+    expect(page).to have_current_path(claims_support_claims_path, ignore_query: true)
+  end
+
+  def and_i_see_a_claim_with_the_status_submitted
+    expect(page).to have_h2("Claims (1)")
+    expect(page).to have_claim_card({
+      "title" => "11111111 - #{@claim.school_name}",
+      "url" => "/support/claims/#{@claim.id}",
+      "status" => "Submitted",
+      "academic_year" => @claim.academic_year.name,
+      "provider_name" => @claim.provider.name,
+      "submitted_at" => I18n.l(@claim.submitted_at.to_date, format: :long),
+      "amount" => "0.00",
+    })
+  end
+
+  def when_i_click_to_view_the_claim
+    click_on "#{@claim.reference} - #{@claim.school.name}"
+  end
+
+  def then_i_see_the_details_of_the_claim
+    expect(page).to have_title(
+      "#{@claim.school.name} - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+    )
+    expect(page).to have_element(:p, text: "Claim #{@claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_h1(@claim.school.name)
+    expect(page).to have_element(:strong, text: "Submitted", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_current_path(claims_support_claim_path(@claim), ignore_query: true)
+  end
+
+  def and_i_can_see_a_support_ticket_has_been_assigned
+    expect(page).to have_link("Zendesk ticket (opens in new tab)", href: "example.zendesk.com")
+  end
+
+  def when_i_click_change_zendesk_ticket
+    click_on "Change Support ticket"
+  end
+
+  def then_i_see_the_zendesk_url_input_page
+    expect(page).to have_title(
+      "Enter a URL for the associated Zendesk ticket - Claim #{@claim.reference} - Claim funding for mentor training - GOV.UK",
+    )
+    expect(page).to have_element(
+      :label,
+      text: "Enter a URL for the associated Zendesk ticket",
+      class: "govuk-label govuk-label--l",
+    )
+  end
+
+  def when_i_enter_a_zendesk_ticket_url
+    fill_in "Enter a URL for the associated Zendesk ticket", with: "another_example.zendesk.com"
+  end
+
+  def and_i_click_continue
+    click_on "Continue"
+  end
+
+  def and_i_see_the_zendesk_ticket_url_has_been_added
+    expect(page).to have_success_banner("Link to Zendesk ticket added")
+    expect(page).not_to have_link("Add link to Zendesk ticket")
+    expect(page).to have_link("Zendesk ticket (opens in new tab)", href: "another_example.zendesk.com")
+  end
+
+  def and_see_the_input_pre_fiiled_with_the_zendesk_link
+    find_field "Enter a URL for the associated Zendesk ticket", with: "example.zendesk.com"
+  end
+end

--- a/spec/wizards/claims/support_details_wizard/support_user_step_spec.rb
+++ b/spec/wizards/claims/support_details_wizard/support_user_step_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Claims::SupportDetailsWizard::SupportUserStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Claims::SupportDetailsWizard)
+  end
+  let(:support_user) { create(:claims_support_user) }
+  let(:attributes) { nil }
+
+  describe "attributes" do
+    it { is_expected.to have_attributes(support_user_id: nil) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:support_user_id) }
+    it { is_expected.to validate_inclusion_of(:support_user_id).in_array(Claims::SupportUser.ids) }
+  end
+end

--- a/spec/wizards/claims/support_details_wizard/zendesk_step_spec.rb
+++ b/spec/wizards/claims/support_details_wizard/zendesk_step_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Claims::SupportDetailsWizard::ZendeskStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Claims::SupportDetailsWizard)
+  end
+  let(:claim) { create(:claim) }
+  let(:attributes) { nil }
+
+  describe "attributes" do
+    it { is_expected.to have_attributes(zendesk_url: nil) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:zendesk_url) }
+  end
+end

--- a/spec/wizards/claims/support_details_wizard_spec.rb
+++ b/spec/wizards/claims/support_details_wizard_spec.rb
@@ -1,0 +1,106 @@
+require "rails_helper"
+
+RSpec.describe Claims::SupportDetailsWizard do
+  subject(:wizard) { described_class.new(claim:, state:, params:, current_step:) }
+
+  let(:state) { {} }
+  let(:params_data) { {} }
+  let(:params) { ActionController::Parameters.new(params_data) }
+  let(:current_step) { nil }
+  let(:claim) { create(:claim) }
+
+  describe "#steps" do
+    subject(:steps) { wizard.steps.keys }
+
+    context "when the current step is zendesk" do
+      let(:current_step) { :zendesk }
+
+      it { is_expected.to contain_exactly(:zendesk) }
+    end
+
+    context "when the current step is support_user" do
+      let(:current_step) { :support_user }
+
+      it { is_expected.to contain_exactly(:support_user) }
+    end
+  end
+
+  describe "#update_support_details" do
+    subject(:update_support_details) { wizard.update_support_details }
+
+    before { claim }
+
+    context "when the step is zendesk" do
+      let(:current_step) { :zendesk }
+      let(:state) do
+        {
+          "zendesk" => { "zendesk_url" => "example.zendesk.com" },
+        }
+      end
+
+      it "updates the zendesk url of the claim" do
+        expect { update_support_details }.to change(claim, :zendesk_url).to("example.zendesk.com")
+      end
+    end
+
+    context "when the step is support_user" do
+      let(:support_user) { create(:claims_support_user) }
+      let(:current_step) { :support_user }
+      let(:state) do
+        {
+          "support_user" => { "support_user_id" => support_user.id },
+        }
+      end
+
+      it "updates the zendesk url of the claim" do
+        expect { update_support_details }.to change(claim, :support_user).to(support_user)
+      end
+    end
+  end
+
+  describe "#setup_state" do
+    subject(:setup_state) { wizard.setup_state }
+
+    let(:support_user) { create(:claims_support_user) }
+
+    before do
+      claim.update!(support_user:, zendesk_url: "example.zendesk.com")
+    end
+
+    context "when the step is zendesk" do
+      let(:current_step) { :zendesk }
+
+      it "returns a hash containing the zendesk attributes of the claim" do
+        expect(wizard.setup_state).to eq(
+          { "zendesk_url" => "example.zendesk.com" },
+        )
+      end
+    end
+
+    context "when the step is support user" do
+      let(:current_step) { :support_user }
+
+      it "returns a hash containing the zendesk attributes of the claim" do
+        expect(wizard.setup_state).to eq(
+          { "support_user_id" => support_user.id },
+        )
+      end
+    end
+  end
+
+  describe "#success_message" do
+    subject(:success_message) { wizard.success_message }
+
+    context "when the step is zendesk" do
+      let(:current_step) { :zendesk }
+
+      it { is_expected.to eq("Link to Zendesk ticket added") }
+    end
+
+    context "when the step is support_user" do
+      let(:current_step) { :support_user }
+
+      it { is_expected.to eq("Support agent assigned") }
+    end
+  end
+end

--- a/spec/wizards/claims/support_details_wizard_spec.rb
+++ b/spec/wizards/claims/support_details_wizard_spec.rb
@@ -32,28 +32,58 @@ RSpec.describe Claims::SupportDetailsWizard do
 
     context "when the step is zendesk" do
       let(:current_step) { :zendesk }
-      let(:state) do
-        {
-          "zendesk" => { "zendesk_url" => "example.zendesk.com" },
-        }
+
+      context "when the zendesk_url is present" do
+        let(:state) do
+          {
+            "zendesk" => { "zendesk_url" => "example.zendesk.com" },
+          }
+        end
+
+        it "updates the zendesk url of the claim" do
+          expect { update_support_details }.to change(claim, :zendesk_url).to("example.zendesk.com")
+        end
       end
 
-      it "updates the zendesk url of the claim" do
-        expect { update_support_details }.to change(claim, :zendesk_url).to("example.zendesk.com")
+      context "when the zendesk_url is blank" do
+        let(:state) do
+          {
+            "zendesk" => { "zendesk_url" => nil },
+          }
+        end
+
+        it "returns an error" do
+          expect { update_support_details }.to raise_error("Invalid wizard state")
+        end
       end
     end
 
     context "when the step is support_user" do
       let(:support_user) { create(:claims_support_user) }
       let(:current_step) { :support_user }
-      let(:state) do
-        {
-          "support_user" => { "support_user_id" => support_user.id },
-        }
+
+      context "when the support_user_id is present" do
+        let(:state) do
+          {
+            "support_user" => { "support_user_id" => support_user.id },
+          }
+        end
+
+        it "updates the zendesk url of the claim" do
+          expect { update_support_details }.to change(claim, :support_user).to(support_user)
+        end
       end
 
-      it "updates the zendesk url of the claim" do
-        expect { update_support_details }.to change(claim, :support_user).to(support_user)
+      context "when the support_user_id is blank" do
+        let(:state) do
+          {
+            "support_user" => { "support_user_id" => nil },
+          }
+        end
+
+        it "returns an error" do
+          expect { update_support_details }.to raise_error("Invalid wizard state")
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

- Add SupportDetailsWizard so Support users can update the Zendesk ticket and support user assigned to a claim.

## Changes proposed in this pull request

- Add SupportDetailsWizard and related steps, controllers and views.

## Guidance to review

- Sign in as Colin (Support user)
- Navigate to Claims
- Click any claim
----------
- Click "Add link to Zendesk ticket"
- Enter any URL (assumption is support will enter the URL to a Zendesk ticket)
- Click "Continue"
- The Claim will now be updated with that Zendesk ticket
----------
- Click "Assign a support agent"
- Select any Support User
- Click "Continue"
- The Claim has now been assigned to that Support User

## Link to Trello card

https://trello.com/c/avRn6IYp/401-add-functionality-to-allow-support-users-the-ability-to-add-support-details

## Screenshots

https://github.com/user-attachments/assets/f699a7b1-00fb-4d4c-b9cc-21e6b58f8b14

https://github.com/user-attachments/assets/8f5e8061-ace0-4895-90e7-080f12517e03


