### PR TITLE
Add Provider search options to claim wizard

### DIFF
--- a/app/views/claims/schools/claims/index.html.erb
+++ b/app/views/claims/schools/claims/index.html.erb
@@ -41,7 +41,7 @@
             <% row.with_cell(text: claim.provider_name) %>
             <% row.with_cell do %>
               <ul class="govuk-list">
-                <% claim.mentors.each do |mentor| %>
+                <% claim.mentors.order_by_full_name.each do |mentor| %>
                   <li><%= mentor.full_name %></li>
                 <% end %>
               </ul>

--- a/app/views/claims/schools/claims/show.html.erb
+++ b/app/views/claims/schools/claims/show.html.erb
@@ -57,7 +57,7 @@
           <% row.with_key(text: t(".mentors")) %>
           <% row.with_value do %>
             <ul class="govuk-list">
-              <% @claim.mentors.each do |mentor| %>
+              <% @claim.mentors.order_by_full_name.each do |mentor| %>
                 <li><%= mentor.full_name %></li>
               <% end %>
             </ul>

--- a/app/views/claims/support/claims/_details.html.erb
+++ b/app/views/claims/support/claims/_details.html.erb
@@ -65,7 +65,7 @@
     <% row.with_key(text: t(".mentors")) %>
     <% row.with_value do %>
       <ul class="govuk-list">
-        <% claim.mentors.each do |mentor| %>
+        <% claim.mentors.order_by_full_name.each do |mentor| %>
           <li><%= mentor.full_name %></li>
         <% end %>
       </ul>

--- a/app/views/claims/support/schools/claims/index.html.erb
+++ b/app/views/claims/support/schools/claims/index.html.erb
@@ -41,7 +41,7 @@
             <% row.with_cell(text: claim.provider_name) %>
             <% row.with_cell do %>
               <ul class="govuk-list">
-                <% claim.mentors.each do |mentor| %>
+                <% claim.mentors.order_by_full_name.each do |mentor| %>
                   <li><%= mentor.full_name %></li>
                 <% end %>
               </ul>

--- a/app/views/wizards/claims/add_claim_wizard/_mentor_training_step.html.erb
+++ b/app/views/wizards/claims/add_claim_wizard/_mentor_training_step.html.erb
@@ -8,7 +8,7 @@
 
    <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <span class="govuk-caption-l"><%= contextual_text %> - <%= @wizard.steps[:provider].provider.name %></span>
+        <span class="govuk-caption-l"><%= contextual_text %> - <%= @wizard.provider_name %></span>
         <h1 class="govuk-heading-l"><%= t(".hours_of_training_for_mentor", mentor: current_step.mentor_full_name) %> </h1>
 
          <%= render Claims::AddClaimWizard::MentorTrainingStep::DisclaimerComponent.new(mentor_training_step: current_step) %>

--- a/app/views/wizards/claims/add_claim_wizard/_provider_options_step.html.erb
+++ b/app/views/wizards/claims/add_claim_wizard/_provider_options_step.html.erb
@@ -1,0 +1,16 @@
+<% content_for :page_title, title_with_error_prefix(
+  t(".title", provider_count: current_step.providers.count, search_param: current_step.search_param, contextual_text:),
+  error: current_step.errors.any?,
+) %>
+
+<%= render OptionsFormComponent.new(
+  model: current_step,
+  scope: current_step.scope,
+  url: current_step_path,
+  title: contextual_text,
+  search_param: current_step.search_param,
+  records: current_step.providers,
+  records_klass: :school,
+  back_link: back_link_path,
+  method: :put,
+) %>

--- a/app/views/wizards/claims/add_claim_wizard/_provider_step.html.erb
+++ b/app/views/wizards/claims/add_claim_wizard/_provider_step.html.erb
@@ -16,6 +16,7 @@
     value: current_step.provider&.name,
     label: t(".title"),
     caption: contextual_text,
+    hint: t(".hint_html"),
     previous_search: current_step.id,
   },
 ) %>

--- a/app/views/wizards/claims/add_claim_wizard/_provider_step.html.erb
+++ b/app/views/wizards/claims/add_claim_wizard/_provider_step.html.erb
@@ -3,21 +3,19 @@
   error: current_step.errors.any?,
 ) %>
 
-<%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
-  <%= f.govuk_error_summary %>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-l"><%= contextual_text %></span>
-
-      <%= f.govuk_collection_radio_buttons(
-        :id,
-        current_step.providers_for_selection,
-        :id, :name,
-        legend: { size: "l", text: t(".title"), tag: "h1" }
-      ) %>
-
-      <%= f.govuk_submit t(".continue") %>
-    </div>
-  </div>
-<% end %>
+<%= render AutocompleteSelectFormComponent.new(
+  model: current_step,
+  scope: current_step.scope,
+  url: current_step_path,
+  method: :put,
+  data: {
+    autocomplete_path_value: current_step.autocomplete_path_value,
+    autocomplete_return_attributes_value: current_step.autocomplete_return_attributes_value,
+  },
+  input: {
+    value: current_step.provider&.name,
+    label: t(".title"),
+    caption: contextual_text,
+    previous_search: current_step.id,
+  },
+) %>

--- a/app/wizards/claims/add_claim_wizard.rb
+++ b/app/wizards/claims/add_claim_wizard.rb
@@ -15,6 +15,7 @@ module Claims
 
     def define_steps
       add_step(ProviderStep)
+      add_step(ProviderOptionsStep) if steps.fetch(:provider).provider.blank?
       if mentors_with_claimable_hours.any? || current_step == :check_your_answers
         add_step(MentorStep)
         # Loop over mentors
@@ -58,7 +59,7 @@ module Claims
     end
 
     def provider
-      steps.fetch(:provider).provider
+      steps[:provider_options]&.provider || steps.fetch(:provider).provider
     end
 
     def mentors_with_claimable_hours

--- a/app/wizards/claims/add_claim_wizard/provider_options_step.rb
+++ b/app/wizards/claims/add_claim_wizard/provider_options_step.rb
@@ -1,0 +1,13 @@
+class Claims::AddClaimWizard::ProviderOptionsStep < Claims::AddClaimWizard::ProviderSelectionStep
+  attribute :search_param
+
+  def providers
+    @providers ||= Claims::Provider.search_name_urn_ukprn_postcode(
+      search_param.downcase,
+    ).decorate
+  end
+
+  def search_param
+    @wizard.steps[:provider].id
+  end
+end

--- a/app/wizards/claims/add_claim_wizard/provider_selection_step.rb
+++ b/app/wizards/claims/add_claim_wizard/provider_selection_step.rb
@@ -1,0 +1,13 @@
+class Claims::AddClaimWizard::ProviderSelectionStep < BaseStep
+  attribute :id
+
+  validates :id, presence: true
+
+  def provider
+    @provider ||= Claims::Provider.find_by(id:)
+  end
+
+  def scope
+    self.class.name.underscore.parameterize(separator: "_")
+  end
+end

--- a/app/wizards/claims/add_claim_wizard/provider_step.rb
+++ b/app/wizards/claims/add_claim_wizard/provider_step.rb
@@ -1,13 +1,11 @@
-class Claims::AddClaimWizard::ProviderStep < BaseStep
-  attribute :id
+class Claims::AddClaimWizard::ProviderStep < Claims::AddClaimWizard::ProviderSelectionStep
+  attribute :name
 
-  validates :id, presence: true, inclusion: { in: ->(step) { step.providers_for_selection.ids } }
-
-  def providers_for_selection
-    Claims::Provider.private_beta_providers.order_by_name.select(:id, :name)
+  def autocomplete_path_value
+    "/api/provider_suggestions"
   end
 
-  def provider
-    @provider ||= Claims::Provider.private_beta_providers.find_by(id:)
+  def autocomplete_return_attributes_value
+    %w[code]
   end
 end

--- a/app/wizards/claims/edit_claim_wizard.rb
+++ b/app/wizards/claims/edit_claim_wizard.rb
@@ -20,6 +20,7 @@ module Claims
         add_step(DeclarationStep)
       else
         add_step(AddClaimWizard::ProviderStep)
+        add_step(AddClaimWizard::ProviderOptionsStep) if steps.fetch(:provider).provider.blank?
         if mentors_with_claimable_hours.any? || current_step == :check_your_answers
           add_step(AddClaimWizard::MentorStep)
           selected_mentors.each do |mentor|
@@ -71,7 +72,9 @@ module Claims
     end
 
     def provider
-      steps[:provider]&.provider || claim.provider
+      steps[:provider_options]&.provider ||
+        steps[:provider]&.provider ||
+        claim.provider
     end
 
     def claim_to_exclude

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -138,7 +138,7 @@ en:
         claims/add_claim_wizard/provider_step:
           attributes:
             id:
-              blank: Select a provider
+              blank: Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode
         claims/add_claim_wizard/mentor_step:
           attributes:
             mentor_ids:
@@ -320,3 +320,7 @@ en:
             child_subject_ids: 
               blank: Please select a subject
               inclusion: Please select a subject
+        claims/add_claim_wizard/provider_options_step:
+          attributes:
+            id:
+              blank: Select a provider

--- a/config/locales/en/wizards/claims/add_claim_wizard.yml
+++ b/config/locales/en/wizards/claims/add_claim_wizard.yml
@@ -4,8 +4,11 @@ en:
       add_claim_wizard:
         provider_step:
           continue: Continue
-          page_title: Enter an accredited provider name, UKPRN, URN or postcode - %{contextual_text}
-          title: Enter an accredited provider name, UKPRN, URN or postcode
+          page_title: Enter the accredited provider for this claime - %{contextual_text}
+          title: Enter the accredited provider for this claim
+          hint_html:
+            You must make a separate claim for each accredited provider you work with.<br><br>
+            Enter a provider name, United Kingdon provider number (UKPRN), unique reference number (URN) or postcode
         provider_options_step:
           title: "%{provider_count} results found for ‘%{search_param}’ - %{contextual_text}"
         mentor_step:

--- a/config/locales/en/wizards/claims/add_claim_wizard.yml
+++ b/config/locales/en/wizards/claims/add_claim_wizard.yml
@@ -4,8 +4,10 @@ en:
       add_claim_wizard:
         provider_step:
           continue: Continue
-          page_title: Accredited provider - %{contextual_text}
-          title: Accredited provider
+          page_title: Enter an accredited provider name, UKPRN, URN or postcode - %{contextual_text}
+          title: Enter an accredited provider name, UKPRN, URN or postcode
+        provider_options_step:
+          title: "%{provider_count} results found for ‘%{search_param}’ - %{contextual_text}"
         mentor_step:
           page_title: Mentors for %{provider_name} - %{contextual_text}
           continue: Continue

