### PR TITLE
Claims phased onboarding for schools

### DIFF
--- a/app/controllers/claims/support/schools/onboard_schools_controller.rb
+++ b/app/controllers/claims/support/schools/onboard_schools_controller.rb
@@ -16,6 +16,7 @@ class Claims::Support::Schools::OnboardSchoolsController < Claims::Support::Appl
       @wizard.reset_state
       redirect_to claims_support_schools_path, flash: {
         heading: t(".success"),
+        body: t(".body"),
       }
     end
   end

--- a/app/controllers/claims/support/schools/onboard_schools_controller.rb
+++ b/app/controllers/claims/support/schools/onboard_schools_controller.rb
@@ -1,0 +1,42 @@
+class Claims::Support::Schools::OnboardSchoolsController < Claims::Support::ApplicationController
+  include WizardController
+
+  before_action :authorize_school
+  before_action :set_wizard
+
+  helper_method :index_path
+
+  def update
+    if !@wizard.save_step
+      render "edit"
+    elsif @wizard.next_step.present?
+      redirect_to step_path(@wizard.next_step)
+    else
+      @wizard.onboard_schools
+      @wizard.reset_state
+      redirect_to claims_support_schools_path, flash: {
+        heading: t(".success"),
+      }
+    end
+  end
+
+  private
+
+  def set_wizard
+    state = session[state_key] ||= {}
+    current_step = params[:step]&.to_sym
+    @wizard = Claims::OnboardMultipleSchoolsWizard.new(params:, state:, current_step:)
+  end
+
+  def authorize_school
+    authorize Claims::School
+  end
+
+  def step_path(step)
+    onboard_schools_claims_support_schools_path(state_key:, step:)
+  end
+
+  def index_path
+    claims_support_schools_path
+  end
+end

--- a/app/decorators/claims/claim_window_decorator.rb
+++ b/app/decorators/claims/claim_window_decorator.rb
@@ -1,0 +1,7 @@
+class Claims::ClaimWindowDecorator < Draper::Decorator
+  delegate_all
+
+  def name
+    "#{I18n.l(starts_on, format: :long)} to #{I18n.l(ends_on, format: :long)}"
+  end
+end

--- a/app/jobs/claims/school/onboard_schools_job.rb
+++ b/app/jobs/claims/school/onboard_schools_job.rb
@@ -1,9 +1,13 @@
 class Claims::School::OnboardSchoolsJob < ApplicationJob
   queue_as :default
 
-  def perform(school_ids:)
+  def perform(school_ids:, claim_window_id: nil)
+    @claim_window_id = claim_window_id
+
     school_ids.each do |school_id|
       school = School.find(school_id)
+      school.update!(claims_service: true)
+
       Claims::Eligibility.find_or_create_by!(
         school:,
         claim_window:,
@@ -13,7 +17,13 @@ class Claims::School::OnboardSchoolsJob < ApplicationJob
 
   private
 
+  attr_reader :claim_window_id
+
   def claim_window
-    Claims::ClaimWindow.current
+    if claim_window_id
+      Claims::ClaimWindow.find(claim_window_id)
+    else
+      Claims::ClaimWindow.current
+    end
   end
 end

--- a/app/jobs/claims/school/onboard_schools_job.rb
+++ b/app/jobs/claims/school/onboard_schools_job.rb
@@ -1,0 +1,19 @@
+class Claims::School::OnboardSchoolsJob < ApplicationJob
+  queue_as :default
+
+  def perform(school_ids:)
+    school_ids.each do |school_id|
+      school = School.find(school_id)
+      Claims::Eligibility.find_or_create_by!(
+        school:,
+        claim_window:,
+      )
+    end
+  end
+
+  private
+
+  def claim_window
+    Claims::ClaimWindow.current
+  end
+end

--- a/app/models/claims/claim_window.rb
+++ b/app/models/claims/claim_window.rb
@@ -26,6 +26,8 @@ class Claims::ClaimWindow < ApplicationRecord
 
   belongs_to :academic_year
 
+  has_many :eligibilities, dependent: :destroy
+
   validates :starts_on, presence: true
   validates :ends_on, presence: true, comparison: { greater_than_or_equal_to: :starts_on }
 

--- a/app/models/claims/claim_window.rb
+++ b/app/models/claims/claim_window.rb
@@ -27,6 +27,7 @@ class Claims::ClaimWindow < ApplicationRecord
   belongs_to :academic_year
 
   has_many :eligibilities, dependent: :destroy
+  has_many :eligible_schools, through: :eligibilities, source: :school
 
   validates :starts_on, presence: true
   validates :ends_on, presence: true, comparison: { greater_than_or_equal_to: :starts_on }
@@ -37,6 +38,8 @@ class Claims::ClaimWindow < ApplicationRecord
   delegate :name, to: :academic_year, prefix: true
   delegate :past?, to: :ends_on
   delegate :future?, to: :starts_on
+
+  scope :eligible_schools, -> { eligibilities.where(claim_window:).present? }
 
   def current?
     (starts_on..ends_on).cover?(Date.current)
@@ -52,6 +55,10 @@ class Claims::ClaimWindow < ApplicationRecord
 
   def self.previous
     where(ends_on: ..Date.current).order(ends_on: :desc).first
+  end
+
+  def self.next
+    where(starts_on: Date.current..).order(starts_on: :asc).first
   end
 
   private

--- a/app/models/claims/eligibility.rb
+++ b/app/models/claims/eligibility.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: eligibilities
+#
+#  id              :uuid             not null, primary key
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  claim_window_id :uuid             not null
+#  school_id       :uuid             not null
+#
+# Indexes
+#
+#  index_eligibilities_on_claim_window_id  (claim_window_id)
+#  index_eligibilities_on_school_id        (school_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (claim_window_id => claim_windows.id)
+#  fk_rails_...  (school_id => schools.id)
+#
+class Claims::Eligibility < ApplicationRecord
+  belongs_to :school
+  belongs_to :claim_window
+
+  delegate :academic_year, to: :claim_window
+end

--- a/app/models/claims/school.rb
+++ b/app/models/claims/school.rb
@@ -82,6 +82,8 @@ class Claims::School < School
 
   delegate :funding_available_per_hour, to: :region, prefix: true, allow_nil: true
 
+  scope :eligible_for_claim_window, ->(claim_window) { eligibilities.where(claim_window:).present? }
+
   def grant_conditions_accepted?
     claims_grant_conditions_accepted_at?
   end

--- a/app/models/claims/school.rb
+++ b/app/models/claims/school.rb
@@ -76,6 +76,7 @@ class Claims::School < School
   has_many :claims
   has_many :mentor_memberships
   has_many :mentors, through: :mentor_memberships
+  has_many :eligibilities, dependent: :destroy
 
   belongs_to :claims_grant_conditions_accepted_by, class_name: "User", optional: true
 

--- a/app/views/claims/support/schools/onboard_schools/edit.html.erb
+++ b/app/views/claims/support/schools/onboard_schools/edit.html.erb
@@ -1,0 +1,13 @@
+<% render "claims/support/primary_navigation", current: :organisations %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: back_link_path) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= render_wizard(@wizard) %>
+
+  <p class="govuk-body">
+    <%= govuk_link_to(t(".cancel"), index_path, no_visited_state: true) %>
+  </p>
+</div>

--- a/app/views/wizards/claims/onboard_multiple_schools_wizard/_claim_window_step.html.erb
+++ b/app/views/wizards/claims/onboard_multiple_schools_wizard/_claim_window_step.html.erb
@@ -1,0 +1,34 @@
+<% content_for :page_title, title_with_error_prefix(
+  t(".page_title"),
+  error: current_step.errors.any?,
+) %>
+
+<%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".caption") %></span>
+
+      <%= f.govuk_collection_radio_buttons(
+        :claim_window_id,
+        current_step.claim_windows_for_selection,
+        :id, :name, :phase_of_time,
+        legend: { size: "l", text: t(".title"), tag: "h1" },
+        hint: { text: t(".hint") }
+      ) %>
+
+      <%= govuk_details(
+        summary_text: t(".claim_window_not_listed"),
+        text: embedded_link_text(
+          t(".create_an_additional_claim_window",
+            link: govuk_link_to(
+              t(".link_to_claim_windows"), claims_support_claim_windows_path, new_tab: true, no_visited_state: true
+            )),
+        ),
+      ) %>
+
+      <%= f.govuk_submit t(".continue") %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/wizards/claims/onboard_multiple_schools_wizard/_confirmation_step.html.erb
+++ b/app/views/wizards/claims/onboard_multiple_schools_wizard/_confirmation_step.html.erb
@@ -5,6 +5,10 @@
     <span class="govuk-caption-l"><%= t(".caption") %></span>
       <h1 class="govuk-heading-l"><%= t(".title") %></h1>
 
+      <p class="govuk-body">
+        <%= t(".schools_listed_will_be_able_to_claim", claim_window_name: current_step.claim_window_name) %>
+      </p>
+
       <%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
         <%= f.govuk_error_summary %>
 
