### PR TITLE
Find a school (clean)

### DIFF
--- a/app/components/placements/schools/interest_tag_component.html.erb
+++ b/app/components/placements/schools/interest_tag_component.html.erb
@@ -1,0 +1,3 @@
+<% if render_interest_tag? %>
+  <%= render GovukComponent::TagComponent.new(text: interest_text, colour: interest_colour) %>
+<% end %>

--- a/app/components/placements/schools/interest_tag_component.html.erb
+++ b/app/components/placements/schools/interest_tag_component.html.erb
@@ -1,3 +1,1 @@
-<% if render_interest_tag? %>
-  <%= render GovukComponent::TagComponent.new(text: interest_text, colour: interest_colour) %>
-<% end %>
+<%= render GovukComponent::TagComponent.new(text: interest_text, colour: interest_colour) %>

--- a/app/components/placements/schools/interest_tag_component.html.erb
+++ b/app/components/placements/schools/interest_tag_component.html.erb
@@ -1,1 +1,0 @@
-<%= render GovukComponent::TagComponent.new(text: interest_text, colour: interest_colour) %>

--- a/app/components/placements/schools/interest_tag_component.rb
+++ b/app/components/placements/schools/interest_tag_component.rb
@@ -23,6 +23,10 @@ class Placements::Schools::InterestTagComponent < ApplicationComponent
     @school = school
   end
 
+  def call
+    render GovukComponent::TagComponent.new(text: interest_text, colour: interest_colour)
+  end
+
   private
 
   attr_reader :school

--- a/app/components/placements/schools/interest_tag_component.rb
+++ b/app/components/placements/schools/interest_tag_component.rb
@@ -1,0 +1,68 @@
+class Placements::Schools::InterestTagComponent < ApplicationComponent
+  INTEREST_COLOURS = {
+    "open" => "yellow",
+    "unfilled_placements" => "green",
+    "filled_placements" => "blue",
+    "not_open" => "red",
+  }.freeze
+
+  INTEREST_TEXT = {
+    "open" => I18n.t("components.placements.schools.interest_tag_component.open"),
+    "unfilled_placements" => I18n.t("components.placements.schools.interest_tag_component.unfilled_placements"),
+    "filled_placements" => I18n.t("components.placements.schools.interest_tag_component.filled_placements"),
+    "not_open" => I18n.t("components.placements.schools.interest_tag_component.not_open"),
+  }.freeze
+
+  private_constant :INTEREST_COLOURS, :INTEREST_TEXT
+
+  def initialize(school:, classes: [], html_attributes: {})
+    super(classes:, html_attributes:)
+
+    @school = school
+  end
+
+  private
+
+  attr_reader :school
+
+  def interest_colour
+    INTEREST_COLOURS[calculated_status]
+  end
+
+  def interest_text
+    INTEREST_TEXT[calculated_status]
+  end
+
+  def calculated_status
+    case
+    when actively_looking? && only_has_unavailable_placements?
+      "filled_placements"
+    when actively_looking? && has_available_placements?
+      "unfilled_placements"
+    when actively_looking?
+      "open"
+    when not_looking?
+      "not_open"
+    end
+  end
+
+  def render_interest_tag?
+    school.current_hosting_interest_appetite.present?
+  end
+
+  def actively_looking?
+    school.current_hosting_interest_appetite == "actively_looking"
+  end
+
+  def not_looking?
+    school.current_hosting_interest_appetite == "not_open"
+  end
+
+  def only_has_unavailable_placements?
+    @only_has_unavailable_placements ||= school.unavailable_placements.exists? && school.available_placements.empty?
+  end
+
+  def has_available_placements?
+    @has_available_placements ||= school.available_placements.exists?
+  end
+end

--- a/app/components/placements/schools/interest_tag_component.rb
+++ b/app/components/placements/schools/interest_tag_component.rb
@@ -34,14 +34,13 @@ class Placements::Schools::InterestTagComponent < ApplicationComponent
   end
 
   def calculated_status
-    case
-    when actively_looking? && only_has_unavailable_placements?
+    if actively_looking? && only_has_unavailable_placements?
       "filled_placements"
-    when actively_looking? && has_available_placements?
+    elsif actively_looking? && has_available_placements?
       "unfilled_placements"
-    when actively_looking?
+    elsif actively_looking?
       "open"
-    when not_looking?
+    elsif not_looking?
       "not_open"
     end
   end

--- a/app/components/placements/schools/interest_tag_component.rb
+++ b/app/components/placements/schools/interest_tag_component.rb
@@ -4,6 +4,7 @@ class Placements::Schools::InterestTagComponent < ApplicationComponent
     "unfilled_placements" => "green",
     "filled_placements" => "blue",
     "not_open" => "red",
+    "not_participating" => "grey",
   }.freeze
 
   INTEREST_TEXT = {
@@ -11,6 +12,7 @@ class Placements::Schools::InterestTagComponent < ApplicationComponent
     "unfilled_placements" => I18n.t("components.placements.schools.interest_tag_component.unfilled_placements"),
     "filled_placements" => I18n.t("components.placements.schools.interest_tag_component.filled_placements"),
     "not_open" => I18n.t("components.placements.schools.interest_tag_component.not_open"),
+    "not_participating" => I18n.t("components.placements.schools.interest_tag_component.not_participating"),
   }.freeze
 
   private_constant :INTEREST_COLOURS, :INTEREST_TEXT
@@ -42,11 +44,9 @@ class Placements::Schools::InterestTagComponent < ApplicationComponent
       "open"
     elsif not_looking?
       "not_open"
+    else
+      "not_participating"
     end
-  end
-
-  def render_interest_tag?
-    school.current_hosting_interest_appetite.present?
   end
 
   def actively_looking?

--- a/app/components/placements/schools/summary_component.html.erb
+++ b/app/components/placements/schools/summary_component.html.erb
@@ -1,0 +1,154 @@
+<li class="app-search-results__item">
+  <h2 class="govuk-heading-m">
+    <% if !open_to_hosting? %>
+      <%= "#{school.name}, #{school.town}" %>
+    <% elsif (unfilled_subjects.exists? || filled_subjects.exists?) && open_to_hosting? %>
+      <%= govuk_link_to(placements_placements_provider_find_path(provider, school), no_visited_state: true) do %>
+        <%= "#{school.name}, #{school.town}" %>
+      <% end %>
+    <% else %>
+      <%= govuk_link_to(placement_information_placements_provider_find_path(provider, school), no_visited_state: true) do %>
+        <%= "#{school.name}, #{school.town}" %>
+      <% end %>
+    <% end %>
+  </h2>
+
+  <div class="app-result-detail">
+    <%= render Placements::Schools::InterestTagComponent.new(school:) %>
+  </div>
+
+  <dl class="app-result-detail">
+    <!-- School details -->
+    <div>
+      <h3 class="govuk-heading-s govuk-!-margin-bottom-2"><%= t(".school_details") %></h3>
+      <div class="app-result-detail__row">
+        <dt class="app-result-detail__key">
+          <%= t(".phase") %>
+        </dt>
+        <dd class="app-result-detail__value">
+          <%= school.phase %>
+        </dd>
+      </div>
+      <div class="app-result-detail__row">
+        <dt class="app-result-detail__key">
+          <%= t(".age_range") %>
+        </dt>
+        <dd class="app-result-detail__value">
+          <%= school.age_range %>
+        </dd>
+      </div>
+      <div class="app-result-detail__row">
+        <dt class="app-result-detail__key">
+          <%= t(".establishment_group") %>
+        </dt>
+        <dd class="app-result-detail__value">
+          <%= school.group %>
+        </dd>
+      </div>
+    </div>
+    <!-- End school details -->
+
+    <!-- Placement information -->
+    <div class="govuk-!-margin-top-2">
+      <h3 class="govuk-heading-s govuk-!-margin-bottom-2"><%= t(".placement_information") %></h3>
+      <% if not_open_to_hosting? %>
+        <div class="app-result-detail__row">
+          <dt class="app-result-detail__key">
+            <%= t(".placement_subjects") %>
+          </dt>
+          <dd class="app-result-detail__value">
+            <%= t(".not_open_to_hosting") %>
+          </dd>
+        </div>
+        <div class="app-result-detail__row">
+          <dt class="app-result-detail__key">
+            <%= t(".placement_status") %>
+          </dt>
+          <dd class="app-result-detail__value">
+            <%= t(".last_offered_count", count: previous_academic_year_placements_count, academic_year_name: Placements::AcademicYear.current.previous.name) %>
+          </dd>
+        </div>
+      <% else %>
+        <% unless school.current_hosting_interest_appetite == "actively_looking" && (school.unavailable_placements.empty? && school.available_placements.empty?) %>
+          <% unless school.current_hosting_interest_appetite == "actively_looking" && (school.unavailable_placements.exists? && school.available_placements.empty?) %>
+            <div class="app-result-detail__row">
+              <dt class="app-result-detail__key">
+                <%= t(".available_placements") %>
+              </dt>
+              <dd class="app-result-detail__value">
+                <%= govuk_link_to t(".available_placements_count", count: available_placements_count), placements_placements_provider_find_path(provider, school), no_visited_state: true %>
+              </dd>
+            </div>
+          <% end %>
+          <div class="app-result-detail__row">
+            <dt class="app-result-detail__key">
+              <%= t(".unavailable_placements") %>
+            </dt>
+            <dd class="app-result-detail__value">
+              <%= t(".unavailable_placements_count", count: unavailable_placements_count) %>
+            </dd>
+          </div>
+        <% end %>
+        <div class="app-result-detail__row">
+          <dt class="app-result-detail__key">
+            <%= t(".last_offered") %>
+          </dt>
+          <dd class="app-result-detail__value">
+            <%= t(".last_offered_count", count: previous_academic_year_placements_count, academic_year_name: Placements::AcademicYear.current.previous.name) %>
+          </dd>
+        </div>
+        <div class="app-result-detail__row">
+          <dt class="app-result-detail__key">
+            <%= t(".placement_contact") %>
+          </dt>
+          <dd class="app-result-detail__value">
+            <%= "#{school_contact_first_name} #{school_contact_last_name}" %>
+            <br>
+            <%= school_contact_email_address %>
+          </dd>
+        </div>
+      <% end %>
+    </div>
+    <!-- End placement information -->
+
+    <!-- Getting there -->
+    <% if location_coordinates.present? && !not_open_to_hosting? %>
+      <div class="govuk-!-margin-top-2">
+        <h3 class="govuk-heading-s govuk-!-margin-bottom-2"><%= t(".getting_there") %></h3>
+        <div class="app-result-detail__row">
+          <dt class="app-result-detail__key">
+            <%= t(".address") %>
+          </dt>
+          <dd class="app-result-detail__value">
+            <%= school.formatted_address %>
+          </dd>
+        </div>
+        <div class="app-result-detail__row">
+          <dt class="app-result-detail__key">
+            <%= t(".distance") %>
+          </dt>
+          <dd class="app-result-detail__value">
+            <%= distance_from_location %>
+          </dd>
+        </div>
+        <div class="app-result-detail__row">
+          <dt class="app-result-detail__key">
+            <%= t(".travel_time") %>
+          </dt>
+          <dd class="app-result-detail__value">
+            <%= t(".travel_time_information",
+                  transit_time: @school.formatted_duration("transit"),
+                  drive_time: @school.formatted_duration("drive"),
+                  walk_time: @school.formatted_duration("walk")) %>
+          </dd>
+        </div>
+      </div>
+    <% end %>
+    <!-- End getting there -->
+  </dl>
+  <div>
+    <% if not_open_to_hosting? %>
+      <%= govuk_warning_text text: t(".warning") %>
+    <% end %>
+  </div>
+</li>

--- a/app/components/placements/schools/summary_component.html.erb
+++ b/app/components/placements/schools/summary_component.html.erb
@@ -102,7 +102,7 @@
             <%= t(".placement_contact") %>
           </dt>
           <dd class="app-result-detail__value">
-            <%= "#{school_contact_first_name} #{school_contact_last_name}" %>
+            <%= school_contact_full_name %>
             <br>
             <%= school_contact_email_address %>
           </dd>

--- a/app/components/placements/schools/summary_component.rb
+++ b/app/components/placements/schools/summary_component.rb
@@ -1,0 +1,82 @@
+class Placements::Schools::SummaryComponent < ApplicationComponent
+  with_collection_parameter :school
+  attr_reader :school, :provider, :location_coordinates
+
+  delegate :school_contact, :current_hosting_interest_appetite, to: :school, allow_nil: true
+  delegate :first_name, :last_name, :email_address, to: :school_contact, prefix: true, allow_nil: true
+  delegate :available_placements, :unavailable_placements, to: :school, prefix: true, allow_nil: true
+
+  def initialize(school:, provider:, location_coordinates: nil, classes: [], html_attributes: {})
+    super(classes:, html_attributes:)
+
+    @provider = provider
+    @school = school.decorate
+    @location_coordinates = location_coordinates
+  end
+
+  def distance_from_location
+    distance = school.distance_to(location_coordinates).round(1)
+    I18n.t("components.placement.summary_component.distance_in_miles", distance:)
+  end
+
+  def available_placements_count
+    @available_placements_count ||= school_available_placements.count
+  end
+
+  def unavailable_placements_count
+    @unavailable_placements_count ||= school_unavailable_placements.count
+  end
+
+  def placement_status
+    I18n.t(
+      "components.school.summary_component.#{latest_academic_year_name ? "placements_hosted" : "placements_never_hosted"}",
+      academic_year_name: latest_academic_year_name,
+    )
+  end
+
+  def unfilled_subjects
+    @unfilled_subjects ||= Subject.where(id: unfilled_subject_ids)
+  end
+
+  def filled_subjects
+    @filled_subjects ||= Subject.where(id: filled_subject_ids)
+  end
+
+  def open_to_hosting?
+    current_hosting_interest_appetite == "actively_looking"
+  end
+
+  def not_open_to_hosting?
+    current_hosting_interest_appetite.blank? || current_hosting_interest_appetite == "not_open"
+  end
+
+  private
+
+  def latest_academic_year
+    @latest_academic_year ||= academic_years_for_school.order_by_date.first
+  end
+
+  def latest_academic_year_name
+    latest_academic_year&.name
+  end
+
+  def previous_academic_year_placements_count
+    @previous_academic_year_placements_count ||= school.placements.where(academic_year: Placements::AcademicYear.current.previous).count
+  end
+
+  def academic_years_for_school
+    Placements::AcademicYear.where(id: school.placements.pluck(:academic_year_id), ends_on: ..current_academic_year_start)
+  end
+
+  def current_academic_year_start
+    @current_academic_year_start ||= Placements::AcademicYear.current.starts_on
+  end
+
+  def unfilled_subject_ids
+    school.placements.where(academic_year_id: Placements::AcademicYear.current.id, provider_id: nil).pluck(:subject_id)
+  end
+
+  def filled_subject_ids
+    school.placements.where(academic_year_id: Placements::AcademicYear.current.id).where.not(provider_id: nil).pluck(:subject_id)
+  end
+end

--- a/app/components/placements/schools/summary_component.rb
+++ b/app/components/placements/schools/summary_component.rb
@@ -27,13 +27,6 @@ class Placements::Schools::SummaryComponent < ApplicationComponent
     @unavailable_placements_count ||= school_unavailable_placements.count
   end
 
-  def placement_status
-    I18n.t(
-      "components.school.summary_component.#{latest_academic_year_name ? "placements_hosted" : "placements_never_hosted"}",
-      academic_year_name: latest_academic_year_name,
-    )
-  end
-
   def unfilled_subjects
     @unfilled_subjects ||= Subject.where(id: unfilled_subject_ids)
   end
@@ -52,24 +45,8 @@ class Placements::Schools::SummaryComponent < ApplicationComponent
 
   private
 
-  def latest_academic_year
-    @latest_academic_year ||= academic_years_for_school.order_by_date.first
-  end
-
-  def latest_academic_year_name
-    latest_academic_year&.name
-  end
-
   def previous_academic_year_placements_count
     @previous_academic_year_placements_count ||= school.placements.where(academic_year: Placements::AcademicYear.current.previous).count
-  end
-
-  def academic_years_for_school
-    Placements::AcademicYear.where(id: school.placements.pluck(:academic_year_id), ends_on: ..current_academic_year_start)
-  end
-
-  def current_academic_year_start
-    @current_academic_year_start ||= Placements::AcademicYear.current.starts_on
   end
 
   def unfilled_subject_ids

--- a/app/components/placements/schools/summary_component.rb
+++ b/app/components/placements/schools/summary_component.rb
@@ -3,7 +3,7 @@ class Placements::Schools::SummaryComponent < ApplicationComponent
   attr_reader :school, :provider, :location_coordinates
 
   delegate :school_contact, :current_hosting_interest_appetite, to: :school, allow_nil: true
-  delegate :first_name, :last_name, :email_address, to: :school_contact, prefix: true, allow_nil: true
+  delegate :full_name, :email_address, to: :school_contact, prefix: true, allow_nil: true
   delegate :available_placements, :unavailable_placements, to: :school, prefix: true, allow_nil: true
 
   def initialize(school:, provider:, location_coordinates: nil, classes: [], html_attributes: {})

--- a/app/controllers/placements/providers/find_controller.rb
+++ b/app/controllers/placements/providers/find_controller.rb
@@ -1,6 +1,5 @@
 class Placements::Providers::FindController < Placements::ApplicationController
   before_action :set_provider
-  before_action :school, only: %i[placements placement_information school_details]
   before_action :load_placements_and_subjects, only: %i[placements placement_information school_details]
   helper_method :filter_form, :location_coordinates
 
@@ -26,8 +25,8 @@ class Placements::Providers::FindController < Placements::ApplicationController
   end
 
   def load_placements_and_subjects
-    @filled_placements = filled_placements(@school).decorate
-    @unfilled_placements = unfilled_placements(@school).decorate
+    @filled_placements = filled_placements(school).decorate
+    @unfilled_placements = unfilled_placements(school).decorate
     @filled_subjects = subjects_for_placements(@filled_placements)
     @unfilled_subjects = subjects_for_placements(@unfilled_placements)
   end
@@ -108,7 +107,7 @@ class Placements::Providers::FindController < Placements::ApplicationController
   end
 
   def placements_last_offered
-    @school.placements
+    school.placements
            .where(academic_year: Placements::AcademicYear.current.previous)
            .decorate
            .includes(:academic_year)

--- a/app/controllers/placements/providers/find_controller.rb
+++ b/app/controllers/placements/providers/find_controller.rb
@@ -1,0 +1,111 @@
+class Placements::Providers::FindController < Placements::ApplicationController
+  before_action :set_provider
+  helper_method :filter_form, :location_coordinates
+
+  def index
+    @subjects = filter_subjects_by_phase
+    query = Placements::SchoolsQuery.call(params: query_params)
+    @pagy, @schools = pagy(all_schools.merge(query).distinct)
+    calculate_travel_time
+  end
+
+  def show
+    @school = find_school
+  end
+
+  def placements
+    @school = find_school
+    @unfilled_placements = unfilled_placements(@school).decorate
+    @filled_placements = filled_placements(@school).decorate
+  end
+
+  def placement_information
+    @school = find_school
+    @placements_last_offered = @school.placements.where(academic_year: Placements::AcademicYear.current.previous).decorate
+    @unfilled_placements = unfilled_placements(@school)
+    @unfilled_subjects = subjects_for_placements(@unfilled_placements)
+    @filled_subjects = subjects_for_placements(filled_placements(@school))
+  end
+
+  def school_details
+    @school = find_school.decorate
+    @unfilled_placements = unfilled_placements(@school)
+    @unfilled_subjects = subjects_for_placements(@unfilled_placements)
+    @filled_subjects = subjects_for_placements(filled_placements(@school))
+  end
+
+  private
+
+  def find_school
+    Placements::School.find(params[:id])
+  end
+
+  def calculate_travel_time
+    return if search_location.blank?
+
+    Placements::TravelTime.call(
+      origin_address: search_location,
+      destinations: @schools.uniq,
+    )
+  end
+
+  def filter_form
+    @filter_form ||= Placements::Schools::FilterForm.new(@provider, filter_params)
+  end
+
+  def location_coordinates
+    return if search_location.blank?
+
+    @location_coordinates ||= Geocoder::Search.call(search_location).coordinates
+  end
+
+  def unfilled_placements(school)
+    school.placements.where(academic_year_id: Placements::AcademicYear.current.id, provider_id: nil).distinct
+  end
+
+  def filled_placements(school)
+    school.placements.where(academic_year_id: Placements::AcademicYear.current.id).where.not(provider_id: nil).distinct
+  end
+
+  def subjects_for_placements(placements)
+    Subject.where(id: placements.pluck(:subject_id))
+  end
+
+  def search_location
+    @search_location ||= params[:search_location] || params.dig(:filters, :search_location)
+  end
+
+  def filter_params
+    params.fetch(:filters, {}).permit(
+      :search_location,
+      :search_by_name,
+      subject_ids: [],
+      phases: [],
+      itt_statuses: [],
+      last_offered_placements_academic_year_ids: [],
+      trained_mentors: [],
+    )
+  end
+
+  def query_params
+    {
+      filters: filter_form.query_params,
+      location_coordinates: location_coordinates,
+      current_provider: @provider,
+    }
+  end
+
+  def all_schools
+    @all_schools ||= Placements::School.all
+  end
+
+  def filter_subjects_by_phase
+    if filter_form.primary_only?
+      Subject.primary
+    elsif filter_form.secondary_only?
+      Subject.secondary
+    else
+      Subject
+    end.order_by_name.select(:id, :name)
+  end
+end

