### PR TITLE
content changes to success message

### DIFF
--- a/app/controllers/placements/schools/placements/add_multiple_placements_controller.rb
+++ b/app/controllers/placements/schools/placements/add_multiple_placements_controller.rb
@@ -21,7 +21,8 @@ class Placements::Schools::Placements::AddMultiplePlacementsController < Placeme
       @wizard.update_school_placements
       @wizard.reset_state
       redirect_to index_path, flash: {
-        heading: t(".success"),
+        heading: t(".heading"),
+        body: t(".body_html"),
       }
     end
   end

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -45,7 +45,10 @@ en:
           edit:
             cancel: Cancel
           update:
-            success: Thank you for providing your responses
+            heading: Placement information uploaded
+            body_html: 
+              Providers can see your placement preferences and may contact you to discuss them.<br><br>
+              You can add details to your placements such as expected date and provider.
         edit_placement:
           update:
             success: 

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/primary_phase_only/school_user_bulk_adds_placements_for_the_primary_phase_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/primary_phase_only/school_user_bulk_adds_placements_for_the_primary_phase_spec.rb
@@ -219,7 +219,10 @@ RSpec.describe "School user bulk adds placements for the primary phases",
   end
 
   def then_i_see_my_responses_with_successfully_updated
-    expect(page).to have_success_banner("Thank you for providing your responses")
+    expect(page).to have_success_banner(
+      "Placement information uploaded",
+      "Providers can see your placement preferences and may contact you to discuss them. You can add details to your placements such as expected date and provider.",
+    )
   end
 
   def and_the_schools_contact_has_been_updated

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
@@ -373,7 +373,10 @@ RSpec.describe "School user bulk adds placements for primary and secondary phase
   end
 
   def then_i_see_my_responses_with_successfully_updated
-    expect(page).to have_success_banner("Thank you for providing your responses")
+    expect(page).to have_success_banner(
+      "Placement information uploaded",
+      "Providers can see your placement preferences and may contact you to discuss them. You can add details to your placements such as expected date and provider.",
+    )
   end
 
   def and_the_schools_contact_has_been_updated

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_selects_all_providers_when_bulk_adding_placements_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_selects_all_providers_when_bulk_adding_placements_spec.rb
@@ -122,22 +122,21 @@ RSpec.describe "School user selects all providers when bulk adding placements",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_actively_looking_to_host_placements
-    choose "Actively looking to host placements"
+    choose "Yes - Let providers know what I'm willing to host"
   end
 
   def when_i_click_on_continue
@@ -290,7 +289,10 @@ RSpec.describe "School user selects all providers when bulk adding placements",
   end
 
   def then_i_see_my_responses_with_successfully_updated
