### PR TITLE
Update provider mentor headers

### DIFF
--- a/app/views/wizards/claims/provider_rejected_claim_wizard/_check_your_answers_step.html.erb
+++ b/app/views/wizards/claims/provider_rejected_claim_wizard/_check_your_answers_step.html.erb
@@ -10,7 +10,7 @@
 
       <% @wizard.selected_mentor_trainings.each_with_index do |mentor_training, index| %>
         <h2 class="govuk-heading-m">
-          <%= t(".provider_rejection_details", index: index + 1) %>
+          <%= t(".provider_rejection_details", mentor_name: mentor_training.mentor_full_name) %>
         </h2>
 
         <%= govuk_summary_list(html_attributes: { id: "provider_rejection_details_#{index + 1}" }) do |summary_list| %>

--- a/config/locales/en/wizards/claims/provider_rejected_claim_wizard.yml
+++ b/config/locales/en/wizards/claims/provider_rejected_claim_wizard.yml
@@ -24,7 +24,7 @@ en:
           title: Check your answers
           caption: Provider rejection - Claim %{reference}
           reason_for_rejection: Reason for rejection
-          provider_rejection_details: Provider's rejection details %{index}
+          provider_rejection_details: Provider's rejection details for %{mentor_name}
           confirm: Confirm and reject claim
           change: Change
           original_number_of_hours_claimed: Original number of hours claimed

--- a/config/locales/en/wizards/claims/provider_rejected_claim_wizard.yml
+++ b/config/locales/en/wizards/claims/provider_rejected_claim_wizard.yml
@@ -3,26 +3,26 @@ en:
     claims:
       provider_rejected_claim_wizard:
         mentor_training_step:
-          page_title: Select a mentor - Rejected by provider - Claim %{reference} - Auditing - Claims
+          page_title: Select a mentor - Provider rejection - Claim %{reference} - Auditing - Claims
           title: Rejection details from the provider
-          caption: Rejected by provider - Claim %{reference}
+          caption: Provider rejection - Claim %{reference}
           continue: Continue
           which_mentors: Which mentors are being rejected?
           include_partial_or_whole_clawback: Include mentors which need partial or whole clawback.
         provider_response_step:
-          page_title:  What reason has the provider given for rejecting %{mentor_name}? - Rejected by provider - Claim %{reference} - Auditing - Claims
+          page_title:  What reason has the provider given for rejecting %{mentor_name}? - Provider rejection - Claim %{reference} - Auditing - Claims
           title: What reason has the provider given for rejecting %{mentor_name}?
-          caption: Rejected by provider - Claim %{reference}
+          caption: Provider rejection - Claim %{reference}
           mentor_training_assured: Has the provider assured this mentor's training?
           please_add_reason: Only include details related to %{mentor_name}.
           continue: Continue
-          hours_completed: 
+          hours_completed:
             one: The school originally claimed %{mentor_name} has completed %{count} hour.
             other: The school originally claimed %{mentor_name} has completed %{count} hours.
         check_your_answers_step:
-          page_title: Check your answers - Rejected by provider - Claim %{reference} - Auditing - Claims
+          page_title: Check your answers - Provider rejection - Claim %{reference} - Auditing - Claims
           title: Check your answers