--- a/app/forms/placements/schools/filter_form.rb
+++ b/app/forms/placements/schools/filter_form.rb
@@ -1,0 +1,76 @@
+class Placements::Schools::FilterForm < ApplicationForm
+  include ActiveModel::Attributes
+
+  attribute :subject_ids, default: []
+  attribute :search_location, default: nil
+  attribute :search_by_name, default: nil
+  attribute :phases, default: []
+  attribute :itt_statuses, default: []
+  attribute :last_offered_placements_academic_year_ids, default: []
+
+  def initialize(provider, params = {})
+    @provider = provider
+    params.each_value { |v| v.compact_blank! if v.is_a?(Array) }
+
+    super(params)
+  end
+
+  def filters_selected?
+    attributes
+      .values
+      .compact
+      .flatten
+      .select(&:present?)
+      .any?
+  end
+
+  def clear_filters_path
+    placements_provider_find_index_path(@provider)
+  end
+
+  def index_path_without_filter(filter:, value: nil)
+    without_filter = if SINGULAR_ATTRIBUTES.include?(filter)
+                       compacted_attributes.reject { |key, _| key == filter }
+                     else
+                       compacted_attributes.merge(filter => compacted_attributes[filter].reject { |filter_value| filter_value == value })
+                     end
+
+    placements_provider_find_index_path(
+      @provider,
+      params: { filters: without_filter },
+    )
+  end
+
+  def query_params
+    {
+      subject_ids:,
+      search_location:,
+      search_by_name:,
+      phases:,
+      itt_statuses:,
+      last_offered_placements_academic_year_ids:,
+    }
+  end
+
+  def subjects
+    @subjects ||= Subject.where(id: subject_ids).order_by_name
+  end
+
+  def last_offered_placements_academic_years
+    Placements::AcademicYear.where(id: last_offered_placements_academic_year_ids)
+  end
+
+  def last_offered_placement_options
+    Placements::AcademicYear.where(id: Placement.distinct.pluck(:academic_year_id))
+                            .where("ends_on <= ?", Placements::AcademicYear.current.starts_on)
+                            .order_by_date.pluck(:name, :id) << ["No recent placements", "never_offered"]
+  end
+
+  private
+
+  SINGULAR_ATTRIBUTES = %w[search_location search_by_name].freeze
+
+  def compacted_attributes
+    @compacted_attributes ||= attributes.compact_blank
+  end
+end

--- a/app/forms/placements/schools/filter_form.rb
+++ b/app/forms/placements/schools/filter_form.rb
@@ -66,6 +66,22 @@ class Placements::Schools::FilterForm < ApplicationForm
                             .order_by_date.pluck(:name, :id) << ["No recent placements", "never_offered"]
   end
 
+  def primary_selected?
+    phases.include?("Primary")
+  end
+
+  def secondary_selected?
+    phases.include?("Secondary")
+  end
+
+  def primary_only?
+    primary_selected? && !secondary_selected?
+  end
+
+  def secondary_only?
+    !primary_selected? && secondary_selected?
+  end
+
   private
 
   SINGULAR_ATTRIBUTES = %w[search_location search_by_name].freeze

--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -60,6 +60,8 @@ class Placement < ApplicationRecord
   delegate :has_child_subjects?, to: :subject, allow_nil: true, prefix: true
 
   scope :order_by_subject_school_name, -> { includes(:subject, :school).order("subjects.name", "schools.name") }
+  scope :available_placements, ->(school) { where(school:, provider: nil, academic_year: Placements::AcademicYear.current) }
+  scope :unavailable_placements, ->(school) { where(school:, academic_year: Placements::AcademicYear.current).where.not(provider: nil) }
 
   # This method is used to order placement, after the schools have been ordered by distance.
   # As distance is not an attribute of school, and is given to us by the Geocoder gem.

--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -60,8 +60,8 @@ class Placement < ApplicationRecord
   delegate :has_child_subjects?, to: :subject, allow_nil: true, prefix: true
 
   scope :order_by_subject_school_name, -> { includes(:subject, :school).order("subjects.name", "schools.name") }
-  scope :available_placements, ->(school) { where(school:, provider: nil, academic_year: Placements::AcademicYear.current) }
-  scope :unavailable_placements, ->(school) { where(school:, academic_year: Placements::AcademicYear.current).where.not(provider: nil) }
+  scope :available_placements_for_academic_year, ->(academic_year) { where(provider: nil, academic_year:) }
+  scope :unavailable_placements_for_academic_year, ->(academic_year) { where(academic_year:).where.not(provider: nil) }
 
   # This method is used to order placement, after the schools have been ordered by distance.
   # As distance is not an attribute of school, and is given to us by the Geocoder gem.

--- a/app/models/placements/school.rb
+++ b/app/models/placements/school.rb
@@ -76,6 +76,7 @@ class Placements::School < School
   has_many :mentor_memberships
   has_many :mentors, through: :mentor_memberships
   has_many :placements
+  has_many :academic_years, through: :placements
 
   has_many :partnerships, dependent: :destroy
   has_many :partner_providers,

--- a/app/models/placements/school.rb
+++ b/app/models/placements/school.rb
@@ -84,7 +84,7 @@ class Placements::School < School
            source: :provider
   has_many :hosting_interests
 
-  delegate :email_address, to: :school_contact, prefix: true, allow_nil: true
+  delegate :email_address, :full_name, to: :school_contact, prefix: true, allow_nil: true
   delegate :appetite, to: :current_hosting_interest, prefix: true, allow_nil: true
 
   def current_hosting_interest

--- a/app/models/placements/school.rb
+++ b/app/models/placements/school.rb
@@ -87,15 +87,15 @@ class Placements::School < School
   delegate :email_address, :full_name, to: :school_contact, prefix: true, allow_nil: true
   delegate :appetite, to: :current_hosting_interest, prefix: true, allow_nil: true
 
-  def current_hosting_interest
-    hosting_interests.find_by(academic_year: Placements::AcademicYear.current)
+  def current_hosting_interest(academic_year: Placements::AcademicYear.current)
+    hosting_interests.find_by(academic_year:)
   end
 
-  def available_placements
-    Placement.available_placements(self)
+  def available_placements(academic_year: Placements::AcademicYear.current)
+    placements.available_placements_for_academic_year(academic_year)
   end
 
-  def unavailable_placements
-    Placement.unavailable_placements(self)
+  def unavailable_placements(academic_year: Placements::AcademicYear.current)
+    placements.unavailable_placements_for_academic_year(academic_year)
   end
 end

--- a/app/models/placements/school.rb
+++ b/app/models/placements/school.rb
@@ -84,4 +84,17 @@ class Placements::School < School
   has_many :hosting_interests
 
   delegate :email_address, to: :school_contact, prefix: true, allow_nil: true
+  delegate :appetite, to: :current_hosting_interest, prefix: true, allow_nil: true
+
+  def current_hosting_interest
+    hosting_interests.find_by(academic_year: Placements::AcademicYear.current)
+  end
+
+  def available_placements
+    Placement.available_placements(self)
+  end
+
+  def unavailable_placements
+    Placement.unavailable_placements(self)
+  end
 end

--- a/app/models/placements/school_contact.rb
+++ b/app/models/placements/school_contact.rb
@@ -35,4 +35,14 @@ class Placements::SchoolContact < ApplicationRecord
             "activerecord.errors.models.placements/school_contact.can_not_be_destroyed",
           )
   end
+
+  def full_name
+    if first_name.present? && last_name.present?
+      "#{first_name} #{last_name}"
+    elsif first_name.present?
+      first_name
+    elsif last_name.present?
+      last_name
+    end
+  end
 end

--- a/app/models/placements/school_contact.rb
+++ b/app/models/placements/school_contact.rb
@@ -37,12 +37,6 @@ class Placements::SchoolContact < ApplicationRecord
   end
 
   def full_name
-    if first_name.present? && last_name.present?
-      "#{first_name} #{last_name}"
-    elsif first_name.present?
-      first_name
-    elsif last_name.present?
-      last_name
-    end
+    "#{first_name} #{last_name}".strip
   end
 end

--- a/app/queries/placements/schools_query.rb
+++ b/app/queries/placements/schools_query.rb
@@ -1,0 +1,106 @@
+class Placements::SchoolsQuery < ApplicationQuery
+  MAX_LOCATION_DISTANCE = 50
+
+  def call
+    scope = Placements::School.left_outer_joins(:hosting_interests, :academic_years, :placements, :mentors)
+
+    scope = search_by_name_condition(scope)
+    scope = subject_condition(scope)
+    scope = phase_condition(scope)
+    scope = last_offered_placements_condition(scope)
+    scope = trained_mentors_condition(scope)
+    scope = itt_statuses_condition(scope)
+    order_condition(scope)
+  end
+
+  private
+
+  def search_by_name_condition(scope)
+    return scope if filter_params[:search_by_name].blank?
+
+    scope.where("schools.name ILIKE ?", "%#{filter_params[:search_by_name]}%")
+         .or(scope.where("urn ILIKE ?", "%#{filter_params[:search_by_name]}%"))
+  end
+
+  def subject_condition(scope)
+    return scope if filter_params[:subject_ids].blank?
+
+    scope.left_outer_joins(placements: :additional_subjects)
+         .where(placements: { subject_id: filter_params[:subject_ids] })
+         .or(
+           scope.left_outer_joins(placements: :additional_subjects)
+                .where(additional_subjects: { id: filter_params[:subject_ids] }),
+         )
+  end
+
+  def itt_statuses_condition(scope)
+    hosting_interests = filter_params[:itt_statuses]
+    return scope if hosting_interests.blank?
+
+    conditions = []
+
+    if hosting_interests.include?("open")
+      conditions << scope.where(hosting_interests: { appetite: "actively_looking" }).excluding(scope.where(placements: { academic_year_id: Placements::AcademicYear.current.id }))
+    end
+
+    if hosting_interests.include?("not_open")
+      conditions << scope.where(hosting_interests: { appetite: "not_open" })
+    end
+
+    if hosting_interests.include?("unfilled_placements")
+      conditions << scope.where(hosting_interests: { appetite: "actively_looking" }, placements: { academic_year_id: Placements::AcademicYear.current.id, provider: nil })
+    end
+
+    if hosting_interests.include?("filled_placements")
+      conditions << scope.where(hosting_interests: { appetite: "actively_looking" }, placements: { academic_year_id: Placements::AcademicYear.current.id }).excluding(scope.where(placements: { provider: nil }))
+    end
+
+    conditions.reduce(scope.none) { |combined_scope, condition| combined_scope.or(condition) }
+  end
+
+  def phase_condition(scope)
+    return scope if filter_params[:phases].blank?
+
+    scope.where(phase: filter_params[:phases])
+  end
+
+  def last_offered_placements_condition(scope)
+    return scope if filter_params[:last_offered_placements_academic_year_ids].blank?
+
+    if filter_params[:last_offered_placements_academic_year_ids].include?("never_offered")
+      scope.where.missing(:academic_years)
+    else
+      scope.where(academic_years: filter_params[:last_offered_placements_academic_year_ids])
+    end
+  end
+
+  def trained_mentors_condition(scope)
+    return scope if filter_params[:trained_mentors].blank?
+
+    scope.where(mentors: { trained: filter_params[:trained_mentors] })
+  end
+
+  def filter_params
+    @filter_params ||= params.fetch(:filters, {})
+  end
+
+  def school_ids_near_location(location_coordinates)
+    School.near(
+      location_coordinates,
+      MAX_LOCATION_DISTANCE,
+      order: :distance,
+    ).map(&:id)
+  end
+
+  def order_condition(scope)
+    if params[:location_coordinates].present?
+      school_ids = school_ids_near_location(
+        params[:location_coordinates],
+      )
+
+      scope.where(id: school_ids).order(:name)
+    else
+      scope.order(:name)
+    end
+  end
+end

--- a/app/queries/placements/schools_query.rb
+++ b/app/queries/placements/schools_query.rb
@@ -8,7 +8,6 @@ class Placements::SchoolsQuery < ApplicationQuery
     scope = subject_condition(scope)
     scope = phase_condition(scope)
     scope = last_offered_placements_condition(scope)
-    scope = trained_mentors_condition(scope)
     scope = itt_statuses_condition(scope)
     order_condition(scope)
   end
@@ -77,12 +76,6 @@ class Placements::SchoolsQuery < ApplicationQuery
     else
       scope.where(academic_years: filter_params[:last_offered_placements_academic_year_ids])
     end
-  end
-
-  def trained_mentors_condition(scope)
-    return scope if filter_params[:trained_mentors].blank?
-
-    scope.where(mentors: { trained: filter_params[:trained_mentors] })
   end
 
   def filter_params

--- a/app/queries/placements/schools_query.rb
+++ b/app/queries/placements/schools_query.rb
@@ -69,6 +69,11 @@ class Placements::SchoolsQuery < ApplicationQuery
 
     if filter_params[:last_offered_placements_academic_year_ids].include?("never_offered")
       scope.where.missing(:academic_years)
+           .or(
+             scope.where(
+               academic_years: filter_params[:last_offered_placements_academic_year_ids] - %w[never_offered],
+             ),
+           )
     else
       scope.where(academic_years: filter_params[:last_offered_placements_academic_year_ids])
     end

--- a/app/views/placements/providers/_primary_navigation.html.erb
+++ b/app/views/placements/providers/_primary_navigation.html.erb
@@ -6,6 +6,7 @@
 
 <%= content_for(:primary_navigation_content) do %>
   <%= render PrimaryNavigationComponent.new do |component| %>
+    <% component.with_navigation_item t(".find"), placements_provider_find_index_path(provider), current: current_navigation == :find %>
     <% component.with_navigation_item t(".placements"), placements_provider_placements_path(provider), current: current_navigation == :placements %>
     <% component.with_navigation_item t(".schools"), placements_provider_partner_schools_path(provider), current: current_navigation == :partner_schools %>
     <% component.with_navigation_item t(".users"), placements_provider_users_path(provider), current: current_navigation == :users %>

--- a/app/views/placements/providers/find/_details_navigation.html.erb
+++ b/app/views/placements/providers/find/_details_navigation.html.erb
@@ -1,0 +1,20 @@
+<%# locals: (school:, provider:, unfilled_subjects:, filled_subjects: -%>
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: placements_provider_find_index_path(provider)) %>
+<% end %>
+
+<h1 class="govuk-heading-l">
+  <%= school.name %>
+</h1>
+
+<%= render Placements::Schools::InterestTagComponent.new(school:) %>
+
+<div class="govuk-!-margin-bottom-2"></div>
+
+<%= render SecondaryNavigationComponent.new do |component| %>
+  <% if (unfilled_subjects.any? || filled_subjects.any?) && school.current_hosting_interest.appetite == "actively_looking" %>
+    <% component.with_navigation_item t(".placements"), placements_placements_provider_find_path %>
+  <% end %>
+  <% component.with_navigation_item t(".placement_information"), placement_information_placements_provider_find_path %>
+  <% component.with_navigation_item t(".school_details"), school_details_placements_provider_find_path %>
+<% end %>

--- a/app/views/placements/providers/find/_filter.html.erb
+++ b/app/views/placements/providers/find/_filter.html.erb
@@ -1,0 +1,247 @@
+<div class="app-filter-layout display-none-on-mobile " data-filter-target="filter">
+  <div class="app-filter-layout__filter">
+    <div class="app-filter__header">
+      <div class="app-filter__header-title">
+        <h2 class="govuk-heading-m"><%= t("filter") %></h2>
+      </div>
+      <div class="app-filter__header-action">
+        <button class="app-filter__close" type="button" data-action="click->filter#close">
+          <%= t("close") %>
+        </button>
+      </div>
+    </div>
+    <div class="app-filter-layout__content">
+      <% if filter_form.filters_selected? %>
+        <div class="app-filter-layout__selected">
+          <div class="app-filter__selected-heading">
+            <div class="app-filter__heading-title">
+              <h2 class="govuk-heading-m govuk-!-margin-bottom-1"><%= t("selected_filters") %></h2>
+              <p class="govuk-body">
+                <%= govuk_link_to(
+                      t("clear_filters"),
+                      filter_form.clear_filters_path,
+                      no_visited_state: true,
+                    ) %>
+              </p>
+            </div>
+          </div>
+
+          <% if @search_location.present? %>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".search_location") %></h3>
+            <ul class="app-filter-tags">
+              <li>
+                <%= govuk_link_to(
+                      @search_location,
+                      filter_form.index_path_without_filter(
+                        filter: "search_location",
+                        value: @search_location,
+                      ),
+                      class: "app-filter__tag",
+                      no_visited_state: true,
+                    ) %>
+              </li>
+            </ul>
+          <% end %>
+
+          <% if filter_form.search_by_name.present? %>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".search_by_name") %></h3>
+            <ul class="app-filter-tags">
+              <li>
+                <%= govuk_link_to(
+                      filter_form.search_by_name,
+                      filter_form.index_path_without_filter(
+                        filter: "search_by_name",
+                        value: filter_form.search_by_name,
+                      ),
+                      class: "app-filter__tag",
+                      no_visited_state: true,
+                    ) %>
+              </li>
+            </ul>
+          <% end %>
+
+          <% if filter_form.phases.present? %>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".phase") %></h3>
+            <ul class="app-filter-tags">
+              <% filter_form.phases.each do |phase| %>
+                <li>
+                  <%= govuk_link_to(
+                        phase,
+                        filter_form.index_path_without_filter(
+                          filter: "phases",
+                          value: phase,
+                        ),
+                        class: "app-filter__tag",
+                        no_visited_state: true,
+                      ) %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+
+          <% if filter_form.itt_statuses.present? %>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".itt_status") %></h3>
+            <ul class="app-filter-tags">
+              <% filter_form.itt_statuses.each do |status| %>
+                <li>
+                  <%= govuk_link_to(
+                        t("components.placements.schools.interest_tag_component.#{status}"),
+                        filter_form.index_path_without_filter(
+                          filter: "itt_statuses",
+                          value: status,
+                        ),
+                        class: "app-filter__tag",
+                        no_visited_state: true,
+                      ) %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+
+          <% if filter_form.last_offered_placements_academic_year_ids.present? %>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".last_offered_placements") %></h3>
+            <ul class="app-filter-tags">
+              <% if filter_form.last_offered_placements_academic_year_ids.include?("never_offered") %>
+                <li>
+                  <%= govuk_link_to(
+                        t(".not_offered_placements_label"),
+                        filter_form.index_path_without_filter(
+                          filter: "last_offered_placements_academic_year_ids",
+                          value: "never_offered",
+                        ),
+                        class: "app-filter__tag",
+                        no_visited_state: true,
+                      ) %>
+                </li>
+              <% end %>
+              <% filter_form.last_offered_placements_academic_years.each do |academic_year_offered| %>
+                <li>
+                  <%= govuk_link_to(
+                        academic_year_offered.name,
+                        filter_form.index_path_without_filter(
+                          filter: "last_offered_placements_academic_year_ids",
+                          value: academic_year_offered.id,
+                        ),
+                        class: "app-filter__tag",
+                        no_visited_state: true,
+                      ) %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+
+          <% if filter_form.subject_ids.present? %>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".subject") %></h3>
+            <ul class="app-filter-tags">
+              <% filter_form.subjects.each do |subject| %>
+                <li>
+                  <%= govuk_link_to(
+                        subject.name,
+                        filter_form.index_path_without_filter(
+                          filter: "subject_ids",
+                          value: subject.id,
+                        ),
+                        class: "app-filter__tag",
+                        no_visited_state: true,
+                      ) %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+        </div>
+      <% end %>
+
+      <div class="app-filter__options">
+        <%= form_with(
+              model: filter_form,
+              scope: :filters,
+              url: placements_provider_find_index_path(@provider),
+              method: "get",
+            ) do |form| %>
+          <%= form.govuk_submit t("apply_filters") %>
+
+          <div class="app-filter__option">
+            <h1 class="govuk-label-wrapper">
+              <label class="govuk-label govuk-label--s"><%= t(".search_by_location") %></label>
+            </h1>
+
+            <div class="app-filter__option">
+              <div class="govuk-form-group">
+                <%= form.govuk_text_field :search_location, type: :search, value: search_location, label: { hidden: true }, caption: { text: t(".location_search_prompt") } %>
+                <p class="govuk-body-s secondary-text"><%= t(".google_attribution") %></p>
+              </div>
+            </div>
+          </div>
+
+          <div class="app-filter__option">
+            <h1 class="govuk-label-wrapper">
+              <label class="govuk-label govuk-label--s"><%= t(".search_by_name") %></label>
+            </h1>
+
+            <div class="app-filter__option">
+              <div class="govuk-form-group">
+                <%= form.govuk_text_field :search_by_name, type: :search, label: { hidden: true }, caption: { text: t(".search_by_name_prompt") } %>
+              </div>
+            </div>
+          </div>
+
+          <div class="app-filter__option">
+            <%= form.govuk_check_boxes_fieldset(
+              :phases,
+              legend: { text: t(".phase"), size: "s" },
+              small: true,
+              multiple: true,
+            ) do %>
+              <% School.distinct.pluck(:phase).each do |phase| %>
+                <%= form.govuk_check_box :phases, phase, label: { text: phase } %>
+              <% end %>
+            <% end %>
+          </div>
+
+          <div class="app-filter__option">
+            <%= form.govuk_check_boxes_fieldset(
+              :itt_statuses,
+              legend: { text: t(".itt_status"), size: "s" },
+              small: true,
+              multiple: true,
+            ) do %>
+              <% %w[open not_open filled_placements unfilled_placements].each do |appetite| %>
+                <%= form.govuk_check_box :itt_statuses, appetite, label: { text: t("components.placements.schools.interest_tag_component.#{appetite}") } %>
+              <% end %>
+            <% end %>
+          </div>
+
+          <div class="app-filter__option">
+            <%= form.govuk_check_boxes_fieldset(
+              :itt_statuses,
+              legend: { text: t(".last_offered_placements"), size: "s" },
+              small: true,
+              multiple: true,
+            ) do %>
+              <% filter_form.last_offered_placement_options.each do |name, value| %>
+                <%= form.govuk_check_box :last_offered_placements_academic_year_ids, value, label: { text: name } %>
+              <% end %>
+            <% end %>
+          </div>
+
+          <div class="app-filter__option" data-controller="filter-search">
+            <%= form.govuk_check_boxes_fieldset(
+              :subject_ids,
+              legend: {
+                text: t(".subject"),
+                size: "s",
+              },
+              small: true,
+            ) do %>
+              <% @subjects.each do |subject| %>
+                <%= form.govuk_check_box :subject_ids,
+                                         subject.id,
+                                         label: { text: subject.name } %>
+              <% end %>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/placements/providers/find/index.html.erb
+++ b/app/views/placements/providers/find/index.html.erb
@@ -1,0 +1,36 @@
+<% content_for(:page_title) { t(".find_placements") } %>
+<%= render "placements/providers/primary_navigation", provider: @provider, current_navigation: :find %>
+
+<div class="govuk-width-container" data-controller="filter">
+  <h1 class="govuk-heading-l">
+    <%= t(".find_placements") %>
+  </h1>
+  <div>
+    <button class="govuk-button govuk-button--secondary show-filter-button" type="button" data-action="click->filter#open">
+      <%= t("show_filter") %>
+    </button>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-third">
+      <%= render partial: "placements/providers/find/filter", locals: { search_location: @search_location } %>
+    </div>
+
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-m">
+        <%= t(".schools_found", count: @pagy.count) %>
+      </h2>
+
+      <% if @schools.any? %>
+        <p class="govuk-hint"><%= @search_location.blank? ? t(".results_sorted_alpha") : t(".results_sorted_distance", search_location: @search_location) %></p>
+        <ul class="app-search-results">
+          <%= render(Placements::Schools::SummaryComponent.with_collection(@schools, provider: @provider, location_coordinates:)) %>
+        </ul>
+        <%= render PaginationComponent.new(pagy: @pagy) %>
+      <% else %>
+        <p>
+          <%= t(".no_results") %>
+        </p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/placements/providers/find/placement_information.html.erb
+++ b/app/views/placements/providers/find/placement_information.html.erb
@@ -1,0 +1,49 @@
+<% content_for(:page_title) { t(".page_title", school_name: @school.name) } %>
+<%= render "placements/providers/primary_navigation", provider: @provider, current_navigation: :find %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "placements/providers/find/details_navigation", school: @school, provider: @provider, unfilled_subjects: @unfilled_subjects, filled_subjects: @filled_subjects %>
+
+      <h2 class="govuk-heading-m">
+        <%= t(".placement_contact") %>
+      </h2>
+
+      <%= govuk_summary_list(actions: false) do |summary_list| %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".name")) %>
+          <% row.with_value(text: @school.school_contact_full_name.to_s) %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".email")) %>
+          <% row.with_value(text: @school.school_contact_email_address) %>
+        <% end %>
+      <% end %>
+
+      <h2 class="govuk-heading-m">
+        <%= t(".placements_hosted_in_previous_years") %>
+      </h2>
+
+      <% if @placements_last_offered.any? %>
+        <%= govuk_summary_list(actions: false) do |summary_list| %>
+          <% @placements_last_offered.each do |academic_year, placements| %>
+            <% summary_list.with_row do |row| %>
+              <% row.with_key(text: academic_year.name) %>
+              <% row.with_value do %>
+                  <p class="govuk-body"><%= t(".offered_placements_in") %></p>
+                  <ul class="govuk-list">
+                    <% placements.each do |placement| %>
+                      <li><%= placement.title %></li>
+                    <% end %>
+                  </ul>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% else %>
+        <p class="govuk-body"><%= t(".unknown") %></p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/placements/providers/find/placements.html.erb
+++ b/app/views/placements/providers/find/placements.html.erb
@@ -7,7 +7,7 @@
       <%= render "placements/providers/find/details_navigation", school: @school, provider: @provider, unfilled_subjects: @unfilled_subjects, filled_subjects: @filled_subjects %>
 
       <p class="govuk-body">
