### PR TITLE
Add actions calculator to the payments index

### DIFF
--- a/app/controllers/claims/support/claims/payments_controller.rb
+++ b/app/controllers/claims/support/claims/payments_controller.rb
@@ -3,14 +3,14 @@ class Claims::Support::Claims::PaymentsController < Claims::Support::Application
 
   before_action :authorize_claims
 
-  helper_method :filter_form
+  helper_method :filter_form, :submitted_claims, :payment_in_progress_claims
 
   def index
     @pagy, @claims = pagy(filtered_claims)
   end
 
   def new
-    @submitted_claims = Claims::Claim.submitted
+    submitted_claims
 
     unless policy(Claims::Payment).create?
       render "new_not_permitted"
@@ -61,5 +61,13 @@ class Claims::Support::Claims::PaymentsController < Claims::Support::Application
 
   def authorize_claims
     authorize [:payments, filtered_claims]
+  end
+
+  def submitted_claims
+    @submitted_claims ||= Claims::Claim.submitted
+  end
+
+  def payment_in_progress_claims
+    @payment_in_progress_claims ||= Claims::Claim.payment_in_progress
   end
 end

--- a/app/views/claims/support/claims/payments/_action_calculator.html.erb
+++ b/app/views/claims/support/claims/payments/_action_calculator.html.erb
@@ -1,0 +1,12 @@
+<%# locals: (submitted_claims:, payment_in_progress_claims:, claims:) -%>
+<div id="action_calculator">
+  <% if submitted_claims.any? %>
+    <p class="govuk-body"><%= t(".waiting_to_send_to_payer_html", count: submitted_claims.count) %></p>
+  <% end %>
+  <% if payment_in_progress_claims.any? %>
+    <p class="govuk-body"><%= t(".awaiting_response_from_payer_html", count: payment_in_progress_claims.count) %></p>
+  <% end %>
+  <% if claims.count.positive? %>
+    <p class="govuk-body"><%= t(".require_more_information_html", count: claims.count) %></p>
+  <% end %>
+</div>

--- a/app/views/claims/support/claims/payments/index.html.erb
+++ b/app/views/claims/support/claims/payments/index.html.erb
@@ -13,7 +13,10 @@
     <%= govuk_button_link_to t(".buttons.upload_esfa_response"), new_upload_payer_response_claims_support_claims_payments_path, secondary: true %>
   </div>
 
-  <h3 class="govuk-heading-s"><%= t(".description", count: @pagy.count) %></h3>
+  <%= render "action_calculator",
+    submitted_claims: submitted_claims,
+    payment_in_progress_claims: payment_in_progress_claims,
+    claims: @pagy %>
 
   <%= render Claims::Claim::FilterFormComponent.new(filter_form:, statuses: Claims::Claim::PAYMENT_ACTIONABLE_STATUSES) do %>
     <div class="govuk-!-margin-bottom-2">

--- a/config/locales/en/claims/support/claims/payments.yml
+++ b/config/locales/en/claims/support/claims/payments.yml
@@ -41,3 +41,13 @@ en:
             body_html:
               The status of these claims have been updated to ‘Payer payment review’.<br><br>
               You must wait for the payer to respond before you can take any further action on these claims.
+          action_calculator:
+            waiting_to_send_to_payer_html:
+              one: <strong>%{count}</strong> claim waiting to be sent to payer
+              other: <strong>%{count}</strong> claims waiting to be sent to payer
+            awaiting_response_from_payer_html:
+              one: <strong>%{count}</strong> claim awaiting a response from payer
+              other: <strong>%{count}</strong> claims awaiting a response from payer
+            require_more_information_html:
+              one: <strong>%{count}</strong> claim requires more information
+              other: <strong>%{count}</strong> claims require more information

--- a/spec/system/claims/support/claims/payments/view_payments_claims_spec.rb
+++ b/spec/system/claims/support/claims/payments/view_payments_claims_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "View payments claims", :js, service: :claims, type: :system do
+RSpec.describe "View payments claims", service: :claims, type: :system do
   let!(:support_user) { create(:claims_support_user) }
 
   before do
@@ -13,11 +13,36 @@ RSpec.describe "View payments claims", :js, service: :claims, type: :system do
     then_i_see("There are no claims waiting to be processed.")
   end
 
-  scenario "Support user visits the claims index page with claims due for payments processing" do
-    information_requested_claim, information_sent_claim = given_there_are_claims_due_for_payments_processing
+  scenario "Support user visits the claims index page when there are submitted claims" do
+    given_there_are_submitted_claims
     when_i_visit_claims_payments_index_page
