### PR TITLE
Fix all mailer previews

### DIFF
--- a/spec/mailers/previews/claims/esfa_mailer_preview.rb
+++ b/spec/mailers/previews/claims/esfa_mailer_preview.rb
@@ -1,9 +1,15 @@
 class Claims::ESFAMailerPreview < ActionMailer::Preview
   def claims_require_clawback
-    Claims::ESFAMailer.claims_require_clawback("https://example.com")
+    Claims::ESFAMailer.claims_require_clawback(clawback)
   end
 
   def resend_claims_require_clawback
-    Claims::ESFAMailer.resend_claims_require_clawback("https://example.com")
+    Claims::ESFAMailer.resend_claims_require_clawback(clawback)
+  end
+
+  private
+
+  def clawback
+    FactoryBot.build_stubbed(:clawback, csv_file: nil)
   end
 end

--- a/spec/mailers/previews/claims/payment_mailer_preview.rb
+++ b/spec/mailers/previews/claims/payment_mailer_preview.rb
@@ -10,6 +10,6 @@ class Claims::PaymentMailerPreview < ActionMailer::Preview
   private
 
   def payment
-    Claims::Payment.order(created_at: :desc).first_or_initialize(id: SecureRandom.uuid)
+    FactoryBot.build_stubbed(:claims_payment, csv_file: nil)
   end
 end

--- a/spec/mailers/previews/claims/provider_mailer_preview.rb
+++ b/spec/mailers/previews/claims/provider_mailer_preview.rb
@@ -1,9 +1,21 @@
 class Claims::ProviderMailerPreview < ActionMailer::Preview
+  include ActionDispatch::TestProcess::FixtureFile
+
   def sampling_checks_required
-    Claims::ProviderMailer.sampling_checks_required(Claims::ProviderSampling.first, email_address: "example@example.com")
+    Claims::ProviderMailer.sampling_checks_required(provider_sampling, email_address: "example@example.com")
   end
 
   def resend_sampling_checks_required
-    Claims::ProviderMailer.resend_sampling_checks_required(Claims::ProviderSampling.first, email_address: "example@example.com")
+    Claims::ProviderMailer.resend_sampling_checks_required(provider_sampling, email_address: "example@example.com")
+  end
+
+  private
+
+  def provider_sampling
+    @provider_sampling ||= FactoryBot.build_stubbed(:provider_sampling, csv_file: nil, sampling: nil)
+  end
+
+  def provider
+    FactoryBot.build_stubbed(:claims_provider)
   end
 end

--- a/spec/mailers/previews/claims/support_user_mailer_preview.rb
+++ b/spec/mailers/previews/claims/support_user_mailer_preview.rb
@@ -1,9 +1,15 @@
 class Claims::SupportUserMailerPreview < ActionMailer::Preview
   def support_user_invitation
-    Claims::SupportUserMailer.support_user_invitation(Claims::SupportUser.first)
+    Claims::SupportUserMailer.support_user_invitation(support_user)
   end
 
   def support_user_removal_notification
-    Claims::SupportUserMailer.support_user_removal_notification(Claims::SupportUser.first)
+    Claims::SupportUserMailer.support_user_removal_notification(support_user)
+  end
+
+  private
+
+  def support_user
+    FactoryBot.build_stubbed(:claims_support_user)
   end
 end

--- a/spec/mailers/previews/claims/user_mailer_preview.rb
+++ b/spec/mailers/previews/claims/user_mailer_preview.rb
@@ -1,21 +1,35 @@
 class Claims::UserMailerPreview < ActionMailer::Preview
   def user_membership_created_notification
-    Claims::UserMailer.user_membership_created_notification(Claims::User.first, Claims::School.first)
+    Claims::UserMailer.user_membership_created_notification(user, school)
   end
 
   def user_membership_destroyed_notification
-    Claims::UserMailer.user_membership_destroyed_notification(Claims::User.first, Claims::School.first)
+    Claims::UserMailer.user_membership_destroyed_notification(user, school)
   end
 
   def claim_submitted_notification
-    Claims::UserMailer.claim_submitted_notification(Claims::User.first, Claims::Claim.submitted.first)
+    Claims::UserMailer.claim_submitted_notification(user, claim)
   end
 
   def claim_created_support_notification
-    Claims::UserMailer.claim_created_support_notification(Claims::Claim.draft.first, Claims::User.first)
+    Claims::UserMailer.claim_created_support_notification(claim, user)
   end
 
   def claim_requires_clawback
-    Claims::UserMailer.claim_requires_clawback(Claims::Claim.first, Claims::User.first)
+    Claims::UserMailer.claim_requires_clawback(claim, user)
+  end
+
+  private
+
+  def user
+    FactoryBot.build_stubbed(:claims_user)
+  end
+
+  def claim
+    FactoryBot.build_stubbed(:claim)
+  end
+
+  def school
+    FactoryBot.build_stubbed(:school)
   end
 end

--- a/spec/mailers/previews/placements/provider_user_mailer_preview.rb
+++ b/spec/mailers/previews/placements/provider_user_mailer_preview.rb
@@ -1,25 +1,43 @@
 class Placements::ProviderUserMailerPreview < ActionMailer::Preview
   def user_membership_created_notification
