### PR TITLE
Add check your answers to multiplacementwizard

### DIFF
--- a/app/views/wizards/placements/multi_placement_wizard/_check_your_answers_step.html.erb
+++ b/app/views/wizards/placements/multi_placement_wizard/_check_your_answers_step.html.erb
@@ -1,0 +1,130 @@
+<% content_for :page_title, title_with_error_prefix(
+  t(".title"),
+  error: current_step.errors.any?,
+) %>
+
+<%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+
+      <h2 class="govuk-heading-m"><%= t(".education_phase") %></h2>
+
+      <%= govuk_summary_list(html_attributes: { id: "education_phase" }) do |summary_list| %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".phase")) %>
+          <% row.with_value(text: current_step.phases.to_sentence) %>
+          <% row.with_action(text: t(".change"),
+                             href: step_path(:phase),
+                             visually_hidden_text: t(".phase"),
+                             classes: ["govuk-link--no-visited-state"]) %>
+        <% end %>
+      <% end %>
+
+      <% if current_step.selected_primary_subjects.present? %>
+        <h2 class="govuk-heading-m">
+          <%= current_step.primary_and_secondary_phases? ? t(".primary_placements") : t(".placements") %>
+        </h2>
+
+        <%= govuk_summary_list(html_attributes: { id: "primary_placements" }) do |summary_list| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".subject")) %>
+            <% row.with_value do %>
+              <strong><%= t(".number_of_placements") %></strong>
+            <% end %>
+            <% row.with_action(text: t(".change"),
+                               href: step_path(:primary_subject_selection),
+                               visually_hidden_text: t(".placements"),
+                               classes: ["govuk-link--no-visited-state"]) %>
+          <% end %>
+
+          <% current_step.selected_primary_subjects.each do |primary_subject| %>
+            <% summary_list.with_row do |row| %>
+              <% row.with_key(text: primary_subject.name) %>
+              <% row.with_value(text: @wizard.placement_quantity_for_subject(primary_subject)) %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <% if current_step.selected_secondary_subjects.present? %>
+        <h2 class="govuk-heading-m">
+          <%= current_step.primary_and_secondary_phases? ? t(".secondary_placements") : t(".placements") %>
+        </h2>
+
+        <%= govuk_summary_list(html_attributes: { id: "secondary_placements" }) do |summary_list| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".subject")) %>
+            <% row.with_value do %>
+              <strong><%= t(".number_of_placements") %></strong>
+            <% end %>
+            <% row.with_action(text: t(".change"),
+                               href: step_path(:secondary_subject_selection),
+                               visually_hidden_text: t(".placements"),
+                               classes: ["govuk-link--no-visited-state"]) %>
+          <% end %>
+
+          <% current_step.selected_secondary_subjects.each do |secondary_subject| %>
+            <% summary_list.with_row do |row| %>
+              <% row.with_key(text: secondary_subject.name) %>
+              <% row.with_value(text: @wizard.placement_quantity_for_subject(secondary_subject)) %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <% if current_step.selected_providers.present? %>
+        <h2 class="govuk-heading-m"><%= t(".providers") %></h2>
+
+        <%= govuk_summary_list(html_attributes: { id: "providers" }) do |summary_list| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".provider_name")) %>
+            <% row.with_action(text: t(".change"),
+                               href: step_path(:secondary_subject_selection),
+                               visually_hidden_text: t(".placements"),
+                               classes: ["govuk-link--no-visited-state"]) %>
+          <% end %>
+
+          <% current_step.selected_providers.each do |provider| %>
+            <% summary_list.with_row do |row| %>
+              <% row.with_key(text: provider.name) %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <h2 class="govuk-heading-m"><%= t(".itt_contact") %></h2>
+
+      <%= govuk_summary_list(html_attributes: { id: "school_contact" }) do |summary_list| %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: User.human_attribute_name(:first_name)) %>
+          <% row.with_value(text: current_step.school_contact_first_name) %>
+          <% row.with_action(text: t(".change"),
+                             href: step_path(:school_contact),
+                             visually_hidden_text: User.human_attribute_name(:first_name),
+                             classes: ["govuk-link--no-visited-state"]) %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: User.human_attribute_name(:last_name)) %>
+          <% row.with_value(text: current_step.school_contact_last_name) %>
+          <% row.with_action(text: t(".change"),
+                             href: step_path(:school_contact),
+                             visually_hidden_text: User.human_attribute_name(:last_name),
+                             classes: ["govuk-link--no-visited-state"]) %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: User.human_attribute_name(:email_address)) %>
+          <% row.with_value(text: current_step.school_contact_email_address) %>
+          <% row.with_action(text: t(".change"),
+                             href: step_path(:school_contact),
+                             visually_hidden_text: User.human_attribute_name(:email_address),
+                             classes: ["govuk-link--no-visited-state"]) %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit t(".continue") %>
+    </div>
+  </div>
+<% end %>