-        <%= t(".description") %>
+        <%= t(".description", academic_year_name: Placements::AcademicYear.current.name) %>
       </p>
 
       <% if @unfilled_placements.present? %>

--- a/app/views/placements/providers/find/placements.html.erb
+++ b/app/views/placements/providers/find/placements.html.erb
@@ -1,0 +1,64 @@
+<% content_for(:page_title) { t(".page_title", school_name: @school.name) } %>
+<%= render "placements/providers/primary_navigation", provider: @provider, current_navigation: :find %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "placements/providers/find/details_navigation", school: @school, provider: @provider, unfilled_subjects: @unfilled_subjects, filled_subjects: @filled_subjects %>
+
+      <p class="govuk-body">
+        <%= t(".description") %>
+      </p>
+
+      <% if @unfilled_placements.present? %>
+        <h2 class="govuk-heading-m">
+          <%= t(".unfilled_placements", count: @unfilled_placements.count) %>
+        </h2>
+
+        <%= govuk_table do |table| %>
+          <% table.with_head do |head| %>
+            <% head.with_row do |row| %>
+              <% row.with_cell text: t(".table.headers.subject") %>
+              <% row.with_cell text: t(".table.headers.expected_date") %>
+            <% end %>
+          <% end %>
+
+          <% @unfilled_placements.each do |placement| %>
+            <% table.with_body do |body| %>
+              <% body.with_row do |row| %>
+                <% row.with_cell do %>
+                  <%= govuk_link_to placement.title, placements_provider_placement_path(@provider, placement) %>
+                <% end %>
+                <% row.with_cell text: placement.term_names %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <% if @filled_placements.present? %>
+        <h2 class="govuk-heading-m">
+          <%= t(".filled_placements", count: @filled_placements.count) %>
+        </h2>
+
+        <%= govuk_table do |table| %>
+          <% table.with_head do |head| %>
+            <% head.with_row do |row| %>
+              <% row.with_cell text: t(".table.headers.subject") %>
+              <% row.with_cell text: t(".table.headers.expected_date") %>
+            <% end %>
+          <% end %>
+
+          <% @filled_placements.each do |placement| %>
+            <% table.with_body do |body| %>
+              <% body.with_row do |row| %>
+                <% row.with_cell text: placement.title %>
+                <% row.with_cell text: placement.term_names %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/placements/providers/find/school_details.html.erb
+++ b/app/views/placements/providers/find/school_details.html.erb
@@ -38,8 +38,8 @@
 
       <%= govuk_summary_list(actions: false) do |summary_list| %>
         <% summary_list.with_row do |row| %>
-          <% row.with_key(text: t(".telephone") || t(".unknown")) %>
-          <% row.with_value(text: @school.telephone) %>
+          <% row.with_key(text: t(".telephone")) %>
+          <% row.with_value(text: @school.telephone) || t(".unknown") %>
         <% end %>
 
         <% summary_list.with_row do |row| %>

--- a/app/views/placements/providers/find/school_details.html.erb
+++ b/app/views/placements/providers/find/school_details.html.erb
@@ -1,0 +1,152 @@
+<% content_for(:page_title) { t(".page_title", school_name: @school.name) } %>
+<%= render "placements/providers/primary_navigation", provider: @provider, current_navigation: :find %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "placements/providers/find/details_navigation", school: @school, provider: @provider, unfilled_subjects: @unfilled_subjects, filled_subjects: @filled_subjects %>
+
+      <h2 class="govuk-heading-m">
+        <%= t(".school_details") %>
+      </h2>
+
+      <%= govuk_summary_list(actions: false) do |summary_list| %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".phase")) %>
+          <% row.with_value(text: @school.phase) %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".age_range")) %>
+          <% row.with_value(text: @school.age_range) %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".ukprn")) %>
+          <% row.with_value(text: @school.ukprn || t(".unknown")) %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".urn")) %>
+          <% row.with_value(text: @school.urn) %>
+        <% end %>
+      <% end %>
+
+      <h2 class="govuk-heading-m">
+        <%= t(".general_contact_details") %>
+      </h2>
+
+      <%= govuk_summary_list(actions: false) do |summary_list| %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".telephone") || t(".unknown")) %>
+          <% row.with_value(text: @school.telephone) %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".website")) %>
+          <% row.with_value do %>
+            <% if @school.website.present? %>
+              <%= govuk_link_to(@school.website,
+                                external_link(@school.website),
+                                new_tab: true) %>
+            <% else %>
+              <%= t(".unknown") %>
+            <% end %>
+          <% end %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".address")) %>
+          <% row.with_value do %>
+            <%= @school.formatted_address %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <h2 class="govuk-heading-m">
+        <%= t(".additional_details") %>
+      </h2>
+
+      <%= govuk_summary_list(actions: false) do |summary_list| %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".school_type")) %>
+          <% row.with_value(text: @school.type_of_establishment) %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".gender")) %>
+          <% row.with_value(text: @school.gender) %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".religious_character")) %>
+          <% row.with_value(text: @school.religious_character || t(".unknown")) %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".admissions_policy")) %>
+          <% row.with_value(text: @school.admissions_policy || t(".unknown")) %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".urban_or_rural")) %>
+          <% row.with_value(text: @school.urban_or_rural || t(".unknown")) %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".school_capacity")) %>
+          <% row.with_value(text: @school.school_capacity || t(".unknown")) %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".total_boys")) %>
+          <% row.with_value(text: @school.total_boys || t(".unknown")) %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".total_girls")) %>
+          <% row.with_value(text: @school.total_girls || t(".unknown")) %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".percentage_fsm")) %>
+          <% row.with_value(text: "#{@school.percentage_free_school_meals}%") %>
+        <% end %>
+      <% end %>
+
+      <h2 class="govuk-heading-m">
+        <%= t(".send_details") %>
+      </h2>
+
+      <%= govuk_summary_list(actions: false) do |summary_list| %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".special_classes")) %>
+          <% row.with_value(text: @school.special_classes || t(".unknown")) %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".sen_provision")) %>
+          <% row.with_value(text: @school.send_provision || t(".unknown")) %>
+        <% end %>
+      <% end %>
+
+      <h2 class="govuk-heading-m">
+        <%= t(".ofsted") %>
+      </h2>
+
+      <%= govuk_summary_list(actions: false) do |summary_list| %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".report")) %>
+          <% row.with_value do %>
+            <%= govuk_link_to t(".ofsted_report"), "#", no_visited_state: true, new_tab: true %>
+            <%= govuk_details summary_text: t(".details_summary") do %>
+              <p class="govuk-body"><%= t(".details_body") %></p>
+            <% end %>
+          <% end %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".last_inspection")) %>
+          <% row.with_value(text: @school.last_inspection_date || t(".unknown")) %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/locales/en/components/placements/schools/interest_tag_component.yml
+++ b/config/locales/en/components/placements/schools/interest_tag_component.yml
@@ -7,3 +7,4 @@ en:
           not_open: Not hosting
           open: Open to hosting
           filled_placements: Already organised placements
+          not_participating: Not participating

--- a/config/locales/en/components/placements/schools/interest_tag_component.yml
+++ b/config/locales/en/components/placements/schools/interest_tag_component.yml
@@ -1,0 +1,9 @@
+en:
+  components:
+    placements:
+      schools:
+        interest_tag_component:
+          unfilled_placements: Has unfilled placements
+          not_open: Not hosting
+          open: Open to hosting
+          filled_placements: Already organised placements

--- a/config/locales/en/components/placements/schools/summary_component.yml
+++ b/config/locales/en/components/placements/schools/summary_component.yml
@@ -1,0 +1,47 @@
+en:
+  components:
+    placements:
+      schools:
+        summary_component:
+          phase: Phase
+          academic_year: Academic year
+          terms: Expected date
+          age_range: Age range
+          establishment_group: Establishment group
+          gender: Gender
+          religious_character: Religious character
+          urban_or_rural: Urban or rural
+          ofsted_rating: Ofsted rating
+          distance: "Distance"
+          distance_in_miles: "%{distance} miles"
+          travel_time: Travel time
+          public_transport: Public transport
+          driving: Driving
+          walking: Walking
+          minutes: minutes
+          warning: This school does not wish to be contacted this academic year.
+          school_details: School details
+          placement_information: Placement information
+          trained_mentors: Trained mentors
+          available_placements: Unfilled placements
+          available_placements_count:
+            one: "%{count} unfilled placement"
+            other: "%{count} unfilled placements"
+          unavailable_placements: Hosting subjects
+          unavailable_placements_count:
+            one: "%{count} filled placement"
+            other: "%{count} filled placements"
+          last_offered: Last offered
+          last_offered_count:
+            zero: "This school has not previously hosted placements"
+            one: "%{count} subject in %{academic_year_name}"
+            other: "%{count} subjects in %{academic_year_name}"
+          placement_contact: Contact
+          address: Address
+          travel_time_information: "%{transit_time} by public transport, %{drive_time} drive, %{walk_time} walk"
+          getting_there: Getting there
+          placement_subjects: Placement subjects
+          unknown: Unknown
+          not_open_to_hosting: Not open to hosting placements
+          placement_status: Placement status
+          offered_placements: Offered placements in %{academic_year_name} (%{subjects})

--- a/config/locales/en/placements/providers/find.yml
+++ b/config/locales/en/placements/providers/find.yml
@@ -1,0 +1,119 @@
+en:
+  placements:
+    academic_year:
+      current_academic_year: This year (%{academic_year})
+      next_academic_year: Next year (%{academic_year})
+      previous_academic_year: Previous year (%{academic_year})
+    providers:
+      find:
+        index:
+          schools_found:
+            zero: No schools
+            one: 1 school
+            other: "%{count} schools"
+          find_placements: Find schools hosting placements
+          no_results: There are no schools that match your selection. Try searching again, or removing one or more filters.
+          enter_a_location: Enter a location
+          results_sorted_alpha: Results sorted alphabetically
+          results_sorted_distance: Results sorted by distance from %{search_location}
+        filter:
+          google_attribution: Powered by Google
+          location_search_prompt: Enter a town, city or postcode
+          partner_schools: Schools I work with
+          terms: Expected date
+          phase: Phase
+          primary: Primary
+          secondary: Secondary
+          only_show_partner_schools: Only show placements from schools I work with
+          school: School
+          search_location: Location
+          search_by_location: Search by location
+          subject: Subject
+          school_phase: School phase
+          establishment_group: Establishment group
+          gender: Gender
+          religious_character: Religious character
+          ofsted_rating: Ofsted rating
+          placements_to_show_title: Placements to show
+          placements_to_show:
+            available_placements: Available placements
+            assigned_to_me: Assigned to me
+            all_placements: All placements
+          year_group: Primary year group
+          academic_year:
+            label: Academic year
+          search_by_name: Search by school name
+          search_by_name_prompt: Enter a school name or URN
+          itt_status: ITT status
+          last_offered_placements: Last offered placements
+          not_offered_placements_label: No recent placements
+          trained_mentors: Trained mentors
+          trained_mentors_true_label: "Yes"
+          trained_mentors_false_label: "No"
+        show:
+          page_title: "%{school_name} - Find"
+          placements: Placements
+          placement_information: Placement information
+          school_details: School details
+        placements:
+          page_title: "%{school_name} - Find"
+          placements: Placements
+          placement_information: Placement information
+          school_details: School details
+          description: This school has specified which placements they would like to host in the 2024-2025 academic year.
+          unfilled_placements:
+            one: "%{count} unfilled placement"
+            other: "%{count} unfilled placements"
+          filled_placements:
+            one: "%{count} filled placement"
+            other: "%{count} filled placements"
+          table:
+            headers:
+              subject: Subject
+              expected_date: Expected date
+        placement_information:
+          page_title: "%{school_name} - Find"
+          placements: Placements
+          placement_information: Placement information
+          school_details: School details
+          placement_contact: Placement contact
+          name: Name
+          email: Email
+          mentors: Mentors
+          trained_mentors: Trained mentors
+          placements_hosted_in_previous_years: Placements hosted in previous years
+          offered_placements_in: "Offered placements in:"
+          unknown: Unknown
+        school_details:
+          page_title: "%{school_name} - Find"
+          placements: Placements
+          placement_information: Placement information
+          school_details: School details
+          phase: Phase
+          age_range: Age range
+          ukprn: UK provider reference number (UKPRN)
+          urn: Unique reference number (URN)
+          general_contact_details: General contact details
+          telephone: Telephone number
+          website: Website
+          address: Address
+          additional_details: Additional details
+          school_type: School type
+          gender: Gender
+          religious_character: Religious character
+          admissions_policy: Admissions policy
+          urban_or_rural: Urban or rural
+          school_capacity: School capacity
+          total_boys: Total boys
+          total_girls: Total girls
+          percentage_fsm: Percentage free school meals
+          send_details: Special educational needs and disabilities (SEND)
+          special_classes: Special classes
+          sen_provision: SEN provision
+          ofsted: OFSTED
+          ofsted_report: Ofsted report
+          details_summary: Why the rating is not displayed
+          details_body: From September 2024, Ofsted no longer makes an overall effectiveness judgement in inspections of state-funded schools.
+          report: Report
+          last_inspection: Last inspection date
+          unknown: Unknown

--- a/config/locales/en/placements/providers/find.yml
+++ b/config/locales/en/placements/providers/find.yml
@@ -55,7 +55,7 @@ en:
           placements: Placements
           placement_information: Placement information
           school_details: School details
-          description: This school has specified which placements they would like to host in the 2024-2025 academic year.
+          description: This school has specified which placements they would like to host in the %{academic_year_name} academic year.
           unfilled_placements:
             one: "%{count} unfilled placement"
             other: "%{count} unfilled placements"

--- a/config/locales/en/placements/providers/find.yml
+++ b/config/locales/en/placements/providers/find.yml
@@ -50,11 +50,6 @@ en:
           trained_mentors: Trained mentors
           trained_mentors_true_label: "Yes"
           trained_mentors_false_label: "No"
-        show:
-          page_title: "%{school_name} - Find"
-          placements: Placements
-          placement_information: Placement information
-          school_details: School details
         placements:
           page_title: "%{school_name} - Find"
           placements: Placements
@@ -71,6 +66,11 @@ en:
             headers:
               subject: Subject
               expected_date: Expected date
+        details_navigation:
+          page_title: "%{school_name} - Find"
+          placements: Placements
+          placement_information: Placement information
+          school_details: School details
         placement_information:
           page_title: "%{school_name} - Find"
           placements: Placements
@@ -83,7 +83,7 @@ en:
           trained_mentors: Trained mentors
           placements_hosted_in_previous_years: Placements hosted in previous years
           offered_placements_in: "Offered placements in:"
-          unknown: Unknown
+          unknown: This school has not previously offered placements
         school_details:
           page_title: "%{school_name} - Find"
           placements: Placements

--- a/config/locales/en/placements/providers/primary_navigation.yml
+++ b/config/locales/en/placements/providers/primary_navigation.yml
@@ -2,6 +2,7 @@ en:
   placements:
     providers:
       primary_navigation:
+        find: Find
         placements: Placements
         schools: Schools
         users: Users

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -141,7 +141,7 @@ scope module: :placements,
 
       resources :placements, only: %i[index show]
 
-      resources :find, only: %i[index show] do
+      resources :find, only: %i[index] do
         member do
           get "placements", to: "find#placements"
           get "placement_information", to: "find#placement_information"

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -140,6 +140,14 @@ scope module: :placements,
       end
 
       resources :placements, only: %i[index show]
+
+      resources :find, only: %i[index show] do
+        member do
+          get "placements", to: "find#placements"
+          get "placement_information", to: "find#placement_information"
+          get "school_details", to: "find#school_details"
+        end
+      end
     end
   end
 end

--- a/spec/components/placements/schools/interest_tag_component_spec.rb
+++ b/spec/components/placements/schools/interest_tag_component_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+RSpec.describe Placements::Schools::InterestTagComponent, type: :component do
+  subject(:component) do
+    described_class.new(school:)
+  end
+
+  let(:school) { create(:placements_school, hosting_interests:, placements:) }
+
+  before do
+    school
+    render_inline(component)
+  end
+
+  context "when the school is open to hosting" do
+    let(:hosting_interests) { [build(:hosting_interest, appetite: "actively_looking")] }
+
+    context "when the school has available placements" do
+      let(:placements) { [build(:placement)] }
+
+      it "renders the correct text" do
+        expect(page).to have_content "Has unfilled placements"
+      end
+
+      it "renders the correct tag" do
+        expect(page).to have_css(".govuk-tag--green")
+      end
+    end
+
+    context "when the school has available and unavailable placements" do
+      let(:placements) { [build(:placement), build(:placement, provider: build(:provider))] }
+
+      it "renders the correct text" do
+        expect(page).to have_content "Has unfilled placements"
+      end
+
+      it "renders the correct tag" do
+        expect(page).to have_css(".govuk-tag--green")
+      end
+
+    end
+
+    context "when the school only has unavailable placements" do
+      let(:placements) { [build(:placement, provider: build(:provider))] }
+
+      it "renders the correct text" do
+        expect(page).to have_content "Already organised placements"
+      end
+
+      it "renders the correct tag" do
+        expect(page).to have_css(".govuk-tag--blue")
+      end
+    end
+
+    context "when the school has no placements" do
+      let(:placements) { [] }
+
+      it "renders the correct text" do
+        expect(page).to have_content "Open to hosting"
+      end
+
+      it "renders the correct tag" do
+        expect(page).to have_css(".govuk-tag--yellow")
+      end
+    end
+  end
+
+  context "when the school is not open to hosting" do
+    let(:hosting_interests) { [build(:hosting_interest, appetite: "not_open")] }
+    let(:placements) { [] }
+
+    it "renders the correct text" do
+      expect(page).to have_content "Not hosting"
+    end
+
+    it "renders the correct tag" do
+      expect(page).to have_css(".govuk-tag--red")
+    end
+  end
+
+  context "when the school has not specified a hosting interest" do
+    let(:school) { create(:placements_school) }
+
+    it "does not render the tag" do
+      expect(page).not_to have_css(".govuk-tag")
+    end
+  end
+end

--- a/spec/components/placements/schools/interest_tag_component_spec.rb
+++ b/spec/components/placements/schools/interest_tag_component_spec.rb
@@ -80,8 +80,12 @@ RSpec.describe Placements::Schools::InterestTagComponent, type: :component do
   context "when the school has not specified a hosting interest" do
     let(:school) { create(:placements_school) }
 
-    it "does not render the tag" do
-      expect(page).not_to have_css(".govuk-tag")
+    it "renders the correct text" do
+      expect(page).to have_content "Not participating"
+    end
+
+    it "renders the correct tag" do
+      expect(page).to have_css(".govuk-tag--grey")
     end
   end
 end

