### PR TITLE
Content changes on appetite step

### DIFF
--- a/app/wizards/placements/multi_placement_wizard/appetite_step.rb
+++ b/app/wizards/placements/multi_placement_wizard/appetite_step.rb
@@ -19,7 +19,9 @@ class Placements::MultiPlacementWizard::AppetiteStep < BaseStep
   end
 
   def placement_appetites
-    @placement_appetites ||= Placements::HostingInterest.appetites.keys
+    appetites = Placements::HostingInterest.appetites.keys
+    appetites.delete("already_organised") # Removed for concept testing
+    @placement_appetites ||= appetites
   end
 
   private

--- a/config/locales/en/wizards/placements/multi_placement_wizard.yml
+++ b/config/locales/en/wizards/placements/multi_placement_wizard.yml
@@ -3,18 +3,18 @@ en:
     placements:
       multi_placement_wizard:
         appetite_step:
-          title: What is your appetite for ITT the coming academic year (%{academic_year_name})?
+          title: Will you host placements this academic year (%{academic_year_name})?
           continue: Continue
           options:
             actively_looking:
-              name: Actively looking to host placements
-              description: You'll have to the option to specify what you'd like to host in the next step
+              name: Yes - Let providers know what I'm willing to host
+              description: You know the subjects you want to host and may know which providers you want to work with
             interested:
-              name: Interested in hosting placements
-              description: Providers will be able to contact you and discuss
+              name: Yes - Let providers know I am open to placements
+              description: You haven't yet decided on your placements. You want to hear from providers to discuss potential opportunities
             not_open: 
-              name: Not open to hosting placements
-              description: Providers will not be able to contact you using this service this academic year
+              name: No - Let providers know I am not hosting and do not want to be contacted
+              description: You do not want to hear from providers this academic year
             already_organised:
               name: Placements already organised with providers
               description: We'll show any providers who search for you that you're at capacity

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/primary_phase_only/school_user_bulk_adds_placements_for_the_primary_phase_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/primary_phase_only/school_user_bulk_adds_placements_for_the_primary_phase_spec.rb
@@ -87,22 +87,21 @@ RSpec.describe "School user bulk adds placements for the primary phases",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_actively_looking_to_host_placements
-    choose "Actively looking to host placements"
+    choose "Yes - Let providers know what I'm willing to host"
   end
 
   def when_i_click_on_continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/primary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/primary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
@@ -75,22 +75,21 @@ RSpec.describe "School user does not enter a placement quantity",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_actively_looking_to_host_placements
-    choose "Actively looking to host placements"
+    choose "Yes - Let providers know what I'm willing to host"
   end
 
   def when_i_click_on_continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/primary_phase_only/school_user_does_not_select_a_subject_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/primary_phase_only/school_user_does_not_select_a_subject_spec.rb
@@ -71,22 +71,21 @@ RSpec.describe "School user does not select a subject",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_actively_looking_to_host_placements
-    choose "Actively looking to host placements"
+    choose "Yes - Let providers know what I'm willing to host"
   end
 
   def when_i_click_on_continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/primary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/primary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
@@ -76,22 +76,21 @@ RSpec.describe "School user enters a float as a placement quantity",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_actively_looking_to_host_placements
-    choose "Actively looking to host placements"
+    choose "Yes - Let providers know what I'm willing to host"
   end
 
   def when_i_click_on_continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/primary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/primary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
@@ -76,22 +76,21 @@ RSpec.describe "School user enters zero as a placement quantity",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_actively_looking_to_host_placements
-    choose "Actively looking to host placements"
+    choose "Yes - Let providers know what I'm willing to host"
   end
 
   def when_i_click_on_continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
@@ -167,22 +167,21 @@ RSpec.describe "School user bulk adds placements for primary and secondary phase
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_actively_looking_to_host_placements
-    choose "Actively looking to host placements"
+    choose "Yes - Let providers know what I'm willing to host"
   end
 
   def when_i_click_on_continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_does_not_select_a_phase_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_does_not_select_a_phase_spec.rb
@@ -67,22 +67,21 @@ RSpec.describe "School user does not select a phases",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_actively_looking_to_host_placements
-    choose "Actively looking to host placements"
+    choose "Yes - Let providers know what I'm willing to host"
   end
 
   def when_i_click_on_continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_does_not_select_if_the_subjects_are_known_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_does_not_select_if_the_subjects_are_known_spec.rb
@@ -72,22 +72,21 @@ RSpec.describe "School user bulk adds placements for primary and secondary phase
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_actively_looking_to_host_placements
-    choose "Actively looking to host placements"
+    choose "Yes - Let providers know what I'm willing to host"
   end
 
   def when_i_click_on_continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_successfully_completes_the_actively_looking_journey_without_placements_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_successfully_completes_the_actively_looking_journey_without_placements_spec.rb
