### PR TITLE
Add SEN provisions to schools

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -87,6 +87,9 @@ class School < ApplicationRecord
   has_many :mentor_memberships
   has_many :mentors, through: :mentor_memberships
 
+  has_many :school_sen_provisions
+  has_many :sen_provisions, through: :school_sen_provisions
+
   normalizes :email_address, with: ->(value) { value.strip.downcase }
 
   validates :urn, presence: true

--- a/app/models/school_sen_provision.rb
+++ b/app/models/school_sen_provision.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: school_sen_provisions
+#
+#  id               :uuid             not null, primary key
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  school_id        :uuid             not null
+#  sen_provision_id :uuid             not null
+#
+# Indexes
+#
+#  index_school_sen_provisions_on_school_id         (school_id)
+#  index_school_sen_provisions_on_sen_provision_id  (sen_provision_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (school_id => schools.id)
+#  fk_rails_...  (sen_provision_id => sen_provisions.id)
+#
+class SchoolSENProvision < ApplicationRecord
+  belongs_to :school
+  belongs_to :sen_provision
+end

--- a/app/models/sen_provision.rb
+++ b/app/models/sen_provision.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: sen_provisions
+#
+#  id         :uuid             not null, primary key
+#  name       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_sen_provisions_on_name  (name) UNIQUE
+#
+class SENProvision < ApplicationRecord
+  has_many :school_sen_provisions
+  has_many :schools, through: :school_sen_provisions
+
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
+end

--- a/app/services/gias/csv_importer.rb
+++ b/app/services/gias/csv_importer.rb
@@ -15,7 +15,9 @@ module Gias
     def call
       school_records = []
       trust_records = []
+      sen_provision_records = []
       trust_associations = Hash.new { |h, k| h[k] = [] }
+      sen_provision_associations = Hash.new { |h, k| h[k] = [] }
 
       CSV.foreach(csv_path, headers: true) do |school|
         school_records << {
@@ -63,14 +65,69 @@ module Gias
 
           trust_associations[school["Trusts (code)"]] << school["URN"]
         end
+
+        if school["SEN1 (name)"].present?
+          sen_provision_records << { name: school["SEN1 (name)"] }
+          sen_provision_associations[school["SEN1 (name)"]] << school["URN"]
+        end
+        if school["SEN2 (name)"].present?
+          sen_provision_records << { name: school["SEN2 (name)"] }
+          sen_provision_associations[school["SEN2 (name)"]] << school["URN"]
+        end
+        if school["SEN3 (name)"].present?
+          sen_provision_records << { name: school["SEN3 (name)"] }
+          sen_provision_associations[school["SEN3 (name)"]] << school["URN"]
+        end
+        if school["SEN4 (name)"].present?
+          sen_provision_records << { name: school["SEN4 (name)"] }
+          sen_provision_associations[school["SEN4 (name)"]] << school["URN"]
+        end
+        if school["SEN5 (name)"].present?
+          sen_provision_records << { name: school["SEN5 (name)"] }
+          sen_provision_associations[school["SEN5 (name)"]] << school["URN"]
+        end
+        if school["SEN6 (name)"].present?
+          sen_provision_records << { name: school["SEN6 (name)"] }
+          sen_provision_associations[school["SEN6 (name)"]] << school["URN"]
+        end
+        if school["SEN7 (name)"].present?
+          sen_provision_records << { name: school["SEN7 (name)"] }
+          sen_provision_associations[school["SEN7 (name)"]] << school["URN"]
+        end
+        if school["SEN8 (name)"].present?
+          sen_provision_records << { name: school["SEN8 (name)"] }
+          sen_provision_associations[school["SEN8 (name)"]] << school["URN"]
+        end
+        if school["SEN9 (name)"].present?
+          sen_provision_records << { name: school["SEN9 (name)"] }
+          sen_provision_associations[school["SEN9 (name)"]] << school["URN"]
+        end
+        if school["SEN10 (name)"].present?
+          sen_provision_records << { name: school["SEN10 (name)"] }
+          sen_provision_associations[school["SEN10 (name)"]] << school["URN"]
+        end
+        if school["SEN11 (name)"].present?
+          sen_provision_records << { name: school["SEN11 (name)"] }
+          sen_provision_associations[school["SEN11 (name)"]] << school["URN"]
+        end
+        if school["SEN12 (name)"].present?
+          sen_provision_records << { name: school["SEN12 (name)"] }
+          sen_provision_associations[school["SEN12 (name)"]] << school["URN"]
+        end
+        if school["SEN13 (name)"].present?
+          sen_provision_records << { name: school["SEN13 (name)"] }
+          sen_provision_associations[school["SEN13 (name)"]] << school["URN"]
+        end
       end
 
       Rails.logger.silence do
         School.upsert_all(school_records, unique_by: :urn)
         Trust.upsert_all(trust_records.uniq, unique_by: :uid)
+        SENProvision.upsert_all(sen_provision_records.uniq, unique_by: :name)
 
         associate_schools_to_regions
         associate_schools_to_trusts(trust_associations)
+        associate_schools_to_sen_provisions(sen_provision_associations)
       end
 
       Rails.logger.info "GIAS Data Imported!"
@@ -104,6 +161,16 @@ module Gias
       trust_data.each do |uid, urns|
         trust = Trust.find_by!(uid:)
         School.where(urn: urns).update_all(trust_id: trust.id)
+      end
+    end
+
+    def associate_schools_to_sen_provisions(sen_provision_data)
+      Rails.logger.debug "Associating schools to SEN provisions... "
+
+      sen_provision_data.each do |sen_provision_name, urns|
+        sen_provision = SENProvision.find_by(name: sen_provision_name)
+        sen_provision.schools = School.where(urn: urns)
+        sen_provision.save!
       end
     end
   end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -170,3 +170,14 @@ shared:
     - school_id
     - created_at
     - updated_at
+  :sen_provisions:
+    - id
+    - name
+    - created_at
+    - updated_at
+  :school_sen_provisions:
+    - id
+    - school_id
+    - sen_provision_id
+    - created_at
+    - updated_at

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -16,4 +16,5 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "QA"
   inflect.acronym "CSV"
   inflect.acronym "ESFA"
+  inflect.acronym "SEN"
 end

--- a/db/migrate/20250401094729_create_sen_provisions.rb
+++ b/db/migrate/20250401094729_create_sen_provisions.rb
@@ -1,0 +1,8 @@
+class CreateSENProvisions < ActiveRecord::Migration[7.2]
+  def change
+    create_table :sen_provisions, id: :uuid do |t|
+      t.string :name, null: false, index: { unique: true }
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250401100217_create_school_sen_provisions.rb
+++ b/db/migrate/20250401100217_create_school_sen_provisions.rb
@@ -1,0 +1,9 @@
+class CreateSchoolSENProvisions < ActiveRecord::Migration[7.2]
+  def change
+    create_table :school_sen_provisions, id: :uuid do |t|
+      t.references :school, null: false, foreign_key: true, type: :uuid
+      t.references :sen_provision, null: false, foreign_key: true, type: :uuid
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_17_094215) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_01_100217) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -502,6 +502,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_17_094215) do
     t.index ["school_id"], name: "index_school_contacts_on_school_id"
   end
 
