### PR TITLE
Multi placement wizard reasons for not taking part in ITT

### DIFF
--- a/app/controllers/placements/schools/placements/add_multiple_placements_controller.rb
+++ b/app/controllers/placements/schools/placements/add_multiple_placements_controller.rb
@@ -1,0 +1,43 @@
+class Placements::Schools::Placements::AddMultiplePlacementsController < Placements::ApplicationController
+  include WizardController
+
+  before_action :set_school
+  before_action :set_wizard
+  before_action :authorize_placement
+
+  attr_reader :school
+
+  def update
+    if !@wizard.save_step
+      render "edit"
+    elsif @wizard.next_step.present?
+      redirect_to step_path(@wizard.next_step)
+    else
+      @wizard.update_school_placements
+      @wizard.reset_state
+      redirect_to index_path, flash: {
+        heading: t(".success"),
+      }
+    end
+  end
+
+  private
+
+  def set_wizard
+    state = session[state_key] ||= {}
+    current_step = params[:step]&.to_sym
+    @wizard = Placements::MultiPlacementWizard.new(school:, params:, state:, current_step:)
+  end
+
+  def authorize_placement
+    authorize school.placements.build, :add_placement_journey?
+  end
+
+  def step_path(step)
+    add_multiple_placements_placements_school_placements_path(state_key:, step:)
+  end
+
+  def index_path
+    placements_school_placements_path(@school)
+  end
+end

--- a/app/controllers/placements/schools/placements/add_multiple_placements_controller.rb
+++ b/app/controllers/placements/schools/placements/add_multiple_placements_controller.rb
@@ -7,6 +7,11 @@ class Placements::Schools::Placements::AddMultiplePlacementsController < Placeme
 
   attr_reader :school
 
+  def new
+    @wizard.setup_state
+    redirect_to step_path(@wizard.first_step)
+  end
+
   def update
     if !@wizard.save_step
       render "edit"
@@ -30,7 +35,7 @@ class Placements::Schools::Placements::AddMultiplePlacementsController < Placeme
   end
 
   def authorize_placement
-    authorize school.placements.build, :add_placement_journey?
+    authorize school.placements.build, :bulk_add_placements?
   end
 
   def step_path(step)

--- a/app/models/placements/academic_year.rb
+++ b/app/models/placements/academic_year.rb
@@ -11,6 +11,7 @@
 #
 class Placements::AcademicYear < AcademicYear
   has_many :placements
+  has_many :hosting_interests
 
   def self.current
     for_date(Date.current)

--- a/app/models/placements/hosting_interest.rb
+++ b/app/models/placements/hosting_interest.rb
@@ -1,0 +1,40 @@
+# == Schema Information
+#
+# Table name: hosting_interests
+#
+#  id                  :uuid             not null, primary key
+#  appetite            :enum
+#  reasons_not_hosting :jsonb
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  academic_year_id    :uuid             not null
+#  school_id           :uuid             not null
+#
+# Indexes
+#
+#  index_hosting_interests_on_academic_year_id                (academic_year_id)
+#  index_hosting_interests_on_school_id                       (school_id)
+#  index_hosting_interests_on_school_id_and_academic_year_id  (school_id,academic_year_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (academic_year_id => academic_years.id)
+#  fk_rails_...  (school_id => schools.id)
+#
+class Placements::HostingInterest < ApplicationRecord
+  belongs_to :academic_year, class_name: "Placements::AcademicYear"
+  belongs_to :school, class_name: "Placements::School"
+
+  validates :academic_year_id, uniqueness: { scope: :school_id }
+
+  enum :appetite,
+       {
+         actively_looking: "actively_looking",
+         interested: "interested",
+         not_open: "not_open",
+         already_organised: "already_organised",
+       },
+       validate: true
+
+  scope :for_academic_year, ->(academic_year) { where(academic_year:) }
+end

--- a/app/models/placements/school.rb
+++ b/app/models/placements/school.rb
@@ -81,6 +81,7 @@ class Placements::School < School
   has_many :partner_providers,
            through: :partnerships,
            source: :provider
+  has_many :hosting_interests
 
   delegate :email_address, to: :school_contact, prefix: true, allow_nil: true
 end

--- a/app/policies/placements/placement_policy.rb
+++ b/app/policies/placements/placement_policy.rb
@@ -15,6 +15,10 @@ class Placements::PlacementPolicy < ApplicationPolicy
     record.provider.blank?
   end
 
+  def bulk_add_placements?
+    Flipper.enabled?(:bulk_add_placements, record.school)
+  end
+
   # Actions in Placements::Schools::PlacementsController
   alias_method :edit_provider?, :new?
   alias_method :edit_mentors?, :new?

--- a/app/views/placements/schools/placements/add_multiple_placements/edit.html.erb
+++ b/app/views/placements/schools/placements/add_multiple_placements/edit.html.erb
@@ -1,0 +1,14 @@
+<%= render "placements/schools/primary_navigation", school: @school, current_navigation: :placements %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: back_link_path) %>
+<% end %>
+
+<div class="govuk-width-container">
+
+  <%= render_wizard(@wizard) %>
+
+  <p class="govuk-body">
+    <%= govuk_link_to(t(".cancel"), placements_school_placements_path(@school), no_visited_state: true) %>
+  </p>
+</div>

--- a/app/views/placements/schools/placements/index.html.erb
+++ b/app/views/placements/schools/placements/index.html.erb
@@ -6,21 +6,30 @@
       <h1 class="govuk-heading-l"><%= t(".placements") %></h1>
 
       <% if @school.school_contact.present? %>
-        <%= govuk_button_link_to(t(".add_placement"), new_add_placement_placements_school_placements_path) %>
+        <div class="govuk-button-group">
+          <%= govuk_button_link_to(t(".add_placement"), new_add_placement_placements_school_placements_path) %>
+          <% if Flipper.enabled?(:bulk_add_placements, @school) %>
+            <%= govuk_button_link_to(t(".bulk_add_placements"), new_add_multiple_placements_placements_school_placements_path) %>
+          <% end %>
+        </div>
 
       <% else %>
         <%= govuk_inset_text(
-              text: embedded_link_text(
-                t(
-                  ".you_must_add_itt_placement_contact",
-                  link_to: govuk_link_to(
-                    t(".add_itt_placement_contact"),
-                    new_add_school_contact_placements_school_school_contacts_path,
-                    no_visited_state: true,
-                  ),
-                ),
+          text: embedded_link_text(
+            t(
+              ".you_must_add_itt_placement_contact",
+              link_to: govuk_link_to(
+                t(".add_itt_placement_contact"),
+                new_add_school_contact_placements_school_school_contacts_path,
+                no_visited_state: true,
               ),
-            ) %>
+            ),
+          ),
+        ) %>
+
+        <% if Flipper.enabled?(:bulk_add_placements, @school) %>
+            <%= govuk_button_link_to(t(".bulk_add_placements"), new_add_multiple_placements_placements_school_placements_path) %>
+          <% end %>
       <% end %>
 
       <%= render SecondaryNavigationComponent.new do |component| %>

--- a/app/views/placements/schools/placements/index.html.erb
+++ b/app/views/placements/schools/placements/index.html.erb
@@ -27,7 +27,7 @@
           ),
         ) %>
 
