### PR TITLE
Prevent schools from creating claims when ineligible

### DIFF
--- a/app/controllers/claims/schools/claims/add_claim_controller.rb
+++ b/app/controllers/claims/schools/claims/add_claim_controller.rb
@@ -33,7 +33,7 @@ class Claims::Schools::Claims::AddClaimController < Claims::ApplicationControlle
   end
 
   def authorize_claim
-    authorize Claims::Claim, :create?
+    authorize Claims::Claim.new(school: @school), :create?
   end
 
   def step_path(step)

--- a/app/controllers/claims/schools/claims_controller.rb
+++ b/app/controllers/claims/schools/claims_controller.rb
@@ -38,7 +38,7 @@ class Claims::Schools::ClaimsController < Claims::ApplicationController
   end
 
   def authorize_claim
-    authorize @claim || Claims::Claim.new
+    authorize @claim || Claims::Claim.new(school: @school)
   end
 
   def edit_attribute_path(attribute)

--- a/app/models/claims/school.rb
+++ b/app/models/claims/school.rb
@@ -87,7 +87,7 @@ class Claims::School < School
     claims_grant_conditions_accepted_at?
   end
 
-  def eligible_for_claim_window(claim_window)
+  def eligible_for_claim_window?(claim_window)
     eligible_claim_windows.include?(claim_window)
   end
 end

--- a/app/policies/claims/claim_policy.rb
+++ b/app/policies/claims/claim_policy.rb
@@ -46,8 +46,6 @@ class Claims::ClaimPolicy < Claims::ApplicationPolicy
   end
 
   def school_eligible_to_claim?
-    return false if record.school.blank?
-
     record.school.eligible_for_claim_window?(Claims::ClaimWindow.current)
   end
 end

--- a/app/policies/claims/claim_policy.rb
+++ b/app/policies/claims/claim_policy.rb
@@ -1,10 +1,10 @@
 class Claims::ClaimPolicy < Claims::ApplicationPolicy
   def create?
-    current_claim_window?
+    current_claim_window? && school_eligible_to_claim?
   end
 
   def edit?
-    claim_claim_window_current? && record.in_draft?
+    claim_claim_window_current? && record.in_draft? && school_eligible_to_claim?
   end
 
   def update?
@@ -16,7 +16,7 @@ class Claims::ClaimPolicy < Claims::ApplicationPolicy
   end
 
   def submit?
-    current_claim_window? && record.in_draft?
+    current_claim_window? && record.in_draft? && school_eligible_to_claim?
   end
 
   def rejected?
@@ -43,5 +43,11 @@ class Claims::ClaimPolicy < Claims::ApplicationPolicy
 
   def claim_claim_window_current?
     record.claim_window.current?
+  end
+
+  def school_eligible_to_claim?
+    return false if record.school.blank?
+
+    record.school.eligible_for_claim_window?(Claims::ClaimWindow.current)
   end
 end

--- a/app/views/claims/schools/claims/index.html.erb
+++ b/app/views/claims/schools/claims/index.html.erb
@@ -6,7 +6,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 
-      <% if policy(Claims::Claim).create? %>
+      <% if policy(Claims::Claim.new(school: @school)).create? %>
         <% if @school.mentors.any? %>
           <%= govuk_warning_text do %>
             <p class="govuk-body"><%= t(".guidance", end_date: l(Claims::ClaimWindow.current.ends_on, format: :long_with_day), start_year: Claims::ClaimWindow.current.starts_on.year, end_year: Claims::ClaimWindow.current.ends_on.year) %></p>
@@ -15,6 +15,10 @@
           <%= govuk_button_link_to(t(".add_claim"), new_add_claim_claims_school_claims_path) %>
         <% else %>
           <%= govuk_inset_text text: t(".add_mentor_guidance_html", link_to: govuk_link_to(t(".add_a_mentor"), claims_school_mentors_path(@school))) %>
+        <% end %>
+      <% elsif !@school.eligible_for_claim_window?(Claims::ClaimWindow.current) %>
+        <%= govuk_warning_text do %>
+          <p class="govuk-body"><%= t(".not_eligible_html", support_email: mail_to(t("claims.support_email"), t("claims.support_email_html"), class: "govuk-link")) %>
         <% end %>
       <% else %>
         <%= govuk_inset_text do %>
@@ -66,7 +70,7 @@
     </p>
   <% end %>
 
-  <% unless policy(Claims::Claim).create? %>
+  <% unless policy(Claims::Claim.new(school: @school)).create? %>
     <p class="govuk-body"><%= sanitize t(".window_closed_support", link_to: govuk_mail_to(t("claims.support_email"))) %></p>
   <% end %>
 </div>