--- a/app/wizards/placements/multi_placement_wizard.rb
+++ b/app/wizards/placements/multi_placement_wizard.rb
@@ -26,6 +26,9 @@ module Placements
         end
       end
       add_step(SchoolContactStep)
+      if appetite == "actively_looking" || appetite == "interested" && list_placements?
+        add_step(CheckYourAnswersStep)
+      end
     end
 
     def update_school_placements
@@ -86,6 +89,17 @@ module Placements
       end.try(subject.name_as_attribute).to_i
     end
 
+    def selected_providers
+      return Provider.none if steps[:provider].blank?
+
+      provider_step = steps.fetch(:provider)
+      if provider_step.provider_ids.include?(provider_step.class::SELECT_ALL)
+        provider_step.providers
+      else
+        ::Provider.where(id: provider_step.provider_ids)
+      end
+    end
+
     private
 
     def create_placements
@@ -110,16 +124,7 @@ module Placements
     end
 
     def create_partnerships
-      return if steps[:provider].blank?
-
-      provider_step = steps.fetch(:provider)
-      providers = if provider_step.provider_ids.include?(provider_step.class::SELECT_ALL)
-                    provider_step.providers
-                  else
-                    ::Provider.where(id: provider_step.provider_ids)
-                  end
-
-      providers.each do |provider|
+      selected_providers.each do |provider|
         school.partnerships.create!(provider:)
       end
     end

--- a/app/wizards/placements/multi_placement_wizard/check_your_answers_step.rb
+++ b/app/wizards/placements/multi_placement_wizard/check_your_answers_step.rb
@@ -1,0 +1,19 @@
+class Placements::MultiPlacementWizard::CheckYourAnswersStep < BaseStep
+  delegate :phases, to: :phase_step
+  delegate :selected_primary_subjects, :selected_secondary_subjects, :selected_providers, to: :wizard
+  delegate :first_name, :last_name, :email_address, to: :school_contact_step, prefix: :school_contact
+
+  def primary_and_secondary_phases?
+    @primary_and_secondary_phases ||= phase_step.class::VALID_PHASES.sort == phases.sort
+  end
+
+  private
+
+  def phase_step
+    wizard.steps.fetch(:phase)
+  end
+
+  def school_contact_step
+    wizard.steps.fetch(:school_contact)
+  end
+end

--- a/config/locales/en/wizards/placements/multi_placement_wizard.yml
+++ b/config/locales/en/wizards/placements/multi_placement_wizard.yml
@@ -73,3 +73,17 @@ en:
           title: Select the providers you currently work with
           continue: Continue
           select_all: Select all
+        check_your_answers_step:
+          title: Check your answers
+          continue: Save and continue
+          education_phase: Education phase
+          phase: Phase
+          change: Change
+          placements: Placements
+          subject: Subject
+          number_of_placements: Number of placements
+          primary_placements: Primary placements
+          secondary_placements: Secondary placements
+          itt_contact: ITT contact
+          providers: Providers
+          provider_name: Provider name

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/primary_phase_only/school_user_bulk_adds_placements_for_the_primary_phase_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/primary_phase_only/school_user_bulk_adds_placements_for_the_primary_phase_spec.rb
@@ -39,6 +39,9 @@ RSpec.describe "School user bulk adds placements for the primary phases",
 
     when_i_fill_in_the_school_contact_details
     and_i_click_on_continue
+    then_i_see_the_check_your_answers_page
+
+    when_i_click_save_and_continue
     then_i_see_my_responses_with_successfully_updated
     and_the_schools_contact_has_been_updated
     and_the_schools_hosting_interest_for_the_next_year_is_updated