@@ -45,6 +49,8 @@
             <%= t(".showing_all_rows") %>
           <% end %>
         </p>
+
+        <%= govuk_warning_text(text: t(".warning")) %>
 
         <%= f.govuk_submit(t(".confirm_upload")) %>
       <% end %>

--- a/app/views/wizards/claims/onboard_multiple_schools_wizard/_confirmation_step.html.erb
+++ b/app/views/wizards/claims/onboard_multiple_schools_wizard/_confirmation_step.html.erb
@@ -1,0 +1,52 @@
+<% content_for(:page_title) { sanitize t(".page_title") } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <span class="govuk-caption-l"><%= t(".caption") %></span>
+      <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+
+      <%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
+        <%= f.govuk_error_summary %>
+
+        <h2 class="govuk-heading-m">
+          <%= t(".preview_of_file", file_name: current_step.file_name) %>
+        </h2>
+
+        <div class="horizontal-scrollable">
+          <%= govuk_table do |table| %>
+            <% table.with_head do |head| %>
+              <% head.with_row do |row| %>
+                <% row.with_cell text: 1 %>
+                <% current_step.csv_headers.each do |header| %>
+                  <% row.with_cell text: header %>
+                <% end %>
+              <% end %>
+            <% end %>
+
+            <% table.with_body do |body| %>
+              <% current_step.csv.first(5).each_with_index do |csv_row, index| %>
+                <% if csv_row["name"].present? || csv_row["urn"].present? %>
+                  <% body.with_row do |row| %>
+                    <% row.with_cell text: index + 2 %>
+                    <% current_step.csv_headers.each do |header| %>
+                      <%= row.with_cell text: csv_row[header] %>
+                    <% end %>
+                  <% end %>
+                <% end %>
+              <% end %>
+            <% end %>
+          <% end %>
+        </div>
+
+        <p class="govuk_body govuk-!-text-align-centre secondary-text">
+          <% if current_step.csv.count > 5 %>
+            <%= t(".only_showing_first_five_rows") %>
+          <% else %>
+            <%= t(".showing_all_rows") %>
+          <% end %>
+        </p>
+
+        <%= f.govuk_submit(t(".confirm_upload")) %>
+      <% end %>
+  </div>
+</div>

--- a/app/views/wizards/claims/onboard_multiple_schools_wizard/_no_claim_window_step.html.erb
+++ b/app/views/wizards/claims/onboard_multiple_schools_wizard/_no_claim_window_step.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title, title_with_error_prefix(
+  t(".page_title"),
+  error: true,
+) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= t(".caption") %></span>
+    <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+
+    <p class="govuk-body">
+      <%= t(".description") %>
+    </p>
+
+    <p class="govuk-body">
+      <%= embedded_link_text(
+        t(".add_a_claim_window",
+          link: govuk_link_to(
+            t(".link_to_claim_windows"), claims_support_claim_windows_path, new_tab: true, no_visited_state: true
+          )),
+      ) %>
+    </p>
+  </div>
+</div>

--- a/app/views/wizards/claims/onboard_multiple_schools_wizard/_upload_errors_step.html.erb
+++ b/app/views/wizards/claims/onboard_multiple_schools_wizard/_upload_errors_step.html.erb
@@ -1,0 +1,69 @@
+<% content_for(:page_title) { sanitize title_with_error_prefix(t(".page_title"), error: true) } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <span class="govuk-caption-l"><%= t(".caption") %></span>
+    <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+
+    <div class="govuk-error-summary" data-module="govuk-error-summary">
+      <div role="alert">
+        <h2 class="govuk-error-summary__title">
+          <%= t(".error_summary.title") %>
+        </h2>
+        <div class="govuk-error-summary__body">
+          <div class="govuk-list govuk-error-summary__list">
+            <% if current_step.error_count > 0 %>
+              <p class="govuk-heading-s">
+                <%= t(".error_summary.errors_to_fix", count: current_step.error_count) %>
+              </p>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <h2 class="govuk-heading-m"><%= current_step.file_name %></h2>
+
+    <%= govuk_table do |table| %>
+      <% table.with_head do |head| %>
+        <% head.with_row do |row| %>
+          <% row.with_cell text: 1 %>
+          <% row.with_cell text: t(".csv_table.headers.name") %>
+          <% row.with_cell text: t(".csv_table.headers.urn") %>
+
+        <% end %>
+      <% end %>
+
+      <% table.with_body do |body| %>
+        <% current_step.row_indexes_with_errors.each do |csv_row_index| %>
+          <% csv_row = current_step.csv[csv_row_index] %>
+          <% body.with_row do |row| %>
+            <% row.with_cell(text: csv_row_index + 2) %>
+            <% row.with_cell do %>
+              <p>
+                <% if current_step.invalid_school_name_rows.include?(csv_row_index) %>
+                  <strong class="error-text"><%= t(".csv_table.errors.invalid_name") %></strong><br>
+                <% end %>
+                <%= csv_row["name"] %>
+              </p>
+            <% end %>
+            <% row.with_cell do %>
+              <p>
+                <% if current_step.invalid_school_urn_rows.include?(csv_row_index) %>
+                  <strong class="error-text"><%= t(".csv_table.errors.invalid_urn") %></strong><br>
+                <% end %>
+                <%= csv_row["urn"] %>
+              </p>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <p class="govuk_body govuk-!-text-align-centre secondary-text">
+      <%= t(".only_showing_rows_with_errors") %>
+    </p>
+
+    <%= govuk_button_link_to t(".upload_your_file_again"), step_path(:upload) %>
+  </div>
+</div>

--- a/app/views/wizards/claims/onboard_multiple_schools_wizard/_upload_step.html.erb
+++ b/app/views/wizards/claims/onboard_multiple_schools_wizard/_upload_step.html.erb
@@ -1,0 +1,23 @@
+<% content_for(:page_title) { sanitize title_with_error_prefix(t(".page_title"), error: current_step.errors.any?) } %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".caption") %></span>
+      <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+
+      <%= form_for(current_step, url: current_step_path, method: :put, multipart: true) do |f| %>
+        <%= f.govuk_error_summary(presenter: DetailedErrorSummaryPresenter) %>
+        <p class="govuk-body"><%= t(".upload_the_csv_file") %></p>
+
+        <%= f.govuk_file_field :csv_upload, label: { text: t(".upload_csv_file"), hidden: true } %>
+
+        <%= govuk_details(summary_text: t(".csv_help")) do %>
+          <%= render_markdown(t(".csv_help_details")) %>
+        <% end %>
+
+        <%= f.govuk_submit(t(".upload")) %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/wizards/claims/add_school_wizard.rb
+++ b/app/wizards/claims/add_school_wizard.rb
@@ -13,6 +13,13 @@ module Claims
 
     def onboard_school
       school.update!(claims_service: true)
+      claim_window = Claims::ClaimWindow.current
+      return if claim_window.blank?
+
+      school
+        .becomes(Claims::School)
+        .eligibilities
+        .create!(claim_window:)
     end
   end
 end

--- a/app/wizards/claims/add_school_wizard.rb
+++ b/app/wizards/claims/add_school_wizard.rb
@@ -13,13 +13,6 @@ module Claims
 
     def onboard_school
       school.update!(claims_service: true)
-      claim_window = Claims::ClaimWindow.current
-      return if claim_window.blank?
-
-      school
-        .becomes(Claims::School)
-        .eligibilities
-        .create!(claim_window:)
     end
   end
 end

--- a/app/wizards/claims/onboard_multiple_schools_wizard.rb
+++ b/app/wizards/claims/onboard_multiple_schools_wizard.rb
@@ -1,0 +1,34 @@
+module Claims
+  class OnboardMultipleSchoolsWizard < BaseWizard
+    def define_steps
+      add_step(UploadStep)
+      if csv_inputs_valid?
+        add_step(ConfirmationStep)
+      else
+        add_step(UploadErrorsStep)
+      end
+    end
+
+    def onboard_schools
+      raise "Invalid wizard state" unless valid? && csv_inputs_valid?
+
+      Claims::School::OnboardSchoolsJob.perform_later(school_ids:)
+    end
+
+    private
+
+    def csv_inputs_valid?
+      @csv_inputs_valid ||= steps.fetch(:upload).csv_inputs_valid?
+    end
+
+    def school_ids
+      @school_ids = ::School.where(urn: csv_rows.pluck("urn")).ids
+    end
+
+    def csv_rows
+      steps.fetch(:upload).csv.reject do |row|
+        row["urn"].blank?
+      end
+    end
+  end
+end

