### PR TITLE
Move the `mentors` `trn` column to analytics_hidden_pii.yml

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -69,6 +69,7 @@ shared:
   :mentors:
     - first_name
     - last_name
+    - trn
     - id
     - created_at
     - updated_at

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -138,8 +138,6 @@ shared:
     - last_name
   :users:
     - email
-  :mentors:
-    - trn
   :providers:
     - telephone
   :provider_email_addresses:

--- a/config/analytics_hidden_pii.yml
+++ b/config/analytics_hidden_pii.yml
@@ -3,6 +3,7 @@ shared:
   mentors:
     - first_name
     - last_name
+    - trn
   users:
     - first_name
     - last_name


### PR DESCRIPTION
## Context

We want to track the `trn` for analytics

## Changes proposed in this pull request

- [x] Moved the `trn` column from the block list to the pii list.

## Guidance to review

- Check that tests pass
- Confirm that the specified field has been moved correctly

## Link to Trello card

[Move TRN to PII list](https://trello.com/c/n1me3SsA/440-move-trn-to-pii-list)