@@ -268,5 +271,31 @@ RSpec.describe "School user bulk adds placements for the primary phases",
     expect(page).to have_field("Test Provider 123", type: :checkbox)
     expect(page).to have_field("Test Provider 456", type: :checkbox)
     expect(page).to have_field("Test Provider 789", type: :checkbox)
+  end
+
+  def when_i_click_save_and_continue
+    click_on "Save and continue"
+  end
+
+  def then_i_see_the_check_your_answers_page
+    expect(page).to have_title(
+      "Check your answers - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Check your answers")
+
+    expect(page).to have_h2("Education phase")
+    expect(page).to have_summary_list_row("Phase", "Primary")
+
+    expect(page).to have_h2("Placements")
+    expect(page).to have_summary_list_row("Primary", "2")
+    expect(page).to have_summary_list_row("Handwriting", "3")
+
+    expect(page).not_to have_h2("Providers")
+
+    expect(page).to have_h2("ITT contact")
+    expect(page).to have_summary_list_row("First name", "Joe")
+    expect(page).to have_summary_list_row("Last name", "Bloggs")
+    expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")
   end
 end

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
@@ -47,6 +47,13 @@ RSpec.describe "School user bulk adds placements for primary and secondary phase
     when_i_click_on_continue
     then_i_see_the_school_contact_form
 
+    when_i_fill_in_the_school_contact_details
+    and_i_click_on_continue
+    then_i_see_the_check_your_answers_page
+
+    when_i_click_on_back
+    then_i_see_the_school_contact_form_prefilled_with_my_inputs
+
     when_i_click_on_back
     then_i_see_the_provider_select_form
 
@@ -119,6 +126,9 @@ RSpec.describe "School user bulk adds placements for primary and secondary phase
 
     when_i_fill_in_the_school_contact_details
     and_i_click_on_continue
+    then_i_see_the_check_your_answers_page
+
+    when_i_click_save_and_continue
     then_i_see_my_responses_with_successfully_updated
     and_the_schools_contact_has_been_updated
     and_the_schools_hosting_interest_for_the_next_year_is_updated
@@ -336,6 +346,19 @@ RSpec.describe "School user bulk adds placements for primary and secondary phase
     expect(page).to have_field("Email address", with: @school_contact.email_address)
   end
 
+  def then_i_see_the_school_contact_form_prefilled_with_my_inputs
+    expect(page).to have_title(
+      "Who is your contact for ITT? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Who is your contact for ITT?")
+
+    @school_contact = @school.school_contact
+    expect(page).to have_field("First name", with: "Joe")
+    expect(page).to have_field("Last name", with: "Bloggs")
+    expect(page).to have_field("Email address", with: "joe_bloggs@example.com")
+  end
+
   def when_i_click_on_back
     click_on "Back"
   end
@@ -420,5 +443,35 @@ RSpec.describe "School user bulk adds placements for primary and secondary phase
     expect(page).to have_field("Test Provider 123", type: :checkbox)
     expect(page).to have_field("Test Provider 456", type: :checkbox)
     expect(page).to have_field("Test Provider 789", type: :checkbox)
+  end
+
+  def when_i_click_save_and_continue
+    click_on "Save and continue"
+  end
+
+  def then_i_see_the_check_your_answers_page
+    expect(page).to have_title(
+      "Check your answers - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Check your answers")
+
+    expect(page).to have_h2("Education phase")
+    expect(page).to have_summary_list_row("Phase", "Primary and Secondary")
+
+    expect(page).to have_h2("Primary placements")
+    expect(page).to have_summary_list_row("Primary", "2")
+    expect(page).to have_summary_list_row("Handwriting", "3")
+
+    expect(page).to have_h2("Secondary placements")
+    expect(page).to have_summary_list_row("English", "1")
+    expect(page).to have_summary_list_row("Mathematics", "4")
+
+    expect(page).not_to have_h2("Providers")
+
+    expect(page).to have_h2("ITT contact")
+    expect(page).to have_summary_list_row("First name", "Joe")
+    expect(page).to have_summary_list_row("Last name", "Bloggs")
+    expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")
   end
 end

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_selects_all_providers_when_bulk_adding_placements_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_selects_all_providers_when_bulk_adding_placements_spec.rb
@@ -50,6 +50,9 @@ RSpec.describe "School user selects all providers when bulk adding placements",
 
     when_i_fill_in_the_school_contact_details
     and_i_click_on_continue
