### PR TITLE
"Yes" in an invalid input for uploading provider response

### DIFF
--- a/app/wizards/claims/upload_provider_response_wizard/upload_step.rb
+++ b/app/wizards/claims/upload_provider_response_wizard/upload_step.rb
@@ -135,7 +135,7 @@ class Claims::UploadProviderResponseWizard::UploadStep < BaseStep
   end
 
   def validate_claim_accepted(row, row_number)
-    return if VALID_ASSURED_STATUS.include?(row["claim_accepted"])
+    return if VALID_ASSURED_STATUS.include?(row["claim_accepted"]&.downcase)
 
     invalid_claim_accepted_rows << row_number
   end

--- a/spec/wizards/claims/upload_provider_response_wizard/upload_step_spec.rb
+++ b/spec/wizards/claims/upload_provider_response_wizard/upload_step_spec.rb
@@ -248,6 +248,27 @@ RSpec.describe Claims::UploadProviderResponseWizard::UploadStep, type: :model do
       end
     end
 
+    context "when the csv_content is in the wrong case" do
+      let(:csv_content) do
+        "claim_reference,mentor_full_name,claim_accepted,rejection_reason\r\n" \
+          "11111111,John Smith,Yes,"
+      end
+      let(:attributes) { { csv_content: } }
+
+      let(:sampling_in_progress_claim) do
+        create(:claim, :submitted, status: :sampling_in_progress, reference: 11_111_111)
+      end
+      let(:mentor_john_smith) { create(:claims_mentor, first_name: "John", last_name: "Smith") }
+
+      before do
+        create(:mentor_training, mentor: mentor_john_smith, claim: sampling_in_progress_claim)
+      end
+
+      it "returns true" do
+        expect(csv_inputs_valid).to be(true)
+      end
+    end
+
     context "when the csv_content contains valid claim references and all necessary attributes" do
       let(:csv_content) do
         "claim_reference,mentor_full_name,claim_accepted,rejection_reason\r\n" \


### PR DESCRIPTION
## Context

- Entering "Yes" causes an error when uploading a provider response.

## Changes proposed in this pull request

- [x] Downcase CSV content before checking against the valid assured values.

- Log in as Colin
- Audit some claims
- Upload a provider response with mixed case for the assured status, e.g. "YeS, TRUE, FAlse, No" and check that it works.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

["Yes" in an invalid input for uploading provider response](https://trello.com/c/y8f8CNAV/431-yes-in-an-invalid-input-for-uploading-provider-response)