-    expect(page).to have_success_banner("Thank you for providing your responses")
+    expect(page).to have_success_banner(
+      "Placement information uploaded",
+      "Providers can see your placement preferences and may contact you to discuss them. You can add details to your placements such as expected date and provider.",
+    )
   end
 
   def and_the_schools_contact_has_been_updated

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_selects_specific_providers_when_bulk_adding_placements_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_selects_specific_providers_when_bulk_adding_placements_spec.rb
@@ -123,22 +123,21 @@ RSpec.describe "School user selects specfic providers when bulk adding placement
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What is your appetite for ITT the coming academic year (#{@next_academic_year_name})?",
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Actively looking to host placements", type: :radio)
-    expect(page).to have_field("Interested in hosting placements", type: :radio)
-    expect(page).to have_field("Not open to hosting placements", type: :radio)
-    expect(page).to have_field("Placements already organised with providers", type: :radio)
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
   end
 
   def when_i_select_actively_looking_to_host_placements
-    choose "Actively looking to host placements"
+    choose "Yes - Let providers know what I'm willing to host"
   end
 
   def when_i_click_on_continue
@@ -291,7 +290,10 @@ RSpec.describe "School user selects specfic providers when bulk adding placement
   end
 
   def then_i_see_my_responses_with_successfully_updated
-    expect(page).to have_success_banner("Thank you for providing your responses")
+    expect(page).to have_success_banner(
+      "Placement information uploaded",
+      "Providers can see your placement preferences and may contact you to discuss them. You can add details to your placements such as expected date and provider.",
+    )
   end
 
   def and_the_schools_contact_has_been_updated

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_successfully_completes_the_actively_looking_journey_without_placements_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/school_user_successfully_completes_the_actively_looking_journey_without_placements_spec.rb
@@ -224,7 +224,10 @@ RSpec.describe "School user successfully completes the actively looking journey 
   end
 
   def then_i_see_my_responses_with_successfully_updated
-    expect(page).to have_success_banner("Thank you for providing your responses")
+    expect(page).to have_success_banner(
+      "Placement information uploaded",
+      "Providers can see your placement preferences and may contact you to discuss them. You can add details to your placements such as expected date and provider.",
+    )
   end
 
   def and_the_schools_contact_has_been_updated

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/secondary_phase_only/school_user_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/secondary_phase_only/school_user_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
@@ -263,7 +263,10 @@ RSpec.describe "School user bulk adds placements for a subject with child subjec
   end
 
   def then_i_see_my_responses_with_successfully_updated
-    expect(page).to have_success_banner("Thank you for providing your responses")
+    expect(page).to have_success_banner(
+      "Placement information uploaded",
+      "Providers can see your placement preferences and may contact you to discuss them. You can add details to your placements such as expected date and provider.",
+    )
   end
 
   def and_the_schools_contact_has_been_updated

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/secondary_phase_only/school_user_bulk_adds_placements_for_the_secondary_phase_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_actively_looking/secondary_phase_only/school_user_bulk_adds_placements_for_the_secondary_phase_spec.rb
@@ -219,7 +219,10 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
   end
 
   def then_i_see_my_responses_with_successfully_updated
-    expect(page).to have_success_banner("Thank you for providing your responses")
+    expect(page).to have_success_banner(
+      "Placement information uploaded",
+      "Providers can see your placement preferences and may contact you to discuss them. You can add details to your placements such as expected date and provider.",
+    )
   end
 
   def and_the_schools_contact_has_been_updated

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_selects_no_and_completes_the_interested_journey_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_selects_no_and_completes_the_interested_journey_spec.rb
@@ -135,7 +135,10 @@ RSpec.describe "School user selects no and completes the interested journey",
   end
 
   def then_i_see_my_responses_with_successfully_updated
-    expect(page).to have_success_banner("Thank you for providing your responses")
+    expect(page).to have_success_banner(
+      "Placement information uploaded",
+      "Providers can see your placement preferences and may contact you to discuss them. You can add details to your placements such as expected date and provider.",
+    )
   end
 
   def and_the_schools_contact_has_been_updated

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_selects_yes_and_completes_the_interested_journey_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_interested/school_user_selects_yes_and_completes_the_interested_journey_spec.rb
@@ -186,7 +186,10 @@ RSpec.describe "School user selects yes and completes the interested journey",
   end
 
   def then_i_see_my_responses_with_successfully_updated
-    expect(page).to have_success_banner("Thank you for providing your responses")
+    expect(page).to have_success_banner(
+      "Placement information uploaded",
+      "Providers can see your placement preferences and may contact you to discuss them. You can add details to your placements such as expected date and provider.",
+    )
   end
 
   def and_the_schools_contact_has_been_updated

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_not_open/school_user_successfully_completes_the_not_open_journey_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_not_open/school_user_successfully_completes_the_not_open_journey_spec.rb
@@ -183,7 +183,10 @@ RSpec.describe "School user successfully completes the not open journey",
   end
 
   def then_i_see_my_responses_with_successfully_updated
-    expect(page).to have_success_banner("Thank you for providing your responses")
+    expect(page).to have_success_banner(
+      "Placement information uploaded",
+      "Providers can see your placement preferences and may contact you to discuss them. You can add details to your placements such as expected date and provider.",
+    )
   end
 
   def and_the_schools_contact_has_been_updated


### PR DESCRIPTION
## Context

- Content changes to the MultikPlacementWizard success message

## Link to Trello card

https://trello.com/c/KWmzEFGm/464-update-success-message-for-multiplacementwizard

## Screenshots

![screencapture-placements-localhost-3000-schools-00004b84-98c7-4bad-83a9-e69310cf4167-placements-2025-03-06-16_17_44 (1)](https://github.com/user-attachments/assets/826cc906-7201-4caa-9269-57fa7fcc0c88)