+    then_i_see_the_check_your_answers_page
+
+    when_i_click_save_and_continue
     then_i_see_my_responses_with_successfully_updated
     and_the_schools_contact_has_been_updated
     and_the_schools_hosting_interest_for_the_next_year_is_updated
@@ -378,5 +381,50 @@ RSpec.describe "School user selects all providers when bulk adding placements",
 
   def and_i_see_test_provider_789
     expect(page).to have_link("Test Provider 789")
+  end
+
+  def when_i_click_save_and_continue
+    click_on "Save and continue"
+  end
+
+  def then_i_see_the_check_your_answers_page
+    expect(page).to have_title(
+      "Check your answers - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Check your answers")
+
+    expect(page).to have_h2("Education phase")
+    expect(page).to have_summary_list_row("Phase", "Primary and Secondary")
+
+    expect(page).to have_h2("Primary placements")
+    expect(page).to have_summary_list_row("Primary", "2")
+    expect(page).to have_summary_list_row("Handwriting", "3")
+
+    expect(page).to have_h2("Secondary placements")
+    expect(page).to have_summary_list_row("English", "1")
+    expect(page).to have_summary_list_row("Mathematics", "4")
+
+    expect(page).to have_h2("Providers")
+    expect(page).to have_element(
+      :dt,
+      text: "Test Provider 123",
+      class: "govuk-summary-list__key",
+    )
+    expect(page).to have_element(
+      :dt,
+      text: "Test Provider 456",
+      class: "govuk-summary-list__key",
+    )
+    expect(page).to have_element(
+      :dt,
+      text: "Test Provider 789",
+      class: "govuk-summary-list__key",
+    )
+
+    expect(page).to have_h2("ITT contact")
+    expect(page).to have_summary_list_row("First name", "Joe")
+    expect(page).to have_summary_list_row("Last name", "Bloggs")
+    expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")
   end
 end

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_selects_specific_providers_when_bulk_adding_placements_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_selects_specific_providers_when_bulk_adding_placements_spec.rb
@@ -51,6 +51,9 @@ RSpec.describe "School user selects specfic providers when bulk adding placement
 
     when_i_fill_in_the_school_contact_details
     and_i_click_on_continue
+    then_i_see_the_check_your_answers_page
+
+    when_i_click_save_and_continue
     then_i_see_my_responses_with_successfully_updated
     and_the_schools_contact_has_been_updated
     and_the_schools_hosting_interest_for_the_next_year_is_updated
@@ -383,5 +386,50 @@ RSpec.describe "School user selects specfic providers when bulk adding placement
 
   def and_i_see_test_provider_789
     expect(page).to have_link("Test Provider 789")
+  end
+
+  def when_i_click_save_and_continue
+    click_on "Save and continue"
+  end
+
+  def then_i_see_the_check_your_answers_page
+    expect(page).to have_title(
+      "Check your answers - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Check your answers")
+
+    expect(page).to have_h2("Education phase")
+    expect(page).to have_summary_list_row("Phase", "Primary and Secondary")
+
+    expect(page).to have_h2("Primary placements")
+    expect(page).to have_summary_list_row("Primary", "2")
+    expect(page).to have_summary_list_row("Handwriting", "3")
+
+    expect(page).to have_h2("Secondary placements")
+    expect(page).to have_summary_list_row("English", "1")
+    expect(page).to have_summary_list_row("Mathematics", "4")
+
+    expect(page).to have_h2("Providers")
+    expect(page).to have_element(
+      :dt,
+      text: "Test Provider 123",
+      class: "govuk-summary-list__key",
+    )
+    expect(page).not_to have_element(
+      :dt,
+      text: "Test Provider 456",
+      class: "govuk-summary-list__key",
+    )
+    expect(page).to have_element(
+      :dt,
+      text: "Test Provider 789",
+      class: "govuk-summary-list__key",
+    )
+
+    expect(page).to have_h2("ITT contact")
+    expect(page).to have_summary_list_row("First name", "Joe")
+    expect(page).to have_summary_list_row("Last name", "Bloggs")
+    expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")
   end
 end

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_successfully_completes_the_actively_looking_journey_without_placements_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_successfully_completes_the_actively_looking_journey_without_placements_spec.rb
@@ -29,6 +29,13 @@ RSpec.describe "School user successfully completes the actively looking journey 
     when_i_click_on_continue
     then_i_see_the_school_contact_form
 