--- a/app/wizards/claims/onboard_multiple_schools_wizard/claim_window_step.rb
+++ b/app/wizards/claims/onboard_multiple_schools_wizard/claim_window_step.rb
@@ -1,0 +1,40 @@
+class Claims::OnboardMultipleSchoolsWizard::ClaimWindowStep < BaseStep
+  attribute :claim_window_id
+
+  validates :claim_window_id, presence: true, inclusion: { in: ->(step) { step.valid_claim_window_ids } }
+
+  def claim_windows_for_selection
+    option = Struct.new(:id, :name, :phase_of_time)
+
+    options = []
+    if current_claim_window.present?
+      options << option.new(
+        id: current_claim_window.id,
+        name: current_claim_window.name,
+        phase_of_time: "Current",
+      )
+    end
+    if upcoming_claim_window.present?
+      options << option.new(
+        id: upcoming_claim_window.id,
+        name: upcoming_claim_window.name,
+        phase_of_time: "Upcoming",
+      )
+    end
+    options
+  end
+
+  def valid_claim_window_ids
+    [current_claim_window&.id, upcoming_claim_window&.id].compact.flatten
+  end
+
+  private
+
+  def current_claim_window
+    @current_claim_window = Claims::ClaimWindow.current&.decorate
+  end
+
+  def upcoming_claim_window
+    @upcoming_claim_window = Claims::ClaimWindow.next&.decorate
+  end
+end

--- a/app/wizards/claims/onboard_multiple_schools_wizard/confirmation_step.rb
+++ b/app/wizards/claims/onboard_multiple_schools_wizard/confirmation_step.rb
@@ -1,8 +1,13 @@
 class Claims::OnboardMultipleSchoolsWizard::ConfirmationStep < BaseStep
   delegate :file_name, :csv, to: :upload_step
+  delegate :claim_window, to: :wizard
 
   def csv_headers
     @csv_headers ||= csv.headers
+  end
+
+  def claim_window_name
+    "#{I18n.l(claim_window.starts_on, format: :long)} to #{I18n.l(claim_window.ends_on, format: :long)}"
   end
 
   private

--- a/app/wizards/claims/onboard_multiple_schools_wizard/confirmation_step.rb
+++ b/app/wizards/claims/onboard_multiple_schools_wizard/confirmation_step.rb
@@ -1,0 +1,13 @@
+class Claims::OnboardMultipleSchoolsWizard::ConfirmationStep < BaseStep
+  delegate :file_name, :csv, to: :upload_step
+
+  def csv_headers
+    @csv_headers ||= csv.headers
+  end
+
+  private
+
+  def upload_step
+    @upload_step ||= wizard.steps.fetch(:upload)
+  end
+end

--- a/app/wizards/claims/onboard_multiple_schools_wizard/no_claim_window_step.rb
+++ b/app/wizards/claims/onboard_multiple_schools_wizard/no_claim_window_step.rb
@@ -1,0 +1,2 @@
+class Claims::OnboardMultipleSchoolsWizard::NoClaimWindowStep < BaseStep
+end

--- a/app/wizards/claims/onboard_multiple_schools_wizard/upload_errors_step.rb
+++ b/app/wizards/claims/onboard_multiple_schools_wizard/upload_errors_step.rb
@@ -1,0 +1,26 @@
+class Claims::OnboardMultipleSchoolsWizard::UploadErrorsStep < BaseStep
+  delegate :invalid_school_name_rows,
+           :invalid_school_urn_rows,
+           :file_name,
+           :csv,
+           to: :upload_step
+
+  def row_indexes_with_errors
+    combined_errors.uniq.sort
+  end
+
+  def error_count
+    combined_errors.count
+  end
+
+  private
+
+  def combined_errors
+    invalid_school_name_rows +
+      invalid_school_urn_rows
+  end
+
+  def upload_step
+    @upload_step ||= wizard.steps.fetch(:upload)
+  end
+end

--- a/app/wizards/claims/onboard_multiple_schools_wizard/upload_step.rb
+++ b/app/wizards/claims/onboard_multiple_schools_wizard/upload_step.rb
@@ -1,0 +1,102 @@
+class Claims::OnboardMultipleSchoolsWizard::UploadStep < BaseStep
+  attribute :csv_upload
+  attribute :csv_content
+  attribute :file_name
+
+  # input validation attributes
+  attribute :invalid_school_name_rows, default: []
+  attribute :invalid_school_urn_rows, default: []
+
+  validates :csv_upload, presence: true, if: -> { csv_content.blank? }
+  validate :validate_csv_file, if: -> { csv_upload.present? }
+  validate :validate_csv_headers, if: -> { csv_content.present? }
+
+  REQUIRED_HEADERS = %w[name urn].freeze
+
+  def initialize(wizard:, attributes:)
+    super(wizard:, attributes:)
+
+    process_csv if csv_upload.present?
+  end
+
+  def validate_csv_file
+    errors.add(:csv_upload, :invalid) unless csv_format
+  end
+
+  def process_csv
+    validate_csv_file
+    return if errors.present?
+
+    assign_csv_content
+    self.file_name = csv_upload.original_filename
+
+    self.csv_upload = nil
+  end
+
+  def csv_inputs_valid?
+    return true if csv_content.blank?
+
+    reset_input_attributes
+    csv.each_with_index do |row, i|
+      validate_name(row, i)
+      validate_urn(row, i)
+    end
+
+    invalid_school_name_rows.blank? &&
+      invalid_school_urn_rows.blank?
+  end
+
+  def validate_csv_headers
+    csv_headers = csv.headers
+    missing_columns = REQUIRED_HEADERS - csv_headers
+    return if missing_columns.empty?
+
+    errors.add(:csv_upload,
+               :invalid_headers,
+               missing_columns: missing_columns.map { |string|
+                 "‘#{string}’"
+               }.to_sentence)
+    errors.add(:csv_upload,
+               :uploaded_headers,
+               uploaded_headers: csv_headers.map { |string|
+                 "‘#{string}’"
+               }.to_sentence)
+  end
+
+  def csv
+    @csv ||= CSV.parse(read_csv, headers: true, skip_blanks: true)
+  end
+
+  private
+
+  def csv_format
+    csv_upload.content_type == "text/csv"
+  end
+
+  def assign_csv_content
+    self.csv_content = read_csv
+  end
+
+  def read_csv
+    @read_csv ||= csv_content || csv_upload.read
+  end
+
+  def reset_input_attributes
+    self.invalid_school_name_rows = []
+    self.invalid_school_urn_rows = []
+  end
+
+  ### CSV input valiations
+
+  def validate_name(row, row_number)
+    return if School.find_by(name: row["name"]).present?
+
+    invalid_school_name_rows << row_number
+  end
+
+  def validate_urn(row, row_number)
+    return if School.find_by(urn: row["urn"]).present?
+
+    invalid_school_urn_rows << row_number
+  end
+end

--- a/app/wizards/claims/onboard_multiple_schools_wizard/upload_step.rb
+++ b/app/wizards/claims/onboard_multiple_schools_wizard/upload_step.rb
@@ -38,6 +38,9 @@ class Claims::OnboardMultipleSchoolsWizard::UploadStep < BaseStep
 
     reset_input_attributes
     csv.each_with_index do |row, i|
+      next if row["name"].blank? &&
+        row["urn"].blank?
+
       validate_name(row, i)
       validate_urn(row, i)
     end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -163,3 +163,9 @@ shared:
     - reasons_not_hosting
     - created_at
     - updated_at
+  :eligibilities:
+    - id
+    - claim_window_id
+    - school_id
+    - created_at
+    - updated_at

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -324,3 +324,12 @@ en:
           attributes:
             id:
               blank: Select a provider
+        claims/onboard_multiple_schools_wizard/upload_step:
+          attributes:
+            csv_upload:
+              blank: Select a CSV file to upload
+              invalid: The selected file must be a CSV
+              invalid_headers:
+                Your file needs a column called %{missing_columns}.
+              uploaded_headers:
+                Right now it has columns called %{uploaded_headers}.

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -333,3 +333,8 @@ en:
                 Your file needs a column called %{missing_columns}.
               uploaded_headers:
                 Right now it has columns called %{uploaded_headers}.
+        claims/onboard_multiple_schools_wizard/claim_window_step:
+          attributes:
+            claim_window_id:
+              blank: Please select a claim window
+              inclusion: Please select a claim window

--- a/config/locales/en/claims/support/schools/onboard_schools.yml
+++ b/config/locales/en/claims/support/schools/onboard_schools.yml
@@ -6,4 +6,7 @@ en:
           edit:
             cancel: Cancel
           update:
-            success: Schools onboarded
+            success: School onboarding CSV uploaded
+            body: | 
+              It may take a moment for the onboarded schools to load. 
+              Refresh the page to see newly uploaded information.

--- a/config/locales/en/claims/support/schools/onboard_schools.yml
+++ b/config/locales/en/claims/support/schools/onboard_schools.yml
@@ -1,0 +1,9 @@
+en:
+  claims:
+    support:
+      schools:
+        onboard_schools:
+          edit:
+            cancel: Cancel
+          update:
+            success: Schools onboarded

