### PR TITLE
Store other_reason_not_hosting in hosting interest

### DIFF
--- a/app/models/placements/hosting_interest.rb
+++ b/app/models/placements/hosting_interest.rb
@@ -2,13 +2,14 @@
 #
 # Table name: hosting_interests
 #
-#  id                  :uuid             not null, primary key
-#  appetite            :enum
-#  reasons_not_hosting :jsonb
-#  created_at          :datetime         not null
-#  updated_at          :datetime         not null
-#  academic_year_id    :uuid             not null
-#  school_id           :uuid             not null
+#  id                       :uuid             not null, primary key
+#  appetite                 :enum
+#  other_reason_not_hosting :text
+#  reasons_not_hosting      :jsonb
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  academic_year_id         :uuid             not null
+#  school_id                :uuid             not null
 #
 # Indexes
 #

--- a/app/views/wizards/placements/multi_placement_wizard/_reason_not_hosting_step.html.erb
+++ b/app/views/wizards/placements/multi_placement_wizard/_reason_not_hosting_step.html.erb
@@ -12,7 +12,7 @@
         <% current_step.reason_options.each_with_index do |reason_option, i| %>
           <%= f.govuk_check_box :reasons_not_hosting, reason_option.value, label: { text: reason_option.name }, link_errors: i.zero? do %>
             <% if reason_option.name == t(".options.other") %>
-              <%= f.govuk_text_field :reason_details, label: { text: t(".tell_us") } %>
+              <%= f.govuk_text_field :other_reason_not_hosting, label: { text: t(".tell_us") } %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/wizards/placements/multi_placement_wizard.rb
+++ b/app/wizards/placements/multi_placement_wizard.rb
@@ -36,6 +36,10 @@ module Placements
         hosting_interest.appetite = appetite
         if steps[:reason_not_hosting].present?
           hosting_interest.reasons_not_hosting = reasons_not_hosting
+          other_reason_not_hosting = steps
+            .fetch(:reason_not_hosting)
+            .other_reason_not_hosting
+          hosting_interest.other_reason_not_hosting = (other_reason_not_hosting.presence)
         end
 
         hosting_interest.save!

--- a/app/wizards/placements/multi_placement_wizard/reason_not_hosting_step.rb
+++ b/app/wizards/placements/multi_placement_wizard/reason_not_hosting_step.rb
@@ -1,8 +1,11 @@
 class Placements::MultiPlacementWizard::ReasonNotHostingStep < BaseStep
   attribute :reasons_not_hosting, default: []
-  attribute :reason_details
+  attribute :other_reason_not_hosting
 
   validates :reasons_not_hosting, presence: true
+  validates :other_reason_not_hosting, presence: true, if: lambda {
+    reasons_not_hosting.include?(I18n.t("#{locale_path}.options.other"))
+  }
 
   def reason_options
     options = Struct.new(:name, :value)

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -161,5 +161,6 @@ shared:
     - school_id
     - appetite
     - reasons_not_hosting
+    - other_reason_not_hosting
     - created_at
     - updated_at

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -292,6 +292,8 @@ en:
           attributes:
             reasons_not_hosting: 
               blank: Please select a reason for not taking part in ITT
+            other_reason_not_hosting:
+              blank: Please enter a reason
         placements/multi_placement_wizard/list_placements_step:
           attributes:
             list_placements:

--- a/db/migrate/20250310101224_add_other_reason_not_hosting_to_hosting_interests.rb
+++ b/db/migrate/20250310101224_add_other_reason_not_hosting_to_hosting_interests.rb
@@ -1,0 +1,5 @@
+class AddOtherReasonNotHostingToHostingInterests < ActiveRecord::Migration[7.2]
+  def change
+    add_column :hosting_interests, :other_reason_not_hosting, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_26_133003) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_10_101224) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -271,6 +271,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_26_133003) do
     t.jsonb "reasons_not_hosting"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "other_reason_not_hosting"
     t.index ["academic_year_id"], name: "index_hosting_interests_on_academic_year_id"
     t.index ["school_id", "academic_year_id"], name: "index_hosting_interests_on_school_id_and_academic_year_id", unique: true
     t.index ["school_id"], name: "index_hosting_interests_on_school_id"

--- a/spec/factories/hosting_interests.rb
+++ b/spec/factories/hosting_interests.rb
@@ -2,13 +2,14 @@
 #
 # Table name: hosting_interests
 #
