### PR TITLE
Update the information when sending claims to the payer for clawback

### DIFF
--- a/app/views/claims/support/claims/clawbacks/new.html.erb
+++ b/app/views/claims/support/claims/clawbacks/new.html.erb
@@ -14,7 +14,9 @@
 
       <p class="govuk-body"><%= t(".description", count: @clawback_requested_claims.count) %></p>
 
-      <div class="govuk-body"><%= t(".details_html") %></div>
+      <p class="govuk-body"><%= t(".csv_details") %></p>
+
+      <p class="govuk-body"><%= t(".status_details") %></p>
 
       <%= govuk_warning_text text: t(".warning") %>
 

--- a/config/locales/en/claims/support/claims/clawbacks.yml
+++ b/config/locales/en/claims/support/claims/clawbacks.yml
@@ -30,13 +30,8 @@ en:
             description:
               one: There is %{count} claim included in this submission.
               other: There are %{count} claims included in this submission.
-            details_html:
-              <p>Selecting ‘Send claims’ will:</p>
-              <ul class="govuk-list govuk-list--bullet">
-                <li>create a CSV containing a list of all claims marked as ‘Clawback requested’</li>
-                <li>send an email to the payer containing a link to the generated CSV - this link expires after 7 days</li>
-                <li>update the claim status from ‘Clawback requested’ to ‘Clawback in progress’</li>
-              </ul>
+            csv_details: By clicking 'send claims' all clawback requests will be sent to the payer. They will receive this via an email containing the link to a csv file.
+            status_details: The status of the claims will change from 'ready for clawback' to 'sent to payer for clawback'.
             warning: This action cannot be undone.
             submit: Send claims
             cancel: Cancel

--- a/spec/system/claims/support/claims/clawbacks/send_to_esfa/support_user_sends_claims_to_esfa_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/send_to_esfa/support_user_sends_claims_to_esfa_spec.rb
@@ -56,19 +56,8 @@ RSpec.describe "Support user sends claims to payer", service: :claims, type: :sy
     expect(page).to have_element(:p, text: "Clawbacks", class: "govuk-caption-l")
     expect(page).to have_h1("Send claims to payer")
     expect(page).to have_element(:p, text: "There is 1 claim included in this submission.", class: "govuk-body")
-    expect(page).to have_element(:div, text: "Selecting ‘Send claims’ will:", class: "govuk-body")
-    expect(page).to have_element(
-      :li,
-      text: "create a CSV containing a list of all claims marked as ‘Clawback requested’",
-    )
-    expect(page).to have_element(
-      :li,
-      text: "send an email to the payer containing a link to the generated CSV - this link expires after 7 days",
-    )
-    expect(page).to have_element(
-      :li,
-      text: "update the claim status from ‘Clawback requested’ to ‘Clawback in progress’",
-    )
+    expect(page).to have_element(:p, text: "By clicking 'send claims' all clawback requests will be sent to the payer. They will receive this via an email containing the link to a csv file.", class: "govuk-body")
+    expect(page).to have_element(:p, text: "The status of the claims will change from 'ready for clawback' to 'sent to payer for clawback'.", class: "govuk-body")
     expect(page).to have_warning_text("This action cannot be undone.")
   end
 


### PR DESCRIPTION
## Context

We removed copy from the auditing flow as it was surfaced at the wrong time, we have now moved that information to the clawbacks flow.

## Changes proposed in this pull request

- [x] Update the copy on the confirmation page for sending clawbacks to payer

## Guidance to review

- Log in as Colin
- Take a claim through to clawback
- Request a clawback
- Confirm the copy matches the expected text

## Link to Trello card

[Update the copy on the Send claims to payer page](https://trello.com/c/99qbfhfv/407-update-the-copy-on-the-send-claims-to-payer-page)

## Screenshots

![image](https://github.com/user-attachments/assets/ab881e5c-87ae-4588-8365-600cb8d659e4)