-        <% if Flipper.enabled?(:bulk_add_placements, @school) %>
+        <% if policy(Placement.new).bulk_add_placements? %>
             <%= govuk_button_link_to(t(".bulk_add_placements"), new_add_multiple_placements_placements_school_placements_path) %>
           <% end %>
       <% end %>

--- a/app/views/wizards/placements/multi_placement_wizard/_appetite_step.html.erb
+++ b/app/views/wizards/placements/multi_placement_wizard/_appetite_step.html.erb
@@ -1,0 +1,21 @@
+<% content_for :page_title, title_with_error_prefix(
+  t(".title", academic_year_name: @wizard.upcoming_academic_year.name),
+  error: current_step.errors.any?,
+) %>
+
+<%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_collection_radio_buttons(
+        :appetite,
+        current_step.appetite_options,
+        :value, :name, :description,
+        legend: { size: "l", text: t(".title", academic_year_name: @wizard.upcoming_academic_year.name), tag: "h1" }
+      ) %>
+
+      <%= f.govuk_submit t(".continue") %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/wizards/placements/multi_placement_wizard/_help_step.html.erb
+++ b/app/views/wizards/placements/multi_placement_wizard/_help_step.html.erb
@@ -1,0 +1,22 @@
+<% content_for :page_title, title_with_error_prefix(
+  t(".title"),
+  error: current_step.errors.any?,
+) %>
+
+<%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+
+      <p class="govuk-body"><%= t(".did_you_know_html") %></p>
+
+      <h2 class="govuk-heading-m"><%= t(".training_providers") %></h2>
+
+      <p class="govuk-body"><%= t(".local_providers") %></p>
+
+      <%# TODO: Add local providers here after Geocoding added %>
+
+      <%= f.govuk_submit t(".continue") %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/wizards/placements/multi_placement_wizard/_reason_not_hosting_step.html.erb
+++ b/app/views/wizards/placements/multi_placement_wizard/_reason_not_hosting_step.html.erb
@@ -1,0 +1,22 @@
+<% content_for :page_title, title_with_error_prefix(
+  t(".title"),
+  error: current_step.errors.any?,
+) %>
+
+<%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_collection_check_boxes(
+        :reasons_not_hosting,
+        current_step.reason_options,
+        :value, :name,
+        legend: { size: "l", text: t(".title"), tag: "h1" },
+        hint: { text: t(".hint") }
+      ) %>
+
+      <%= f.govuk_submit t(".continue") %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/wizards/placements/multi_placement_wizard/_school_contact_step.html.erb
+++ b/app/views/wizards/placements/multi_placement_wizard/_school_contact_step.html.erb
@@ -1,0 +1,32 @@
+<% content_for :page_title, title_with_error_prefix(
+  t(".title"),
+  error: current_step.errors.any?,
+) %>
+
+<%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+
+      <div class="govuk-form-group">
+        <%= f.govuk_text_field :first_name,
+                               width: 20,
+                               label: { text: User.human_attribute_name(:first_name), size: "s" } %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= f.govuk_text_field :last_name,
+                               width: 20,
+                               label: { text: User.human_attribute_name(:last_name), size: "s" } %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= f.govuk_text_field :email_address, label: { text: User.human_attribute_name(:email_address), size: "s" } %>
+      </div>
+
+      <%= f.govuk_submit t(".continue") %>
+    </div>
+  </div>
+<% end %>

--- a/app/wizards/placements/multi_placement_wizard.rb
+++ b/app/wizards/placements/multi_placement_wizard.rb
@@ -1,0 +1,64 @@
+module Placements
+  class MultiPlacementWizard < BaseWizard
+    attr_reader :school
+
+    delegate :school_contact, to: :school
+
+    def initialize(school:, params:, state:, current_step: nil)
+      @school = school
+      super(state:, params:, current_step:)
+    end
+
+    def define_steps
+      # Define the wizard steps here
+      add_step(AppetiteStep)
+      if appetite == "not_open"
+        add_step(ReasonNotHostingStep)
+        add_step(HelpStep)
+      end
+      add_step(SchoolContactStep)
+    end
+
+    def update_school_placements
+      raise "Invalid wizard state" unless valid?
+
+      hosting_interest.appetite = appetite
+      if steps[:reason_not_hosting].present?
+        hosting_interest.reasons_not_hosting = reasons_not_hosting
+      end
+
+      hosting_interest.save!
+
+      wizard_school_contact.first_name = steps[:school_contact].first_name
+      wizard_school_contact.last_name = steps[:school_contact].last_name
+      wizard_school_contact.email_address = steps[:school_contact].email_address
+
+      wizard_school_contact.save!
+    end
+
+    def upcoming_academic_year
+      @upcoming_academic_year ||= AcademicYear.current.next
+    end
+
+    private
+
+    def wizard_school_contact
+      @wizard_school_contact = steps[:school_contact].school_contact
+    end
+
+    def appetite
+      @appetite ||= steps.fetch(:appetite).appetite
+    end
+
+    def reasons_not_hosting
+      @reasons_not_hosting ||= steps.fetch(:reason_not_hosting).reasons_not_hosting
+    end
+
+    def hosting_interest
+      @hosting_interest ||= begin
+        upcoming_interest = school.hosting_interests.for_academic_year(upcoming_academic_year).last
+        upcoming_interest.presence || school.hosting_interests.build(academic_year: upcoming_academic_year)
+      end
+    end
+  end
+end

--- a/app/wizards/placements/multi_placement_wizard.rb
+++ b/app/wizards/placements/multi_placement_wizard.rb
@@ -40,6 +40,21 @@ module Placements
       @upcoming_academic_year ||= AcademicYear.current.next
     end
 
+    def setup_state
+      unless hosting_interest.new_record?
+        state["appetite"] = { "appetite" => hosting_interest.appetite }
+        state["reason_not_hosting"] = { "reasons_not_hosting" => hosting_interest.reasons_not_hosting }
+      end
+
+      if school_contact.present?
+        state["school_contact"] = {
+          "first_name" => school_contact.first_name,
+          "last_name" => school_contact.last_name,
+          "email_address" => school_contact.email_address,
+        }
+      end
+    end
+
     private
 
     def wizard_school_contact

--- a/app/wizards/placements/multi_placement_wizard/appetite_step.rb
+++ b/app/wizards/placements/multi_placement_wizard/appetite_step.rb
@@ -1,0 +1,30 @@
+class Placements::MultiPlacementWizard::AppetiteStep < BaseStep
+  attribute :appetite
+
+  validates :appetite, presence: true, inclusion: { in: ->(step) { step.placement_appetites } }
+
+  def appetite_options
+    options = Struct.new(:value, :name, :description)
+    placement_appetites.map do |key|
+      options.new(
+        value: key,
+        name: I18n.t(
+          "#{locale_path}.options.#{key}.name",
+        ),
+        description: I18n.t(
+          "#{locale_path}.options.#{key}.description",
+        ),
+      )
+    end
+  end
+
+  def placement_appetites
+    @placement_appetites ||= Placements::HostingInterest.appetites.keys
+  end
+
+  private
+
+  def locale_path
+    ".wizards.placements.multi_placement_wizard.appetite_step"
+  end
+end