--- a/app/views/claims/support/schools/claims/index.html.erb
+++ b/app/views/claims/support/schools/claims/index.html.erb
@@ -6,13 +6,17 @@
   <%= render "claims/support/schools/secondary_navigation", school: @school %>
   <h2 class="govuk-heading-m"><%= t(".heading") %></h2>
 
-  <% if policy(Claims::Claim).create? %>
+  <% if policy(Claims::Claim.new(school: @school)).create? %>
     <% if @school.mentors.any? %>
       <%= govuk_inset_text text: t(".guidance", start_year: Claims::ClaimWindow.current.academic_year.starts_on.year, end_year: Claims::ClaimWindow.current.academic_year.ends_on.year) %>
 
       <%= govuk_button_link_to t(".add_claim"), new_add_claim_claims_support_school_claims_path %>
     <% else %>
       <%= govuk_inset_text text: t(".add_mentor_guidance_html", link_to: govuk_link_to(t(".add_a_mentor"), claims_support_school_mentors_path(@school))) %>
+    <% end %>
+  <% elsif !@school.eligible_for_claim_window?(Claims::ClaimWindow.current) %>
+    <%= govuk_warning_text do %>
+      <p class="govuk-body"><%= t(".not_eligible_html", support_email: mail_to(t("claims.support_email"), t("claims.support_email_html"), class: "govuk-link")) %>
     <% end %>
   <% else %>
     <%= govuk_inset_text do %>

--- a/config/locales/en/claims/schools/claims.yml
+++ b/config/locales/en/claims/schools/claims.yml
@@ -34,6 +34,7 @@ en:
           guidance: You have until 11:59pm on %{end_date} to submit claims for the academic year September %{start_year} to July %{end_year}.
           add_mentor_guidance_html: Before you can start a claim you will need to %{link_to}.
           add_a_mentor: add a mentor
+          not_eligible_html: You are not eligible to claim funding for mentor training as our records show you have not hosted placements for trainee teachers this academic year. Email %{support_email} if you have any queries.
           window_closed: Claims can no longer be submitted for school year September %{start_year} to July %{end_year}.
           window_closed_guidance: "You can still %{link_to}. Final closing date for claims: <strong>%{time}</strong>."
           window_closed_guidance_link_text: add a mentor

--- a/config/locales/en/claims/support/schools/claims.yml
+++ b/config/locales/en/claims/support/schools/claims.yml
@@ -16,6 +16,7 @@ en:
             closing_date_disclaimer_title: Important
             closing_date_disclaimer: You must submit a claim by 11:59pm on Friday 19 July 2024
             add_mentor_guidance_html: You need to %{link_to} before creating a claim.</p>
+            not_eligible_html: You are not eligible to claim funding for mentor training as our records show you have not hosted placements for trainee teachers this academic year. Email %{support_email} if you have any queries.
             add_a_mentor: add a mentor
             window_closed: Claims can no longer be submitted for school year September %{start_year} to July %{end_year}.
             window_closed_guidance: You can still %{link_to}.

--- a/spec/models/claims/school_spec.rb
+++ b/spec/models/claims/school_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Claims::School do
     end
   end
 
-  describe "#eligible_for_claim_window" do
+  describe "#eligible_for_claim_window?" do
     let(:current_claim_window) { create(:claim_window, :current) }
     let(:historic_claim_window) { create(:claim_window, :historic) }
     let(:school) { create(:claims_school) }
@@ -134,11 +134,11 @@ RSpec.describe Claims::School do
 
     it "returns true when it is assciated with a claim window" do
       expect(
-        school.eligible_for_claim_window(current_claim_window),
+        school.eligible_for_claim_window?(current_claim_window),
       ).to be(true)
 
       expect(
-        school.eligible_for_claim_window(historic_claim_window),
+        school.eligible_for_claim_window?(historic_claim_window),
       ).to be(false)
     end
   end

--- a/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/schools/claims/change_claim_on_check_page_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "Change claim on check page", :js, service: :claims, type: :syste
   before do
     user_exists_in_dfe_sign_in(user: anne)
     given_there_is_a_current_claim_window
+    and_the_school_is_eligible_to_claim
     given_i_sign_in
 
     when_i_click("Add claim")
@@ -133,6 +134,10 @@ RSpec.describe "Change claim on check page", :js, service: :claims, type: :syste
 
   def given_there_is_a_current_claim_window
     @claim_window = create(:claim_window, :current)
+  end
+
+  def and_the_school_is_eligible_to_claim
+    school.eligible_claim_windows << @claim_window
   end
 
   def given_i_visit_claim_check_page

--- a/spec/system/claims/schools/claims/edit_draft_claim_spec.rb
+++ b/spec/system/claims/schools/claims/edit_draft_claim_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Edit a claim", service: :claims, type: :system do
   let!(:claim_window) { create(:claim_window, :current) }
