### PR TITLE
Update the success messages for uploading a CSV file

### DIFF
--- a/config/locales/en/claims/support/claims/clawbacks/upload_esfa_response.yml
+++ b/config/locales/en/claims/support/claims/clawbacks/upload_esfa_response.yml
@@ -8,4 +8,4 @@ en:
               cancel: Cancel
             update: 
               heading: Payer response uploaded
-              body: It may take a moment for the responses to load
+              body: It may take a moment for the responses to load. Refresh the page to see newly uploaded information.

--- a/config/locales/en/claims/support/claims/samplings.yml
+++ b/config/locales/en/claims/support/claims/samplings.yml
@@ -38,7 +38,7 @@ en:
           upload_data:
             update:
               heading: Auditing data uploaded
-              body: It may take a moment for the uploaded claims to update
+              body: It may take a moment for the responses to load. Refresh the page to see newly uploaded information.
           confirm_provider_rejected:
             page_title: Are you sure you want to confirm the provider has rejected the claim? - Auditing - Claim %{reference}
             caption: Auditing - Claim %{reference}

--- a/config/locales/en/claims/support/claims/samplings/upload_provider_response.yml
+++ b/config/locales/en/claims/support/claims/samplings/upload_provider_response.yml
@@ -8,5 +8,4 @@ en:
               cancel: Cancel
             update: 
               heading: Provider response uploaded
-              body: It may take a moment for the responses to load
-
+              body: It may take a moment for the responses to load. Refresh the page to see newly uploaded information.

--- a/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_esfa_responses_for_claims_with_the_status_clawback_in_progress_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/upload_esfa_response/support_user_uploads_esfa_responses_for_claims_with_the_status_clawback_in_progress_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe "Support user uploads ESFA responses for claims with the status '
   def then_i_see_the_upload_has_been_successful
     expect(page).to have_success_banner(
       "Payer response uploaded",
-      "It may take a moment for the responses to load",
+      "It may take a moment for the responses to load. Refresh the page to see newly uploaded information.",
     )
   end
 

--- a/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_provider_responses_for_claims_with_the_status_sampling_in_progress_spec.rb
+++ b/spec/system/claims/support/claims/sampling/upload_provider_response/support_user_uploads_provider_responses_for_claims_with_the_status_sampling_in_progress_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe "Support user uploads provider responses for claims with the stat
   def then_i_see_the_upload_has_been_successful
     expect(page).to have_success_banner(
       "Provider response uploaded",
-      "It may take a moment for the responses to load",
+      "It may take a moment for the responses to load. Refresh the page to see newly uploaded information.",
     )
   end
 


### PR DESCRIPTION
## Context

It was not clear that the user needed to refresh the page to see updated claims

## Changes proposed in this pull request

- [x] Altered the text to ask users to reload the page after uploading a CSV file.

## Guidance to review

- Log in as Colin
- Take a claim through the entire flow from payments to clawback
- Check that the success messages ask you to refresh the page after uploading a file

## Link to Trello card

[Update upload success messages](https://trello.com/c/UaYxxVPo/413-update-upload-success-messages)

## Screenshots

![image](https://github.com/user-attachments/assets/763dd23d-e577-49a1-a0e9-4829071b584c)
![image](https://github.com/user-attachments/assets/9b99b033-6d46-4dc4-926f-ebe02bc760ce)
![image](https://github.com/user-attachments/assets/6c0fe494-f7e1-41ea-98f9-5ae0ec0bca20)