@@ -106,22 +106,21 @@ RSpec.describe "School user successfully completes the actively looking journey 
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_actively_looking_to_host_placements
-    choose "Actively looking to host placements"
+    choose "Yes - Let providers know what I'm willing to host"
   end
 
   def when_i_click_on_continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/secondary_phase_only/school_user_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/secondary_phase_only/school_user_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
@@ -101,22 +101,21 @@ RSpec.describe "School user bulk adds placements for a subject with child subjec
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_actively_looking_to_host_placements
-    choose "Actively looking to host placements"
+    choose "Yes - Let providers know what I'm willing to host"
   end
 
   def when_i_click_on_continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/secondary_phase_only/school_user_bulk_adds_placements_for_the_secondary_phase_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/secondary_phase_only/school_user_bulk_adds_placements_for_the_secondary_phase_spec.rb
@@ -87,22 +87,21 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_actively_looking_to_host_placements
-    choose "Actively looking to host placements"
+    choose "Yes - Let providers know what I'm willing to host"
   end
 
   def when_i_click_on_continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/secondary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/secondary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
@@ -75,22 +75,21 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_actively_looking_to_host_placements
-    choose "Actively looking to host placements"
+    choose "Yes - Let providers know what I'm willing to host"
   end
 
   def when_i_click_on_continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
@@ -83,22 +83,21 @@ RSpec.describe "School user does not select a child subjects",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_actively_looking_to_host_placements
-    choose "Actively looking to host placements"
+    choose "Yes - Let providers know what I'm willing to host"
   end
 
   def when_i_click_on_continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
@@ -71,22 +71,21 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_actively_looking_to_host_placements
-    choose "Actively looking to host placements"
+    choose "Yes - Let providers know what I'm willing to host"
   end
 
   def when_i_click_on_continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/secondary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/secondary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
@@ -76,22 +76,21 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_actively_looking_to_host_placements
-    choose "Actively looking to host placements"
+    choose "Yes - Let providers know what I'm willing to host"
   end
 
   def when_i_click_on_continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/secondary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/secondary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
@@ -76,22 +76,21 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_actively_looking_to_host_placements
-    choose "Actively looking to host placements"
+    choose "Yes - Let providers know what I'm willing to host"
   end
 
   def when_i_click_on_continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_does_not_enter_a_response_for_listing_placements_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_does_not_enter_a_response_for_listing_placements_spec.rb
@@ -59,22 +59,21 @@ RSpec.describe "School user does not enter a response for listing placements",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_interested_in_hosting_placements
-    choose "Interested in hosting placements"
+    choose "Yes - Let providers know I am open to placements"
   end
 
   def when_i_click_on_continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_does_not_enter_any_school_contact_details_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_does_not_enter_any_school_contact_details_spec.rb
@@ -63,22 +63,21 @@ RSpec.describe "School user does not enter any school contact details",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_interested_in_hosting_placements
-    choose "Interested in hosting placements"
+    choose "Yes - Let providers know I am open to placements"
   end
 
   def when_i_click_on_continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_selects_no_and_completes_the_interested_journey_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_selects_no_and_completes_the_interested_journey_spec.rb
@@ -68,22 +68,21 @@ RSpec.describe "School user selects no and completes the interested journey",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_interested_in_hosting_placements
-    choose "Interested in hosting placements"
+    choose "Yes - Let providers know I am open to placements"
   end
 
   def when_i_click_on_continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_selects_yes_and_completes_the_interested_journey_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_selects_yes_and_completes_the_interested_journey_spec.rb
@@ -106,22 +106,21 @@ RSpec.describe "School user selects yes and completes the interested journey",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_interested_in_hosting_placements
-    choose "Interested in hosting placements"
+    choose "Yes - Let providers know I am open to placements"
   end
 
   def when_i_click_on_continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_not_open/school_user_does_not_enter_any_school_contact_details_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_not_open/school_user_does_not_enter_any_school_contact_details_spec.rb
@@ -64,22 +64,21 @@ RSpec.describe "School user does not enter any school contact details",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_not_open_to_hosting_placements
-    choose "Not open to hosting placements"
+    choose "No - Let providers know I am not hosting and do not want to be contacted"
   end
 
   def when_i_click_on_continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_not_open/school_user_does_not_select_any_reasons_not_to_host_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_not_open/school_user_does_not_select_any_reasons_not_to_host_spec.rb
@@ -57,22 +57,21 @@ RSpec.describe "School user does not select any reasons not to host",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_not_open_to_hosting_placements
-    choose "Not open to hosting placements"
+    choose "No - Let providers know I am not hosting and do not want to be contacted"
   end
 
   def when_i_click_on_continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_not_open/school_user_successfully_completes_the_not_open_journey_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_not_open/school_user_successfully_completes_the_not_open_journey_spec.rb