-  let(:school) { create(:claims_school, name: "A School", region: regions(:inner_london)) }
+  let(:school) { create(:claims_school, name: "A School", region: regions(:inner_london), eligible_claim_windows: [claim_window]) }
 
   let(:anne) do
     create(

--- a/spec/system/claims/schools/claims/school_user_creates_a_claim_with_javascript_disabled_spec.rb
+++ b/spec/system/claims/schools/claims/school_user_creates_a_claim_with_javascript_disabled_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe "School user creates a claim with javascript disabled", service: 
       :claims_school,
       mentors: [@mentor_1, @mentor_2, @mentor_3],
       region: regions(:inner_london),
+      eligible_claim_windows: [@claim_window],
     )
   end
 

--- a/spec/system/claims/schools/claims/submit_draft_claim_spec.rb
+++ b/spec/system/claims/schools/claims/submit_draft_claim_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Submit a draft claim", service: :claims, type: :system do
   scenario "Anne visits the show page of a draft claim" do
     user_exists_in_dfe_sign_in(user: anne)
     given_i_sign_in
-    given_there_is_a_current_claim_window
+    given_the_school_is_eligible_to_claim
 
     when_i_visit_the_claim_show_page(draft_claim)
     then_i_can_then_see_the_draft_claim_details
@@ -64,8 +64,8 @@ RSpec.describe "Submit a draft claim", service: :claims, type: :system do
     click_on "Sign in using DfE Sign In"
   end
 
-  def given_there_is_a_current_claim_window
-    Claims::ClaimWindow::Build.call(claim_window_params: { starts_on: 2.days.ago, ends_on: 2.days.from_now }).save!(validate: false)
+  def given_the_school_is_eligible_to_claim
+    school.eligible_claim_windows << Claims::ClaimWindow.current || create(:claim_window, :current)
   end
 
   def when_i_click_submit_button

--- a/spec/system/claims/schools/claims/view_claim_spec.rb
+++ b/spec/system/claims/schools/claims/view_claim_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "View a claim", service: :claims, type: :system do
   let(:claim_window) { create(:claim_window, :current) }
-  let(:school) { create(:claims_school, name: "A School", region: regions(:inner_london)) }
+  let(:school) { create(:claims_school, name: "A School", region: regions(:inner_london), eligible_claim_windows: [claim_window]) }
 
   let(:anne) do
     create(

--- a/spec/system/claims/schools/claims/view_claims_spec.rb
+++ b/spec/system/claims/schools/claims/view_claims_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "View claims", service: :claims, type: :system do
 
   before do
     create(:claim, status: :internal_draft, school:)
-    given_there_is_a_current_claim_window
+    given_the_school_is_eligible_to_claim
   end
 
   scenario "Anne visits the claims index page with no mentors" do
@@ -68,21 +68,22 @@ RSpec.describe "View claims", service: :claims, type: :system do
   scenario "Anne visits the claims index page with internal draft claims" do
     user_exists_in_dfe_sign_in(user: anne)
     given_i_sign_in
-    vist_claims_index_page
+    visit_claims_index_page
     i_do_not_see_any_internal_draft_claims
   end
 
   private
 
-  def given_there_is_a_current_claim_window
-    Claims::ClaimWindow::Build.call(claim_window_params: { starts_on: 2.days.ago, ends_on: 2.days.from_now }).save!(validate: false)
+  def given_the_school_is_eligible_to_claim
+    school.eligible_claim_windows << claim_window
+    school_with_mentors.eligible_claim_windows << claim_window
   end
 
   def i_do_not_see_any_internal_draft_claims
     expect(page).to have_content("There are no claims for #{school.name}")
   end
 
-  def vist_claims_index_page
+  def visit_claims_index_page
     click_on "Claims"
   end
 


### PR DESCRIPTION
## Context

We added the groundwork to prevent schools from creating claims for academic years where they did not have any trained mentors in the register service. We now need to hook that policy up to the front end and related policies.

## Changes proposed in this pull request

- Add an eligibily check to claims policy
- Remove the "Add claim" button and render some text to explain why a school cannot create a claim when ineligible

## Guidance to review

- Log in as Anne
- See that you cannot create a claim
- Log out

- Log in as Colin
- Onboard Anne's school
- Log out

- Log in as Anne
- Confirm that you can now make a claim

## Link to Trello card

[Prevent schools from creating claims if they have not been onboarded for the current claim window
](https://trello.com/c/IJVgLOZM/555-prevent-schools-from-creating-claims-if-they-have-not-been-onboarded-for-the-current-claim-window)

## Screenshots

![image](https://github.com/user-attachments/assets/58d3051d-ac07-4d2d-b716-78677276012a)