+    when_i_fill_in_the_school_contact_details
+    and_i_click_on_continue
+    then_i_see_the_check_your_answers_page
+
+    when_i_click_on_back
+    then_i_see_the_school_contact_form_prefilled_with_my_inputs
+
     when_i_click_on_back
     then_i_see_the_provider_select_form
 
@@ -65,6 +72,9 @@ RSpec.describe "School user successfully completes the actively looking journey 
 
     when_i_fill_in_the_school_contact_details
     and_i_click_on_continue
+    then_i_see_the_check_your_answers_page
+
+    when_i_click_save_and_continue
     then_i_see_my_responses_with_successfully_updated
     and_the_schools_contact_has_been_updated
     and_the_schools_hosting_interest_for_the_next_year_is_updated
@@ -244,5 +254,44 @@ RSpec.describe "School user successfully completes the actively looking journey 
     expect(page).to have_field("Test Provider 123", type: :checkbox)
     expect(page).to have_field("Test Provider 456", type: :checkbox)
     expect(page).to have_field("Test Provider 789", type: :checkbox)
+  end
+
+  def when_i_click_save_and_continue
+    click_on "Save and continue"
+  end
+
+  def then_i_see_the_check_your_answers_page
+    expect(page).to have_title(
+      "Check your answers - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Check your answers")
+
+    expect(page).to have_h2("Education phase")
+    expect(page).to have_summary_list_row("Phase", "Primary and Secondary")
+
+    expect(page).not_to have_h2("Primary placements")
+
+    expect(page).not_to have_h2("Secondary placements")
+
+    expect(page).not_to have_h2("Providers")
+
+    expect(page).to have_h2("ITT contact")
+    expect(page).to have_summary_list_row("First name", "Joe")
+    expect(page).to have_summary_list_row("Last name", "Bloggs")
+    expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")
+  end
+
+  def then_i_see_the_school_contact_form_prefilled_with_my_inputs
+    expect(page).to have_title(
+      "Who is your contact for ITT? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Who is your contact for ITT?")
+
+    @school_contact = @school.school_contact
+    expect(page).to have_field("First name", with: "Joe")
+    expect(page).to have_field("Last name", with: "Bloggs")
+    expect(page).to have_field("Email address", with: "joe_bloggs@example.com")
   end
 end

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/secondary_phase_only/school_user_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/secondary_phase_only/school_user_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
@@ -49,6 +49,9 @@ RSpec.describe "School user bulk adds placements for a subject with child subjec
 
     when_i_fill_in_the_school_contact_details
     and_i_click_on_continue
+    then_i_see_the_check_your_answers_page
+
+    when_i_click_save_and_continue
     then_i_see_my_responses_with_successfully_updated
     and_the_schools_contact_has_been_updated
     and_the_schools_hosting_interest_for_the_next_year_is_updated
@@ -312,5 +315,30 @@ RSpec.describe "School user bulk adds placements for a subject with child subjec
     expect(page).to have_field("Test Provider 123", type: :checkbox)
     expect(page).to have_field("Test Provider 456", type: :checkbox)
     expect(page).to have_field("Test Provider 789", type: :checkbox)
+  end
+
+  def when_i_click_save_and_continue
+    click_on "Save and continue"
+  end
+
+  def then_i_see_the_check_your_answers_page
+    expect(page).to have_title(
+      "Check your answers - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Check your answers")
+
+    expect(page).to have_h2("Education phase")
+    expect(page).to have_summary_list_row("Phase", "Secondary")
+
+    expect(page).to have_h2("Placements")
+    expect(page).to have_summary_list_row("Modern languages", "2")
+
+    expect(page).not_to have_h2("Providers")
+
+    expect(page).to have_h2("ITT contact")
+    expect(page).to have_summary_list_row("First name", "Joe")
+    expect(page).to have_summary_list_row("Last name", "Bloggs")
+    expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")
   end
 end

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/secondary_phase_only/school_user_bulk_adds_placements_for_the_secondary_phase_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/secondary_phase_only/school_user_bulk_adds_placements_for_the_secondary_phase_spec.rb
@@ -39,6 +39,9 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
     when_i_fill_in_the_school_contact_details
     and_i_click_on_continue
