### PR TITLE
Add provider page to actively look path

### DIFF
--- a/app/views/wizards/placements/multi_placement_wizard/_provider_step.html.erb
+++ b/app/views/wizards/placements/multi_placement_wizard/_provider_step.html.erb
@@ -1,0 +1,23 @@
+<% content_for :page_title, title_with_error_prefix(
+  t(".title"),
+  error: current_step.errors.any?,
+) %>
+
+<%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_check_boxes_fieldset :provider_ids, legend: { text: t(".title"), size: "l", tag: "h1" } do %>
+        <%= f.govuk_check_box :provider_ids, current_step.class::SELECT_ALL, exclusive: true, label: { text: t(".#{current_step.class::SELECT_ALL}") }, link_errors: true %>
+        <%= f.govuk_check_box_divider %>
+
+        <% current_step.providers.each do |provider| %>
+          <%= f.govuk_check_box :provider_ids, provider.id, label: { text: provider.name } %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit t(".continue") %>
+    </div>
+  </div>
+<% end %>

--- a/app/wizards/placements/multi_placement_wizard.rb
+++ b/app/wizards/placements/multi_placement_wizard.rb
@@ -113,15 +113,14 @@ module Placements
       return if steps[:provider].blank?
 
       provider_step = steps.fetch(:provider)
-      if provider_step.provider_ids.include?(provider_step.class::SELECT_ALL)
-        provider_step.providers.each do |provider|
-          school.partnerships.create!(provider:)
-        end
-      else
-        provider_step.provider_ids.each do |provider_id|
-          provider = ::Provider.find(provider_id)
-          school.partnerships.create!(provider:)
-        end
+      providers = if provider_step.provider_ids.include?(provider_step.class::SELECT_ALL)
+                    provider_step.providers
+                  else
+                    ::Provider.where(id: provider_step.provider_ids)
+                  end
+
+      providers.each do |provider|
+        school.partnerships.create!(provider:)
       end
     end
 

--- a/app/wizards/placements/multi_placement_wizard/provider_step.rb
+++ b/app/wizards/placements/multi_placement_wizard/provider_step.rb
@@ -1,0 +1,22 @@
+class Placements::MultiPlacementWizard::ProviderStep < BaseStep
+  attribute :provider_ids, default: []
+
+  SELECT_ALL = "select_all".freeze
+
+  def providers
+    # This is for User Research and Testing
+    Provider.where("name LIKE ?", "Test Provider %").order_by_name
+  end
+
+  def provider_ids=(value)
+    super normalised_provider_ids(value)
+  end
+
+  private
+
+  def normalised_provider_ids(selected_ids)
+    return [] if selected_ids.blank?
+
+    selected_ids.reject(&:blank?)
+  end
+end

--- a/config/locales/en/wizards/placements/multi_placement_wizard.yml
+++ b/config/locales/en/wizards/placements/multi_placement_wizard.yml
@@ -69,3 +69,7 @@ en:
           caption: Placement details
           continue: Continue
           placement_number: "%{placement_number} placement"
+        provider_step:
+          title: Select the providers you currently work with
+          continue: Continue
+          select_all: Select all

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -231,6 +231,11 @@ Claims::School.all.find_each do |school|
   end
 end
 
+# Test providers for UR
+Provider.create!(name: "Test Provider 123", code: "TEST 123")
+Provider.create!(name: "Test Provider 456", code: "TEST 456")
+Provider.create!(name: "Test Provider 789", code: "TEST 789")
+
 # Feature flags
 
 Flipper.add(:bulk_add_placements)

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/primary_phase_only/school_user_bulk_adds_placements_for_the_primary_phase_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/primary_phase_only/school_user_bulk_adds_placements_for_the_primary_phase_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "School user bulk adds placements for the primary phases",
   scenario do
     given_the_bulk_add_placements_flag_is_enabled
     and_subjects_exist
+    and_test_providers_exist
     and_academic_years_exist
     and_i_am_signed_in
     when_i_am_on_the_placements_index_page
@@ -31,6 +32,9 @@ RSpec.describe "School user bulk adds placements for the primary phases",
 
     when_i_fill_in_the_number_of_primary_placements_i_require
     and_i_click_on_continue
+    then_i_see_the_provider_select_form
+
+    when_i_click_on_continue
     then_i_see_the_school_contact_form
 
     when_i_fill_in_the_school_contact_details
@@ -62,6 +66,12 @@ RSpec.describe "School user bulk adds placements for the primary phases",
     @current_academic_year_name = current_academic_year.name
     @next_academic_year = current_academic_year.next
     @next_academic_year_name = @next_academic_year.name