--- a/config/locales/en/wizards/claims/add_mentor_wizard.yml
+++ b/config/locales/en/wizards/claims/add_mentor_wizard.yml
@@ -21,7 +21,6 @@ en:
           date_of_birth: Date of birth
           privacy_link: privacy notice
           disclaimer_html: I confirm that %{mentor_name} has been informed that the Department for Education will store their information in line with the %{privacy_link} and have provided them with a copy of this notice for reference.
-        no_results:
         no_results_step:
           page_title: No results found for ‘%{trn}’ - %{contextual_text}
           change_your_search: Change your search

--- a/config/locales/en/wizards/claims/onboard_schools_wizard.yml
+++ b/config/locales/en/wizards/claims/onboard_schools_wizard.yml
@@ -1,0 +1,45 @@
+en:
+  wizards:
+    claims:
+      onboard_multiple_schools_wizard:
+        upload_step:
+          page_title: Upload schools - Onboarding - Schools
+          title: Upload schools
+          caption: Onboarding
+          upload_csv_file: Upload CSV file
+          upload: Upload
+          csv_help: Help with the CSV file
+          upload_the_csv_file: Upload the CSV file of schools.
+          csv_help_details: |
+            Use this form to upload the CSV file sent of schools you want to onboard for the current claim window.
+
+            The CSV file must contain the following headers in the first row:
+
+              - name
+              - urn
+        confirmation_step:
+          page_title: Confirm you want to upload the schools - Onboarding -Schools
+          title: Confirm you want to upload the schools
+          caption: Onboarding
+          confirm_upload: Confirm upload
+          only_showing_first_five_rows: Only showing the first 5 rows
+          showing_all_rows: Showing all rows
+          preview_of_file: Preview of %{file_name}
+        upload_errors_step:
+          title: Upload schools
+          caption: Onboarding
+          page_title: Upload schools - Onboarding - Schools
+          error_summary:
+            title: There is a problem
+            errors_to_fix:
+              one: You need to fix %{count} error related to specific rows
+              other: You need to fix %{count} errors related to specific rows
+          csv_table:
+            headers:
+              name: name
+              urn: urn
+            errors:
+              invalid_name: Enter a valid name
+              invalid_urn: Enter a valid urn
+          only_showing_rows_with_errors: Only showing rows with errors
+          upload_your_file_again: Upload your file again

--- a/config/locales/en/wizards/claims/onboard_schools_wizard.yml
+++ b/config/locales/en/wizards/claims/onboard_schools_wizard.yml
@@ -3,13 +3,13 @@ en:
     claims:
       onboard_multiple_schools_wizard:
         upload_step:
-          page_title: Upload schools - Onboarding - Schools
-          title: Upload schools
+          page_title: Upload schools for onboarding - Onboarding - Schools
+          title: Upload schools for onboarding
           caption: Onboarding
           upload_csv_file: Upload CSV file
           upload: Upload
           csv_help: Help with the CSV file
-          upload_the_csv_file: Upload the CSV file of schools.
+          upload_the_csv_file: Upload the CSV file of schools you want to onboard to the service.
           csv_help_details: |
             Use this form to upload the CSV file sent of schools you want to onboard for the current claim window.
 
@@ -25,10 +25,14 @@ en:
           only_showing_first_five_rows: Only showing the first 5 rows
           showing_all_rows: Showing all rows
           preview_of_file: Preview of %{file_name}
+          schools_listed_will_be_able_to_claim:
+            Schools listed in the CSV will be able to claim mentor training funding for the claim window %{claim_window_name}.
+          warning: |
+            You cannot undo this action.
         upload_errors_step:
-          title: Upload schools
+          title: Upload schools for onboarding
           caption: Onboarding
-          page_title: Upload schools - Onboarding - Schools
+          page_title: Upload schools for onboarding - Onboarding - Schools
           error_summary:
             title: There is a problem
             errors_to_fix:
@@ -43,3 +47,23 @@ en:
               invalid_urn: Enter a valid urn
           only_showing_rows_with_errors: Only showing rows with errors
           upload_your_file_again: Upload your file again
+        claim_window_step:
+          page_title: Select a claim window - Onboarding
+          caption: Onboarding
+          title: Select a claim window
+          continue: Continue
+          hint: Select the current or upcoming claim window
+          claim_window_not_listed: The claim window I need is not listed
+          create_an_additional_claim_window:
+            If you cannot see the dates you need you can %{link}.
+          link_to_claim_windows:
+            create an additional claim window
+        no_claim_window_step: 
+          page_title: No claim windows - Onboarding
+          caption: Onboarding
+          title: No claim windows
+          description: | 
+            The are currently no claim windows available to allow schools be eligible to claim funding for mentor training.
+          add_a_claim_window: |
+            To onboard a school you will need to %{link}.
+          link_to_claim_windows: create a claim window

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -216,6 +216,10 @@ scope module: :claims, as: :claims, constraints: {
         get "new", to: "schools/add_school#new", as: :new_add_school
         get "new/:state_key/:step", to: "schools/add_school#edit", as: :add_school
         put "new/:state_key/:step", to: "schools/add_school#update"
+
+        get "onboard", to: "schools/onboard_schools#new", as: :new_onboard_schools
+        get "onboard/:state_key/:step", to: "schools/onboard_schools#edit", as: :onboard_schools
+        put "onboard/:state_key/:step", to: "schools/onboard_schools#update"
       end
 
       scope module: :schools do

--- a/db/migrate/20250317094215_create_eligibilities.rb
+++ b/db/migrate/20250317094215_create_eligibilities.rb
@@ -1,0 +1,9 @@
+class CreateEligibilities < ActiveRecord::Migration[7.2]
+  def change
+    create_table :eligibilities, id: :uuid do |t|
+      t.references :claim_window, null: false, foreign_key: true, type: :uuid
+      t.references :school, null: false, foreign_key: true, type: :uuid
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_26_133003) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_17_094215) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -157,6 +157,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_26_133003) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["activity_record_type", "activity_record_id"], name: "index_download_access_tokens_on_activity_record"
+  end
+
+  create_table "eligibilities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "claim_window_id", null: false
+    t.uuid "school_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["claim_window_id"], name: "index_eligibilities_on_claim_window_id"
+    t.index ["school_id"], name: "index_eligibilities_on_school_id"
   end
 
   create_table "flipper_features", force: :cascade do |t|
@@ -615,6 +624,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_26_133003) do
   add_foreign_key "claims", "schools"
   add_foreign_key "clawback_claims", "claims"
   add_foreign_key "clawback_claims", "clawbacks"
+  add_foreign_key "eligibilities", "claim_windows"
+  add_foreign_key "eligibilities", "schools"
   add_foreign_key "hosting_interests", "academic_years"
   add_foreign_key "hosting_interests", "schools"
   add_foreign_key "mentor_memberships", "mentors"

--- a/spec/factories/claims/claim_windows.rb
+++ b/spec/factories/claims/claim_windows.rb
@@ -32,5 +32,11 @@ FactoryBot.define do
       ends_on { starts_on + 2.months }
       academic_year { AcademicYear.for_date(starts_on) }
     end
+
+    trait :upcoming do
+      starts_on { 2.months.from_now }
+      ends_on { 4.months.from_now }
+      academic_year { AcademicYear.for_date(starts_on) }
+    end
   end
 end

--- a/spec/factories/eligibilities.rb
+++ b/spec/factories/eligibilities.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: eligibilities
+#
+#  id              :uuid             not null, primary key
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  claim_window_id :uuid             not null
+#  school_id       :uuid             not null
+#
+# Indexes
+#
+#  index_eligibilities_on_claim_window_id  (claim_window_id)
+#  index_eligibilities_on_school_id        (school_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (claim_window_id => claim_windows.id)
+#  fk_rails_...  (school_id => schools.id)
+#
+FactoryBot.define do
+  factory :eligibility do
+    claim_window { Claims::ClaimWindow.current || create(:claim_window, :current) }
+    association :school, factory: :claims_school
+  end
+end

--- a/spec/fixtures/claims/school/invalid_onboading_schools.csv
+++ b/spec/fixtures/claims/school/invalid_onboading_schools.csv
@@ -1,0 +1,4 @@
+name,urn
+,111111
+Guildford School,
+,

--- a/spec/fixtures/claims/school/onboarding_schools.csv
+++ b/spec/fixtures/claims/school/onboarding_schools.csv
@@ -1,0 +1,4 @@
+name,urn
+London School,111111
+Guildford School,222222
+,

