### PR TITLE
Mailer previews use intialised records

### DIFF
--- a/spec/mailers/previews/claims/esfa_mailer_preview.rb
+++ b/spec/mailers/previews/claims/esfa_mailer_preview.rb
@@ -10,6 +10,6 @@ class Claims::ESFAMailerPreview < ActionMailer::Preview
   private
 
   def clawback
-    FactoryBot.build_stubbed(:clawback, csv_file: nil)
+    Claims::Clawback.new
   end
 end

--- a/spec/mailers/previews/claims/payment_mailer_preview.rb
+++ b/spec/mailers/previews/claims/payment_mailer_preview.rb
@@ -10,6 +10,6 @@ class Claims::PaymentMailerPreview < ActionMailer::Preview
   private
 
   def payment
-    FactoryBot.build_stubbed(:claims_payment, csv_file: nil)
+    Claims::Payment.new
   end
 end

--- a/spec/mailers/previews/claims/provider_mailer_preview.rb
+++ b/spec/mailers/previews/claims/provider_mailer_preview.rb
@@ -12,10 +12,14 @@ class Claims::ProviderMailerPreview < ActionMailer::Preview
   private
 
   def provider_sampling
-    @provider_sampling ||= FactoryBot.build_stubbed(:provider_sampling, csv_file: nil, sampling: nil)
+    @provider_sampling ||= Claims::ProviderSampling.new(id: stubbed_id, provider:)
   end
 
   def provider
-    FactoryBot.build_stubbed(:claims_provider)
+    Claims::Provider.new(id: stubbed_id, name: "Test Provider")
+  end
+
+  def stubbed_id
+    SecureRandom.uuid
   end
 end

--- a/spec/mailers/previews/claims/support_user_mailer_preview.rb
+++ b/spec/mailers/previews/claims/support_user_mailer_preview.rb
@@ -10,6 +10,11 @@ class Claims::SupportUserMailerPreview < ActionMailer::Preview
   private
 
   def support_user
-    FactoryBot.build_stubbed(:claims_support_user)
+    Claims::SupportUser.new(
+      id: SecureRandom.uuid,
+      first_name: "Joe",
+      last_name: "Bloggs",
+      email: "example@education.gov.uk",
+    )
   end
 end

--- a/spec/mailers/previews/claims/user_mailer_preview.rb
+++ b/spec/mailers/previews/claims/user_mailer_preview.rb
@@ -22,14 +22,27 @@ class Claims::UserMailerPreview < ActionMailer::Preview
   private
 
   def user
-    FactoryBot.build_stubbed(:claims_user)
+    Claims::User.new(
+      id: SecureRandom.uuid,
+      first_name: "Joe",
+      last_name: "Bloggs",
+      email: "joe_bloggs@example.com",
+    )
   end
 
   def claim
-    FactoryBot.build_stubbed(:claim)
+    Claims::Claim.new(id: SecureRandom.uuid, school:)
   end
 
   def school
-    FactoryBot.build_stubbed(:school)
+    Claims::School.new(id: SecureRandom.uuid, name: "Test School", region:)
+  end
+
+  def region
+    Region.new(
+      name: "Test Region",
+      claims_funding_available_per_hour_pence: 5360,
+      claims_funding_available_per_hour_currency: "GBP",
+    )
   end
 end

--- a/spec/mailers/previews/placements/provider_user_mailer_preview.rb
+++ b/spec/mailers/previews/placements/provider_user_mailer_preview.rb
@@ -26,18 +26,31 @@ class Placements::ProviderUserMailerPreview < ActionMailer::Preview
   private
 
   def user
-    FactoryBot.build_stubbed(:placements_user)
+    Placements::User.new(
+      id: stubbed_id,
+      first_name: "Joe",
+      last_name: "Bloggs",
+      email: "joe_bloggs@example.com",
+    )
   end
 
   def school
-    FactoryBot.build_stubbed(:placements_school)
+    Placements::School.new(id: stubbed_id, name: "Test School")
   end
 
   def provider
-    FactoryBot.build_stubbed(:placements_provider)
+    Placements::Provider.new(id: stubbed_id, name: "Test Provider")
   end
 
   def placement
-    FactoryBot.build_stubbed(:placement, school:, provider:)
+    Placement.new(id: stubbed_id, school:, provider:, subject:)
+  end
+
+  def subject
+    Subject.new(id: stubbed_id, name: "English")
+  end
+
+  def stubbed_id
+    SecureRandom.uuid
   end
 end

--- a/spec/mailers/previews/placements/school_user_mailer_preview.rb
+++ b/spec/mailers/previews/placements/school_user_mailer_preview.rb
@@ -18,26 +18,27 @@ class Placements::SchoolUserMailerPreview < ActionMailer::Preview
   private
 
   def user
-    FactoryBot.build_stubbed(:placements_user)
+    Placements::User.new(
+      id: stubbed_id,
+      first_name: "Joe",
+      last_name: "Bloggs",
+      email: "joe_bloggs@example.com",
+    )
   end
 
   def school
-    FactoryBot.build_stubbed(:placements_school)
+    Placements::School.new(id: stubbed_id, name: "Test School")
   end
 
   def provider
-    PreviewProvider.new
+    PreviewProvider.new(id: stubbed_id, name: "Test Provider")
   end
 
-  def provider_email_address
-    FactoryBot.build_stubbed(:provider_email_address, primary: true)
+  def stubbed_id
+    SecureRandom.uuid
   end
 
-  class PreviewProvider < Provider
-    def name
-      "Test Provider"
-    end
-
+  class PreviewProvider < Placements::Provider
     def primary_email_address
       "test@example.com"
     end

--- a/spec/mailers/previews/placements/support_user_mailer_preview.rb
+++ b/spec/mailers/previews/placements/support_user_mailer_preview.rb
@@ -10,6 +10,11 @@ class Placements::SupportUserMailerPreview < ActionMailer::Preview
   private
 
   def support_user
-    FactoryBot.build_stubbed(:placements_support_user)
+    Placements::SupportUser.new(
+      id: SecureRandom.uuid,
+      first_name: "Joe",
+      last_name: "Bloggs",
+      email: "example@education.gov.uk",
+    )
   end
 end


### PR DESCRIPTION
## Context

- Fix for mailer previews

## Changes proposed in this pull request

- Mailer previews now us initialised records, instead of FactoryBot