+  end
+
+  def and_test_providers_exist
+    @provider_1 = create(:provider, name: "Test Provider 123")
+    @provider_2 = create(:provider, name: "Test Provider 456")
+    @provider_3 = create(:provider, name: "Test Provider 789")
   end
 
   def and_i_am_signed_in
@@ -242,5 +252,21 @@ RSpec.describe "School user bulk adds placements for the primary phases",
       match: :prefer_exact,
       count: 3,
     )
+  end
+
+  def then_i_see_the_provider_select_form
+    expect(page).to have_title(
+      "Select the providers you currently work with - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :h1,
+      text: "Select the providers you currently work with",
+      class: "govuk-fieldset__heading",
+    )
+    expect(page).to have_field("Select all", type: :checkbox)
+    expect(page).to have_field("Test Provider 123", type: :checkbox)
+    expect(page).to have_field("Test Provider 456", type: :checkbox)
+    expect(page).to have_field("Test Provider 789", type: :checkbox)
   end
 end

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "School user bulk adds placements for primary and secondary phase
   scenario do
     given_the_bulk_add_placements_flag_is_enabled
     and_subjects_exist
+    and_test_providers_exist
     and_academic_years_exist
     and_i_am_signed_in
     when_i_am_on_the_placements_index_page
@@ -41,7 +42,13 @@ RSpec.describe "School user bulk adds placements for primary and secondary phase
 
     when_i_fill_in_the_number_of_secondary_placements_i_require
     and_i_click_on_continue
+    then_i_see_the_provider_select_form
+
+    when_i_click_on_continue
     then_i_see_the_school_contact_form
+
+    when_i_click_on_back
+    then_i_see_the_provider_select_form
 
     when_i_click_on_back
     then_i_see_the_secondary_subject_placement_quantity_form
@@ -105,6 +112,9 @@ RSpec.describe "School user bulk adds placements for primary and secondary phase
 
     when_i_fill_in_the_number_of_secondary_placements_i_require
     and_i_click_on_continue
+    then_i_see_the_provider_select_form
+
+    when_i_click_on_continue
     then_i_see_the_school_contact_form
 
     when_i_fill_in_the_school_contact_details
@@ -142,6 +152,12 @@ RSpec.describe "School user bulk adds placements for primary and secondary phase
     @current_academic_year_name = current_academic_year.name
     @next_academic_year = current_academic_year.next
     @next_academic_year_name = @next_academic_year.name
+  end
+
+  def and_test_providers_exist
+    @provider_1 = create(:provider, name: "Test Provider 123")
+    @provider_2 = create(:provider, name: "Test Provider 456")
+    @provider_3 = create(:provider, name: "Test Provider 789")
   end
 
   def and_i_am_signed_in
@@ -388,5 +404,21 @@ RSpec.describe "School user bulk adds placements for primary and secondary phase
       match: :prefer_exact,
       count: 4,
     )
+  end
+
+  def then_i_see_the_provider_select_form
+    expect(page).to have_title(
+      "Select the providers you currently work with - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :h1,
+      text: "Select the providers you currently work with",
+      class: "govuk-fieldset__heading",
+    )
+    expect(page).to have_field("Select all", type: :checkbox)
+    expect(page).to have_field("Test Provider 123", type: :checkbox)
+    expect(page).to have_field("Test Provider 456", type: :checkbox)
+    expect(page).to have_field("Test Provider 789", type: :checkbox)
   end
 end

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_selects_all_providers_when_bulk_adding_placements_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_selects_all_providers_when_bulk_adding_placements_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "School user bulk adds placements for the secondary phase",
+RSpec.describe "School user selects all providers when bulk adding placements",
                service: :placements,
                type: :system do
   scenario do
@@ -17,11 +17,21 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
     and_i_click_on_continue
     then_i_see_the_phase_form
 
-    when_i_select_secondary
+    when_i_select_primary
+    and_i_select_secondary
     and_i_click_on_continue
     then_i_see_the_subjects_known_form
 
     when_i_select_yes
+    and_i_click_on_continue
+    then_i_see_the_primary_subject_selection_form
+
+    when_i_select_primary
+    and_i_select_primary_with_science
+    and_i_click_on_continue
+    then_i_see_the_primary_subject_placement_quantity_form
+
+    when_i_fill_in_the_number_of_primary_placements_i_require
     and_i_click_on_continue
     then_i_see_the_secondary_subject_selection_form
 
@@ -34,7 +44,8 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
     and_i_click_on_continue
     then_i_see_the_provider_select_form
 
-    when_i_click_on_continue
+    when_i_click_select_all
+    and_i_click_on_continue
     then_i_see_the_school_contact_form
 
     when_i_fill_in_the_school_contact_details
@@ -44,8 +55,15 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
     and_the_schools_hosting_interest_for_the_next_year_is_updated
 
     when_i_click_on_the_academic_year_tab
