### PR TITLE
Move mentor disclaimer to below checkboxes for adding a claim

### DIFF
--- a/app/views/wizards/claims/add_claim_wizard/_mentor_step.html.erb
+++ b/app/views/wizards/claims/add_claim_wizard/_mentor_step.html.erb
@@ -11,8 +11,6 @@
       <span class="govuk-caption-l"><%= contextual_text %></span>
       <h1 class="govuk-heading-l"><%= t(".heading", provider_name: @wizard.provider_name) %></h1>
 
-      <%= render Claims::AddClaimWizard::MentorStep::DisclaimerComponent.new(mentor_step: current_step) %>
-
       <%= f.govuk_collection_check_boxes(
         :mentor_ids,
         current_step.mentors_with_claimable_hours,
@@ -23,6 +21,8 @@
         },
         hint: { text: t(".select_all_that_apply") }
       ) %>
+
+      <%= render Claims::AddClaimWizard::MentorStep::DisclaimerComponent.new(mentor_step: current_step) %>
 
       <%= f.govuk_submit t(".continue") %>
     </div>


### PR DESCRIPTION
## Context

The mentor disclaimer was incorrectly positioned on the "Add mentor" step for the add claim wizard.

## Changes proposed in this pull request

- [x] Move the discalimer text

## Guidance to review

- Log in as Anne
- Add a placement
- Observe the location of the mentor disclaimer

## Link to Trello card

[Move location of mentor disclaimer
](https://trello.com/c/eyYOGxEj/429-move-location-of-mentor-disclaimer)
## Screenshots

<img width="998" alt="image" src="https://github.com/user-attachments/assets/3a4b11f4-2474-464d-807f-998ca3ea60eb" />

