### PR TITLE
Change caption and title to Provider rejection

### DIFF
--- a/config/locales/en/wizards/claims/provider_rejected_claim_wizard.yml
+++ b/config/locales/en/wizards/claims/provider_rejected_claim_wizard.yml
@@ -3,26 +3,26 @@ en:
     claims:
       provider_rejected_claim_wizard:
         mentor_training_step:
-          page_title: Select a mentor - Rejected by provider - Claim %{reference} - Auditing - Claims
+          page_title: Select a mentor - Provider rejection - Claim %{reference} - Auditing - Claims
           title: Rejection details from the provider
-          caption: Rejected by provider - Claim %{reference}
+          caption: Provider rejection - Claim %{reference}
           continue: Continue
           which_mentors: Which mentors are being rejected?
           include_partial_or_whole_clawback: Include mentors which need partial or whole clawback.
         provider_response_step:
-          page_title:  What reason has the provider given for rejecting %{mentor_name}? - Rejected by provider - Claim %{reference} - Auditing - Claims
+          page_title:  What reason has the provider given for rejecting %{mentor_name}? - Provider rejection - Claim %{reference} - Auditing - Claims
           title: What reason has the provider given for rejecting %{mentor_name}?
-          caption: Rejected by provider - Claim %{reference}
+          caption: Provider rejection - Claim %{reference}
           mentor_training_assured: Has the provider assured this mentor's training?
           please_add_reason: Only include details related to %{mentor_name}.
           continue: Continue
-          hours_completed: 
+          hours_completed:
             one: The school originally claimed %{mentor_name} has completed %{count} hour.
             other: The school originally claimed %{mentor_name} has completed %{count} hours.
         check_your_answers_step:
-          page_title: Check your answers - Rejected by provider - Claim %{reference} - Auditing - Claims
+          page_title: Check your answers - Provider rejection - Claim %{reference} - Auditing - Claims
           title: Check your answers