--- a/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe "Change claim on check page", :js, service: :claims, type: :syste
   end
 
   def and_i_enter_a_provider_named_best_practice_network
-    fill_in "Enter an accredited provider", with: "Best Practice Network"
+    fill_in "Enter the accredited provider", with: "Best Practice Network"
   end
 
   def then_i_see_a_dropdown_item_for_best_practice_network
@@ -280,7 +280,7 @@ RSpec.describe "Change claim on check page", :js, service: :claims, type: :syste
   end
 
   def when_i_enter_a_provider_named_niot
-    fill_in "Enter an accredited provider", with: niot.name
+    fill_in "Enter the accredited provider", with: niot.name
   end
 
   def then_i_see_a_dropdown_item_for_niot

--- a/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Change claim on check page", service: :claims, type: :system do
+RSpec.describe "Change claim on check page", :js, service: :claims, type: :system do
   let!(:school) { create(:claims_school, mentors: [mentor1, mentor2, mentor3], region: regions(:inner_london)) }
   let!(:anne) do
     create(
@@ -22,7 +22,10 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
     given_i_sign_in
 
     when_i_click("Add claim")
-    when_i_choose_a_provider(bpn)
+    and_i_enter_a_provider_named_best_practice_network
+    then_i_see_a_dropdown_item_for_best_practice_network
+
+    when_i_click_the_dropdown_item_for_best_practice_network
     when_i_click("Continue")
     when_i_select_a_mentor(mentor1)
     when_i_select_a_mentor(mentor2)
@@ -38,9 +41,12 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
 
   scenario "Anne changes the provider on claim on check page and doesn't need to add the mentor hours again" do
     when_i_click_change_provider
-    then_i_expect_the_provider_to_be_checked(bpn)
-    when_i_change_the_provider
-    then_i_expect_the_provider_to_be_checked(niot)
+    then_i_expect_the_provider_to_be_prefilled_with_best_practice_network
+
+    when_i_enter_a_provider_named_niot
+    then_i_see_a_dropdown_item_for_niot
+
+    when_i_click_the_dropdown_item_for_niot
     when_i_click("Continue")
     when_i_click("Continue") # Mentors step
     when_i_click("Continue") # Mentors 1 step
@@ -134,27 +140,15 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
   end
 
   def when_i_click_change_provider
-    within("dl.govuk-summary-list:nth(1)") do
-      within(".govuk-summary-list__row:nth(3)") do
-        click_link("Change")
-      end
-    end
+    click_link("Change Accredited provider")
   end
 
   def when_i_click_change_mentors
-    within("dl.govuk-summary-list:nth(1)") do
-      within(".govuk-summary-list__row:nth(4)") do
-        click_link("Change")
-      end
-    end
+    click_link("Change Mentors")
   end
 
   def when_i_click_change_training_hours_for_mentor
-    within("dl.govuk-summary-list:nth(2)") do
-      within(".govuk-summary-list__row:nth(1)") do
-        click_link("Change")
-      end
-    end
+    click_link("Change Hours of training for #{mentor1.full_name}")
   end
 
   def when_i_choose_other_amount
@@ -200,9 +194,9 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
 
   def then_i_expect_the_training_hours_to_be_selected(hours)
     if hours.to_i == 20
-      find("#claims-add-claim-wizard-mentor-training-step-hours-to-claim-maximum-field").checked?
+      find("#claims-add-claim-wizard-mentor-training-step-hours-to-claim-maximum-field", visible: :all).checked?
     else
-      find("#claims-add-claim-wizard-mentor-training-step-hours-to-claim-custom-field").checked?
+      find("#claims-add-claim-wizard-mentor-training-step-hours-to-claim-custom-field", visible: :all).checked?
     end
   end
 
@@ -212,51 +206,26 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
   end
 
   def then_i_check_my_answers(provider, mentors, mentor_hours)
-    expect(page).to have_content("Check your answers")
-    expect(page).to have_content("Hours of training")
-    expect(page).to have_content("Grant funding")
+    expect(page).to have_h1("Check your answers", class: "govuk-heading-l")
 
-    within("dl.govuk-summary-list:nth(1)") do
-      within(".govuk-summary-list__row:nth(2)") do
-        expect(page).to have_content("Academic year")
-        expect(page).to have_content(@claim_window.academic_year_name)
-      end
+    expect(page).to have_summary_list_row("Academic year", @claim_window.academic_year_name)
+    expect(page).to have_summary_list_row("Accredited provider", provider.name)
 
-      within(".govuk-summary-list__row:nth(3)") do
-        expect(page).to have_content("Accredited provider")
-        expect(page).to have_content(provider.name)
-      end
+    expect(page).to have_h2("Hours of training", class: "govuk-heading-m")
 
-      within(".govuk-summary-list__row:nth(4)") do
-        expect(page).to have_content("Mentors")
-        mentors.each do |mentor|
-          expect(page).to have_content(mentor.full_name)
-        end
-      end
+    mentors.each_with_index do |mentor, index|
+      expect(page).to have_summary_list_row(mentor.full_name, mentor_hours[index])
     end
 
-    within("dl.govuk-summary-list:nth(2)") do
-      mentors.each_with_index do |mentor, index|
-        expect(page).to have_content(mentor.full_name)
-        expect(page).to have_content(mentor_hours[index])
-      end
-    end
+    expect(page).to have_h2("Grant funding", class: "govuk-heading-m")
 
-    within("dl.govuk-summary-list:nth(3)") do
-      within(".govuk-summary-list__row:nth(1)") do
-        expect(page).to have_content("Total hours#{mentor_hours.sum} hours")
-      end
-
-      within(".govuk-summary-list__row:nth(2)") do
-        expect(page).to have_content("Hourly rate£53.60")
-      end
-
-      amount = Money.new(mentor_hours.sum * school.region.claims_funding_available_per_hour_pence, "GBP")
-      within(".govuk-summary-list__row:nth(3)") do
-        expect(page).to have_content("Claim amount")
-        expect(page).to have_content(amount.format(symbol: true, decimal_mark: ".", no_cents: true))
-      end
-    end
+    expect(page).to have_summary_list_row("Total hours", "#{mentor_hours.sum} hours")
+    expect(page).to have_summary_list_row("Hourly rate", "£53.60")
+    amount = Money.new(mentor_hours.sum * school.region.claims_funding_available_per_hour_pence, "GBP")
+    expect(page).to have_summary_list_row(
+      "Claim amount",
+      amount.format(symbol: true, decimal_mark: ".", no_cents: true),
+    )
   end
 
   def then_i_cant_see_the_mentor(mentor)
@@ -290,5 +259,35 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
 
   def then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor)
     expect(page).to have_content("Hours of training for #{mentor.full_name}")
+  end
+
+  def and_i_enter_a_provider_named_best_practice_network
+    fill_in "Enter an accredited provider", with: "Best Practice Network"
+  end
+
+  def then_i_see_a_dropdown_item_for_best_practice_network
+    expect(page).to have_css(".autocomplete__option", text: "Best Practice Network", wait: 10)
+  end
+
+  def when_i_click_the_dropdown_item_for_best_practice_network
+    page.find(".autocomplete__option", text: "Best Practice Network").click
+  end
+
+  def then_i_expect_the_provider_to_be_prefilled_with_best_practice_network
+    expect(page.find("#claims-add-claim-wizard-provider-step-id-field").value).to eq(
+      "Best Practice Network",
+    )
+  end
+
+  def when_i_enter_a_provider_named_niot
+    fill_in "Enter an accredited provider", with: niot.name
+  end
+
+  def then_i_see_a_dropdown_item_for_niot
+    expect(page).to have_css(".autocomplete__option", text: niot.name, wait: 10)
+  end
+
+  def when_i_click_the_dropdown_item_for_niot
+    page.find(".autocomplete__option", text: niot.name).click
   end
 end

--- a/spec/system/claims/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/schools/claims/create_claim_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Create claim", service: :claims, type: :system do
+RSpec.describe "Create claim", :js, service: :claims, type: :system do
   let!(:claim_window) { create(:claim_window, :current) }
   let(:mentor1) { build(:claims_mentor, first_name: "Anne") }
   let(:mentor2) { build(:claims_mentor, first_name: "Joe") }
@@ -23,8 +23,10 @@ RSpec.describe "Create claim", service: :claims, type: :system do
 
   scenario "Anne creates a claim" do
     when_i_click("Add claim")
-    then_i_should_see_providers_ordered_by_name
-    when_i_choose_a_provider(bpn)
+    and_i_enter_a_provider_named_best_practice_network
+    then_i_see_a_dropdown_item_for_best_practice_network
+
+    when_i_click_the_dropdown_item_for_best_practice_network
     when_i_click("Continue")
     when_i_select_all_mentors
     when_i_click("Continue")
@@ -46,7 +48,10 @@ RSpec.describe "Create claim", service: :claims, type: :system do
 
   scenario "Anne attempts to create a claim but backs off before the check page" do
     when_i_click("Add claim")
-    when_i_choose_a_provider(bpn)
+    and_i_enter_a_provider_named_best_practice_network
+    then_i_see_a_dropdown_item_for_best_practice_network
+
+    when_i_click_the_dropdown_item_for_best_practice_network
     when_i_click("Continue")
     when_i_select_all_mentors
     when_i_click("Continue")
@@ -66,7 +71,10 @@ RSpec.describe "Create claim", service: :claims, type: :system do
 
   scenario "Anne creates a claim with mentor training hours over the maximum limit per provider" do
     when_i_click("Add claim")
-    when_i_choose_a_provider(bpn)
+    and_i_enter_a_provider_named_best_practice_network
+    then_i_see_a_dropdown_item_for_best_practice_network
+
+    when_i_click_the_dropdown_item_for_best_practice_network
     when_i_click("Continue")
     when_i_select_all_mentors
     when_i_click("Continue")
@@ -85,8 +93,14 @@ RSpec.describe "Create claim", service: :claims, type: :system do
   scenario "Anne does not fill the form correctly" do
     when_i_click("Add claim")
     when_i_click("Continue")
-    then_i_see_the_error("Select a provider")
-    when_i_choose_a_provider(bpn)
+    then_i_see_the_error(
+      "Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode",
+    )
+
+    and_i_enter_a_provider_named_best_practice_network
+    then_i_see_a_dropdown_item_for_best_practice_network
+
+    when_i_click_the_dropdown_item_for_best_practice_network
     when_i_click("Continue")
     when_i_click("Continue")
     then_i_see_the_error("Select a mentor")