-    then_i_see_placements_i_created_for_the_subject_english
+    then_i_see_placements_i_created_for_the_subject_primary
+    and_i_see_placements_i_created_for_the_subject_handwriting
+    and_i_see_placements_i_created_for_the_subject_english
     and_i_see_placements_i_created_for_the_subject_mathematics
+
+    when_i_click_on_the_providers_navigation
+    then_i_see_test_provider_123
+    and_i_see_test_provider_456
+    and_i_see_test_provider_789
   end
 
   private
@@ -56,6 +74,10 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
   end
 
   def and_subjects_exist
+    @primary = create(:subject, :primary, name: "Primary")
+    @phonics = create(:subject, :primary, name: "Phonics")
+    @handwriting = create(:subject, :primary, name: "Handwriting")
+
     @english = create(:subject, :secondary, name: "English")
     @mathematics = create(:subject, :secondary, name: "Mathematics")
     @science = create(:subject, :secondary, name: "Science")
@@ -135,7 +157,11 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
     expect(page).to have_field("Secondary", type: :checkbox)
   end
 
-  def when_i_select_secondary
+  def when_i_select_primary
+    check "Primary"
+  end
+
+  def and_i_select_secondary
     check "Secondary"
   end
 
@@ -155,6 +181,42 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def when_i_select_yes
     choose "Yes"
