### PR TITLE
Removes the plpgsql extension which is now enabled by default

### DIFF
--- a/terraform/application/database.tf
+++ b/terraform/application/database.tf
@@ -10,7 +10,7 @@ module "postgres" {
   cluster_configuration_map   = module.cluster_data.configuration_map
   use_azure                   = var.deploy_azure_backing_services
   azure_enable_monitoring     = var.enable_monitoring
-  azure_extensions            = ["pg_trgm", "plpgsql"]
+  azure_extensions            = ["pg_trgm"]
   azure_enable_backup_storage = var.enable_postgres_backup_storage
   server_version              = "14"
   azure_sku_name          = var.postgres_flexible_server_sku


### PR DESCRIPTION
## Context

The plpgsql extension is now enabled by default and is no longer required as a parameter.

## Changes proposed in this pull request

- Remove plpgsql from `terraform/application/database.tf`

## Guidance to review

- Ensure that only plpgsql has been removed