-          caption: Rejected by provider - Claim %{reference}
+          caption: Provider rejection - Claim %{reference}
           reason_for_rejection: Reason for rejection
           provider_rejection_details: Provider's rejection details %{index}
           confirm: Confirm and reject claim

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_mentor_who_is_being_rejected_by_the_provider_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_mentor_who_is_being_rejected_by_the_provider_spec.rb
@@ -114,9 +114,9 @@ RSpec.describe "Support user changes the mentor who is being rejected by the pro
 
   def then_i_see_the_mentor_selection_page
     expect(page).to have_title(
-      "Select a mentor - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "Select a mentor - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
-    expect(page).to have_element(:span, text: "Rejected by provider - Claim #{@claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Provider rejection - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1("Rejection details from the provider")
     expect(page).to have_element(:legend, text: "Which mentors are being rejected?")
     expect(page).to have_element(:div, text: "Include mentors which need partial or whole clawback.", class: "govuk-hint")
@@ -132,11 +132,11 @@ RSpec.describe "Support user changes the mentor who is being rejected by the pro
 
   def then_i_see_the_rejection_reason_page_for_john_smith
     expect(page).to have_title(
-      "What reason has the provider given for rejecting John Smith? - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "What reason has the provider given for rejecting John Smith? - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
-      text: "Rejected by provider - Claim #{@claim.reference}",
+      text: "Provider rejection - Claim #{@claim.reference}",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1("What reason has the provider given for rejecting John Smith?")
@@ -154,11 +154,11 @@ RSpec.describe "Support user changes the mentor who is being rejected by the pro
 
   def then_i_see_the_check_your_answers_page
     expect(page).to have_title(
-      "Check your answers - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "Check your answers - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
-      text: "Rejected by provider - Claim #{@claim.reference}",
+      text: "Provider rejection - Claim #{@claim.reference}",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1("Check your answers")
@@ -197,11 +197,11 @@ RSpec.describe "Support user changes the mentor who is being rejected by the pro
 
   def then_i_see_the_rejection_reason_page_for_jane_doe
     expect(page).to have_title(
-      "What reason has the provider given for rejecting Jane Doe? - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "What reason has the provider given for rejecting Jane Doe? - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
-      text: "Rejected by provider - Claim #{@claim.reference}",
+      text: "Provider rejection - Claim #{@claim.reference}",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1("What reason has the provider given for rejecting Jane Doe?")

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_reason_the_provider_rejected_the_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_reason_the_provider_rejected_the_mentor_spec.rb
@@ -109,9 +109,9 @@ RSpec.describe "Support user changes the reason the provider rejected the mentor
 
   def then_i_see_the_mentor_selection_page
     expect(page).to have_title(
-      "Select a mentor - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "Select a mentor - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
-    expect(page).to have_element(:span, text: "Rejected by provider - Claim #{@claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Provider rejection - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1("Rejection details from the provider")
     expect(page).to have_element(:legend, text: "Which mentors are being rejected?")
     expect(page).to have_element(:div, text: "Include mentors which need partial or whole clawback.", class: "govuk-hint")
@@ -127,11 +127,11 @@ RSpec.describe "Support user changes the reason the provider rejected the mentor
 
   def then_i_see_the_rejection_reason_page_for_john_smith
     expect(page).to have_title(
-      "What reason has the provider given for rejecting John Smith? - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "What reason has the provider given for rejecting John Smith? - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
-      text: "Rejected by provider - Claim #{@claim.reference}",
+      text: "Provider rejection - Claim #{@claim.reference}",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1("What reason has the provider given for rejecting John Smith?")
@@ -149,11 +149,11 @@ RSpec.describe "Support user changes the reason the provider rejected the mentor
 
   def then_i_see_the_check_your_answers_page
     expect(page).to have_title(
-      "Check your answers - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "Check your answers - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
-      text: "Rejected by provider - Claim #{@claim.reference}",
+      text: "Provider rejection - Claim #{@claim.reference}",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1("Check your answers")

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_reason_the_provider_rejected_the_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_changes_the_reason_the_provider_rejected_the_mentor_spec.rb
@@ -157,6 +157,7 @@ RSpec.describe "Support user changes the reason the provider rejected the mentor
       class: "govuk-caption-l",
     )
     expect(page).to have_h1("Check your answers")
+    expect(page).to have_h2("Provider's rejection details for John Smith")
     expect(page).to have_element(
       :div,
       text: "Rejecting these mentors will update the claim status to ‘rejected by provider’.",

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_does_not_enter_a_reason_why_the_provider_rejected_the_mentor_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_does_not_enter_a_reason_why_the_provider_rejected_the_mentor_spec.rb
@@ -78,9 +78,9 @@ RSpec.describe "Support user does not enter a reason why the provider rejected t
 
   def then_i_see_the_mentor_selection_page
     expect(page).to have_title(
-      "Select a mentor - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "Select a mentor - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
-    expect(page).to have_element(:span, text: "Rejected by provider - Claim #{@claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Provider rejection - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1("Rejection details from the provider")
     expect(page).to have_element(:legend, text: "Which mentors are being rejected?")
     expect(page).to have_element(:div, text: "Include mentors which need partial or whole clawback.", class: "govuk-hint")
@@ -97,11 +97,11 @@ RSpec.describe "Support user does not enter a reason why the provider rejected t
 
   def then_i_see_the_rejection_reason_page_for_john_smith
     expect(page).to have_title(
-      "What reason has the provider given for rejecting John Smith? - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "What reason has the provider given for rejecting John Smith? - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
-      text: "Rejected by provider - Claim #{@claim.reference}",
+      text: "Provider rejection - Claim #{@claim.reference}",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1("What reason has the provider given for rejecting John Smith?")

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_does_not_select_any_mentors_rejected_by_the_provider_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_does_not_select_any_mentors_rejected_by_the_provider_spec.rb
@@ -72,9 +72,9 @@ RSpec.describe "Support user does not select any mentors rejected by the provide
 
   def then_i_see_the_mentor_selection_page
     expect(page).to have_title(
-      "Select a mentor - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "Select a mentor - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
-    expect(page).to have_element(:span, text: "Rejected by provider - Claim #{@claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Provider rejection - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1("Rejection details from the provider")
     expect(page).to have_element(:legend, text: "Which mentors are being rejected?")
     expect(page).to have_element(:div, text: "Include mentors which need partial or whole clawback.", class: "govuk-hint")

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_marks_the_claim_as_provider_not_approved_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_marks_the_claim_as_provider_not_approved_spec.rb
@@ -213,6 +213,8 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
       class: "govuk-caption-l",
     )
     expect(page).to have_h1("Check your answers")
+    expect(page).to have_h2("Provider's rejection details for John Smith")
+    expect(page).to have_h2("Provider's rejection details for Jane Doe")
     expect(page).to have_element(
       :div,
       text: "Rejecting these mentors will update the claim status to ‘rejected by provider’.",

--- a/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_marks_the_claim_as_provider_not_approved_spec.rb
+++ b/spec/system/claims/support/claims/sampling/mark_claim_as_provider_not_approved/support_user_marks_the_claim_as_provider_not_approved_spec.rb
@@ -158,9 +158,9 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
 
   def then_i_see_the_mentor_selection_page
     expect(page).to have_title(
-      "Select a mentor - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "Select a mentor - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
-    expect(page).to have_element(:span, text: "Rejected by provider - Claim #{@claim.reference}", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Provider rejection - Claim #{@claim.reference}", class: "govuk-caption-l")
     expect(page).to have_h1("Rejection details from the provider")
     expect(page).to have_element(:legend, text: "Which mentors are being rejected?")
     expect(page).to have_element(:div, text: "Include mentors which need partial or whole clawback.", class: "govuk-hint")
@@ -181,11 +181,11 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
 
   def then_i_see_the_rejection_reason_page_for_john_smith
     expect(page).to have_title(
-      "What reason has the provider given for rejecting John Smith? - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "What reason has the provider given for rejecting John Smith? - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
-      text: "Rejected by provider - Claim #{@claim.reference}",
+      text: "Provider rejection - Claim #{@claim.reference}",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1("What reason has the provider given for rejecting John Smith?")
@@ -205,11 +205,11 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
 
   def then_i_see_the_check_your_answers_page
     expect(page).to have_title(
-      "Check your answers - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "Check your answers - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
-      text: "Rejected by provider - Claim #{@claim.reference}",
+      text: "Provider rejection - Claim #{@claim.reference}",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1("Check your answers")
@@ -262,11 +262,11 @@ RSpec.describe "Support user marks a claim as provider not approved", service: :
 
   def then_i_see_the_rejection_reason_page_for_jane_doe
     expect(page).to have_title(
-      "What reason has the provider given for rejecting Jane Doe? - Rejected by provider - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
+      "What reason has the provider given for rejecting Jane Doe? - Provider rejection - Claim #{@claim.reference} - Auditing - Claims - Claim funding for mentor training - GOV.UK",
     )
     expect(page).to have_element(
       :span,
-      text: "Rejected by provider - Claim #{@claim.reference}",
+      text: "Provider rejection - Claim #{@claim.reference}",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1("What reason has the provider given for rejecting Jane Doe?")


### PR DESCRIPTION
## Context

We don't display the mentor names on the check your answers page for the provider rejection journey.

## Changes proposed in this pull request

- [x] Replace the index of the mentor with their name

## Guidance to review

- Log in as Colin
- Upload a claim to be audited
- Reject the claim
- Assert the the mentor headings in the check your answers page include their names

## Link to Trello card

[Update rejected by provider copy](https://trello.com/c/hpcg3yQi/409-update-rejected-by-provider-copy)

## Screenshots

![image](https://github.com/user-attachments/assets/e5812872-aeb7-421c-a8a8-d7227cbc02a1)
