### PR TITLE
Add tracking links to all URL's in emails

### DIFF
--- a/app/mailers/claims/provider_mailer.rb
+++ b/app/mailers/claims/provider_mailer.rb
@@ -8,8 +8,8 @@ class Claims::ProviderMailer < Claims::ApplicationMailer
                  body: t(
                    ".body",
                    provider_name: @provider_sampling.provider_name,
-                   download_csv_url: claims_sampling_claims_url(token:),
-                   support_email:, service_name:, completion_date:, service_url: claims_root_url
+                   download_csv_url: claims_sampling_claims_url(token:, utm_source: "email", utm_medium: "notification", utm_campaign: "provider"),
+                   support_email:, service_name:, completion_date:, service_url: claims_root_url(utm_source: "email", utm_medium: "notification", utm_campaign: "provider")
                  )
   end
 
@@ -22,8 +22,8 @@ class Claims::ProviderMailer < Claims::ApplicationMailer
                  body: t(
                    ".body",
                    provider_name: @provider_sampling.provider_name,
-                   download_csv_url: claims_sampling_claims_url(token:),
-                   support_email:, service_name:, completion_date:, service_url: claims_root_url
+                   download_csv_url: claims_sampling_claims_url(token:, utm_source: "email", utm_medium: "notification", utm_campaign: "provider"),
+                   support_email:, service_name:, completion_date:, service_url: claims_root_url(utm_source: "email", utm_medium: "notification", utm_campaign: "provider")
                  )
   end
 

--- a/app/mailers/claims/user_mailer.rb
+++ b/app/mailers/claims/user_mailer.rb
@@ -9,7 +9,7 @@ class Claims::UserMailer < Claims::ApplicationMailer
                    service_name:,
                    heading: t(".heading"),
                    support_email:,
-                   sign_in_url:,
+                   sign_in_url: sign_in_url(utm_source: "email", utm_medium: "notification", utm_campaign: "school"),
                  )
   end
 
@@ -26,7 +26,7 @@ class Claims::UserMailer < Claims::ApplicationMailer
   end
 
   def claim_submitted_notification(user, claim)
-    link_to_claim = claims_school_claim_url(id: claim.id, school_id: claim.school.id)
+    link_to_claim = claims_school_claim_url(id: claim.id, school_id: claim.school.id, utm_source: "email", utm_medium: "notification", utm_campaign: "school")
 
     notify_email to: user.email,
                  subject: t(".subject"),
@@ -44,7 +44,7 @@ class Claims::UserMailer < Claims::ApplicationMailer
   end
 
   def claim_created_support_notification(claim, user)
-    link_to_claim = claims_school_claim_url(id: claim.id, school_id: claim.school.id)
+    link_to_claim = claims_school_claim_url(id: claim.id, school_id: claim.school.id, utm_source: "email", utm_medium: "notification", utm_campaign: "school")
 
     notify_email to: user.email,
                  subject: t(".subject"),
@@ -60,7 +60,7 @@ class Claims::UserMailer < Claims::ApplicationMailer
   end
 
   def claim_requires_clawback(claim, user)
-    link_to_claim = claims_school_claim_url(id: claim.id, school_id: claim.school.id)
+    link_to_claim = claims_school_claim_url(id: claim.id, school_id: claim.school.id, utm_source: "email", utm_medium: "notification", utm_campaign: "school")
 
     notify_email to: user.email,
                  subject: t(".subject"),
@@ -71,6 +71,6 @@ class Claims::UserMailer < Claims::ApplicationMailer
                          link_to_claim:,
                          support_email:,
                          service_name:,
-                         service_url: claims_root_url)
+                         service_url: claims_root_url(utm_source: "email", utm_medium: "notification", utm_campaign: "school"))
   end
 end

--- a/app/mailers/placements/provider_user_mailer.rb
+++ b/app/mailers/placements/provider_user_mailer.rb
@@ -4,7 +4,7 @@ class Placements::ProviderUserMailer < Placements::UserMailer
     @school_name = source_organisation.name
     @provider_name = partner_organisation.name
     @itt_contact_email = source_organisation.school_contact_email_address
-    @sign_in_url = sign_in_url
+    @sign_in_url = sign_in_url(utm_source: "email", utm_medium: "notification", utm_campaign: "provider")
     @service_name = service_name
 
     notify_email to: user.email, subject: t(".subject")