-    Placements::ProviderUserMailer.user_membership_created_notification(Placements::User.first, Placements::School.first)
+    Placements::ProviderUserMailer.user_membership_created_notification(user, school)
   end
 
   def user_membership_destroyed_notification
-    Placements::ProviderUserMailer.user_membership_destroyed_notification(Placements::User.first, Placements::School.first)
+    Placements::ProviderUserMailer.user_membership_destroyed_notification(user, school)
   end
 
   def partnership_created_notification
-    Placements::ProviderUserMailer.partnership_created_notification(Placements::User.first, Placements::School.first, Placements::Provider.first)
+    Placements::ProviderUserMailer.partnership_created_notification(user, school, provider)
   end
 
   def partnership_destroyed_notification
-    Placements::ProviderUserMailer.partnership_destroyed_notification(Placements::User.first, Placements::School.first, Placements::Provider.first)
+    Placements::ProviderUserMailer.partnership_destroyed_notification(user, school, provider)
   end
 
   def placement_provider_assigned_notification
-    Placements::ProviderUserMailer.placement_provider_assigned_notification(Placements::User.first, Placements::Provider.first, Placement.first)
+    Placements::ProviderUserMailer.placement_provider_assigned_notification(user, provider, placement)
   end
 
   def placement_provider_removed_notification
-    Placements::ProviderUserMailer.placement_provider_removed_notification(Placements::User.first, Placements::Provider.first, Placement.first)
+    Placements::ProviderUserMailer.placement_provider_removed_notification(user, provider, placement)
+  end
+
+  private
+
+  def user
+    FactoryBot.build_stubbed(:placements_user)
+  end
+
+  def school
+    FactoryBot.build_stubbed(:placements_school)
+  end
+
+  def provider
+    FactoryBot.build_stubbed(:placements_provider)
+  end
+
+  def placement
+    FactoryBot.build_stubbed(:placement, school:, provider:)
   end
 end

--- a/spec/mailers/previews/placements/school_user_mailer_preview.rb
+++ b/spec/mailers/previews/placements/school_user_mailer_preview.rb
@@ -1,17 +1,45 @@
 class Placements::SchoolUserMailerPreview < ActionMailer::Preview
   def user_membership_created_notification
-    Placements::SchoolUserMailer.user_membership_created_notification(Placements::User.first, Placements::School.first)
+    Placements::SchoolUserMailer.user_membership_created_notification(user, school)
   end
 
   def user_membership_destroyed_notification
-    Placements::SchoolUserMailer.user_membership_destroyed_notification(Placements::User.first, Placements::School.first)
+    Placements::SchoolUserMailer.user_membership_destroyed_notification(user, school)
   end
 
   def partnership_created_notification
-    Placements::SchoolUserMailer.partnership_created_notification(Placements::User.first, Placements::Provider.first, Placements::School.first)
+    Placements::SchoolUserMailer.partnership_created_notification(user, provider, school)
   end
 
   def partnership_destroyed_notification
-    Placements::SchoolUserMailer.partnership_destroyed_notification(Placements::User.first, Placements::Provider.first, Placements::School.first)
+    Placements::SchoolUserMailer.partnership_destroyed_notification(user, provider, school)
+  end
+
+  private
+
+  def user
+    FactoryBot.build_stubbed(:placements_user)
+  end
+
+  def school
+    FactoryBot.build_stubbed(:placements_school)
+  end
+
+  def provider
+    PreviewProvider.new
+  end
+
+  def provider_email_address
+    FactoryBot.build_stubbed(:provider_email_address, primary: true)
+  end
+
+  class PreviewProvider < Provider
+    def name
+      "Test Provider"
+    end
+
+    def primary_email_address
+      "test@example.com"
+    end
   end
 end

--- a/spec/mailers/previews/placements/support_user_mailer_preview.rb
+++ b/spec/mailers/previews/placements/support_user_mailer_preview.rb
@@ -1,9 +1,15 @@
 class Placements::SupportUserMailerPreview < ActionMailer::Preview
   def support_user_invitation
-    Placements::SupportUserMailer.support_user_invitation(Placements::SupportUser.first)
+    Placements::SupportUserMailer.support_user_invitation(support_user)
   end
 
   def support_user_removal_notification
-    Placements::SupportUserMailer.support_user_removal_notification(Placements::SupportUser.first)
+    Placements::SupportUserMailer.support_user_removal_notification(support_user)
+  end
+
+  private
+
+  def support_user
+    FactoryBot.build_stubbed(:placements_support_user)
   end
 end


### PR DESCRIPTION
## Context

- Fix all mailer previews.

## Changes proposed in this pull request

- Previews should not use or rely on real data. 
- Change previews to use stubbed records.

## Guidance to review

- Sign in as Colin (Support user)
- Navigate to Settings -> Emails
- Test all Email previews show without error

## Link to Trello card

https://ukgovernmentdfe.slack.com/archives/C085GP37FPA/p1739891736255579

