### PR TITLE
Add total hours to clawback flow

### DIFF
--- a/app/models/claims/claim.rb
+++ b/app/models/claims/claim.rb
@@ -99,7 +99,7 @@ class Claims::Claim < ApplicationRecord
        validate: true
 
   delegate :name, to: :provider, prefix: true, allow_nil: true
-  delegate :urn, :postcode, to: :school, prefix: true, allow_nil: true
+  delegate :urn, :postcode, :region_funding_available_per_hour, to: :school, prefix: true, allow_nil: true
   delegate :name, :users, to: :school, prefix: true
   delegate :full_name, to: :submitted_by, prefix: true, allow_nil: true
   delegate :name, to: :academic_year, prefix: true, allow_nil: true

--- a/app/views/wizards/claims/request_clawback_wizard/_check_your_answers_step.html.erb
+++ b/app/views/wizards/claims/request_clawback_wizard/_check_your_answers_step.html.erb
@@ -7,6 +7,24 @@
 
       <h1 class="govuk-heading-l"><%= t(".title") %></h1>
 
+      <p class="govuk-body"><%= t(".information_shared_with_school", school_name: @claim.school_name) %></p>
+
+      <h2 class="govuk-heading-m"><%= t(".original_claim") %></h2>
+      <%= govuk_summary_list(html_attributes: { id: "claim-totals" }) do |summary_list| %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".number_of_hours")) %>
+          <% row.with_value(text: @claim.total_hours_completed) %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".rate")) %>
+          <% row.with_value(text: humanized_money_with_symbol(@claim.school_region_funding_available_per_hour)) %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".amount")) %>
+          <% row.with_value(text: humanized_money_with_symbol(@claim.amount)) %>
+        <% end %>
+      <% end %>
+
       <h2 class="govuk-heading-m"><%= t(".total_title") %></h2>
       <%= govuk_summary_list(html_attributes: { id: "clawback-totals" }) do |summary_list| %>
         <% summary_list.with_row do |row| %>
@@ -52,8 +70,6 @@
           <% end %>
         <% end %>
       <% end %>
-
-      <%= govuk_warning_text(text: t(".warning")) %>
 
       <%= f.govuk_submit t(".submit") %>
     <% end %>

--- a/config/locales/en/wizards/claims/request_clawback_wizard.yml
+++ b/config/locales/en/wizards/claims/request_clawback_wizard.yml
@@ -22,9 +22,11 @@ en:
           total_title: Total clawback
           mentor_training_title: Clawback request for %{mentor_name}
           rate: Hourly rate
-          number_of_hours: Number of hours
+          number_of_hours: Hours
           clawback_amount: Clawback amount
           reason: Notes on your decision
           submit: Request clawback
-          warning: We will show clawback details to the school.
           change: Change
+          original_claim: Original claim
+          amount: Amount
+          information_shared_with_school: This information will be shared with %{school_name}.

--- a/spec/models/claims/claim_spec.rb
+++ b/spec/models/claims/claim_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe Claims::Claim, type: :model do
     it { is_expected.to delegate_method(:name).to(:provider).with_prefix }
     it { is_expected.to delegate_method(:users).to(:school).with_prefix }
     it { is_expected.to delegate_method(:urn).to(:school).with_prefix }
+    it { is_expected.to delegate_method(:region_funding_available_per_hour).to(:school).with_prefix }
     it { is_expected.to delegate_method(:postcode).to(:school).with_prefix }
     it { is_expected.to delegate_method(:full_name).to(:submitted_by).with_prefix.allow_nil }
     it { is_expected.to delegate_method(:name).to(:academic_year).with_prefix.allow_nil }

--- a/spec/system/claims/support/claims/clawbacks/support_user_requests_a_clawback_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/support_user_requests_a_clawback_spec.rb
@@ -171,25 +171,32 @@ RSpec.describe "Support user requests a clawback on a claim", service: :claims, 
     expect(primary_navigation).to have_current_item("Claims")
     expect(page).to have_element(:span, text: "Clawbacks - Claim 11111111", class: "govuk-caption-l")
     expect(page).to have_h1("Check your answers")
+    expect(page).to have_element(:p, text: "This information will be shared with #{@claim_one.school_name}.", class: "govuk-body")
+
+    within "#claim-totals" do
+      expect(page).to have_summary_list_row("Hours", "40")
+      expect(page).to have_summary_list_row("Hourly rate", @claim_one.school_region_funding_available_per_hour)
+      expect(page).to have_summary_list_row("Amount", "£#{ActiveSupport::NumberHelper.number_to_delimited(@claim_one.school_region_funding_available_per_hour * 40)}")
+    end
+
     within "#clawback-totals" do
-      expect(page).to have_summary_list_row("Number of hours", "16")
-      expect(page).to have_summary_list_row("Hourly rate", @claim_one.school.region.funding_available_per_hour)
-      expect(page).to have_summary_list_row("Clawback amount", "£#{@claim_one.school.region.funding_available_per_hour * 16}")
+      expect(page).to have_summary_list_row("Hours", "16")
+      expect(page).to have_summary_list_row("Hourly rate", @claim_one.school_region_funding_available_per_hour)
+      expect(page).to have_summary_list_row("Clawback amount", "£#{@claim_one.school_region_funding_available_per_hour * 16}")
     end
 
     within "#mentor-training-#{@john_doe_training.id}" do
-      expect(page).to have_summary_list_row("Number of hours", "8")
-      expect(page).to have_summary_list_row("Hourly rate", @claim_one.school.region.funding_available_per_hour)
-      expect(page).to have_summary_list_row("Clawback amount", "£#{@claim_one.school.region.funding_available_per_hour * 8}")
+      expect(page).to have_summary_list_row("Hours", "8")
+      expect(page).to have_summary_list_row("Hourly rate", @claim_one.school_region_funding_available_per_hour)
+      expect(page).to have_summary_list_row("Clawback amount", "£#{@claim_one.school_region_funding_available_per_hour * 8}")
     end
 
     within "#mentor-training-#{@john_doe_training.id}" do
-      expect(page).to have_summary_list_row("Number of hours", "8")
-      expect(page).to have_summary_list_row("Hourly rate", @claim_one.school.region.funding_available_per_hour)
-      expect(page).to have_summary_list_row("Clawback amount", "£#{@claim_one.school.region.funding_available_per_hour * 8}")
+      expect(page).to have_summary_list_row("Hours", "8")
+      expect(page).to have_summary_list_row("Hourly rate", @claim_one.school_region_funding_available_per_hour)
+      expect(page).to have_summary_list_row("Clawback amount", "£#{@claim_one.school_region_funding_available_per_hour * 8}")
     end
 
-    expect(page).to have_element(:strong, text: "We will show clawback details to the school.", class: "govuk-warning-text__text")
     expect(page).to have_button("Request clawback")
     expect(page).to have_link("Cancel", href: "/support/claims/clawbacks/claims")
   end


### PR DESCRIPTION
## Context

User research showed that there was a desire to see the original claim amount when requesting a clawback.

## Changes proposed in this pull request

- [x] Delegate `region_funding_available_per_hour` to the school in the claim model.
- [x] Add an original claim section on the check your answers page for the clawback flow

## Guidance to review

- Log in as Colin
- Take a claim through to clawback
- Request a clawback
- Verify the information on the Check your answers step.

## Link to Trello card

[Update clawbacks check your answers page](https://trello.com/c/e9wybGbW/415-update-clawbacks-check-your-answers-page)

## Screenshots

![image](https://github.com/user-attachments/assets/aca3a27d-07e9-4cf6-9822-f86ed5aaa9fa)