-          caption: Rejected by provider - Claim %{reference}
+          caption: Provider rejection - Claim %{reference}
           reason_for_rejection: Reason for rejection
           provider_rejection_details: Provider's rejection details %{index}
           confirm: Confirm and reject claim

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_mentor_who_is_being_rejected_by_the_provider_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_mentor_who_is_being_rejected_by_the_provider_spec.rb
@@ -114,9 +114,9 @@ RSpec.describe "Support user changes the mentor who is being rejected by the pro
 
   def then_i_see_the_mentor_selection_page
     expect(page).to have_title(
-      "Select a mentor - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "Select a mentor - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
-    expect(page).to have_element(:span, text: "Rejected by provider - Claim #{@claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Provider rejection - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1("Rejection details from the provider")
     expect(page).to have_element(:legend, text: "Which mentors are being rejected?")
     expect(page).to have_element(:div, text: "Include mentors which need partial or whole clawback.", class: "govuk-hint")
@@ -132,11 +132,11 @@ RSpec.describe "Support user changes the mentor who is being rejected by the pro
 
   def then_i_see_the_rejection_reason_page_for_john_smith
     expect(page).to have_title(
-      "What reason has the provider given for rejecting John Smith? - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "What reason has the provider given for rejecting John Smith? - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
-      text: "Rejected by provider - Claim #{@claim.reference}",
+      text: "Provider rejection - Claim #{@claim.reference}",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1("What reason has the provider given for rejecting John Smith?")
@@ -154,11 +154,11 @@ RSpec.describe "Support user changes the mentor who is being rejected by the pro
 
   def then_i_see_the_check_your_answers_page
     expect(page).to have_title(
-      "Check your answers - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "Check your answers - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
-      text: "Rejected by provider - Claim #{@claim.reference}",
+      text: "Provider rejection - Claim #{@claim.reference}",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1("Check your answers")
@@ -197,11 +197,11 @@ RSpec.describe "Support user changes the mentor who is being rejected by the pro
 
   def then_i_see_the_rejection_reason_page_for_jane_doe
     expect(page).to have_title(
-      "What reason has the provider given for rejecting Jane Doe? - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "What reason has the provider given for rejecting Jane Doe? - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
-      text: "Rejected by provider - Claim #{@claim.reference}",
+      text: "Provider rejection - Claim #{@claim.reference}",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1("What reason has the provider given for rejecting Jane Doe?")

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_reason_the_provider_rejected_the_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_reason_the_provider_rejected_the_mentor_spec.rb
@@ -109,9 +109,9 @@ RSpec.describe "Support user changes the reason the provider rejected the mentor
 
   def then_i_see_the_mentor_selection_page
     expect(page).to have_title(
-      "Select a mentor - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "Select a mentor - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
-    expect(page).to have_element(:span, text: "Rejected by provider - Claim #{@claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Provider rejection - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1("Rejection details from the provider")
     expect(page).to have_element(:legend, text: "Which mentors are being rejected?")
     expect(page).to have_element(:div, text: "Include mentors which need partial or whole clawback.", class: "govuk-hint")
@@ -127,11 +127,11 @@ RSpec.describe "Support user changes the reason the provider rejected the mentor
 
   def then_i_see_the_rejection_reason_page_for_john_smith
     expect(page).to have_title(
-      "What reason has the provider given for rejecting John Smith? - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "What reason has the provider given for rejecting John Smith? - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
-      text: "Rejected by provider - Claim #{@claim.reference}",
+      text: "Provider rejection - Claim #{@claim.reference}",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1("What reason has the provider given for rejecting John Smith?")
@@ -149,11 +149,11 @@ RSpec.describe "Support user changes the reason the provider rejected the mentor
 
   def then_i_see_the_check_your_answers_page
     expect(page).to have_title(
-      "Check your answers - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "Check your answers - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
-      text: "Rejected by provider - Claim #{@claim.reference}",
+      text: "Provider rejection - Claim #{@claim.reference}",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1("Check your answers")

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_does_not_enter_a_reason_why_the_provider_rejected_the_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_does_not_enter_a_reason_why_the_provider_rejected_the_mentor_spec.rb
@@ -78,9 +78,9 @@ RSpec.describe "Support user does not enter a reason why the provider rejected t
 
   def then_i_see_the_mentor_selection_page
     expect(page).to have_title(
-      "Select a mentor - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "Select a mentor - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
-    expect(page).to have_element(:span, text: "Rejected by provider - Claim #{@claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Provider rejection - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1("Rejection details from the provider")
     expect(page).to have_element(:legend, text: "Which mentors are being rejected?")
     expect(page).to have_element(:div, text: "Include mentors which need partial or whole clawback.", class: "govuk-hint")
@@ -97,11 +97,11 @@ RSpec.describe "Support user does not enter a reason why the provider rejected t
 
   def then_i_see_the_rejection_reason_page_for_john_smith
     expect(page).to have_title(
-      "What reason has the provider given for rejecting John Smith? - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "What reason has the provider given for rejecting John Smith? - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
-      text: "Rejected by provider - Claim #{@claim.reference}",
+      text: "Provider rejection - Claim #{@claim.reference}",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1("What reason has the provider given for rejecting John Smith?")

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_does_not_select_any_mentors_rejected_by_the_provider_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_does_not_select_any_mentors_rejected_by_the_provider_spec.rb
@@ -72,9 +72,9 @@ RSpec.describe "Support user does not select any mentors rejected by the provide
 
   def then_i_see_the_mentor_selection_page
     expect(page).to have_title(
-      "Select a mentor - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "Select a mentor - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
-    expect(page).to have_element(:span, text: "Rejected by provider - Claim #{@claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Provider rejection - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1("Rejection details from the provider")
     expect(page).to have_element(:legend, text: "Which mentors are being rejected?")
     expect(page).to have_element(:div, text: "Include mentors which need partial or whole clawback.", class: "govuk-hint")

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_marks_the_claim_as_provider_not_approved_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_marks_the_claim_as_provider_not_approved_spec.rb
@@ -158,9 +158,9 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
 
   def then_i_see_the_mentor_selection_page
     expect(page).to have_title(
-      "Select a mentor - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "Select a mentor - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
-    expect(page).to have_element(:span, text: "Rejected by provider - Claim #{@claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Provider rejection - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1("Rejection details from the provider")
     expect(page).to have_element(:legend, text: "Which mentors are being rejected?")
     expect(page).to have_element(:div, text: "Include mentors which need partial or whole clawback.", class: "govuk-hint")
@@ -181,11 +181,11 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
 
   def then_i_see_the_rejection_reason_page_for_john_smith
     expect(page).to have_title(
-      "What reason has the provider given for rejecting John Smith? - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "What reason has the provider given for rejecting John Smith? - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
-      text: "Rejected by provider - Claim #{@claim.reference}",
+      text: "Provider rejection - Claim #{@claim.reference}",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1("What reason has the provider given for rejecting John Smith?")
@@ -205,11 +205,11 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
 
   def then_i_see_the_check_your_answers_page
     expect(page).to have_title(
-      "Check your answers - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "Check your answers - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
-      text: "Rejected by provider - Claim #{@claim.reference}",
+      text: "Provider rejection - Claim #{@claim.reference}",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1("Check your answers")
@@ -262,11 +262,11 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
 
   def then_i_see_the_rejection_reason_page_for_jane_doe
     expect(page).to have_title(
-      "What reason has the provider given for rejecting Jane Doe? - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "What reason has the provider given for rejecting Jane Doe? - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
-      text: "Rejected by provider - Claim #{@claim.reference}",
+      text: "Provider rejection - Claim #{@claim.reference}",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1("What reason has the provider given for rejecting Jane Doe?")


### PR DESCRIPTION
## Context

Update the page captionfor provider rejection to present tense

## Changes proposed in this pull request
 
-[x] Update the caption

## Guidance to review

- Log in as Colin
- Upload a claim to be audited
- Select the claim and reject it

## Link to Trello card

[Update rejected by provider copy](https://trello.com/c/hpcg3yQi/409-update-rejected-by-provider-copy)

## Screenshots

![image](https://github.com/user-attachments/assets/bd32f114-4b68-4e87-92a4-4f9bd803a53f)
![image](https://github.com/user-attachments/assets/31d6beae-103e-4381-8d57-28bc6d0d8cbe)
![image](https://github.com/user-attachments/assets/d1fb1434-941d-44af-ab79-b174aec7414f)