+    then_i_see_the_check_your_answers_page
+
+    when_i_click_save_and_continue
     then_i_see_my_responses_with_successfully_updated
     and_the_schools_contact_has_been_updated
     and_the_schools_hosting_interest_for_the_next_year_is_updated
@@ -268,5 +271,31 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
     expect(page).to have_field("Test Provider 123", type: :checkbox)
     expect(page).to have_field("Test Provider 456", type: :checkbox)
     expect(page).to have_field("Test Provider 789", type: :checkbox)
+  end
+
+  def when_i_click_save_and_continue
+    click_on "Save and continue"
+  end
+
+  def then_i_see_the_check_your_answers_page
+    expect(page).to have_title(
+      "Check your answers - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Check your answers")
+
+    expect(page).to have_h2("Education phase")
+    expect(page).to have_summary_list_row("Phase", "Secondary")
+
+    expect(page).to have_h2("Placements")
+    expect(page).to have_summary_list_row("English", "1")
+    expect(page).to have_summary_list_row("Mathematics", "4")
+
+    expect(page).not_to have_h2("Providers")
+
+    expect(page).to have_h2("ITT contact")
+    expect(page).to have_summary_list_row("First name", "Joe")
+    expect(page).to have_summary_list_row("Last name", "Bloggs")
+    expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")
   end
 end

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_selects_yes_and_completes_the_interested_journey_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_selects_yes_and_completes_the_interested_journey_spec.rb
@@ -56,6 +56,9 @@ RSpec.describe "School user selects yes and completes the interested journey",
 
     when_i_fill_in_the_school_contact_details
     and_i_click_on_continue
+    then_i_see_the_check_your_answers_page
+
+    when_i_click_save_and_continue
     then_i_see_my_responses_with_successfully_updated
     and_the_schools_contact_has_been_updated
     and_the_schools_hosting_interest_for_the_next_year_is_updated
@@ -369,5 +372,35 @@ RSpec.describe "School user selects yes and completes the interested journey",
     expect(page).to have_field("Test Provider 123", type: :checkbox)
     expect(page).to have_field("Test Provider 456", type: :checkbox)
     expect(page).to have_field("Test Provider 789", type: :checkbox)
+  end
+
+  def when_i_click_save_and_continue
+    click_on "Save and continue"
+  end
+
+  def then_i_see_the_check_your_answers_page
+    expect(page).to have_title(
+      "Check your answers - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Check your answers")
+
+    expect(page).to have_h2("Education phase")
+    expect(page).to have_summary_list_row("Phase", "Primary and Secondary")
+
+    expect(page).to have_h2("Primary placements")
+    expect(page).to have_summary_list_row("Primary", "2")
+    expect(page).to have_summary_list_row("Handwriting", "3")
+
+    expect(page).to have_h2("Secondary placements")
+    expect(page).to have_summary_list_row("English", "1")
+    expect(page).to have_summary_list_row("Mathematics", "4")
+
+    expect(page).not_to have_h2("Providers")
+
+    expect(page).to have_h2("ITT contact")
+    expect(page).to have_summary_list_row("First name", "Joe")
+    expect(page).to have_summary_list_row("Last name", "Bloggs")
+    expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")
   end
 end