@@ -111,7 +125,10 @@ RSpec.describe "Create claim", service: :claims, type: :system do
   scenario "School attempts to create a claim when their mentors have all been claimed for" do
     given_my_school_has_fully_claimed_for_all_mentors_for_provider(bpn)
     when_i_click("Add claim")
-    when_i_choose_a_provider(bpn)
+    and_i_enter_a_provider_named_best_practice_network
+    then_i_see_a_dropdown_item_for_best_practice_network
+
+    when_i_click_the_dropdown_item_for_best_practice_network
     when_i_click("Continue")
     then_i_should_see_the_message("There are no mentors you can include in a claim because they have already had 20 hours of training claimed for with Best Practice Network.")
   end
@@ -119,7 +136,10 @@ RSpec.describe "Create claim", service: :claims, type: :system do
   scenario "School attempts to create a claim then changes the provider to an invalid one" do
     given_my_school_has_fully_claimed_for_all_mentors_for_provider(bpn)
     when_i_click("Add claim")
-    when_i_choose_a_provider(niot)
+    when_i_enter_a_provider_named_niot
+    then_i_see_a_dropdown_item_for_niot
+
+    when_i_click_the_dropdown_item_for_niot
     when_i_click("Continue")
     when_i_select_a_mentor(mentor1)
     when_i_click("Continue")
@@ -127,11 +147,17 @@ RSpec.describe "Create claim", service: :claims, type: :system do
     when_i_add_training_hours("20 hours")
     when_i_click("Continue")
     when_i_click("Change Accredited provider")
-    when_i_choose_a_provider(bpn)
+    and_i_enter_a_provider_named_best_practice_network
+    then_i_see_a_dropdown_item_for_best_practice_network
+
+    when_i_click_the_dropdown_item_for_best_practice_network
     when_i_click("Continue")
     then_i_should_see_the_message("There are no mentors you can include in a claim because they have already had 20 hours of training claimed for with Best Practice Network.")
     when_i_click("Change the accredited provider")
-    when_i_choose_a_provider(niot)
+    when_i_enter_a_provider_named_niot
+    then_i_see_a_dropdown_item_for_niot
+
+    when_i_click_the_dropdown_item_for_niot
     when_i_click("Continue")
     when_i_click("Continue")
     when_i_click("Continue")
@@ -149,7 +175,10 @@ RSpec.describe "Create claim", service: :claims, type: :system do
 
     scenario "Anne creates a claim" do
       when_i_click("Add claim")
-      when_i_choose_a_provider(bpn)
+      and_i_enter_a_provider_named_best_practice_network
+      then_i_see_a_dropdown_item_for_best_practice_network
+
+      when_i_click_the_dropdown_item_for_best_practice_network
       when_i_click("Continue")
       when_i_select_a_mentor(mentor1)
       when_i_click("Continue")
@@ -164,7 +193,10 @@ RSpec.describe "Create claim", service: :claims, type: :system do
 
     scenario "Anne creates a claim with more than the remaining hours" do
       when_i_click("Add claim")
-      when_i_choose_a_provider(bpn)
+      and_i_enter_a_provider_named_best_practice_network
+      then_i_see_a_dropdown_item_for_best_practice_network
+
+      when_i_click_the_dropdown_item_for_best_practice_network
       when_i_click("Continue")
       when_i_select_a_mentor(mentor1)
       when_i_click("Continue")
@@ -232,54 +264,25 @@ RSpec.describe "Create claim", service: :claims, type: :system do
   end
 
   def then_i_check_my_answers
-    expect(page).to have_content("Check your answers")
-    expect(page).to have_content("Hours of training")
-    expect(page).to have_content("Grant funding")
+    expect(page).to have_h1("Check your answers", class: "govuk-heading-l")
 
-    within("dl.govuk-summary-list:nth(1)") do
-      within(".govuk-summary-list__row:nth(2)") do
-        expect(page).to have_content("Academic year")
-        expect(page).to have_content(claim_window.academic_year_name)
-      end
+    expect(page).to have_summary_list_row("Academic year", claim_window.academic_year_name)
+    expect(page).to have_summary_list_row("Accredited provider", bpn.name)
+    expect(page).to have_summary_list_row(
+      "Mentors",
+      "#{mentor1.full_name}\n#{mentor2.full_name}",
+    )
 
-      within(".govuk-summary-list__row:nth(3)") do
-        expect(page).to have_content("Accredited provider")
-        expect(page).to have_content(bpn.name)
-      end
+    expect(page).to have_h2("Hours of training", class: "govuk-heading-m")
 
-      within(".govuk-summary-list__row:nth(4)") do
-        expect(page).to have_content("Mentors")
-        expect(page).to have_content(mentor1.full_name)
-        expect(page).to have_content(mentor2.full_name)
-      end
-    end
+    expect(page).to have_summary_list_row(mentor1.full_name, "20 hours")
+    expect(page).to have_summary_list_row(mentor2.full_name, "12 hours")
 
-    within("dl.govuk-summary-list:nth(2)") do
-      within(".govuk-summary-list__row:nth(1)") do
-        expect(page).to have_content(mentor1.full_name)
-        expect(page).to have_content("20 hours")
-      end
+    expect(page).to have_h2("Grant funding", class: "govuk-heading-m")
 
-      within(".govuk-summary-list__row:nth(2)") do
-        expect(page).to have_content(mentor2.full_name)
-        expect(page).to have_content("12 hours")
-      end
-    end
-
-    within("dl.govuk-summary-list:nth(3)") do
-      within(".govuk-summary-list__row:nth(1)") do
-        expect(page).to have_content("Total hours32 hours")
-      end
-
-      within(".govuk-summary-list__row:nth(2)") do
-        expect(page).to have_content("Hourly rate£53.60")
-      end
-
-      within(".govuk-summary-list__row:nth(3)") do
-        expect(page).to have_content("Claim amount")
-        expect(page).to have_content("£1,715.20")
-      end
-    end
+    expect(page).to have_summary_list_row("Total hours", "32 hours")
+    expect(page).to have_summary_list_row("Hourly rate", "£53.60")
+    expect(page).to have_summary_list_row("Claim amount", "£1,715.20")
   end
 
   def then_i_get_a_claim_reference_and_see_next_steps
@@ -297,17 +300,11 @@ RSpec.describe "Create claim", service: :claims, type: :system do
 
   def then_i_expect_the_training_hours_for(_hours, mentor)
     expect(page).to have_content("Hours of training for #{mentor.full_name}")
-    find("#claims-add-claim-wizard-mentor-training-step-hours-to-claim-maximum-field").checked?
+    find("#claims-add-claim-wizard-mentor-training-step-hours-to-claim-maximum-field", visible: :all).checked?
   end
 
   def then_i_see_the_error(message)
-    within(".govuk-error-summary") do
-      expect(page).to have_content message
-    end
-
-    within(".govuk-form-group--error") do
-      expect(page).to have_content message
-    end
+    expect(page).to have_validation_error(message)
   end
 
   def given_i_visit_claim_check_page_after_submitting
@@ -362,5 +359,35 @@ RSpec.describe "Create claim", service: :claims, type: :system do
   def and_the_total_claimable_hours_are_for_refresher_training
     expect(page).to have_content("6 hours")
     expect(page).to have_content("The remaining amount of hours for standard training")
+  end
+
+  def and_i_enter_a_provider_named_best_practice_network
+    fill_in "Enter an accredited provider", with: "Best Practice Network"
+  end
+
+  def then_i_see_a_dropdown_item_for_best_practice_network
+    expect(page).to have_css(".autocomplete__option", text: "Best Practice Network", wait: 10)
+  end
+
+  def when_i_click_the_dropdown_item_for_best_practice_network
+    page.find(".autocomplete__option", text: "Best Practice Network").click
+  end
+
+  def when_i_enter_a_provider_named_niot
+    fill_in "Enter an accredited provider", with: niot.name
+  end
+
+  def then_i_see_a_dropdown_item_for_niot
+    expect(page).to have_css(".autocomplete__option", text: niot.name, wait: 10)
+  end
+
+  def when_i_click_the_dropdown_item_for_niot
+    page.find(".autocomplete__option", text: niot.name).click
+  end
+
+  def then_i_expect_the_provider_to_be_prefilled_with_best_practice_network
+    expect(page.find("#claims-add-claim-wizard-provider-step-id-field").value).to eq(
+      "Best Practice Network",
+    )
   end
 end

--- a/spec/system/claims/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/schools/claims/create_claim_spec.rb
@@ -362,7 +362,7 @@ RSpec.describe "Create claim", :js, service: :claims, type: :system do
   end
 
   def and_i_enter_a_provider_named_best_practice_network
-    fill_in "Enter an accredited provider", with: "Best Practice Network"
+    fill_in "Enter the accredited provider", with: "Best Practice Network"
   end
 
   def then_i_see_a_dropdown_item_for_best_practice_network
@@ -374,7 +374,7 @@ RSpec.describe "Create claim", :js, service: :claims, type: :system do
   end
 
   def when_i_enter_a_provider_named_niot
-    fill_in "Enter an accredited provider", with: niot.name
+    fill_in "Enter the accredited provider", with: niot.name
   end
 
   def then_i_see_a_dropdown_item_for_niot

--- a/spec/system/claims/schools/claims/edit_draft_claim_spec.rb
+++ b/spec/system/claims/schools/claims/edit_draft_claim_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe "Edit a claim", service: :claims, type: :system do
   end
 
   def when_i_enter_a_provider_named_niot
-    fill_in "Enter an accredited provider", with: another_provider.name
+    fill_in "Enter the accredited provider", with: another_provider.name
   end
 
   def then_i_see_a_dropdown_item_for_niot