@@ -16,9 +16,9 @@ class Placements::ProviderUserMailer < Placements::UserMailer
     @school_name = source_organisation.name
     @itt_contact_email = source_organisation.school_contact_email_address
     @placements = source_organisation.placements.where(provider: partner_organisation).decorate.map do |placement|
-      { title: placement.title, url: placements_provider_placement_url(partner_organisation, placement) }
+      { title: placement.title, url: placements_provider_placement_url(partner_organisation, placement, utm_source: "email", utm_medium: "notification", utm_campaign: "provider") }
     end
-    @sign_in_url = sign_in_url
+    @sign_in_url = sign_in_url(utm_source: "email", utm_medium: "notification", utm_campaign: "provider")
     @service_name = service_name
 
     notify_email to: user.email, subject: t(".subject")
@@ -30,9 +30,9 @@ class Placements::ProviderUserMailer < Placements::UserMailer
     @school_name = placement.school.name
     @itt_contact_email = placement.school.school_contact_email_address
     @placement_name = placement.decorate.title
-    @placement_url = placements_provider_placement_url(provider, placement)
+    @placement_url = placements_provider_placement_url(provider, placement, utm_source: "email", utm_medium: "notification", utm_campaign: "provider")
     @service_name = service_name
-    @sign_in_url = sign_in_url
+    @sign_in_url = sign_in_url(utm_source: "email", utm_medium: "notification", utm_campaign: "provider")
 
     notify_email to: user.email, subject: t(".subject")
   end
@@ -43,9 +43,9 @@ class Placements::ProviderUserMailer < Placements::UserMailer
     @school_name = placement.school.name
     @itt_contact_email = placement.school.school_contact_email_address
     @placement_name = placement.decorate.title
-    @placement_url = placements_provider_placement_url(provider, placement)
+    @placement_url = placements_provider_placement_url(provider, placement, utm_source: "email", utm_medium: "notification", utm_campaign: "provider")
     @service_name = service_name
-    @sign_in_url = sign_in_url
+    @sign_in_url = sign_in_url(utm_source: "email", utm_medium: "notification", utm_campaign: "provider")
 
     notify_email to: user.email, subject: t(".subject")
   end

--- a/app/mailers/placements/provider_user_mailer.rb
+++ b/app/mailers/placements/provider_user_mailer.rb
@@ -1,4 +1,10 @@
 class Placements::ProviderUserMailer < Placements::UserMailer
+  def user_membership_created_notification(user, organisation)
+    @campaign_type = "provider"
+
+    super
+  end
+
   def partnership_created_notification(user, source_organisation, partner_organisation)
     @user_name = user.first_name
     @school_name = source_organisation.name

--- a/app/mailers/placements/school_user_mailer.rb
+++ b/app/mailers/placements/school_user_mailer.rb
@@ -1,4 +1,10 @@
 class Placements::SchoolUserMailer < Placements::UserMailer
+  def user_membership_created_notification(user, organisation)
+    @campaign_type = "school"
+
+    super
+  end
+
   def user_membership_destroyed_notification(user, organisation)
     @itt_contact_email = organisation.school_contact_email_address
 

--- a/app/mailers/placements/school_user_mailer.rb
+++ b/app/mailers/placements/school_user_mailer.rb
@@ -10,7 +10,7 @@ class Placements::SchoolUserMailer < Placements::UserMailer
     @school_name = partner_organisation.name
     @provider_name = source_organisation.name
     @provider_email_address = source_organisation.primary_email_address
-    @sign_in_url = sign_in_url
+    @sign_in_url = sign_in_url(utm_source: "email", utm_medium: "notification", utm_campaign: "school")
     @service_name = service_name
 
     notify_email to: user.email, subject: t(".subject")
@@ -23,9 +23,9 @@ class Placements::SchoolUserMailer < Placements::UserMailer
     @provider_email_address = source_organisation.primary_email_address
     placements_school = partner_organisation.becomes(Placements::School)
     @placements = placements_school.placements.where(provider: source_organisation).decorate.map do |placement|
-      { title: placement.title, url: placements_school_placement_url(placements_school, placement) }
+      { title: placement.title, url: placements_school_placement_url(placements_school, placement, utm_source: "email", utm_medium: "notification", utm_campaign: "school") }
     end
-    @sign_in_url = sign_in_url
+    @sign_in_url = sign_in_url(utm_source: "email", utm_medium: "notification", utm_campaign: "school")
     @service_name = service_name
 
     notify_email to: user.email, subject: t(".subject")