--- a/spec/jobs/claims/school/onboard_schools_job_spec.rb
+++ b/spec/jobs/claims/school/onboard_schools_job_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe Claims::School::OnboardSchoolsJob, type: :job do
+  describe "#perform" do
+    let(:london_school) { create(:school, name: "London School") }
+    let(:guildford_school) { create(:school, name: "Guildford School") }
+    let(:york_school) { create(:school, name: "York School") }
+    let(:school_ids) { [london_school.id, york_school.id] }
+
+    context "when a current claim window exists" do
+      let(:current_claim_window) { create(:claim_window, :current) }
+
+      before { current_claim_window }
+
+      it "onboards the school and adds eligibilty for the current claim window" do
+        expect { described_class.perform_now(school_ids:) }.to change(Claims::School, :count).by(2)
+          .and change(Claims::Eligibility, :count).by(2)
+
+        london_school.reload
+        york_school.reload
+        guildford_school.reload
+
+        expect(london_school.claims_service).to be(true)
+        expect(york_school.claims_service).to be(true)
+        expect(guildford_school.claims_service).to be(false)
+
+        expect(current_claim_window.eligible_schools.ids).to match_array(school_ids)
+      end
+    end
+
+    context "when given a specific claim window" do
+      let(:claim_window) { create(:claim_window, :historic) }
+
+      it "onboards the school and adds eligibilty for the given claim window" do
+        expect {
+          described_class.perform_now(school_ids:, claim_window_id: claim_window.id)
+        }.to change(Claims::School, :count).by(2)
+          .and change(Claims::Eligibility, :count).by(2)
+
+        london_school.reload
+        york_school.reload
+        guildford_school.reload
+
+        expect(london_school.claims_service).to be(true)
+        expect(york_school.claims_service).to be(true)
+        expect(guildford_school.claims_service).to be(false)
+
+        expect(claim_window.eligible_schools.ids).to match_array(school_ids)
+      end
+
+      context "when the given specific claim window is invalid" do
+        it "returns an error" do
+          expect {
+            described_class.perform_now(school_ids:, claim_window_id: "ABC")
+          }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+    end
+
+    it "enqueues the job in the default queue" do
+      expect {
+        described_class.perform_later(school_ids:)
+      }.to have_enqueued_job(described_class).on_queue("default")
+    end
+  end
+end

--- a/spec/models/claims/claim_window_spec.rb
+++ b/spec/models/claims/claim_window_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe Claims::ClaimWindow, type: :model do
 
   describe "associations" do
     it { is_expected.to belong_to(:academic_year) }
+
+    it { is_expected.to have_many(:eligibilities).dependent(:destroy) }
   end
 
   describe "validations" do

--- a/spec/models/claims/eligibility_spec.rb
+++ b/spec/models/claims/eligibility_spec.rb
@@ -1,0 +1,32 @@
+# == Schema Information
+#
+# Table name: eligibilities
+#
+#  id              :uuid             not null, primary key
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  claim_window_id :uuid             not null
+#  school_id       :uuid             not null
+#
+# Indexes
+#
+#  index_eligibilities_on_claim_window_id  (claim_window_id)
+#  index_eligibilities_on_school_id        (school_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (claim_window_id => claim_windows.id)
+#  fk_rails_...  (school_id => schools.id)
+#
+require "rails_helper"
+
+RSpec.describe Claims::Eligibility, type: :model do
+  context "with associations" do
+    it { is_expected.to belong_to(:school).class_name("Claims::School") }
+    it { is_expected.to belong_to(:claim_window) }
+  end
+
+  context "with delegations" do
+    it { is_expected.to delegate_method(:academic_year).to(:claim_window) }
+  end
+end

--- a/spec/models/claims/school_spec.rb
+++ b/spec/models/claims/school_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe Claims::School do
     it { is_expected.to have_many(:mentor_memberships) }
     it { is_expected.to have_many(:mentors).through(:mentor_memberships) }
     it { is_expected.to belong_to(:claims_grant_conditions_accepted_by).class_name("User").optional }
+    it { is_expected.to have_many(:eligibilities).dependent(:destroy) }
 
     describe "#users" do
       it { is_expected.to have_many(:users).through(:user_memberships) }

--- a/spec/system/claims/support/schools/onboard_multiple_schools/support_user_can_not_onboard_schools_when_there_are_no_claim_windows_spec.rb
+++ b/spec/system/claims/support/schools/onboard_multiple_schools/support_user_can_not_onboard_schools_when_there_are_no_claim_windows_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe "Support user can not onboard schools when there are no claim windows",
+               service: :claims,
+               type: :system do
+  scenario do
+    given_schools_exist
+    and_i_am_signed_in
+    when_i_navigate_to_onboard_multiple_schools
+    then_i_see_the_no_claim_window_page
+  end
+
+  private
+
+  def given_schools_exist
+    @london_school = create(:school, name: "London School", urn: 111_111)
+    @guildford_school = create(:school, name: "Guildford School", urn: 222_222)
+    @york_school = create(:school, name: "York School", urn: 333_333)
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_organisations_index_page
+    within(primary_navigation) do
+      click_on "Organisations"
+    end
+  end
+
+  def when_i_navigate_to_onboard_multiple_schools
+    visit new_onboard_schools_claims_support_schools_path
+  end
+
+  def then_i_see_the_no_claim_window_page
+    expect(page).to have_title("Error: No claim windows - Onboarding")
+    expect(page).to have_element(:span, text: "Onboarding", class: "govuk-caption-l")
+    expect(page).to have_h1("No claim windows", class: "govuk-heading-l")
+    expect(page).to have_element(
+      :p,
+      text: "The are currently no claim windows available to allow schools be eligible to claim funding for mentor training.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "To onboard a school you will need to create a claim window (opens in new tab).",
+      class: "govuk-body",
+    )
+    expect(page).to have_link("create a claim window (opens in new tab)")
+  end
+end

--- a/spec/system/claims/support/schools/onboard_multiple_schools/support_user_does_not_select_a_claim_window_spec.rb
+++ b/spec/system/claims/support/schools/onboard_multiple_schools/support_user_does_not_select_a_claim_window_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe "Support user does not select a claim window", service: :claims, type: :system do
+  scenario do
+    given_a_current_claim_windows_exist
+    and_schools_exist
+    and_i_am_signed_in
+    when_i_navigate_to_onboard_multiple_schools
+    then_i_see_the_claim_window_page
+
+    when_click_on_continue
+    then_i_see_validation_error_regarding_selecting_a_claim_window
+  end
+
+  private
+
+  def given_a_current_claim_windows_exist
+    @current_claim_window = create(:claim_window, :current).decorate
+    @upcoming_claim_window = create(:claim_window, :upcoming).decorate
+  end
+
+  def and_schools_exist
+    @london_school = create(:school, name: "London School", urn: 111_111)
+    @guildford_school = create(:school, name: "Guildford School", urn: 222_222)
+    @york_school = create(:school, name: "York School", urn: 333_333)
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_organisations_index_page
+    within(primary_navigation) do
+      click_on "Organisations"
+    end
+  end
+
+  def when_i_navigate_to_onboard_multiple_schools
+    visit new_onboard_schools_claims_support_schools_path
+  end
+
+  def then_i_see_the_claim_window_page
+    expect(page).to have_title("Select a claim window - Onboarding")
+    expect(page).to have_element(:span, text: "Onboarding", class: "govuk-caption-l")
+    expect(page).to have_element(:h1, text: "Select a claim window", class: "govuk-fieldset__heading")
+
+    expect(page).to have_field(@current_claim_window.name, type: :radio)
+    expect(page).to have_field(@upcoming_claim_window.name, type: :radio)
+  end
+
+  def when_click_on_continue
+    click_on "Continue"
+  end
+
+  def then_i_see_validation_error_regarding_selecting_a_claim_window
+    expect(page).to have_validation_error("Please select a claim window")
+  end
+end

--- a/spec/system/claims/support/schools/onboard_multiple_schools/support_user_does_not_upload_a_file_spec.rb
+++ b/spec/system/claims/support/schools/onboard_multiple_schools/support_user_does_not_upload_a_file_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe "Support user does not upload a file", service: :claims, type: :system do
+  scenario do
+    given_a_current_claim_windows_exist
+    and_schools_exist
+    and_i_am_signed_in
+    when_i_navigate_to_onboard_multiple_schools
+    then_i_see_the_claim_window_page
+
+    when_i_select_the_upcoming_claim_window
+    and_click_on_continue
+    then_i_see_the_upload_page
+
+    when_i_click_on_upload
+    then_i_see_validation_error_regarding_uploading_a_file
+  end
+
+  private
+
+  def given_a_current_claim_windows_exist
+    @current_claim_window = create(:claim_window, :current).decorate
+    @upcoming_claim_window = create(:claim_window, :upcoming).decorate
+  end
+
+  def and_schools_exist
+    @london_school = create(:school, name: "London School", urn: 111_111)
+    @guildford_school = create(:school, name: "Guildford School", urn: 222_222)
+    @york_school = create(:school, name: "York School", urn: 333_333)
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_organisations_index_page
+    within(primary_navigation) do
+      click_on "Organisations"
+    end
+  end
+
+  def when_i_navigate_to_onboard_multiple_schools
+    visit new_onboard_schools_claims_support_schools_path
+  end
+
+  def then_i_see_the_upload_page
+    expect(page).to have_title("Upload schools for onboarding - Onboarding")
+    expect(page).to have_element(:span, text: "Onboarding", class: "govuk-caption-l")
+    expect(page).to have_h1("Upload schools for onboarding", class: "govuk-heading-l")
+    expect(page).to have_button("Upload")
+  end
+
+  def when_i_click_on_upload
+    click_on "Upload"
+  end
+
+  def then_i_see_validation_error_regarding_uploading_a_file
+    expect(page).to have_validation_error("Select a CSV file to upload")
+  end
+
+  def then_i_see_the_claim_window_page
+    expect(page).to have_title("Select a claim window - Onboarding")
+    expect(page).to have_element(:span, text: "Onboarding", class: "govuk-caption-l")
+    expect(page).to have_element(:h1, text: "Select a claim window", class: "govuk-fieldset__heading")
+
+    expect(page).to have_field(@current_claim_window.name, type: :radio)
+    expect(page).to have_field(@upcoming_claim_window.name, type: :radio)
+  end
+
+  def when_i_select_the_upcoming_claim_window
+    choose @upcoming_claim_window.name
+  end
+
+  def and_click_on_continue
+    click_on "Continue"
+  end
+end