+  end
+
+  def then_i_see_the_primary_subject_selection_form
+    expect(page).to have_title(
+      "Select primary subjects - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "Select primary subjects",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_field("Primary", type: :checkbox)
+    expect(page).to have_field("Phonics", type: :checkbox)
+    expect(page).to have_field("Handwriting", type: :checkbox)
+  end
+
+  def and_i_select_primary_with_science
+    check "Handwriting"
+  end
+
+  def then_i_see_the_primary_subject_placement_quantity_form
+    expect(page).to have_title(
+      "Enter the number of placements - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Enter the number of placements", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_field("Primary", type: :number)
+    expect(page).to have_field("Handwriting", type: :number)
+  end
+
+  def when_i_fill_in_the_number_of_primary_placements_i_require
+    fill_in "Primary", with: 2
+    fill_in "Handwriting", with: 3
   end
 
   def then_i_see_the_secondary_subject_selection_form
@@ -210,6 +272,14 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
     expect(page).to have_field("Email address", with: @school_contact.email_address)
   end
 
+  def when_i_click_on_back
+    click_on "Back"
+  end
+
+  def when_i_click_on_cancel
+    click_on "Cancel"
+  end
+
   def when_i_fill_in_the_school_contact_details
     fill_in "First name", with: "Joe"
     fill_in "Last name", with: "Bloggs"
@@ -236,7 +306,25 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
     click_on "Next year (#{@next_academic_year.name})"
   end
 
-  def then_i_see_placements_i_created_for_the_subject_english
+  def then_i_see_placements_i_created_for_the_subject_primary
+    expect(page).to have_link(
+      "Primary",
+      class: "govuk-link govuk-link--no-visited-state",
+      match: :prefer_exact,
+      count: 2,
+    )
+  end
+
+  def and_i_see_placements_i_created_for_the_subject_handwriting
+    expect(page).to have_link(
+      "Handwriting",
+      class: "govuk-link govuk-link--no-visited-state",
+      match: :prefer_exact,
+      count: 3,
+    )
+  end
+
+  def and_i_see_placements_i_created_for_the_subject_english
     expect(page).to have_link(
       "English",
       class: "govuk-link govuk-link--no-visited-state",
@@ -268,5 +356,27 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
     expect(page).to have_field("Test Provider 123", type: :checkbox)
     expect(page).to have_field("Test Provider 456", type: :checkbox)
     expect(page).to have_field("Test Provider 789", type: :checkbox)
+  end
+
+  def when_i_click_select_all
+    check "Select all"
+  end
+
+  def when_i_click_on_the_providers_navigation
+    within(primary_navigation) do
+      click_on "Providers"
+    end
+  end
+
+  def then_i_see_test_provider_123
+    expect(page).to have_link("Test Provider 123")
+  end
+
+  def and_i_see_test_provider_456
+    expect(page).to have_link("Test Provider 456")
+  end
+
+  def and_i_see_test_provider_789
+    expect(page).to have_link("Test Provider 789")
   end
 end

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_selects_specific_providers_when_bulk_adding_placements_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_selects_specific_providers_when_bulk_adding_placements_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "School user bulk adds placements for the secondary phase",
+RSpec.describe "School user selects specfic providers when bulk adding placements",
                service: :placements,
                type: :system do
   scenario do
@@ -17,11 +17,21 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
     and_i_click_on_continue
     then_i_see_the_phase_form
 
-    when_i_select_secondary
+    when_i_select_primary
+    and_i_select_secondary
     and_i_click_on_continue
     then_i_see_the_subjects_known_form
 
     when_i_select_yes
+    and_i_click_on_continue
+    then_i_see_the_primary_subject_selection_form
+
+    when_i_select_primary
+    and_i_select_primary_with_science
+    and_i_click_on_continue
+    then_i_see_the_primary_subject_placement_quantity_form
+
+    when_i_fill_in_the_number_of_primary_placements_i_require
     and_i_click_on_continue
     then_i_see_the_secondary_subject_selection_form
 
@@ -34,7 +44,9 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
     and_i_click_on_continue
     then_i_see_the_provider_select_form
 
-    when_i_click_on_continue
+    when_i_select_provider_123
+    and_i_select_provider_789
+    and_i_click_on_continue
     then_i_see_the_school_contact_form
 
     when_i_fill_in_the_school_contact_details
@@ -44,8 +56,15 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
     and_the_schools_hosting_interest_for_the_next_year_is_updated
 
     when_i_click_on_the_academic_year_tab
-    then_i_see_placements_i_created_for_the_subject_english
+    then_i_see_placements_i_created_for_the_subject_primary
+    and_i_see_placements_i_created_for_the_subject_handwriting
+    and_i_see_placements_i_created_for_the_subject_english
     and_i_see_placements_i_created_for_the_subject_mathematics
+
+    when_i_click_on_the_providers_navigation
+    then_i_see_test_provider_123
+    and_i_see_test_provider_789
+    and_i_do_not_see_test_provider_456
   end
 
   private
@@ -56,6 +75,10 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
   end
 
   def and_subjects_exist
+    @primary = create(:subject, :primary, name: "Primary")
+    @phonics = create(:subject, :primary, name: "Phonics")
+    @handwriting = create(:subject, :primary, name: "Handwriting")
+
     @english = create(:subject, :secondary, name: "English")
     @mathematics = create(:subject, :secondary, name: "Mathematics")
     @science = create(:subject, :secondary, name: "Science")
@@ -135,7 +158,11 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
     expect(page).to have_field("Secondary", type: :checkbox)
   end
 
-  def when_i_select_secondary
+  def when_i_select_primary
+    check "Primary"
+  end
+
+  def and_i_select_secondary
     check "Secondary"
   end
 
@@ -155,6 +182,42 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def when_i_select_yes
     choose "Yes"
+  end
+
+  def then_i_see_the_primary_subject_selection_form
+    expect(page).to have_title(
+      "Select primary subjects - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "Select primary subjects",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_field("Primary", type: :checkbox)
+    expect(page).to have_field("Phonics", type: :checkbox)
+    expect(page).to have_field("Handwriting", type: :checkbox)
+  end
+
+  def and_i_select_primary_with_science
+    check "Handwriting"
+  end
+
+  def then_i_see_the_primary_subject_placement_quantity_form
+    expect(page).to have_title(
+      "Enter the number of placements - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Enter the number of placements", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_field("Primary", type: :number)
+    expect(page).to have_field("Handwriting", type: :number)
+  end
+
+  def when_i_fill_in_the_number_of_primary_placements_i_require
+    fill_in "Primary", with: 2
+    fill_in "Handwriting", with: 3
   end
 
   def then_i_see_the_secondary_subject_selection_form
@@ -210,6 +273,14 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
     expect(page).to have_field("Email address", with: @school_contact.email_address)
   end
 
+  def when_i_click_on_back
+    click_on "Back"
+  end
+
+  def when_i_click_on_cancel
+    click_on "Cancel"
+  end
+
   def when_i_fill_in_the_school_contact_details
     fill_in "First name", with: "Joe"
     fill_in "Last name", with: "Bloggs"
@@ -236,7 +307,25 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
     click_on "Next year (#{@next_academic_year.name})"
   end
 
-  def then_i_see_placements_i_created_for_the_subject_english
+  def then_i_see_placements_i_created_for_the_subject_primary
+    expect(page).to have_link(
+      "Primary",
+      class: "govuk-link govuk-link--no-visited-state",
+      match: :prefer_exact,
+      count: 2,
+    )
+  end
+
+  def and_i_see_placements_i_created_for_the_subject_handwriting
+    expect(page).to have_link(
+      "Handwriting",
+      class: "govuk-link govuk-link--no-visited-state",
+      match: :prefer_exact,
+      count: 3,
+    )
+  end
+
+  def and_i_see_placements_i_created_for_the_subject_english
     expect(page).to have_link(
       "English",
       class: "govuk-link govuk-link--no-visited-state",
@@ -268,5 +357,31 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
     expect(page).to have_field("Test Provider 123", type: :checkbox)
     expect(page).to have_field("Test Provider 456", type: :checkbox)
     expect(page).to have_field("Test Provider 789", type: :checkbox)
+  end
+
+  def when_i_select_provider_123
+    check "Provider 123"
+  end
+
+  def and_i_select_provider_789
+    check "Provider 789"
+  end
+
+  def when_i_click_on_the_providers_navigation
+    within(primary_navigation) do
+      click_on "Providers"
+    end
+  end
+
+  def then_i_see_test_provider_123
+    expect(page).to have_link("Test Provider 123")
+  end
+
+  def and_i_do_not_see_test_provider_456
+    expect(page).not_to have_link("Test Provider 456")
+  end
+
+  def and_i_see_test_provider_789
+    expect(page).to have_link("Test Provider 789")
   end
 end

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_successfully_completes_the_actively_looking_journey_without_placements_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_successfully_completes_the_actively_looking_journey_without_placements_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "School user successfully completes the actively looking journey 
     given_the_bulk_add_placements_flag_is_enabled
     and_subjects_exist
     and_academic_years_exist
+    and_test_providers_exist
     and_i_am_signed_in
     when_i_am_on_the_placements_index_page
     and_i_click_on_bulk_add_placements
@@ -23,7 +24,13 @@ RSpec.describe "School user successfully completes the actively looking journey 
 
     when_i_select_no
     and_i_click_on_continue
+    then_i_see_the_provider_select_form
+
+    when_i_click_on_continue
     then_i_see_the_school_contact_form
+
+    when_i_click_on_back
+    then_i_see_the_provider_select_form
 
     when_i_click_on_back
     then_i_see_the_subjects_known_form
@@ -51,6 +58,10 @@ RSpec.describe "School user successfully completes the actively looking journey 
 
     when_i_select_no
     and_i_click_on_continue
+    then_i_see_the_provider_select_form
+
+    when_i_click_on_continue
+    then_i_see_the_school_contact_form
 
     when_i_fill_in_the_school_contact_details
     and_i_click_on_continue
@@ -81,6 +92,12 @@ RSpec.describe "School user successfully completes the actively looking journey 
     @current_academic_year_name = current_academic_year.name
     @next_academic_year = current_academic_year.next
     @next_academic_year_name = @next_academic_year.name
+  end
+
+  def and_test_providers_exist
+    @provider_1 = create(:provider, name: "Test Provider 123")
+    @provider_2 = create(:provider, name: "Test Provider 456")
+    @provider_3 = create(:provider, name: "Test Provider 789")
   end
 
   def and_i_am_signed_in
@@ -211,5 +228,21 @@ RSpec.describe "School user successfully completes the actively looking journey 
   def and_the_schools_hosting_interest_for_the_next_year_is_updated
     hosting_interest = @school.hosting_interests.for_academic_year(@next_academic_year).last
     expect(hosting_interest.appetite).to eq("actively_looking")
+  end
+
+  def then_i_see_the_provider_select_form
+    expect(page).to have_title(
+      "Select the providers you currently work with - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :h1,
+      text: "Select the providers you currently work with",
+      class: "govuk-fieldset__heading",
+    )
+    expect(page).to have_field("Select all", type: :checkbox)
+    expect(page).to have_field("Test Provider 123", type: :checkbox)
+    expect(page).to have_field("Test Provider 456", type: :checkbox)
+    expect(page).to have_field("Test Provider 789", type: :checkbox)
   end
 end

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/secondary_phase_only/school_user_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/secondary_phase_only/school_user_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "School user bulk adds placements for a subject with child subjec
     given_the_bulk_add_placements_flag_is_enabled
     and_subjects_exist
     and_academic_years_exist
+    and_test_providers_exist
     and_i_am_signed_in
     when_i_am_on_the_placements_index_page
     and_i_click_on_bulk_add_placements
@@ -41,6 +42,9 @@ RSpec.describe "School user bulk adds placements for a subject with child subjec
     when_i_select_spanish
     and_i_select_russian
     and_i_click_on_continue
+    then_i_see_the_provider_select_form
+
+    when_i_click_on_continue
     then_i_see_the_school_contact_form
 
     when_i_fill_in_the_school_contact_details
@@ -76,6 +80,12 @@ RSpec.describe "School user bulk adds placements for a subject with child subjec
     @current_academic_year_name = current_academic_year.name
     @next_academic_year = current_academic_year.next
     @next_academic_year_name = @next_academic_year.name
+  end
+
+  def and_test_providers_exist
+    @provider_1 = create(:provider, name: "Test Provider 123")
+    @provider_2 = create(:provider, name: "Test Provider 456")
+    @provider_3 = create(:provider, name: "Test Provider 789")
   end
 
   def and_i_am_signed_in
@@ -286,5 +296,21 @@ RSpec.describe "School user bulk adds placements for a subject with child subjec
       match: :prefer_exact,
       count: 1,
     )
+  end
+
+  def then_i_see_the_provider_select_form
+    expect(page).to have_title(
+      "Select the providers you currently work with - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :h1,
+      text: "Select the providers you currently work with",
+      class: "govuk-fieldset__heading",
+    )
+    expect(page).to have_field("Select all", type: :checkbox)
+    expect(page).to have_field("Test Provider 123", type: :checkbox)
+    expect(page).to have_field("Test Provider 456", type: :checkbox)
+    expect(page).to have_field("Test Provider 789", type: :checkbox)
   end
 end

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_selects_yes_and_completes_the_interested_journey_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_selects_yes_and_completes_the_interested_journey_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "School user selects yes and completes the interested journey",
     given_the_bulk_add_placements_flag_is_enabled
     and_subjects_exist
     and_academic_years_exist
+    and_test_providers_exist
     and_i_am_signed_in
     when_i_am_on_the_placements_index_page
     and_i_click_on_bulk_add_placements
@@ -48,6 +49,9 @@ RSpec.describe "School user selects yes and completes the interested journey",
 
     when_i_fill_in_the_number_of_secondary_placements_i_require
     and_i_click_on_continue
+    then_i_see_the_provider_select_form
+
+    when_i_click_on_continue
     then_i_see_the_school_contact_form
 
     when_i_fill_in_the_school_contact_details
@@ -79,6 +83,12 @@ RSpec.describe "School user selects yes and completes the interested journey",
     @english = create(:subject, :secondary, name: "English")
     @mathematics = create(:subject, :secondary, name: "Mathematics")
     @science = create(:subject, :secondary, name: "Science")
+  end
+
+  def and_test_providers_exist
+    @provider_1 = create(:provider, name: "Test Provider 123")
+    @provider_2 = create(:provider, name: "Test Provider 456")
+    @provider_3 = create(:provider, name: "Test Provider 789")
   end
 
   def and_i_am_signed_in
@@ -343,5 +353,21 @@ RSpec.describe "School user selects yes and completes the interested journey",
       match: :prefer_exact,
       count: 4,
     )
+  end
+
+  def then_i_see_the_provider_select_form
+    expect(page).to have_title(
+      "Select the providers you currently work with - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :h1,
+      text: "Select the providers you currently work with",
+      class: "govuk-fieldset__heading",
+    )
+    expect(page).to have_field("Select all", type: :checkbox)
+    expect(page).to have_field("Test Provider 123", type: :checkbox)
+    expect(page).to have_field("Test Provider 456", type: :checkbox)
+    expect(page).to have_field("Test Provider 789", type: :checkbox)
   end
 end

--- a/spec/wizards/placements/multi_placement_wizard/provider_step_spec.rb
+++ b/spec/wizards/placements/multi_placement_wizard/provider_step_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.describe Placements::MultiPlacementWizard::ProviderStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Placements::MultiPlacementWizard).tap do |mock_wizard|
+      allow(mock_wizard).to receive_messages(
+        school:,
+      )
+    end
+  end
+
+  let(:attributes) { nil }
+  let!(:school) { create(:placements_school) }
+  let(:state) { {} }
+
+  describe "attributes" do
+    it { is_expected.to have_attributes(provider_ids: []) }
+  end
+
+  describe "#providers" do
+    subject(:providers) { step.providers }
+
+    context "when no test providers exist" do
+      it "returns an empty list" do
+        expect(providers).to eq([])
+      end
+    end
+
+    context "when test providers exist" do
+      let(:test_provider) { create(:provider, name: "Test Provider 123") }
+      let(:random_provider) { create(:provider) }
+
+      it "returns only the test providers" do
+        expect(providers).to contain_exactly(test_provider)
+      end
+    end
+  end
+
+  describe "#provider_ids" do
+    subject(:provider_ids) { step.provider_ids }
+
+    context "when provider_ids is blank" do
+      it "returns an empty array" do
+        expect(provider_ids).to eq([])
+      end
+    end
+
+    context "when the provider_ids attribute contains a blank element" do
+      let(:attributes) { { provider_ids: ["123", nil] } }
+
+      it "removes the nil element from the provider_ids" do
+        expect(provider_ids).to contain_exactly("123")
+      end
+    end
+
+    context "when the provider_ids attribute contains no blank elements" do
+      let(:attributes) { { provider_ids: %w[123 456] } }
+
+      it "returns the provider_ids attribute unchanged" do
+        expect(provider_ids).to contain_exactly(
+          "123",
+          "456",
+        )
+      end
+    end
+
+    context "when the provider_ids attribute contains select_all" do
+      let(:attributes) { { provider_ids: ["", "select_all"] } }
+
+      it "returns the provider_ids attribute unchanged" do
+        expect(provider_ids).to contain_exactly(
+          "select_all",
+        )
+      end
+    end
+  end
+end

--- a/spec/wizards/placements/multi_placement_wizard_spec.rb
+++ b/spec/wizards/placements/multi_placement_wizard_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Placements::MultiPlacementWizard do
         }
       end
 
-      it { is_expected.to eq %i[appetite phase subjects_known school_contact] }
+      it { is_expected.to eq %i[appetite phase subjects_known provider school_contact] }
 
       context "when the subjects_know is set to 'Yes' during the subjects_known step" do
         context "when the phase is set to 'Primary' during the phase step" do
@@ -40,6 +40,7 @@ RSpec.describe Placements::MultiPlacementWizard do
                  subjects_known
                  primary_subject_selection
                  primary_placement_quantity
+                 provider
                  school_contact],
             )
           }
