### PR TITLE
Add interested journey to multi-placement wizard

### DIFF
--- a/app/views/wizards/placements/multi_placement_wizard/_list_placements_step.html.erb
+++ b/app/views/wizards/placements/multi_placement_wizard/_list_placements_step.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title, title_with_error_prefix(t(".title"), error: current_step.errors.any?) %>
+
+<%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_collection_radio_buttons(
+            :list_placements,
+            current_step.responses_for_selection,
+            :name, :name,
+            legend: { size: "l", text: t(".title"), tag: "h1" }
+          ) %>
+
+      <%= f.govuk_submit t(".continue") %>
+    </div>
+  </div>
+<% end %>

--- a/app/wizards/placements/multi_placement_wizard.rb
+++ b/app/wizards/placements/multi_placement_wizard.rb
@@ -15,6 +15,9 @@ module Placements
       if appetite == "not_open"
         add_step(ReasonNotHostingStep)
         add_step(HelpStep)
+      elsif appetite == "interested"
+        add_step(HelpStep)
+        add_step(ListPlacementsStep)
       end
       add_step(SchoolContactStep)
     end

--- a/app/wizards/placements/multi_placement_wizard/list_placements_step.rb
+++ b/app/wizards/placements/multi_placement_wizard/list_placements_step.rb
@@ -1,0 +1,16 @@
+class Placements::MultiPlacementWizard::ListPlacementsStep < BaseStep
+  attribute :list_placements
+
+  YES = "Yes".freeze
+  NO = "No".freeze
+  LIST_PLACEMENTS = [YES, NO].freeze
+
+  validates :list_placements, presence: true, inclusion: LIST_PLACEMENTS
+
+  def responses_for_selection
+    [
+      OpenStruct.new(name: YES),
+      OpenStruct.new(name: NO),
+    ]
+  end
+end

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -292,4 +292,7 @@ en:
           attributes:
             reasons_not_hosting: 
               blank: Please select a reason for not taking part in ITT
-
+        placements/multi_placement_wizard/list_placements_step:
+          attributes:
+            list_placements:
+              blank: Please select an option

--- a/config/locales/en/wizards/placements/multi_placement_wizard.yml
+++ b/config/locales/en/wizards/placements/multi_placement_wizard.yml
@@ -18,6 +18,12 @@ en:
             already_organised:
               name: Placements already organised with providers
               description: We'll show any providers who search for you that you're at capacity
+        list_placements_step:
+          title: Would you like to list some placements to be seen by providers?
+          continue: Continue
+          options:
+            agree: Yes
+            disagree: No
         reason_not_hosting_step:
           title: What are your reasons for not taking part in ITT this year?
           continue: Continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_does_not_enter_a_response_for_listing_placements_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_does_not_enter_a_response_for_listing_placements_spec.rb