--- a/spec/wizards/placements/multi_placement_wizard/check_your_answers_step_spec.rb
+++ b/spec/wizards/placements/multi_placement_wizard/check_your_answers_step_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe Placements::MultiPlacementWizard::CheckYourAnswersStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Placements::MultiPlacementWizard).tap do |mock_wizard|
+      allow(mock_wizard).to receive_messages(
+        school:,
+        steps: {
+          phase: mock_phase_step,
+          school_contact: mock_school_contact_step,
+        },
+      )
+    end
+  end
+  let(:mock_phase_step) do
+    instance_double(Placements::MultiPlacementWizard::PhaseStep).tap do |mock_phase_step|
+      allow(mock_phase_step).to receive_messages(
+        phases: selected_phases,
+        class: Placements::MultiPlacementWizard::PhaseStep,
+      )
+    end
+  end
+  let(:mock_school_contact_step) do
+    instance_double(Placements::MultiPlacementWizard::SchoolContactStep).tap do |mock_school_contact_step|
+      allow(mock_school_contact_step).to receive_messages(
+        first_name:,
+        last_name:,
+        email_address:,
+      )
+    end
+  end
+  let(:attributes) { nil }
+  let!(:school) { create(:placements_school) }
+  let(:first_name) { "Joe" }
+  let(:last_name) { "Bloggs" }
+  let(:email_address) { "joe_bloggs@example.com" }
+  let(:selected_phases) { %w[Primary Secondary] }
+
+  describe "delegations" do
+    it { is_expected.to delegate_method(:phases).to(:phase_step) }
+    it { is_expected.to delegate_method(:selected_primary_subjects).to(:wizard) }
+    it { is_expected.to delegate_method(:selected_secondary_subjects).to(:wizard) }
+    it { is_expected.to delegate_method(:selected_providers).to(:wizard) }
+    it { is_expected.to delegate_method(:first_name).to(:school_contact_step).with_prefix(:school_contact) }
+    it { is_expected.to delegate_method(:last_name).to(:school_contact_step).with_prefix(:school_contact) }
+    it { is_expected.to delegate_method(:email_address).to(:school_contact_step).with_prefix(:school_contact) }
+  end
+
+  describe "#primary_and_secondary_phases?" do
+    subject(:primary_and_secondary_phases) { step.primary_and_secondary_phases? }
+
+    context "when both Primary and Secondary phases are selected" do
+      it "returns true" do
+        expect(primary_and_secondary_phases).to be(true)
+      end
+    end
+
+    context "when only the Primary phase is selected" do
+      let(:selected_phases) { %w[Primary] }
+
+      it "returns false" do
+        expect(primary_and_secondary_phases).to be(false)
+      end
+    end
+
+    context "when only the Secondary phase is selected" do
+      let(:selected_phases) { %w[Secondary] }
+
+      it "returns false" do
+        expect(primary_and_secondary_phases).to be(false)
+      end
+    end
+  end
+end

--- a/spec/wizards/placements/multi_placement_wizard_spec.rb
+++ b/spec/wizards/placements/multi_placement_wizard_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Placements::MultiPlacementWizard do
         }
       end
 
-      it { is_expected.to eq %i[appetite phase subjects_known provider school_contact] }
+      it { is_expected.to eq %i[appetite phase subjects_known provider school_contact check_your_answers] }
 
       context "when the subjects_know is set to 'Yes' during the subjects_known step" do
         context "when the phase is set to 'Primary' during the phase step" do
@@ -41,7 +41,8 @@ RSpec.describe Placements::MultiPlacementWizard do
                  primary_subject_selection
                  primary_placement_quantity
                  provider
-                 school_contact],
+                 school_contact
+                 check_your_answers],
             )
           }
         end
@@ -63,7 +64,8 @@ RSpec.describe Placements::MultiPlacementWizard do
                  secondary_subject_selection
                  secondary_placement_quantity
                  provider
-                 school_contact],
+                 school_contact
+                 check_your_answers],
             )
           }
 
@@ -92,7 +94,8 @@ RSpec.describe Placements::MultiPlacementWizard do
                    secondary_child_subject_placement_selection_modern_languages_1
                    secondary_child_subject_placement_selection_modern_languages_2
                    provider
-                   school_contact],
+                   school_contact
+                   check_your_answers],
               )
             }
           end
@@ -117,7 +120,8 @@ RSpec.describe Placements::MultiPlacementWizard do
                  secondary_subject_selection
                  secondary_placement_quantity
                  provider
-                 school_contact],
+                 school_contact
+                 check_your_answers],
             )
           }
         end
@@ -162,7 +166,7 @@ RSpec.describe Placements::MultiPlacementWizard do
           }
         end
 
-        it { is_expected.to eq %i[appetite help list_placements phase subjects_known provider school_contact] }
+        it { is_expected.to eq %i[appetite help list_placements phase subjects_known provider school_contact check_your_answers] }
 
         context "when the subjects_know is set to 'Yes' during the subjects_known step" do
           context "when the phase is set to 'Primary' during the phase step" do