--- a/spec/components/placements/schools/interest_tag_component_spec.rb
+++ b/spec/components/placements/schools/interest_tag_component_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe Placements::Schools::InterestTagComponent, type: :component do
       it "renders the correct tag" do
         expect(page).to have_css(".govuk-tag--green")
       end
-
     end
 
     context "when the school only has unavailable placements" do

--- a/spec/components/placements/schools/summary_component_spec.rb
+++ b/spec/components/placements/schools/summary_component_spec.rb
@@ -1,0 +1,410 @@
+require "rails_helper"
+
+RSpec.describe Placements::Schools::SummaryComponent, type: :component do
+  subject(:component) do
+    described_class.new(school:, provider:)
+  end
+
+  let(:provider) { create(:placements_provider) }
+  let(:hosting_interests) { [] }
+  let(:placements) { [] }
+  let(:school_contact) { build(:school_contact) }
+  let(:school) do
+    create(:placements_school,
+           hosting_interests:,
+           placements:,
+           school_contact:,
+           phase: "All-through",
+           name: "Hogwarts",
+           group: "Local authority maintained schools",
+           minimum_age: 5,
+           maximum_age: 11,
+           longitude: -3.0581722753,
+           latitude: 52.8409318812,
+           address1: "Magical Lane",
+           postcode: "SW1A 1AA",
+           town: "London")
+  end
+
+  before do
+    allow(school).to receive_messages(distance_to: 42, drive_travel_duration: "15 mins", transit_travel_duration: "30 mins", walk_travel_duration: "45 mins")
+    render_inline(component)
+  end
+
+  context "when the school is open to hosting" do
+    let(:hosting_interests) { build_list(:hosting_interest, 1, appetite: "actively_looking") }
+
+    context "when the school does not have any placements" do
+      it "displays the school's hosting interest" do
+        expect(page).to have_content("Open to hosting")
+      end
+
+      it "displays a link to the school's details page" do
+        expect(page).to have_link("Hogwarts, London", href: "/providers/#{provider.id}/find/#{school.id}/placement_information")
+      end
+
+      it "displays the school's name" do
+        expect(page).to have_content("Hogwarts")
+      end
+
+      it "displays the school's details", :aggregate_failures do
+        expect(page).to have_content("School details")
+        expect(page).to have_content("Phase")
+        expect(page).to have_content("All-through")
+        expect(page).to have_content("Age range")
+        expect(page).to have_content("5 to 11")
+        expect(page).to have_content("Establishment group")
+        expect(page).to have_content("Local authority maintained schools")
+      end
+
+      it "displays placement information", :aggregate_failures do
+        expect(page).to have_content("Placement information")
+        expect(page).to have_content("Last offered")
+        expect(page).to have_content("This school has not previously hosted placements")
+        expect(page).to have_content("Contact")
+        expect(page).to have_content("Placement Coordinator")
+        expect(page).to have_content("placement_coordinator@example.school")
+      end
+
+      context "when location coordinates have been provided" do
+        subject(:component) do
+          described_class.new(school:, provider:, location_coordinates: "41.40338, 2.17403")
+        end
+
+        it "displays the getting there section", :aggregate_failures do
+          expect(page).to have_content("Getting there")
+          expect(page).to have_content("Address")
+          expect(page).to have_content("Magical Lane")
+          expect(page).to have_content("London")
+          expect(page).to have_content("SW1A 1AA")
+          expect(page).to have_content("Distance")
+          expect(page).to have_content("42 miles")
+          expect(page).to have_content("Travel time")
+          expect(page).to have_content("30 minutes by public transport")
+          expect(page).to have_content("15 minutes drive")
+          expect(page).to have_content("45 minutes walk")
+        end
+      end
+    end
+
+    context "when the school has unfilled placements" do
+      let(:placements) { build_list(:placement, 1) }
+
+      it "displays the school's hosting interest" do
+        expect(page).to have_content("Has unfilled placements")
+      end
+
+      it "displays a link to the school's details page" do
+        expect(page).to have_link("Hogwarts, London", href: "/providers/#{provider.id}/find/#{school.id}/placements")
+      end
+
+      it "displays the school's name" do
+        expect(page).to have_content("Hogwarts")
+      end
+
+      it "displays the school's details", :aggregate_failures do
+        expect(page).to have_content("School details")
+        expect(page).to have_content("Phase")
+        expect(page).to have_content("All-through")
+        expect(page).to have_content("Age range")
+        expect(page).to have_content("5 to 11")
+        expect(page).to have_content("Establishment group")
+        expect(page).to have_content("Local authority maintained schools")
+      end
+
+      it "displays placement information", :aggregate_failures do
+        expect(page).to have_content("Placement information")
+        expect(page).to have_content("Unfilled placements")
+        expect(page).to have_link("1 unfilled placement", href: "/providers/#{provider.id}/find/#{school.id}/placements")
+        expect(page).to have_content("Hosting subjects")
+        expect(page).to have_content("0 filled placements")
+        expect(page).to have_content("Last offered")
+        expect(page).to have_content("This school has not previously hosted placements")
+        expect(page).to have_content("Contact")
+        expect(page).to have_content("Placement Coordinator")
+        expect(page).to have_content("placement_coordinator@example.school")
+      end
+
+      context "when location coordinates have been provided" do
+        subject(:component) do
+          described_class.new(school:, provider:, location_coordinates: "41.40338, 2.17403")
+        end
+
+        it "displays the getting there section", :aggregate_failures do
+          expect(page).to have_content("Getting there")
+          expect(page).to have_content("Address")
+          expect(page).to have_content("Magical Lane")
+          expect(page).to have_content("London")
+          expect(page).to have_content("SW1A 1AA")
+          expect(page).to have_content("Distance")
+          expect(page).to have_content("42 miles")
+          expect(page).to have_content("Travel time")
+          expect(page).to have_content("30 minutes by public transport")
+          expect(page).to have_content("15 minutes drive")
+          expect(page).to have_content("45 minutes walk")
+        end
+      end
+    end
+
+    context "when the school has unfilled and filled placements" do
+      let(:placements) { [build(:placement, provider:), build(:placement)] }
+
+      it "displays the school's hosting interest" do
+        expect(page).to have_content("Has unfilled placements")
+      end
+
+      it "displays a link to the school's details page" do
+        expect(page).to have_link("Hogwarts, London", href: "/providers/#{provider.id}/find/#{school.id}/placements")
+      end
+
+      it "displays the school's name" do
+        expect(page).to have_content("Hogwarts")
+      end
+
+      it "displays the school's details", :aggregate_failures do
+        expect(page).to have_content("School details")
+        expect(page).to have_content("Phase")
+        expect(page).to have_content("All-through")
+        expect(page).to have_content("Age range")
+        expect(page).to have_content("5 to 11")
+        expect(page).to have_content("Establishment group")
+        expect(page).to have_content("Local authority maintained schools")
+      end
+
+      it "displays placement information", :aggregate_failures do
+        expect(page).to have_content("Placement information")
+        expect(page).to have_content("Unfilled placements")
+        expect(page).to have_link("1 unfilled placement", href: "/providers/#{provider.id}/find/#{school.id}/placements")
+        expect(page).to have_content("Hosting subjects")
+        expect(page).to have_content("1 filled placement")
+        expect(page).to have_content("Last offered")
+        expect(page).to have_content("This school has not previously hosted placements")
+        expect(page).to have_content("Contact")
+        expect(page).to have_content("Placement Coordinator")
+        expect(page).to have_content("placement_coordinator@example.school")
+      end
+
+      context "when location coordinates have been provided" do
+        subject(:component) do
+          described_class.new(school:, provider:, location_coordinates: "41.40338, 2.17403")
+        end
+
+        it "displays the getting there section", :aggregate_failures do
+          expect(page).to have_content("Getting there")
+          expect(page).to have_content("Address")
+          expect(page).to have_content("Magical Lane")
+          expect(page).to have_content("London")
+          expect(page).to have_content("SW1A 1AA")
+          expect(page).to have_content("Distance")
+          expect(page).to have_content("42 miles")
+          expect(page).to have_content("Travel time")
+          expect(page).to have_content("30 minutes by public transport")
+          expect(page).to have_content("15 minutes drive")
+          expect(page).to have_content("45 minutes walk")
+        end
+      end
+    end
+
+    context "when the school only has filled placements" do
+      let(:placements) { build_list(:placement, 1, provider:) }
+
+      it "displays the school's hosting interest" do
+        expect(page).to have_content("Already organised placements")
+      end
+
+      it "displays a link to the school's details page" do
+        expect(page).to have_link("Hogwarts, London", href: "/providers/#{provider.id}/find/#{school.id}/placements")
+      end
+
+      it "displays the school's name" do
+        expect(page).to have_content("Hogwarts")
+      end
+
+      it "displays the school's details", :aggregate_failures do
+        expect(page).to have_content("School details")
+        expect(page).to have_content("Phase")
+        expect(page).to have_content("All-through")
+        expect(page).to have_content("Age range")
+        expect(page).to have_content("5 to 11")
+        expect(page).to have_content("Establishment group")
+        expect(page).to have_content("Local authority maintained schools")
+      end
+
+      it "displays placement information", :aggregate_failures do
+        expect(page).to have_content("Placement information")
+        expect(page).to have_content("Hosting subjects")
+        expect(page).to have_content("1 filled placement")
+        expect(page).to have_content("Last offered")
+        expect(page).to have_content("This school has not previously hosted placements")
+        expect(page).to have_content("Contact")
+        expect(page).to have_content("Placement Coordinator")
+        expect(page).to have_content("placement_coordinator@example.school")
+      end
+
+      context "when location coordinates have been provided" do
+        subject(:component) do
+          described_class.new(school:, provider:, location_coordinates: "41.40338, 2.17403")
+        end
+
+        it "displays the getting there section", :aggregate_failures do
+          expect(page).to have_content("Getting there")
+          expect(page).to have_content("Address")
+          expect(page).to have_content("Magical Lane")
+          expect(page).to have_content("London")
+          expect(page).to have_content("SW1A 1AA")
+          expect(page).to have_content("Distance")
+          expect(page).to have_content("42 miles")
+          expect(page).to have_content("Travel time")
+          expect(page).to have_content("30 minutes by public transport")
+          expect(page).to have_content("15 minutes drive")
+          expect(page).to have_content("45 minutes walk")
+        end
+      end
+    end
+
+    context "when the school has previously hosted placements" do
+      let(:previous_academic_year) { Placements::AcademicYear.current.previous }
+      let(:placements) { build_list(:placement, 1, academic_year: previous_academic_year, provider:) }
+
+      it "displays the school's hosting interest" do
+        expect(page).to have_content("Open to hosting")
+      end
+
+      it "displays a link to the school's details page" do
+        expect(page).to have_link("Hogwarts, London", href: "/providers/#{provider.id}/find/#{school.id}/placement_information")
+      end
+
+      it "displays the school's name" do
+        expect(page).to have_content("Hogwarts")
+      end
+
+      it "displays the school's details", :aggregate_failures do
+        expect(page).to have_content("School details")
+        expect(page).to have_content("Phase")
+        expect(page).to have_content("All-through")
+        expect(page).to have_content("Age range")
+        expect(page).to have_content("5 to 11")
+        expect(page).to have_content("Establishment group")
+        expect(page).to have_content("Local authority maintained schools")
+      end
+
+      it "displays placement information", :aggregate_failures do
+        expect(page).to have_content("Placement information")
+        expect(page).to have_content("Last offered")
+        expect(page).to have_content("1 subject in #{previous_academic_year.name}")
+        expect(page).to have_content("Contact")
+        expect(page).to have_content("Placement Coordinator")
+        expect(page).to have_content("placement_coordinator@example.school")
+      end
+
+      context "when location coordinates have been provided" do
+        subject(:component) do
+          described_class.new(school:, provider:, location_coordinates: "41.40338, 2.17403")
+        end
+
+        it "displays the getting there section", :aggregate_failures do
+          expect(page).to have_content("Getting there")
+          expect(page).to have_content("Address")
+          expect(page).to have_content("Magical Lane")
+          expect(page).to have_content("London")
+          expect(page).to have_content("SW1A 1AA")
+          expect(page).to have_content("Distance")
+          expect(page).to have_content("42 miles")
+          expect(page).to have_content("Travel time")
+          expect(page).to have_content("30 minutes by public transport")
+          expect(page).to have_content("15 minutes drive")
+          expect(page).to have_content("45 minutes walk")
+        end
+      end
+    end
+  end
+
+  context "when the school is not open to hosting" do
+    let(:hosting_interests) { build_list(:hosting_interest, 1, appetite: "not_open") }
+
+    it "displays the school's hosting interest" do
+      expect(page).to have_content("Not hosting")
+    end
+
+    it "displays the school's name" do
+      expect(page).to have_content("Hogwarts")
+    end
+
+    it "displays the school's details", :aggregate_failures do
+      expect(page).to have_content("School details")
+      expect(page).to have_content("Phase")
+      expect(page).to have_content("All-through")
+      expect(page).to have_content("Age range")
+      expect(page).to have_content("5 to 11")
+      expect(page).to have_content("Establishment group")
+      expect(page).to have_content("Local authority maintained schools")
+    end
+
+    it "displays placement information", :aggregate_failures do
+      expect(page).to have_content("Placement information")
+      expect(page).to have_content("Placement subjects")
+      expect(page).to have_content("Not open to hosting placements")
+      expect(page).to have_content("Placement status")
+      expect(page).to have_content("This school has not previously hosted placements")
+    end
+
+    it "displays a message indicating the school doesn't want to be contacted" do
+      expect(page).to have_content("This school does not wish to be contacted this academic year.")
+    end
+
+    context "when location coordinates have been provided" do
+      subject(:component) do
+        described_class.new(school:, provider:, location_coordinates: "41.40338, 2.17403")
+      end
+
+      it "does not display the getting there section" do
+        expect(page).not_to have_content("Getting there")
+      end
+    end
+  end
+
+  context "when the school has not registered a hosting interest" do
+    it "does not display a hosting interest" do
+      expect(page).not_to have_content("Not hosting")
+      expect(page).not_to have_content("Open to hosting")
+      expect(page).not_to have_content("Already organised placements")
+      expect(page).not_to have_content("Unfilled placements")
+    end
+
+    it "displays the school's name" do
+      expect(page).to have_content("Hogwarts")
+    end
+
+    it "displays the school's details", :aggregate_failures do
+      expect(page).to have_content("School details")
+      expect(page).to have_content("Phase")
+      expect(page).to have_content("All-through")
+      expect(page).to have_content("Age range")
+      expect(page).to have_content("5 to 11")
+      expect(page).to have_content("Establishment group")
+      expect(page).to have_content("Local authority maintained schools")
+    end
+
+    it "displays placement information", :aggregate_failures do
+      expect(page).to have_content("Placement information")
+      expect(page).to have_content("Placement subjects")
+      expect(page).to have_content("Not open to hosting placements")
+      expect(page).to have_content("Placement status")
+      expect(page).to have_content("This school has not previously hosted placements")
+    end
+
+    it "displays a message indicating the school doesn't want to be contacted" do
+      expect(page).to have_content("This school does not wish to be contacted this academic year.")
+    end
+
+    context "when location coordinates have been provided" do
+      subject(:component) do
+        described_class.new(school:, provider:, location_coordinates: "41.40338, 2.17403")
+      end
+
+      it "does not display the getting there section" do
+        expect(page).not_to have_content("Getting there")
+      end
+    end
+  end
+end

--- a/spec/forms/placements/schools/filter_form_spec.rb
+++ b/spec/forms/placements/schools/filter_form_spec.rb
@@ -1,0 +1,280 @@
+require "rails_helper"
+
+describe Placements::Schools::FilterForm, type: :model do
+  include Rails.application.routes.url_helpers
+
+  let(:provider) { create(:placements_provider) }
+  let(:current_academic_year) { Placements::AcademicYear.current }
+
+  describe "#filters_selected?" do
+    subject(:filter_form) { described_class.new(provider, params).filters_selected? }
+
+    context "when given subject id params" do
+      let(:params) { { subject_ids: %w[subject_id] } }
+
+      it "returns true" do
+        expect(filter_form).to be(true)
+      end
+    end
+
+    context "when given search location params" do
+      context "when search location an empty string" do
+        let(:params) { { search_location: "" } }
+
+        it "return false" do
+          expect(filter_form).to be(false)
+        end
+      end
+
+      context "when search location not an empty string" do
+        let(:params) { { search_location: "London" } }
+
+        it "return true" do
+          expect(filter_form).to be(true)
+        end
+      end
+    end
+
+    context "when given search by name params" do
+      context "when search by name an empty string" do
+        let(:params) { { search_by_name: "" } }
+
+        it "return false" do
+          expect(filter_form).to be(false)
+        end
+      end
+
+      context "when search by name a non-empty string" do
+        let(:params) { { search_by_name: "Hogwarts" } }
+
+        it "returns true" do
+          expect(filter_form).to be(true)
+        end
+      end
+    end
+
+    context "when given phase params" do
+      let(:params) { { phases: %w[primary secondary] } }
+
+      it "returns true" do
+        expect(filter_form).to be(true)
+      end
+    end
+
+    context "when given itt status params" do
+      let(:params) { { itt_statuses: %w[itt_status] } }
+
+      it "returns true" do
+        expect(filter_form).to be(true)
+      end
+    end
+
+    context "when given last offered placements academic year ids params" do
+      let(:params) { { last_offered_placements_academic_year_ids: %w[academic_year_id] } }
+
+      it "returns true" do
+        expect(filter_form).to be(true)
+      end
+    end
+
+    context "when given no params" do
+      let(:params) { {} }
+
+      it "returns false" do
+        expect(filter_form).to be(false)
+      end
+    end
+  end
+
+  describe "#clear_filters_path" do
+    subject(:filter_form) { described_class.new(provider) }
+
+    it "returns the find index page path" do
+      expect(filter_form.clear_filters_path).to eq(placements_provider_find_index_path(provider))
+    end
+  end
+
+  describe "index_path_without_filter" do
+    subject(:filter_form) { described_class.new(provider, params) }
+
+    context "when removing subject id params" do
+      let(:params) do
+        { subject_ids: %w[subject_id_1 subject_id_2] }
+      end
+
+      it "returns the find index page path without the given subject id param" do
+        expect(
+          filter_form.index_path_without_filter(
+            filter: "subject_ids",
+            value: "subject_id_1",
+          ),
+        ).to eq(
+          placements_provider_find_index_path(
+            provider,
+            filters: {
+              subject_ids: %w[subject_id_2],
+            },
+          ),
+        )
+      end
+    end
+
+    context "when removing search location params" do
+      let(:params) do
+        { search_location: "London" }
+      end
+
+      it "returns the find index page path without the given search location param" do
+        expect(
+          filter_form.index_path_without_filter(
+            filter: "search_location",
+            value: "London",
+          ),
+        ).to eq(
+          placements_provider_find_index_path(provider),
+        )
+      end
+    end
+
+    context "when removing search by name params" do
+      let(:params) do
+        { search_by_name: "Hogwarts" }
+      end
+
+      it "returns the find index page path without the given search by name param" do
+        expect(
+          filter_form.index_path_without_filter(
+            filter: "search_by_name",
+            value: "Hogwarts",
+          ),
+        ).to eq(
+          placements_provider_find_index_path(provider),
+        )
+      end
+    end
+
+    context "when removing phase params" do
+      let(:params) do
+        { phases: %w[primary secondary] }
+      end
+
+      it "returns the find index page path without the given phase param" do
+        expect(
+          filter_form.index_path_without_filter(
+            filter: "phases",
+            value: "primary",
+          ),
+        ).to eq(
+          placements_provider_find_index_path(
+            provider,
+            filters: {
+              phases: %w[secondary],
+            },
+          ),
+        )
+      end
+    end
+
+    context "when removing itt status params" do
+      let(:params) do
+        { itt_statuses: %w[itt_status itt_status_2] }
+      end
+
+      it "returns the find index page path without the given itt status param" do
+        expect(
+          filter_form.index_path_without_filter(
+            filter: "itt_statuses",
+            value: "itt_status_2",
+          ),
+        ).to eq(
+          placements_provider_find_index_path(
+            provider,
+            filters: {
+              itt_statuses: %w[itt_status],
+            },
+          ),
+        )
+      end
+    end
+
+    context "when removing last offered placements academic year ids params" do
+      let(:params) do
+        { last_offered_placements_academic_year_ids: %w[academic_year_id_1 academic_year_id_2] }
+      end
+
+      it "returns the find index page path without the given last offered placements academic year ids param" do
+        expect(
+          filter_form.index_path_without_filter(
+            filter: "last_offered_placements_academic_year_ids",
+            value: "academic_year_id_1",
+          ),
+        ).to eq(
+          placements_provider_find_index_path(
+            provider,
+            filters: {
+              last_offered_placements_academic_year_ids: %w[academic_year_id_2],
+            },
+          ),
+        )
+      end
+    end
+  end
+
+  describe "#query_params" do
+    it "returns the expected result" do
+      expect(described_class.new(provider).query_params).to eq(
+        {
+          subject_ids: [],
+          search_location: nil,
+          search_by_name: nil,
+          phases: [],
+          itt_statuses: [],
+          last_offered_placements_academic_year_ids: [],
+        },
+      )
+    end
+  end
+
+  describe "#subjects" do
+    it "returns the subjects associated with the subject_id params given" do
+      subjects = create_list(:subject, 2)
+
+      expect(
+        described_class.new(provider, subject_ids: subjects.pluck(:id)).subjects,
+      ).to match_array(subjects)
+    end
+  end
+
+  describe "#last_offered_placements_academic_years" do
+    it "returns the academic years associated with the last_offered_placements_academic_year_ids params given" do
+      academic_years = create_list(:placements_academic_year, 2)
+
+      expect(
+        described_class.new(provider, last_offered_placements_academic_year_ids: academic_years.pluck(:id)).last_offered_placements_academic_years,
+      ).to match_array(academic_years)
+    end
+  end
+
+  describe "#last_offered_placement_options" do
+    context "when placements have been offered previously" do
+      let(:previous_academic_year) { Placements::AcademicYear.current.previous }
+      let(:placements) { create_list(:placement, 2, academic_year: previous_academic_year) }
+
+      before { placements }
+
+      it "returns the academic years associated with the last_offered_placements_academic_year_ids params given" do
+        expect(
+          described_class.new(provider).last_offered_placement_options,
+        ).to contain_exactly([previous_academic_year.name, previous_academic_year.id], ["No recent placements", "never_offered"])
+      end
+    end
+
+    context "when no placements have been offered previously" do
+      it "returns the 'No recent placements' option" do
+        expect(
+          described_class.new(provider).last_offered_placement_options,
+        ).to contain_exactly(["No recent placements", "never_offered"])
+      end
+    end
+  end
+end