@@ -101,22 +101,21 @@ RSpec.describe "School user successfully completes the not open journey",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_not_open_to_hosting_placements
-    choose "Not open to hosting placements"
+    choose "No - Let providers know I am not hosting and do not want to be contacted"
   end
 
   def when_i_click_on_continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_not_open/school_user_views_their_local_providers_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_not_open/school_user_views_their_local_providers_spec.rb
@@ -82,22 +82,21 @@ RSpec.describe "School user views their local providers",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_not_open_to_hosting_placements
-    choose "Not open to hosting placements"
+    choose "No - Let providers know I am not hosting and do not want to be contacted"
   end
 
   def when_i_click_on_continue

--- a/spec/system/placements/schools/placements/bulk_add_placements/school_user_does_not_select_an_appetite_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/school_user_does_not_select_an_appetite_spec.rb
@@ -53,18 +53,17 @@ RSpec.describe "School user does not select an appetite",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_click_on_continue

--- a/spec/wizards/placements/multi_placement_wizard/appetite_step_spec.rb
+++ b/spec/wizards/placements/multi_placement_wizard/appetite_step_spec.rb
@@ -17,9 +17,11 @@ RSpec.describe Placements::MultiPlacementWizard::AppetiteStep, type: :model do
   end
 
   describe "validations" do
+    let(:appetites) { %w[actively_looking interested not_open] }
+
     it {
       expect(step).to validate_inclusion_of(:appetite).in_array(
-        Placements::HostingInterest.appetites.keys,
+        appetites,
       )
     }
   end
@@ -31,39 +33,41 @@ RSpec.describe Placements::MultiPlacementWizard::AppetiteStep, type: :model do
       actively_looking = appetite_options[0]
       interested = appetite_options[1]
       not_open = appetite_options[2]
-      already_organised = appetite_options[3]
+      # already_organised = appetite_options[3] # Remove for concept testing
 
       expect(actively_looking.value).to eq("actively_looking")
-      expect(actively_looking.name).to eq("Actively looking to host placements")
+      expect(actively_looking.name).to eq("Yes - Let providers know what I'm willing to host")
       expect(actively_looking.description).to eq(
-        "You'll have to the option to specify what you'd like to host in the next step",
+        "You know the subjects you want to host and may know which providers you want to work with",
       )
 
       expect(interested.value).to eq("interested")
-      expect(interested.name).to eq("Interested in hosting placements")
+      expect(interested.name).to eq("Yes - Let providers know I am open to placements")
       expect(interested.description).to eq(
-        "Providers will be able to contact you and discuss",
+        "You haven't yet decided on your placements. You want to hear from providers to discuss potential opportunities",
       )
 
       expect(not_open.value).to eq("not_open")
-      expect(not_open.name).to eq("Not open to hosting placements")
+      expect(not_open.name).to eq("No - Let providers know I am not hosting and do not want to be contacted")
       expect(not_open.description).to eq(
-        "Providers will not be able to contact you using this service this academic year",
+        "You do not want to hear from providers this academic year",
       )
 
-      expect(already_organised.value).to eq("already_organised")
-      expect(already_organised.name).to eq("Placements already organised with providers")
-      expect(already_organised.description).to eq(
-        "We'll show any providers who search for you that you're at capacity",
-      )
+      # expect(already_organised.value).to eq("already_organised")
+      # expect(already_organised.name).to eq("Placements already organised with providers")
+      # expect(already_organised.description).to eq(
+      #   "We'll show any providers who search for you that you're at capacity",
+      # )
     end
   end
 
   describe "#placement_appetites" do
     subject(:placement_appetites) { step.placement_appetites }
 
+    let(:appetites) { %w[actively_looking interested not_open] }
+
     it "returns the keys of the appetites" do
-      expect(placement_appetites).to match_array(Placements::HostingInterest.appetites.keys)
+      expect(placement_appetites).to match_array(appetites)
     end
   end
 end


### PR DESCRIPTION
## Context

- Content changes to the Appetite step of the MultiPlacementWizard

## Guidance to review

## Link to Trello card

https://trello.com/c/R9RrkEEs/462-content-changes-for-appetite-step-of-multiplacementwizard

## Screenshots

![screencapture-placements-localhost-3000-schools-00004b84-98c7-4bad-83a9-e69310cf4167-placements-multiple-2b48464a-09d3-4457-96e7-2561acadd38d-appetite-2025-03-06-13_26_13](https://github.com/user-attachments/assets/5330d094-a3ce-4c88-aba8-853545e3345b)