@@ -61,6 +62,7 @@ RSpec.describe Placements::MultiPlacementWizard do
                  subjects_known
                  secondary_subject_selection
                  secondary_placement_quantity
+                 provider
                  school_contact],
             )
           }
@@ -89,6 +91,7 @@ RSpec.describe Placements::MultiPlacementWizard do
                    secondary_placement_quantity
                    secondary_child_subject_placement_selection_modern_languages_1
                    secondary_child_subject_placement_selection_modern_languages_2
+                   provider
                    school_contact],
               )
             }
@@ -113,6 +116,7 @@ RSpec.describe Placements::MultiPlacementWizard do
                  primary_placement_quantity
                  secondary_subject_selection
                  secondary_placement_quantity
+                 provider
                  school_contact],
             )
           }
@@ -158,7 +162,7 @@ RSpec.describe Placements::MultiPlacementWizard do
           }
         end
 
-        it { is_expected.to eq %i[appetite help list_placements phase subjects_known school_contact] }
+        it { is_expected.to eq %i[appetite help list_placements phase subjects_known provider school_contact] }
 
         context "when the subjects_know is set to 'Yes' during the subjects_known step" do
           context "when the phase is set to 'Primary' during the phase step" do
@@ -180,6 +184,7 @@ RSpec.describe Placements::MultiPlacementWizard do
                    subjects_known
                    primary_subject_selection
                    primary_placement_quantity