@@ -185,7 +189,8 @@ RSpec.describe Placements::MultiPlacementWizard do
                    primary_subject_selection
                    primary_placement_quantity
                    provider
-                   school_contact],
+                   school_contact
+                   check_your_answers],
               )
             }
           end
@@ -210,7 +215,8 @@ RSpec.describe Placements::MultiPlacementWizard do
                    secondary_subject_selection
                    secondary_placement_quantity
                    provider
-                   school_contact],
+                   school_contact
+                   check_your_answers],
               )
             }
 
@@ -242,7 +248,8 @@ RSpec.describe Placements::MultiPlacementWizard do
                      secondary_child_subject_placement_selection_modern_languages_1
                      secondary_child_subject_placement_selection_modern_languages_2
                      provider
-                     school_contact],
+                     school_contact
+                     check_your_answers],
                 )
               }
             end
@@ -270,7 +277,8 @@ RSpec.describe Placements::MultiPlacementWizard do
                    secondary_subject_selection
                    secondary_placement_quantity
                    provider
-                   school_contact],
+                   school_contact
+                   check_your_answers],
               )
             }
           end
@@ -851,6 +859,65 @@ RSpec.describe Placements::MultiPlacementWizard do
 
       it "returns a list of selected secondary subjects" do
         expect(selected_secondary_subjects).to contain_exactly(english, mathematics)
+      end
+    end
+  end
+
+  describe "#selected_providers" do
+    subject(:selected_providers) { wizard.selected_providers }
+
+    let(:test_provider_1) { create(:provider, name: "Test Provider 123") }
+    let(:test_provider_2) { create(:provider, name: "Test Provider 456") }
+    let(:test_provider_3) { create(:provider, name: "Test Provider 789") }
+
+    context "when no provider_ids have been selected in the provider step" do
+      it "returns an empty list" do
+        expect(selected_providers).to eq([])
+      end
+    end
+
+    context "when 'select_all' has been selected in the provider step" do
+      let(:state) do
+        {
+          "appetite" => { "appetite" => "actively_looking" },
+          "provider" => { "provider_ids" => %w[select_all] },
+        }
+      end
+
+      before do
+        test_provider_1
+        test_provider_2
+        test_provider_3
+      end
+
+      it "returns all test providers" do
+        expect(selected_providers).to contain_exactly(
+          test_provider_1,
+          test_provider_2,
+          test_provider_3,
+        )
+      end
+    end
+
+    context "when specific provider ids have been selected in the provider step" do
+      let(:state) do
+        {
+          "appetite" => { "appetite" => "actively_looking" },
+          "provider" => { "provider_ids" => [test_provider_1.id, test_provider_3.id] },
+        }
+      end
+
+      before do
+        test_provider_1
+        test_provider_2
+        test_provider_3
+      end
+
+      it "returns all test providers" do
+        expect(selected_providers).to contain_exactly(
+          test_provider_1,
+          test_provider_3,
+        )
       end
     end
   end


### PR DESCRIPTION
## Context

- Add Check your answers step to MultiPlacementWizard

## Changes proposed in this pull request

- Add Check your answers step and views to MultiPlacementWizard

## Guidance to review

⚠️ You will need to enable the ":bulk_add_placements" flag ⚠️

- Sign in as Anne (School user)
- Navigate to "Placements"
- Click "Bulk add placements"
- Choose "Interested in hosting placements"
- Follow the rest of the journey - You should now see the check your answers step
- This should result in creating/updating your school's HostingInterest for next year
- This should result in any changes made to the school contact
- This should result in creating any placements set in the journey
- This should result in creating any partnerships between providers you selected

## Link to Trello card

https://trello.com/c/Elwp022x/463-check-your-answers-page-for-multiplacementwizard

## Screenshots

![screencapture-placements-localhost-3000-schools-00004b84-98c7-4bad-83a9-e69310cf4167-placements-multiple-78526edf-b721-4e6e-b934-bd143f796ad7-check-your-answers-2025-03-06-16_01_23](https://github.com/user-attachments/assets/f3f8d0a9-ed88-4423-ba84-d568c28f9287)