+  create_table "school_sen_provisions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "school_id", null: false
+    t.uuid "sen_provision_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["school_id"], name: "index_school_sen_provisions_on_school_id"
+    t.index ["sen_provision_id"], name: "index_school_sen_provisions_on_sen_provision_id"
+  end
+
   create_table "schools", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "urn", null: false
     t.boolean "placements_service", default: false
@@ -557,6 +566,13 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_17_094215) do
     t.index ["trust_id"], name: "index_schools_on_trust_id"
     t.index ["urn"], name: "index_schools_on_urn", unique: true
     t.index ["urn"], name: "index_schools_on_urn_trigram", opclass: :gin_trgm_ops, using: :gin
+  end
+
+  create_table "sen_provisions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_sen_provisions_on_name", unique: true
   end
 
   create_table "sessions", force: :cascade do |t|
@@ -656,6 +672,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_17_094215) do
   add_foreign_key "provider_samplings", "providers"
   add_foreign_key "provider_samplings", "samplings"
   add_foreign_key "school_contacts", "schools"
+  add_foreign_key "school_sen_provisions", "schools"
+  add_foreign_key "school_sen_provisions", "sen_provisions"
   add_foreign_key "schools", "regions"
   add_foreign_key "schools", "trusts"
   add_foreign_key "schools", "users", column: "claims_grant_conditions_accepted_by_id"

--- a/spec/factories/school_sen_provisions.rb
+++ b/spec/factories/school_sen_provisions.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: school_sen_provisions
+#
+#  id               :uuid             not null, primary key
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  school_id        :uuid             not null
+#  sen_provision_id :uuid             not null
+#
+# Indexes
+#
+#  index_school_sen_provisions_on_school_id         (school_id)
+#  index_school_sen_provisions_on_sen_provision_id  (sen_provision_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (school_id => schools.id)
+#  fk_rails_...  (sen_provision_id => sen_provisions.id)
+#
+FactoryBot.define do
+  factory :school_sen_provision do
+    association :school
+    association :sen_provision
+  end
+end