--- a/app/wizards/placements/multi_placement_wizard/help_step.rb
+++ b/app/wizards/placements/multi_placement_wizard/help_step.rb
@@ -1,0 +1,2 @@
+class Placements::MultiPlacementWizard::HelpStep < BaseStep
+end

--- a/app/wizards/placements/multi_placement_wizard/reason_not_hosting_step.rb
+++ b/app/wizards/placements/multi_placement_wizard/reason_not_hosting_step.rb
@@ -1,0 +1,36 @@
+class Placements::MultiPlacementWizard::ReasonNotHostingStep < BaseStep
+  attribute :reasons_not_hosting, default: []
+
+  validates :reasons_not_hosting, presence: true
+
+  def reason_options
+    options = Struct.new(:name, :value)
+    reasons.map do |a_reason|
+      options.new(name: a_reason, value: a_reason)
+    end
+  end
+
+  def reasons_not_hosting=(value)
+    super normalised_reasons_not_hosting(value)
+  end
+
+  private
+
+  def normalised_reasons_not_hosting(selected_reasons)
+    return [] if selected_reasons.blank?
+
+    selected_reasons.reject(&:blank?)
+  end
+
+  def reasons
+    [
+      I18n.t("#{locale_path}.options.not_enough_trained_mentors"),
+      I18n.t("#{locale_path}.options.number_of_pupils_with_send_needs"),
+      I18n.t("#{locale_path}.options.working_to_improve_our_ofsted_rating"),
+    ]
+  end
+
+  def locale_path
+    ".wizards.placements.multi_placement_wizard.reason_not_hosting_step"
+  end
+end

--- a/app/wizards/placements/multi_placement_wizard/school_contact_step.rb
+++ b/app/wizards/placements/multi_placement_wizard/school_contact_step.rb
@@ -1,0 +1,5 @@
+class Placements::MultiPlacementWizard::SchoolContactStep < Placements::AddSchoolContactWizard::SchoolContactStep
+  def school_contact
+    @school_contact ||= wizard.school_contact.presence || school.build_school_contact(first_name:, last_name:, email_address:)
+  end
+end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -155,3 +155,11 @@ shared:
     - data
     - created_at
     - updated_at
+  :hosting_interests:
+    - id
+    - academic_year_id
+    - school_id
+    - appetite
+    - reasons_not_hosting
+    - created_at
+    - updated_at

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -283,3 +283,13 @@ en:
             support_user_id: 
               blank: Please select a support agent
               inclusion: Please select a support agent
+        placements/multi_placement_wizard/appetite_step:
+          attributes:
+            appetite: 
+              blank: Please select your appetite to host ITT for the coming academic year
+              inclusion: Please select your appetite to host ITT for the coming academic year
+        placements/multi_placement_wizard/reason_not_hosting_step:
+          attributes:
+            reasons_not_hosting: 
+              blank: Please select a reason for not taking part in ITT
+

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -41,6 +41,11 @@ en:
           edit:
             cancel: Cancel
             placement_details: Placement details
+        add_multiple_placements:
+          edit:
+            cancel: Cancel
+          update:
+            success: Thank you for providing your responses
         edit_placement:
           update:
             success: 

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -88,6 +88,7 @@ en:
           this_year: This year (%{academic_year_name})
           next_year: Next year (%{academic_year_name})
           add_placement: Add placement
+          bulk_add_placements: Bulk add placements
           you_must_add_itt_placement_contact: |
             Before you add a placement, you must %{link_to} so that the teacher training providers can contact you.
           add_itt_placement_contact: add a placement contact

--- a/config/locales/en/wizards/placements/multi_placement_wizard.yml
+++ b/config/locales/en/wizards/placements/multi_placement_wizard.yml
@@ -1,0 +1,40 @@
+en:
+  wizards:
+    placements:
+      multi_placement_wizard:
+        appetite_step:
+          title: What is your appetite for ITT the coming academic year (%{academic_year_name})?
+          continue: Continue
+          options:
+            actively_looking:
+              name: Actively looking to host placements
+              description: You'll have to the option to specify what you'd like to host in the next step
+            interested:
+              name: Interested in hosting placements
+              description: Providers will be able to contact you and discuss
+            not_open: 
+              name: Not open to hosting placements
+              description: Providers will not be able to contact you using this service this academic year
+            already_organised:
+              name: Placements already organised with providers
+              description: We'll show any providers who search for you that you're at capacity
+        reason_not_hosting_step:
+          title: What are your reasons for not taking part in ITT this year?
+          continue: Continue
+          hint: "Select all that apply"
+          options:
+            not_enough_trained_mentors: Not enough trained mentors
+            number_of_pupils_with_send_needs: Number of pupils with SEND needs
+            working_to_improve_our_ofsted_rating: Working to improve our OFSTED rating
+        help_step:
+          title: Help available to you
+          continue: Continue
+          did_you_know_html: |
+            Did you know that training providers are able to help specifically with making placements work in SEND environments?
+            <br><br>
+            There are a number of organisations who could help you to make teacher training work.
+          training_providers: Training providers
+          local_providers: These training providers are local to you and could help.
+        school_contact_step:
+          title: Who is your contact for ITT?
+          continue: Continue

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -78,6 +78,10 @@ scope module: :placements,
           get "new", to: "placements/add_placement#new", as: :new_add_placement
           get "new/:state_key/:step", to: "placements/add_placement#edit", as: :add_placement
           put "new/:state_key/:step", to: "placements/add_placement#update"
+
+          get "multiple", to: "placements/add_multiple_placements#new", as: :new_add_multiple_placements
+          get "multiple/:state_key/:step", to: "placements/add_multiple_placements#edit", as: :add_multiple_placements
+          put "multiple/:state_key/:step", to: "placements/add_multiple_placements#update"
         end
       end
 

--- a/db/migrate/20250224102221_create_hosting_interests.rb
+++ b/db/migrate/20250224102221_create_hosting_interests.rb
@@ -1,0 +1,14 @@
+class CreateHostingInterests < ActiveRecord::Migration[7.2]
+  create_enum :appetite, %w[actively_looking interested not_open already_organised]
+
+  def change
+    create_table :hosting_interests, id: :uuid do |t|
+      t.references :academic_year, null: false, foreign_key: true, type: :uuid
+      t.references :school, null: false, foreign_key: true, type: :uuid
+      t.enum :appetite, enum_type: "appetite"
+      t.jsonb :reasons_not_hosting
+      t.index %i[school_id academic_year_id], unique: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250225141558_add_bulk_add_placements_flag.rb
+++ b/db/migrate/20250225141558_add_bulk_add_placements_flag.rb
@@ -1,0 +1,5 @@
+class AddBulkAddPlacementsFlag < ActiveRecord::Migration[7.2]
+  def change
+    Flipper.add(:bulk_add_placements)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_24_092828) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_24_102221) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
+  create_enum "appetite", ["actively_looking", "interested", "not_open", "already_organised"]
   create_enum "claim_status", ["internal_draft", "draft", "submitted", "payment_in_progress", "payment_information_requested", "payment_information_sent", "paid", "payment_not_approved", "sampling_in_progress", "sampling_provider_not_approved", "sampling_not_approved", "clawback_requested", "clawback_in_progress", "clawback_complete"]
   create_enum "mentor_training_type", ["refresher", "initial"]
   create_enum "placement_status", ["draft", "published"]
