### PR TITLE
Add geocoding to Providers

### DIFF
--- a/app/decorators/organisation_decorator.rb
+++ b/app/decorators/organisation_decorator.rb
@@ -2,10 +2,10 @@ class OrganisationDecorator < Draper::Decorator
   include ActionView::Helpers::TextHelper
   delegate_all
 
-  def formatted_address
+  def formatted_address(wrapper_tag: "p")
     address_string = address_parts.reject(&:blank?)&.join("\n")
     return if address_string.blank?
 
-    simple_format(address_string)
+    simple_format(address_string, {}, wrapper_tag:)
   end
 end

--- a/app/models/claims/provider.rb
+++ b/app/models/claims/provider.rb
@@ -10,6 +10,8 @@
 #  city               :string
 #  code               :string           not null
 #  county             :string
+#  latitude           :float
+#  longitude          :float
 #  name               :string           default(""), not null
 #  placements_service :boolean          default(FALSE)
 #  postcode           :string
@@ -25,6 +27,8 @@
 # Indexes
 #
 #  index_providers_on_code                (code) UNIQUE
+#  index_providers_on_latitude            (latitude)
+#  index_providers_on_longitude           (longitude)
 #  index_providers_on_name_trigram        (name) USING gin
 #  index_providers_on_placements_service  (placements_service)
 #  index_providers_on_postcode_trigram    (postcode) USING gin

--- a/app/models/placements/provider.rb
+++ b/app/models/placements/provider.rb
@@ -10,6 +10,8 @@
 #  city               :string
 #  code               :string           not null
 #  county             :string
+#  latitude           :float
+#  longitude          :float
 #  name               :string           default(""), not null
 #  placements_service :boolean          default(FALSE)
 #  postcode           :string
@@ -25,6 +27,8 @@
 # Indexes
 #
 #  index_providers_on_code                (code) UNIQUE
+#  index_providers_on_latitude            (latitude)
+#  index_providers_on_longitude           (longitude)
 #  index_providers_on_name_trigram        (name) USING gin
 #  index_providers_on_placements_service  (placements_service)
 #  index_providers_on_postcode_trigram    (postcode) USING gin

--- a/app/queries/provider_query.rb
+++ b/app/queries/provider_query.rb
@@ -1,0 +1,31 @@
+class ProviderQuery < ApplicationQuery
+  MAX_LOCATION_DISTANCE = 50
+
+  def call
+    scope = Provider
+    order_condition(scope)
+  end
+
+  private
+
+  def provider_ids_near_location(location_coordinates)
+    Provider.near(
+      location_coordinates,
+      MAX_LOCATION_DISTANCE,
+      order: :distance,
+    ).map(&:id)
+  end
+
+  def order_condition(scope)
+    if params[:location_coordinates].present?
+      provider_ids = provider_ids_near_location(
+        params[:location_coordinates],
+      )
+
+      scope.where(id: provider_ids)
+        .order_by_ids(provider_ids)
+    else
+      scope.order_by_name
+    end
+  end
+end

--- a/app/services/publish_teacher_training/provider/importer.rb
+++ b/app/services/publish_teacher_training/provider/importer.rb
@@ -52,6 +52,8 @@ module PublishTeacherTraining
             county: provider_attributes["county"],
             postcode: provider_attributes["postcode"],
             accredited: provider_attributes["accredited_body"],
+            latitude: provider_attributes["latitude"],
+            longitude: provider_attributes["longitude"],
           }
 
           next if provider_attributes["email"].blank?

--- a/app/views/wizards/placements/multi_placement_wizard/_help_step.html.erb
+++ b/app/views/wizards/placements/multi_placement_wizard/_help_step.html.erb
@@ -12,9 +12,21 @@
 
       <h2 class="govuk-heading-m"><%= t(".training_providers") %></h2>
 
-      <p class="govuk-body"><%= t(".local_providers") %></p>
+      <% if current_step.local_providers.present? %>
 
-      <%# TODO: Add local providers here after Geocoding added %>
+        <p class="govuk-body"><%= t(".local_providers") %></p>
+
+        <% current_step.local_providers.each do |provider| %>
+          <p class="govuk-body">
+            <strong><%= provider.name %></strong><br>
+            <%= provider.formatted_address(wrapper_tag: "span") %>
+          </p>
+        <% end %>
+      <% end %>
+
+      <div>
+        <%= govuk_button_link_to(t(".find_providers"), "#", secondary: true, new_tab: true) %>
+      </div>
 
       <%= f.govuk_submit t(".continue") %>
     </div>