--- a/spec/system/claims/support/schools/onboard_multiple_schools/support_user_onboards_multiple_schools_for_the_current_claim_window_spec.rb
+++ b/spec/system/claims/support/schools/onboard_multiple_schools/support_user_onboards_multiple_schools_for_the_current_claim_window_spec.rb
@@ -1,0 +1,128 @@
+require "rails_helper"
+
+RSpec.describe "Support user onboards multiple schools for the current claim window", service: :claims, type: :system do
+  include ActiveJob::TestHelper
+
+  around do |example|
+    perform_enqueued_jobs { example.run }
+  end
+
+  scenario do
+    given_a_current_claim_windows_exist
+    and_schools_exist
+    and_i_am_signed_in
+    when_i_navigate_to_onboard_multiple_schools
+    then_i_see_the_claim_window_page
+
+    when_i_select_the_upcoming_claim_window
+    and_click_on_continue
+    then_i_see_the_upload_page
+
+    when_i_upload_a_file_containing_schools_to_be_onboarded
+    and_i_click_on_upload
+    then_i_see_the_confirmation_page_for_onboarding_schools
+
+    when_i_click_on_back
+    then_i_see_the_upload_page
+
+    when_i_upload_a_file_containing_schools_to_be_onboarded
+    and_i_click_on_upload
+    then_i_see_the_confirmation_page_for_onboarding_schools
+
+    when_i_click_on_confirm_upload
+    then_i_see_the_school_onboarding_uploaded_successfully
+  end
+
+  private
+
+  def given_a_current_claim_windows_exist
+    @current_claim_window = create(:claim_window, :current).decorate
+    @upcoming_claim_window = create(:claim_window, :upcoming).decorate
+  end
+
+  def and_schools_exist
+    @london_school = create(:school, name: "London School", urn: 111_111)
+    @guildford_school = create(:school, name: "Guildford School", urn: 222_222)
+    @york_school = create(:school, name: "York School", urn: 333_333)
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_organisations_index_page
+    within(primary_navigation) do
+      click_on "Organisations"
+    end
+  end
+
+  def when_i_navigate_to_onboard_multiple_schools
+    visit new_onboard_schools_claims_support_schools_path
+  end
+
+  def then_i_see_the_upload_page
+    expect(page).to have_title("Upload schools for onboarding - Onboarding")
+    expect(page).to have_element(:span, text: "Onboarding", class: "govuk-caption-l")
+    expect(page).to have_h1("Upload schools for onboarding", class: "govuk-heading-l")
+    expect(page).to have_button("Upload")
+  end
+
+  def when_i_upload_a_file_containing_schools_to_be_onboarded
+    attach_file "Upload CSV file",
+                "spec/fixtures/claims/school/onboarding_schools.csv"
+  end
+
+  def and_i_click_on_upload
+    click_on "Upload"
+  end
+
+  def then_i_see_the_confirmation_page_for_onboarding_schools
+    expect(page).to have_title("Confirm you want to upload the schools - Onboarding")
+    expect(page).to have_element(:span, text: "Onboarding", class: "govuk-caption-l")
+    expect(page).to have_h1("Confirm you want to upload the schools", class: "govuk-heading-l")
+    expect(page).to have_h2("onboarding_schools.csv")
+    expect(page).to have_table_row(
+      "1" => "2",
+      "name" => "London School",
+      "urn" => "111111",
+    )
+    expect(page).to have_table_row(
+      "1" => "3",
+      "name" => "Guildford School",
+      "urn" => "222222",
+    )
+    expect(page).to have_button("Confirm upload")
+  end
+
+  def when_i_click_on_back
+    click_on "Back"
+  end
+
+  def when_i_click_on_confirm_upload
+    click_on "Confirm upload"
+  end
+
+  def then_i_see_the_school_onboarding_uploaded_successfully
+    expect(page).to have_success_banner(
+      "School onboarding CSV uploaded",
+      "It may take a moment for the onboarded schools to load. Refresh the page to see newly uploaded information.",
+    )
+  end
+
+  def then_i_see_the_claim_window_page
+    expect(page).to have_title("Select a claim window - Onboarding")
+    expect(page).to have_element(:span, text: "Onboarding", class: "govuk-caption-l")
+    expect(page).to have_element(:h1, text: "Select a claim window", class: "govuk-fieldset__heading")
+
+    expect(page).to have_field(@current_claim_window.name, type: :radio)
+    expect(page).to have_field(@upcoming_claim_window.name, type: :radio)
+  end
+
+  def when_i_select_the_upcoming_claim_window
+    choose @upcoming_claim_window.name
+  end
+
+  def and_click_on_continue
+    click_on "Continue"
+  end
+end

--- a/spec/system/claims/support/schools/onboard_multiple_schools/support_user_uploads_a_file_with_invalid_inputs_spec.rb
+++ b/spec/system/claims/support/schools/onboard_multiple_schools/support_user_uploads_a_file_with_invalid_inputs_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+RSpec.describe "Support user uploads a file with invalid inputs", service: :claims, type: :system do
+  scenario do
+    given_a_current_claim_windows_exist
+    and_schools_exist
+    and_i_am_signed_in
+    when_i_navigate_to_onboard_multiple_schools
+    then_i_see_the_claim_window_page
+
+    when_i_select_the_upcoming_claim_window
+    and_click_on_continue
+    then_i_see_the_upload_page
+
+    when_i_upload_a_file_containing_containing_invalid_inputs
+    and_i_click_on_upload
+    then_i_see_the_errors_page
+  end
+
+  private
+
+  def given_a_current_claim_windows_exist
+    @current_claim_window = create(:claim_window, :current).decorate
+    @upcoming_claim_window = create(:claim_window, :upcoming).decorate
+  end
+
+  def and_schools_exist
+    @london_school = create(:school, name: "London School", urn: 111_111)
+    @guildford_school = create(:school, name: "Guildford School", urn: 222_222)
+    @york_school = create(:school, name: "York School", urn: 333_333)
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_organisations_index_page
+    within(primary_navigation) do
+      click_on "Organisations"
+    end
+  end
+
+  def when_i_navigate_to_onboard_multiple_schools
+    visit new_onboard_schools_claims_support_schools_path
+  end
+
+  def then_i_see_the_upload_page
+    expect(page).to have_title("Upload schools for onboarding - Onboarding")
+    expect(page).to have_element(:span, text: "Onboarding", class: "govuk-caption-l")
+    expect(page).to have_h1("Upload schools for onboarding", class: "govuk-heading-l")
+    expect(page).to have_button("Upload")
+  end
+
+  def when_i_upload_a_file_containing_containing_invalid_inputs
+    attach_file "Upload CSV file",
+                "spec/fixtures/claims/school/invalid_onboading_schools.csv"
+  end
+
+  def and_i_click_on_upload
+    click_on "Upload"
+  end
+
+  def then_i_see_the_errors_page
+    expect(page).to have_title("Upload schools for onboarding - Onboarding")
+    expect(page).to have_element(:span, text: "Onboarding", class: "govuk-caption-l")
+    expect(page).to have_h1("Upload schools for onboarding", class: "govuk-heading-l")
+    expect(page).to have_element(:h2, text: "There is a problem")
+    expect(page).to have_element(:div, text: "You need to fix 2 errors related to specific rows", class: "govuk-error-summary")
+    expect(page).to have_element(:td, text: "Enter a valid name", class: "govuk-table__cell", count: 1)
+    expect(page).to have_element(:td, text: "Enter a valid urn", class: "govuk-table__cell", count: 1)
+    expect(page).to have_element(:p, text: "Only showing rows with errors", class: "govuk-!-text-align-centre")
+  end
+
+  def then_i_see_the_claim_window_page
+    expect(page).to have_title("Select a claim window - Onboarding")
+    expect(page).to have_element(:span, text: "Onboarding", class: "govuk-caption-l")
+    expect(page).to have_element(:h1, text: "Select a claim window", class: "govuk-fieldset__heading")
+
+    expect(page).to have_field(@current_claim_window.name, type: :radio)
+    expect(page).to have_field(@upcoming_claim_window.name, type: :radio)
+  end
+
+  def when_i_select_the_upcoming_claim_window
+    choose @upcoming_claim_window.name
+  end
+
+  def and_click_on_continue
+    click_on "Continue"
+  end
+end