@@ -261,6 +262,18 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_24_092828) do
     t.index ["priority", "scheduled_at"], name: "index_good_jobs_on_priority_scheduled_at_unfinished_unlocked", where: "((finished_at IS NULL) AND (locked_by_id IS NULL))"
     t.index ["queue_name", "scheduled_at"], name: "index_good_jobs_on_queue_name_and_scheduled_at", where: "(finished_at IS NULL)"
     t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
+  end
+
+  create_table "hosting_interests", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "academic_year_id", null: false
+    t.uuid "school_id", null: false
+    t.enum "appetite", enum_type: "appetite"
+    t.jsonb "reasons_not_hosting"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["academic_year_id"], name: "index_hosting_interests_on_academic_year_id"
+    t.index ["school_id", "academic_year_id"], name: "index_hosting_interests_on_school_id_and_academic_year_id", unique: true
+    t.index ["school_id"], name: "index_hosting_interests_on_school_id"
   end
 
   create_table "mentor_memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -598,6 +611,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_24_092828) do
   add_foreign_key "claims", "schools"
   add_foreign_key "clawback_claims", "claims"
   add_foreign_key "clawback_claims", "clawbacks"
+  add_foreign_key "hosting_interests", "academic_years"
+  add_foreign_key "hosting_interests", "schools"
   add_foreign_key "mentor_memberships", "mentors"
   add_foreign_key "mentor_memberships", "schools"
   add_foreign_key "mentor_trainings", "claims"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_24_102221) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_25_141558) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"

--- a/spec/factories/hosting_interests.rb
+++ b/spec/factories/hosting_interests.rb
@@ -1,0 +1,36 @@
+# == Schema Information
+#
+# Table name: hosting_interests
+#
+#  id                  :uuid             not null, primary key
+#  appetite            :enum
+#  reasons_not_hosting :jsonb
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  academic_year_id    :uuid             not null
+#  school_id           :uuid             not null
+#
+# Indexes
+#
+#  index_hosting_interests_on_academic_year_id                (academic_year_id)
+#  index_hosting_interests_on_school_id                       (school_id)
+#  index_hosting_interests_on_school_id_and_academic_year_id  (school_id,academic_year_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (academic_year_id => academic_years.id)
+#  fk_rails_...  (school_id => schools.id)
+#
+FactoryBot.define do
+  factory :hosting_interest, class: Placements::HostingInterest do
+    academic_year { Placements::AcademicYear.current }
+
+    association :school, factory: :placements_school
+
+    appetite { "actively_looking" }
+
+    trait :for_next_year do
+      academic_year { Placements::AcademicYear.current.next }
+    end
+  end
+end

--- a/spec/models/placements/hosting_interest_spec.rb
+++ b/spec/models/placements/hosting_interest_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe Placements::HostingInterest, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:school) }
+    it { is_expected.to belong_to(:academic_year) }
+  end
+
+  describe "validations" do
+    subject(:hosting_interest) { build(:hosting_interest) }
+
+    it { is_expected.to validate_uniqueness_of(:academic_year_id).scoped_to(:school_id).case_insensitive }
+  end
+
+  describe "enums" do
+    subject(:hosting_interest) { build(:hosting_interest) }
+
+    it "defines the expected values" do
+      expect(hosting_interest).to define_enum_for(:appetite)
+        .with_values(
+          actively_looking: "actively_looking",
+          interested: "interested",
+          not_open: "not_open",
+          already_organised: "already_organised",
+        )
+        .backed_by_column_of_type(:enum)
+    end
+  end
+
+  describe "scopes" do
+    describe "for_academic_year" do
+      let(:current_year_hosting_interest_1) { create(:hosting_interest) }
+      let(:current_year_hosting_interest_2) { create(:hosting_interest) }
+      let(:previous_year_hosting_interest) do
+        create(:hosting_interest, academic_year: Placements::AcademicYear.current.previous)
+      end
+      let(:next_year_hosting_interest) do
+        create(:hosting_interest, academic_year: Placements::AcademicYear.current.previous)
+      end
+
+      it "returns the hosting interests for the given academic year" do
+        expect(
+          described_class.for_academic_year(Placements::AcademicYear.current),
+        ).to contain_exactly(
+          current_year_hosting_interest_1,
+          current_year_hosting_interest_2,
+        )
+      end
+    end
+  end
+end

--- a/spec/models/placements/hosting_interest_spec.rb
+++ b/spec/models/placements/hosting_interest_spec.rb
@@ -1,3 +1,26 @@
+# == Schema Information
+#
+# Table name: hosting_interests
+#
+#  id                  :uuid             not null, primary key
+#  appetite            :enum
+#  reasons_not_hosting :jsonb
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  academic_year_id    :uuid             not null
+#  school_id           :uuid             not null
+#
+# Indexes
+#
+#  index_hosting_interests_on_academic_year_id                (academic_year_id)
+#  index_hosting_interests_on_school_id                       (school_id)
+#  index_hosting_interests_on_school_id_and_academic_year_id  (school_id,academic_year_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (academic_year_id => academic_years.id)
+#  fk_rails_...  (school_id => schools.id)
+#
 require "rails_helper"
 
 RSpec.describe Placements::HostingInterest, type: :model do

--- a/spec/policies/placements/placement_policy_spec.rb
+++ b/spec/policies/placements/placement_policy_spec.rb
@@ -45,6 +45,29 @@ RSpec.describe Placements::PlacementPolicy do
     end
   end
 