-#  id                  :uuid             not null, primary key
-#  appetite            :enum
-#  reasons_not_hosting :jsonb
-#  created_at          :datetime         not null
-#  updated_at          :datetime         not null
-#  academic_year_id    :uuid             not null
-#  school_id           :uuid             not null
+#  id                       :uuid             not null, primary key
+#  appetite                 :enum
+#  other_reason_not_hosting :text
+#  reasons_not_hosting      :jsonb
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  academic_year_id         :uuid             not null
+#  school_id                :uuid             not null
 #
 # Indexes
 #

--- a/spec/models/placements/hosting_interest_spec.rb
+++ b/spec/models/placements/hosting_interest_spec.rb
@@ -2,13 +2,14 @@
 #
 # Table name: hosting_interests
 #
-#  id                  :uuid             not null, primary key
-#  appetite            :enum
-#  reasons_not_hosting :jsonb
-#  created_at          :datetime         not null
-#  updated_at          :datetime         not null
-#  academic_year_id    :uuid             not null
-#  school_id           :uuid             not null
+#  id                       :uuid             not null, primary key
+#  appetite                 :enum
+#  other_reason_not_hosting :text
+#  reasons_not_hosting      :jsonb
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  academic_year_id         :uuid             not null
+#  school_id                :uuid             not null
 #
 # Indexes
 #

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_not_open/school_user_does_not_enter_a_reason_when_selecting_other_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_not_open/school_user_does_not_enter_a_reason_when_selecting_other_spec.rb
@@ -1,0 +1,112 @@
+require "rails_helper"
+
+RSpec.describe "School user does not select any reasons not to host",
+               service: :placements,
+               type: :system do
+  scenario do
+    given_the_bulk_add_placements_flag_is_enabled
+    and_academic_years_exist
+    and_i_am_signed_in
+    when_i_am_on_the_placements_index_page
+    and_i_click_on_bulk_add_placements
+    then_i_see_the_appetite_form
+
+    when_i_select_not_open_to_hosting_placements
+    and_i_click_on_continue
+    then_i_see_the_reasons_for_not_hosting_form
+
+    when_i_select_other
+    and_i_click_on_continue
+    then_i_see_a_validation_error_not_entering_an_other_reason
+  end
+
+  private
+
+  def given_the_bulk_add_placements_flag_is_enabled
+    Flipper.add(:bulk_add_placements)
+    Flipper.enable(:bulk_add_placements)
+  end
+
+  def and_academic_years_exist
+    current_academic_year = Placements::AcademicYear.current
+    @current_academic_year_name = current_academic_year.name
+    @next_academic_year = current_academic_year.next
+    @next_academic_year_name = @next_academic_year.name
+  end
+
+  def and_i_am_signed_in
+    @school = create(:placements_school)
+    sign_in_placements_user(organisations: [@school])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Placements")
+    expect(secondary_navigation).to have_current_item("This year (#{@current_academic_year_name}")
+    expect(page).to have_link("Add placement")
+    expect(page).to have_link("Bulk add placements")
+  end
+  alias_method :then_i_am_on_the_placements_index_page,
+               :when_i_am_on_the_placements_index_page
+
+  def when_i_click_on_bulk_add_placements
+    click_on "Bulk add placements"
+  end
+  alias_method :and_i_click_on_bulk_add_placements,
+               :when_i_click_on_bulk_add_placements
+
+  def then_i_see_the_appetite_form
+    expect(page).to have_title(
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
+  end
+
+  def when_i_select_not_open_to_hosting_placements
+    choose "No - Let providers know I am not hosting and do not want to be contacted"
+  end
+
+  def when_i_click_on_continue
+    click_on "Continue"
+  end
+  alias_method :and_i_click_on_continue,
+               :when_i_click_on_continue
+
+  def then_i_see_the_reasons_for_not_hosting_form
+    expect(page).to have_title(
+      "What are your reasons for not taking part in ITT this year? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "What are your reasons for not taking part in ITT this year?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Concerns about trainee quality", type: :checkbox)
+    expect(page).to have_field("Don't get offered trainees", type: :checkbox)
+    expect(page).to have_field("Don't know how to get involved", type: :checkbox)
+    expect(page).to have_field("Not enough trained mentors", type: :checkbox)
+    expect(page).to have_field("Number of pupils with SEND needs", type: :checkbox)
+    expect(page).to have_field("Working to improve our OFSTED rating", type: :checkbox)
+    expect(page).to have_field("Other", type: :checkbox)
+  end
+
+  def when_i_select_other
+    check "Other"
+  end
+
+  def then_i_see_a_validation_error_not_entering_an_other_reason
+    expect(page).to have_validation_error(
+      "Please enter a reason",
+    )
+  end
+end

--- a/spec/system/placements/schools/placements/bulk_add_placements/appetite_not_open/school_user_enters_another_reason_why_they_are_not_hosting_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/appetite_not_open/school_user_enters_another_reason_why_they_are_not_hosting_spec.rb
@@ -1,0 +1,213 @@
+require "rails_helper"
+
+RSpec.describe "School user enters another reason why they are not hosting",
+               service: :placements,
+               type: :system do
+  scenario do
+    given_the_bulk_add_placements_flag_is_enabled
+    and_academic_years_exist
+    and_i_am_signed_in
+    when_i_am_on_the_placements_index_page
+    and_i_click_on_bulk_add_placements
+    then_i_see_the_appetite_form
+
+    when_i_select_not_open_to_hosting_placements
+    and_i_click_on_continue
+    then_i_see_the_reasons_for_not_hosting_form
+
+    when_i_select_other
+    and_i_enter_another_reason
+    and_i_click_on_continue
+    then_i_see_the_school_contact_form
+
+    when_i_fill_in_the_school_contact_details
+    and_i_click_on_continue
+    then_i_see_the_are_you_sure_page
+
+    when_i_click_on_continue
+    then_i_see_my_responses_with_successfully_updated
+    and_the_schools_contact_has_been_updated
+    and_the_schools_hosting_interest_for_the_next_year_is_updated
+  end
+
+  private
+
+  def given_the_bulk_add_placements_flag_is_enabled
+    Flipper.add(:bulk_add_placements)
+    Flipper.enable(:bulk_add_placements)
+  end
+
+  def and_academic_years_exist
+    current_academic_year = Placements::AcademicYear.current
+    @current_academic_year_name = current_academic_year.name
+    @next_academic_year = current_academic_year.next
+    @next_academic_year_name = @next_academic_year.name
+  end
+
+  def and_i_am_signed_in
+    @school = create(:placements_school)
+    sign_in_placements_user(organisations: [@school])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Placements")
+    expect(secondary_navigation).to have_current_item("This year (#{@current_academic_year_name}")
+    expect(page).to have_link("Add placement")
+    expect(page).to have_link("Bulk add placements")
+  end
+  alias_method :then_i_am_on_the_placements_index_page,
+               :when_i_am_on_the_placements_index_page
+
+  def when_i_click_on_bulk_add_placements
+    click_on "Bulk add placements"
+  end
+  alias_method :and_i_click_on_bulk_add_placements,
+               :when_i_click_on_bulk_add_placements
+
+  def then_i_see_the_appetite_form
+    expect(page).to have_title(
+      "Will you host placements this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "Will you host placements this academic year (#{@next_academic_year_name})?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Yes - Let providers know what I'm willing to host", type: :radio)
+    expect(page).to have_field("Yes - Let providers know I am open to placements", type: :radio)
+    expect(page).to have_field("No - Let providers know I am not hosting and do not want to be contacted", type: :radio)
+  end
+
+  def when_i_select_not_open_to_hosting_placements
+    choose "No - Let providers know I am not hosting and do not want to be contacted"
+  end
+
+  def when_i_click_on_continue
+    click_on "Continue"
+  end
+  alias_method :and_i_click_on_continue,
+               :when_i_click_on_continue
+
+  def then_i_see_the_reasons_for_not_hosting_form
+    expect(page).to have_title(
+      "What are your reasons for not taking part in ITT this year? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "What are your reasons for not taking part in ITT this year?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Not enough trained mentors", type: :checkbox)
+    expect(page).to have_field("Number of pupils with SEND needs", type: :checkbox)
+    expect(page).to have_field("Working to improve our OFSTED rating", type: :checkbox)
+  end
+
+  def when_i_select_other
+    check "Other"
+  end
+
+  def and_i_select_number_of_pupils_with_send_needs
+    check "Number of pupils with SEND needs"
+  end
+
+  def then_i_see_the_help_available_to_you_page
+    expect(page).to have_title(
+      "Help available to you - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Help available to you")
+  end
+
+  def then_i_see_the_school_contact_form
+    expect(page).to have_title(
+      "Who should providers contact? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Who should providers contact?")
+    expect(page).to have_element(
+      :p,
+      text: "Choose the person best placed to organise ITT placements at your school. "\
+        "This information will be shown on your profile.",
+      class: "govuk-body",
+    )
+
+    @school_contact = @school.school_contact
+    expect(page).to have_field("First name", with: @school_contact.first_name)
+    expect(page).to have_field("Last name", with: @school_contact.last_name)
+    expect(page).to have_field("Email address", with: @school_contact.email_address)
+  end
+
+  def then_i_see_the_school_contact_form_prefilled_with_my_inputs
+    expect(page).to have_title(
+      "Who should providers contact? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Who should providers contact?")
+    expect(page).to have_element(
+      :p,
+      text: "Choose the person best placed to organise ITT placements at your school. "\
+        "This information will be shown on your profile.",
+      class: "govuk-body",
+    )
+
+    @school_contact = @school.school_contact
+    expect(page).to have_field("First name", with: "Joe")
+    expect(page).to have_field("Last name", with: "Bloggs")
+    expect(page).to have_field("Email address", with: "joe_bloggs@example.com")
+  end
+
+  def when_i_click_on_back
+    click_on "Back"
+  end
+
+  def when_i_click_on_cancel
+    click_on "Cancel"
+  end
+
+  def when_i_fill_in_the_school_contact_details
+    fill_in "First name", with: "Joe"
+    fill_in "Last name", with: "Bloggs"
+    fill_in "Email address", with: "joe_bloggs@example.com"
+  end
+
+  def then_i_see_my_responses_with_successfully_updated
+    expect(page).to have_success_banner(
+      "Your profile has been updated",
+      "You can change your profile in settings if your circumstances change.",
+    )
+  end
+
+  def and_the_schools_contact_has_been_updated
+    @school_contact.reload
+    expect(@school_contact.first_name).to eq("Joe")
+    expect(@school_contact.last_name).to eq("Bloggs")
+    expect(@school_contact.email_address).to eq("joe_bloggs@example.com")
+  end
+
+  def and_the_schools_hosting_interest_for_the_next_year_is_updated
+    hosting_interest = @school.hosting_interests.for_academic_year(@next_academic_year).last
+    expect(hosting_interest.appetite).to eq("not_open")
+    expect(hosting_interest.reasons_not_hosting).to contain_exactly("Other")
+    expect(hosting_interest.other_reason_not_hosting).to eq("Some other reason")
+  end
+
+  def then_i_see_the_are_you_sure_page
+    expect(page).to have_title(
+      "Are you sure you do not want to be contacted about placements? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Are you sure you do not want to be contacted about placements?")
+    expect(page).to have_element(
+      :span,
+      text: "Not interested in hosting this year",
+    )
+  end
+
+  def and_i_enter_another_reason
+    fill_in "Tell us your reason", with: "Some other reason"
+  end
+end

--- a/spec/wizards/placements/multi_placement_wizard/reason_not_hosting_step_spec.rb
+++ b/spec/wizards/placements/multi_placement_wizard/reason_not_hosting_step_spec.rb
@@ -13,11 +13,20 @@ RSpec.describe Placements::MultiPlacementWizard::ReasonNotHostingStep, type: :mo
   let!(:school) { create(:placements_school) }
 
   describe "attributes" do
-    it { is_expected.to have_attributes(reasons_not_hosting: [], reason_details: nil) }
+    it { is_expected.to have_attributes(reasons_not_hosting: [], other_reason_not_hosting: nil) }
   end
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:reasons_not_hosting) }
+    it { is_expected.not_to validate_presence_of(:other_reason_not_hosting) }
+
+    context "when the 'reasons_not_hosting' is 'Other'" do
+      context "when" do
+        let(:attributes) { { reasons_not_hosting: %w[Other], other_reason_not_hosting: nil } }
+
+        it { is_expected.to validate_presence_of(:other_reason_not_hosting) }
+      end
+    end
   end
 
   describe "#reason_options" do


### PR DESCRIPTION
## Context

- Make changes so the "Other" reason why the user is not hosting can be stored on the HostingInterest

## Changes proposed in this pull request

- Migration to add `other_reason_not_hosting` column to `hosting_interests`
- Change name of input text_field to `other_reason_not_hosting`

## Guidance to review

- Sign in as Anne (School user)
- Navigate to "Placements"
- Click "Bulk add placements"
- Choose "No - Let providers know I am not hosting and do not want to be contacted"
- Check "Other" and enter a reason
- Continue with the journey