--- a/spec/system/claims/schools/claims/school_user_creates_a_claim_with_javascript_disabled_spec.rb
+++ b/spec/system/claims/schools/claims/school_user_creates_a_claim_with_javascript_disabled_spec.rb
@@ -1,0 +1,224 @@
+require "rails_helper"
+
+RSpec.describe "School user creates a claim with javascript disabled", service: :claims, type: :system do
+  scenario do
+    given_an_claim_window_exists
+    and_a_school_exists
+    and_providers_exist
+    and_i_am_signed_in
+    when_i_click_on_add_claim
+    then_i_see_the_enter_a_provider_step
+
+    when_i_enter_the_provider_name
+    and_i_click_on_continue
+    then_i_see_the_provider_options_step
+    and_i_see_a_radio_button_for_best_practice_network
+    and_i_do_not_see_a_radio_button_for_niot
+
+    when_i_select_best_practice_network
+    and_i_click_on_continue
+    then_i_see_the_mentor_selection_step
+
+    when_i_select_joe_bloggs
+    and_i_select_sarah_doe
+    and_i_click_on_continue
+    then_i_see_the_mentor_training_hours_step_for_joe_bloggs
+
+    when_i_choose_20_hours
+    and_i_click_on_continue
+    then_i_see_the_mentor_training_hours_step_for_sarah_doe
+
+    when_i_choose_another_amount
+    and_enter_6_hours
+    and_i_click_on_continue
+    then_i_see_the_check_your_answers_page
+
+    when_i_click_on_submit_claim
+    then_i_see_the_claim_has_been_successfully_created
+  end
+
+  private
+
+  def given_an_claim_window_exists
+    @claim_window = create(:claim_window, :current)
+    @academic_year = @claim_window.academic_year
+  end
+
+  def and_a_school_exists
+    @mentor_1 = build(:claims_mentor, first_name: "Joe", last_name: "Bloggs")
+    @mentor_2 = build(:claims_mentor, first_name: "Sarah", last_name: "Doe")
+    @mentor_3 = build(:claims_mentor, first_name: "John", last_name: "Smith")
+
+    @school = create(
+      :claims_school,
+      mentors: [@mentor_1, @mentor_2, @mentor_3],
+      region: regions(:inner_london),
+    )
+  end
+
+  def and_providers_exist
+    @niot_provider = create(:provider, :niot)
+    @bpn_provider = create(:provider, :best_practice_network)
+  end
+
+  def and_i_am_signed_in
+    @user = create(:claims_user, schools: [@school])
+    sign_in_as(@user)
+  end
+
+  def when_i_click_on_add_claim
+    click_on "Add claim"
+  end
+
+  def then_i_see_the_enter_a_provider_step
+    expect(page).to have_element(
+      :label,
+      text: "Enter an accredited provider name, UKPRN, URN or postcode",
+      class: "govuk-label govuk-label--l",
+    )
+    expect(page).to have_element(
+      :span,
+      text: "Add claim",
+      class: "govuk-caption-l",
+    )
+    expect(page).to have_button("Continue")
+  end
+
+  def when_i_enter_the_provider_name
+    fill_in "Enter an accredited provider", with: "Best Practice Network"
+  end
+
+  def and_i_click_on_continue
+    click_on "Continue"
+  end
+  alias_method :when_i_click_on_continue,
+               :and_i_click_on_continue
+
+  def then_i_see_the_provider_options_step
+    expect(page).to have_element(:span, text: "Add claim", class: "govuk-caption-l")
+    expect(page).to have_element(
+      :h1,
+      text: "1 results found for 'Best Practice Network'",
+      class: "govuk-fieldset__heading",
+    )
+  end
+
+  def and_i_see_a_radio_button_for_best_practice_network
+    expect(page).to have_field("Best Practice Network", type: :radio)
+  end
+
+  def and_i_do_not_see_a_radio_button_for_niot
+    expect(page).not_to have_field(
+      "NIoT: National Institute of Teaching, founded by the School-Led Development Trust",
+      type: :radio,
+    )
+  end
+
+  def when_i_select_best_practice_network
+    choose "Best Practice Network"
+  end
+
+  def then_i_see_the_mentor_selection_step
+    expect(page).to have_element(:span, text: "Add claim", class: "govuk-caption-l")
+    expect(page).to have_h1("Mentors for Best Practice Network", class: "govuk-heading-l")
+
+    expect(page).to have_field("Joe Bloggs", type: :checkbox)
+    expect(page).to have_field("John Smith", type: :checkbox)
+    expect(page).to have_field("Sarah Doe", type: :checkbox)
+  end
+
+  def when_i_select_joe_bloggs
+    check "Joe Bloggs"
+  end
+
+  def and_i_select_sarah_doe
+    check "Sarah Doe"
+  end
+
+  def then_i_see_the_mentor_training_hours_step_for_joe_bloggs
+    expect(page).to have_element(:span, text: "Add claim - Best Practice Network", class: "govuk-caption-l")
+    expect(page).to have_h1("Hours of training for Joe Bloggs", class: "govuk-heading-l")
+
+    expect(page).to have_field("20 hours", type: :radio)
+    expect(page).to have_field("Another amount", type: :radio)
+  end
+
+  def when_i_choose_20_hours
+    choose "20 hours"
+  end
+
+  def then_i_see_the_mentor_training_hours_step_for_sarah_doe
+    expect(page).to have_element(:span, text: "Add claim - Best Practice Network", class: "govuk-caption-l")
+    expect(page).to have_h1("Hours of training for Sarah Doe", class: "govuk-heading-l")
+
+    expect(page).to have_field("20 hours", type: :radio)
+    expect(page).to have_field("Another amount", type: :radio)
+  end
+
+  def when_i_choose_another_amount
+    choose "Another amount"
+  end
+
+  def and_enter_6_hours
+    fill_in "Number of hours", with: 6
+  end
+
+  def then_i_see_the_check_your_answers_page
+    expect(page).to have_h1("Check your answers", class: "govuk-heading-l")
+
+    expect(page).to have_summary_list_row("Academic year", @academic_year.name)
+    expect(page).to have_summary_list_row("Accredited provider", "Best Practice Network")
+    expect(page).to have_summary_list_row(
+      "Mentors",
+      "Joe Bloggs Sarah Doe",
+    )
+
+    expect(page).to have_h2("Hours of training", class: "govuk-heading-m")
+
+    expect(page).to have_summary_list_row("Joe Bloggs", "20 hours")
+    expect(page).to have_summary_list_row("Sarah Doe", "6 hours")
+
+    expect(page).to have_h2("Grant funding", class: "govuk-heading-m")
+
+    expect(page).to have_summary_list_row("Total hours", "26 hours")
+    expect(page).to have_summary_list_row("Hourly rate", "£53.60")
+    expect(page).to have_summary_list_row("Claim amount", "£1,393.60")
+  end
+
+  def when_i_click_on_submit_claim
+    click_on "Submit claim"
+  end
+
+  def then_i_see_the_claim_has_been_successfully_created
+    expect(page).to have_element(:h1, text: "Claim submitted", class: "govuk-panel__title")
+
+    claim = Claims::Claim.submitted.order(:submitted_at).last
+
+    expect(page).to have_element(
+      :div,
+      text: "Your reference number\n#{claim.reference}",
+      class: "govuk-panel__body",
+    )
+
+    expect(page).to have_element(
+      :p,
+      text: "We have emailed you a copy of your claim.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "This claim will be shared with Best Practice Network.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "We will check your claim before processing payment. If we need to contact you for further information, we will use the email you used to access this service.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "We will process this claim at the end of September 2024 and all payments will be paid from December 2024.",
+      class: "govuk-body",
+    )
+  end
+end