--- a/app/mailers/placements/user_mailer.rb
+++ b/app/mailers/placements/user_mailer.rb
@@ -4,7 +4,7 @@ class Placements::UserMailer < Placements::ApplicationMailer
     @organisation_name = organisation.name
     @service_name = service_name
     @support_email = support_email
-    @sign_in_url = sign_in_url
+    @sign_in_url = sign_in_url(utm_campaign: "school", utm_medium: "notification", utm_source: "email")
 
     notify_email to: user.email, subject: t(".subject", service_name:)
   end

--- a/app/mailers/placements/user_mailer.rb
+++ b/app/mailers/placements/user_mailer.rb
@@ -4,7 +4,7 @@ class Placements::UserMailer < Placements::ApplicationMailer
     @organisation_name = organisation.name
     @service_name = service_name
     @support_email = support_email
-    @sign_in_url = sign_in_url(utm_campaign: "school", utm_medium: "notification", utm_source: "email")
+    @sign_in_url = sign_in_url(utm_campaign: @campaign_type, utm_medium: "notification", utm_source: "email")
 
     notify_email to: user.email, subject: t(".subject", service_name:)
   end

--- a/spec/mailers/claims/provider_mailer_spec.rb
+++ b/spec/mailers/claims/provider_mailer_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Claims::ProviderMailer, type: :mailer do
 
           Visit the GOV.UK claim funding for mentor training website to download the file:
 