--- a/spec/forms/placements/schools/filter_form_spec.rb
+++ b/spec/forms/placements/schools/filter_form_spec.rb
@@ -277,4 +277,84 @@ describe Placements::Schools::FilterForm, type: :model do
       end
     end
   end
+
+  describe "#primary_selected?" do
+    subject(:filter_form) { described_class.new(provider, params) }
+
+    context "when primary is selected" do
+      let(:params) { { phases: %w[Primary] } }
+
+      it "returns true" do
+        expect(filter_form.primary_selected?).to be(true)
+      end
+    end
+
+    context "when primary is not selected" do
+      let(:params) { { phases: %w[Secondary] } }
+
+      it "returns false" do
+        expect(filter_form.primary_selected?).to be(false)
+      end
+    end
+  end
+
+  describe "#secondary_selected?" do
+    subject(:filter_form) { described_class.new(provider, params) }
+
+    context "when secondary is selected" do
+      let(:params) { { phases: %w[Secondary] } }
+
+      it "returns true" do
+        expect(filter_form.secondary_selected?).to be(true)
+      end
+    end
+
+    context "when secondary is not selected" do
+      let(:params) { { phases: %w[Primary] } }
+
+      it "returns false" do
+        expect(filter_form.secondary_selected?).to be(false)
+      end
+    end
+  end
+
+  describe "#primary_only?" do
+    subject(:filter_form) { described_class.new(provider, params) }
+
+    context "when only primary is selected" do
+      let(:params) { { phases: %w[Primary] } }
+
+      it "returns true" do
+        expect(filter_form.primary_only?).to be(true)
+      end
+    end
+
+    context "when secondary is also selected" do
+      let(:params) { { phases: %w[Primary Secondary] } }
+
+      it "returns false" do
+        expect(filter_form.primary_only?).to be(false)
+      end
+    end
+  end
+
+  describe "#secondary_only?" do
+    subject(:filter_form) { described_class.new(provider, params) }
+
+    context "when only secondary is selected" do
+      let(:params) { { phases: %w[Secondary] } }
+
+      it "returns true" do
+        expect(filter_form.secondary_only?).to be(true)
+      end
+    end
+
+    context "when primary is also selected" do
+      let(:params) { { phases: %w[Primary Secondary] } }
+
+      it "returns false" do
+        expect(filter_form.secondary_only?).to be(false)
+      end
+    end
+  end
 end

--- a/spec/models/placement_spec.rb
+++ b/spec/models/placement_spec.rb
@@ -73,6 +73,60 @@ RSpec.describe Placement, type: :model do
         )
       end
     end
+
+    describe "#available_placements" do
+      it "returns placements that are available for a given school" do
+        school = create(:placements_school)
+        placement_1 = create(:placement, school:, provider: nil)
+        _placement_2 = create(:placement, school:, provider: create(:provider))
+        placement_3 = create(:placement, school:, provider: nil)
+
+        expect(described_class.available_placements(school)).to contain_exactly(
+          placement_1,
+          placement_3,
+        )
+      end
+
+      it "returns placements that are available for a given school in the current academic year" do
+        school = create(:placements_school)
+        current_academic_year = Placements::AcademicYear.current
+        placement_1 = create(:placement, school:, provider: nil, academic_year: current_academic_year)
+        _placement_2 = create(:placement, school:, provider: nil, academic_year: current_academic_year.previous)
+        placement_3 = create(:placement, school:, provider: nil, academic_year: current_academic_year)
+
+        expect(described_class.available_placements(school)).to contain_exactly(
+          placement_1,
+          placement_3,
+        )
+      end
+    end
+
+    describe "#unavailable_placements" do
+      it "returns placements that are unavailable for a given school" do
+        school = create(:placements_school)
+        placement_1 = create(:placement, school:, provider: create(:provider))
+        _placement_2 = create(:placement, school:, provider: nil)
+        placement_3 = create(:placement, school:, provider: create(:provider))
+
+        expect(described_class.unavailable_placements(school)).to contain_exactly(
+          placement_1,
+          placement_3,
+        )
+      end
+
+      it "returns placements that are unavailable for a given school in the current academic year" do
+        school = create(:placements_school)
+        current_academic_year = Placements::AcademicYear.current
+        placement_1 = create(:placement, school:, provider: create(:provider), academic_year: current_academic_year)
+        _placement_2 = create(:placement, school:, provider: create(:provider), academic_year: current_academic_year.previous)
+        placement_3 = create(:placement, school:, provider: create(:provider), academic_year: current_academic_year)
+
+        expect(described_class.unavailable_placements(school)).to contain_exactly(
+          placement_1,
+          placement_3,
+        )
+      end
+    end
   end
 
   describe "order_by_school_ids" do

--- a/spec/models/placement_spec.rb
+++ b/spec/models/placement_spec.rb
@@ -74,56 +74,31 @@ RSpec.describe Placement, type: :model do
       end
     end
 
-    describe "#available_placements" do
-      it "returns placements that are available for a given school" do
+    describe "#available_placements_for_academic_year" do
+      it "returns placements that are available for a given academic year" do
         school = create(:placements_school)
-        placement_1 = create(:placement, school:, provider: nil)
-        _placement_2 = create(:placement, school:, provider: create(:provider))
-        placement_3 = create(:placement, school:, provider: nil)
+        academic_year = Placements::AcademicYear.current
+        placement_1 = create(:placement, school:, provider: nil, academic_year:)
+        _placement_2 = create(:placement, school:, provider: nil, academic_year: academic_year.previous)
+        placement_3 = create(:placement, school:, provider: nil, academic_year:)
 
