### PR TITLE
Connect the interested path to the actively looking steps

### DIFF
--- a/app/wizards/placements/multi_placement_wizard.rb
+++ b/app/wizards/placements/multi_placement_wizard.rb
@@ -21,6 +21,9 @@ module Placements
       when "interested"
         add_step(HelpStep)
         add_step(ListPlacementsStep)
+        if list_placements?
+          actively_looking_steps
+        end
       end
       add_step(SchoolContactStep)
     end
@@ -184,6 +187,11 @@ module Placements
 
     def reasons_not_hosting
       @reasons_not_hosting ||= steps.fetch(:reason_not_hosting).reasons_not_hosting
+    end
+
+    def list_placements?
+      list_placements_step = steps.fetch(:list_placements)
+      list_placements_step.list_placements == list_placements_step.class::YES
     end
 
     def hosting_interest

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_does_not_enter_any_school_contact_details_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_does_not_enter_any_school_contact_details_spec.rb
@@ -18,10 +18,8 @@ RSpec.describe "School user does not enter any school contact details",
     when_i_click_on_continue
     then_i_see_the_are_you_interested_in_listing_placements_form
 
-    when_i_select_yes
+    when_i_select_no
     and_i_click_on_continue
-
-    when_i_click_on_continue
     then_i_see_the_school_contact_form
 
     when_i_click_on_continue
@@ -109,8 +107,8 @@ RSpec.describe "School user does not enter any school contact details",
     )
   end
 
-  def when_i_select_yes
-    choose "Yes"
+  def when_i_select_no
+    choose "No"
   end
 
   def then_i_see_the_school_contact_form

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_selects_no_and_completes_the_interested_journey_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_selects_no_and_completes_the_interested_journey_spec.rb
@@ -20,8 +20,6 @@ RSpec.describe "School user selects no and completes the interested journey",
 
     when_i_select_no
     and_i_click_on_continue
-
-    when_i_click_on_continue
     then_i_see_the_school_contact_form
 
     when_i_fill_in_the_school_contact_details

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_selects_yes_and_completes_the_interested_journey_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_selects_yes_and_completes_the_interested_journey_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "School user selects yes and completes the interested journey",
                type: :system do
   scenario do
     given_the_bulk_add_placements_flag_is_enabled
+    and_subjects_exist
     and_academic_years_exist
     and_i_am_signed_in
     when_i_am_on_the_placements_index_page
@@ -20,8 +21,33 @@ RSpec.describe "School user selects yes and completes the interested journey",
 
     when_i_select_yes
     and_i_click_on_continue
+    then_i_see_the_phase_form
 
-    when_i_click_on_continue
+    when_i_select_primary
+    and_i_select_secondary
+    and_i_click_on_continue
+    then_i_see_the_subjects_known_form
+
+    when_i_select_yes
+    and_i_click_on_continue
+    then_i_see_the_primary_subject_selection_form
+
+    when_i_select_primary
+    and_i_select_primary_with_science
+    and_i_click_on_continue
+    then_i_see_the_primary_subject_placement_quantity_form
+
+    when_i_fill_in_the_number_of_primary_placements_i_require
+    and_i_click_on_continue
+    then_i_see_the_secondary_subject_selection_form
+
+    when_i_select_english
+    and_i_select_mathematics
+    and_i_click_on_continue
+    then_i_see_the_secondary_subject_placement_quantity_form
+
+    when_i_fill_in_the_number_of_secondary_placements_i_require
+    and_i_click_on_continue
     then_i_see_the_school_contact_form
 
     when_i_fill_in_the_school_contact_details
@@ -43,6 +69,16 @@ RSpec.describe "School user selects yes and completes the interested journey",
     @current_academic_year_name = current_academic_year.name
     @next_academic_year = current_academic_year.next
     @next_academic_year_name = @next_academic_year.name
+  end
+
+  def and_subjects_exist
+    @primary = create(:subject, :primary, name: "Primary")
+    @phonics = create(:subject, :primary, name: "Phonics")
+    @handwriting = create(:subject, :primary, name: "Handwriting")
+
+    @english = create(:subject, :secondary, name: "English")
+    @mathematics = create(:subject, :secondary, name: "Mathematics")
+    @science = create(:subject, :secondary, name: "Science")
   end
 
   def and_i_am_signed_in