-    then_i_see("2 claims need processing")
-    and_i_see_a_list_of_claims([information_requested_claim, information_sent_claim])
+    then_i_see_claims_are_waiting_to_be_sent_to_payer
+  end
+
+  scenario "Support user visits the claims index page when there are claims waiting for a payer response" do
+    given_there_are_payment_in_progress_claims
+    when_i_visit_claims_payments_index_page
+    then_i_see_claims_are_awaiting_a_response_from_payer
+  end
+
+  scenario "Support user visits the claims index page with claims due for payments processing" do
+    given_there_are_claims_due_for_payments_processing
+    when_i_visit_claims_payments_index_page
+    then_i_see_claims_require_more_information
+    and_i_see_an_information_requested_claim
+    and_i_see_an_information_sent_claim
+  end
+
+  scenario "Support user visits the claims index page with claims in all stages of the payments process" do
+    given_there_are_claims_due_for_payments_processing
+    and_there_are_submitted_claims
+    and_there_are_payment_in_progress_claims
+    when_i_visit_claims_payments_index_page
+    then_i_see_claims_are_waiting_to_be_sent_to_payer
+    and_i_see_claims_are_waiting_to_be_sent_to_payer
+    and_i_see_claims_require_more_information
+    and_i_see_an_information_requested_claim
+    and_i_see_an_information_sent_claim
   end
 
   private
@@ -28,10 +53,8 @@ RSpec.describe "View payments claims", :js, service: :claims, type: :system do
   end
 
   def given_there_are_claims_due_for_payments_processing
-    [
-      create(:claim, :payment_information_requested),
-      create(:claim, :payment_information_sent),
-    ]
+    @information_requested_claim = create(:claim, :payment_information_requested)
+    @information_sent_claim = create(:claim, :payment_information_sent)
   end
 
   def when_i_visit_claims_payments_index_page
@@ -43,11 +66,72 @@ RSpec.describe "View payments claims", :js, service: :claims, type: :system do
     expect(page).to have_content(message)
   end
 
-  def and_i_see_a_list_of_claims(claims)
-    claims.each_with_index do |claim, index|
-      within(".claim-card:nth-child(#{index + 1})") do
-        expect(page).to have_content(claim.reference)
-      end
+  def and_i_see_an_information_requested_claim
+    expect(page).to have_claim_card({
+      "title" => "#{@information_requested_claim.reference} - #{@information_requested_claim.school.name}",
+      "url" => "/support/claims/payments/claims/#{@information_requested_claim.id}",
+      "status" => "Payer needs information",
+      "academic_year" => @information_requested_claim.academic_year.name,
+      "provider_name" => @information_requested_claim.provider.name,
+      "submitted_at" => I18n.l(@information_requested_claim.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+  end
+
+  def and_i_see_an_information_sent_claim
+    expect(page).to have_claim_card({
+      "title" => "#{@information_sent_claim.reference} - #{@information_sent_claim.school.name}",
+      "url" => "/support/claims/payments/claims/#{@information_sent_claim.id}",
+      "status" => "Information sent to payer",
+      "academic_year" => @information_sent_claim.academic_year.name,
+      "provider_name" => @information_sent_claim.provider.name,
+      "submitted_at" => I18n.l(@information_sent_claim.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+  end
+
+  def given_there_are_submitted_claims
+    create_list(:claim, 3, :submitted)
+  end
+  alias_method :and_there_are_submitted_claims, :given_there_are_submitted_claims
+
+  def given_there_are_payment_in_progress_claims
+    create_list(:claim, 5, :payment_in_progress)
+  end
+  alias_method :and_there_are_payment_in_progress_claims,
+               :given_there_are_payment_in_progress_claims
+
+  def then_i_see_claims_are_awaiting_a_response_from_payer
+    within("#action_calculator") do
+      expect(page).to have_element(
+        :p,
+        text: "5 claims awaiting a response from payer",
+        class: "govuk-body",
+      )
     end
   end
+
+  def then_i_see_claims_are_waiting_to_be_sent_to_payer
+    within("#action_calculator") do
+      expect(page).to have_element(
+        :p,
+        text: "3 claims waiting to be sent to payer",
+        class: "govuk-body",
+      )
+    end
+  end
+  alias_method :and_i_see_claims_are_waiting_to_be_sent_to_payer,
+               :then_i_see_claims_are_waiting_to_be_sent_to_payer
+
+  def then_i_see_claims_require_more_information
+    within("#action_calculator") do
+      expect(page).to have_element(
+        :p,
+        text: "2 claims require more information",
+        class: "govuk-body",
+      )
+    end
+  end
+  alias_method :and_i_see_claims_require_more_information,
+               :then_i_see_claims_require_more_information
 end


### PR DESCRIPTION
## Context

- Add actions calculator to the Payments index page.

## Changes proposed in this pull request

- Add helper methods to calculate the number of claims in each stage of the payments process.
- Add view to show a helpful message regarding steps to take in the payments process.

## Link to Trello card

https://trello.com/c/WGWUILGW/405-add-action-calculator-to-payments-page

## Screenshots

![Screenshot 2025-02-11 at 14 13 09](https://github.com/user-attachments/assets/2cc68b29-c20b-464d-b250-3fefcebe6242)