--- a/spec/system/claims/support/schools/onboard_multiple_schools/support_user_uploads_a_file_with_the_wrong_headers_spec.rb
+++ b/spec/system/claims/support/schools/onboard_multiple_schools/support_user_uploads_a_file_with_the_wrong_headers_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+RSpec.describe "Support user does upload a file with wrong headers", service: :claims, type: :system do
+  scenario do
+    given_a_current_claim_windows_exist
+    and_schools_exist
+    and_i_am_signed_in
+    when_i_navigate_to_onboard_multiple_schools
+    then_i_see_the_claim_window_page
+
+    when_i_select_the_upcoming_claim_window
+    and_click_on_continue
+    then_i_see_the_upload_page
+
+    when_i_upload_a_csv_file_not_containing_valid_headers
+    and_i_click_on_upload
+    then_i_see_validation_error_regarding_invalid_headers
+  end
+
+  private
+
+  def given_a_current_claim_windows_exist
+    @current_claim_window = create(:claim_window, :current).decorate
+    @upcoming_claim_window = create(:claim_window, :upcoming).decorate
+  end
+
+  def and_schools_exist
+    @london_school = create(:school, name: "London School", urn: 111_111)
+    @guildford_school = create(:school, name: "Guildford School", urn: 222_222)
+    @york_school = create(:school, name: "York School", urn: 333_333)
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_organisations_index_page
+    within(primary_navigation) do
+      click_on "Organisations"
+    end
+  end
+
+  def when_i_navigate_to_onboard_multiple_schools
+    visit new_onboard_schools_claims_support_schools_path
+  end
+
+  def then_i_see_the_upload_page
+    expect(page).to have_title("Upload schools for onboarding - Onboarding")
+    expect(page).to have_element(:span, text: "Onboarding", class: "govuk-caption-l")
+    expect(page).to have_h1("Upload schools for onboarding", class: "govuk-heading-l")
+    expect(page).to have_button("Upload")
+  end
+
+  def when_i_upload_a_csv_file_not_containing_valid_headers
+    attach_file "Upload CSV file",
+                "spec/fixtures/files/example-payments-response.csv"
+  end
+
+  def and_i_click_on_upload
+    click_on "Upload"
+  end
+
+  def then_i_see_validation_error_regarding_invalid_headers
+    expect(page).to have_validation_error(
+      "Your file needs a column called ‘name’ and ‘urn’.",
+    )
+    expect(page).to have_element(
+      :ul,
+      text: "Right now it has columns called ‘claim_reference’, ‘school_urn’, ‘school_name’, ‘claim_status’, and ‘claim_unpaid_reason’.",
+      class: "govuk-error-summary__list",
+    )
+  end
+
+  def then_i_see_the_claim_window_page
+    expect(page).to have_title("Select a claim window - Onboarding")
+    expect(page).to have_element(:span, text: "Onboarding", class: "govuk-caption-l")
+    expect(page).to have_element(:h1, text: "Select a claim window", class: "govuk-fieldset__heading")
+
+    expect(page).to have_field(@current_claim_window.name, type: :radio)
+    expect(page).to have_field(@upcoming_claim_window.name, type: :radio)
+  end
+
+  def when_i_select_the_upcoming_claim_window
+    choose @upcoming_claim_window.name
+  end
+
+  def and_click_on_continue
+    click_on "Continue"
+  end
+end

--- a/spec/wizards/claims/onboard_multiple_schools_wizard/confirmation_step_spec.rb
+++ b/spec/wizards/claims/onboard_multiple_schools_wizard/confirmation_step_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe Claims::OnboardMultipleSchoolsWizard::ConfirmationStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Claims::OnboardMultipleSchoolsWizard).tap do |mock_wizard|
+      allow(mock_wizard).to receive_messages(steps: { upload: mock_upload_step })
+    end
+  end
+  let(:mock_upload_step) do
+    instance_double(Claims::OnboardMultipleSchoolsWizard::UploadStep).tap do |mock_upload_step|
+      allow(mock_upload_step).to receive_messages(
+        invalid_school_name_rows:,
+        invalid_school_urn_rows:,
+        file_name:,
+        csv:,
+      )
+    end
+  end
+  let(:attributes) { nil }
+  let(:invalid_school_name_rows) { nil }
+  let(:invalid_school_urn_rows) { nil }
+  let(:file_name) { "uploaded.csv" }
+  let(:csv) { CSV.parse(csv_content, headers: true, skip_blanks: true) }
+  let(:csv_content) do
+    "name,urn\r\n" \
+    "London School,111111"
+  end
+
+  describe "delegations" do
+    it { is_expected.to delegate_method(:csv).to(:upload_step) }
+    it { is_expected.to delegate_method(:file_name).to(:upload_step) }
+  end
+
+  describe "#csv_headers" do
+    it "returns the headers of the CSV file" do
+      expect(step.csv_headers).to match_array(
+        %w[name urn],
+      )
+    end
+  end
+end

--- a/spec/wizards/claims/onboard_multiple_schools_wizard/upload_errors_step_spec.rb
+++ b/spec/wizards/claims/onboard_multiple_schools_wizard/upload_errors_step_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe Claims::OnboardMultipleSchoolsWizard::UploadErrorsStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Claims::OnboardMultipleSchoolsWizard).tap do |mock_wizard|
+      allow(mock_wizard).to receive_messages(steps: { upload: mock_upload_step })
+    end
+  end
+  let(:mock_upload_step) do
+    instance_double(Claims::OnboardMultipleSchoolsWizard::UploadStep).tap do |mock_upload_step|
+      allow(mock_upload_step).to receive_messages(
+        csv_content:,
+        file_name:,
+        invalid_school_name_rows:,
+        invalid_school_urn_rows:,
+      )
+    end
+  end
+  let(:attributes) { nil }
+  let(:csv_content) { nil }
+  let(:file_name) { nil }
+  let(:invalid_school_name_rows) { [] }
+  let(:invalid_school_urn_rows) { [] }
+
+  describe "delegations" do
+    it { is_expected.to delegate_method(:invalid_school_name_rows).to(:upload_step) }
+    it { is_expected.to delegate_method(:invalid_school_urn_rows).to(:upload_step) }
+    it { is_expected.to delegate_method(:file_name).to(:upload_step) }
+    it { is_expected.to delegate_method(:csv).to(:upload_step) }
+  end
+
+  describe "#row_indexes_with_errors" do
+    subject(:row_indexes_with_errors) { step.row_indexes_with_errors }
+
+    let(:invalid_school_name_rows) { [1] }
+    let(:invalid_school_urn_rows) { [1, 2, 3] }
+
+    it "merges all the validation attributes containing row numbers together (removing duplicates)" do
+      expect(row_indexes_with_errors).to contain_exactly(1, 2, 3)
+    end
+  end
+
+  describe "#error_count" do
+    subject(:error_count) { step.error_count }
+
+    let(:invalid_school_name_rows) { [1] }
+    let(:invalid_school_urn_rows) { [1, 2, 3, 4] }
+
+    it "adds together the number of elements in validation attribute" do
+      expect(error_count).to eq(5)
+    end
+  end
+end