--- a/spec/system/claims/schools/claims/school_user_creates_a_claim_with_javascript_disabled_spec.rb
+++ b/spec/system/claims/schools/claims/school_user_creates_a_claim_with_javascript_disabled_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "School user creates a claim with javascript disabled", service: 
   def then_i_see_the_enter_a_provider_step
     expect(page).to have_element(
       :label,
-      text: "Enter an accredited provider name, UKPRN, URN or postcode",
+      text: "Enter the accredited provider for this claim",
       class: "govuk-label govuk-label--l",
     )
     expect(page).to have_element(
@@ -85,7 +85,7 @@ RSpec.describe "School user creates a claim with javascript disabled", service: 
   end
 
   def when_i_enter_the_provider_name
-    fill_in "Enter an accredited provider", with: "Best Practice Network"
+    fill_in "Enter the accredited provider for this claim", with: "Best Practice Network"
   end
 
   def and_i_click_on_continue

--- a/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-RSpec.describe "Change claim on check page", service: :claims, type: :system do
-  let!(:school) { create(:claims_school, mentors: [mentor1, mentor2, mentor3]) }
+RSpec.describe "Change claim on check page", :js, service: :claims, type: :system do
+  let!(:school) { create(:claims_school, mentors: [mentor1, mentor2, mentor3], region: regions(:inner_london)) }
   let!(:colin) do
     create(
       :claims_support_user,
@@ -24,7 +24,10 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
     when_i_click_on_claims
 
     when_i_click("Add claim")
-    when_i_choose_a_provider(bpn)
+    and_i_enter_a_provider_named_best_practice_network
+    then_i_see_a_dropdown_item_for_best_practice_network
+
+    when_i_click_the_dropdown_item_for_best_practice_network
     when_i_click("Continue")
     when_i_select_a_mentor(mentor1)
     when_i_select_a_mentor(mentor2)
@@ -40,9 +43,12 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
 
   scenario "Colin changes the provider on claim on check page and doesn't need to add the mentor hours again" do
     when_i_click_change_provider
-    then_i_expect_the_provider_to_be_checked(bpn)
-    when_i_change_the_provider
-    then_i_expect_the_provider_to_be_checked(niot)
+    then_i_expect_the_provider_to_be_prefilled_with_best_practice_network
+
+    when_i_enter_a_provider_named_niot
+    then_i_see_a_dropdown_item_for_niot
+
+    when_i_click_the_dropdown_item_for_niot
     when_i_click("Continue")
     when_i_click("Continue") # Mentors step
     when_i_click("Continue") # Mentors 1 step
@@ -132,27 +138,15 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
   end
 
   def when_i_click_change_provider
-    within("dl.govuk-summary-list:nth(1)") do
-      within(".govuk-summary-list__row:nth(2)") do
-        click_link("Change")
-      end
-    end
+    click_link("Change Accredited provider")
   end
 
   def when_i_click_change_mentors
-    within("dl.govuk-summary-list:nth(1)") do
-      within(".govuk-summary-list__row:nth(3)") do
-        click_link("Change")
-      end
-    end
+    click_link("Change Mentors")
   end
 
   def when_i_click_change_training_hours_for_mentor
-    within("dl.govuk-summary-list:nth(2)") do
-      within(".govuk-summary-list__row:nth(1)") do
-        click_link("Change")
-      end
-    end
+    click_link("Change Hours of training for #{mentor1.full_name}")
   end
 
   def when_i_choose_other_amount
@@ -198,9 +192,9 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
 
   def then_i_expect_the_training_hours_to_be_selected(hours)
     if hours == 20
-      find("#claims-add-claim-wizard-mentor-training-step-hours-to-claim-maximum-field").checked?
+      find("#claims-add-claim-wizard-mentor-training-step-hours-to-claim-maximum-field", visible: :all).checked?
     else
-      find("#claims-add-claim-wizard-mentor-training-step-hours-to-claim-custom-field").checked?
+      find("#claims-add-claim-wizard-mentor-training-step-hours-to-claim-custom-field", visible: :all).checked?
     end
   end
 
@@ -210,33 +204,26 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
   end
 
   def then_i_check_my_answers(provider, mentors, mentor_hours)
-    expect(page).to have_content("Check your answers")
+    expect(page).to have_h1("Check your answers", class: "govuk-heading-l")
 
-    within("dl.govuk-summary-list:nth(1)") do
-      within(".govuk-summary-list__row:nth(1)") do
-        expect(page).to have_content("Academic year")
-        expect(page).to have_content(@claim_window.academic_year_name)
-      end
+    expect(page).to have_summary_list_row("Academic year", @claim_window.academic_year_name)
+    expect(page).to have_summary_list_row("Accredited provider", provider.name)
 
-      within(".govuk-summary-list__row:nth(2)") do
-        expect(page).to have_content("Accredited provider")
-        expect(page).to have_content(provider.name)
-      end
+    expect(page).to have_h2("Hours of training", class: "govuk-heading-m")
 
-      within(".govuk-summary-list__row:nth(3)") do
-        expect(page).to have_content("Mentors")
-        mentors.each do |mentor|
-          expect(page).to have_content(mentor.full_name)
-        end
-      end
+    mentors.each_with_index do |mentor, index|
+      expect(page).to have_summary_list_row(mentor.full_name, mentor_hours[index])
     end
 
-    within("dl.govuk-summary-list:nth(2)") do
-      mentors.each_with_index do |mentor, index|
-        expect(page).to have_content(mentor.full_name)
-        expect(page).to have_content(mentor_hours[index])
-      end
-    end
+    expect(page).to have_h2("Grant funding", class: "govuk-heading-m")
+
+    expect(page).to have_summary_list_row("Total hours", "#{mentor_hours.sum} hours")
+    expect(page).to have_summary_list_row("Hourly rate", "£53.60")
+    amount = Money.new(mentor_hours.sum * school.region.claims_funding_available_per_hour_pence, "GBP")
+    expect(page).to have_summary_list_row(
+      "Claim amount",
+      amount.format(symbol: true, decimal_mark: ".", no_cents: true),
+    )
   end
 
   def then_i_cant_see_the_mentor(mentor)
@@ -275,5 +262,35 @@ RSpec.describe "Change claim on check page", service: :claims, type: :system do
 
   def then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor)
     expect(page).to have_content("Hours of training for #{mentor.full_name}")
+  end
+
+  def and_i_enter_a_provider_named_best_practice_network
+    fill_in "Enter an accredited provider", with: "Best Practice Network"
+  end
+
+  def then_i_see_a_dropdown_item_for_best_practice_network
+    expect(page).to have_css(".autocomplete__option", text: "Best Practice Network", wait: 10)
+  end
+
+  def when_i_click_the_dropdown_item_for_best_practice_network
+    page.find(".autocomplete__option", text: "Best Practice Network").click
+  end
+
+  def then_i_expect_the_provider_to_be_prefilled_with_best_practice_network
+    expect(page.find("#claims-add-claim-wizard-provider-step-id-field").value).to eq(
+      "Best Practice Network",
+    )
+  end
+
+  def when_i_enter_a_provider_named_niot
+    fill_in "Enter an accredited provider", with: niot.name
+  end
+
+  def then_i_see_a_dropdown_item_for_niot
+    expect(page).to have_css(".autocomplete__option", text: niot.name, wait: 10)
+  end
+
+  def when_i_click_the_dropdown_item_for_niot
+    page.find(".autocomplete__option", text: niot.name).click
   end
 end

--- a/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
@@ -265,7 +265,7 @@ RSpec.describe "Change claim on check page", :js, service: :claims, type: :syste
   end
 
   def and_i_enter_a_provider_named_best_practice_network
-    fill_in "Enter an accredited provider", with: "Best Practice Network"
+    fill_in "Enter the accredited provider", with: "Best Practice Network"
   end
 
   def then_i_see_a_dropdown_item_for_best_practice_network
@@ -283,7 +283,7 @@ RSpec.describe "Change claim on check page", :js, service: :claims, type: :syste
   end
 
   def when_i_enter_a_provider_named_niot
-    fill_in "Enter an accredited provider", with: niot.name
+    fill_in "Enter the accredited provider", with: niot.name
   end
 
   def then_i_see_a_dropdown_item_for_niot

--- a/spec/system/claims/support/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/create_claim_spec.rb
@@ -311,7 +311,7 @@ RSpec.describe "Create claim", :js, service: :claims, type: :system do
   end
 
   def and_i_enter_a_provider_named_best_practice_network
-    fill_in "Enter an accredited provider", with: "Best Practice Network"
+    fill_in "Enter the accredited provider", with: "Best Practice Network"
   end
 
   def then_i_see_a_dropdown_item_for_best_practice_network
@@ -329,7 +329,7 @@ RSpec.describe "Create claim", :js, service: :claims, type: :system do
   end
 
   def when_i_enter_a_provider_named_niot
-    fill_in "Enter an accredited provider", with: niot.name
+    fill_in "Enter the accredited provider", with: niot.name
   end
 
   def then_i_see_a_dropdown_item_for_niot
@@ -338,23 +338,5 @@ RSpec.describe "Create claim", :js, service: :claims, type: :system do
 
   def when_i_click_the_dropdown_item_for_niot
     page.find(".autocomplete__option", text: niot.name).click
-  end
-
-  def when_i_enter_a_provider_named_niot
-    fill_in "Enter an accredited provider", with: niot.name
-  end
-
-  def then_i_see_a_dropdown_item_for_niot
-    expect(page).to have_css(".autocomplete__option", text: niot.name, wait: 10)
-  end
-
-  def when_i_click_the_dropdown_item_for_niot
-    page.find(".autocomplete__option", text: niot.name).click
-  end
-
-  def then_i_expect_the_provider_to_be_prefilled_with_best_practice_network
-    expect(page.find("#claims-add-claim-wizard-provider-step-id-field").value).to eq(
-      "Best Practice Network",
-    )
   end
 end

--- a/spec/system/claims/support/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/create_claim_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Create claim", service: :claims, type: :system do
+RSpec.describe "Create claim", :js, service: :claims, type: :system do
   let(:academic_year) do
     build(:academic_year,
           starts_on: Date.parse("1 September 2020"),
@@ -8,7 +8,7 @@ RSpec.describe "Create claim", service: :claims, type: :system do
           name: "2020 to 2021")
   end
   let!(:claim_window) { create(:claim_window, :current, academic_year:) }
-  let!(:school) { create(:claims_school) }
+  let!(:school) { create(:claims_school, region: regions(:inner_london)) }
   let!(:mentor1) { create(:claims_mentor, first_name: "Anne", schools: [school]) }
   let!(:mentor2) { create(:claims_mentor, first_name: "Joe", schools: [school]) }
   let!(:colin) do
@@ -30,7 +30,10 @@ RSpec.describe "Create claim", service: :claims, type: :system do
     when_i_click(school.name)
     when_i_click_on_claims
     when_i_click("Add claim")
-    when_i_choose_a_provider(bpn)
+    and_i_enter_a_provider_named_best_practice_network
+    then_i_see_a_dropdown_item_for_best_practice_network
+
+    when_i_click_the_dropdown_item_for_best_practice_network
     when_i_click("Continue")
     when_i_select_all_mentors
     when_i_click("Continue")
@@ -54,7 +57,10 @@ RSpec.describe "Create claim", service: :claims, type: :system do
     when_i_click(school.name)
     when_i_click_on_claims
     when_i_click("Add claim")
-    when_i_choose_a_provider(bpn)
+    and_i_enter_a_provider_named_best_practice_network
+    then_i_see_a_dropdown_item_for_best_practice_network
+
+    when_i_click_the_dropdown_item_for_best_practice_network
     when_i_click("Continue")
     when_i_select_all_mentors
     when_i_click("Continue")
@@ -76,7 +82,10 @@ RSpec.describe "Create claim", service: :claims, type: :system do
     when_i_click(school.name)
     when_i_click_on_claims
     when_i_click("Add claim")
-    when_i_choose_a_provider(bpn)
+    and_i_enter_a_provider_named_best_practice_network
+    then_i_see_a_dropdown_item_for_best_practice_network
+
+    when_i_click_the_dropdown_item_for_best_practice_network
     when_i_click("Continue")
     when_i_select_all_mentors
     when_i_click("Continue")
@@ -97,8 +106,14 @@ RSpec.describe "Create claim", service: :claims, type: :system do
     when_i_click_on_claims
     when_i_click("Add claim")
     when_i_click("Continue")
-    then_i_see_the_error("Select a provider")
-    when_i_choose_a_provider(bpn)
+    then_i_see_the_error(
+      "Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode",
+    )
+
+    and_i_enter_a_provider_named_best_practice_network
+    then_i_see_a_dropdown_item_for_best_practice_network
+
+    when_i_click_the_dropdown_item_for_best_practice_network
     when_i_click("Continue")
     when_i_click("Continue")
     then_i_see_the_error("Select a mentor")
@@ -125,7 +140,10 @@ RSpec.describe "Create claim", service: :claims, type: :system do
     when_i_click(school.name)
     when_i_click_on_claims
     when_i_click("Add claim")
-    when_i_choose_a_provider(bpn)
+    and_i_enter_a_provider_named_best_practice_network
+    then_i_see_a_dropdown_item_for_best_practice_network
+
+    when_i_click_the_dropdown_item_for_best_practice_network
     when_i_click("Continue")
     then_i_should_see_the_message("There are no mentors you can include in a claim because they have already had 20 hours of training claimed for with Best Practice Network.")
   end
@@ -135,7 +153,10 @@ RSpec.describe "Create claim", service: :claims, type: :system do
     when_i_click(school.name)
     when_i_click_on_claims
     when_i_click("Add claim")
-    when_i_choose_a_provider(niot)
+    when_i_enter_a_provider_named_niot
+    then_i_see_a_dropdown_item_for_niot
+
+    when_i_click_the_dropdown_item_for_niot
     when_i_click("Continue")
     when_i_select_a_mentor(mentor1)
     when_i_click("Continue")
@@ -143,11 +164,17 @@ RSpec.describe "Create claim", service: :claims, type: :system do
     when_i_add_training_hours("20 hours")
     when_i_click("Continue")
     when_i_click("Change Accredited provider")
-    when_i_choose_a_provider(bpn)
+    and_i_enter_a_provider_named_best_practice_network
+    then_i_see_a_dropdown_item_for_best_practice_network
+
+    when_i_click_the_dropdown_item_for_best_practice_network
     when_i_click("Continue")
     then_i_should_see_the_message("There are no mentors you can include in a claim because they have already had 20 hours of training claimed for with Best Practice Network.")
     when_i_click("Change the accredited provider")
-    when_i_choose_a_provider(niot)
+    when_i_enter_a_provider_named_niot
+    then_i_see_a_dropdown_item_for_niot
+
+    when_i_click_the_dropdown_item_for_niot
     when_i_click("Continue")
     when_i_click("Continue")
     when_i_click("Continue")
@@ -212,43 +239,30 @@ RSpec.describe "Create claim", service: :claims, type: :system do
   end
 
   def then_i_check_my_answers
-    expect(page).to have_content("Check your answers")
-    expect(page).to have_content("Hours of training")
+    expect(page).to have_h1("Check your answers", class: "govuk-heading-l")
 
-    within("dl.govuk-summary-list:nth(1)") do
-      within(".govuk-summary-list__row:nth(1)") do
-        expect(page).to have_content("Academic year")
-        expect(page).to have_content(claim_window.academic_year_name)
-      end
+    expect(page).to have_summary_list_row("Academic year", claim_window.academic_year_name)
+    expect(page).to have_summary_list_row("Accredited provider", bpn.name)
+    expect(page).to have_summary_list_row(
+      "Mentors",
+      "#{mentor1.full_name}\n#{mentor2.full_name}",
+    )
 
-      within(".govuk-summary-list__row:nth(2)") do
-        expect(page).to have_content("Accredited provider")
-        expect(page).to have_content(bpn.name)
-      end
+    expect(page).to have_h2("Hours of training", class: "govuk-heading-m")
 
-      within(".govuk-summary-list__row:nth(3)") do
-        expect(page).to have_content("Mentors")
-        expect(page).to have_content(mentor1.full_name)
-        expect(page).to have_content(mentor2.full_name)
-      end
-    end
+    expect(page).to have_summary_list_row(mentor1.full_name, "20 hours")
+    expect(page).to have_summary_list_row(mentor2.full_name, "12 hours")
 
-    within("dl.govuk-summary-list:nth(2)") do
-      within(".govuk-summary-list__row:nth(1)") do
-        expect(page).to have_content(mentor1.full_name)
-        expect(page).to have_content("20 hours")
-      end
+    expect(page).to have_h2("Grant funding", class: "govuk-heading-m")
 
-      within(".govuk-summary-list__row:nth(2)") do
-        expect(page).to have_content(mentor2.full_name)
-        expect(page).to have_content("12 hours")
-      end
-    end
+    expect(page).to have_summary_list_row("Total hours", "32 hours")
+    expect(page).to have_summary_list_row("Hourly rate", "£53.60")
+    expect(page).to have_summary_list_row("Claim amount", "£1,715.20")
   end
 
   def then_i_expect_the_training_hours_for(_hours, mentor)
     expect(page).to have_content("Hours of training for #{mentor.full_name}")
-    find("#claims-add-claim-wizard-mentor-training-step-hours-to-claim-maximum-field").checked?
+    find("#claims-add-claim-wizard-mentor-training-step-hours-to-claim-maximum-field", visible: :all).checked?
   end
 
   def then_i_am_redirectd_to_index_page(claim)
@@ -260,13 +274,7 @@ RSpec.describe "Create claim", service: :claims, type: :system do
   end
 
   def then_i_see_the_error(message)
-    within(".govuk-error-summary") do
-      expect(page).to have_content message
-    end
-
-    within(".govuk-form-group--error") do
-      expect(page).to have_content message
-    end
+    expect(page).to have_validation_error(message)
   end
 
   def when_another_claim_with_same_mentors_has_been_created(mentors)
@@ -300,5 +308,53 @@ RSpec.describe "Create claim", service: :claims, type: :system do
 
   def then_i_expect_to_be_on_the_claims_index_page
     expect(page).to have_current_path(claims_support_school_claims_path(school))
+  end
+
+  def and_i_enter_a_provider_named_best_practice_network
+    fill_in "Enter an accredited provider", with: "Best Practice Network"
+  end
+
+  def then_i_see_a_dropdown_item_for_best_practice_network
+    expect(page).to have_css(".autocomplete__option", text: "Best Practice Network", wait: 10)
+  end
+
+  def when_i_click_the_dropdown_item_for_best_practice_network
+    page.find(".autocomplete__option", text: "Best Practice Network").click
+  end
+
+  def then_i_expect_the_provider_to_be_prefilled_with_best_practice_network
+    expect(page.find("#claims-add-claim-wizard-provider-step-id-field").value).to eq(
+      "Best Practice Network",
+    )
+  end
+
+  def when_i_enter_a_provider_named_niot
+    fill_in "Enter an accredited provider", with: niot.name
+  end
+
+  def then_i_see_a_dropdown_item_for_niot
+    expect(page).to have_css(".autocomplete__option", text: niot.name, wait: 10)
+  end
+
+  def when_i_click_the_dropdown_item_for_niot
+    page.find(".autocomplete__option", text: niot.name).click
+  end
+
+  def when_i_enter_a_provider_named_niot
+    fill_in "Enter an accredited provider", with: niot.name
+  end
+
+  def then_i_see_a_dropdown_item_for_niot
+    expect(page).to have_css(".autocomplete__option", text: niot.name, wait: 10)
+  end
+
+  def when_i_click_the_dropdown_item_for_niot
+    page.find(".autocomplete__option", text: niot.name).click
+  end
+
+  def then_i_expect_the_provider_to_be_prefilled_with_best_practice_network
+    expect(page.find("#claims-add-claim-wizard-provider-step-id-field").value).to eq(
+      "Best Practice Network",
+    )
   end
 end

--- a/spec/system/claims/support/schools/claims/edit_draft_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/edit_draft_claim_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe "Edit a draft claim", service: :claims, type: :system do
   end
 
   def when_i_enter_a_provider_named_niot
-    fill_in "Enter an accredited provider", with: niot_provider.name
+    fill_in "Enter the accredited provider", with: niot_provider.name
   end
 
   def then_i_see_a_dropdown_item_for_niot

--- a/spec/system/claims/support/schools/claims/edit_draft_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/edit_draft_claim_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Edit a draft claim", service: :claims, type: :system do
     )
   end
 