-        expect(described_class.available_placements(school)).to contain_exactly(
-          placement_1,
-          placement_3,
-        )
-      end
-
-      it "returns placements that are available for a given school in the current academic year" do
-        school = create(:placements_school)
-        current_academic_year = Placements::AcademicYear.current
-        placement_1 = create(:placement, school:, provider: nil, academic_year: current_academic_year)
-        _placement_2 = create(:placement, school:, provider: nil, academic_year: current_academic_year.previous)
-        placement_3 = create(:placement, school:, provider: nil, academic_year: current_academic_year)
-
-        expect(described_class.available_placements(school)).to contain_exactly(
+        expect(described_class.available_placements_for_academic_year(academic_year)).to contain_exactly(
           placement_1,
           placement_3,
         )
       end
     end
 
-    describe "#unavailable_placements" do
-      it "returns placements that are unavailable for a given school" do
+    describe "#unavailable_placements_for_academic_year" do
+      it "returns placements that are unavailable for a given academic year" do
         school = create(:placements_school)
-        placement_1 = create(:placement, school:, provider: create(:provider))
-        _placement_2 = create(:placement, school:, provider: nil)
-        placement_3 = create(:placement, school:, provider: create(:provider))
+        academic_year = Placements::AcademicYear.current
+        placement_1 = create(:placement, school:, provider: create(:provider), academic_year:)
+        _placement_2 = create(:placement, school:, provider: nil, academic_year: academic_year.previous)
+        _placement_3 = create(:placement, school:, provider: nil, academic_year:)
 
-        expect(described_class.unavailable_placements(school)).to contain_exactly(
+        expect(described_class.unavailable_placements_for_academic_year(academic_year)).to contain_exactly(
           placement_1,
-          placement_3,
-        )
-      end
-
-      it "returns placements that are unavailable for a given school in the current academic year" do
-        school = create(:placements_school)
-        current_academic_year = Placements::AcademicYear.current
-        placement_1 = create(:placement, school:, provider: create(:provider), academic_year: current_academic_year)
-        _placement_2 = create(:placement, school:, provider: create(:provider), academic_year: current_academic_year.previous)
-        placement_3 = create(:placement, school:, provider: create(:provider), academic_year: current_academic_year)
-
-        expect(described_class.unavailable_placements(school)).to contain_exactly(
-          placement_1,
-          placement_3,
         )
       end
     end

--- a/spec/models/placements/school_contact_spec.rb
+++ b/spec/models/placements/school_contact_spec.rb
@@ -67,11 +67,5 @@ RSpec.describe Placements::SchoolContact, type: :model do
       school_contact.first_name = nil
       expect(school_contact.full_name).to eq("Doe")
     end
-
-    it "returns nil when both names are absent" do
-      school_contact.first_name = nil
-      school_contact.last_name = nil
-      expect(school_contact.full_name).to be_nil
-    end
   end
 end

--- a/spec/models/placements/school_contact_spec.rb
+++ b/spec/models/placements/school_contact_spec.rb
@@ -50,4 +50,28 @@ RSpec.describe Placements::SchoolContact, type: :model do
       end
     end
   end
+
+  describe "#full_name" do
+    let(:school_contact) { build(:school_contact, first_name: "John", last_name: "Doe") }
+
+    it "returns the full name when both first and last names are present" do
+      expect(school_contact.full_name).to eq("John Doe")
+    end
+
+    it "returns the first name when only the first name is present" do
+      school_contact.last_name = nil
+      expect(school_contact.full_name).to eq("John")
+    end
+
+    it "returns the last name when only the last name is present" do
+      school_contact.first_name = nil
+      expect(school_contact.full_name).to eq("Doe")
+    end
+
+    it "returns nil when both names are absent" do
+      school_contact.first_name = nil
+      school_contact.last_name = nil
+      expect(school_contact.full_name).to be_nil
+    end
+  end
 end

--- a/spec/models/placements/school_spec.rb
+++ b/spec/models/placements/school_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe Placements::School do
     it { is_expected.to have_many(:mentor_memberships) }
     it { is_expected.to have_many(:mentors).through(:mentor_memberships) }
     it { is_expected.to have_many(:placements) }
+    it { is_expected.to have_many(:academic_years).through(:placements) }
 
     describe "#users" do
       it { is_expected.to have_many(:users).through(:user_memberships) }

--- a/spec/models/placements/school_spec.rb
+++ b/spec/models/placements/school_spec.rb
@@ -127,6 +127,7 @@ RSpec.describe Placements::School do
 
   describe "delegations" do
     it { is_expected.to delegate_method(:email_address).to(:school_contact).with_prefix(true).allow_nil }
+    it { is_expected.to delegate_method(:full_name).to(:school_contact).with_prefix(true).allow_nil }
     it { is_expected.to delegate_method(:appetite).to(:current_hosting_interest).with_prefix(true).allow_nil }
   end
 

--- a/spec/models/placements/school_spec.rb
+++ b/spec/models/placements/school_spec.rb
@@ -126,5 +126,57 @@ RSpec.describe Placements::School do
 
   describe "delegations" do
     it { is_expected.to delegate_method(:email_address).to(:school_contact).with_prefix(true).allow_nil }
+    it { is_expected.to delegate_method(:appetite).to(:current_hosting_interest).with_prefix(true).allow_nil }
+  end
+
+  describe "#current_hosting_interest" do
+    let(:academic_year) { Placements::AcademicYear.current }
+    let(:school) { create(:placements_school, hosting_interests:) }
+
+    context "when there is a current hosting interest" do
+      let(:hosting_interests) { [build(:hosting_interest, academic_year:)] }
+
+      it "returns the current hosting interest for the school" do
+        expect(school.current_hosting_interest).to eq(hosting_interests.first)
+      end
+    end
+
+    context "when there is no current hosting interest" do
+      let(:hosting_interests) { [] }
+
+      it "returns nil" do
+        expect(school.current_hosting_interest).to be_nil
+      end
+    end
+
+    context "when there are multiple hosting interests" do
+      let(:current_hosting_interest) { build(:hosting_interest) }
+      let(:previous_hosting_interest) { build(:hosting_interest, academic_year: academic_year.previous) }
+      let(:hosting_interests) { [current_hosting_interest, previous_hosting_interest] }
+
+      it "returns the current hosting interest for the school" do
+        expect(school.current_hosting_interest).to eq(current_hosting_interest)
+      end
+    end
+  end
+
+  describe "#available_placements" do
+    let!(:school) { create(:placements_school, placements: [available_placement, unavailable_placement]) }
+    let(:available_placement) { build(:placement) }
+    let(:unavailable_placement) { build(:placement, provider: create(:provider)) }
+
+    it "returns the available placements for the school" do
+      expect(school.available_placements).to contain_exactly(available_placement)
+    end
+  end
+
+  describe "#unavailable_placements" do
+    let!(:school) { create(:placements_school, placements: [available_placement, unavailable_placement]) }
+    let(:available_placement) { build(:placement) }
+    let(:unavailable_placement) { build(:placement, provider: create(:provider)) }
+
+    it "returns the unavailable placements for the school" do
+      expect(school.unavailable_placements).to contain_exactly(unavailable_placement)
+    end
   end
 end

--- a/spec/queries/placements/schools_query_spec.rb
+++ b/spec/queries/placements/schools_query_spec.rb
@@ -1,0 +1,179 @@
+require "rails_helper"
+
+describe Placements::SchoolsQuery do
+  subject(:query) { described_class.new(params:) }
+
+  let(:params) { {} }
+  let(:query_school) do
+    create(
+      :placements_school,
+      name: "London Primary School",
+      phase: "All-through",
+      minimum_age: "4",
+      maximum_age: "11",
+      gender: "Mixed",
+      group: "Local authority maintained schools",
+      religious_character: "Jewish",
+      urban_or_rural: "(England/Wales) Urban city and town",
+      rating: "Good",
+      latitude: 51.648438,
+      longitude: 14.350231,
+    )
+  end
+  let(:non_query_school) do
+    create(:placements_school, name: "York Secondary School", latitude: 29.732613, longitude: 105.448063)
+  end
+  let(:academic_year) { create(:placements_academic_year) }
+  let(:placement) { create(:placement, school: query_school, academic_year:) }
+
+  before do
+    query_school
+    non_query_school
+  end
+
+  describe "#call" do
+    it "returns all schools" do
+      expect(query.call).to include(query_school)
+      expect(query.call).to include(non_query_school)
+    end
+
+    context "when filtering by name" do
+      let(:params) { { filters: { search_by_name: "London" } } }
+
+      it "returns the filtered schools" do
+        expect(query.call).to include(query_school)
+        expect(query.call).not_to include(non_query_school)
+      end
+    end
+
+    context "when filtering by subject" do
+      let(:placement_subject) { create(:subject) }
+      let(:params) { { filters: { subject_ids: [placement_subject.id] } } }
+
+      before do
+        placement.update(subject: placement_subject)
+      end
+
+      it "returns the filtered schools" do
+        expect(query.call).to include(query_school)
+        expect(query.call).not_to include(non_query_school)
+      end
+
+      context "when searching for an additional subject" do
+        let(:additional_subject) { create(:subject, parent_subject: create(:subject)) }
+        let(:params) { { filters: { subject_ids: [additional_subject.id] } } }
+
+        before do
+          placement.update(additional_subjects: [additional_subject])
+        end
+
+        it "returns the filtered schools" do
+          expect(query.call).to include(query_school)
+          expect(query.call).not_to include(non_query_school)
+        end
+      end
+    end
+
+    context "when filtering by phase" do
+      let(:params) { { filters: { phases: [query_school.phase] } } }
+
+      it "returns the filtered schools" do
+        expect(query.call).to include(query_school)
+        expect(query.call).not_to include(non_query_school)
+      end
+    end
+
+    context "when filtering by last offered placements" do
+      let(:params) { { filters: { last_offered_placements_academic_year_ids: [academic_year.id] } } }
+
+      before do
+        placement.update(academic_year:)
+      end
+
+      it "returns the filtered schools" do
+        expect(query.call).to include(query_school)
+        expect(query.call).not_to include(non_query_school)
+      end
+    end
+
+    context "when filtering by hosting interest statuses" do
+      context "when searching for open hosting interests" do
+        let(:params) { { filters: { itt_statuses: %w[open] } } }
+
+        before do
+          query_school.hosting_interests.create!(appetite: "actively_looking", academic_year: Placements::AcademicYear.current)
+        end
+
+        it "returns the filtered schools" do
+          expect(query.call).to include(query_school)
+          expect(query.call).not_to include(non_query_school)
+        end
+      end
+
+      context "when searching for not open hosting interests" do
+        let(:params) { { filters: { itt_statuses: %w[not_open] } } }
+
+        before do
+          query_school.hosting_interests.create!(appetite: "not_open", academic_year: Placements::AcademicYear.current)
+        end
+
+        it "returns the filtered schools" do
+          expect(query.call).to include(query_school)
+          expect(query.call).not_to include(non_query_school)
+        end
+      end
+
+      context "when searching for unfilled placements" do
+        let(:params) { { filters: { itt_statuses: %w[unfilled_placements] } } }
+
+        before do
+          query_school.hosting_interests.create!(appetite: "actively_looking", academic_year: Placements::AcademicYear.current)
+          create(:placement, school: query_school, academic_year:, provider: nil)
+        end
+
+        it "returns the filtered schools" do
+          expect(query.call).to include(query_school)
+          expect(query.call).not_to include(non_query_school)
+        end
+      end
+
+      context "when searching for filled placements" do
+        let(:params) { { filters: { itt_statuses: %w[filled_placements] } } }
+
+        before do
+          query_school.hosting_interests.create!(appetite: "actively_looking", academic_year: Placements::AcademicYear.current)
+          create(:placement, school: query_school, academic_year:, provider: create(:provider))
+        end
+
+        it "returns the filtered schools" do
+          expect(query.call).to include(query_school)
+          expect(query.call).not_to include(non_query_school)
+        end
+      end
+
+      context "when searching conflicting hosting interests" do
+        let(:params) { { filters: { itt_statuses: %w[open not_open] } } }
+
+        before do
+          query_school.hosting_interests.create!(appetite: "actively_looking", academic_year: Placements::AcademicYear.current)
+          non_query_school.hosting_interests.create!(appetite: "not_open", academic_year: Placements::AcademicYear.current)
+        end
+
+        it "returns the filtered schools" do
+          expect(query.call).to include(query_school)
+          expect(query.call).to include(non_query_school)
+        end
+      end
+    end
+
+    context "when filtering by location" do
+      let(:location_coordinates) { [query_school.latitude, query_school.longitude] }
+      let(:params) { { location_coordinates: } }
+
+      it "returns the filtered schools" do
+        expect(query.call).to include(query_school)
+        expect(query.call).not_to include(non_query_school)
+      end
+    end
+  end
+end

--- a/spec/queries/placements/schools_query_spec.rb
+++ b/spec/queries/placements/schools_query_spec.rb
@@ -23,7 +23,7 @@ describe Placements::SchoolsQuery do
   let(:non_query_school) do
     create(:placements_school, name: "York Secondary School", latitude: 29.732613, longitude: 105.448063)
   end
-  let(:academic_year) { create(:placements_academic_year) }
+  let(:academic_year) { Placements::AcademicYear.current }
   let(:placement) { create(:placement, school: query_school, academic_year:) }
 
   before do
@@ -114,7 +114,7 @@ describe Placements::SchoolsQuery do
         let(:params) { { filters: { itt_statuses: %w[open] } } }
 
         before do
-          query_school.hosting_interests.create!(appetite: "actively_looking", academic_year: Placements::AcademicYear.current)
+          query_school.hosting_interests.create!(appetite: "actively_looking", academic_year:)
         end
 
         it "returns the filtered schools" do
@@ -127,7 +127,7 @@ describe Placements::SchoolsQuery do
         let(:params) { { filters: { itt_statuses: %w[not_open] } } }
 
         before do
-          query_school.hosting_interests.create!(appetite: "not_open", academic_year: Placements::AcademicYear.current)
+          query_school.hosting_interests.create!(appetite: "not_open", academic_year:)
         end
 
         it "returns the filtered schools" do
@@ -140,7 +140,7 @@ describe Placements::SchoolsQuery do
         let(:params) { { filters: { itt_statuses: %w[unfilled_placements] } } }
 
         before do
-          query_school.hosting_interests.create!(appetite: "actively_looking", academic_year: Placements::AcademicYear.current)
+          query_school.hosting_interests.create!(appetite: "actively_looking", academic_year:)
           create(:placement, school: query_school, academic_year:, provider: nil)
         end
 
@@ -154,7 +154,7 @@ describe Placements::SchoolsQuery do
         let(:params) { { filters: { itt_statuses: %w[filled_placements] } } }
 
         before do
-          query_school.hosting_interests.create!(appetite: "actively_looking", academic_year: Placements::AcademicYear.current)
+          query_school.hosting_interests.create!(appetite: "actively_looking", academic_year:)
           create(:placement, school: query_school, academic_year:, provider: create(:provider))
         end
 
@@ -168,8 +168,8 @@ describe Placements::SchoolsQuery do
         let(:params) { { filters: { itt_statuses: %w[open not_open] } } }
 
         before do
-          query_school.hosting_interests.create!(appetite: "actively_looking", academic_year: Placements::AcademicYear.current)
-          non_query_school.hosting_interests.create!(appetite: "not_open", academic_year: Placements::AcademicYear.current)
+          query_school.hosting_interests.create!(appetite: "actively_looking", academic_year:)
+          non_query_school.hosting_interests.create!(appetite: "not_open", academic_year:)
         end
 
         it "returns the filtered schools" do

--- a/spec/queries/placements/schools_query_spec.rb
+++ b/spec/queries/placements/schools_query_spec.rb
@@ -94,6 +94,19 @@ describe Placements::SchoolsQuery do
         expect(query.call).to include(query_school)
         expect(query.call).not_to include(non_query_school)
       end
+
+      context "when searching for no recent placements and recent placements" do
+        let(:params) { { filters: { last_offered_placements_academic_year_ids: [academic_year.id, "never_offered"] } } }
+
+        before do
+          placement.update(academic_year:)
+        end
+
+        it "returns the filtered schools" do
+          expect(query.call).to include(query_school)
+          expect(query.call).to include(non_query_school)
+        end
+      end
     end
 
     context "when filtering by hosting interest statuses" do

--- a/spec/system/placements/providers/find/provider_user_filters_schools_by_itt_status_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_filters_schools_by_itt_status_spec.rb
@@ -1,0 +1,154 @@
+require "rails_helper"
+
+RSpec.describe "Provider user filters schools by ITT status", service: :placements, type: :system do
+  scenario do
+    given_that_schools_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_find_schools_page
+    then_i_see_the_find_schools_page
+    and_i_see_all_schools
+    and_i_see_the_itt_status_filter
+
+    when_i_select_open_to_hosting_from_the_itt_status_filter
+    and_i_click_on_apply_filters
+    then_i_see_the_open_to_hosting_school
+    and_i_do_not_see_the_not_open_to_hosting_school
+    and_i_see_that_the_open_to_hosting_itt_status_checkbox_is_selected
+    and_i_see_the_open_to_hosting_filter_tag
+
+    when_i_select_not_hosting_from_the_itt_status_filter
+    and_i_click_on_apply_filters
+    then_i_see_all_schools
+    and_i_see_that_the_open_to_hosting_and_not_hosting_itt_status_checkboxes_are_selected
+    and_i_see_that_the_open_to_hosting_and_not_hosting_filter_tags
+
+    when_i_click_on_the_not_hosting_itt_status_tag
+    then_i_see_the_open_to_hosting_school
+    and_i_do_not_see_the_not_open_to_hosting_school
+    and_i_do_not_see_the_not_opening_itt_status_checkbox_selected
+    and_i_do_not_see_the_not_open_filter_tag
+
+    when_i_click_on_the_open_to_hosting_itt_status_tag
+    then_i_see_all_schools
+    and_i_do_not_see_any_selected_itt_status_checkboxes
+    and_i_do_not_see_any_itt_status_filter_tags
+  end
+
+  private
+
+  def given_that_schools_exist
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+
+    @open_hosting_interest = build(:hosting_interest, appetite: "actively_looking", academic_year: Placements::AcademicYear.current)
+    @not_open_hosting_interest = build(:hosting_interest, appetite: "not_open", academic_year: Placements::AcademicYear.current)
+
+    @open_to_hosting_school = create(:placements_school, phase: "Primary", name: "Springfield Elementary", hosting_interests: [@open_hosting_interest])
+    @not_hosting_school = create(:placements_school, phase: "Secondary", name: "Shelbyville High School", hosting_interests: [@not_open_hosting_interest])
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_navigate_to_the_find_schools_page
+    within ".app-primary-navigation__nav" do
+      click_on "Find"
+    end
+  end
+
+  def then_i_see_the_find_schools_page
+    expect(page).to have_title("Find schools hosting placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Find schools hosting placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def and_i_see_all_schools
+    expect(page).to have_h2("Springfield Elementary")
+    expect(page).to have_h2("Shelbyville High School")
+  end
+
+  def and_i_see_the_itt_status_filter
+    expect(page).to have_element(:legend, text: "ITT status", class: "govuk-fieldset__legend")
+    expect(page).to have_unchecked_field("Open to hosting")
+    expect(page).to have_unchecked_field("Not hosting")
+    expect(page).to have_unchecked_field("Already organised placements")
+    expect(page).to have_unchecked_field("Has unfilled placements")
+  end
+
+  def when_i_select_open_to_hosting_from_the_itt_status_filter
+    check "Open to hosting"
+  end
+
+  def and_i_click_on_apply_filters
+    click_on "Apply filters"
+  end
+
+  def then_i_see_the_open_to_hosting_school
+    expect(page).to have_h2("Springfield Elementary")
+  end
+
+  def and_i_do_not_see_the_not_open_to_hosting_school
+    expect(page).not_to have_h2("Shelbyville High School")
+  end
+
+  def and_i_see_that_the_open_to_hosting_itt_status_checkbox_is_selected
+    expect(page).to have_checked_field("Open to hosting")
+  end
+
+  def and_i_see_the_open_to_hosting_filter_tag
+    expect(page).to have_filter_tag("Open to hosting")
+  end
+
+  def when_i_select_not_hosting_from_the_itt_status_filter
+    check "Not hosting"
+  end
+
+  def and_i_see_that_the_open_to_hosting_and_not_hosting_itt_status_checkboxes_are_selected
+    expect(page).to have_checked_field("Open to hosting")
+    expect(page).to have_checked_field("Not hosting")
+  end
+
+  def and_i_see_that_the_open_to_hosting_and_not_hosting_filter_tags
+    expect(page).to have_filter_tag("Open to hosting")
+    expect(page).to have_filter_tag("Not hosting")
+  end
+
+  def when_i_click_on_the_not_hosting_itt_status_tag
+    within ".app-filter-tags" do
+      click_on "Not hosting"
+    end
+  end
+
+  def and_i_do_not_see_the_not_opening_itt_status_checkbox_selected
+    expect(page).to have_checked_field("Open to hosting")
+    expect(page).to have_unchecked_field("Not hosting")
+  end
+
+  def and_i_do_not_see_the_not_open_filter_tag
+    expect(page).not_to have_filter_tag("Not hosting")
+  end
+
+  def when_i_click_on_the_open_to_hosting_itt_status_tag
+    within ".app-filter-tags" do
+      click_on "Open to hosting"
+    end
+  end
+
+  def then_i_see_all_schools
+    expect(page).to have_h2("Springfield Elementary")
+    expect(page).to have_h2("Shelbyville High School")
+  end
+
+  def and_i_do_not_see_any_selected_itt_status_checkboxes
+    expect(page).to have_unchecked_field("Open to hosting")
+    expect(page).to have_unchecked_field("Not hosting")
+  end
+
+  def and_i_do_not_see_any_itt_status_filter_tags
+    expect(page).not_to have_h3("ITT status")
+    expect(page).not_to have_filter_tag("Open to hosting")
+    expect(page).not_to have_filter_tag("Not hosting")
+  end
+end

--- a/spec/system/placements/providers/find/provider_user_filters_schools_by_last_offered_placements_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_filters_schools_by_last_offered_placements_spec.rb
@@ -1,0 +1,160 @@
+require "rails_helper"
+
+RSpec.describe "Provider user filters schools by last offered placements", service: :placements, type: :system do
+  scenario do
+    given_that_schools_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_find_schools_page
+    then_i_see_the_find_schools_page
+    and_i_see_all_schools
+    and_i_see_the_last_offered_placements_filter
+
+    when_i_select_no_recent_placements
+    and_i_click_on_apply_filters
+    then_i_see_the_school_with_no_recent_placements
+    and_i_do_not_see_the_school_with_recent_placements
+    and_i_see_that_the_no_recent_placements_checkbox_is_selected
+    and_i_see_the_no_recent_placements_filter_tag
+
+    when_i_select_recent_placements_from_the_last_offered_placements_filter
+    and_i_click_on_apply_filters
+    then_i_see_all_schools
+    and_i_see_that_the_recent_placements_and_no_recent_placements_checkboxes_are_selected
+    and_i_see_the_recent_placements_and_no_recent_placements_filter_tags
+
+    when_i_click_on_the_no_recent_placements_filter_tag
+    then_i_see_the_school_with_recent_placements
+    and_i_do_not_see_the_school_with_no_recent_placements
+    and_i_do_not_see_the_no_recent_placements_checkbox_selected
+    and_i_do_not_see_the_no_recent_placements_filter_tag
+
+    when_i_click_on_the_recent_placements_filter_tag
+    then_i_see_all_schools
+    and_i_do_not_see_any_selected_last_offered_placements_checkboxes
+    and_i_do_not_see_any_last_offered_placements_filter_tags
+  end
+
+  private
+
+  def given_that_schools_exist
+    @previous_academic_year = Placements::AcademicYear.current.previous
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+
+    @primary_school_no_placement = create(:placements_school, phase: "Primary", name: "Springfield Elementary")
+
+    @primary_school_with_previous_placement = build(:placements_school, phase: "Primary", name: "Hogwarts Elementary")
+    _primary_english_placement = create(:placement, school: @primary_school_with_previous_placement, academic_year: @previous_academic_year)
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_navigate_to_the_find_schools_page
+    within ".app-primary-navigation__nav" do
+      click_on "Find"
+    end
+  end
+
+  def then_i_see_the_find_schools_page
+    expect(page).to have_title("Find schools hosting placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Find schools hosting placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def and_i_see_all_schools
+    expect(page).to have_h2("Springfield Elementary")
+    expect(page).to have_h2("Hogwarts Elementary")
+  end
+
+  def and_i_see_the_last_offered_placements_filter
+    expect(page).to have_element(:legend, text: "Last offered placements", class: "govuk-fieldset__legend")
+    expect(page).to have_unchecked_field(@previous_academic_year.name)
+    expect(page).to have_unchecked_field("No recent placements")
+  end
+
+  def when_i_select_no_recent_placements
+    check "No recent placements"
+  end
+
+  def and_i_click_on_apply_filters
+    click_on "Apply filters"
+  end
+
+  def then_i_see_the_school_with_no_recent_placements
+    expect(page).to have_h2("Springfield Elementary")
+  end
+
+  def and_i_do_not_see_the_school_with_recent_placements
+    expect(page).not_to have_h2("Hogwarts Elementary")
+  end
+
+  def then_i_see_the_school_with_recent_placements
+    expect(page).to have_h2("Hogwarts Elementary")
+  end
+
+  def and_i_do_not_see_the_school_with_no_recent_placements
+    expect(page).not_to have_h2("Springfield Elementary")
+  end
+
+  def and_i_see_that_the_no_recent_placements_checkbox_is_selected
+    expect(page).to have_checked_field("No recent placements")
+  end
+
+  def and_i_see_the_no_recent_placements_filter_tag
+    expect(page).to have_filter_tag("No recent placements")
+  end
+
+  def when_i_select_recent_placements_from_the_last_offered_placements_filter
+    check @previous_academic_year.name
+  end
+
+  def and_i_see_that_the_recent_placements_and_no_recent_placements_checkboxes_are_selected
+    expect(page).to have_checked_field(@previous_academic_year.name)
+    expect(page).to have_checked_field("No recent placements")
+  end
+
+  def and_i_see_the_recent_placements_and_no_recent_placements_filter_tags
+    expect(page).to have_filter_tag(@previous_academic_year.name)
+    expect(page).to have_filter_tag("No recent placements")
+  end
+
+  def when_i_click_on_the_no_recent_placements_filter_tag
+    within ".app-filter-tags" do
+      click_on "No recent placements"
+    end
+  end
+
+  def and_i_do_not_see_the_no_recent_placements_checkbox_selected
+    expect(page).to have_checked_field(@previous_academic_year.name)
+    expect(page).to have_unchecked_field("No recent placements")
+  end
+
+  def and_i_do_not_see_the_no_recent_placements_filter_tag
+    expect(page).not_to have_filter_tag("No recent placements")
+  end
+
+  def when_i_click_on_the_recent_placements_filter_tag
+    within ".app-filter-tags" do
+      click_on @previous_academic_year.name
+    end
+  end
+
+  def then_i_see_all_schools
+    expect(page).to have_h2("Springfield Elementary")
+    expect(page).to have_h2("Hogwarts Elementary")
+  end
+
+  def and_i_do_not_see_any_selected_last_offered_placements_checkboxes
+    expect(page).to have_unchecked_field(@previous_academic_year.name)
+    expect(page).to have_unchecked_field("No recent placements")
+  end
+
+  def and_i_do_not_see_any_last_offered_placements_filter_tags
+    expect(page).not_to have_h3("Last offered placements")
+    expect(page).not_to have_filter_tag(@previous_academic_year.name)
+    expect(page).not_to have_filter_tag("No recent placements")
+  end
+end

--- a/spec/system/placements/providers/find/provider_user_filters_schools_by_phase_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_filters_schools_by_phase_spec.rb
@@ -1,0 +1,176 @@
+require "rails_helper"
+
+RSpec.describe "Provider user filters schools by phase", service: :placements, type: :system do
+  scenario do
+    given_that_schools_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_find_schools_page
+    then_i_see_the_find_schools_page
+    and_i_see_all_schools
+    and_i_see_the_phase_filter
+
+    when_i_select_secondary_from_the_phase_filter
+    and_i_click_on_apply_filters
+    then_i_see_the_secondary_school
+    and_i_do_not_see_the_primary_school
+    and_i_see_only_secondary_subjects_listed_in_the_subjects_filter
+    and_i_see_that_the_secondary_phase_checkbox_is_selected
+    and_i_see_the_secondary_filter_tag
+
+    when_i_select_primary_from_the_phase_filter
+    and_i_click_on_apply_filters
+    then_i_see_all_schools
+    and_i_see_all_subjects_listed_in_the_subjects_filter
+    and_i_see_that_the_primary_and_secondary_phases_checkbox_are_selected
+    and_i_see_the_primary_and_secondary_filter_tags
+
+    when_i_click_on_the_secondary_phase_tag
+    then_i_see_the_primary_school
+    and_i_do_not_see_the_secondary_school
+    and_i_do_not_see_the_secondary_phase_checkbox_selected
+    and_i_do_not_see_the_secondary_filter_tag
+
+    when_i_click_on_the_primary_phase_tag
+    then_i_see_all_schools
+    and_i_see_all_subjects_listed_in_the_subjects_filter
+    and_i_do_not_see_any_selected_phase_checkboxes
+    and_i_do_not_see_any_phase_filter_tags
+  end
+
+  private
+
+  def given_that_schools_exist
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+
+    @primary_school = build(:placements_school, phase: "Primary", name: "Springfield Elementary")
+    @secondary_school = build(:placements_school, phase: "Secondary", name: "Shelbyville High School")
+
+    @primary_subject = build(:subject, name: "Primary with mathematics", subject_area: "primary")
+    @springfield_primary_placement = create(:placement, school: @primary_school, subject: @primary_subject)
+
+    @secondary_subject = build(:subject, name: "Music", subject_area: "secondary")
+    @shelbyville_secondary_placement = create(:placement, school: @secondary_school, subject: @secondary_subject)
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_navigate_to_the_find_schools_page
+    within ".app-primary-navigation__nav" do
+      click_on "Find"
+    end
+  end
+
+  def then_i_see_the_find_schools_page
+    expect(page).to have_title("Find schools hosting placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Find schools hosting placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def and_i_see_all_schools
+    expect(page).to have_h2("Springfield Elementary")
+    expect(page).to have_h2("Shelbyville High School")
+  end
+
+  def and_i_see_the_phase_filter
+    expect(page).to have_element(:legend, text: "Phase", class: "govuk-fieldset__legend")
+    expect(page).to have_unchecked_field("Primary")
+    expect(page).to have_unchecked_field("Secondary")
+  end
+
+  def when_i_select_secondary_from_the_phase_filter
+    check "Secondary"
+  end
+
+  def and_i_click_on_apply_filters
+    click_on "Apply filters"
+  end
+
+  def then_i_see_the_secondary_school
+    expect(page).to have_h2("Shelbyville High School")
+  end
+
+  def and_i_do_not_see_the_primary_school
+    expect(page).not_to have_h2("Springfield Elementary")
+  end
+
+  def and_i_see_only_secondary_subjects_listed_in_the_subjects_filter
+    expect(page).to have_unchecked_field("Music")
+    expect(page).not_to have_unchecked_field("Primary with mathematics")
+  end
+
+  def and_i_see_that_the_secondary_phase_checkbox_is_selected
+    expect(page).to have_checked_field("Secondary")
+  end
+
+  def and_i_see_the_secondary_filter_tag
+    expect(page).to have_filter_tag("Secondary")
+  end
+
+  def when_i_select_primary_from_the_phase_filter
+    check "Primary"
+  end
+
+  def and_i_see_all_subjects_listed_in_the_subjects_filter
+    expect(page).to have_unchecked_field("Primary with mathematics")
+    expect(page).to have_unchecked_field("Music")
+  end
+
+  def and_i_see_that_the_primary_and_secondary_phases_checkbox_are_selected
+    expect(page).to have_checked_field("Primary")
+    expect(page).to have_checked_field("Secondary")
+  end
+
+  def and_i_see_the_primary_and_secondary_filter_tags
+    expect(page).to have_filter_tag("Primary")
+    expect(page).to have_filter_tag("Secondary")
+  end
+
+  def when_i_click_on_the_secondary_phase_tag
+    within ".app-filter-tags" do
+      click_on "Secondary"
+    end
+  end
+
+  def then_i_see_the_primary_school
+    expect(page).to have_h2("Springfield Elementary")
+  end
+
+  def and_i_do_not_see_the_secondary_school
+    expect(page).not_to have_h2("Shelbyville High School")
+  end
+
+  def and_i_do_not_see_the_secondary_phase_checkbox_selected
+    expect(page).to have_field("Secondary", type: "checkbox", checked: false)
+    expect(page).to have_field("Primary", type: "checkbox", checked: true)
+  end
+
+  def and_i_do_not_see_the_secondary_filter_tag
+    expect(page).not_to have_filter_tag("Secondary")
+  end
+
+  def when_i_click_on_the_primary_phase_tag
+    within ".app-filter-tags" do
+      click_on "Primary"
+    end
+  end
+
+  def then_i_see_all_schools
+    expect(page).to have_h2("Springfield Elementary")
+    expect(page).to have_h2("Shelbyville High School")
+  end
+
+  def and_i_do_not_see_any_selected_phase_checkboxes
+    expect(page).not_to have_field("Primary", type: "checkbox", checked: true)
+    expect(page).not_to have_field("Secondary", type: "checkbox", checked: true)
+  end
+
+  def and_i_do_not_see_any_phase_filter_tags
+    expect(page).not_to have_h3("Phase")
+    expect(page).not_to have_filter_tag("Primary")
+    expect(page).not_to have_filter_tag("Secondary")
+  end
+end

--- a/spec/system/placements/providers/find/provider_user_filters_schools_by_search_by_location_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_filters_schools_by_search_by_location_spec.rb
@@ -1,0 +1,167 @@
+require "rails_helper"
+
+RSpec.describe "Provider user filters schools by search by location", service: :placements, type: :system do
+  scenario do
+    given_that_schools_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_find_schools_page
+    then_i_see_the_find_schools_page
+    and_i_see_all_schools
+    and_i_see_the_search_by_location_filter
+
+    when_i_search_for_schools_near_guildford
+    and_i_click_on_apply_filters
+    then_i_see_the_guildford_school
+    and_i_do_not_see_the_bath_school
+    and_i_see_the_guildford_search_by_location_filter
+
+    when_i_search_for_schools_in_a_made_up_location
+    and_i_click_on_apply_filters
+    then_i_see_no_schools
+    and_i_see_my_made_up_location_search_by_location_filter
+    and_i_do_not_see_my_guildford_search_by_location_filter
+
+    when_i_click_on_the_made_up_location_search_by_location_filter_tag
+    then_i_see_all_schools
+    and_i_do_not_see_any_selected_search_by_location_filters
+  end
+
+  private
+
+  def given_that_schools_exist
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+    @guildford_school = create(:placements_school, phase: "Primary", name: "Springfield Elementary", latitude: 51.23622,
+                                                   longitude: -0.570409, hosting_interests: [build(:hosting_interest, appetite: "actively_looking", academic_year: Placements::AcademicYear.current)])
+    @bath_school = create(:placements_school, phase: "Secondary", name: "Hogwarts", latitude: 51.3781018,
+                                              longitude: -2.3596827, hosting_interests: [build(:hosting_interest, appetite: "actively_looking", academic_year: Placements::AcademicYear.current)])
+
+    stub_geocoder_results
+    stub_routes_request
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_navigate_to_the_find_schools_page
+    within ".app-primary-navigation__nav" do
+      click_on "Find"
+    end
+  end
+
+  def then_i_see_the_find_schools_page
+    expect(page).to have_title("Find schools hosting placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Find schools hosting placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def and_i_see_all_schools
+    expect(page).to have_h2("Springfield Elementary")
+    expect(page).to have_h2("Hogwarts")
+  end
+
+  def and_i_see_the_search_by_location_filter
+    expect(page).to have_field("Enter a town, city or postcode", type: :search)
+    expect(page).to have_element(:p, text: "Powered by Google", class: "govuk-body-s secondary-text")
+  end
+
+  def when_i_search_for_schools_near_guildford
+    fill_in "Enter a town, city or postcode", with: "Guildford"
+  end
+
+  def and_i_click_on_apply_filters
+    click_on "Apply filters"
+  end
+
+  def then_i_see_the_guildford_school
+    expect(page).to have_h2("Springfield Elementary")
+    expect(page).to have_result_detail_row("Distance", "0.0 mi")
+    expect(page).to have_result_detail_row("Travel time", "42 minutes by public transport, 42 minutes drive, 42 minutes walk")
+  end
+
+  def and_i_do_not_see_the_bath_school
+    expect(page).not_to have_h2("Hogwarts")
+  end
+
+  def and_i_see_the_guildford_search_by_location_filter
+    expect(page).to have_filter_tag("Guildford")
+    expect(page).to have_field("Enter a town, city or postcode", type: :search, with: "Guildford")
+  end
+
+  def when_i_search_for_schools_in_a_made_up_location
+    fill_in "Enter a town, city or postcode", with: "Mordor"
+  end
+
+  def then_i_see_no_schools
+    expect(page).to have_h2("No schools")
+    expect(page).to have_element(:p, text: "There are no schools that match your selection. Try searching again, or removing one or more filters.")
+  end
+
+  def and_i_see_my_made_up_location_search_by_location_filter
+    expect(page).to have_filter_tag("Mordor")
+    expect(page).to have_field("Enter a town, city or postcode", type: :search, with: "Mordor")
+  end
+
+  def and_i_do_not_see_my_guildford_search_by_location_filter
+    expect(page).not_to have_filter_tag("Guildford")
+    expect(page).not_to have_field("Enter a town, city or postcode", type: :search, with: "Guildford")
+  end
+
+  def when_i_click_on_the_made_up_location_search_by_location_filter_tag
+    within ".app-filter-tags" do
+      click_on "Mordor"
+    end
+  end
+
+  def and_i_do_not_see_any_selected_search_by_location_filters
+    expect(page).not_to have_filter_tag("Guildford")
+    expect(page).not_to have_field("Enter a town, city or postcode", type: :search, with: "Guildford")
+    expect(page).not_to have_result_detail_row("Distance", "0.0 mi")
+    expect(page).not_to have_result_detail_row("Travel time", "42 minutes by public transport, 42 minutes drive, 42 minutes walk")
+  end
+
+  def then_i_see_all_schools
+    expect(page).to have_h2("Springfield Elementary")
+    expect(page).to have_h2("Hogwarts")
+  end
+
+  def stub_geocoder_results
+    guildford_geocoder_results = instance_double("geocoder_results")
+    guildford_geocoder_result = instance_double("geocoder_result")
+    allow(guildford_geocoder_results).to receive(:first).and_return(guildford_geocoder_result)
+    allow(guildford_geocoder_result).to receive(:coordinates).and_return([51.23622, -0.570409])
+
+    mordor_geocoder_results = instance_double("geocoder_results")
+    mordor_geocoder_result = instance_double("geocoder_result")
+    allow(mordor_geocoder_results).to receive(:first).and_return(mordor_geocoder_result)
+    allow(mordor_geocoder_result).to receive(:coordinates).and_return([55.378051, -3.435973])
+
+    allow(Geocoder).to receive(:search).and_return(guildford_geocoder_results, mordor_geocoder_results)
+  end
+
+  def stub_routes_request
+    body = [
+      {
+        "destinationIndex" => 0,
+        "localizedValues" => {
+          "distance" => { "text" => "20 mi" },
+          "duration" => { "text" => "42 mins" },
+          "staticDuration" => { "text" => "36 mins" },
+        },
+      },
+      {
+        "destinationIndex" => 1,
+        "localizedValues" => {
+          "distance" => { "text" => "20 mi" },
+          "duration" => { "text" => "42 mins" },
+          "staticDuration" => { "text" => "36 mins" },
+        },
+      },
+    ].to_json
+
+    stub_request(:post, "https://routes.googleapis.com/distanceMatrix/v2:computeRouteMatrix")
+      .to_return(status: 200, body:, headers: { "Content-Type" => "application/json" })
+  end
+end

--- a/spec/system/placements/providers/find/provider_user_filters_schools_by_search_by_school_name_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_filters_schools_by_search_by_school_name_spec.rb
@@ -1,0 +1,130 @@
+require "rails_helper"
+
+RSpec.describe "Provider user filters schools by search by location", service: :placements, type: :system do
+  scenario do
+    given_that_schools_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_find_schools_page
+    then_i_see_the_find_schools_page
+    and_i_see_all_schools
+    and_i_see_the_search_by_school_name_filter
+
+    when_i_search_for_springfield_elementary
+    and_i_click_on_apply_filters
+    then_i_see_springfield_elementary
+    and_i_do_not_see_shelbyville_high_school
+    and_i_see_the_springfield_elementary_search_by_name_filter
+
+    when_i_click_on_the_springfield_elementary_search_by_name_filter_tag
+    then_i_see_all_schools
+    and_i_do_not_see_the_springfield_search_by_name_filter
+
+    when_i_search_for_a_school_that_doesnt_exist
+    and_i_click_on_apply_filters
+    then_i_see_no_schools
+    and_i_see_my_made_up_school_name_search_by_name_filter
+
+    when_i_click_on_the_made_up_school_name_search_by_name_filter_tag
+    then_i_see_all_schools
+    and_i_do_not_see_the_hogwarts_search_by_name_filter
+  end
+
+  private
+
+  def given_that_schools_exist
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+
+    @primary_school = build(:placements_school, phase: "Primary", name: "Springfield Elementary")
+    @secondary_school = build(:placements_school, phase: "Secondary", name: "Shelbyville High School")
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_navigate_to_the_find_schools_page
+    within ".app-primary-navigation__nav" do
+      click_on "Find"
+    end
+  end
+
+  def then_i_see_the_find_schools_page
+    expect(page).to have_title("Find schools hosting placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Find schools hosting placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def and_i_see_all_schools
+    expect(page).to have_content(@primary_school.name)
+    expect(page).to have_content(@secondary_school.name)
+  end
+
+  def and_i_see_the_search_by_school_name_filter
+    expect(page).to have_element(:label, text: "Search by school name")
+    expect(page).to have_field("Enter a school name or URN", type: :search)
+  end
+
+  def when_i_search_for_springfield_elementary
+    fill_in "Enter a school name or URN", with: "springfield elementary"
+  end
+
+  def and_i_click_on_apply_filters
+    click_on "Apply filters"
+  end
+
+  def then_i_see_springfield_elementary
+    expect(page).to have_h2("Springfield Elementary")
+  end
+
+  def and_i_do_not_see_shelbyville_high_school
+    expect(page).not_to have_h2("Shelbyville High School")
+  end
+
+  def and_i_see_the_springfield_elementary_search_by_name_filter
+    expect(page).to have_filter_tag("springfield elementary")
+    expect(page).to have_field("Enter a school name or URN", type: :search, with: "springfield elementary")
+  end
+
+  def when_i_click_on_the_springfield_elementary_search_by_name_filter_tag
+    within ".app-filter-tags" do
+      click_on "springfield elementary"
+    end
+  end
+
+  def then_i_see_all_schools
+    expect(page).to have_content(@primary_school.name)
+    expect(page).to have_content(@secondary_school.name)
+  end
+
+  def and_i_do_not_see_the_springfield_search_by_name_filter
+    expect(page).not_to have_filter_tag("springfield elementary")
+    expect(page).not_to have_field("Enter a school name or URN", type: :search, with: "springfield elementary")
+  end
+
+  def when_i_search_for_a_school_that_doesnt_exist
+    fill_in "Enter a school name or URN", with: "Hogwarts"
+  end
+
+  def then_i_see_no_schools
+    expect(page).to have_h2("No schools")
+    expect(page).to have_element(:p, text: "There are no schools that match your selection. Try searching again, or removing one or more filters.")
+  end
+
+  def and_i_see_my_made_up_school_name_search_by_name_filter
+    expect(page).to have_filter_tag("Hogwarts")
+    expect(page).to have_field("Enter a school name or URN", type: :search, with: "Hogwarts")
+  end
+
+  def when_i_click_on_the_made_up_school_name_search_by_name_filter_tag
+    within ".app-filter-tags" do
+      click_on "Hogwarts"
+    end
+  end
+
+  def and_i_do_not_see_the_hogwarts_search_by_name_filter
+    expect(page).not_to have_filter_tag("Hogwarts")
+    expect(page).not_to have_field("Enter a school name or URN", type: :search, with: "Hogwarts")
+  end
+end

--- a/spec/system/placements/providers/find/provider_user_filters_schools_by_subject_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_filters_schools_by_subject_spec.rb
@@ -1,0 +1,144 @@
+require "rails_helper"
+
+RSpec.describe "Provider user filters schools by subject", service: :placements, type: :system do
+  scenario do
+    given_that_schools_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_find_schools_page
+    then_i_see_the_find_schools_page
+    and_i_see_all_schools
+    and_i_see_the_subject_filter
+
+    when_i_select_primary_with_maths_from_the_subject_filter
+    and_i_click_on_apply_filters
+    then_i_see_the_primary_school_with_the_maths_placement
+    and_i_do_not_see_the_primary_school_with_the_english_placement
+    and_i_see_my_selected_subject_filter
+
+    when_i_select_primary_with_english_from_the_subject_filter
+    and_i_click_on_apply_filters
+    then_i_see_all_schools
+    and_i_see_my_selected_subject_filters
+
+    when_i_click_on_the_primary_with_maths_subject_filter_tag
+    then_i_see_the_primary_school_with_the_english_placement
+    and_i_do_not_see_the_primary_school_with_the_maths_placement
+    and_i_do_not_see_the_primary_with_maths_subject_filter
+
+    when_i_click_on_the_primary_with_english_subject_filter_tag
+    then_i_see_all_schools
+    and_i_do_not_see_any_selected_subject_filters
+  end
+
+  private
+
+  def given_that_schools_exist
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+
+    @primary_school_with_maths = build(:placements_school, phase: "Primary", name: "Springfield Elementary")
+    @primary_maths_subject = build(:subject, name: "Primary with mathematics", subject_area: "primary")
+    _primary_maths_placement = create(:placement, school: @primary_school_with_maths, subject: @primary_maths_subject)
+
+    @primary_school_with_english = build(:placements_school, phase: "Primary", name: "Hogwarts Elementary")
+    @primary_english_subject = build(:subject, name: "Primary with english", subject_area: "primary")
+    _primary_english_placement = create(:placement, school: @primary_school_with_english, subject: @primary_english_subject)
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_navigate_to_the_find_schools_page
+    within ".app-primary-navigation__nav" do
+      click_on "Find"
+    end
+  end
+
+  def then_i_see_the_find_schools_page
+    expect(page).to have_title("Find schools hosting placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Find schools hosting placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def and_i_see_all_schools
+    expect(page).to have_h2("Springfield Elementary")
+    expect(page).to have_h2("Hogwarts Elementary")
+  end
+  alias_method :then_i_see_all_schools, :and_i_see_all_schools
+
+  def and_i_see_the_subject_filter
+    expect(page).to have_element(:legend, text: "Subject", class: "govuk-fieldset__legend")
+    expect(page).to have_field("Primary with mathematics", type: :checkbox, checked: false)
+    expect(page).to have_field("Primary with english", type: :checkbox, unchecked: true)
+  end
+
+  def when_i_select_primary_with_maths_from_the_subject_filter
+    check "Primary with mathematics"
+  end
+
+  def and_i_click_on_apply_filters
+    click_on "Apply filters"
+  end
+
+  def then_i_see_the_primary_school_with_the_maths_placement
+    expect(page).to have_h2("Springfield Elementary")
+  end
+
+  def and_i_do_not_see_the_primary_school_with_the_english_placement
+    expect(page).not_to have_h2("Hogwarts Elementary")
+  end
+
+  def and_i_see_my_selected_subject_filter
+    expect(page).to have_filter_tag("Primary with mathematics")
+    expect(page).to have_checked_field("Primary with mathematics")
+    expect(page).not_to have_filter_tag("Primary with english")
+    expect(page).not_to have_checked_field("Primary with english")
+  end
+
+  def when_i_select_primary_with_english_from_the_subject_filter
+    check "Primary with english"
+  end
+
+  def and_i_see_my_selected_subject_filters
+    expect(page).to have_filter_tag("Primary with mathematics")
+    expect(page).to have_checked_field("Primary with mathematics")
+    expect(page).to have_filter_tag("Primary with english")
+    expect(page).to have_checked_field("Primary with english")
+  end
+
+  def when_i_click_on_the_primary_with_maths_subject_filter_tag
+    within ".app-filter-tags" do
+      click_on "Primary with mathematics"
+    end
+  end
+
+  def then_i_see_the_primary_school_with_the_english_placement
+    expect(page).to have_h2("Hogwarts Elementary")
+  end
+
+  def and_i_do_not_see_the_primary_school_with_the_maths_placement
+    expect(page).not_to have_h2("Springfield Elementary")
+  end
+
+  def and_i_do_not_see_the_primary_with_maths_subject_filter
+    expect(page).not_to have_filter_tag("Primary with mathematics")
+    expect(page).not_to have_checked_field("Primary with mathematics")
+    expect(page).to have_filter_tag("Primary with english")
+    expect(page).to have_checked_field("Primary with english")
+  end
+
+  def when_i_click_on_the_primary_with_english_subject_filter_tag
+    within ".app-filter-tags" do
+      click_on "Primary with english"
+    end
+  end
+
+  def and_i_do_not_see_any_selected_subject_filters
+    expect(page).not_to have_filter_tag("Primary with mathematics")
+    expect(page).not_to have_checked_field("Primary with mathematics")
+    expect(page).not_to have_filter_tag("Primary with english")
+    expect(page).not_to have_checked_field("Primary with english")
+  end
+end

--- a/spec/system/placements/providers/find/provider_user_views_a_not_hosting_school_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_views_a_not_hosting_school_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe "Provider user views a not hosting school", service: :placements, type: :system do
+  scenario do
+    given_that_schools_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_find_schools_page
+    then_i_see_the_find_schools_page
+    and_i_see_all_schools
+    and_i_cannot_see_a_link_to_view_the_not_hosting_school_details
+  end
+
+  private
+
+  def given_that_schools_exist
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+
+    @not_hosting_school = create(
+      :placements_school,
+      phase: "Secondary", name: "Shelbyville High School",
+      hosting_interests: [
+        build(:hosting_interest,
+              appetite: "not_open",
+              academic_year: Placements::AcademicYear.current),
+      ]
+    )
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_navigate_to_the_find_schools_page
+    within ".app-primary-navigation__nav" do
+      click_on "Find"
+    end
+  end
+
+  def then_i_see_the_find_schools_page
+    expect(page).to have_title("Find schools hosting placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Find schools hosting placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def and_i_see_all_schools
+    expect(page).to have_content("Shelbyville High School")
+  end
+
+  def and_i_cannot_see_a_link_to_view_the_not_hosting_school_details
+    expect(page).not_to have_link("Shelbyville High School", href: placements_placements_provider_find_path(@provider, @not_hosting_school))
+    expect(page).not_to have_link("Shelbyville High School", href: placement_information_placements_provider_find_path(@provider, @not_hosting_school))
+  end
+end

--- a/spec/system/placements/providers/find/provider_user_views_a_placements_already_organised_school_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_views_a_placements_already_organised_school_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Provider user views a school which is not onboarded", service: :
     expect(page).to have_h1("Shelbyville High School")
     expect(page).to have_tag("Already organised placements", "blue")
     expect(secondary_navigation).to have_current_item("Placements")
-    expect(page).to have_element(:p, text: "This school has specified which placements they would like to host in the 2024-2025 academic year.", class: "govuk-body")
+    expect(page).to have_element(:p, text: "This school has specified which placements they would like to host in the 2024 to 2025 academic year.", class: "govuk-body")
     expect(page).to have_h2("1 filled placement")
     expect(page).to have_table_row({
       "Subject" => "Primary (Year 1)",

--- a/spec/system/placements/providers/find/provider_user_views_a_placements_already_organised_school_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_views_a_placements_already_organised_school_spec.rb
@@ -1,0 +1,160 @@
+require "rails_helper"
+
+RSpec.describe "Provider user views a school which is not onboarded", service: :placements, type: :system do
+  scenario do
+    given_that_schools_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_find_schools_page
+    then_i_see_the_find_schools_page
+    and_i_see_all_schools
+
+    when_i_click_on_the_already_organised_school_name
+    then_i_can_see_the_placements_school_detail_page
+    and_i_do_not_see_available_placements
+
+    when_i_navigate_to_the_placement_information_page
+    then_i_see_the_placement_information_page
+
+    when_i_navigate_to_the_school_details_page
+    then_i_see_the_school_details_page
+  end
+
+  private
+
+  def given_that_schools_exist
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+    placements = build_list(:placement, 1, provider: @provider, terms: [build(:placements_term, :spring)], subject: build(:subject, name: "Primary (Year 1)"))
+    hosting_interests = build_list(:hosting_interest, 1, appetite: "actively_looking")
+    @already_hosting_school = create(
+      :placements_school,
+      phase: "Secondary",
+      name: "Shelbyville High School",
+      minimum_age: 11,
+      maximum_age: 16,
+      urn: "123456",
+      ukprn: "12345678",
+      telephone: "01234567890",
+      website: "www.shelbyville.sch.uk",
+      address1: "123 Main St",
+      town: "Shelbyville",
+      postcode: "12345",
+      type_of_establishment: "Voluntary controlled school",
+      gender: "Mixed",
+      religious_character: "Church of England",
+      admissions_policy: "Not applicable",
+      urban_or_rural: "Urban city and town",
+      school_capacity: 147,
+      total_boys: 53,
+      total_girls: 62,
+      percentage_free_school_meals: 17,
+      special_classes: "No Special Classes",
+      send_provision: "Resourced provision",
+      hosting_interests:,
+      placements:,
+    )
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_navigate_to_the_find_schools_page
+    within ".app-primary-navigation__nav" do
+      click_on "Find"
+    end
+  end
+
+  def then_i_see_the_find_schools_page
+    expect(page).to have_title("Find schools hosting placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Find schools hosting placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def and_i_see_all_schools
+    expect(page).to have_content("Shelbyville High School")
+  end
+
+  def when_i_click_on_the_already_organised_school_name
+    click_on "Shelbyville High School"
+  end
+
+  def then_i_can_see_the_placements_school_detail_page
+    expect(page).to have_title("Shelbyville High School - Find - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Shelbyville High School")
+    expect(page).to have_tag("Already organised placements", "blue")
+    expect(secondary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(:p, text: "This school has specified which placements they would like to host in the 2024-2025 academic year.", class: "govuk-body")
+    expect(page).to have_h2("1 filled placement")
+    expect(page).to have_table_row({
+      "Subject" => "Primary (Year 1)",
+      "Expected date" => "Spring term",
+    })
+  end
+
+  def and_i_do_not_see_available_placements
+    expect(page).not_to have_h2("Available placements")
+  end
+
+  def when_i_navigate_to_the_placement_information_page
+    click_on "Placement information"
+  end
+
+  def then_i_see_the_placement_information_page
+    expect(page).to have_title("Shelbyville High School - Find - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Shelbyville High School")
+    expect(page).to have_tag("Already organised placements", "blue")
+    expect(secondary_navigation).to have_current_item("Placement information")
+    expect(page).to have_h2("Placement contact")
+    expect(page).to have_summary_list_row("Name", "Placement Coordinator")
+    expect(page).to have_summary_list_row("Email", "placement_coordinator@example.school")
+    expect(page).to have_h2("Placements hosted in previous years")
+    expect(page).to have_element(:p, text: "This school has not previously offered placements", class: "govuk-body")
+  end
+
+  def when_i_navigate_to_the_school_details_page
+    click_on "School details"
+  end
+
+  def then_i_see_the_school_details_page
+    expect(page).to have_title("Shelbyville High School - Find - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Shelbyville High School")
+    expect(page).to have_tag("Already organised placements", "blue")
+    expect(secondary_navigation).to have_current_item("School details")
+
+    expect(page).to have_h2("School details")
+    expect(page).to have_summary_list_row("Phase", "Secondary")
+    expect(page).to have_summary_list_row("Age range", "11 to 16")
+    expect(page).to have_summary_list_row("UK provider reference number (UKPRN)", "12345678")
+    expect(page).to have_summary_list_row("Unique reference number (URN)", "123456")
+
+    expect(page).to have_h2("General contact details")
+    expect(page).to have_summary_list_row("Telephone number", "01234567890")
+    expect(page).to have_summary_list_row("Website", "www.shelbyville.sch.uk (opens in new tab)")
+    expect(page).to have_link("www.shelbyville.sch.uk (opens in new tab)", href: "http://www.shelbyville.sch.uk", target: "_blank")
+    expect(page).to have_summary_list_row("Address", "123 Main St Shelbyville 12345")
+
+    expect(page).to have_h2("Additional details")
+    expect(page).to have_summary_list_row("School type", "Voluntary controlled school")
+    expect(page).to have_summary_list_row("Gender", "Mixed")
+    expect(page).to have_summary_list_row("Religious character", "Church of England")
+    expect(page).to have_summary_list_row("Admissions policy", "Not applicable")
+    expect(page).to have_summary_list_row("Urban or rural", "Urban city and town")
+    expect(page).to have_summary_list_row("School capacity", "147")
+    expect(page).to have_summary_list_row("Total boys", "53")
+    expect(page).to have_summary_list_row("Total girls", "62")
+    expect(page).to have_summary_list_row("Percentage free school meals", "17%")
+
+    expect(page).to have_h2("Special educational needs and disabilities (SEND)")
+    expect(page).to have_summary_list_row("Special classes", "No Special Classes")
+    expect(page).to have_summary_list_row("SEN provision", "Resourced provision")
+
+    expect(page).to have_h2("OFSTED")
+    expect(page).to have_summary_list_row("Report", "Ofsted report (opens in new tab)")
+    expect(page).to have_summary_list_row("Last inspection date", "Unknown")
+  end
+end

--- a/spec/system/placements/providers/find/provider_user_views_a_school_which_is_not_onboarded_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_views_a_school_which_is_not_onboarded_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Provider user views a school which is not onboarded", service: :
     when_i_navigate_to_the_find_schools_page
     then_i_see_the_find_schools_page
     and_i_see_all_schools
-    and_i_cannot_see_a_link_to_view_the_not_hosting_school_details
+    and_i_cannot_see_a_link_to_view_the_school_that_is_not_onboarded
   end
 
   private
@@ -39,7 +39,7 @@ RSpec.describe "Provider user views a school which is not onboarded", service: :
     expect(page).to have_content("Shelbyville High School")
   end
 
-  def and_i_cannot_see_a_link_to_view_the_school_that_is_not_onboarded_details
+  def and_i_cannot_see_a_link_to_view_the_school_that_is_not_onboarded
     expect(page).not_to have_link("Shelbyville High School", href: placements_placements_provider_find_path(@provider, @not_onboarded_school))
     expect(page).not_to have_link("Shelbyville High School", href: placement_information_placements_provider_find_path(@provider, @not_onboarded_school))
   end

--- a/spec/system/placements/providers/find/provider_user_views_a_school_which_is_not_onboarded_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_views_a_school_which_is_not_onboarded_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe "Provider user views a school which is not onboarded", service: :placements, type: :system do
+  scenario do
+    given_that_schools_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_find_schools_page
+    then_i_see_the_find_schools_page
+    and_i_see_all_schools
+    and_i_cannot_see_a_link_to_view_the_not_hosting_school_details
+  end
+
+  private
+
+  def given_that_schools_exist
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+    @not_onboarded_school = create(:placements_school, phase: "Secondary", name: "Shelbyville High School")
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_navigate_to_the_find_schools_page
+    within ".app-primary-navigation__nav" do
+      click_on "Find"
+    end
+  end
+
+  def then_i_see_the_find_schools_page
+    expect(page).to have_title("Find schools hosting placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Find schools hosting placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def and_i_see_all_schools
+    expect(page).to have_content("Shelbyville High School")
+  end
+
+  def and_i_cannot_see_a_link_to_view_the_school_that_is_not_onboarded_details
+    expect(page).not_to have_link("Shelbyville High School", href: placements_placements_provider_find_path(@provider, @not_onboarded_school))
+    expect(page).not_to have_link("Shelbyville High School", href: placement_information_placements_provider_find_path(@provider, @not_onboarded_school))
+  end
+end

--- a/spec/system/placements/providers/find/provider_user_views_a_school_with_previous_filled_unfilled_placements_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_views_a_school_with_previous_filled_unfilled_placements_spec.rb
@@ -1,0 +1,169 @@
+require "rails_helper"
+
+RSpec.describe "Provider user views a school with previous, filled and unfilled placements", service: :placements, type: :system do
+  scenario do
+    given_that_schools_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_find_schools_page
+    then_i_see_the_find_schools_page
+    and_i_see_all_schools
+
+    when_i_click_on_the_unfilled_placements_school_name
+    then_i_can_see_the_placements_school_detail_page
+
+    when_i_navigate_to_the_placement_information_page
+    then_i_see_the_placement_information_page
+
+    when_i_navigate_to_the_school_details_page
+    then_i_see_the_school_details_page
+  end
+
+  private
+
+  def given_that_schools_exist
+    @previous_academic_year = Placements::AcademicYear.current.previous
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+    available_placement = build(:placement, terms: [build(:placements_term, :spring)], subject: build(:subject, name: "Primary (Year 1)"))
+    unavailable_placement = build(:placement, provider: @provider, terms: [build(:placements_term, :autumn)], subject: build(:subject, name: "Primary (Year 2)"))
+    previous_placement = build(:placement, subject: build(:subject, name: "Primary (Year 3)"),
+                                           academic_year: @previous_academic_year)
+    hosting_interests = build_list(:hosting_interest, 1, appetite: "actively_looking")
+    @already_hosting_school = create(
+      :placements_school,
+      phase: "Secondary",
+      name: "Shelbyville High School",
+      minimum_age: 11,
+      maximum_age: 16,
+      urn: "123456",
+      ukprn: "12345678",
+      telephone: "01234567890",
+      website: "www.shelbyville.sch.uk",
+      address1: "123 Main St",
+      town: "Shelbyville",
+      postcode: "12345",
+      type_of_establishment: "Voluntary controlled school",
+      gender: "Mixed",
+      religious_character: "Church of England",
+      admissions_policy: "Not applicable",
+      urban_or_rural: "Urban city and town",
+      school_capacity: 147,
+      total_boys: 53,
+      total_girls: 62,
+      percentage_free_school_meals: 17,
+      special_classes: "No Special Classes",
+      send_provision: "Resourced provision",
+      hosting_interests:,
+      placements: [available_placement, unavailable_placement, previous_placement],
+    )
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_navigate_to_the_find_schools_page
+    within ".app-primary-navigation__nav" do
+      click_on "Find"
+    end
+  end
+
+  def then_i_see_the_find_schools_page
+    expect(page).to have_title("Find schools hosting placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Find schools hosting placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def and_i_see_all_schools
+    expect(page).to have_content("Shelbyville High School")
+  end
+
+  def when_i_click_on_the_unfilled_placements_school_name
+    click_on "Shelbyville High School"
+  end
+
+  def then_i_can_see_the_placements_school_detail_page
+    expect(page).to have_title("Shelbyville High School - Find - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Shelbyville High School")
+    expect(page).to have_tag("Has unfilled placements", "green")
+    expect(secondary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(:p, text: "This school has specified which placements they would like to host in the 2024-2025 academic year.", class: "govuk-body")
+    expect(page).to have_h2("1 unfilled placement")
+    expect(page).to have_table_row({
+      "Subject" => "Primary (Year 1)",
+      "Expected date" => "Spring term",
+    })
+    expect(page).to have_h2("1 filled placement")
+    expect(page).to have_table_row({
+      "Subject" => "Primary (Year 2)",
+      "Expected date" => "Autumn term",
+    })
+  end
+
+  def and_i_do_not_see_unavailable_placements
+    expect(page).not_to have_h2("filled placements")
+  end
+
+  def when_i_navigate_to_the_placement_information_page
+    click_on "Placement information"
+  end
+
+  def then_i_see_the_placement_information_page
+    expect(page).to have_title("Shelbyville High School - Find - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Shelbyville High School")
+    expect(page).to have_tag("Has unfilled placements", "green")
+    expect(secondary_navigation).to have_current_item("Placement information")
+    expect(page).to have_h2("Placement contact")
+    expect(page).to have_summary_list_row("Name", "Placement Coordinator")
+    expect(page).to have_summary_list_row("Email", "placement_coordinator@example.school")
+    expect(page).to have_h2("Placements hosted in previous years")
+    expect(page).to have_summary_list_row(@previous_academic_year.name, "Offered placements in:")
+    expect(page).to have_summary_list_row(@previous_academic_year.name, "Primary (Year 3)")
+  end
+
+  def when_i_navigate_to_the_school_details_page
+    click_on "School details"
+  end
+
+  def then_i_see_the_school_details_page
+    expect(page).to have_title("Shelbyville High School - Find - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Shelbyville High School")
+    expect(page).to have_tag("Has unfilled placements", "green")
+    expect(secondary_navigation).to have_current_item("School details")
+
+    expect(page).to have_h2("School details")
+    expect(page).to have_summary_list_row("Phase", "Secondary")
+    expect(page).to have_summary_list_row("Age range", "11 to 16")
+    expect(page).to have_summary_list_row("UK provider reference number (UKPRN)", "12345678")
+    expect(page).to have_summary_list_row("Unique reference number (URN)", "123456")
+
+    expect(page).to have_h2("General contact details")
+    expect(page).to have_summary_list_row("Telephone number", "01234567890")
+    expect(page).to have_summary_list_row("Website", "www.shelbyville.sch.uk (opens in new tab)")
+    expect(page).to have_link("www.shelbyville.sch.uk (opens in new tab)", href: "http://www.shelbyville.sch.uk", target: "_blank")
+    expect(page).to have_summary_list_row("Address", "123 Main St Shelbyville 12345")
+
+    expect(page).to have_h2("Additional details")
+    expect(page).to have_summary_list_row("School type", "Voluntary controlled school")
+    expect(page).to have_summary_list_row("Gender", "Mixed")
+    expect(page).to have_summary_list_row("Religious character", "Church of England")
+    expect(page).to have_summary_list_row("Admissions policy", "Not applicable")
+    expect(page).to have_summary_list_row("Urban or rural", "Urban city and town")
+    expect(page).to have_summary_list_row("School capacity", "147")
+    expect(page).to have_summary_list_row("Total boys", "53")
+    expect(page).to have_summary_list_row("Total girls", "62")
+    expect(page).to have_summary_list_row("Percentage free school meals", "17%")
+
+    expect(page).to have_h2("Special educational needs and disabilities (SEND)")
+    expect(page).to have_summary_list_row("Special classes", "No Special Classes")
+    expect(page).to have_summary_list_row("SEN provision", "Resourced provision")
+
+    expect(page).to have_h2("OFSTED")
+    expect(page).to have_summary_list_row("Report", "Ofsted report (opens in new tab)")
+    expect(page).to have_summary_list_row("Last inspection date", "Unknown")
+  end
+end

--- a/spec/system/placements/providers/find/provider_user_views_a_school_with_previous_filled_unfilled_placements_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_views_a_school_with_previous_filled_unfilled_placements_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Provider user views a school with previous, filled and unfilled 
     expect(page).to have_h1("Shelbyville High School")
     expect(page).to have_tag("Has unfilled placements", "green")
     expect(secondary_navigation).to have_current_item("Placements")
-    expect(page).to have_element(:p, text: "This school has specified which placements they would like to host in the 2024-2025 academic year.", class: "govuk-body")
+    expect(page).to have_element(:p, text: "This school has specified which placements they would like to host in the 2024 to 2025 academic year.", class: "govuk-body")
     expect(page).to have_h2("1 unfilled placement")
     expect(page).to have_table_row({
       "Subject" => "Primary (Year 1)",

--- a/spec/system/placements/providers/find/provider_user_views_an_open_to_hosting_school_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_views_an_open_to_hosting_school_spec.rb
@@ -1,0 +1,137 @@
+require "rails_helper"
+
+RSpec.describe "Provider user views a school which is open to hosting", service: :placements, type: :system do
+  scenario do
+    given_that_schools_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_find_schools_page
+    then_i_see_the_find_schools_page
+    and_i_see_all_schools
+
+    when_i_click_on_the_open_to_hosting_school_name
+    then_i_see_the_placement_information_page
+    and_i_cannot_see_the_placements_tab
+
+    when_i_navigate_to_the_school_details_page
+    then_i_see_the_school_details_page
+  end
+
+  private
+
+  def given_that_schools_exist
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+    hosting_interests = build_list(:hosting_interest, 1, appetite: "actively_looking")
+    @already_hosting_school = create(
+      :placements_school,
+      phase: "Secondary",
+      name: "Shelbyville High School",
+      minimum_age: 11,
+      maximum_age: 16,
+      urn: "123456",
+      ukprn: "12345678",
+      telephone: "01234567890",
+      website: "www.shelbyville.sch.uk",
+      address1: "123 Main St",
+      town: "Shelbyville",
+      postcode: "12345",
+      type_of_establishment: "Voluntary controlled school",
+      gender: "Mixed",
+      religious_character: "Church of England",
+      admissions_policy: "Not applicable",
+      urban_or_rural: "Urban city and town",
+      school_capacity: 147,
+      total_boys: 53,
+      total_girls: 62,
+      percentage_free_school_meals: 17,
+      special_classes: "No Special Classes",
+      send_provision: "Resourced provision",
+      hosting_interests:,
+    )
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_navigate_to_the_find_schools_page
+    within ".app-primary-navigation__nav" do
+      click_on "Find"
+    end
+  end
+
+  def then_i_see_the_find_schools_page
+    expect(page).to have_title("Find schools hosting placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Find schools hosting placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def and_i_see_all_schools
+    expect(page).to have_content("Shelbyville High School")
+  end
+
+  def when_i_click_on_the_open_to_hosting_school_name
+    click_on "Shelbyville High School"
+  end
+
+  def and_i_cannot_see_the_placements_tab
+    expect(primary_navigation).not_to have_link("Placements", href: placements_placements_provider_find_path(@provider, @already_hosting_school))
+  end
+
+  def then_i_see_the_placement_information_page
+    expect(page).to have_title("Shelbyville High School - Find - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Shelbyville High School")
+    expect(page).to have_tag("Open to hosting", "yellow")
+    expect(secondary_navigation).to have_current_item("Placement information")
+    expect(page).to have_h2("Placement contact")
+    expect(page).to have_summary_list_row("Name", "Placement Coordinator")
+    expect(page).to have_summary_list_row("Email", "placement_coordinator@example.school")
+    expect(page).to have_h2("Placements hosted in previous years")
+    expect(page).to have_element(:p, text: "This school has not previously offered placements", class: "govuk-body")
+  end
+
+  def when_i_navigate_to_the_school_details_page
+    click_on "School details"
+  end
+
+  def then_i_see_the_school_details_page
+    expect(page).to have_title("Shelbyville High School - Find - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Shelbyville High School")
+    expect(page).to have_tag("Open to hosting", "yellow")
+    expect(secondary_navigation).to have_current_item("School details")
+
+    expect(page).to have_h2("School details")
+    expect(page).to have_summary_list_row("Phase", "Secondary")
+    expect(page).to have_summary_list_row("Age range", "11 to 16")
+    expect(page).to have_summary_list_row("UK provider reference number (UKPRN)", "12345678")
+    expect(page).to have_summary_list_row("Unique reference number (URN)", "123456")
+
+    expect(page).to have_h2("General contact details")
+    expect(page).to have_summary_list_row("Telephone number", "01234567890")
+    expect(page).to have_summary_list_row("Website", "www.shelbyville.sch.uk (opens in new tab)")
+    expect(page).to have_link("www.shelbyville.sch.uk (opens in new tab)", href: "http://www.shelbyville.sch.uk", target: "_blank")
+    expect(page).to have_summary_list_row("Address", "123 Main St Shelbyville 12345")
+
+    expect(page).to have_h2("Additional details")
+    expect(page).to have_summary_list_row("School type", "Voluntary controlled school")
+    expect(page).to have_summary_list_row("Gender", "Mixed")
+    expect(page).to have_summary_list_row("Religious character", "Church of England")
+    expect(page).to have_summary_list_row("Admissions policy", "Not applicable")
+    expect(page).to have_summary_list_row("Urban or rural", "Urban city and town")
+    expect(page).to have_summary_list_row("School capacity", "147")
+    expect(page).to have_summary_list_row("Total boys", "53")
+    expect(page).to have_summary_list_row("Total girls", "62")
+    expect(page).to have_summary_list_row("Percentage free school meals", "17%")
+
+    expect(page).to have_h2("Special educational needs and disabilities (SEND)")
+    expect(page).to have_summary_list_row("Special classes", "No Special Classes")
+    expect(page).to have_summary_list_row("SEN provision", "Resourced provision")
+
+    expect(page).to have_h2("OFSTED")
+    expect(page).to have_summary_list_row("Report", "Ofsted report (opens in new tab)")
+    expect(page).to have_summary_list_row("Last inspection date", "Unknown")
+  end
+end

--- a/spec/system/placements/providers/find/provider_user_views_an_unfilled_placements_school_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_views_an_unfilled_placements_school_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Provider user views a school which has unfilled placements", ser
     expect(page).to have_h1("Shelbyville High School")
     expect(page).to have_tag("Has unfilled placements", "green")
     expect(secondary_navigation).to have_current_item("Placements")
-    expect(page).to have_element(:p, text: "This school has specified which placements they would like to host in the 2024-2025 academic year.", class: "govuk-body")
+    expect(page).to have_element(:p, text: "This school has specified which placements they would like to host in the 2024 to 2025 academic year.", class: "govuk-body")
     expect(page).to have_h2("1 unfilled placement")
     expect(page).to have_table_row({
       "Subject" => "Primary (Year 1)",

--- a/spec/system/placements/providers/find/provider_user_views_an_unfilled_placements_school_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_views_an_unfilled_placements_school_spec.rb
@@ -1,0 +1,160 @@
+require "rails_helper"
+
+RSpec.describe "Provider user views a school which has unfilled placements", service: :placements, type: :system do
+  scenario do
+    given_that_schools_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_find_schools_page
+    then_i_see_the_find_schools_page
+    and_i_see_all_schools
+
+    when_i_click_on_the_unfilled_placements_school_name
+    then_i_can_see_the_placements_school_detail_page
+    and_i_do_not_see_unavailable_placements
+
+    when_i_navigate_to_the_placement_information_page
+    then_i_see_the_placement_information_page
+
+    when_i_navigate_to_the_school_details_page
+    then_i_see_the_school_details_page
+  end
+
+  private
+
+  def given_that_schools_exist
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+    placements = build_list(:placement, 1, terms: [build(:placements_term, :spring)], subject: build(:subject, name: "Primary (Year 1)"))
+    hosting_interests = build_list(:hosting_interest, 1, appetite: "actively_looking")
+    @already_hosting_school = create(
+      :placements_school,
+      phase: "Secondary",
+      name: "Shelbyville High School",
+      minimum_age: 11,
+      maximum_age: 16,
+      urn: "123456",
+      ukprn: "12345678",
+      telephone: "01234567890",
+      website: "www.shelbyville.sch.uk",
+      address1: "123 Main St",
+      town: "Shelbyville",
+      postcode: "12345",
+      type_of_establishment: "Voluntary controlled school",
+      gender: "Mixed",
+      religious_character: "Church of England",
+      admissions_policy: "Not applicable",
+      urban_or_rural: "Urban city and town",
+      school_capacity: 147,
+      total_boys: 53,
+      total_girls: 62,
+      percentage_free_school_meals: 17,
+      special_classes: "No Special Classes",
+      send_provision: "Resourced provision",
+      hosting_interests:,
+      placements:,
+    )
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_navigate_to_the_find_schools_page
+    within ".app-primary-navigation__nav" do
+      click_on "Find"
+    end
+  end
+
+  def then_i_see_the_find_schools_page
+    expect(page).to have_title("Find schools hosting placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Find schools hosting placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def and_i_see_all_schools
+    expect(page).to have_content("Shelbyville High School")
+  end
+
+  def when_i_click_on_the_unfilled_placements_school_name
+    click_on "Shelbyville High School"
+  end
+
+  def then_i_can_see_the_placements_school_detail_page
+    expect(page).to have_title("Shelbyville High School - Find - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Shelbyville High School")
+    expect(page).to have_tag("Has unfilled placements", "green")
+    expect(secondary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(:p, text: "This school has specified which placements they would like to host in the 2024-2025 academic year.", class: "govuk-body")
+    expect(page).to have_h2("1 unfilled placement")
+    expect(page).to have_table_row({
+      "Subject" => "Primary (Year 1)",
+      "Expected date" => "Spring term",
+    })
+  end
+
+  def and_i_do_not_see_unavailable_placements
+    expect(page).not_to have_h2("filled placements")
+  end
+
+  def when_i_navigate_to_the_placement_information_page
+    click_on "Placement information"
+  end
+
+  def then_i_see_the_placement_information_page
+    expect(page).to have_title("Shelbyville High School - Find - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Shelbyville High School")
+    expect(page).to have_tag("Has unfilled placements", "green")
+    expect(secondary_navigation).to have_current_item("Placement information")
+    expect(page).to have_h2("Placement contact")
+    expect(page).to have_summary_list_row("Name", "Placement Coordinator")
+    expect(page).to have_summary_list_row("Email", "placement_coordinator@example.school")
+    expect(page).to have_h2("Placements hosted in previous years")
+    expect(page).to have_element(:p, text: "This school has not previously offered placements", class: "govuk-body")
+  end
+
+  def when_i_navigate_to_the_school_details_page
+    click_on "School details"
+  end
+
+  def then_i_see_the_school_details_page
+    expect(page).to have_title("Shelbyville High School - Find - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Shelbyville High School")
+    expect(page).to have_tag("Has unfilled placements", "green")
+    expect(secondary_navigation).to have_current_item("School details")
+
+    expect(page).to have_h2("School details")
+    expect(page).to have_summary_list_row("Phase", "Secondary")
+    expect(page).to have_summary_list_row("Age range", "11 to 16")
+    expect(page).to have_summary_list_row("UK provider reference number (UKPRN)", "12345678")
+    expect(page).to have_summary_list_row("Unique reference number (URN)", "123456")
+
+    expect(page).to have_h2("General contact details")
+    expect(page).to have_summary_list_row("Telephone number", "01234567890")
+    expect(page).to have_summary_list_row("Website", "www.shelbyville.sch.uk (opens in new tab)")
+    expect(page).to have_link("www.shelbyville.sch.uk (opens in new tab)", href: "http://www.shelbyville.sch.uk", target: "_blank")
+    expect(page).to have_summary_list_row("Address", "123 Main St Shelbyville 12345")
+
+    expect(page).to have_h2("Additional details")
+    expect(page).to have_summary_list_row("School type", "Voluntary controlled school")
+    expect(page).to have_summary_list_row("Gender", "Mixed")
+    expect(page).to have_summary_list_row("Religious character", "Church of England")
+    expect(page).to have_summary_list_row("Admissions policy", "Not applicable")
+    expect(page).to have_summary_list_row("Urban or rural", "Urban city and town")
+    expect(page).to have_summary_list_row("School capacity", "147")
+    expect(page).to have_summary_list_row("Total boys", "53")
+    expect(page).to have_summary_list_row("Total girls", "62")
+    expect(page).to have_summary_list_row("Percentage free school meals", "17%")
+
+    expect(page).to have_h2("Special educational needs and disabilities (SEND)")
+    expect(page).to have_summary_list_row("Special classes", "No Special Classes")
+    expect(page).to have_summary_list_row("SEN provision", "Resourced provision")
+
+    expect(page).to have_h2("OFSTED")
+    expect(page).to have_summary_list_row("Report", "Ofsted report (opens in new tab)")
+    expect(page).to have_summary_list_row("Last inspection date", "Unknown")
+  end
+end


### PR DESCRIPTION
## Context

We've collectively agreed that we're changing the provider experience for the private beta in Essex, this lays the foundation for the new provider experience.

## Changes proposed in this pull request

- Creates the new Find page that will serve as the entry point to the service in the Essex private beta launch
- Adds 3 new school focused views to look at and enjoy 👀 
- Introduces the InterestTagComponent which calculates a schools desire to host placements and outputs a handy tag
- Includes filters for schools, therefore a new filter form and query object
- So many specs I thought my brain would leak out of my ears

## Guidance to review

- Functionally this one will be tricky to test without the data and the complete EOI/Find a school logic on a combined branch but I'm happy to demo the changes.
- Code wise, this is vastly too large but time is short and there isn't really the time to split it out into smaller PR's, so I apolgise but it's going to be a marathon.

## Link to Trello card

[Find a school page](https://trello.com/c/JJHaWl9Q/523-find-a-school-page)

## Screenshots

![image](https://github.com/user-attachments/assets/96efc93b-ad1e-4d6f-992c-e7c3d8fd9877)
![image](https://github.com/user-attachments/assets/a4f6a70a-3acd-4b05-85f3-5b7447cda538)
![image](https://github.com/user-attachments/assets/aacf521c-8ecd-4aaf-b29f-6803b5b1a16f)
![image](https://github.com/user-attachments/assets/8892f0fa-cbf4-42ec-9499-9f7b443baf5e)

