### PR TITLE
Add claim funding dns zone

### DIFF
--- a/terraform/domains/infrastructure/config/zones.tfvars.json
+++ b/terraform/domains/infrastructure/config/zones.tfvars.json
@@ -18,6 +18,19 @@
       "txt_records": {},
       "resource_group_name": "s189p01-ittmsdomains-rg",
       "front_door_name": "s189p01-ittmssp-domains-fd"
+    },
+    "claim-funding-for-itt-mentor-training.service.gov.uk": {
+      "caa_records": {},
+      "txt_records": {
+        "@": {
+          "value": "v=spf1 -all"
+        },
+        "_dmarc": {
+          "value": "v=DMARC1;p=quarantine;sp=quarantine;pct=100;fo=1;rua=mailto:dmarc-rua@dmarc.service.gov.uk,mailto:dmarc-rua@education.gov.uk;ruf=mailto:DMARC.Forensic@education.gov.uk"
+        }
+      },
+      "resource_group_name": "s189p01-ittmsdomains-rg",
+      "front_door_name": "s189p01-ittmssvc-domains-fd"
     }
   },
   "tags": {


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
A new domain - claim-funding-for-itt-mentor-training.service.gov.uk needs to be added

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
A new dns zone via terraform configuration

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
The domain plan should be successful

## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/Y3u8I72m