### PR TITLE
Fix row count on claims sampling csv upload

### DIFF
--- a/app/views/wizards/claims/upload_sampling_data_wizard/_confirmation_step.html.erb
+++ b/app/views/wizards/claims/upload_sampling_data_wizard/_confirmation_step.html.erb
@@ -38,7 +38,7 @@
 
         <p class="govuk_body govuk-!-text-align-centre secondary-text">
           <% if current_step.csv.count > 5 %>
-            <%= t(".only_showing_first_rows", row_count: current_step.csv.count) %>
+            <%= t(".only_showing_first_five_rows") %>
           <% else %>
             <%= t(".showing_all_rows") %>
           <% end %>

--- a/config/locales/en/wizards/claims/upload_sampling_data_wizard.yml
+++ b/config/locales/en/wizards/claims/upload_sampling_data_wizard.yml
@@ -17,7 +17,7 @@ en:
           preview_file_name: Preview of %{file_name}
           caption: Auditing
           confirm_upload: Confirm upload
-          only_showing_first_rows: Only showing the first %{row_count} rows
+          only_showing_first_five_rows: Only showing the first 5 rows
           showing_all_rows: Showing all rows
         upload_errors_step:
           page_title: Upload claims to be audited - Auditing - Claims


### PR DESCRIPTION
## Context

- Sampling/Auditing CSV upload page show "Only showing the first 5 rows"

## Changes proposed in this pull request

- Sampling/Auditing CSV upload page show "Only showing the first 5 rows"

## Link to Trello card

- https://trello.com/c/f9PvAZIs/466-row-count-when-uploading-csv-is-incorrect

## Screenshots

![screencapture-claims-localhost-3000-support-claims-sampling-claims-new-6fc86fac-7c10-44f9-8dc2-2fa8bfd85afb-confirmation-2025-03-11-13_14_12 (1)](https://github.com/user-attachments/assets/188c6151-5cf2-4e24-8a01-4a6f8e578c08)