--- a/app/wizards/placements/multi_placement_wizard/help_step.rb
+++ b/app/wizards/placements/multi_placement_wizard/help_step.rb
@@ -1,2 +1,9 @@
 class Placements::MultiPlacementWizard::HelpStep < BaseStep
+  delegate :school, to: :wizard
+
+  def local_providers
+    @local_providers ||= ProviderQuery.call(
+      params: { location_coordinates: [school.latitude, school.longitude] },
+    ).limit(2).decorate
+  end
 end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -142,6 +142,8 @@ shared:
     - trn
   :providers:
     - telephone
+    - longitude
+    - latitude
   :provider_email_addresses:
     - id
     - email_address

--- a/config/locales/en/wizards/placements/multi_placement_wizard.yml
+++ b/config/locales/en/wizards/placements/multi_placement_wizard.yml
@@ -35,6 +35,7 @@ en:
             There are a number of organisations who could help you to make teacher training work.
           training_providers: Training providers
           local_providers: These training providers are local to you and could help.
+          find_providers: Find providers near me
         school_contact_step:
           title: Who is your contact for ITT?
           continue: Continue

--- a/db/migrate/20250226133003_add_longitude_and_latitude_to_providers.rb
+++ b/db/migrate/20250226133003_add_longitude_and_latitude_to_providers.rb
@@ -1,0 +1,9 @@
+class AddLongitudeAndLatitudeToProviders < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured do
+      change_table(:providers, bulk: true) do |provider|
+        provider.float :longitude, :latitude, index: true
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_25_141558) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_26_133003) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -454,7 +454,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_25_141558) do
     t.string "county"
     t.string "postcode"
     t.boolean "accredited", default: false
+    t.float "longitude"
+    t.float "latitude"
     t.index ["code"], name: "index_providers_on_code", unique: true
+    t.index ["latitude"], name: "index_providers_on_latitude"
+    t.index ["longitude"], name: "index_providers_on_longitude"
     t.index ["name"], name: "index_providers_on_name_trigram", opclass: :gin_trgm_ops, using: :gin
     t.index ["placements_service"], name: "index_providers_on_placements_service"
     t.index ["postcode"], name: "index_providers_on_postcode_trigram", opclass: :gin_trgm_ops, using: :gin

--- a/spec/decorators/provider_decorator_spec.rb
+++ b/spec/decorators/provider_decorator_spec.rb
@@ -61,5 +61,24 @@ RSpec.describe ProviderDecorator do
         ).to be_nil
       end
     end
+
+    context "when given a 'div' wrapper tag" do
+      it "returns the formatted address wrapped in a 'div' tag" do
+        provider = create(:provider,
+                          address1: "A School",
+                          address2: "The School Road",
+                          address3: "Somewhere",
+                          town: "London",
+                          city: "City of London",
+                          county: "London",
+                          postcode: "LN12 1LN")
+
+        expect(
+          provider.decorate.formatted_address(wrapper_tag: "div"),
+        ).to eq(
+          "<div>A School\n<br />The School Road\n<br />Somewhere\n<br />London\n<br />City of London\n<br />London\n<br />LN12 1LN</div>",
+        )
+      end
+    end
   end
 end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -10,6 +10,8 @@
 #  city               :string
 #  code               :string           not null
 #  county             :string
+#  latitude           :float
+#  longitude          :float
 #  name               :string           default(""), not null
 #  placements_service :boolean          default(FALSE)
 #  postcode           :string
@@ -25,6 +27,8 @@
 # Indexes
 #
 #  index_providers_on_code                (code) UNIQUE
+#  index_providers_on_latitude            (latitude)
+#  index_providers_on_longitude           (longitude)
 #  index_providers_on_name_trigram        (name) USING gin
 #  index_providers_on_placements_service  (placements_service)
 #  index_providers_on_postcode_trigram    (postcode) USING gin

--- a/spec/models/claims/provider_spec.rb
+++ b/spec/models/claims/provider_spec.rb
@@ -10,6 +10,8 @@
 #  city               :string
 #  code               :string           not null
 #  county             :string
+#  latitude           :float
+#  longitude          :float
 #  name               :string           default(""), not null
 #  placements_service :boolean          default(FALSE)
 #  postcode           :string