+  permissions :bulk_add_placements? do
+    let(:school) { create(:placements_school) }
+    let(:placement) { build(:placement) }
+
+    before { Flipper.add(:bulk_add_placements) }
+
+    context "when the feature flag bulk_add_placements is disabled" do
+      before { Flipper.disable(:bulk_add_placements) }
+
+      it "denies access" do
+        expect(placement_policy).not_to permit(current_user, placement)
+      end
+    end
+
+    context "when the feature flag bulk_add_placements is enabled" do
+      before { Flipper.enable(:bulk_add_placements) }
+
+      it "denies access" do
+        expect(placement_policy).to permit(current_user, placement)
+      end
+    end
+  end
+
   describe "scope" do
     let(:scope) { Placement.all }
 

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_not_open/school_user_does_not_enter_any_school_contact_details_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_not_open/school_user_does_not_enter_any_school_contact_details_spec.rb
@@ -1,0 +1,140 @@
+require "rails_helper"
+
+RSpec.describe "School user does not enter any school contact details",
+               service: :placements,
+               type: :system do
+  scenario do
+    given_the_bulk_add_placements_flag_is_enabled
+    and_academic_years_exist
+    and_i_am_signed_in
+    when_i_am_on_the_placements_index_page
+    and_i_click_on_bulk_add_placements
+    then_i_see_the_appetite_form
+
+    when_i_select_not_open_to_hosting_placements
+    and_i_click_on_continue
+    then_i_see_the_reasons_for_not_hosting_form
+
+    when_i_select_not_enough_trained_mentors
+    and_i_select_number_of_pupils_with_send_needs
+    and_i_click_on_continue
+    then_i_see_the_help_available_to_you_page
+
+    when_i_click_on_continue
+    then_i_see_the_school_contact_form
+
+    when_i_click_on_continue
+    then_i_see_a_validation_error_for_entering_a_school_contact_email_address
+  end
+
+  private
+
+  def given_the_bulk_add_placements_flag_is_enabled
+    Flipper.add(:bulk_add_placements)
+    Flipper.enable(:bulk_add_placements)
+  end
+
+  def and_academic_years_exist
+    current_academic_year = Placements::AcademicYear.current
+    @current_academic_year_name = current_academic_year.name
+    @next_academic_year = current_academic_year.next
+    @next_academic_year_name = @next_academic_year.name
+  end
+
+  def and_i_am_signed_in
+    @school = create(:placements_school, with_school_contact: false)
+    sign_in_placements_user(organisations: [@school])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Placements")
+    expect(secondary_navigation).to have_current_item("This year (#{@current_academic_year_name}")
+    expect(page).to have_link("Bulk add placements")
+  end
+  alias_method :then_i_am_on_the_placements_index_page,
+               :when_i_am_on_the_placements_index_page
+
+  def when_i_click_on_bulk_add_placements
+    click_on "Bulk add placements"
+  end
+  alias_method :and_i_click_on_bulk_add_placements,
+               :when_i_click_on_bulk_add_placements
+
+  def then_i_see_the_appetite_form
+    expect(page).to have_title(
+      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Actively looking to host placements", type: :radio)
+    expect(page).to have_field("Interested in hosting placements", type: :radio)
+    expect(page).to have_field("Not open to hosting placements", type: :radio)
+    expect(page).to have_field("Placements already organised with providers", type: :radio)
+  end
+
+  def when_i_select_not_open_to_hosting_placements
+    choose "Not open to hosting placements"
+  end
+
+  def when_i_click_on_continue
+    click_on "Continue"
+  end
+  alias_method :and_i_click_on_continue,
+               :when_i_click_on_continue
+
+  def then_i_see_the_reasons_for_not_hosting_form
+    expect(page).to have_title(
+      "What are your reasons for not taking part in ITT this year? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "What are your reasons for not taking part in ITT this year?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Not enough trained mentors", type: :checkbox)
+    expect(page).to have_field("Number of pupils with SEND needs", type: :checkbox)
+    expect(page).to have_field("Working to improve our OFSTED rating", type: :checkbox)
+  end
+
+  def when_i_select_not_enough_trained_mentors
+    check "Not enough trained mentors"
+  end
+
+  def and_i_select_number_of_pupils_with_send_needs
+    check "Number of pupils with SEND needs"
+  end
+
+  def then_i_see_the_help_available_to_you_page
+    expect(page).to have_title(
+      "Help available to you - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Help available to you")
+  end
+
+  def then_i_see_the_school_contact_form
+    expect(page).to have_title(
+      "Who is your contact for ITT? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Who is your contact for ITT?")
+
+    @school_contact = @school.school_contact
+    expect(page).to have_field("First name")
+    expect(page).to have_field("Last name")
+    expect(page).to have_field("Email address")
+  end
+
+  def then_i_see_a_validation_error_for_entering_a_school_contact_email_address
+    expect(page).to have_validation_error(
+      "Enter an email address",
+    )
+  end
+end

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_not_open/school_user_does_not_select_any_reasons_not_to_host_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_not_open/school_user_does_not_select_any_reasons_not_to_host_spec.rb
@@ -1,0 +1,104 @@
+require "rails_helper"
+
+RSpec.describe "School user does not select any reasons not to host",
+               service: :placements,
+               type: :system do
+  scenario do
+    given_the_bulk_add_placements_flag_is_enabled
+    and_academic_years_exist
+    and_i_am_signed_in
+    when_i_am_on_the_placements_index_page
+    and_i_click_on_bulk_add_placements
+    then_i_see_the_appetite_form
+
+    when_i_select_not_open_to_hosting_placements
+    and_i_click_on_continue
+    then_i_see_the_reasons_for_not_hosting_form
+
+    when_i_click_on_continue
+    then_i_see_a_validation_error_for_selection_a_reason_not_to_host
+  end
+
+  private
+
+  def given_the_bulk_add_placements_flag_is_enabled
+    Flipper.add(:bulk_add_placements)
+    Flipper.enable(:bulk_add_placements)
+  end
+
+  def and_academic_years_exist
+    current_academic_year = Placements::AcademicYear.current
+    @current_academic_year_name = current_academic_year.name
+    @next_academic_year = current_academic_year.next
+    @next_academic_year_name = @next_academic_year.name
+  end
+
+  def and_i_am_signed_in
+    @school = create(:placements_school)
+    sign_in_placements_user(organisations: [@school])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Placements")
+    expect(secondary_navigation).to have_current_item("This year (#{@current_academic_year_name}")
+    expect(page).to have_link("Add placement")
+    expect(page).to have_link("Bulk add placements")
+  end
+  alias_method :then_i_am_on_the_placements_index_page,
+               :when_i_am_on_the_placements_index_page
+
+  def when_i_click_on_bulk_add_placements
+    click_on "Bulk add placements"
+  end
+  alias_method :and_i_click_on_bulk_add_placements,
+               :when_i_click_on_bulk_add_placements
+
+  def then_i_see_the_appetite_form
+    expect(page).to have_title(
+      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Actively looking to host placements", type: :radio)
+    expect(page).to have_field("Interested in hosting placements", type: :radio)
+    expect(page).to have_field("Not open to hosting placements", type: :radio)
+    expect(page).to have_field("Placements already organised with providers", type: :radio)
+  end
+
+  def when_i_select_not_open_to_hosting_placements
+    choose "Not open to hosting placements"
+  end
+
+  def when_i_click_on_continue
+    click_on "Continue"
+  end
+  alias_method :and_i_click_on_continue,
+               :when_i_click_on_continue
+
+  def then_i_see_the_reasons_for_not_hosting_form
+    expect(page).to have_title(
+      "What are your reasons for not taking part in ITT this year? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "What are your reasons for not taking part in ITT this year?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Not enough trained mentors", type: :checkbox)
+    expect(page).to have_field("Number of pupils with SEND needs", type: :checkbox)
+    expect(page).to have_field("Working to improve our OFSTED rating", type: :checkbox)
+  end
+
+  def then_i_see_a_validation_error_for_selection_a_reason_not_to_host
+    expect(page).to have_validation_error(
+      "Please select a reason for not taking part in ITT",
+    )
+  end
+end

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_not_open/school_user_successfully_completes_the_not_open_journey_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_not_open/school_user_successfully_completes_the_not_open_journey_spec.rb
@@ -1,0 +1,205 @@
+require "rails_helper"
+
+RSpec.describe "School user successfully completes the not open journey",
+               service: :placements,
+               type: :system do
+  scenario do
+    given_the_bulk_add_placements_flag_is_enabled
+    and_academic_years_exist
+    and_i_am_signed_in
+    when_i_am_on_the_placements_index_page
+    and_i_click_on_bulk_add_placements
+    then_i_see_the_appetite_form
+
+    when_i_select_not_open_to_hosting_placements
+    and_i_click_on_continue
+    then_i_see_the_reasons_for_not_hosting_form
+
+    when_i_select_not_enough_trained_mentors
+    and_i_select_number_of_pupils_with_send_needs
+    and_i_click_on_continue
+    then_i_see_the_help_available_to_you_page
+
+    when_i_click_on_continue
+    then_i_see_the_school_contact_form
+
+    when_i_click_on_back
+    then_i_see_the_help_available_to_you_page
+
+    when_i_click_on_back
+    then_i_see_the_reasons_for_not_hosting_form
+
+    when_i_click_on_back
+    then_i_see_the_appetite_form
+
+    when_i_click_on_back
+    then_i_am_on_the_placements_index_page
+
+    when_i_click_on_bulk_add_placements
+    then_i_see_the_appetite_form
+
+    when_i_click_on_cancel
+    then_i_am_on_the_placements_index_page
+
+    when_i_click_on_bulk_add_placements
+    then_i_see_the_appetite_form
+
+    when_i_select_not_open_to_hosting_placements
+    and_i_click_on_continue
+    then_i_see_the_reasons_for_not_hosting_form
+
+    when_i_select_not_enough_trained_mentors
+    and_i_select_number_of_pupils_with_send_needs
+    and_i_click_on_continue
+    then_i_see_the_help_available_to_you_page
+
+    when_i_click_on_continue
+    then_i_see_the_school_contact_form
+
+    when_i_fill_in_the_school_contact_details
+    and_i_click_on_continue
+    then_i_see_my_responses_with_successfully_updated
+    and_the_schools_contact_has_been_updated
+    and_the_schools_hosting_interest_for_the_next_year_is_updated
+  end
+
+  private
+
+  def given_the_bulk_add_placements_flag_is_enabled
+    Flipper.add(:bulk_add_placements)
+    Flipper.enable(:bulk_add_placements)
+  end
+
+  def and_academic_years_exist
+    current_academic_year = Placements::AcademicYear.current
+    @current_academic_year_name = current_academic_year.name
+    @next_academic_year = current_academic_year.next
+    @next_academic_year_name = @next_academic_year.name
+  end
+
+  def and_i_am_signed_in
+    @school = create(:placements_school)
+    sign_in_placements_user(organisations: [@school])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Placements")
+    expect(secondary_navigation).to have_current_item("This year (#{@current_academic_year_name}")
+    expect(page).to have_link("Add placement")
+    expect(page).to have_link("Bulk add placements")
+  end
+  alias_method :then_i_am_on_the_placements_index_page,
+               :when_i_am_on_the_placements_index_page
+
+  def when_i_click_on_bulk_add_placements
+    click_on "Bulk add placements"
+  end
+  alias_method :and_i_click_on_bulk_add_placements,
+               :when_i_click_on_bulk_add_placements
+
+  def then_i_see_the_appetite_form
+    expect(page).to have_title(
+      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Actively looking to host placements", type: :radio)
+    expect(page).to have_field("Interested in hosting placements", type: :radio)
+    expect(page).to have_field("Not open to hosting placements", type: :radio)
+    expect(page).to have_field("Placements already organised with providers", type: :radio)
+  end
+
+  def when_i_select_not_open_to_hosting_placements
+    choose "Not open to hosting placements"
+  end
+
+  def when_i_click_on_continue
+    click_on "Continue"
+  end
+  alias_method :and_i_click_on_continue,
+               :when_i_click_on_continue
+
+  def then_i_see_the_reasons_for_not_hosting_form
+    expect(page).to have_title(
+      "What are your reasons for not taking part in ITT this year? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "What are your reasons for not taking part in ITT this year?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Not enough trained mentors", type: :checkbox)
+    expect(page).to have_field("Number of pupils with SEND needs", type: :checkbox)
+    expect(page).to have_field("Working to improve our OFSTED rating", type: :checkbox)
+  end
+
+  def when_i_select_not_enough_trained_mentors
+    check "Not enough trained mentors"
+  end
+
+  def and_i_select_number_of_pupils_with_send_needs
+    check "Number of pupils with SEND needs"
+  end
+
+  def then_i_see_the_help_available_to_you_page
+    expect(page).to have_title(
+      "Help available to you - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Help available to you")
+  end
+
+  def then_i_see_the_school_contact_form
+    expect(page).to have_title(
+      "Who is your contact for ITT? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Who is your contact for ITT?")
+
+    @school_contact = @school.school_contact
+    expect(page).to have_field("First name", with: @school_contact.first_name)
+    expect(page).to have_field("Last name", with: @school_contact.last_name)
+    expect(page).to have_field("Email address", with: @school_contact.email_address)
+  end
+
+  def when_i_click_on_back
+    click_on "Back"
+  end
+
+  def when_i_click_on_cancel
+    click_on "Cancel"
+  end
+
+  def when_i_fill_in_the_school_contact_details
+    fill_in "First name", with: "Joe"
+    fill_in "Last name", with: "Bloggs"
+    fill_in "Email address", with: "joe_bloggs@example.com"
+  end
+
+  def then_i_see_my_responses_with_successfully_updated
+    expect(page).to have_success_banner("Thank you for providing your responses")
+  end
+
+  def and_the_schools_contact_has_been_updated
+    @school_contact.reload
+    expect(@school_contact.first_name).to eq("Joe")
+    expect(@school_contact.last_name).to eq("Bloggs")
+    expect(@school_contact.email_address).to eq("joe_bloggs@example.com")
+  end
+
+  def and_the_schools_hosting_interest_for_the_next_year_is_updated
+    hosting_interest = @school.hosting_interests.for_academic_year(@next_academic_year).last
+    expect(hosting_interest.appetite).to eq("not_open")
+    expect(hosting_interest.reasons_not_hosting).to contain_exactly(
+      "Not enough trained mentors",
+      "Number of pupils with SEND needs",
+    )
+  end
+end

--- a/spec/system/placements/schools/placements/bulk_add_placements/school_user_does_not_select_an_appetite_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/school_user_does_not_select_an_appetite_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+RSpec.describe "School user does not select an appetite",
+               service: :placements,
+               type: :system do
+  scenario do
+    given_the_bulk_add_placements_flag_is_enabled
+    and_academic_years_exist
+    and_i_am_signed_in
+    when_i_am_on_the_placements_index_page
+    and_i_click_on_bulk_add_placements
+    then_i_see_the_appetite_form
+
+    when_i_click_on_continue
+    then_i_see_a_validation_error_for_selection_an_appetite
+  end
+
+  private
+
+  def given_the_bulk_add_placements_flag_is_enabled
+    Flipper.add(:bulk_add_placements)
+    Flipper.enable(:bulk_add_placements)
+  end
+
+  def and_academic_years_exist
+    current_academic_year = Placements::AcademicYear.current
+    @current_academic_year_name = current_academic_year.name
+    @next_academic_year = current_academic_year.next
+    @next_academic_year_name = @next_academic_year.name
+  end
+
+  def and_i_am_signed_in
+    @school = create(:placements_school)
+    sign_in_placements_user(organisations: [@school])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Placements")
+    expect(secondary_navigation).to have_current_item("This year (#{@current_academic_year_name}")
+    expect(page).to have_link("Add placement")
+    expect(page).to have_link("Bulk add placements")
+  end
+  alias_method :then_i_am_on_the_placements_index_page,
+               :when_i_am_on_the_placements_index_page
+
+  def when_i_click_on_bulk_add_placements
+    click_on "Bulk add placements"
+  end
+  alias_method :and_i_click_on_bulk_add_placements,
+               :when_i_click_on_bulk_add_placements
+
+  def then_i_see_the_appetite_form
+    expect(page).to have_title(
+      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Actively looking to host placements", type: :radio)
+    expect(page).to have_field("Interested in hosting placements", type: :radio)
+    expect(page).to have_field("Not open to hosting placements", type: :radio)
+    expect(page).to have_field("Placements already organised with providers", type: :radio)
+  end
+
+  def when_i_click_on_continue
+    click_on "Continue"
+  end
+  alias_method :and_i_click_on_continue,
+               :when_i_click_on_continue
+
+  def then_i_see_a_validation_error_for_selection_an_appetite
+    expect(page).to have_validation_error(
+      "Please select your appetite to host ITT for the coming academic year",
+    )
+  end
+end

--- a/spec/wizards/placements/multi_placement_wizard/appetite_step_spec.rb
+++ b/spec/wizards/placements/multi_placement_wizard/appetite_step_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe Placements::MultiPlacementWizard::AppetiteStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Placements::MultiPlacementWizard).tap do |mock_wizard|
+      allow(mock_wizard).to receive(:school).and_return(school)
+    end
+  end
+
+  let(:attributes) { nil }
+  let!(:school) { create(:placements_school) }
+
+  describe "attributes" do
+    it { is_expected.to have_attributes(appetite: nil) }
+  end
+
+  describe "validations" do
+    it {
+      expect(step).to validate_inclusion_of(:appetite).in_array(
+        Placements::HostingInterest.appetites.keys,
+      )
+    }
+  end
+
+  describe "#appetite_options" do
+    subject(:appetite_options) { step.appetite_options }
+
+    it "returns struct objects for each appetite" do
+      actively_looking = appetite_options[0]
+      interested = appetite_options[1]
+      not_open = appetite_options[2]
+      already_organised = appetite_options[3]
+
+      expect(actively_looking.value).to eq("actively_looking")
+      expect(actively_looking.name).to eq("Actively looking to host placements")
+      expect(actively_looking.description).to eq(
+        "You'll have to the option to specify what you'd like to host in the next step",
+      )
+
+      expect(interested.value).to eq("interested")
+      expect(interested.name).to eq("Interested in hosting placements")
+      expect(interested.description).to eq(
+        "Providers will be able to contact you and discuss",
+      )
+
+      expect(not_open.value).to eq("not_open")
+      expect(not_open.name).to eq("Not open to hosting placements")
+      expect(not_open.description).to eq(
+        "Providers will not be able to contact you using this service this academic year",
+      )
+
+      expect(already_organised.value).to eq("already_organised")
+      expect(already_organised.name).to eq("Placements already organised with providers")
+      expect(already_organised.description).to eq(
+        "We'll show any providers who search for you that you're at capacity",
+      )
+    end
+  end
+
+  describe "#placement_appetites" do
+    subject(:placement_appetites) { step.placement_appetites }
+
+    it "returns the keys of the appetites" do
+      expect(placement_appetites).to match_array(Placements::HostingInterest.appetites.keys)
+    end
+  end
+end

--- a/spec/wizards/placements/multi_placement_wizard/reason_not_hosting_step_spec.rb
+++ b/spec/wizards/placements/multi_placement_wizard/reason_not_hosting_step_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe Placements::MultiPlacementWizard::ReasonNotHostingStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Placements::MultiPlacementWizard).tap do |mock_wizard|
+      allow(mock_wizard).to receive(:school).and_return(school)
+    end
+  end
+
+  let(:attributes) { nil }
+  let!(:school) { create(:placements_school) }
+
+  describe "attributes" do
+    it { is_expected.to have_attributes(reasons_not_hosting: []) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:reasons_not_hosting) }
+  end
+
+  describe "#reason_options" do
+    subject(:reason_options) { step.reason_options }
+
+    it "returns struct objects for each reason not to host ITT" do
+      not_enough_trained_mentors = reason_options[0]
+      number_of_pupils_with_send_needs = reason_options[1]
+      working_to_improve_our_ofsted_rating = reason_options[2]
+
+      expect(not_enough_trained_mentors.name).to eq("Not enough trained mentors")
+      expect(not_enough_trained_mentors.value).to eq("Not enough trained mentors")
+
+      expect(number_of_pupils_with_send_needs.name).to eq("Number of pupils with SEND needs")
+      expect(number_of_pupils_with_send_needs.value).to eq("Number of pupils with SEND needs")
+
+      expect(working_to_improve_our_ofsted_rating.name).to eq("Working to improve our OFSTED rating")
+      expect(working_to_improve_our_ofsted_rating.value).to eq("Working to improve our OFSTED rating")
+    end
+  end
+
+  describe "#reasons_not_hosting" do
+    subject(:reasons_not_hosting) { step.reasons_not_hosting }
+
+    context "when reasons_not_hosting is blank" do
+      it "returns an empty array" do
+        expect(reasons_not_hosting).to eq([])
+      end
+    end
+
+    context "when the reasons_not_hosting attribute contains a blank element" do
+      let(:attributes) { { reasons_not_hosting: ["Number of pupils with SEND needs", nil] } }
+
+      it "removes the nil element from the reasons_not_hosting attribute" do
+        expect(reasons_not_hosting).to contain_exactly("Number of pupils with SEND needs")
+      end
+    end
+
+    context "when the reasons_not_hosting attribute contains no blank elements" do
+      let(:attributes) { { reasons_not_hosting: ["Not enough trained mentors", "Number of pupils with SEND needs"] } }
+
+      it "returns the reasons_not_hosting attribute unchanged" do
+        expect(reasons_not_hosting).to contain_exactly(
+          "Not enough trained mentors",
+          "Number of pupils with SEND needs",
+        )
+      end
+    end
+  end
+end

--- a/spec/wizards/placements/multi_placement_wizard/school_contact_step_spec.rb
+++ b/spec/wizards/placements/multi_placement_wizard/school_contact_step_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe Placements::MultiPlacementWizard::SchoolContactStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Placements::MultiPlacementWizard).tap do |mock_wizard|
+      allow(mock_wizard).to receive_messages(
+        school: school,
+        school_contact: school.school_contact,
+      )
+    end
+  end
+
+  let(:attributes) { nil }
+  let!(:school) { create(:placements_school, with_school_contact: false) }
+
+  describe "attributes" do
+    it { is_expected.to have_attributes(first_name: nil, last_name: nil, email_address: nil) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:email_address) }
+    it { is_expected.to allow_value("name@education.gov.uk").for(:email_address) }
+    it { is_expected.to allow_value("name@example.com").for(:email_address) }
+    it { is_expected.not_to allow_value("some_text").for(:email_address) }
+
+    describe "#only_one_contact_per_school" do
+      let(:first_name) { "John" }
+      let(:last_name) { "Doe" }
+      let(:email_address) { "joe_doe@example.com" }
+      let(:attributes) { { first_name:, last_name:, email_address: } }
+
+      context "when the school does not have a school contact" do
+        it "returns valid" do
+          expect(step.valid?).to be(true)
+        end
+      end
+
+      context "when the school already has a school contact" do
+        let(:school) { create(:placements_school) }
+
+        context "when the school contact is the existing school contact" do
+          let(:mock_wizard) do
+            instance_double(Placements::EditSchoolContactWizard).tap do |mock_wizard|
+              allow(mock_wizard).to receive_messages(
+                school:,
+                school_contact: school.school_contact,
+              )
+            end
+          end
+
+          it "returns valid" do
+            expect(step.valid?).to be(true)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/wizards/placements/multi_placement_wizard_spec.rb
+++ b/spec/wizards/placements/multi_placement_wizard_spec.rb
@@ -1,0 +1,163 @@
+require "rails_helper"
+
+RSpec.describe Placements::MultiPlacementWizard do
+  subject(:wizard) { described_class.new(state:, params:, school:, current_step:) }
+
+  let(:school) { create(:placements_school) }
+  let(:state) { {} }
+  let(:params_data) { {} }
+  let(:params) { ActionController::Parameters.new(params_data) }
+  let(:current_step) { nil }
+
+  describe "#steps" do
+    subject { wizard.steps.keys }
+
+    it { is_expected.to eq %i[appetite school_contact] }
+
+    context "when an appetite is set to 'not_open' during the appetite step" do
+      let(:state) do
+        {
+          "appetite" => { "appetite" => "not_open" },
+        }
+      end
+
+      it { is_expected.to eq %i[appetite reason_not_hosting help school_contact] }
+    end
+  end
+
+  describe "#update_school_placements" do
+    subject(:update_school_placements) { wizard.update_school_placements }
+
+    before { school }
+
+    context "when the attributes passed are valid" do
+      context "when the appetite is 'not_open'" do
+        let(:state) do
+          {
+            "appetite" => { "appetite" => "not_open" },
+            "reason_not_hosting" => {
+              "reasons_not_hosting" => [
+                "Not enough trained mentors",
+                "Number of pupils with SEND needs",
+                "Working to improve our OFSTED rating",
+              ],
+            },
+            "school_contact" => {
+              "first_name" => "Joe",
+              "last_name" => "Bloggs",
+              "email_address" => "joe_bloggs@example.com",
+            },
+          }
+        end
+
+        context "when school has no hosting interest for the next academic year" do
+          context "when school has no school contact assigned" do
+            let(:school) { create(:placements_school, with_school_contact: false) }
+
+            it "creates hosting interest for the next academic year, assigns the appetite,
+              reasons not hosting and creates a school contact" do
+              expect { update_school_placements }.to change(Placements::HostingInterest, :count).by(1)
+                .and change(Placements::SchoolContact, :count).by(1)
+              school.reload
+
+              hosting_interest = school.hosting_interests.last
+              expect(hosting_interest.appetite).to eq("not_open")
+              expect(hosting_interest.reasons_not_hosting).to contain_exactly(
+                "Not enough trained mentors",
+                "Number of pupils with SEND needs",
+                "Working to improve our OFSTED rating",
+              )
+
+              school_contact = school.school_contact
+              expect(school_contact.first_name).to eq("Joe")
+              expect(school_contact.last_name).to eq("Bloggs")
+              expect(school_contact.email_address).to eq("joe_bloggs@example.com")
+            end
+          end
+
+          context "when the school already has a school contact" do
+            it "creates hosting interest for the next academic year, assigns the appetite,
+              reasons not hosting and updates the school contact" do
+              expect { update_school_placements }.not_to change(Placements::SchoolContact, :count)
+              school.reload
+
+              hosting_interest = school.hosting_interests.last
+              expect(hosting_interest.appetite).to eq("not_open")
+              expect(hosting_interest.reasons_not_hosting).to contain_exactly(
+                "Not enough trained mentors",
+                "Number of pupils with SEND needs",
+                "Working to improve our OFSTED rating",
+              )
+
+              school_contact = school.school_contact
+              expect(school_contact.first_name).to eq("Joe")
+              expect(school_contact.last_name).to eq("Bloggs")
+              expect(school_contact.email_address).to eq("joe_bloggs@example.com")
+            end
+          end
+        end
+
+        context "when the school already has a hosting interest for the next academic year" do
+          let(:hosting_interest) { create(:hosting_interest, :for_next_year, school:) }
+
+          before { hosting_interest }
+
+          it "updates the hosting interest for the next academic year, assigns the appetite,
+            reasons not hosting and updates the school contact" do
+            expect { update_school_placements }.not_to change(Placements::HostingInterest, :count)
+            school.reload
+            hosting_interest.reload
+
+            expect(hosting_interest.appetite).to eq("not_open")
+            expect(hosting_interest.reasons_not_hosting).to contain_exactly(
+              "Not enough trained mentors",
+              "Number of pupils with SEND needs",
+              "Working to improve our OFSTED rating",
+            )
+
+            school_contact = school.school_contact
+            expect(school_contact.first_name).to eq("Joe")
+            expect(school_contact.last_name).to eq("Bloggs")
+            expect(school_contact.email_address).to eq("joe_bloggs@example.com")
+          end
+        end
+      end
+
+      context "when a step is invalid" do
+        let(:state) do
+          {
+            "appetite" => { "appetite" => "blah" },
+            "reason_not_hosting" => {
+              "reasons_not_hosting" => [
+                "Not enough trained mentors",
+                "Number of pupils with SEND needs",
+                "Working to improve our OFSTED rating",
+              ],
+            },
+            "school_contact" => {
+              "first_name" => "Joe",
+              "last_name" => "Bloggs",
+              "email_address" => "joe_bloggs@example.com",
+            },
+          }
+        end
+
+        it "returns an error" do
+          expect { update_school_placements }.to raise_error "Invalid wizard state"
+        end
+      end
+    end
+  end
+
+  describe "#upcoming_academic_year" do
+    subject(:upcoming_academic_year) { wizard.upcoming_academic_year }
+
+    let(:next_academic_year) { Placements::AcademicYear.current.next }
+
+    before { next_academic_year }
+
+    it "returns the next academic year" do
+      expect(upcoming_academic_year).to eq(next_academic_year)
+    end
+  end
+end


### PR DESCRIPTION
## Context

- Add Multi Placement Wizard to allow new concepts for creating multiple placements at once.
- Add "not_open" journey of Multi Placement Wizard

## Changes proposed in this pull request

- Add Multi Placement Wizard and related steps, views, controllers, etc. To begin working on the "not_open" journey

## Guidance to review

⚠️ You will need to enable the ":bulk_add_placements" flag ⚠️ 

- Sign in as Anne (School user)
- Navigate to "Placements"
- Click "Bulk add placements"
- Choose "Not open to hosting placements"
- Follow the rest of the journey
- This should result in creating/updating your school's HostingInterest for next year
- This should result in any changes made to the school contact

## Link to Trello card

https://trello.com/c/mcGI3ldq/433-multi-placement-wizard-reasons-for-not-taking-part-in-itt

## Screenshots

https://github.com/user-attachments/assets/f3285253-03cf-433a-8c72-2d3cfbc81570


