### PR TITLE
Fix for sampling reason

### DIFF
--- a/app/services/claims/sampling/create_and_deliver.rb
+++ b/app/services/claims/sampling/create_and_deliver.rb
@@ -38,6 +38,6 @@ class Claims::Sampling::CreateAndDeliver < ApplicationService
   end
 
   def sampling_reason(claim)
-    csv_data.find { |csv_data| csv_data[:id] == claim.id }[:sample_reason]
+    csv_data.find { |csv_data| csv_data[:id] == claim.id }[:sampling_reason]
   end
 end

--- a/spec/services/claims/sampling/create_and_deliver_spec.rb
+++ b/spec/services/claims/sampling/create_and_deliver_spec.rb
@@ -5,7 +5,7 @@ describe Claims::Sampling::CreateAndDeliver do
 
   let(:current_user) { create(:claims_support_user) }
   let!(:claims) { [create(:claim, :paid)] }
-  let(:csv_data) { [{ id: claims.first.id, sample_reason: "ABCD" }] }
+  let(:csv_data) { [{ id: claims.first.id, sampling_reason: "ABCD" }] }
 
   describe "#call" do
     context "when there are submitted claims" do


### PR DESCRIPTION
## Context

The data passed to `Claims::Sampling::CreateAndDeliver` is `{id:, sampling_reason:}`

See `app/wizards/claims/upload_sampling_data_wizard.rb`:
```
def claim_update_details
      return [] if steps[:upload].blank?

      csv_rows.map do |row|
        claim = paid_claims.find_by!(reference: row["claim_reference"])
        {
          id: claim.id,
          sampling_reason: row["sample_reason"],
        }
      end
end
```

## Changes proposed in this pull request

- Fix for sampling reason being added to claims.