@@ -25,6 +27,8 @@
 # Indexes
 #
 #  index_providers_on_code                (code) UNIQUE
+#  index_providers_on_latitude            (latitude)
+#  index_providers_on_longitude           (longitude)
 #  index_providers_on_name_trigram        (name) USING gin
 #  index_providers_on_placements_service  (placements_service)
 #  index_providers_on_postcode_trigram    (postcode) USING gin

--- a/spec/models/placements/provider_spec.rb
+++ b/spec/models/placements/provider_spec.rb
@@ -10,6 +10,8 @@
 #  city               :string
 #  code               :string           not null
 #  county             :string
+#  latitude           :float
+#  longitude          :float
 #  name               :string           default(""), not null
 #  placements_service :boolean          default(FALSE)
 #  postcode           :string
@@ -25,6 +27,8 @@
 # Indexes
 #
 #  index_providers_on_code                (code) UNIQUE
+#  index_providers_on_latitude            (latitude)
+#  index_providers_on_longitude           (longitude)
 #  index_providers_on_name_trigram        (name) USING gin
 #  index_providers_on_placements_service  (placements_service)
 #  index_providers_on_postcode_trigram    (postcode) USING gin

--- a/spec/queries/provider_query_spec.rb
+++ b/spec/queries/provider_query_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe ProviderQuery do
+  subject(:provider_query) { described_class.call(params:) }
+
+  let(:params) { {} }
+  let(:provider_1) do
+    create(:provider,
+           name: "Ashford Provider",
+           latitude: 51.240551,
+           longitude: -0.580243)
+  end
+  let(:provider_2) do
+    create(:provider,
+           name: "Bath Provider",
+           latitude: 51.1844249,
+           longitude: -0.617529)
+  end
+  let(:provider_3) do
+    create(:provider,
+           name: "Coventry Provider",
+           latitude: 53.68806439999999,
+           longitude: -1.853286)
+  end
+
+  before do
+    provider_1
+    provider_2
+    provider_3
+  end
+
+  describe "#call" do
+    it "returns the providers by the provider name" do
+      expect(provider_query).to eq([provider_1, provider_2, provider_3])
+    end
+
+    context "when given location coordinates" do
+      let(:params) { { location_coordinates: [51.1844248, -0.580242] } }
+
+      it "returns the providers within 50 miles of the given coordinates,
+        ordered by their proximity to the location coordinates" do
+        expect(provider_query).to eq([provider_2, provider_1])
+      end
+    end
+  end
+end

--- a/spec/services/publish_teacher_training/provider/importer_spec.rb
+++ b/spec/services/publish_teacher_training/provider/importer_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe PublishTeacherTraining::Provider::Importer do
           name: "Provider 1",
           code: "Prov1",
           provider_type: :scitt,
+          latitude: 51.0644359,
+          longitude: -0.351266,
         ),
       ).to be_present
       expect(
@@ -25,6 +27,8 @@ RSpec.describe PublishTeacherTraining::Provider::Importer do
           name: "Provider 2",
           code: "Prov2",
           provider_type: :university,
+          latitude: 51.6139603,
+          longitude: -0.0927213,
         ),
       ).to be_present
       expect(
@@ -32,6 +36,8 @@ RSpec.describe PublishTeacherTraining::Provider::Importer do
           name: "Provider 3",
           code: "Prov3",
           provider_type: :lead_school,
+          latitude: 53.68806439999999,
+          longitude: -1.853286,
         ),
       ).to be_present
     end
@@ -53,6 +59,8 @@ RSpec.describe PublishTeacherTraining::Provider::Importer do
         name: "Provider 1",
         code: "Prov1",
         provider_type: :scitt,
+        latitude: 51.0644359,
+        longitude: -0.351266,
       )
       expect(new_provider).to be_present
       expect(
@@ -113,6 +121,8 @@ RSpec.describe PublishTeacherTraining::Provider::Importer do
               "code" => "Prov1",
               "provider_type" => "scitt",
               "email" => "provider_1@example.com",
+              "latitude" => 51.0644359,
+              "longitude" => -0.351266,
             },
           },
           {
@@ -122,6 +132,8 @@ RSpec.describe PublishTeacherTraining::Provider::Importer do
               "code" => "Prov2",
               "provider_type" => "university",
               "email" => nil,
+              "latitude" => 51.6139603,
+              "longitude" => -0.0927213,
             },
           },
           {
@@ -131,6 +143,8 @@ RSpec.describe PublishTeacherTraining::Provider::Importer do
               "code" => "Prov3",
               "provider_type" => "lead_school",
               "email" => "provider_3@example.com",
+              "latitude" => 53.68806439999999,
+              "longitude" => -1.853286,
             },
           },
         ],