@@ -151,5 +187,161 @@ RSpec.describe "School user selects yes and completes the interested journey",
   def and_the_schools_hosting_interest_for_the_next_year_is_updated
     hosting_interest = @school.hosting_interests.for_academic_year(@next_academic_year).last
     expect(hosting_interest.appetite).to eq("interested")
+  end
+
+  def then_i_see_the_phase_form
+    expect(page).to have_title(
+      "What phase are you looking to host placements at? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "What phase are you looking to host placements at?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Primary", type: :checkbox)
+    expect(page).to have_field("Secondary", type: :checkbox)
+  end
+
+  def when_i_select_primary
+    check "Primary"
+  end
+
+  def and_i_select_secondary
+    check "Secondary"
+  end
+
+  def then_i_see_the_subjects_known_form
+    expect(page).to have_title(
+      "Do you know which subjects you would like to host? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "Do you know which subjects you would like to host?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Yes", type: :radio)
+    expect(page).to have_field("No", type: :radio)
+  end
+
+  def when_i_select_yes
+    choose "Yes"
+  end
+
+  def then_i_see_the_primary_subject_selection_form
+    expect(page).to have_title(
+      "Select primary subjects - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "Select primary subjects",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_field("Primary", type: :checkbox)
+    expect(page).to have_field("Phonics", type: :checkbox)
+    expect(page).to have_field("Handwriting", type: :checkbox)
+  end
+
+  def and_i_select_primary_with_science
+    check "Handwriting"
+  end
+
+  def then_i_see_the_primary_subject_placement_quantity_form
+    expect(page).to have_title(
+      "Enter the number of placements - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Enter the number of placements", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_field("Primary", type: :number)
+    expect(page).to have_field("Handwriting", type: :number)
+  end
+
+  def when_i_fill_in_the_number_of_primary_placements_i_require
+    fill_in "Primary", with: 2
+    fill_in "Handwriting", with: 3
+  end
+
+  def then_i_see_the_secondary_subject_selection_form
+    expect(page).to have_title(
+      "Select secondary subjects - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "Select secondary subjects",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_field("English", type: :checkbox)
+    expect(page).to have_field("Mathematics", type: :checkbox)
+    expect(page).to have_field("Science", type: :checkbox)
+  end
+
+  def when_i_select_english
+    check "English"
+  end
+
+  def and_i_select_mathematics
+    check "Mathematics"
+  end
+
+  def then_i_see_the_secondary_subject_placement_quantity_form
+    expect(page).to have_title(
+      "Enter the number of placements - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Enter the number of placements", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_field("English", type: :number)
+    expect(page).to have_field("Mathematics", type: :number)
+  end
+
+  def when_i_fill_in_the_number_of_secondary_placements_i_require
+    fill_in "English", with: 1
+    fill_in "Mathematics", with: 4
+  end
+
+  def when_i_click_on_the_academic_year_tab
+    click_on "Next year (#{@next_academic_year.name})"
+  end
+
+  def then_i_see_placements_i_created_for_the_subject_primary
+    expect(page).to have_link(
+      "Primary",
+      class: "govuk-link govuk-link--no-visited-state",
+      match: :prefer_exact,
+      count: 2,
+    )
+  end
+
+  def and_i_see_placements_i_created_for_the_subject_handwriting
+    expect(page).to have_link(
+      "Handwriting",
+      class: "govuk-link govuk-link--no-visited-state",
+      match: :prefer_exact,
+      count: 3,
+    )
+  end
+
+  def and_i_see_placements_i_created_for_the_subject_english
+    expect(page).to have_link(
+      "English",
+      class: "govuk-link govuk-link--no-visited-state",
+      match: :prefer_exact,
+      count: 1,
+    )
+  end
+
+  def and_i_see_placements_i_created_for_the_subject_mathematics
+    expect(page).to have_link(
+      "Mathematics",
+      class: "govuk-link govuk-link--no-visited-state",
+      match: :prefer_exact,
+      count: 4,
+    )
   end
 end

--- a/spec/wizards/placements/multi_placement_wizard_spec.rb
+++ b/spec/wizards/placements/multi_placement_wizard_spec.rb
@@ -138,6 +138,136 @@ RSpec.describe Placements::MultiPlacementWizard do
       end
 
       it { is_expected.to eq %i[appetite help list_placements school_contact] }
+
+      context "when list_placement is set to 'No' during the list_placement step" do
+        let(:state) do
+          {
+            "appetite" => { "appetite" => "interested" },
+            "list_placements" => { "list_placements" => "No" },
+          }
+        end
+
+        it { is_expected.to eq %i[appetite help list_placements school_contact] }
+      end
+
+      context "when list_placement is set to 'Yes' during the list_placement step" do
+        let(:state) do
+          {
+            "appetite" => { "appetite" => "interested" },
+            "list_placements" => { "list_placements" => "Yes" },
+          }
+        end
+
+        it { is_expected.to eq %i[appetite help list_placements phase subjects_known school_contact] }
+
+        context "when the subjects_know is set to 'Yes' during the subjects_known step" do
+          context "when the phase is set to 'Primary' during the phase step" do
+            let(:state) do
+              {
+                "appetite" => { "appetite" => "interested" },
+                "list_placements" => { "list_placements" => "Yes" },
+                "phase" => { "phases" => %w[Primary] },
+                "subjects_known" => { "subjects_known" => "Yes" },
+              }
+            end
+
+            it {
+              expect(steps).to eq(
+                %i[appetite
+                   help
+                   list_placements
+                   phase
+                   subjects_known
+                   primary_subject_selection
+                   primary_placement_quantity
+                   school_contact],
+              )
+            }
+          end
+
+          context "when the phase is set to 'Secondary' during the phase step" do
+            let(:state) do
+              {
+                "appetite" => { "appetite" => "interested" },
+                "list_placements" => { "list_placements" => "Yes" },
+                "phase" => { "phases" => %w[Secondary] },
+                "subjects_known" => { "subjects_known" => "Yes" },
+              }
+            end
+
+            it {
+              expect(steps).to eq(
+                %i[appetite
+                   help
+                   list_placements
+                   phase
+                   subjects_known
+                   secondary_subject_selection
+                   secondary_placement_quantity
+                   school_contact],
+              )
+            }
+
+            context "when the subject selected has child subjects" do
+              let(:modern_languages) { create(:subject, :secondary, name: "Modern Languages") }
+              let(:french) { create(:subject, :secondary, name: "French", parent_subject: modern_languages) }
+              let(:state) do
+                {
+                  "appetite" => { "appetite" => "interested" },
+                  "list_placements" => { "list_placements" => "Yes" },
+                  "phase" => { "phases" => %w[Secondary] },
+                  "subjects_known" => { "subjects_known" => "Yes" },
+                  "secondary_subject_selection" => { "subject_ids" => [modern_languages.id] },
+                  "secondary_placement_quantity" => { "modern_languages" => "2" },
+                }
+              end
+
+              before { french }
+
+              it {
+                expect(steps).to eq(
+                  %i[appetite
+                     help
+                     list_placements
+                     phase
+                     subjects_known
+                     secondary_subject_selection
+                     secondary_placement_quantity
+                     secondary_child_subject_placement_selection_modern_languages_1
+                     secondary_child_subject_placement_selection_modern_languages_2
+                     school_contact],
+                )
+              }
+            end
+          end
+
+          context "when the phase is set to 'Primary' and 'Secondary' during the phase step" do
+            let(:state) do
+              {
+                "appetite" => { "appetite" => "interested" },
+                "list_placements" => { "list_placements" => "Yes" },
+                "phase" => { "phases" => %w[Primary Secondary] },
+                "subjects_known" => { "subjects_known" => "Yes" },
+              }
+            end
+
+            it {
+              expect(steps).to eq(
+                %i[appetite
+                   help
+                   list_placements
+                   phase
+                   subjects_known
+                   primary_subject_selection
+                   primary_placement_quantity
+                   secondary_subject_selection
+                   secondary_placement_quantity
+                   school_contact],
+              )
+            }
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Context

- Join the `actively_looking_steps` to the `interested` path when selecting "Yes" when asked to list placements.

## Changes proposed in this pull request

- Add steps `actively_looking_steps` when "Yes" is selected on the List placements step.

## Guidance to review

⚠️ You will need to enable the ":bulk_add_placements" flag ⚠️

- Sign in as Anne (School user)
- Navigate to "Placements"
- Click "Bulk add placements"
- Choose "Interested in hosting placements"
- Follow the rest of the journey - Pick "Yes" when asked "Would you like to list some placements to be seen by providers?"
- Follow the rest of the journey to create placements
- This should result in creating/updating your school's HostingInterest for next year
- This should result in any changes made to the school contact
- This should result in creating any placements set in the journey

## Screenshots

https://github.com/user-attachments/assets/4c7dad6d-7569-4f47-8e0d-b50911d41812