--- a/spec/wizards/claims/onboard_multiple_schools_wizard/upload_step_spec.rb
+++ b/spec/wizards/claims/onboard_multiple_schools_wizard/upload_step_spec.rb
@@ -1,0 +1,210 @@
+require "rails_helper"
+
+RSpec.describe Claims::OnboardMultipleSchoolsWizard::UploadStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Claims::OnboardMultipleSchoolsWizard)
+  end
+  let(:attributes) { nil }
+
+  describe "attributes" do
+    it {
+      expect(step).to have_attributes(
+        csv_upload: nil,
+        csv_content: nil,
+        file_name: nil,
+        invalid_school_name_rows: [],
+        invalid_school_urn_rows: [],
+      )
+    }
+  end
+
+  describe "validations" do
+    describe "#csv_upload" do
+      context "when the csv_content is blank" do
+        it { is_expected.to validate_presence_of(:csv_upload) }
+      end
+
+      context "when the csv_content is present" do
+        let(:csv_content) do
+          "name,urn\r\n" \
+          "London School,111111\r\n"
+        end
+        let(:attributes) { { csv_content: } }
+
+        it { is_expected.not_to validate_presence_of(:csv_upload) }
+      end
+    end
+
+    describe "#validate_csv_file" do
+      context "when the csv_upload is present" do
+        context "when the csv_upload is not a CSV" do
+          let(:attributes) { { csv_upload: invalid_file } }
+          let(:invalid_file) do
+            ActionDispatch::Http::UploadedFile.new({
+              filename: "invalid.jpg",
+              type: "image/jpeg",
+              tempfile: Tempfile.new("invalid.jpg"),
+            })
+          end
+
+          it "validates that the file is the incorrect format" do
+            expect(step.valid?).to be(false)
+            expect(step.errors.messages[:csv_upload]).to include("The selected file must be a CSV")
+          end
+        end
+
+        context "when the csv_upload is a CSV file" do
+          let(:attributes) { { csv_upload: valid_file } }
+          let(:valid_file) do
+            ActionDispatch::Http::UploadedFile.new({
+              filename: "valid.csv",
+              type: "text/csv",
+              tempfile: File.open(
+                "spec/fixtures/claims/school/onboarding_schools.csv",
+              ),
+            })
+          end
+
+          it "validates that the file is the correct format" do
+            expect(step.valid?).to be(true)
+          end
+        end
+      end
+    end
+
+    describe "#validate_csv_headers" do
+      context "when csv_content is present" do
+        context "when the csv content is missing valid headers" do
+          let(:csv_content) do
+            "something_random\r\n" \
+            "blah"
+          end
+          let(:attributes) { { csv_content: } }
+
+          it "returns errors for missing headers" do
+            expect(step.valid?).to be(false)
+            expect(step.errors.messages[:csv_upload]).to include(
+              "Your file needs a column called ‘name’ and ‘urn’.",
+            )
+            expect(step.errors.messages[:csv_upload]).to include(
+              "Right now it has columns called ‘something_random’.",
+            )
+          end
+        end
+      end
+    end
+  end
+
+  describe "#csv_inputs_valid?" do
+    subject(:csv_inputs_valid) { step.csv_inputs_valid? }
+
+    before { create(:school, name: "London School", urn: "111111") }
+
+    context "when the csv_content is blank" do
+      it "returns true" do
+        expect(csv_inputs_valid).to be(true)
+      end
+    end
+
+    context "when csv_content contains invalid school name" do
+      let(:csv_content) do
+        "name,urn\r\n" \
+        "Random School,111111\r\n"
+      end
+      let(:attributes) { { csv_content: } }
+
+      it "returns false and assigns the csv row to the 'invalid_school_name_rows' attribute" do
+        expect(csv_inputs_valid).to be(false)
+        expect(step.invalid_school_name_rows).to contain_exactly(0)
+      end
+    end
+
+    context "when csv_content contains invalid school urn" do
+      let(:csv_content) do
+        "name,urn\r\n" \
+        "London School,222222\r\n"
+      end
+      let(:attributes) { { csv_content: } }
+
+      it "returns false and assigns the csv row to the 'invalid_school_urn_rows' attribute" do
+        expect(csv_inputs_valid).to be(false)
+        expect(step.invalid_school_urn_rows).to contain_exactly(0)
+      end
+    end
+
+    context "when the csv_content contains valid claim references and all necessary valid attributes" do
+      let(:csv_content) do
+        "name,urn\r\n" \
+        "London School,111111\r\n"
+      end
+      let(:attributes) { { csv_content: } }
+
+      it "returns true" do
+        expect(csv_inputs_valid).to be(true)
+      end
+    end
+  end
+
+  describe "#process_csv" do
+    let(:london_school) { create(:school, name: "London School", urn: "111111") }
+    let(:guildford_school) { create(:school, name: "Guildford School", urn: "222222") }
+    let(:attributes) { { csv_upload: valid_file } }
+    let(:valid_file) do
+      ActionDispatch::Http::UploadedFile.new({
+        filename: "valid.csv",
+        type: "text/csv",
+        tempfile: File.open(
+          "spec/fixtures/claims/school/onboarding_schools.csv",
+        ),
+      })
+    end
+
+    before do
+      london_school
+      guildford_school
+    end
+
+    it "reads a given CSV and assigns the content to the csv_content attribute" do
+      expect(step.csv_content).to eq(
+        "name,urn\n" \
+        "London School,111111\n" \
+        "Guildford School,222222\n" \
+        ",\n",
+      )
+    end
+  end
+
+  describe "#csv" do
+    subject(:csv) { step.csv }
+
+    let(:csv_content) do
+      "name,urn\n" \
+      "London School,111111\n" \
+      "Guildford School,222222\n" \
+      ""
+    end
+    let(:attributes) { { csv_content: } }
+
+    it "converts the csv content into a CSV record" do
+      expect(csv).to be_a(CSV::Table)
+      expect(csv.headers).to match_array(
+        %w[name urn],
+      )
+      expect(csv.count).to eq(2)
+
+      expect(csv[0]).to be_a(CSV::Row)
+      expect(csv[0].to_h).to eq({
+        "name" => "London School",
+        "urn" => "111111",
+      })
+
+      expect(csv[1]).to be_a(CSV::Row)
+      expect(csv[1].to_h).to eq({
+        "name" => "Guildford School",
+        "urn" => "222222",
+      })
+    end
+  end
+end

--- a/spec/wizards/claims/onboard_multiple_schools_wizard_spec.rb
+++ b/spec/wizards/claims/onboard_multiple_schools_wizard_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+RSpec.describe Claims::OnboardMultipleSchoolsWizard, type: :model do
+  subject(:wizard) { described_class.new(state:, params:, current_step: nil) }
+
+  let(:params_data) { {} }
+  let(:params) { ActionController::Parameters.new(params_data) }
+  let(:state) { {} }
+
+  describe "#steps" do
+    subject { wizard.steps.keys }
+
+    context "when the csv contains is valid" do
+      it { is_expected.to eq(%i[upload confirmation]) }
+    end
+
+    context "when the csv contains invalid inputs" do
+      let(:csv_content) do
+        "name,urn\r\n" \
+        "A school,"
+      end
+      let(:state) do
+        {
+          "upload" => {
+            "csv_upload" => nil,
+            "csv_content" => csv_content,
+          },
+        }
+      end
+
+      it { is_expected.to eq(%i[upload upload_errors]) }
+    end
+  end
+
+  describe "#onboard_schools" do
+    subject(:onboard_schools) { wizard.onboard_schools }
+
+    let(:school) { create(:school, name: "London School", urn: 111_111) }
+    let(:state) do
+      {
+        "upload" => {
+          "csv_upload" => nil,
+          "csv_content" => csv_content,
+        },
+      }
+    end
+
+    before { school }
+
+    context "when the steps are valid" do
+      let(:csv_content) do
+        "name,urn\r\n" \
+        "London School,111111"
+      end
+
+      it "queues a job to update the claim with the ESFA response" do
+        expect { onboard_schools }.to have_enqueued_job(
+          Claims::School::OnboardSchoolsJob,
+        ).exactly(:once)
+      end
+    end
+
+    context "when a step is invalid" do
+      context "when the a step is invalid" do
+        let(:csv_content) { nil }
+
+        it "returns an invalid wizard error" do
+          expect { onboard_schools }.to raise_error("Invalid wizard state")
+        end
+      end
+
+      context "when the uploaded content includes an invalid input" do
+        let(:csv_content) do
+          "name,urn\r\n" \
+          "London School,333333"
+        end
+
+        it "returns an invalid wizard error" do
+          expect { onboard_schools }.to raise_error("Invalid wizard state")
+        end
+      end
+    end
+  end
+end

--- a/spec/wizards/claims/upload_esfa_clawback_response_wizard_spec.rb
+++ b/spec/wizards/claims/upload_esfa_clawback_response_wizard_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Claims::UploadESFAClawbackResponseWizard do
     end
 
     context "when a step is invalid" do
-      context "when the a step is valid" do
+      context "when the a step is invalid" do
         let(:csv_content) { nil }
 
         it "returns an invalid wizard error" do

--- a/spec/wizards/claims/upload_payer_payment_response_wizard_spec.rb
+++ b/spec/wizards/claims/upload_payer_payment_response_wizard_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Claims::UploadPayerPaymentResponseWizard do
     end
 
     context "when a step is invalid" do
-      context "when the a step is valid" do
+      context "when the a step is invalid" do
         let(:csv_content) { nil }
 
         it "returns an invalid wizard error" do

--- a/spec/wizards/claims/upload_provider_response_wizard_spec.rb
+++ b/spec/wizards/claims/upload_provider_response_wizard_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Claims::UploadProviderResponseWizard do
     end
 
     context "when a step is invalid" do
-      context "when the a step is valid" do
+      context "when the a step is invalid" do
         let(:csv_content) { nil }
 
         it "returns an invalid wizard error" do


### PR DESCRIPTION
## Context

- Support users require a way to onboard multiple schools at once via CSV upload

## Changes proposed in this pull request
- Add `OnboardMultipleSchoolsWizard` and related steps, views, routes, etc.

## Guidance to review

- Sign in as Colin (Support user)
- visit support/schools/onboard URL
- Follow the onboarding schools journey
- This should result in the schools in the uploaded CSV being onboarded and eligibility being created for the selected claim window.

## Link to Trello card

https://trello.com/c/OFaV5xpP/469-explore-phased-onboarding-for-schools

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