@@ -153,6 +167,8 @@ RSpec.describe PublishTeacherTraining::Provider::Importer do
               "code" => "Prov1",
               "provider_type" => "scitt",
               "email" => "provider_1@example.com",
+              "latitude" => 51.0644359,
+              "longitude" => -0.351266,
             },
           },
           {
@@ -173,6 +189,8 @@ RSpec.describe PublishTeacherTraining::Provider::Importer do
               "county" => existing_provider.county,
               "postcode" => existing_provider.postcode,
               "accredited_body" => existing_provider.accredited,
+              "latitude" => existing_provider.latitude,
+              "longitude" => existing_provider.longitude,
             },
           },
           {
@@ -182,6 +200,8 @@ RSpec.describe PublishTeacherTraining::Provider::Importer do
               "code" => changeable_provider.code,
               "provider_type" => changeable_provider.provider_type,
               "email" => "changed_provider@example.com",
+              "latitude" => changeable_provider.latitude,
+              "longitude" => changeable_provider.longitude,
             },
           },
         ],

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_not_open/school_user_views_their_local_providers_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_not_open/school_user_views_their_local_providers_spec.rb
@@ -1,0 +1,153 @@
+require "rails_helper"
+
+RSpec.describe "School user views their local providers",
+               service: :placements,
+               type: :system do
+  scenario do
+    given_the_bulk_add_placements_flag_is_enabled
+    and_providers_exist
+    and_academic_years_exist
+    and_i_am_signed_in
+    when_i_am_on_the_placements_index_page
+    and_i_click_on_bulk_add_placements
+    then_i_see_the_appetite_form
+
+    when_i_select_not_open_to_hosting_placements
+    and_i_click_on_continue
+    then_i_see_the_reasons_for_not_hosting_form
+
+    when_i_select_not_enough_trained_mentors
+    and_i_select_number_of_pupils_with_send_needs
+    and_i_click_on_continue
+    then_i_see_the_help_available_to_you_page
+    and_i_see_the_local_providers
+  end
+
+  private
+
+  def given_the_bulk_add_placements_flag_is_enabled
+    Flipper.add(:bulk_add_placements)
+    Flipper.enable(:bulk_add_placements)
+  end
+
+  def and_providers_exist
+    @provider_1 = create(:provider,
+                         name: "London Provider",
+                         address1: "London Provider",
+                         address2: "The Provider Road",
+                         address3: "Somewhere",
+                         town: "London",
+                         city: "City of London",
+                         county: "London",
+                         postcode: "LN12 1LN")
+    @provider_2 = create(:provider, name: "Brixton Provider",
+                                    address1: "Brixton Provider",
+                                    address2: "Brixton Road",
+                                    town: "London",
+                                    postcode: "LN13 3BX")
+
+    allow(Provider).to receive(:near).and_return(
+      Provider.where(id: [@provider_1.id, @provider_2.id]),
+    )
+  end
+
+  def and_academic_years_exist
+    current_academic_year = Placements::AcademicYear.current
+    @current_academic_year_name = current_academic_year.name
+    @next_academic_year = current_academic_year.next
+    @next_academic_year_name = @next_academic_year.name
+  end
+
+  def and_i_am_signed_in
+    @school = create(:placements_school)
+    sign_in_placements_user(organisations: [@school])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Placements")
+    expect(secondary_navigation).to have_current_item("This year (#{@current_academic_year_name}")
+    expect(page).to have_link("Add placement")
+    expect(page).to have_link("Bulk add placements")
+  end
+  alias_method :then_i_am_on_the_placements_index_page,
+               :when_i_am_on_the_placements_index_page
+
+  def when_i_click_on_bulk_add_placements
+    click_on "Bulk add placements"
+  end
+  alias_method :and_i_click_on_bulk_add_placements,
+               :when_i_click_on_bulk_add_placements
+
+  def then_i_see_the_appetite_form
+    expect(page).to have_title(
+      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Actively looking to host placements", type: :radio)
+    expect(page).to have_field("Interested in hosting placements", type: :radio)
+    expect(page).to have_field("Not open to hosting placements", type: :radio)
+    expect(page).to have_field("Placements already organised with providers", type: :radio)
+  end
+
+  def when_i_select_not_open_to_hosting_placements
+    choose "Not open to hosting placements"
+  end
+
+  def when_i_click_on_continue
+    click_on "Continue"
+  end
+  alias_method :and_i_click_on_continue,
+               :when_i_click_on_continue
+
+  def then_i_see_the_reasons_for_not_hosting_form
+    expect(page).to have_title(
+      "What are your reasons for not taking part in ITT this year? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "What are your reasons for not taking part in ITT this year?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Not enough trained mentors", type: :checkbox)
+    expect(page).to have_field("Number of pupils with SEND needs", type: :checkbox)
+    expect(page).to have_field("Working to improve our OFSTED rating", type: :checkbox)
+  end
+
+  def when_i_select_not_enough_trained_mentors
+    check "Not enough trained mentors"
+  end
+
+  def and_i_select_number_of_pupils_with_send_needs
+    check "Number of pupils with SEND needs"
+  end
+
+  def then_i_see_the_help_available_to_you_page
+    expect(page).to have_title(
+      "Help available to you - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Help available to you")
+  end
+
+  def and_i_see_the_local_providers
+    expect(page).to have_element(
+      :p,
+      text: "London Provider London Provider The Provider Road Somewhere " \
+            "London City of London London LN12 1LN",
+    )
+
+    expect(page).to have_element(
+      :p,
+      text: "Brixton Provider Brixton Provider Brixton Road London " \
+      "LN13 3BX",
+    )
+  end
+end

--- a/spec/wizards/placements/multi_placement_wizard/help_step_spec.rb
+++ b/spec/wizards/placements/multi_placement_wizard/help_step_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe Placements::MultiPlacementWizard::HelpStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Placements::MultiPlacementWizard).tap do |mock_wizard|
+      allow(mock_wizard).to receive(:school).and_return(school)
+    end
+  end
+
+  let(:attributes) { nil }
+  let!(:school) { create(:placements_school, latitude: 51.1844248, longitude: -0.580242) }
+
+  describe "delegations" do
+    it { is_expected.to delegate_method(:school).to(:wizard) }
+  end
+
+  describe "#local_providers" do
+    subject(:local_providers) { step.local_providers }
+
+    let(:provider_1) do
+      create(:provider,
+             name: "Ashford Provider",
+             latitude: 51.240551,
+             longitude: -0.580243)
+    end
+    let(:provider_2) do
+      create(:provider,
+             name: "Bath Provider",
+             latitude: 51.1844249,
+             longitude: -0.617529)
+    end
+    let(:provider_3) do
+      create(:provider,
+             name: "Coventry Provider",
+             latitude: 53.68806439999999,
+             longitude: -1.853286)
+    end
+    let(:provider_4) do
+      create(:provider,
+             name: "Woking Provider",
+             latitude: 51.240554,
+             longitude: -0.617530)
+    end
+
+    before do
+      provider_1
+      provider_2
+      provider_3
+      provider_4
+    end
+
+    it "returns the 2 closest providers to the school's location" do
+      expect(local_providers).to eq([provider_2.decorate, provider_1.decorate])
+    end
+  end
+end


### PR DESCRIPTION
## Context

- Add geocoding to Providers

## Changes proposed in this pull request

- Geocoding added to providers
- Local providers added to the MultiPlacementWizard HelpStep

## Guidance to review

⚠️ You will need to enable the ":bulk_add_placements" flag ⚠️

- Sign in as Anne (School user)
- Navigate to "Placements"
- Click "Bulk add placements"
- Choose "Not open to hosting placements"
- Follow the rest of the journey, until you reach the help page.
- You should be able to see the 2 closest providers to the school

## Link to Trello card

https://trello.com/c/IMtlJJb2/442-add-geocoding-to-providers

## Screenshots

![screencapture-placements-localhost-3000-schools-54283c35-b340-4b53-ace8-96c2a4b28113-placements-multiple-ce316e12-1d08-4855-a759-62341d3b84b6-help-2025-02-27-11_16_40](https://github.com/user-attachments/assets/70d4c93a-2cdd-4b7c-a6db-8f79924b40b3)

