### PR TITLE
Add details headers to summary lists for claim show pages

### DIFF
--- a/app/views/claims/schools/claims/show.html.erb
+++ b/app/views/claims/schools/claims/show.html.erb
@@ -22,6 +22,7 @@
         <p class="govuk-body"><%= t(".submitted_by", name: @claim.submitted_by.full_name, date: l(@claim.submitted_on, format: :long)) %></p>
       <% end %>
 
+      <h2 class="govuk-heading-m"><%= t(".details") %></h2>
       <%= govuk_summary_list(actions: policy(@claim).edit?) do |summary_list| %>
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: Claims::Claim.human_attribute_name(:school)) %>

--- a/app/views/claims/schools/mentors/show.html.erb
+++ b/app/views/claims/schools/mentors/show.html.erb
@@ -10,6 +10,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l"><%= @mentor.full_name %></h1>
 
+      <h2 class="govuk-heading-m"><%= t(".details") %></h2>
       <%= govuk_summary_list(actions: false) do |summary_list| %>
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: Mentor.human_attribute_name(:first_name)) %>

--- a/app/views/claims/schools/users/show.html.erb
+++ b/app/views/claims/schools/users/show.html.erb
@@ -10,6 +10,7 @@
       <span class="govuk-caption-l"><%= @school.name %></span>
       <h1 class="govuk-heading-l"><%= @user.full_name %></h1>
 
+      <h2 class="govuk-heading-m"><%= t(".details") %></h2>
       <%= govuk_summary_list(actions: false) do |summary_list| %>
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: User.human_attribute_name(:first_name)) %>

--- a/config/locales/en/claims/schools/claims.yml
+++ b/config/locales/en/claims/schools/claims.yml
@@ -41,6 +41,7 @@ en:
         destroy:
           success: Claim has been removed
         show:
+          details: Details
           mentors: Mentors
           remove_claim: Remove claim
           page_title: Claim - %{reference}

--- a/config/locales/en/claims/schools/mentors.yml
+++ b/config/locales/en/claims/schools/mentors.yml
@@ -14,6 +14,7 @@ en:
           add_mentor: Add mentor
           page_title: Mentors
         show:
+          details: Details
           page_title: "%{mentor_name} - Mentors"
           caption: "Mentors"
           remove_mentor: Remove mentor

--- a/config/locales/en/claims/schools/users.yml
+++ b/config/locales/en/claims/schools/users.yml
@@ -7,6 +7,7 @@ en:
           add_user: Add user
           no_users: There are no users for %{school_name}.
         show:
+          details: Details
           remove_user: Remove user
         remove:
           page_title: Are you sure you want to remove this user? - %{user_name}


### PR DESCRIPTION
## Context

According to guidance from our content designer, all summary lists should have headings.

Note that I have not updated the system specs to include the addition of this new heading, this was by design. The system specs for this are are extremely old and very method driven. Given we are refactoring our system tests I have instead created tickets to address this properly in another PR.

[Refactor the claims mentor system tests](https://trello.com/c/ykwexbOH/484-refactor-the-claims-mentor-system-tests)
[Refactor the claims school system tests](https://trello.com/c/zPlmKTWb/485-refactor-the-claims-school-system-tests)
[Refactor the claims user system tests](https://trello.com/c/m96GMDk3/482-refactor-the-claims-user-system-tests)

## Changes proposed in this pull request

- [x] Added a "Details" heading to the claim show page
- [x] Added a "Details" heading to the mentor show page
- [x] Added a "Details" heading to the user show page

## Guidance to review

Review screenshots

## Link to Trello card

[Update the claims user show page content](https://trello.com/c/XNlvsPe2/481-update-the-claims-user-show-page-content)
[Update the claims mentor show page content](https://trello.com/c/9YtbU4ql/479-update-the-claims-mentor-show-page-content)
[Update the claim show page content](https://trello.com/c/WtRbjuFr/477-update-the-claim-show-page-content)

## Screenshots

![image](https://github.com/user-attachments/assets/3d54441c-cc6c-4602-b46c-b321b58ac7e6)
![image](https://github.com/user-attachments/assets/b191803f-b168-4658-802a-0b6c7560eb5b)
![image](https://github.com/user-attachments/assets/e419336a-2a41-45af-9b61-cbed73a53d4d)