+                   provider
                    school_contact],
               )
             }
@@ -204,6 +209,7 @@ RSpec.describe Placements::MultiPlacementWizard do
                    subjects_known
                    secondary_subject_selection
                    secondary_placement_quantity
+                   provider
                    school_contact],
               )
             }
@@ -235,6 +241,7 @@ RSpec.describe Placements::MultiPlacementWizard do
                      secondary_placement_quantity
                      secondary_child_subject_placement_selection_modern_languages_1
                      secondary_child_subject_placement_selection_modern_languages_2
+                     provider
                      school_contact],
                 )
               }
@@ -262,6 +269,7 @@ RSpec.describe Placements::MultiPlacementWizard do
                    primary_placement_quantity
                    secondary_subject_selection
                    secondary_placement_quantity
+                   provider
                    school_contact],
               )
             }
@@ -478,6 +486,115 @@ RSpec.describe Placements::MultiPlacementWizard do
               expect(school_contact.first_name).to eq("Joe")
               expect(school_contact.last_name).to eq("Bloggs")
               expect(school_contact.email_address).to eq("joe_bloggs@example.com")
+            end
+
+            context "when provider_ids is set to 'select_all'" do
+              let(:state) do
+                {
+                  "appetite" => { "appetite" => "actively_looking" },
+                  "phase" => { "phases" => %w[Primary Secondary] },
+                  "subjects_known" => { "subjects_known" => "Yes" },
+                  "primary_subject_selection" => { "subject_ids" => [primary_with_english.id] },
+                  "primary_placement_quantity" => { "primary_with_english" => "1" },
+                  "secondary_subject_selection" => { "subject_ids" => [english.id] },
+                  "secondary_placement_quantity" => { "english" => "1" },
+                  "provider" => { "provider_ids" => %w[select_all] },
+                  "school_contact" => {
+                    "first_name" => "Joe",
+                    "last_name" => "Bloggs",
+                    "email_address" => "joe_bloggs@example.com",
+                  },
+                }
+              end
+              let(:test_provider_1) { create(:provider, name: "Test Provider 123") }
+              let(:test_provider_2) { create(:provider, name: "Test Provider 456") }
+              let(:test_provider_3) { create(:provider, name: "Test Provider 789") }
+
+              before do
+                test_provider_1
+                test_provider_2
+                test_provider_3
+              end
+
+              it "creates hosting interest for the next academic year, assigns the appetite,
+                creates a school contact and creates a placement for each selected subject and it's quantity
+                and create partnerships with all test providers" do
+                expect { update_school_placements }.to change(Placements::HostingInterest, :count).by(1)
+                  .and change(Placement, :count).by(2)
+                  .and change(Placements::Partnership, :count).by(3)
+                school.reload
+
+                hosting_interest = school.hosting_interests.last
+                expect(hosting_interest.appetite).to eq("actively_looking")
+
+                expect(school.placements.where(subject_id: primary_with_english.id).count).to eq(1)
+                expect(school.placements.where(subject_id: english.id).count).to eq(1)
+
+                expect(school.partner_providers).to contain_exactly(
+                  test_provider_1,
+                  test_provider_2,
+                  test_provider_3,
+                )
+
+                school_contact = school.school_contact
+                expect(school_contact.first_name).to eq("Joe")
+                expect(school_contact.last_name).to eq("Bloggs")
+                expect(school_contact.email_address).to eq("joe_bloggs@example.com")
+              end
+            end
+
+            context "when provider_ids is contains specific provider ids" do
+              let(:state) do
+                {
+                  "appetite" => { "appetite" => "actively_looking" },
+                  "phase" => { "phases" => %w[Primary Secondary] },
+                  "subjects_known" => { "subjects_known" => "Yes" },
+                  "primary_subject_selection" => { "subject_ids" => [primary_with_english.id] },
+                  "primary_placement_quantity" => { "primary_with_english" => "1" },
+                  "secondary_subject_selection" => { "subject_ids" => [english.id] },
+                  "secondary_placement_quantity" => { "english" => "1" },
+                  "provider" => { "provider_ids" => [test_provider_1.id, test_provider_3.id] },
+                  "school_contact" => {
+                    "first_name" => "Joe",
+                    "last_name" => "Bloggs",
+                    "email_address" => "joe_bloggs@example.com",
+                  },
+                }
+              end
+              let(:test_provider_1) { create(:provider, name: "Test Provider 123") }
+              let(:test_provider_2) { create(:provider, name: "Test Provider 456") }
+              let(:test_provider_3) { create(:provider, name: "Test Provider 789") }
+
+              before do
+                test_provider_1
+                test_provider_2
+                test_provider_3
+              end
+
+              it "creates hosting interest for the next academic year, assigns the appetite,
+                creates a school contact and creates a placement for each selected subject and it's quantity
+                and create partnerships for the selected test providers" do
+                expect { update_school_placements }.to change(Placements::HostingInterest, :count).by(1)
+                  .and change(Placement, :count).by(2)
+                  .and change(Placements::Partnership, :count).by(2)
+                school.reload
+
+                hosting_interest = school.hosting_interests.last
+                expect(hosting_interest.appetite).to eq("actively_looking")
+
+                expect(school.placements.where(subject_id: primary_with_english.id).count).to eq(1)
+                expect(school.placements.where(subject_id: english.id).count).to eq(1)
+
+                expect(school.partner_providers).to contain_exactly(
+                  test_provider_1,
+                  test_provider_3,
+                )
+
+                school_contact = school.school_contact
+                expect(school_contact.first_name).to eq("Joe")
+                expect(school_contact.last_name).to eq("Bloggs")
+                expect(school_contact.email_address).to eq("joe_bloggs@example.com")
+              end
             end
           end
         end


### PR DESCRIPTION
## Context

- Add provider step to the `actively_looking` journey of the MultiPlacementWizard

## Changes proposed in this pull request

- Add provider step and related views to the `actively_looking` journey of the MultiPlacementWizard

## Guidance to review

⚠️ You will need to enable the ":bulk_add_placements" flag ⚠️

- Sign in as Anne (School user)
- Navigate to "Placements"
- Click "Bulk add placements"
- Choose "Interested in hosting placements"
- Follow the rest of the journey - You should now see the providers step (assuming you have providers with the name "Test Provider [0-9]"
- This should result in creating/updating your school's HostingInterest for next year
- This should result in any changes made to the school contact
- This should result in creating any placements set in the journey
- This should result in creating any partnerships between providers you selected

## Link to Trello card

https://trello.com/c/ftSI6zg5/448-multi-placement-wizard-add-provider-step-to-happy-path

## Screenshots

![screencapture-placements-localhost-3000-schools-00004b84-98c7-4bad-83a9-e69310cf4167-placements-multiple-e537114b-ac42-416b-a6f8-ea2071127ade-provider-2025-03-06-11_00_06](https://github.com/user-attachments/assets/77ed7d10-fe47-4dac-8f21-d9ca91247e76)