@@ -1,0 +1,111 @@
+require "rails_helper"
+
+RSpec.describe "School user does not enter a response for listing placements",
+               service: :placements,
+               type: :system do
+  scenario do
+    given_the_bulk_add_placements_flag_is_enabled
+    and_academic_years_exist
+    and_i_am_signed_in
+    when_i_am_on_the_placements_index_page
+    and_i_click_on_bulk_add_placements
+    then_i_see_the_appetite_form
+
+    when_i_select_interested_in_hosting_placements
+    and_i_click_on_continue
+    then_i_see_the_help_available_to_you_page
+
+    when_i_click_on_continue
+    then_i_see_the_are_you_interested_in_listing_placements_form
+
+    when_i_click_on_continue
+    then_i_see_a_validation_error_for_selecting_a_list_placements_response
+  end
+
+  private
+
+  def given_the_bulk_add_placements_flag_is_enabled
+    Flipper.add(:bulk_add_placements)
+    Flipper.enable(:bulk_add_placements)
+  end
+
+  def and_academic_years_exist
+    current_academic_year = Placements::AcademicYear.current
+    @current_academic_year_name = current_academic_year.name
+    @next_academic_year = current_academic_year.next
+    @next_academic_year_name = @next_academic_year.name
+  end
+
+  def and_i_am_signed_in
+    @school = create(:placements_school, with_school_contact: false)
+    sign_in_placements_user(organisations: [@school])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Placements")
+    expect(secondary_navigation).to have_current_item("This year (#{@current_academic_year_name}")
+    expect(page).to have_link("Bulk add placements")
+  end
+  alias_method :then_i_am_on_the_placements_index_page,
+               :when_i_am_on_the_placements_index_page
+
+  def when_i_click_on_bulk_add_placements
+    click_on "Bulk add placements"
+  end
+  alias_method :and_i_click_on_bulk_add_placements,
+               :when_i_click_on_bulk_add_placements
+
+  def then_i_see_the_appetite_form
+    expect(page).to have_title(
+      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Actively looking to host placements", type: :radio)
+    expect(page).to have_field("Interested in hosting placements", type: :radio)
+    expect(page).to have_field("Not open to hosting placements", type: :radio)
+    expect(page).to have_field("Placements already organised with providers", type: :radio)
+  end
+
+  def when_i_select_interested_in_hosting_placements
+    choose "Interested in hosting placements"
+  end
+
+  def when_i_click_on_continue
+    click_on "Continue"
+  end
+  alias_method :and_i_click_on_continue,
+               :when_i_click_on_continue
+
+  def then_i_see_the_help_available_to_you_page
+    expect(page).to have_title(
+      "Help available to you - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Help available to you")
+  end
+
+  def then_i_see_the_are_you_interested_in_listing_placements_form
+    expect(page).to have_title(
+      "Would you like to list some placements to be seen by providers? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :h1,
+      text: "Would you like to list some placements to be seen by providers?",
+      class: "govuk-fieldset__heading",
+    )
+  end
+
+  def then_i_see_a_validation_error_for_selecting_a_list_placements_response
+    expect(page).to have_validation_error(
+      "Please select an option",
+    )
+  end
+end

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_does_not_enter_any_school_contact_details_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_does_not_enter_any_school_contact_details_spec.rb
@@ -1,0 +1,134 @@
+require "rails_helper"
+
+RSpec.describe "School user does not enter any school contact details",
+               service: :placements,
+               type: :system do
+  scenario do
+    given_the_bulk_add_placements_flag_is_enabled
+    and_academic_years_exist
+    and_i_am_signed_in
+    when_i_am_on_the_placements_index_page
+    and_i_click_on_bulk_add_placements
+    then_i_see_the_appetite_form
+
+    when_i_select_interested_in_hosting_placements
+    and_i_click_on_continue
+    then_i_see_the_help_available_to_you_page
+
+    when_i_click_on_continue
+    then_i_see_the_are_you_interested_in_listing_placements_form
+
+    when_i_select_yes
+    and_i_click_on_continue
+
+    when_i_click_on_continue
+    then_i_see_the_school_contact_form
+
+    when_i_click_on_continue
+    then_i_see_a_validation_error_for_entering_a_school_contact_email_address
+  end
+
+  private
+
+  def given_the_bulk_add_placements_flag_is_enabled
+    Flipper.add(:bulk_add_placements)
+    Flipper.enable(:bulk_add_placements)
+  end
+
+  def and_academic_years_exist
+    current_academic_year = Placements::AcademicYear.current
+    @current_academic_year_name = current_academic_year.name
+    @next_academic_year = current_academic_year.next
+    @next_academic_year_name = @next_academic_year.name
+  end
+
+  def and_i_am_signed_in
+    @school = create(:placements_school, with_school_contact: false)
+    sign_in_placements_user(organisations: [@school])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Placements")
+    expect(secondary_navigation).to have_current_item("This year (#{@current_academic_year_name}")
+    expect(page).to have_link("Bulk add placements")
+  end
+  alias_method :then_i_am_on_the_placements_index_page,
+               :when_i_am_on_the_placements_index_page
+
+  def when_i_click_on_bulk_add_placements
+    click_on "Bulk add placements"
+  end
+  alias_method :and_i_click_on_bulk_add_placements,
+               :when_i_click_on_bulk_add_placements
+
+  def then_i_see_the_appetite_form
+    expect(page).to have_title(
+      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Actively looking to host placements", type: :radio)
+    expect(page).to have_field("Interested in hosting placements", type: :radio)
+    expect(page).to have_field("Not open to hosting placements", type: :radio)
+    expect(page).to have_field("Placements already organised with providers", type: :radio)
+  end
+
+  def when_i_select_interested_in_hosting_placements
+    choose "Interested in hosting placements"
+  end
+
+  def when_i_click_on_continue
+    click_on "Continue"
+  end
+  alias_method :and_i_click_on_continue,
+               :when_i_click_on_continue
+
+  def then_i_see_the_help_available_to_you_page
+    expect(page).to have_title(
+      "Help available to you - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Help available to you")
+  end
+
+  def then_i_see_the_are_you_interested_in_listing_placements_form
+    expect(page).to have_title(
+      "Would you like to list some placements to be seen by providers? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :h1,
+      text: "Would you like to list some placements to be seen by providers?",
+      class: "govuk-fieldset__heading",
+    )
+  end
+
+  def when_i_select_yes
+    choose "Yes"
+  end
+
+  def then_i_see_the_school_contact_form
+    expect(page).to have_title(
+      "Who is your contact for ITT? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Who is your contact for ITT?")
+
+    @school_contact = @school.school_contact
+    expect(page).to have_field("First name")
+    expect(page).to have_field("Last name")
+    expect(page).to have_field("Email address")
+  end
+
+  def then_i_see_a_validation_error_for_entering_a_school_contact_email_address
+    expect(page).to have_validation_error(
+      "Enter an email address",
+    )
+  end
+end

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_selects_no_and_completes_the_interested_journey_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_selects_no_and_completes_the_interested_journey_spec.rb
@@ -1,0 +1,155 @@
+require "rails_helper"
+
+RSpec.describe "School user selects no and completes the interested journey",
+               service: :placements,
+               type: :system do
+  scenario do
+    given_the_bulk_add_placements_flag_is_enabled
+    and_academic_years_exist
+    and_i_am_signed_in
+    when_i_am_on_the_placements_index_page
+    and_i_click_on_bulk_add_placements
+    then_i_see_the_appetite_form
+
+    when_i_select_interested_in_hosting_placements
+    and_i_click_on_continue
+    then_i_see_the_help_available_to_you_page
+
+    when_i_click_on_continue
+    then_i_see_the_are_you_interested_in_listing_placements_form
+
+    when_i_select_no
+    and_i_click_on_continue
+
+    when_i_click_on_continue
+    then_i_see_the_school_contact_form
+
+    when_i_fill_in_the_school_contact_details
+    and_i_click_on_continue
+    then_i_see_my_responses_with_successfully_updated
+    and_the_schools_contact_has_been_updated
+    and_the_schools_hosting_interest_for_the_next_year_is_updated
+  end
+
+  private
+
+  def given_the_bulk_add_placements_flag_is_enabled
+    Flipper.add(:bulk_add_placements)
+    Flipper.enable(:bulk_add_placements)
+  end
+
+  def and_academic_years_exist
+    current_academic_year = Placements::AcademicYear.current
+    @current_academic_year_name = current_academic_year.name
+    @next_academic_year = current_academic_year.next
+    @next_academic_year_name = @next_academic_year.name
+  end
+
+  def and_i_am_signed_in
+    @school = create(:placements_school, with_school_contact: false)
+    sign_in_placements_user(organisations: [@school])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Placements")
+    expect(secondary_navigation).to have_current_item("This year (#{@current_academic_year_name}")
+    expect(page).to have_link("Bulk add placements")
+  end
+
+  alias_method :then_i_am_on_the_placements_index_page,
+               :when_i_am_on_the_placements_index_page
+
+  def when_i_click_on_bulk_add_placements
+    click_on "Bulk add placements"
+  end
+
+  alias_method :and_i_click_on_bulk_add_placements,
+               :when_i_click_on_bulk_add_placements
+
+  def then_i_see_the_appetite_form
+    expect(page).to have_title(
+      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Actively looking to host placements", type: :radio)
+    expect(page).to have_field("Interested in hosting placements", type: :radio)
+    expect(page).to have_field("Not open to hosting placements", type: :radio)
+    expect(page).to have_field("Placements already organised with providers", type: :radio)
+  end
+
+  def when_i_select_interested_in_hosting_placements
+    choose "Interested in hosting placements"
+  end
+
+  def when_i_click_on_continue
+    click_on "Continue"
+  end
+
+  alias_method :and_i_click_on_continue,
+               :when_i_click_on_continue
+
+  def then_i_see_the_help_available_to_you_page
+    expect(page).to have_title(
+      "Help available to you - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Help available to you")
+  end
+
+  def then_i_see_the_are_you_interested_in_listing_placements_form
+    expect(page).to have_title(
+      "Would you like to list some placements to be seen by providers? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :h1,
+      text: "Would you like to list some placements to be seen by providers?",
+      class: "govuk-fieldset__heading",
+    )
+  end
+
+  def when_i_select_no
+    choose "No"
+  end
+
+  def then_i_see_the_school_contact_form
+    expect(page).to have_title(
+      "Who is your contact for ITT? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Who is your contact for ITT?")
+
+    expect(page).to have_field("First name")
+    expect(page).to have_field("Last name")
+    expect(page).to have_field("Email address")
+  end
+
+  def when_i_fill_in_the_school_contact_details
+    fill_in "First name", with: "Joe"
+    fill_in "Last name", with: "Bloggs"
+    fill_in "Email address", with: "joe_bloggs@example.com"
+  end
+
+  def then_i_see_my_responses_with_successfully_updated
+    expect(page).to have_success_banner("Thank you for providing your responses")
+  end
+
+  def and_the_schools_contact_has_been_updated
+    school_contact = @school.school_contact
+    expect(school_contact.first_name).to eq("Joe")
+    expect(school_contact.last_name).to eq("Bloggs")
+    expect(school_contact.email_address).to eq("joe_bloggs@example.com")
+  end
+
+  def and_the_schools_hosting_interest_for_the_next_year_is_updated
+    hosting_interest = @school.hosting_interests.for_academic_year(@next_academic_year).last
+    expect(hosting_interest.appetite).to eq("interested")
+  end
+end

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_selects_yes_and_completes_the_interested_journey_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_selects_yes_and_completes_the_interested_journey_spec.rb
@@ -1,0 +1,155 @@
+require "rails_helper"
+
+RSpec.describe "School user selects yes and completes the interested journey",
+               service: :placements,
+               type: :system do
+  scenario do
+    given_the_bulk_add_placements_flag_is_enabled
+    and_academic_years_exist
+    and_i_am_signed_in
+    when_i_am_on_the_placements_index_page
+    and_i_click_on_bulk_add_placements
+    then_i_see_the_appetite_form
+
+    when_i_select_interested_in_hosting_placements
+    and_i_click_on_continue
+    then_i_see_the_help_available_to_you_page
+
+    when_i_click_on_continue
+    then_i_see_the_are_you_interested_in_listing_placements_form
+
+    when_i_select_yes
+    and_i_click_on_continue
+
+    when_i_click_on_continue
+    then_i_see_the_school_contact_form
+
+    when_i_fill_in_the_school_contact_details
+    and_i_click_on_continue
+    then_i_see_my_responses_with_successfully_updated
+    and_the_schools_contact_has_been_updated
+    and_the_schools_hosting_interest_for_the_next_year_is_updated
+  end
+
+  private
+
+  def given_the_bulk_add_placements_flag_is_enabled
+    Flipper.add(:bulk_add_placements)
+    Flipper.enable(:bulk_add_placements)
+  end
+
+  def and_academic_years_exist
+    current_academic_year = Placements::AcademicYear.current
+    @current_academic_year_name = current_academic_year.name
+    @next_academic_year = current_academic_year.next
+    @next_academic_year_name = @next_academic_year.name
+  end
+
+  def and_i_am_signed_in
+    @school = create(:placements_school, with_school_contact: false)
+    sign_in_placements_user(organisations: [@school])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Placements")
+    expect(secondary_navigation).to have_current_item("This year (#{@current_academic_year_name}")
+    expect(page).to have_link("Bulk add placements")
+  end
+
+  alias_method :then_i_am_on_the_placements_index_page,
+               :when_i_am_on_the_placements_index_page
+
+  def when_i_click_on_bulk_add_placements
+    click_on "Bulk add placements"
+  end
+
+  alias_method :and_i_click_on_bulk_add_placements,
+               :when_i_click_on_bulk_add_placements
+
+  def then_i_see_the_appetite_form
+    expect(page).to have_title(
+      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Actively looking to host placements", type: :radio)
+    expect(page).to have_field("Interested in hosting placements", type: :radio)
+    expect(page).to have_field("Not open to hosting placements", type: :radio)
+    expect(page).to have_field("Placements already organised with providers", type: :radio)
+  end
+
+  def when_i_select_interested_in_hosting_placements
+    choose "Interested in hosting placements"
+  end
+
+  def when_i_click_on_continue
+    click_on "Continue"
+  end
+
+  alias_method :and_i_click_on_continue,
+               :when_i_click_on_continue
+
+  def then_i_see_the_help_available_to_you_page
+    expect(page).to have_title(
+      "Help available to you - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Help available to you")
+  end
+
+  def then_i_see_the_are_you_interested_in_listing_placements_form
+    expect(page).to have_title(
+      "Would you like to list some placements to be seen by providers? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :h1,
+      text: "Would you like to list some placements to be seen by providers?",
+      class: "govuk-fieldset__heading",
+    )
+  end
+
+  def when_i_select_yes
+    choose "Yes"
+  end
+
+  def then_i_see_the_school_contact_form
+    expect(page).to have_title(
+      "Who is your contact for ITT? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Who is your contact for ITT?")
+
+    expect(page).to have_field("First name")
+    expect(page).to have_field("Last name")
+    expect(page).to have_field("Email address")
+  end
+
+  def when_i_fill_in_the_school_contact_details
+    fill_in "First name", with: "Joe"
+    fill_in "Last name", with: "Bloggs"
+    fill_in "Email address", with: "joe_bloggs@example.com"
+  end
+
+  def then_i_see_my_responses_with_successfully_updated
+    expect(page).to have_success_banner("Thank you for providing your responses")
+  end
+
+  def and_the_schools_contact_has_been_updated
+    school_contact = @school.school_contact
+    expect(school_contact.first_name).to eq("Joe")
+    expect(school_contact.last_name).to eq("Bloggs")
+    expect(school_contact.email_address).to eq("joe_bloggs@example.com")
+  end
+
+  def and_the_schools_hosting_interest_for_the_next_year_is_updated
+    hosting_interest = @school.hosting_interests.for_academic_year(@next_academic_year).last
+    expect(hosting_interest.appetite).to eq("interested")
+  end
+end

--- a/spec/wizards/placements/multi_placement_wizard/list_placements_step_spec.rb
+++ b/spec/wizards/placements/multi_placement_wizard/list_placements_step_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe Placements::MultiPlacementWizard::ListPlacementsStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Placements::MultiPlacementWizard).tap do |mock_wizard|
+      allow(mock_wizard).to receive(:school).and_return(school)
+    end
+  end
+
+  let(:attributes) { nil }
+  let!(:school) { create(:placements_school) }
+
+  describe "attributes" do
+    it { is_expected.to have_attributes(list_placements: nil) }
+  end
+
+  describe "validations" do
+    it {
+      expect(step).to validate_inclusion_of(:list_placements).in_array(
+        Placements::MultiPlacementWizard::ListPlacementsStep::LIST_PLACEMENTS,
+      )
+    }
+  end
+
+  describe "#responses_for_selection" do
+    subject(:responses_for_selection) { step.responses_for_selection }
+
+    it "returns struct objects for each response" do
+      yes = responses_for_selection[0]
+      no = responses_for_selection[1]
+
+      expect(yes.name).to eq("Yes")
+      expect(no.name).to eq("No")
+    end
+  end
+end

--- a/spec/wizards/placements/multi_placement_wizard_spec.rb
+++ b/spec/wizards/placements/multi_placement_wizard_spec.rb
@@ -23,6 +23,16 @@ RSpec.describe Placements::MultiPlacementWizard do
 
       it { is_expected.to eq %i[appetite reason_not_hosting help school_contact] }
     end
+
+    context "when an appetite is set to 'interested' during the appetite step" do
+      let(:state) do
+        {
+          "appetite" => { "appetite" => "interested" },
+        }
+      end
+
+      it { is_expected.to eq %i[appetite help list_placements school_contact] }
+    end
   end
 
   describe "#update_school_placements" do


### PR DESCRIPTION
## Context

Adds the "Interested" journey to the multi-placement journey to allow schools to register their interest in adding places.

## Changes proposed in this pull request

- [x] Adds the `interested` journey path to the multi-placement wizard
- [x] Creates the `ListPlacementsStep`

## Guidance to review

- Log in as Anne
- Click on "Bulk add placements"
- Select "Interested in hosting placements"
- Complete the journey

## Link to Trello card

[Multi-placement wizard, offer help](https://trello.com/c/LNEaJO1x/434-multi-placement-wizard-offer-help)

## Screenshots

![image](https://github.com/user-attachments/assets/0f02b771-9e1b-40bc-92f6-06b3f09d36a5)
![image](https://github.com/user-attachments/assets/080eb7ac-8082-4f5d-a36e-9f41f1b26998)
![image](https://github.com/user-attachments/assets/58a88084-e911-4814-9c38-c2dd8256eaf1)
![image](https://github.com/user-attachments/assets/1c4ec8b4-bf61-45b7-a0d0-bc9be31eb414)
