### PR TITLE
Copy change to the Clawback requested mailer

### DIFF
--- a/app/mailers/claims/user_mailer.rb
+++ b/app/mailers/claims/user_mailer.rb
@@ -64,9 +64,11 @@ class Claims::UserMailer < Claims::ApplicationMailer
                  subject: t(".subject"),
                  body: t(".body",
                          user_name: user.first_name,
-                         reference: claim.reference,
+                         claim_reference: claim.reference,
+                         clawback_amount: claim.total_clawback_amount.format(symbol: true, decimal_mark: ".", no_cents: false),
                          link_to_claim:,
                          support_email:,
-                         service_name:)
+                         service_name:,
+                         service_url: claims_root_url)
   end
 end

--- a/app/wizards/claims/request_clawback_wizard.rb
+++ b/app/wizards/claims/request_clawback_wizard.rb
@@ -43,6 +43,9 @@ module Claims
         claim:,
         esfa_responses: esfa_responses_for_mentor_trainings,
       )
+      claim.school_users.each do |user|
+        Claims::UserMailer.claim_requires_clawback(claim, user).deliver_later
+      end
 
       Claims::ClaimActivity.create!(action: :clawback_requested, user: current_user, record: claim)
     end

--- a/config/locales/en/claims/user_mailer.yml
+++ b/config/locales/en/claims/user_mailer.yml
@@ -83,20 +83,28 @@ en:
           Claim funding for mentor training team
 
       claim_requires_clawback:
-        subject: ITT mentor claim requires a clawback
+        subject: Your funding for mentor training will be taken back
         body: |
           Dear %{user_name},
-  
-          We have amended your claim to reflect the amount being clawed back by the payer. They will contact you to discuss how they will claim this money from you.
-        
-          The affected claim reference is: %{reference}
+
+          A claim you made was audited and there was insufficient proof from you that some or all of the claim was valid. Your funding for mentor training will be taken from you and returned to the Department for Education.
+
+          Retrieving this funding is known as clawback.
+
+          Amount being clawed back: %{clawback_amount}
+          Claim reference: %{claim_reference}
           
-          You can view the updated claim on Claim funding for mentor training:
+          # What happens next
+          The funds will automatically be taken from you.
           
-          %{link_to_claim}
+          For academies, any recovery will be offset in your next available monthly payment. For maintained schools, any recovery will be offset in your local authority’s next available monthly payment and they will recover funding from you via their usual processes.
           
-          # Give feedback or report a problem
-          If you have any questions or feedback, please contact the team at [%{support_email}](mailto:%{support_email}).
+          Sign in to your account on Claim funding for mentor training to see more details:
+          %{service_url}
+          
+          # Contact us
+          If you need any help, contact the team at [%{support_email}](mailto:%{support_email}). It may take up to 5 days to receive a response.
           
           Regards
+          
           %{service_name} team

--- a/spec/mailers/claims/user_mailer_spec.rb
+++ b/spec/mailers/claims/user_mailer_spec.rb
@@ -218,27 +218,42 @@ RSpec.describe Claims::UserMailer, type: :mailer do
     subject(:clawback_email) { described_class.claim_requires_clawback(claim, user) }
 
     let(:user) { create(:claims_user) }
-    let(:school) { create(:claims_school, region: regions(:inner_london)) }
-    let(:claim) { create(:claim, reference: "123", school:) }
+    let(:school) { build(:claims_school, region: regions(:inner_london)) }
+    let(:claim) { build(:claim, reference: "123", school:) }
+    let(:mentor_trainings) do
+      create_list(:mentor_training,
+                  2,
+                  :rejected,
+                  claim:,
+                  hours_completed: 5,
+                  hours_clawed_back: 2)
+    end
+
+    before { mentor_trainings }
 
     it "sends the clawback email" do
-      create(:mentor_training, claim:, hours_completed: 10)
-
       expect(clawback_email.to).to contain_exactly(user.email)
-      expect(clawback_email.subject).to eq("ITT mentor claim requires a clawback")
-      expect(clawback_email.body.to_s.strip).to eq(<<~EMAIL.strip)
+      expect(clawback_email.subject).to eq("Your funding for mentor training will be taken back")
+      expect(clawback_email.body.to_s.squish).to eq(<<~EMAIL.squish)
         Dear #{user.first_name},
 
-        We have amended your claim to reflect the amount being clawed back by the payer. They will contact you to discuss how they will claim this money from you.
+        A claim you made was audited and there was insufficient proof from you that some or all of the claim was valid. Your funding for mentor training will be taken from you and returned to the Department for Education.
 
-        The affected claim reference is: #{claim.reference}
+        Retrieving this funding is known as clawback.
 
-        You can view the updated claim on Claim funding for mentor training:
+        Amount being clawed back: £214.40
+        Claim reference: 123
 
-        http://claims.localhost/schools/#{school.id}/claims/#{claim.id}
+        # What happens next
+        The funds will automatically be taken from you.
 
-        # Give feedback or report a problem
-        If you have any questions or feedback, please contact the team at [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk).
+        For academies, any recovery will be offset in your next available monthly payment. For maintained schools, any recovery will be offset in your local authority’s next available monthly payment and they will recover funding from you via their usual processes.
+
+        Sign in to your account on Claim funding for mentor training to see more details:
+        http://claims.localhost/
+
+        # Contact us
+        If you need any help, contact the team at [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk). It may take up to 5 days to receive a response.
 
         Regards
         Claim funding for mentor training team

--- a/spec/mailers/previews/claims/user_mailer_preview.rb
+++ b/spec/mailers/previews/claims/user_mailer_preview.rb
@@ -31,7 +31,7 @@ class Claims::UserMailerPreview < ActionMailer::Preview
   end
 
   def claim
-    Claims::Claim.new(id: SecureRandom.uuid, school:)
+    PreviewClaim.new(id: SecureRandom.uuid, school:, reference: 123_456_789)
   end
 
   def school
@@ -44,5 +44,11 @@ class Claims::UserMailerPreview < ActionMailer::Preview
       claims_funding_available_per_hour_pence: 5360,
       claims_funding_available_per_hour_currency: "GBP",
     )
+  end
+
+  class PreviewClaim < Claims::Claim
+    def total_clawback_amount
+      Money.new(38_910, "GBP")
+    end
   end
 end


### PR DESCRIPTION
## Context

- Content changes to the `Claims::UserMailer.claim_requires_clawback` mailer.

## Changes proposed in this pull request

- Make content changes to the `Claims::UserMailer.claim_requires_clawback` mailer.
- Add code to trigger the `Claims::UserMailer.claim_requires_clawback` in the `Claims::RequestClawbackWizard`

## Guidance to review

- Sign in as Colin (Support user)
- Navigate to Settings
- Click "Emails"
- Click "User Mailer" -> "claim_requires_clawback (opens in new tab)"
- Preview the content changes

## Link to Trello card

https://trello.com/c/pl1BUzIb/425-update-clawback-email-to-schools

## Screenshots

![screencapture-claims-localhost-3000-rails-mailers-claims-user-mailer-claim-requires-clawback-2025-02-21-11_00_18](https://github.com/user-attachments/assets/1b9cb9ec-95b1-41ce-983c-dfceecee835c)

![screencapture-notifications-service-gov-uk-services-022acc23-c40a-4077-bbd6-fc98b2155534-notification-3fabea86-14ac-4c82-a643-ae3f8691cd42-2025-02-21-10_13_34](https://github.com/user-attachments/assets/ea5be4db-b999-4d98-8a7c-3c482f2bb5cf)