-  let!(:draft_mentor_training) do
+  let(:draft_mentor_training) do
     create(
       :mentor_training,
       claim: draft_claim,
@@ -43,6 +43,7 @@ RSpec.describe "Edit a draft claim", service: :claims, type: :system do
   end
 
   before do
+    draft_mentor_training
     user_exists_in_dfe_sign_in(user: colin)
     given_i_sign_in
     when_i_select_a_school

--- a/spec/system/claims/support/schools/claims/edit_draft_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/edit_draft_claim_spec.rb
@@ -49,11 +49,10 @@ RSpec.describe "Edit a draft claim", service: :claims, type: :system do
     when_i_click_on_claims
   end
 
-  scenario "As a support user I can edit a draft claim" do
+  scenario "As a support user I can edit a draft claim", :js do
     when_i_visit_the_draft_claim_show_page
     then_i_edit_the_provider(
       current_provider: best_practice_network_provider,
-      new_provider: niot_provider,
     )
     then_i_edit_the_mentors
     then_i_edit_the_hours_of_training
@@ -76,16 +75,18 @@ RSpec.describe "Edit a draft claim", service: :claims, type: :system do
     then_i_see_a_validation_error_for_selecting_a_mentor
   end
 
-  scenario "Anne submits the draft claim which is invalid" do
+  scenario "Anne submits the draft claim which is invalid", :js do
     when_i_visit_the_draft_claim_show_page
     when_i_click("Change Accredited provider")
-    and_i_select_provider_niot
+    when_i_enter_a_provider_named_niot
+    then_i_see_a_dropdown_item_for_niot
+
+    when_i_click_the_dropdown_item_for_niot
     when_i_click("Continue") # To mentors step
     when_i_click("Continue") # To mentor training step
     when_i_click("Continue") # To check your answers
     then_i_see_the_check_your_answers_page(
       provider: niot_provider,
-      mentor: claims_mentor,
       hours_completed: 6,
     )
 
@@ -118,19 +119,38 @@ RSpec.describe "Edit a draft claim", service: :claims, type: :system do
     click_on("Continue")
   end
 
-  def then_i_edit_the_provider(current_provider:, new_provider:)
+  def then_i_edit_the_provider(current_provider:)
     expect(page).to have_content(current_provider.name)
-    first("a", text: "Change").click
-    page.choose(new_provider.name)
+    click_on "Change Accredited provider"
+    when_i_enter_a_provider_named_niot
+    then_i_see_a_dropdown_item_for_niot
+    when_i_click_the_dropdown_item_for_niot
     click_on("Continue")
   end
 
   def when_i_visit_the_draft_claim_show_page
     click_on draft_claim.reference
 
-    expect(page).to have_content("Best Practice Network")
-    expect(page).to have_content("Barry Garlow")
-    expect(page).to have_content("Barry Garlow#{draft_mentor_training.hours_completed} hours")
+    expect(page).to have_h1("Claim - #{draft_claim.reference}", class: "govuk-heading-l")
+    expect(page).to have_summary_list_row("School", "A School")
+    expect(page).to have_content("Draft")
+    expect(page).not_to have_content("Submitted by")
+    expect(page).to have_summary_list_row("Accredited provider", "Best Practice Network")
+
+    expect(page).to have_summary_list_row("Mentors", "Barry Garlow")
+
+    expect(page).to have_h2("Hours of training", class: "govuk-heading-m")
+    expect(page).to have_summary_list_row("Barry Garlow", "6 hours")
+
+    expect(page).to have_h2("Grant funding", class: "govuk-heading-m")
+    expect(page).to have_summary_list_row("Total hours", "6 hours")
+    expect(page).to have_summary_list_row("Hourly rate", "£53.60")
+
+    amount = Money.new(6 * school.region.claims_funding_available_per_hour_pence, "GBP")
+    expect(page).to have_summary_list_row(
+      "Claim amount",
+      amount.format(symbol: true, decimal_mark: ".", no_cents: true),
+    )
   end
 
   def then_i_cant_edit_the_submitted_claim
@@ -216,16 +236,36 @@ RSpec.describe "Edit a draft claim", service: :claims, type: :system do
     expect(page).to have_content("You cannot submit the claim because your mentors’ information has recently changed.")
   end
 
-  def then_i_see_the_check_your_answers_page(provider:, mentor:, hours_completed:)
-    expect(page).to have_content("A School")
-    expect(page).not_to have_content("Submitted by")
-    expect(page).to have_content("Accredited provider#{provider.name}")
-    expect(page).to have_content("Mentors\n#{mentor.full_name}")
-    expect(page).to have_content("Hours of training")
-    expect(page).to have_content("Barry Garlow#{hours_completed} hours")
-    expect(page).to have_content("Total hours#{hours_completed} hours")
-    expect(page).to have_content("Hourly rate£53.60")
+  def then_i_see_the_check_your_answers_page(provider:, hours_completed:)
+    expect(page).to have_h1("Check your answers", class: "govuk-heading-l")
+
+    expect(page).to have_summary_list_row("Accredited provider", provider.name)
+
+    expect(page).to have_summary_list_row("Mentors", "Barry Garlow")
+
+    expect(page).to have_h2("Hours of training", class: "govuk-heading-m")
+    expect(page).to have_summary_list_row("Barry Garlow", "#{hours_completed} hours")
+
+    expect(page).to have_h2("Grant funding", class: "govuk-heading-m")
+    expect(page).to have_summary_list_row("Total hours", "#{hours_completed} hours")
+    expect(page).to have_summary_list_row("Hourly rate", "£53.60")
+
     amount = Money.new(hours_completed * school.region.claims_funding_available_per_hour_pence, "GBP")
-    expect(page).to have_content("Claim amount#{amount.format(symbol: true, decimal_mark: ".", no_cents: true)}")
+    expect(page).to have_summary_list_row(
+      "Claim amount",
+      amount.format(symbol: true, decimal_mark: ".", no_cents: true),
+    )
+  end
+
+  def when_i_enter_a_provider_named_niot
+    fill_in "Enter an accredited provider", with: niot_provider.name
+  end
+
+  def then_i_see_a_dropdown_item_for_niot
+    expect(page).to have_css(".autocomplete__option", text: niot_provider.name, wait: 10)
+  end
+
+  def when_i_click_the_dropdown_item_for_niot
+    page.find(".autocomplete__option", text: niot_provider.name).click
   end
 end

--- a/spec/system/claims/support/schools/claims/support_user_creates_a_claim_with_javascript_spec.rb
+++ b/spec/system/claims/support/schools/claims/support_user_creates_a_claim_with_javascript_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "School user creates a claim with javascript disabled", service: 
   def then_i_see_the_enter_a_provider_step
     expect(page).to have_element(
       :label,
-      text: "Enter an accredited provider name, UKPRN, URN or postcode",
+      text: "Enter the accredited provider for this claim",
       class: "govuk-label govuk-label--l",
     )
     expect(page).to have_element(
@@ -97,7 +97,7 @@ RSpec.describe "School user creates a claim with javascript disabled", service: 
   end
 
   def when_i_enter_the_provider_name
-    fill_in "Enter an accredited provider", with: "Best Practice Network"
+    fill_in "Enter the accredited provider for this claim", with: "Best Practice Network"
   end
 
   def and_i_click_on_continue

--- a/spec/system/claims/support/schools/claims/support_user_creates_a_claim_with_javascript_spec.rb
+++ b/spec/system/claims/support/schools/claims/support_user_creates_a_claim_with_javascript_spec.rb
@@ -1,0 +1,225 @@
+require "rails_helper"
+
+RSpec.describe "School user creates a claim with javascript disabled", service: :claims, type: :system do
+  scenario do
+    given_an_claim_window_exists
+    and_a_school_exists
+    and_providers_exist
+    and_i_am_signed_in
+    when_i_click_on_the_school
+    and_i_navigate_to_claims
+    and_i_click_on_add_claim
+    then_i_see_the_enter_a_provider_step
+
+    when_i_enter_the_provider_name
+    and_i_click_on_continue
+    then_i_see_the_provider_options_step
+    and_i_see_a_radio_button_for_best_practice_network
+    and_i_do_not_see_a_radio_button_for_niot
+
+    when_i_select_best_practice_network
+    and_i_click_on_continue
+    then_i_see_the_mentor_selection_step
+
+    when_i_select_joe_bloggs
+    and_i_select_sarah_doe
+    and_i_click_on_continue
+    then_i_see_the_mentor_training_hours_step_for_joe_bloggs
+
+    when_i_choose_20_hours
+    and_i_click_on_continue
+    then_i_see_the_mentor_training_hours_step_for_sarah_doe
+
+    when_i_choose_another_amount
+    and_enter_6_hours
+    and_i_click_on_continue
+    then_i_see_the_check_your_answers_page
+
+    when_i_click_on_save_claim
+    then_i_see_the_claim_has_been_successfully_created
+  end
+
+  private
+
+  def given_an_claim_window_exists
+    @claim_window = create(:claim_window, :current)
+    @academic_year = @claim_window.academic_year
+  end
+
+  def and_a_school_exists
+    @mentor_1 = build(:claims_mentor, first_name: "Joe", last_name: "Bloggs")
+    @mentor_2 = build(:claims_mentor, first_name: "Sarah", last_name: "Doe")
+    @mentor_3 = build(:claims_mentor, first_name: "John", last_name: "Smith")
+
+    @school = create(
+      :claims_school,
+      mentors: [@mentor_1, @mentor_2, @mentor_3],
+      region: regions(:inner_london),
+    )
+  end
+
+  def and_providers_exist
+    @niot_provider = create(:provider, :niot)
+    @bpn_provider = create(:provider, :best_practice_network)
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_click_on_the_school
+    click_on @school.name
+  end
+
+  def and_i_navigate_to_claims
+    within(secondary_navigation) do
+      click_on "Claims"
+    end
+  end
+
+  def and_i_click_on_add_claim
+    click_on "Add claim"
+  end
+
+  def then_i_see_the_enter_a_provider_step
+    expect(page).to have_element(
+      :label,
+      text: "Enter an accredited provider name, UKPRN, URN or postcode",
+      class: "govuk-label govuk-label--l",
+    )
+    expect(page).to have_element(
+      :span,
+      text: "Add claim",
+      class: "govuk-caption-l",
+    )
+    expect(page).to have_button("Continue")
+  end
+
+  def when_i_enter_the_provider_name
+    fill_in "Enter an accredited provider", with: "Best Practice Network"
+  end
+
+  def and_i_click_on_continue
+    click_on "Continue"
+  end
+  alias_method :when_i_click_on_continue,
+               :and_i_click_on_continue
+
+  def then_i_see_the_provider_options_step
+    expect(page).to have_element(:span, text: "Add claim", class: "govuk-caption-l")
+    expect(page).to have_element(
+      :h1,
+      text: "1 results found for 'Best Practice Network'",
+      class: "govuk-fieldset__heading",
+    )
+  end
+
+  def and_i_see_a_radio_button_for_best_practice_network
+    expect(page).to have_field("Best Practice Network", type: :radio)
+  end
+
+  def and_i_do_not_see_a_radio_button_for_niot
+    expect(page).not_to have_field(
+      "NIoT: National Institute of Teaching, founded by the School-Led Development Trust",
+      type: :radio,
+    )
+  end
+
+  def when_i_select_best_practice_network
+    choose "Best Practice Network"
+  end
+
+  def then_i_see_the_mentor_selection_step
+    expect(page).to have_element(:span, text: "Add claim", class: "govuk-caption-l")
+    expect(page).to have_h1("Mentors for Best Practice Network", class: "govuk-heading-l")
+
+    expect(page).to have_field("Joe Bloggs", type: :checkbox)
+    expect(page).to have_field("John Smith", type: :checkbox)
+    expect(page).to have_field("Sarah Doe", type: :checkbox)
+  end
+
+  def when_i_select_joe_bloggs
+    check "Joe Bloggs"
+  end
+
+  def and_i_select_sarah_doe
+    check "Sarah Doe"
+  end
+
+  def then_i_see_the_mentor_training_hours_step_for_joe_bloggs
+    expect(page).to have_element(
+      :span,
+      text: "Add claim - #{@school.name} - Best Practice Network",
+      class: "govuk-caption-l",
+    )
+    expect(page).to have_h1("Hours of training for Joe Bloggs", class: "govuk-heading-l")
+
+    expect(page).to have_field("20 hours", type: :radio)
+    expect(page).to have_field("Another amount", type: :radio)
+  end
+
+  def when_i_choose_20_hours
+    choose "20 hours"
+  end
+
+  def then_i_see_the_mentor_training_hours_step_for_sarah_doe
+    expect(page).to have_element(
+      :span,
+      text: "Add claim - #{@school.name} - Best Practice Network",
+      class: "govuk-caption-l",
+    )
+    expect(page).to have_h1("Hours of training for Sarah Doe", class: "govuk-heading-l")
+
+    expect(page).to have_field("20 hours", type: :radio)
+    expect(page).to have_field("Another amount", type: :radio)
+  end
+
+  def when_i_choose_another_amount
+    choose "Another amount"
+  end
+
+  def and_enter_6_hours
+    fill_in "Number of hours", with: 6
+  end
+
+  def then_i_see_the_check_your_answers_page
+    expect(page).to have_h1("Check your answers", class: "govuk-heading-l")
+
+    expect(page).to have_summary_list_row("Academic year", @academic_year.name)
+    expect(page).to have_summary_list_row("Accredited provider", "Best Practice Network")
+    expect(page).to have_summary_list_row(
+      "Mentors",
+      "Joe Bloggs Sarah Doe",
+    )
+
+    expect(page).to have_h2("Hours of training", class: "govuk-heading-m")
+
+    expect(page).to have_summary_list_row("Joe Bloggs", "20 hours")
+    expect(page).to have_summary_list_row("Sarah Doe", "6 hours")
+
+    expect(page).to have_h2("Grant funding", class: "govuk-heading-m")
+
+    expect(page).to have_summary_list_row("Total hours", "26 hours")
+    expect(page).to have_summary_list_row("Hourly rate", "£53.60")
+    expect(page).to have_summary_list_row("Claim amount", "£1,393.60")
+  end
+
+  def when_i_click_on_save_claim
+    click_on "Save claim"
+  end
+
+  def then_i_see_the_claim_has_been_successfully_created
+    expect(page).to have_success_banner("Claim added")
+
+    claim = Claims::Claim.draft.order(:submitted_at).last
+
+    expect(page).to have_table_row({
+      "Claim reference" => claim.reference,
+      "Accredited provider" => "Best Practice Network",
+      "Mentors" => "Joe Bloggs Sarah Doe",
+      "Claim amount" => "£1,393.60",
+      "Date submitted" => "-",
+      "Status" => "Draft",
+    })
+  end
+end

--- a/spec/system/claims/support/schools/claims/support_user_creates_a_claim_with_javascript_spec.rb
+++ b/spec/system/claims/support/schools/claims/support_user_creates_a_claim_with_javascript_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe "School user creates a claim with javascript disabled", service: 
 
     @school = create(
       :claims_school,
+      name: "London School",
       mentors: [@mentor_1, @mentor_2, @mentor_3],
       region: regions(:inner_london),
     )
@@ -68,7 +69,7 @@ RSpec.describe "School user creates a claim with javascript disabled", service: 
   end
 
   def when_i_click_on_the_school
-    click_on @school.name
+    click_on "London School"
   end
 
   def and_i_navigate_to_claims
@@ -212,7 +213,6 @@ RSpec.describe "School user creates a claim with javascript disabled", service: 
     expect(page).to have_success_banner("Claim added")
 
     claim = Claims::Claim.draft.order(:submitted_at).last
-
     expect(page).to have_table_row({
       "Claim reference" => claim.reference,
       "Accredited provider" => "Best Practice Network",

--- a/spec/wizards/claims/add_claim_wizard/provider_options_step_spec.rb
+++ b/spec/wizards/claims/add_claim_wizard/provider_options_step_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+RSpec.describe Claims::AddClaimWizard::ProviderOptionsStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:attributes) { nil }
+  let!(:niot_provider) { create(:claims_provider, :niot) }
+
+  let(:mock_wizard) do
+    instance_double(Claims::AddClaimWizard).tap do |mock_wizard|
+      allow(mock_wizard).to receive_messages(
+        steps: { provider: mock_provider_step },
+      )
+    end
+  end
+
+  let(:mock_provider_step) do
+    instance_double(Claims::AddClaimWizard::ProviderStep).tap do |mock_provider_step|
+      allow(mock_provider_step).to receive(:id).and_return(provider_search_name)
+    end
+  end
+  let(:provider_search_name) { nil }
+
+  describe "attributes" do
+    it { is_expected.to have_attributes(id: nil, search_param: nil) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:id) }
+  end
+
+  describe "#provider" do
+    subject { step.provider }
+
+    context "when id is set" do
+      context "when the provider is present" do
+        let(:attributes) { { id: niot_provider.id } }
+
+        it { is_expected.to eq(niot_provider) }
+      end
+
+      context "when the provider is not a valid provider id" do
+        let(:attributes) { { id: "123" } }
+
+        it { is_expected.to be_nil }
+      end
+    end
+
+    context "when id is nil" do
+      let(:attributes) { { id: nil } }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe "providers" do
+    let(:provider_search_name) { "York" }
+    let(:liverpool_provider) { create(:claims_provider, name: "Liverpool provider") }
+    let!(:york_provider) { create(:claims_provider, name: "York provider") }
+    let!(:yorkshire_provider) { create(:claims_provider, name: "Yorkshire provider") }
+    let(:york_school) { create(:claims_school, name: "York school") }
+
+    before do
+      liverpool_provider
+      york_school
+    end
+
+    it "returns a list of providers with names similar to the search params" do
+      expect(step.providers).to contain_exactly(york_provider, yorkshire_provider)
+    end
+  end
+
+  describe "search_param" do
+    let(:provider_search_name) { "Provider" }
+
+    it "returns the provider search name from the previous step" do
+      expect(step.search_param).to eq("Provider")
+    end
+  end
+
+  describe "#scope" do
+    subject(:scope) { step.scope }
+
+    it {
+      expect(scope).to eq(
+        "claims_add_claim_wizard_provider_options_step",
+      )
+    }
+  end
+end

--- a/spec/wizards/claims/add_claim_wizard/provider_selection_step_spec.rb
+++ b/spec/wizards/claims/add_claim_wizard/provider_selection_step_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Claims::AddClaimWizard::ProviderStep, type: :model do
+RSpec.describe Claims::AddClaimWizard::ProviderSelectionStep, type: :model do
   subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
 
   let(:attributes) { nil }
@@ -11,7 +11,7 @@ RSpec.describe Claims::AddClaimWizard::ProviderStep, type: :model do
   end
 
   describe "attributes" do
-    it { is_expected.to have_attributes(id: nil, name: nil) }
+    it { is_expected.to have_attributes(id: nil) }
   end
 
   describe "validations" do
@@ -42,21 +42,9 @@ RSpec.describe Claims::AddClaimWizard::ProviderStep, type: :model do
     end
   end
 
-  describe "#autocomplete_path_value" do
-    subject { step.autocomplete_path_value }
-
-    it { is_expected.to eq("/api/provider_suggestions") }
-  end
-
-  describe "#autocomplete_return_attributes_value" do
-    subject { step.autocomplete_return_attributes_value }
-
-    it { is_expected.to contain_exactly("code") }
-  end
-
   describe "#scope" do
     subject { step.scope }
 
-    it { is_expected.to eq("claims_add_claim_wizard_provider_step") }
+    it { is_expected.to eq("claims_add_claim_wizard_provider_selection_step") }
   end
 end

--- a/spec/wizards/claims/add_claim_wizard_spec.rb
+++ b/spec/wizards/claims/add_claim_wizard_spec.rb
@@ -26,11 +26,32 @@ RSpec.describe Claims::AddClaimWizard do
       it { is_expected.to eq %i[provider no_mentors] }
     end
 
+    context "when the 'id' set in the provider step is a provider name" do
+      let(:state) do
+        {
+          "provider" => { "id" => provider.name },
+        }
+      end
+
+      it { is_expected.to eq %i[provider provider_options no_mentors] }
+    end
+
     context "when the school has mentors" do
       let!(:mentor_1) { create(:claims_mentor, schools: [school], first_name: "Alan", last_name: "Anderson") }
 
       context "with claimable hours" do
         it { is_expected.to eq %i[provider mentor check_your_answers] }
+
+        context "when the provider is set in the provider options step" do
+          let(:state) do
+            {
+              "provider" => { "id" => provider.name },
+              "provider_options" => { "id" => provider.id, "search_param" => provider.name },
+            }
+          end
+
+          it { is_expected.to eq %i[provider provider_options mentor check_your_answers] }
+        end
       end
 
       context "when mentors have been selected" do
@@ -248,14 +269,29 @@ RSpec.describe Claims::AddClaimWizard do
   end
 
   describe "#provider" do
-    let(:state) do
-      {
-        "provider" => { "id" => provider.id },
-      }
+    context "when the provider 'id' is set in the provider step" do
+      let(:state) do
+        {
+          "provider" => { "id" => provider.id },
+        }
+      end
+
+      it "returns the provider given by the provider step" do
+        expect(wizard.provider).to eq(provider)
+      end
     end
 
-    it "returns the provider given by the provider step" do
-      expect(wizard.provider).to eq(provider)
+    context "when the provider 'id' is set in the provider options step" do
+      let(:state) do
+        {
+          "provider" => { "id" => provider.name },
+          "provider_options" => { "id" => provider.id, "search_param" => provider.name },
+        }
+      end
+
+      it "returns the provider given by the provider step" do
+        expect(wizard.provider).to eq(provider)
+      end
     end
   end
 

--- a/spec/wizards/claims/edit_claim_wizard_spec.rb
+++ b/spec/wizards/claims/edit_claim_wizard_spec.rb
@@ -56,6 +56,19 @@ RSpec.describe Claims::EditClaimWizard do
       it { is_expected.to eq [:declaration] }
     end
 
+    context "when the provider 'id' is set in the provider options step" do
+      let(:state) do
+        {
+          "provider" => { "id" => provider.name },
+          "provider_options" => { "id" => provider.id, "search_param" => provider.name },
+          "mentor" => { "mentor_ids" => [mentor_1.id] },
+          "mentor_training_#{mentor_1.id}" => { mentor_id: mentor_1.id, hours_to_claim: "custom", custom_hours: 6 },
+        }
+      end
+
+      it { is_expected.to eq [:provider, :provider_options, :mentor, "mentor_training_#{mentor_1.id}".to_sym, :check_your_answers] }
+    end
+
     context "when there are no mentors with claimable hours for the given provider" do
       let(:another_provider) { create(:claims_provider, :best_practice_network) }
       let(:another_claim) do
@@ -262,7 +275,22 @@ RSpec.describe Claims::EditClaimWizard do
         }
       end
 
-      it "returns the provider assigned to the claim" do
+      it "returns the provider assigned to the provider step" do
+        expect(wizard.provider).to eq(another_provider)
+      end
+    end
+
+    context "when the provider is set in the provider options step" do
+      let(:another_provider) { create(:claims_provider, :niot) }
+
+      let(:state) do
+        {
+          "provider" => { "id" => another_provider.name },
+          "provider_options" => { "id" => another_provider.id, "search_param" => another_provider.name },
+        }
+      end
+
+      it "returns the provider assigned to the provider options step" do
         expect(wizard.provider).to eq(another_provider)
       end
     end


### PR DESCRIPTION
## Context

- Add provider search as part of the Claim Wizard.

## Changes proposed in this pull request

- Use components in Provider and ProviderOptions steps of the AddClaimWizard and EditClaimWizard.

## Guidance to review

- Sign in as Anne (School user)
- Click "Add claim"
- Search for a provider
- Click "Continue"
--------
(if JavaScript is disabled)
- You should see a radio button selection of providers
- Select the provider you want
- Click "Continue"
--------
- The rest of the journey remains the same

## Link to Trello card

https://trello.com/c/HwekgugS/470-iterate-on-the-provider-selection-when-creating-a-claim

## Screenshots


https://github.com/user-attachments/assets/2ecd4e5f-7632-4ffa-a9cc-624bc3a60269


https://github.com/user-attachments/assets/bc22a62f-0ba9-404a-9576-bf1e2c5e6ba4

_Content change_
![screencapture-claims-localhost-3000-schools-0003d793-91ab-4a49-8dad-a6ed921c2c53-claims-new-6af68798-1713-474e-9d18-0fb1a006f547-provider-2025-03-14-14_52_52](https://github.com/user-attachments/assets/9d9796b4-052f-4a40-8736-54993b40c334)