-          [http://claims.localhost/sampling/claims?token=token](http://claims.localhost/sampling/claims?token=token)
+          [http://claims.localhost/sampling/claims?token=token&utm_campaign=provider&utm_medium=notification&utm_source=email](http://claims.localhost/sampling/claims?token=token&utm_campaign=provider&utm_medium=notification&utm_source=email)
 
           This link will expire in 7 days due to data security. To request a new link, reply to this email.
 
@@ -95,7 +95,7 @@ RSpec.describe Claims::ProviderMailer, type: :mailer do
 
           If you need any help with completing the quality assurance, contact the team at [#{support_email}](mailto:#{support_email})
 
-          Learn more about [funding for mentor training on GOV.UK](http://claims.localhost/)
+          Learn more about [funding for mentor training on GOV.UK](http://claims.localhost/?utm_campaign=provider&utm_medium=notification&utm_source=email)
 
 
           Claim funding for mentor training team
@@ -136,7 +136,7 @@ RSpec.describe Claims::ProviderMailer, type: :mailer do
 
           Visit the GOV.UK claim funding for mentor training website to download the file:
 
-          [http://claims.localhost/sampling/claims?token=token](http://claims.localhost/sampling/claims?token=token)
+          [http://claims.localhost/sampling/claims?token=token&utm_campaign=provider&utm_medium=notification&utm_source=email](http://claims.localhost/sampling/claims?token=token&utm_campaign=provider&utm_medium=notification&utm_source=email)
 
           This link will expire in 7 days due to data security. To request a new link, reply to this email.
 
@@ -180,7 +180,7 @@ RSpec.describe Claims::ProviderMailer, type: :mailer do
 
           If you need any help with completing the quality assurance, contact the team at [#{support_email}](mailto:#{support_email})
 
-          Learn more about [funding for mentor training on GOV.UK](http://claims.localhost/)
+          Learn more about [funding for mentor training on GOV.UK](http://claims.localhost/?utm_campaign=provider&utm_medium=notification&utm_source=email)
 
 
           Claim funding for mentor training team
@@ -227,7 +227,7 @@ RSpec.describe Claims::ProviderMailer, type: :mailer do
 
           Visit the GOV.UK claim funding for mentor training website to download the file:
 
-          [http://claims.localhost/sampling/claims?token=token](http://claims.localhost/sampling/claims?token=token)
+          [http://claims.localhost/sampling/claims?token=token&utm_campaign=provider&utm_medium=notification&utm_source=email](http://claims.localhost/sampling/claims?token=token&utm_campaign=provider&utm_medium=notification&utm_source=email)
 
           This link will expire in 7 days due to data security. To request a new link, reply to this email.
 
@@ -271,7 +271,7 @@ RSpec.describe Claims::ProviderMailer, type: :mailer do
 
           If you need any help with completing the quality assurance, contact the team at [#{support_email}](mailto:#{support_email})
 
-          Learn more about [funding for mentor training on GOV.UK](http://claims.localhost/)
+          Learn more about [funding for mentor training on GOV.UK](http://claims.localhost/?utm_campaign=provider&utm_medium=notification&utm_source=email)
 
 
           Claim funding for mentor training team
@@ -314,7 +314,7 @@ RSpec.describe Claims::ProviderMailer, type: :mailer do
 
           Visit the GOV.UK claim funding for mentor training website to download the file:
 
-          [http://claims.localhost/sampling/claims?token=token](http://claims.localhost/sampling/claims?token=token)
+          [http://claims.localhost/sampling/claims?token=token&utm_campaign=provider&utm_medium=notification&utm_source=email](http://claims.localhost/sampling/claims?token=token&utm_campaign=provider&utm_medium=notification&utm_source=email)
 
           This link will expire in 7 days due to data security. To request a new link, reply to this email.
 
@@ -358,7 +358,7 @@ RSpec.describe Claims::ProviderMailer, type: :mailer do
 
           If you need any help with completing the quality assurance, contact the team at [#{support_email}](mailto:#{support_email})
 
-          Learn more about [funding for mentor training on GOV.UK](http://claims.localhost/)
+          Learn more about [funding for mentor training on GOV.UK](http://claims.localhost/?utm_campaign=provider&utm_medium=notification&utm_source=email)
 
 
           Claim funding for mentor training team

--- a/spec/mailers/claims/user_mailer_spec.rb
+++ b/spec/mailers/claims/user_mailer_spec.rb
@@ -19,11 +19,11 @@ RSpec.describe Claims::UserMailer, type: :mailer do
 
         If you have a DfE Sign-in account, you can use it to sign in:
 
-        [http://claims.localhost/sign-in](http://claims.localhost/sign-in)
+        [http://claims.localhost/sign-in?utm_campaign=school&utm_medium=notification&utm_source=email](http://claims.localhost/sign-in?utm_campaign=school&utm_medium=notification&utm_source=email)
 
         If you need to create a DfE Sign-in account, you can do this after clicking "Sign in using DfE Sign-in"
 
-        After creating a DfE Sign-in account, you will need to return to this email and [sign in to access the service](http://claims.localhost/sign-in).
+        After creating a DfE Sign-in account, you will need to return to this email and [sign in to access the service](http://claims.localhost/sign-in?utm_campaign=school&utm_medium=notification&utm_source=email).
 
         # Give feedback or report a problem
 
@@ -126,7 +126,7 @@ RSpec.describe Claims::UserMailer, type: :mailer do
 
           See your claims on the claim funding for mentor training website:
 
-          http://claims.localhost/schools/#{school.id}/claims/#{claim.id}
+          http://claims.localhost/schools/#{school.id}/claims/#{claim.id}?utm_campaign=school&utm_medium=notification&utm_source=email
 
           # Contact us
 
@@ -181,7 +181,7 @@ RSpec.describe Claims::UserMailer, type: :mailer do
 
           You can view the claim, edit and submit it on Claim funding for mentor training:
 
-          http://claims.localhost/schools/#{school.id}/claims/#{claim.id}
+          http://claims.localhost/schools/#{school.id}/claims/#{claim.id}?utm_campaign=school&utm_medium=notification&utm_source=email
 
           # Give feedback or report a problem
 
@@ -251,7 +251,7 @@ RSpec.describe Claims::UserMailer, type: :mailer do
         For academies, any recovery will be offset in your next available monthly payment. For maintained schools, any recovery will be offset in your local authority’s next available monthly payment and they will recover funding from you via their usual processes.
 
         Sign in to your account on Claim funding for mentor training to see more details:
-        http://claims.localhost/
+        http://claims.localhost/?utm_campaign=school&utm_medium=notification&utm_source=email
 
         # Contact us
         If you need any help, contact the team at [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk). It may take up to 5 days to receive a response.

--- a/spec/mailers/placements/provider_user_mailer_spec.rb
+++ b/spec/mailers/placements/provider_user_mailer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Placements::ProviderUserMailer, type: :mailer do
 
         This service allows you to view placements published by schools. Schools can also assign you to placements they want you to place a trainee on.
 
-        [Sign in to Manage school placements](http://placements.localhost/sign-in)
+        [Sign in to Manage school placements](http://placements.localhost/sign-in?utm_campaign=provider&utm_medium=notification&utm_source=email)
 
         If you do not have DfE Sign-in, create an account. You can then return to this email to access the service.
 
@@ -115,7 +115,7 @@ RSpec.describe Placements::ProviderUserMailer, type: :mailer do
         Contact the school on [#{source_organisation.school_contact_email_address}](mailto:#{source_organisation.school_contact_email_address}) if you have any questions.
 
         ## Your account
-        [Sign in to Manage school placements](http://placements.localhost/sign-in)
+        [Sign in to Manage school placements](http://placements.localhost/sign-in?utm_campaign=provider&utm_medium=notification&utm_source=email)
 
         Manage school placements service
       EMAIL
@@ -148,7 +148,7 @@ RSpec.describe Placements::ProviderUserMailer, type: :mailer do
           If you think this is a mistake, contact them on [#{source_organisation.school_contact_email_address}](mailto:#{source_organisation.school_contact_email_address}).
 
           ## Your account
-          [Sign in to Manage school placements](http://placements.localhost/sign-in)
+          [Sign in to Manage school placements](http://placements.localhost/sign-in?utm_campaign=provider&utm_medium=notification&utm_source=email)
 
           Manage school placements service
         EMAIL
@@ -173,12 +173,12 @@ RSpec.describe Placements::ProviderUserMailer, type: :mailer do
           ## What happens next?
           You will remain assigned to current placements for this academic year unless the school removes you. This placement is:
 
-          - [#{placement.decorate.title}](http://placements.localhost/providers/#{partner_organisation.id}/placements/#{placement.id})
+          - [#{placement.decorate.title}](http://placements.localhost/providers/#{partner_organisation.id}/placements/#{placement.id}?utm_campaign=provider&utm_medium=notification&utm_source=email)
 
           We recommend you speak to the school to check whether they expect you to fill this placement. Contact them on [#{source_organisation.school_contact_email_address}](mailto:#{source_organisation.school_contact_email_address}).
 
           ## Your account
-          [Sign in to Manage school placements](http://placements.localhost/sign-in)
+          [Sign in to Manage school placements](http://placements.localhost/sign-in?utm_campaign=provider&utm_medium=notification&utm_source=email)
 
           Manage school placements service
         EMAIL
@@ -205,13 +205,13 @@ RSpec.describe Placements::ProviderUserMailer, type: :mailer do
           ## What happens next?
           You will remain assigned to current placements for this academic year unless the school removes you. These placements are:
 
-          - [#{placement_one.decorate.title}](http://placements.localhost/providers/#{partner_organisation.id}/placements/#{placement_one.id})
-          - [#{placement_two.decorate.title}](http://placements.localhost/providers/#{partner_organisation.id}/placements/#{placement_two.id})
+          - [#{placement_one.decorate.title}](http://placements.localhost/providers/#{partner_organisation.id}/placements/#{placement_one.id}?utm_campaign=provider&utm_medium=notification&utm_source=email)
+          - [#{placement_two.decorate.title}](http://placements.localhost/providers/#{partner_organisation.id}/placements/#{placement_two.id}?utm_campaign=provider&utm_medium=notification&utm_source=email)
 
           We recommend you speak to the school to check whether they expect you to fill these placements. Contact them on [#{source_organisation.school_contact_email_address}](mailto:#{source_organisation.school_contact_email_address}).
 
           ## Your account
-          [Sign in to Manage school placements](http://placements.localhost/sign-in)
+          [Sign in to Manage school placements](http://placements.localhost/sign-in?utm_campaign=provider&utm_medium=notification&utm_source=email)
 
           Manage school placements service
         EMAIL
@@ -243,7 +243,7 @@ RSpec.describe Placements::ProviderUserMailer, type: :mailer do
 
         #{school.name} has assigned #{provider.name} to the following placement:
 
-        - [#{placement.decorate.title}](http://placements.localhost/providers/#{provider.id}/placements/#{placement.id})
+        - [#{placement.decorate.title}](http://placements.localhost/providers/#{provider.id}/placements/#{placement.id}?utm_campaign=provider&utm_medium=notification&utm_source=email)
 
         ## What happens next?
         You should now arrange for one of your trainees to fulfil this placement.
@@ -251,7 +251,7 @@ RSpec.describe Placements::ProviderUserMailer, type: :mailer do
         Contact the school at [#{school.school_contact_email_address}](mailto:#{school.school_contact_email_address}).
 
         ## Your account
-        [Sign in to Manage school placements](http://placements.localhost/sign-in)
+        [Sign in to Manage school placements](http://placements.localhost/sign-in?utm_campaign=provider&utm_medium=notification&utm_source=email)
 
         Manage school placements service
       EMAIL
@@ -282,7 +282,7 @@ RSpec.describe Placements::ProviderUserMailer, type: :mailer do
 
         #{school.name} has removed #{provider.name} from the following placement:
 
-        - [#{placement.decorate.title}](http://placements.localhost/providers/#{provider.id}/placements/#{placement.id})
+        - [#{placement.decorate.title}](http://placements.localhost/providers/#{provider.id}/placements/#{placement.id}?utm_campaign=provider&utm_medium=notification&utm_source=email)
 
         You can no longer allocate a trainee onto this placement.
 
@@ -290,7 +290,7 @@ RSpec.describe Placements::ProviderUserMailer, type: :mailer do
         If you think this is a mistake, contact the school on [#{school.school_contact_email_address}](mailto:#{school.school_contact_email_address}).
 
         ## Your account
-        [Sign in to Manage school placements](http://placements.localhost/sign-in)
+        [Sign in to Manage school placements](http://placements.localhost/sign-in?utm_campaign=provider&utm_medium=notification&utm_source=email)
 
         Manage school placements service
       EMAIL

--- a/spec/mailers/placements/school_user_mailer_spec.rb
+++ b/spec/mailers/placements/school_user_mailer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Placements::SchoolUserMailer, type: :mailer do
 
         This service allows you to publish and manage placements at your school. You can assign your preferred providers to fulfil your placements with suitable trainees.
 
-        [Sign in to Manage school placements](http://placements.localhost/sign-in)
+        [Sign in to Manage school placements](http://placements.localhost/sign-in?utm_campaign=school&utm_medium=notification&utm_source=email)
 
         If you do not have DfE Sign-in, create an account. You can then return to this email to access the service.
 
@@ -112,7 +112,7 @@ RSpec.describe Placements::SchoolUserMailer, type: :mailer do
         Contact the provider on [#{source_organisation.email_addresses.first}](mailto:#{source_organisation.email_addresses.first}) if you have any questions.
 
         ## Your account
-        [Sign in to Manage school placements](http://placements.localhost/sign-in)
+        [Sign in to Manage school placements](http://placements.localhost/sign-in?utm_campaign=school&utm_medium=notification&utm_source=email)
 
         Manage school placements service
       EMAIL
@@ -146,7 +146,7 @@ RSpec.describe Placements::SchoolUserMailer, type: :mailer do
           If you think this is a mistake, contact them on [#{source_organisation.email_addresses.first}](mailto:#{source_organisation.email_addresses.first}).
 
           ## Your account
-          [Sign in to Manage school placements](http://placements.localhost/sign-in)
+          [Sign in to Manage school placements](http://placements.localhost/sign-in?utm_campaign=school&utm_medium=notification&utm_source=email)
 
           Manage school placements service
         EMAIL
@@ -169,12 +169,12 @@ RSpec.describe Placements::SchoolUserMailer, type: :mailer do
           ## What happens next?
           They will remain assigned to current placements unless you remove them. These placements are:
 
-          - [#{placement.decorate.title}](http://placements.localhost/schools/#{partner_organisation.id}/placements/#{placement.id})
+          - [#{placement.decorate.title}](http://placements.localhost/schools/#{partner_organisation.id}/placements/#{placement.id}?utm_campaign=school&utm_medium=notification&utm_source=email)
 
           We recommend you speak to the provider to avoid confusion about placing trainees at your school. Contact them on [#{source_organisation.email_addresses.first}](mailto:#{source_organisation.email_addresses.first}).
 
           ## Your account
-          [Sign in to Manage school placements](http://placements.localhost/sign-in)
+          [Sign in to Manage school placements](http://placements.localhost/sign-in?utm_campaign=school&utm_medium=notification&utm_source=email)
 
           Manage school placements service
         EMAIL


### PR DESCRIPTION
## Context

We have the ability to track how people navigate to our application from the emails that we send, all of the infrastructure for this exists and we weren't utilising it.

## Changes proposed in this pull request

- Add tracking links to all user facing URL's in emails.

## Guidance to review

- Log into both the claims and placements services as Colin
- Check each email and make sure that the links work

## Link to Trello card

[Set-up email tracking tags to measure user engagement](https://trello.com/c/zRCkHO9E/373-set-up-email-tracking-tags-to-measure-user-engagement)
