### PR TITLE
Add Initial teacher training reform funding guidance

### DIFF
--- a/app/views/claims/pages/start.en.html.erb
+++ b/app/views/claims/pages/start.en.html.erb
@@ -86,6 +86,9 @@
 
         <%= govuk_list do %>
           <li class="app-related__list-item">
+            <%= govuk_link_to "Initial teacher training reform funding guidance - GOV.UK", "https://www.gov.uk/government/publications/initial-teacher-training-reform-funding-guidance" %>
+          </li>
+          <li class="app-related__list-item">
             <%= govuk_link_to "Guidance for providers on initial teacher training (ITT)", "https://www.gov.uk/government/collections/initial-teacher-training" %>
           </li>
           <li class="app-related__list-item">

--- a/spec/system/claims/start_page_spec.rb
+++ b/spec/system/claims/start_page_spec.rb
@@ -131,6 +131,10 @@ RSpec.describe "Start Page", freeze: "17 July 2024", service: :claims, type: :sy
   end
 
   def then_i_see_a_link_to_all_service_updates
+    expect(page).to have_link(
+      "Initial teacher training reform funding guidance - GOV.UK",
+      href: "https://www.gov.uk/government/publications/initial-teacher-training-reform-funding-guidance",
+    )
     expect(page).to have_link("Service Update", href: "/service-updates#service-update")
     expect(page).to have_link("View all news and updates", href: "/service-updates")
   end


### PR DESCRIPTION
## Context

To help our users understand the service and the grant we can link to the published [gov.uk](http://gov.uk/) guidance - [Initial teacher training reform funding guidance - GOV.UK](https://www.gov.uk/government/publications/initial-teacher-training-reform-funding-guidance) in the related content section of the start page [Claim funding for mentor training - GOV.UK](https://claim-funding-for-mentor-training.education.gov.uk/)

## Changes proposed in this pull request

- Adds a link to [Initial teacher training reform funding guidance - GOV.UK](https://www.gov.uk/government/publications/initial-teacher-training-reform-funding-guidance) on the start page

## Guidance to review

- Open the claims review app
- Ensure the link is visible in the related cotent section and goes to the right page

## Link to Trello card

[Add grant guidance to the claim funding start page
](https://trello.com/c/CKiCo6Xy/370-add-grant-guidance-to-the-claim-funding-start-page)

## Screenshots

![image](https://github.com/user-attachments/assets/28404386-28b3-44eb-ae03-4b27ac773618)