--- a/spec/factories/sen_provisions.rb
+++ b/spec/factories/sen_provisions.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: sen_provisions
+#
+#  id         :uuid             not null, primary key
+#  name       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_sen_provisions_on_name  (name) UNIQUE
+#
+FactoryBot.define do
+  factory :sen_provision do
+    name { "ASD - Autistic Spectrum Disorder" }
+
+    trait :asd do
+      name { "ASD - Autistic Spectrum Disorder" }
+    end
+
+    trait :hi do
+      name { "HI - Hearing Impairment" }
+    end
+
+    trait :not_applicable do
+      name { "Not Applicable" }
+    end
+  end
+end

--- a/spec/fixtures/gias/import_with_trusts_and_regions.csv
+++ b/spec/fixtures/gias/import_with_trusts_and_regions.csv
@@ -1,6 +1,7 @@
-URN,EstablishmentName,Town,Postcode,EstablishmentStatus (code),TypeOfEstablishment (code),DistrictAdministrative (code),TrustSchoolFlag (code),Trusts (code),Trusts (name),Latitude,Longitude
-130,InnerLondonSchool,InnerLondonTown,Postcode,1,7,E09000007,,,,51.5139702631,-0.0775045667
-131,OuterLondonSchool,OuterLondonTown,Postcode,1,7,E09000004,,,,,
-123,FringeSchool,FringeTown,Postcode,1,7,E06000039,,,,,
-132,RestOfEnglandSchool,RestOfEnglandTown,Postcode,1,7,E09000099,,,,,
-140,TrustSchool,TrustTown,Postcode,1,7,E09000007,1,12345,Department for Education Trust,,
+URN,EstablishmentName,Town,Postcode,EstablishmentStatus (code),TypeOfEstablishment (code),DistrictAdministrative (code),TrustSchoolFlag (code),Trusts (code),Trusts (name),Latitude,Longitude,SEN1 (name),SEN2 (name),SEN3 (name),SEN4 (name),SEN5 (name),SEN6 (name),SEN7 (name),SEN8 (name),SEN9 (name),SEN10 (name),SEN11 (name),SEN12 (name),SEN13 (name)
+130,InnerLondonSchool,InnerLondonTown,Postcode,1,7,E09000007,,,,51.5139702631,-0.0775045667,,,,,,,,,,,,,
+131,OuterLondonSchool,OuterLondonTown,Postcode,1,7,E09000004,,,,,,,,,,,,,,,,,,
+123,FringeSchool,FringeTown,Postcode,1,7,E06000039,,,,,,,,,,,,,,,,,,
+132,RestOfEnglandSchool,RestOfEnglandTown,Postcode,1,7,E09000099,,,,,,,,,,,,,,,,,,
+140,TrustSchool,TrustTown,Postcode,1,7,E09000007,1,12345,Department for Education Trust,,,,,,,,,,,,,,,
+142,SenSchool,SenTown,Postcode,1,7,E09000017,,,,,,ASD - Autistic Spectrum Disorder,HI - Hearing Impairment,MLD - Moderate Learning Difficulty,MSI - Multi-Sensory Impairment,Not Applicable,OTH - Other Difficulty/Disability,PD - Physical Disability,PMLD - Profound and Multiple Learning Difficulty,"SEMH - Social, Emotional and Mental Health","SLCN - Speech, language and Communication",SLD - Severe Learning Difficulty,SpLD - Specific Learning Difficulty,VI - Visual Impairment

--- a/spec/models/school_sen_provision_spec.rb
+++ b/spec/models/school_sen_provision_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe SchoolSENProvision, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:school) }
+    it { is_expected.to belong_to(:sen_provision) }
+  end
+end

--- a/spec/models/sen_provision_spec.rb
+++ b/spec/models/sen_provision_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe SENProvision, type: :model do
+  describe "associations" do
+    it { is_expected.to have_many(:school_sen_provisions) }
+    it { is_expected.to have_many(:schools).through(:school_sen_provisions) }
+  end
+
+  describe "validations" do
+    subject { create(:sen_provision) }
+
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
+  end
+end


### PR DESCRIPTION
## Context

- Add SEN provisions to schools as part of the GIAS Import.

## Changes proposed in this pull request

- Create table for `sen_provisions`
- Create table for `school_sen_provisions`
- Amend `app/services/gias/csv_importer.rb` to create and assign SEN provisions to schools.

## Guidance to review

- run `bundle exec rake db:drop db:create db:setup`
- This should result in 13 SEN Provision records being created and approx 9099 School SEN Provisions join records.

## Link to Trello card

https://trello.com/c/VFfGnu5j/400-import-sen-data-from-gias
