### PR TITLE
Claims manually add organisation

### DIFF
--- a/app/controllers/claims/support/organisations/add_organisation_controller.rb
+++ b/app/controllers/claims/support/organisations/add_organisation_controller.rb
@@ -1,0 +1,40 @@
+class Claims::Support::Organisations::AddOrganisationController < Claims::Support::ApplicationController
+  include WizardController
+
+  before_action :authorize_school
+  before_action :set_wizard
+
+  def update
+    if !@wizard.save_step
+      render "edit"
+    elsif @wizard.next_step.present?
+      redirect_to step_path(@wizard.next_step)
+    else
+      @wizard.create_organisation
+      @wizard.reset_state
+      redirect_to claims_support_schools_path, flash: {
+        heading: t(".success"),
+      }
+    end
+  end
+
+  private
+
+  def set_wizard
+    state = session[state_key] ||= {}
+    current_step = params[:step]&.to_sym
+    @wizard = Claims::AddOrganisationWizard.new(params:, state:, current_step:)
+  end
+
+  def authorize_school
+    authorize Claims::School
+  end
+
+  def step_path(step)
+    add_organisation_claims_support_organisations_path(state_key:, step:)
+  end
+
+  def index_path
+    claims_support_schools_path
+  end
+end

--- a/app/models/claims/school.rb
+++ b/app/models/claims/school.rb
@@ -39,7 +39,7 @@
 #  type_of_establishment                  :string
 #  ukprn                                  :string
 #  urban_or_rural                         :string
-#  urn                                    :string           not null
+#  urn                                    :string
 #  vendor_number                          :string
 #  website                                :string
 #  created_at                             :datetime         not null

--- a/app/models/claims/school.rb
+++ b/app/models/claims/school.rb
@@ -40,6 +40,7 @@
 #  ukprn                                  :string
 #  urban_or_rural                         :string
 #  urn                                    :string           not null
+#  vendor_number                          :string
 #  website                                :string
 #  created_at                             :datetime         not null
 #  updated_at                             :datetime         not null

--- a/app/models/claims/school.rb
+++ b/app/models/claims/school.rb
@@ -82,7 +82,7 @@ class Claims::School < School
 
   belongs_to :claims_grant_conditions_accepted_by, class_name: "User", optional: true
 
-  delegate :funding_available_per_hour, to: :region, prefix: true, allow_nil: true
+  delegate :funding_available_per_hour, :name, to: :region, prefix: true, allow_nil: true
 
   def grant_conditions_accepted?
     claims_grant_conditions_accepted_at?

--- a/app/models/placements/school.rb
+++ b/app/models/placements/school.rb
@@ -39,7 +39,7 @@
 #  type_of_establishment                  :string
 #  ukprn                                  :string
 #  urban_or_rural                         :string
-#  urn                                    :string           not null
+#  urn                                    :string
 #  vendor_number                          :string
 #  website                                :string
 #  created_at                             :datetime         not null

--- a/app/models/placements/school.rb
+++ b/app/models/placements/school.rb
@@ -40,6 +40,7 @@
 #  ukprn                                  :string
 #  urban_or_rural                         :string
 #  urn                                    :string           not null
+#  vendor_number                          :string
 #  website                                :string
 #  created_at                             :datetime         not null
 #  updated_at                             :datetime         not null

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -40,6 +40,7 @@
 #  ukprn                                  :string
 #  urban_or_rural                         :string
 #  urn                                    :string           not null
+#  vendor_number                          :string
 #  website                                :string
 #  created_at                             :datetime         not null
 #  updated_at                             :datetime         not null

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -93,8 +93,10 @@ class School < ApplicationRecord
 
   normalizes :email_address, with: ->(value) { value.strip.downcase }
 
-  validates :urn, presence: true
+  validates_with UniqueIdentifierValidator
   validates :urn, uniqueness: { case_sensitive: false }
+  validates :vendor_number, uniqueness: { case_sensitive: false }
+
   validates :name, presence: true
   validates :email_address, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_nil: true
 
@@ -113,6 +115,8 @@ class School < ApplicationRecord
   pg_search_scope :search_name_postcode,
                   against: %i[name postcode],
                   using: { trigram: { word_similarity: true } }
+
+  delegate :name, to: :region, prefix: true, allow_nil: true
 
   PRIMARY_PHASE = "Primary".freeze
   SECONDARY_PHASE = "Secondary".freeze

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -93,8 +93,11 @@ class School < ApplicationRecord
 
   normalizes :email_address, with: ->(value) { value.strip.downcase }
 
-  validates :urn, presence: true
-  validates :urn, uniqueness: { case_sensitive: false }
+  validates_with UniqueIdentifierValidator
+
+  validates :urn, uniqueness: { case_sensitive: false }, if: -> { urn.present? }
+  validates :vendor_number, uniqueness: { case_sensitive: false }, if: -> { vendor_number.present? }
+
   validates :name, presence: true
   validates :email_address, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_nil: true
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -39,7 +39,7 @@
 #  type_of_establishment                  :string
 #  ukprn                                  :string
 #  urban_or_rural                         :string
-#  urn                                    :string           not null
+#  urn                                    :string
 #  vendor_number                          :string
 #  website                                :string
 #  created_at                             :datetime         not null
@@ -93,10 +93,8 @@ class School < ApplicationRecord
 
   normalizes :email_address, with: ->(value) { value.strip.downcase }
 
-  validates_with UniqueIdentifierValidator
+  validates :urn, presence: true
   validates :urn, uniqueness: { case_sensitive: false }
-  validates :vendor_number, uniqueness: { case_sensitive: false }
-
   validates :name, presence: true
   validates :email_address, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_nil: true
 
@@ -115,8 +113,6 @@ class School < ApplicationRecord
   pg_search_scope :search_name_postcode,
                   against: %i[name postcode],
                   using: { trigram: { word_similarity: true } }
-
-  delegate :name, to: :region, prefix: true, allow_nil: true
 
   PRIMARY_PHASE = "Primary".freeze
   SECONDARY_PHASE = "Secondary".freeze

--- a/app/services/gias/csv_importer.rb
+++ b/app/services/gias/csv_importer.rb
@@ -20,6 +20,8 @@ module Gias
       sen_provision_associations = Hash.new { |h, k| h[k] = [] }
 
       CSV.foreach(csv_path, headers: true) do |school|
+        next if school["URN"].blank?
+
         school_records << {
           urn: school["URN"],
           name: school["EstablishmentName"],

--- a/app/validators/unique_identifier_validator.rb
+++ b/app/validators/unique_identifier_validator.rb
@@ -1,0 +1,7 @@
+class UniqueIdentifierValidator < ActiveModel::Validator
+  def validate(record)
+    if record.urn.blank? && record.vendor_number.blank?
+      record.errors.add(:base, "A unique reference number (URN) or vendor number is required")
+    end
+  end
+end

--- a/app/views/claims/support/organisations/add_organisation/edit.html.erb
+++ b/app/views/claims/support/organisations/add_organisation/edit.html.erb
@@ -1,0 +1,13 @@
+<% render "claims/support/primary_navigation", current: :organisations %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: back_link_path) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= render_wizard(@wizard) %>
+
+  <p class="govuk-body">
+    <%= govuk_link_to(t(".cancel"), claims_support_schools_path, no_visited_state: true) %>
+  </p>
+</div>

--- a/app/views/wizards/claims/add_organisation_wizard/_address_step.html.erb
+++ b/app/views/wizards/claims/add_organisation_wizard/_address_step.html.erb
@@ -1,0 +1,30 @@
+<%= content_for :page_title, sanitize(t(".title")) %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-caption-l"><%= t(".caption") %></p>
+      <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+
+      <%= form_with(model: current_step, url: current_step_path, method: :put) do |f| %>
+        <div class="govuk-form-group">
+          <%= f.govuk_text_field :address1, class: "govuk-input--width-20", label: { text: t(".address1"), size: "s" } %>
+        </div>
+
+        <div class="govuk-form-group">
+          <%= f.govuk_text_field :address2, class: "govuk-input--width-20", label: { text: t(".address2"), size: "s" } %>
+        </div>
+
+        <div class="govuk-form-group">
+          <%= f.govuk_text_field :town, class: "govuk-input--width-20", label: { text: t(".town"), size: "s" } %>
+        </div>
+
+        <div class="govuk-form-group">
+          <%= f.govuk_text_field :postcode, class: "govuk-input--width-20", label: { text: t(".postcode"), size: "s" } %>
+        </div>
+
+        <%= f.govuk_submit t(".continue") %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/wizards/claims/add_organisation_wizard/_address_step.html.erb
+++ b/app/views/wizards/claims/add_organisation_wizard/_address_step.html.erb
@@ -1,12 +1,17 @@
-<%= content_for :page_title, sanitize(t(".title")) %>
+<% content_for :page_title, title_with_error_prefix(
+  t(".title"),
+  error: current_step.errors.any?,
+) %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-caption-l"><%= t(".caption") %></p>
+      <span class="govuk-caption-l"><%= t(".caption") %></span>
       <h1 class="govuk-heading-l"><%= t(".title") %></h1>
 
       <%= form_with(model: current_step, url: current_step_path, method: :put) do |f| %>
+        <%= f.govuk_error_summary %>
+
         <div class="govuk-form-group">
           <%= f.govuk_text_field :address1, class: "govuk-input--width-20", label: { text: t(".address1"), size: "s" } %>
         </div>

--- a/app/views/wizards/claims/add_organisation_wizard/_check_your_answers_step.html.erb
+++ b/app/views/wizards/claims/add_organisation_wizard/_check_your_answers_step.html.erb
@@ -1,0 +1,101 @@
+<%= content_for :page_title, sanitize(t(".title")) %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= form_with(model: current_step, url: current_step_path, method: :put) do |f| %>
+          <span class="govuk-caption-l"><%= t(".caption") %></span>
+          <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+
+        <%= govuk_summary_list do |summary_list| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".name")) %>
+            <% row.with_value(text: wizard.organisation.name) %>
+            <% row.with_action(text: t(".change"),
+                               href: step_path(:name),
+                               html_attributes: {
+                                 class: "govuk-link--no-visited-state",
+                               },
+                               visually_hidden_text: t(".name")) %>
+          <% end %>
+
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".vendor_number")) %>
+            <% row.with_value(text: wizard.organisation.vendor_number) %>
+            <% row.with_action(text: t(".change"),
+                               href: step_path(:vendor_number),
+                               html_attributes: {
+                                 class: "govuk-link--no-visited-state",
+                               },
+                               visually_hidden_text: t(".vendor_number")) %>
+          <% end %>
+
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".claim_window")) %>
+            <% row.with_value(text: wizard.claim_window.decorate.name) %>
+            <% row.with_action(text: t(".change"),
+                               href: step_path(:claim_window),
+                               html_attributes: {
+                                 class: "govuk-link--no-visited-state",
+                               },
+                               visually_hidden_text: t(".claim_window")) %>
+          <% end %>
+
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".region")) %>
+            <% row.with_value(text: wizard.organisation.region_name) %>
+            <% row.with_action(text: t(".change"),
+                               href: step_path(:address),
+                               html_attributes: {
+                                 class: "govuk-link--no-visited-state",
+                               },
+                               visually_hidden_text: t(".region")) %>
+          <% end %>
+        <% end %>
+
+        <h2 class="govuk-heading-m govuk-!-margin-top-7">
+          <%= t(".contact_details") %>
+        </h2>
+
+        <%= govuk_summary_list do |summary_list| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".address")) %>
+            <% row.with_value(text: wizard.organisation.formatted_address) %>
+            <% row.with_action(text: t(".change"),
+                               href: step_path(:address),
+                               html_attributes: {
+                                 class: "govuk-link--no-visited-state",
+                               },
+                               visually_hidden_text: t(".address")) %>
+          <% end %>
+
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".telephone")) %>
+            <% row.with_value(text: wizard.organisation.telephone) %>
+            <% row.with_action(text: t(".change"),
+                               href: step_path(:contact_details),
+                               html_attributes: {
+                                 class: "govuk-link--no-visited-state",
+                               },
+                               visually_hidden_text: t(".telephone")) %>
+          <% end %>
+
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".website")) %>
+            <% row.with_value do %>
+              <%= govuk_link_to(wizard.organisation.website, external_link(wizard.organisation.website), target: "_blank", rel: "noopener noreferrer") %>
+            <% end %>
+            <% row.with_action(text: t(".change"),
+                               href: step_path(:contact_details),
+                               html_attributes: {
+                                 class: "govuk-link--no-visited-state",
+                               },
+                               visually_hidden_text: t(".website")) %>
+          <% end %>
+        <% end %>
+
+        <%= f.govuk_submit t(".save_organisation") %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/wizards/claims/add_organisation_wizard/_check_your_answers_step.html.erb
+++ b/app/views/wizards/claims/add_organisation_wizard/_check_your_answers_step.html.erb
@@ -45,7 +45,7 @@
             <% row.with_key(text: t(".region")) %>
             <% row.with_value(text: wizard.organisation.region_name) %>
             <% row.with_action(text: t(".change"),
-                               href: step_path(:address),
+                               href: step_path(:region),
                                html_attributes: {
                                  class: "govuk-link--no-visited-state",
                                },

--- a/app/views/wizards/claims/add_organisation_wizard/_contact_details_step.html.erb
+++ b/app/views/wizards/claims/add_organisation_wizard/_contact_details_step.html.erb
@@ -1,12 +1,17 @@
-<%= content_for :page_title, sanitize(t(".title")) %>
+<% content_for :page_title, title_with_error_prefix(
+  t(".title"),
+  error: current_step.errors.any?,
+) %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-caption-l"><%= t(".caption") %></p>
+      <span class="govuk-caption-l"><%= t(".caption") %></span>
       <h1 class="govuk-heading-l"><%= t(".title") %></h1>
 
       <%= form_with(model: current_step, url: current_step_path, method: :put) do |f| %>
+        <%= f.govuk_error_summary %>
+
         <div class="govuk-form-group">
           <%= f.govuk_text_field :telephone, class: "govuk-input--width-20", label: { text: t(".telephone"), size: "s" } %>
         </div>

--- a/app/views/wizards/claims/add_organisation_wizard/_contact_details_step.html.erb
+++ b/app/views/wizards/claims/add_organisation_wizard/_contact_details_step.html.erb
@@ -1,0 +1,22 @@
+<%= content_for :page_title, sanitize(t(".title")) %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-caption-l"><%= t(".caption") %></p>
+      <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+
+      <%= form_with(model: current_step, url: current_step_path, method: :put) do |f| %>
+        <div class="govuk-form-group">
+          <%= f.govuk_text_field :telephone, class: "govuk-input--width-20", label: { text: t(".telephone"), size: "s" } %>
+        </div>
+
+        <div class="govuk-form-group">
+          <%= f.govuk_text_field :website, class: "govuk-input--width-20", label: { text: t(".website"), size: "s" } %>
+        </div>
+
+        <%= f.govuk_submit t(".continue") %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/wizards/claims/add_organisation_wizard/_name_step.html.erb
+++ b/app/views/wizards/claims/add_organisation_wizard/_name_step.html.erb
@@ -1,0 +1,18 @@
+<%= content_for :page_title, sanitize(t(".title")) %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= form_with(model: current_step, url: current_step_path, method: :put) do |f| %>
+        <div class="govuk-form-group">
+          <%= f.govuk_text_field :name,
+                                 class: "govuk-input--width-20",
+                                 label: { text: t(".title"), size: "l", tag: "h1" },
+                                 caption: { text: t(".caption"), size: "l" } %>
+        </div>
+
+        <%= f.govuk_submit t(".continue") %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/wizards/claims/add_organisation_wizard/_name_step.html.erb
+++ b/app/views/wizards/claims/add_organisation_wizard/_name_step.html.erb
@@ -1,9 +1,14 @@
-<%= content_for :page_title, sanitize(t(".title")) %>
+<% content_for :page_title, title_with_error_prefix(
+  t(".title"),
+  error: current_step.errors.any?,
+) %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= form_with(model: current_step, url: current_step_path, method: :put) do |f| %>
+        <%= f.govuk_error_summary %>
+
         <div class="govuk-form-group">
           <%= f.govuk_text_field :name,
                                  class: "govuk-input--width-20",

--- a/app/views/wizards/claims/add_organisation_wizard/_region_step.html.erb
+++ b/app/views/wizards/claims/add_organisation_wizard/_region_step.html.erb
@@ -1,9 +1,14 @@
-<%= content_for :page_title, sanitize(t(".title")) %>
+<% content_for :page_title, title_with_error_prefix(
+  t(".title"),
+  error: current_step.errors.any?,
+) %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= form_with(model: current_step, url: current_step_path, method: :put) do |f| %>
+        <%= f.govuk_error_summary %>
+
         <%= f.govuk_radio_buttons_fieldset(:region_id,
           legend: { text: t(".title"), size: "l", tag: "h1" }, caption: { text: t(".caption"), size: "l" },
           hint: { text: t(".hint") }) do %>

--- a/app/views/wizards/claims/add_organisation_wizard/_region_step.html.erb
+++ b/app/views/wizards/claims/add_organisation_wizard/_region_step.html.erb
@@ -1,0 +1,19 @@
+<%= content_for :page_title, sanitize(t(".title")) %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= form_with(model: current_step, url: current_step_path, method: :put) do |f| %>
+        <%= f.govuk_radio_buttons_fieldset(:region_id,
+          legend: { text: t(".title"), size: "l", tag: "h1" }, caption: { text: t(".caption"), size: "l" },
+          hint: { text: t(".hint") }) do %>
+          <% current_step.regions.each do |region| %>
+            <%= f.govuk_radio_button :region_id, region.id, label: { text: region.name }, link_errors: true %>
+          <% end %>
+        <% end %>
+
+        <%= f.govuk_submit t(".continue") %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/wizards/claims/add_organisation_wizard/_vendor_number_step.html.erb
+++ b/app/views/wizards/claims/add_organisation_wizard/_vendor_number_step.html.erb
@@ -1,9 +1,14 @@
-<%= content_for :page_title, sanitize(t(".title")) %>
+<% content_for :page_title, title_with_error_prefix(
+  t(".title"),
+  error: current_step.errors.any?,
+) %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= form_with(model: current_step, url: current_step_path, method: :put) do |f| %>
+        <%= f.govuk_error_summary %>
+
         <%= f.govuk_text_field :vendor_number,
                                class: "govuk-input--width-20",
                                label: { text: t(".title"), size: "l", tag: "h1" },

--- a/app/views/wizards/claims/add_organisation_wizard/_vendor_number_step.html.erb
+++ b/app/views/wizards/claims/add_organisation_wizard/_vendor_number_step.html.erb
@@ -1,0 +1,25 @@
+<%= content_for :page_title, sanitize(t(".title")) %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= form_with(model: current_step, url: current_step_path, method: :put) do |f| %>
+        <%= f.govuk_text_field :vendor_number,
+                               class: "govuk-input--width-20",
+                               label: { text: t(".title"), size: "l", tag: "h1" },
+                               caption: { text: t(".caption"), size: "l" } %>
+
+        <%= f.govuk_submit t(".continue") %>
+
+        <%= govuk_details(summary_text: t(".no_vendor_number")) do %>
+          <p class="govuk-body"><%= t(".vendor_number_information_html", link: govuk_link_to(
+            t(".link_text"),
+            external_link("www.gov.uk/guidance/provide-information-about-your-banking-and-payments-to-dfe"),
+            new_tab: true,
+          )) %></p>
+          <p class="govuk-body"><%= t(".once_provided") %></p>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/wizards/claims/add_school_wizard/_check_your_answers_step.html.erb
+++ b/app/views/wizards/claims/add_school_wizard/_check_your_answers_step.html.erb
@@ -9,16 +9,6 @@
 
         <%= govuk_summary_list do |summary_list| %>
           <% summary_list.with_row do |row| %>
-            <% row.with_key(text: t(".claim_window")) %>
-            <% row.with_value(text: wizard.claim_window.decorate.name) %>
-            <% row.with_action(text: t(".change"),
-                               href: step_path(:claim_window),
-                               html_attributes: {
-                                 class: "govuk-link--no-visited-state",
-                               },
-                               visually_hidden_text: t(".claim_window")) %>
-          <% end %>
-          <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".organisation_name")) %>
             <% row.with_value(text: wizard.school.name) %>
             <% row.with_action(text: t(".change"),
@@ -27,6 +17,16 @@
                                  class: "govuk-link--no-visited-state",
                                },
                                visually_hidden_text: t(".organisation_name")) %>
+          <% end %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".claim_window")) %>
+            <% row.with_value(text: wizard.claim_window.decorate.name) %>
+            <% row.with_action(text: t(".change"),
+                               href: step_path(:claim_window),
+                               html_attributes: {
+                                 class: "govuk-link--no-visited-state",
+                               },
+                               visually_hidden_text: t(".claim_window")) %>
           <% end %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".ukprn")) %>

--- a/app/views/wizards/claims/add_school_wizard/_school_step.html.erb
+++ b/app/views/wizards/claims/add_school_wizard/_school_step.html.erb
@@ -16,3 +16,26 @@
     previous_search: current_step.id,
   },
 ) %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= govuk_details(summary_text: t(".organisation_not_listed")) do %>
+        <%= govuk_list type: :number do %>
+          <li>
+            <%= t(".ask_organisation_html", link: govuk_link_to(
+              t(".ask_link"),
+              external_link("www.gov.uk/guidance/provide-information-about-your-banking-and-payments-to-dfe"),
+              new_tab: true,
+            )) %>
+          </li>
+          <li><%= t(".wait_for_organisation") %></li>
+          <li>
+            <%= t(".return_html", link: govuk_link_to(t(".manually_add"),
+              new_add_organisation_claims_support_organisations_path, no_visited_state: true)) %>
+          </li>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/wizards/claims/add_organisation_wizard.rb
+++ b/app/wizards/claims/add_organisation_wizard.rb
@@ -1,0 +1,38 @@
+module Claims
+  class AddOrganisationWizard < BaseWizard
+    def define_steps
+      add_step(NameStep)
+      add_step(VendorNumberStep)
+      add_step(AddSchoolWizard::ClaimWindowStep)
+      add_step(RegionStep)
+      add_step(AddressStep)
+      add_step(ContactDetailsStep)
+      add_step(CheckYourAnswersStep)
+    end
+
+    def organisation
+      @organisation ||= Claims::School.build(
+        name: steps.fetch(:name).name,
+        vendor_number: steps.fetch(:vendor_number).vendor_number,
+        address1: steps.fetch(:address).address1,
+        address2: steps.fetch(:address).address2,
+        postcode: steps.fetch(:address).postcode,
+        town: steps.fetch(:address).town,
+        region_id: steps.fetch(:region).region_id,
+        website: steps.fetch(:contact_details).website,
+        telephone: steps.fetch(:contact_details).telephone,
+      ).decorate
+    end
+
+    def create_organisation
+      organisation.eligibilities.build(claim_window:)
+      organisation.save!
+    end
+
+    def claim_window
+      @claim_window ||= Claims::ClaimWindow.find(
+        steps.fetch(:claim_window).claim_window_id,
+      )
+    end
+  end
+end

--- a/app/wizards/claims/add_organisation_wizard.rb
+++ b/app/wizards/claims/add_organisation_wizard.rb
@@ -1,13 +1,17 @@
 module Claims
   class AddOrganisationWizard < BaseWizard
     def define_steps
-      add_step(NameStep)
-      add_step(VendorNumberStep)
-      add_step(AddSchoolWizard::ClaimWindowStep)
-      add_step(RegionStep)
-      add_step(AddressStep)
-      add_step(ContactDetailsStep)
-      add_step(CheckYourAnswersStep)
+      if claim_windows_exist?
+        add_step(NameStep)
+        add_step(VendorNumberStep)
+        add_step(AddSchoolWizard::ClaimWindowStep)
+        add_step(RegionStep)
+        add_step(AddressStep)
+        add_step(ContactDetailsStep)
+        add_step(CheckYourAnswersStep)
+      else
+        add_step(AddSchoolWizard::NoClaimWindowStep)
+      end
     end
 
     def organisation
@@ -33,6 +37,13 @@ module Claims
       @claim_window ||= Claims::ClaimWindow.find(
         steps.fetch(:claim_window).claim_window_id,
       )
+    end
+
+    private
+
+    def claim_windows_exist?
+      Claims::ClaimWindow.current.present? ||
+        Claims::ClaimWindow.next.present?
     end
   end
 end

--- a/app/wizards/claims/add_organisation_wizard/address_step.rb
+++ b/app/wizards/claims/add_organisation_wizard/address_step.rb
@@ -1,0 +1,10 @@
+class Claims::AddOrganisationWizard::AddressStep < BaseStep
+  attribute :address1
+  attribute :address2
+  attribute :town
+  attribute :postcode
+
+  validates :address1, presence: true
+  validates :town, presence: true
+  validates :postcode, presence: true, format: { with: /\A[a-zA-Z0-9 ]+\z/, message: "only allows letters and numbers" }
+end

--- a/app/wizards/claims/add_organisation_wizard/check_your_answers_step.rb
+++ b/app/wizards/claims/add_organisation_wizard/check_your_answers_step.rb
@@ -1,0 +1,1 @@
+class Claims::AddOrganisationWizard::CheckYourAnswersStep < BaseStep; end

--- a/app/wizards/claims/add_organisation_wizard/contact_details_step.rb
+++ b/app/wizards/claims/add_organisation_wizard/contact_details_step.rb
@@ -1,0 +1,7 @@
+class Claims::AddOrganisationWizard::ContactDetailsStep < BaseStep
+  attribute :telephone
+  attribute :website
+
+  validates :telephone, presence: true, format: { with: /\A[0-9 ]+\z/, message: "only allows numbers and spaces" }
+  validates :website, presence: true
+end

--- a/app/wizards/claims/add_organisation_wizard/name_step.rb
+++ b/app/wizards/claims/add_organisation_wizard/name_step.rb
@@ -1,0 +1,5 @@
+class Claims::AddOrganisationWizard::NameStep < BaseStep
+  attribute :name
+
+  validates :name, presence: true
+end

--- a/app/wizards/claims/add_organisation_wizard/region_step.rb
+++ b/app/wizards/claims/add_organisation_wizard/region_step.rb
@@ -1,0 +1,9 @@
+class Claims::AddOrganisationWizard::RegionStep < BaseStep
+  attribute :region_id
+
+  validates :region_id, presence: true
+
+  def regions
+    @regions ||= Region.all
+  end
+end

--- a/app/wizards/claims/add_organisation_wizard/vendor_number_step.rb
+++ b/app/wizards/claims/add_organisation_wizard/vendor_number_step.rb
@@ -1,0 +1,5 @@
+class Claims::AddOrganisationWizard::VendorNumberStep < BaseStep
+  attribute :vendor_number
+
+  validates :vendor_number, presence: true
+end

--- a/app/wizards/claims/add_school_wizard.rb
+++ b/app/wizards/claims/add_school_wizard.rb
@@ -2,9 +2,9 @@ module Claims
   class AddSchoolWizard < BaseWizard
     def define_steps
       if claim_windows_exist?
-        add_step(ClaimWindowStep)
         add_step(SchoolStep)
         add_step(SchoolOptionsStep) if steps.fetch(:school).school.blank?
+        add_step(ClaimWindowStep)
         add_step(CheckYourAnswersStep)
       else
         add_step(NoClaimWindowStep)

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -171,6 +171,7 @@ shared:
     - local_authority_code
     - claims_grant_conditions_accepted_at
     - claims_grant_conditions_accepted_by_id
+    - vendor_number
   :providers:
     - id
     - code

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -357,3 +357,29 @@ en:
                 Your file needs a column called %{missing_columns}.
               uploaded_headers:
                 Right now it has columns called %{uploaded_headers}.
+        claims/add_organisation_wizard/name_step:
+          attributes:
+            name:
+              blank: Please enter the name of the organisation
+        claims/add_organisation_wizard/vendor_number_step:
+          attributes:
+            vendor_number:
+              blank: Please enter a vendor number for the organisation
+        claims/add_organisation_wizard/region_step:
+          attributes:
+            region_id:
+              blank: Please select a region for the organisation
+        claims/add_organisation_wizard/address_step:
+          attributes:
+            address1:
+              blank: Please enter the first line of the address for the organisation
+            town:
+              blank: Please enter the town or city for the organisation
+            postcode:
+              blank: Please enter the postcode for the organisation
+        claims/add_organisation_wizard/contact_details_step:
+          attributes:
+            telephone:
+              blank: Please enter a telephone number for the organisation
+            website:
+              blank: Please enter a website address for the organisation

--- a/config/locales/en/claims/support/organisations/add_organisation.yml
+++ b/config/locales/en/claims/support/organisations/add_organisation.yml
@@ -1,0 +1,9 @@
+en:
+  claims:
+    support:
+      organisations:
+        add_organisation:
+          edit:
+            cancel: Cancel
+          update:
+            success: Organisation added

--- a/config/locales/en/wizards/claims/add_organisation_wizard.yml
+++ b/config/locales/en/wizards/claims/add_organisation_wizard.yml
@@ -1,0 +1,50 @@
+en:
+  wizards:
+    claims:
+      add_organisation_wizard:
+        name_step:
+          caption: Add organisation
+          title: Enter the organisation name
+          continue: Continue
+        vendor_number_step:
+          caption: Add organisation
+          title: Enter the organisation's vendor number
+          continue: Continue
+          no_vendor_number: The organisation has not provided a vendor number
+          link_text: providing information about their banking and payments to DfE
+          vendor_number_information_html: | 
+            The organisation can get a vendor number by %{link}.
+            Receiving a vendor number may take up to 6 weeks.
+          once_provided: Once they have provided you with a vendor number, you will be able to manually add them.
+        address_step:
+          caption: Add organisation
+          title: Enter the organisation's address
+          address1: Address line 1
+          address2: Address line 2 (optional)
+          town: Town or city
+          postcode: Postcode
+          continue: Continue
+        region_step:
+          caption: Add organisation
+          title: Enter the organisation's region
+          hint: The region is required to calculate the claim amount
+          continue: Continue
+        contact_details_step:
+          caption: Add organisation
+          title: Enter the organisation's contact details
+          telephone: Telephone number
+          website: Website address
+          continue: Continue
+        check_your_answers_step:
+          caption: Add organisation
+          title: Check your answers
+          name: Organisation name
+          claim_window: Claim window
+          vendor_number: Vendor number
+          address: Address
+          region: Region
+          contact_details: Contact details
+          telephone: Telephone number
+          website: Website address
+          change: Change
+          save_organisation: Save organisation

--- a/config/locales/en/wizards/claims/add_school_wizard.yml
+++ b/config/locales/en/wizards/claims/add_school_wizard.yml
@@ -5,7 +5,7 @@ en:
         school_step:
           caption: Add organisation
           continue: Continue
-          title: Enter an organisation
+          title: Enter a school name, URN or postcode
           description: Use a name, unique reference number (URN) or postcode to find an organisation.
           organisation_not_listed: The organisation is not listed
           organisation_not_listed_description: If the organisation is not listed on the service you must

--- a/config/locales/en/wizards/claims/add_school_wizard.yml
+++ b/config/locales/en/wizards/claims/add_school_wizard.yml
@@ -5,7 +5,19 @@ en:
         school_step:
           caption: Add organisation
           continue: Continue
-          title: Enter a school name, URN or postcode
+          title: Enter an organisation
+          description: Use a name, unique reference number (URN) or postcode to find an organisation.
+          organisation_not_listed: The organisation is not listed
+          organisation_not_listed_description: If the organisation is not listed on the service you must
+          ask_organisation_html: |
+            Ask the organisation to %{link}. This will give them a vendor number, 
+            it may take up to 6 weeks for them to receive it.
+          ask_link: provide information about your banking and payments to DfE
+          wait_for_organisation: Wait for the organisation to send you their vendor number.
+          return_html: | 
+            Return to this page to %{link}. You will need the vendor number, organisation name, 
+            address, phone number and website url.
+          manually_add: manually add them to the service
         school_options_step:
           title: "%{organisation_count} results found for ‘%{search_param}’ - Add organisation"
         check_your_answers_step:

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -206,6 +206,14 @@ scope module: :claims, as: :claims, constraints: {
       end
     end
 
+    resources :organisations do
+      collection do
+        get "new", to: "organisations/add_organisation#new", as: :new_add_organisation
+        get "new/:state_key/:step", to: "organisations/add_organisation#edit", as: :add_organisation
+        put "new/:state_key/:step", to: "organisations/add_organisation#update"
+      end
+    end
+
     resources :schools, only: %i[index show] do
       member do
         put :remove_grant_conditions_acceptance, path: "remove-grant-conditions-acceptance"

--- a/db/migrate/20250417220451_add_vendor_number_to_school.rb
+++ b/db/migrate/20250417220451_add_vendor_number_to_school.rb
@@ -1,0 +1,5 @@
+class AddVendorNumberToSchool < ActiveRecord::Migration[7.2]
+  def change
+    add_column :schools, :vendor_number, :string
+  end
+end

--- a/db/migrate/20250422083009_change_schools_urn_null.rb
+++ b/db/migrate/20250422083009_change_schools_urn_null.rb
@@ -1,0 +1,5 @@
+class ChangeSchoolsUrnNull < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :schools, :urn, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -512,7 +512,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_22_121713) do
   end
 
   create_table "schools", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "urn", null: false
+    t.string "urn"
     t.boolean "placements_service", default: false
     t.boolean "claims_service", default: false
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -555,6 +555,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_22_121713) do
     t.string "local_authority_code"
     t.datetime "claims_grant_conditions_accepted_at"
     t.uuid "claims_grant_conditions_accepted_by_id"
+    t.string "vendor_number"
     t.index ["claims_grant_conditions_accepted_by_id"], name: "index_schools_on_claims_grant_conditions_accepted_by_id"
     t.index ["claims_service"], name: "index_schools_on_claims_service"
     t.index ["latitude"], name: "index_schools_on_latitude"

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -39,7 +39,7 @@
 #  type_of_establishment                  :string
 #  ukprn                                  :string
 #  urban_or_rural                         :string
-#  urn                                    :string           not null
+#  urn                                    :string
 #  vendor_number                          :string
 #  website                                :string
 #  created_at                             :datetime         not null

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -40,6 +40,7 @@
 #  ukprn                                  :string
 #  urban_or_rural                         :string
 #  urn                                    :string           not null
+#  vendor_number                          :string
 #  website                                :string
 #  created_at                             :datetime         not null
 #  updated_at                             :datetime         not null

--- a/spec/fixtures/gias/import_with_trusts_and_regions_without_urn.csv
+++ b/spec/fixtures/gias/import_with_trusts_and_regions_without_urn.csv
@@ -1,0 +1,7 @@
+URN,EstablishmentName,Town,Postcode,EstablishmentStatus (code),TypeOfEstablishment (code),DistrictAdministrative (code),TrustSchoolFlag (code),Trusts (code),Trusts (name),Latitude,Longitude,SEN1 (name),SEN2 (name),SEN3 (name),SEN4 (name),SEN5 (name),SEN6 (name),SEN7 (name),SEN8 (name),SEN9 (name),SEN10 (name),SEN11 (name),SEN12 (name),SEN13 (name)
+,InnerLondonSchool,InnerLondonTown,Postcode,1,7,E09000007,,,,51.5139702631,-0.0775045667,,,,,,,,,,,,,
+,OuterLondonSchool,OuterLondonTown,Postcode,1,7,E09000004,,,,,,,,,,,,,,,,,,
+,FringeSchool,FringeTown,Postcode,1,7,E06000039,,,,,,,,,,,,,,,,,,
+,RestOfEnglandSchool,RestOfEnglandTown,Postcode,1,7,E09000099,,,,,,,,,,,,,,,,,,
+,TrustSchool,TrustTown,Postcode,1,7,E09000007,1,12345,Department for Education Trust,,,,,,,,,,,,,,,
+,SenSchool,SenTown,Postcode,1,7,E09000017,,,,,,ASD - Autistic Spectrum Disorder,HI - Hearing Impairment,MLD - Moderate Learning Difficulty,MSI - Multi-Sensory Impairment,Not Applicable,OTH - Other Difficulty/Disability,PD - Physical Disability,PMLD - Profound and Multiple Learning Difficulty,"SEMH - Social, Emotional and Mental Health","SLCN - Speech, language and Communication",SLD - Severe Learning Difficulty,SpLD - Specific Learning Difficulty,VI - Visual Impairment

--- a/spec/models/claims/school_spec.rb
+++ b/spec/models/claims/school_spec.rb
@@ -97,6 +97,7 @@ RSpec.describe Claims::School do
 
   describe "delegations" do
     it { is_expected.to delegate_method(:funding_available_per_hour).to(:region).with_prefix(true) }
+    it { is_expected.to delegate_method(:name).to(:region).with_prefix(true) }
   end
 
   describe "#grant_conditions_accepted?" do

--- a/spec/models/claims/school_spec.rb
+++ b/spec/models/claims/school_spec.rb
@@ -39,7 +39,7 @@
 #  type_of_establishment                  :string
 #  ukprn                                  :string
 #  urban_or_rural                         :string
-#  urn                                    :string           not null
+#  urn                                    :string
 #  vendor_number                          :string
 #  website                                :string
 #  created_at                             :datetime         not null

--- a/spec/models/claims/school_spec.rb
+++ b/spec/models/claims/school_spec.rb
@@ -40,6 +40,7 @@
 #  ukprn                                  :string
 #  urban_or_rural                         :string
 #  urn                                    :string           not null
+#  vendor_number                          :string
 #  website                                :string
 #  created_at                             :datetime         not null
 #  updated_at                             :datetime         not null

--- a/spec/models/placements/school_spec.rb
+++ b/spec/models/placements/school_spec.rb
@@ -39,7 +39,7 @@
 #  type_of_establishment                  :string
 #  ukprn                                  :string
 #  urban_or_rural                         :string
-#  urn                                    :string           not null
+#  urn                                    :string
 #  vendor_number                          :string
 #  website                                :string
 #  created_at                             :datetime         not null

--- a/spec/models/placements/school_spec.rb
+++ b/spec/models/placements/school_spec.rb
@@ -40,6 +40,7 @@
 #  ukprn                                  :string
 #  urban_or_rural                         :string
 #  urn                                    :string           not null
+#  vendor_number                          :string
 #  website                                :string
 #  created_at                             :datetime         not null
 #  updated_at                             :datetime         not null

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -39,7 +39,7 @@
 #  type_of_establishment                  :string
 #  ukprn                                  :string
 #  urban_or_rural                         :string
-#  urn                                    :string           not null
+#  urn                                    :string
 #  vendor_number                          :string
 #  website                                :string
 #  created_at                             :datetime         not null

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -40,6 +40,7 @@
 #  ukprn                                  :string
 #  urban_or_rural                         :string
 #  urn                                    :string           not null
+#  vendor_number                          :string
 #  website                                :string
 #  created_at                             :datetime         not null
 #  updated_at                             :datetime         not null

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -116,8 +116,9 @@ RSpec.describe School, type: :model do
   context "with validations" do
     subject { create(:school) }
 
-    it { is_expected.to validate_presence_of(:urn) }
     it { is_expected.to validate_uniqueness_of(:urn).case_insensitive }
+    it { is_expected.to validate_uniqueness_of(:vendor_number).case_insensitive }
+
     it { is_expected.to validate_presence_of(:name) }
   end
 

--- a/spec/services/gias/csv_importer_spec.rb
+++ b/spec/services/gias/csv_importer_spec.rb
@@ -80,6 +80,14 @@ RSpec.describe Gias::CSVImporter do
     end
   end
 
+  context "when URN is not present" do
+    let(:csv_path) { "spec/fixtures/gias/import_with_trusts_and_regions_without_urn.csv" }
+
+    it "does not create a school" do
+      expect { gias_importer }.not_to change(School, :count)
+    end
+  end
+
   describe "geocoding schools" do
     subject(:school) { School.find_by!(urn:) }
 

--- a/spec/support/govuk_component_matchers.rb
+++ b/spec/support/govuk_component_matchers.rb
@@ -106,6 +106,15 @@ module GovukComponentMatchers
     end
   end
 
+  matcher :have_caption do |text|
+    match do |page|
+      page.find("span[class^='govuk-caption-']", text:)
+      true
+    rescue Capybara::ElementNotFound
+      false
+    end
+  end
+
   matcher :have_warning_text do |text|
     match do |page|
       page.within(".govuk-warning-text") do

--- a/spec/system/claims/support/schools/add_a_school_spec.rb
+++ b/spec/system/claims/support/schools/add_a_school_spec.rb
@@ -16,16 +16,17 @@ RSpec.describe "Support User adds a School", service: :claims, type: :system do
 
   scenario "Colin adds a new School", :js do
     when_i_visit_the_add_school_page
-    then_i_see_the_claim_window_page
-
-    when_i_select_the_current_claim_window
-    and_click_on_continue
     and_i_enter_a_school_named("School 1")
     then_i_see_a_dropdown_item_for("School 1")
     when_i_click_the_dropdown_item_for("School 1")
     and_i_click_continue
+    then_i_see_the_claim_window_page
+
+    when_i_select_the_current_claim_window
+    and_click_on_continue
     then_i_see_the_check_details_page_for_school("School 1")
     i_then_click_change_school_link
+    and_i_click_continue
     when_i_click_save_organisation
     then_i_return_to_support_organisations_index
     and_a_school_is_listed(school_name: "School 1")
@@ -35,10 +36,6 @@ RSpec.describe "Support User adds a School", service: :claims, type: :system do
   scenario "Colin adds a school which already exists", :js do
     given_a_school_already_exists_for_claims
     when_i_visit_the_add_school_page
-    then_i_see_the_claim_window_page
-
-    when_i_select_the_current_claim_window
-    and_click_on_continue
     and_i_enter_a_school_named("Claims School")
     then_i_see_a_dropdown_item_for("Claims School")
     when_i_click_the_dropdown_item_for("Claims School")
@@ -48,27 +45,25 @@ RSpec.describe "Support User adds a School", service: :claims, type: :system do
 
   scenario "Colin submits the search form without selecting a school", :js do
     when_i_visit_the_add_school_page
-    then_i_see_the_claim_window_page
-
-    when_i_select_the_current_claim_window
-    and_click_on_continue
     and_i_click_continue
     then_i_see_an_error("Enter a school name, unique reference number (URN) or postcode")
   end
 
   scenario "Colin reconsiders onboarding a school", :js do
     when_i_visit_the_add_school_page
-    then_i_see_the_claim_window_page
-
-    when_i_select_the_current_claim_window
-    and_click_on_continue
     and_i_enter_a_school_named("School 1")
     then_i_see_a_dropdown_item_for("School 1")
     when_i_click_the_dropdown_item_for("School 1")
     and_i_click_continue
+    then_i_see_the_claim_window_page
+
+    when_i_select_the_current_claim_window
+    and_click_on_continue
     then_i_see_the_check_details_page_for_school("School 1")
     when_i_click_back
+    and_i_click_back
     then_i_see_the_search_input_pre_filled_with("School 1")
+    and_i_click_continue
     and_i_click_continue
     then_i_see_the_check_details_page_for_school("School 1")
   end
@@ -115,6 +110,7 @@ RSpec.describe "Support User adds a School", service: :claims, type: :system do
   def when_i_click_back
     click_on "Back"
   end
+  alias_method :and_i_click_back, :when_i_click_back
 
   def then_i_see_the_check_details_page_for_school(school_name)
     expect(page).to have_css(".govuk-caption-l", text: "Add organisation")

--- a/spec/system/claims/support/schools/add_a_school_without_javascript_spec.rb
+++ b/spec/system/claims/support/schools/add_a_school_without_javascript_spec.rb
@@ -17,15 +17,15 @@ RSpec.describe "Support User adds a School without JavaScript", service: :claims
 
   scenario "Colin adds a new School" do
     when_i_visit_the_add_school_page
-    then_i_see_the_claim_window_page
-
-    when_i_select_the_current_claim_window
-    and_click_on_continue
     and_i_enter_a_school_named("Manch")
     and_i_click_continue
     then_i_see_list_of_schools
     then_i_choose("Manchester 1")
     and_i_click_continue
+    then_i_see_the_claim_window_page
+
+    when_i_select_the_current_claim_window
+    and_click_on_continue
     then_i_see_the_check_details_page_for_school("Manchester 1")
     when_i_click_save_organisation
     then_i_return_to_support_organisations_index
@@ -35,10 +35,6 @@ RSpec.describe "Support User adds a School without JavaScript", service: :claims
   scenario "Colin adds a school which already exists" do
     given_a_school_already_exists_for_claims
     when_i_visit_the_add_school_page
-    then_i_see_the_claim_window_page
-
-    when_i_select_the_current_claim_window
-    and_click_on_continue
     and_i_enter_a_school_named("Manch")
     and_i_click_continue
     then_i_see_list_of_schools
@@ -49,20 +45,12 @@ RSpec.describe "Support User adds a School without JavaScript", service: :claims
 
   scenario "Colin submits the search form without selecting a school" do
     when_i_visit_the_add_school_page
-    then_i_see_the_claim_window_page
-
-    when_i_select_the_current_claim_window
-    and_click_on_continue
     and_i_click_continue
     then_i_see_an_error("Enter a school name, unique reference number (URN) or postcode")
   end
 
   scenario "Colin submits the options form without selecting a school" do
     when_i_visit_the_add_school_page
-    then_i_see_the_claim_window_page
-
-    when_i_select_the_current_claim_window
-    and_click_on_continue
     and_i_enter_a_school_named("Manch")
     and_i_click_continue
     then_i_see_list_of_schools
@@ -72,23 +60,25 @@ RSpec.describe "Support User adds a School without JavaScript", service: :claims
 
   scenario "Colin reconsiders onboarding a school" do
     when_i_visit_the_add_school_page
-    then_i_see_the_claim_window_page
-
-    when_i_select_the_current_claim_window
-    and_click_on_continue
     and_i_enter_a_school_named("Manch")
     and_i_click_continue
     then_i_see_list_of_schools
     then_i_choose("Manchester 1")
     and_i_click_continue
+    then_i_see_the_claim_window_page
+
+    when_i_select_the_current_claim_window
+    and_click_on_continue
     then_i_see_the_check_details_page_for_school("Manchester 1")
     when_i_click_back
+    and_i_click_back
     and_the_option_for_school_has_been_pre_selected("Manchester 1")
     when_i_click_back
     then_i_see_the_search_input_pre_filled_with("Manch")
     and_i_click_continue
     then_i_see_list_of_schools
     then_i_choose("Manchester 1")
+    and_i_click_continue
     and_i_click_continue
     then_i_see_the_check_details_page_for_school("Manchester 1")
   end
@@ -121,6 +111,7 @@ RSpec.describe "Support User adds a School without JavaScript", service: :claims
   def when_i_click_back
     click_on "Back"
   end
+  alias_method :and_i_click_back, :when_i_click_back
 
   def then_i_see_list_of_schools
     expect(page).to have_content("Manchester 1")

--- a/spec/system/claims/support/schools/support_user_adds_an_organisation_spec.rb
+++ b/spec/system/claims/support/schools/support_user_adds_an_organisation_spec.rb
@@ -1,0 +1,544 @@
+require "rails_helper"
+
+RSpec.describe "Support user adds an organisation", service: :claims, type: :system do
+  scenario do
+    given_a_claim_window_exists
+    and_i_am_signed_in
+    then_i_am_on_the_organisations_page
+
+    when_i_click_on_add_organisation
+    then_i_see_the_enter_an_organisation_page
+
+    when_i_click_on_the_organisation_is_not_listed
+    then_i_see_the_details_text
+
+    when_i_click_on_manually_add_them_to_the_service
+    then_i_see_the_enter_the_organisation_name_page
+
+    when_i_click_continue
+    then_i_see_the_organisation_name_error
+
+    when_i_enter_an_organisation_name
+    and_i_click_continue
+    then_i_see_the_vendor_number_page
+
+    when_i_click_continue
+    then_i_see_the_vendor_number_error
+
+    when_i_click_on_the_vendor_number_details_summary
+    then_i_see_the_vendor_number_details_text
+
+    when_i_enter_a_vendor_number
+    and_i_click_continue
+    then_i_see_the_claim_window_page
+
+    when_i_click_continue
+    then_i_see_the_claim_window_error
+
+    when_i_click_on_the_claim_window_details_summary
+    then_i_see_the_claim_window_details_text
+
+    when_i_select_the_current_claim_window
+    and_i_click_continue
+    then_i_see_the_region_page
+
+    when_i_click_continue
+    then_i_see_the_region_error
+
+    when_i_select_a_region
+    and_i_click_continue
+    then_i_see_the_address_page
+
+    when_i_click_continue
+    then_i_see_the_address1_error
+    and_i_see_the_town_error
+    and_i_see_the_postcode_error
+
+    when_i_enter_address1
+    and_i_enter_town
+    and_i_enter_postcode
+    and_i_click_continue
+    then_i_see_the_contact_details_page
+
+    when_i_click_continue
+    then_i_see_the_website_error
+    and_i_see_the_telephone_error
+
+    when_i_enter_a_website
+    and_i_enter_a_telephone
+    and_i_click_continue
+    then_i_see_the_check_your_answers_page
+
+    when_i_click_to_change_the_organisation_name
+    then_i_see_the_enter_the_organisation_name_page
+
+    when_i_change_the_organisation_name
+    and_i_navigate_back_to_check_your_answers_from_the_organisation_name_page
+    then_i_see_the_check_your_answers_page_with_changed_organisation_name
+
+    when_i_click_to_change_the_vendor_number
+    then_i_see_the_vendor_number_page
+
+    when_i_change_the_vendor_number
+    and_i_navigate_back_to_check_your_answers_from_the_vendor_number_page
+    then_i_see_the_check_your_answers_page_with_changed_vendor_number
+
+    when_i_click_to_change_the_claim_window
+    then_i_see_the_claim_window_page
+
+    when_i_change_the_claim_window
+    and_i_navigate_back_to_check_your_answers_from_the_claim_window_page
+    then_i_see_the_check_your_answers_page_with_changed_claim_window
+
+    when_i_click_to_change_the_region
+    then_i_see_the_region_page
+
+    when_i_change_the_region
+    and_i_navigate_back_to_check_your_answers_from_the_region_page
+    then_i_see_the_check_your_answers_page_with_changed_region
+
+    when_i_click_to_change_the_address
+    then_i_see_the_address_page
+
+    when_i_change_the_address
+    and_i_navigate_back_to_check_your_answers_from_the_address_page
+    then_i_see_the_check_your_answers_page_with_changed_address
+
+    when_i_click_to_change_the_telephone_number
+    then_i_see_the_contact_details_page
+
+    when_i_change_the_telephone_number
+    and_i_navigate_back_to_check_your_answers_from_the_contact_details_page
+    then_i_see_the_check_your_answers_page_with_changed_telephone_number
+
+    when_i_click_to_change_the_website
+    then_i_see_the_contact_details_page
+
+    when_i_change_the_website
+    and_i_navigate_back_to_check_your_answers_from_the_website_page
+    then_i_see_the_check_your_answers_page_with_changed_website
+
+    when_i_click_save_organisation
+    then_i_see_the_organisations_page
+    and_i_see_the_success_message
+  end
+
+  def given_a_claim_window_exists
+    @claim_window = create(:claim_window, :current).decorate
+    @claim_window_2 = create(:claim_window, :upcoming).decorate
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def then_i_am_on_the_organisations_page
+    expect(page).to have_title("Organisations (0) - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Organisations")
+    expect(page).to have_h1("Organisations (0)")
+    expect(page).to have_link("Add organisation")
+  end
+
+  def when_i_click_on_add_organisation
+    click_on "Add organisation"
+  end
+
+  def then_i_see_the_enter_an_organisation_page
+    expect(page).to have_title("Enter a school name, URN or postcode - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Organisations")
+    expect(page).to have_caption("Add organisation")
+    expect(page).to have_element(:label, text: "Enter a school name, URN or postcode", class: "govuk-label govuk-label--l")
+  end
+
+  def when_i_click_on_the_organisation_is_not_listed
+    find(".govuk-details__summary").click
+  end
+
+  def then_i_see_the_details_text
+    within ".govuk-details" do
+      within ".govuk-details__text" do
+        expect(page).to have_element(:li, text: "Ask the organisation to provide information about your banking and payments to DfE (opens in new tab). This will give them a vendor number, it may take up to 6 weeks for them to receive it.")
+        expect(page).to have_element(:li, text: "Wait for the organisation to send you their vendor number.")
+        expect(page).to have_element(:li, text: "Return to this page to manually add them to the service. You will need the vendor number, organisation name, address, phone number and website url.")
+        expect(page).to have_link("provide information about your banking and payments to DfE (opens in new tab)", href: "http://www.gov.uk/guidance/provide-information-about-your-banking-and-payments-to-dfe")
+      end
+    end
+  end
+
+  def when_i_click_on_manually_add_them_to_the_service
+    click_on "manually add them to the service"
+  end
+
+  def then_i_see_the_enter_the_organisation_name_page
+    expect(page).to have_title("Enter the organisation name - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Organisations")
+    expect(page).to have_caption("Add organisation")
+    expect(page).to have_element(:label, text: "Enter the organisation name", class: "govuk-label govuk-label--l")
+    expect(page).to have_link("Back")
+  end
+
+  def when_i_click_continue
+    click_on "Continue"
+  end
+  alias_method :and_i_click_continue, :when_i_click_continue
+
+  def then_i_see_the_organisation_name_error
+    expect(page).to have_validation_error("Please enter the name of the organisation")
+  end
+
+  def when_i_enter_an_organisation_name
+    fill_in "Enter the organisation name", with: "Test Organisation"
+  end
+
+  def then_i_see_the_vendor_number_page
+    expect(page).to have_title("Enter the organisation&#39;s vendor number - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Organisations")
+    expect(page).to have_caption("Add organisation")
+    expect(page).to have_element(:label, text: "Enter the organisation's vendor number", class: "govuk-label govuk-label--l")
+    expect(page).to have_link("Back")
+  end
+
+  def then_i_see_the_vendor_number_error
+    expect(page).to have_validation_error("Please enter a vendor number for the organisation")
+  end
+
+  def when_i_click_on_the_vendor_number_details_summary
+    find(".govuk-details__summary").click
+  end
+
+  def then_i_see_the_vendor_number_details_text
+    within ".govuk-details" do
+      within ".govuk-details__text" do
+        expect(page).to have_element(:p, text: "The organisation can get a vendor number by providing information about their banking and payments to DfE (opens in new tab). Receiving a vendor number may take up to 6 weeks", class: "govuk-body")
+        expect(page).to have_element(:p, text: "Once they have provided you with a vendor number, you will be able to manually add them.", class: "govuk-body")
+        expect(page).to have_link("providing information about their banking and payments to DfE (opens in new tab)", href: "http://www.gov.uk/guidance/provide-information-about-your-banking-and-payments-to-dfe")
+      end
+    end
+  end
+
+  def when_i_enter_a_vendor_number
+    fill_in "Enter the organisation's vendor number", with: "123456789"
+  end
+
+  def then_i_see_the_claim_window_page
+    expect(page).to have_title("Select a claim window - Add organisation - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Organisations")
+    expect(page).to have_caption("Add organisation")
+    expect(page).to have_element(:h1, text: "Select a claim window", class: "govuk-fieldset__heading")
+    expect(page).to have_link("Back")
+  end
+
+  def then_i_see_the_claim_window_error
+    expect(page).to have_validation_error("Please select a claim window")
+  end
+
+  def when_i_click_on_the_claim_window_details_summary
+    find(".govuk-details__summary").click
+  end
+
+  def then_i_see_the_claim_window_details_text
+    within ".govuk-details" do
+      within ".govuk-details__text" do
+        expect(page).to have_content("If you cannot see the dates you need you can create an additional claim window (opens in new tab).")
+        expect(page).to have_link("create an additional claim window (opens in new tab)", href: "/support/claim_windows")
+      end
+    end
+  end
+
+  def when_i_select_the_current_claim_window
+    choose @claim_window.name
+  end
+
+  def then_i_see_the_region_page
+    expect(page).to have_title("Enter the organisation&#39;s region - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Organisations")
+    expect(page).to have_caption("Add organisation")
+    expect(page).to have_element(:h1, text: "Enter the organisation's region", class: "govuk-fieldset__heading")
+    expect(page).to have_element(:div, text: "The region is required to calculate the claim amount", class: "govuk-hint")
+    expect(page).to have_link("Back")
+  end
+
+  def then_i_see_the_region_error
+    expect(page).to have_validation_error("Please select a region for the organisation")
+  end
+
+  def when_i_select_a_region
+    find("label", text: "Fringe").click
+  end
+
+  def then_i_see_the_address_page
+    expect(page).to have_title("Enter the organisation&#39;s address - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Organisations")
+    expect(page).to have_caption("Add organisation")
+    expect(page).to have_h1("Enter the organisation's address")
+    expect(page).to have_link("Back")
+  end
+
+  def then_i_see_the_address1_error
+    expect(page).to have_validation_error("Please enter the first line of the address for the organisation")
+  end
+
+  def and_i_see_the_town_error
+    expect(page).to have_validation_error("Please enter the town or city for the organisation")
+  end
+
+  def and_i_see_the_postcode_error
+    expect(page).to have_validation_error("Please enter the postcode for the organisation")
+  end
+
+  def when_i_enter_address1
+    fill_in "Address line 1", with: "123 Test Street"
+  end
+
+  def and_i_enter_town
+    fill_in "Town or city", with: "Test Town"
+  end
+
+  def and_i_enter_postcode
+    fill_in "Postcode", with: "AB12 3CD"
+  end
+
+  def then_i_see_the_contact_details_page
+    expect(page).to have_title("Enter the organisation&#39;s contact details - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Organisations")
+    expect(page).to have_caption("Add organisation")
+    expect(page).to have_h1("Enter the organisation's contact details")
+    expect(page).to have_link("Back")
+  end
+
+  def then_i_see_the_website_error
+    expect(page).to have_validation_error("Please enter a website address for the organisation")
+  end
+
+  def and_i_see_the_telephone_error
+    expect(page).to have_validation_error("Please enter a telephone number for the organisation")
+  end
+
+  def when_i_enter_a_website
+    fill_in "Website", with: "https://www.testorganisation.com"
+  end
+
+  def and_i_enter_a_telephone
+    fill_in "Telephone number", with: "01234 567890"
+  end
+
+  def then_i_see_the_check_your_answers_page
+    expect(page).to have_title("Check your answers - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Organisations")
+    expect(page).to have_caption("Add organisation")
+    expect(page).to have_h1("Check your answers")
+
+    expect(page).to have_summary_list_row("Organisation name", "Test Organisation")
+    expect(page).to have_summary_list_row("Vendor number", "123456789")
+    expect(page).to have_summary_list_row("Claim window", @claim_window.name)
+    expect(page).to have_summary_list_row("Region", "Inner London")
+
+    expect(page).to have_h2("Contact details")
+    expect(page).to have_summary_list_row("Address", "123 Test Street Test Town AB12 3CD")
+    expect(page).to have_summary_list_row("Website", "https://www.testorganisation.com")
+    expect(page).to have_summary_list_row("Telephone number", "01234 567890")
+
+    expect(page).to have_link("Back")
+  end
+
+  def when_i_click_to_change_the_organisation_name
+    click_link "Change Organisation name"
+  end
+
+  def when_i_change_the_organisation_name
+    fill_in "Enter the organisation name", with: "Changed Organisation"
+  end
+
+  def and_i_navigate_back_to_check_your_answers_from_the_organisation_name_page
+    click_on "Continue"
+    click_on "Continue"
+    click_on "Continue"
+    click_on "Continue"
+    click_on "Continue"
+    click_on "Continue"
+  end
+
+  def then_i_see_the_check_your_answers_page_with_changed_organisation_name
+    expect(page).to have_summary_list_row("Organisation name", "Changed Organisation")
+    expect(page).to have_summary_list_row("Vendor number", "123456789")
+    expect(page).to have_summary_list_row("Claim window", @claim_window.name)
+    expect(page).to have_summary_list_row("Region", "Inner London")
+
+    expect(page).to have_h2("Contact details")
+    expect(page).to have_summary_list_row("Address", "123 Test Street Test Town AB12 3CD")
+    expect(page).to have_summary_list_row("Website", "https://www.testorganisation.com")
+    expect(page).to have_summary_list_row("Telephone number", "01234 567890")
+  end
+
+  def when_i_click_to_change_the_vendor_number
+    click_link "Change Vendor number"
+  end
+
+  def when_i_change_the_vendor_number
+    fill_in "Enter the organisation's vendor number", with: "987654321"
+  end
+
+  def and_i_navigate_back_to_check_your_answers_from_the_vendor_number_page
+    click_on "Continue"
+    click_on "Continue"
+    click_on "Continue"
+    click_on "Continue"
+    click_on "Continue"
+  end
+
+  def then_i_see_the_check_your_answers_page_with_changed_vendor_number
+    expect(page).to have_summary_list_row("Organisation name", "Changed Organisation")
+    expect(page).to have_summary_list_row("Vendor number", "987654321")
+    expect(page).to have_summary_list_row("Claim window", @claim_window.name)
+    expect(page).to have_summary_list_row("Region", "Inner London")
+
+    expect(page).to have_h2("Contact details")
+    expect(page).to have_summary_list_row("Address", "123 Test Street Test Town AB12 3CD")
+    expect(page).to have_summary_list_row("Website", "https://www.testorganisation.com")
+    expect(page).to have_summary_list_row("Telephone number", "01234 567890")
+  end
+
+  def when_i_click_to_change_the_claim_window
+    click_link "Change Claim window"
+  end
+
+  def when_i_change_the_claim_window
+    choose @claim_window_2.name
+  end
+
+  def and_i_navigate_back_to_check_your_answers_from_the_claim_window_page
+    click_on "Continue"
+    click_on "Continue"
+    click_on "Continue"
+    click_on "Continue"
+  end
+
+  def then_i_see_the_check_your_answers_page_with_changed_claim_window
+    expect(page).to have_summary_list_row("Organisation name", "Changed Organisation")
+    expect(page).to have_summary_list_row("Vendor number", "987654321")
+    expect(page).to have_summary_list_row("Claim window", @claim_window_2.name)
+    expect(page).to have_summary_list_row("Region", "Inner London")
+
+    expect(page).to have_h2("Contact details")
+    expect(page).to have_summary_list_row("Address", "123 Test Street Test Town AB12 3CD")
+    expect(page).to have_summary_list_row("Website", "https://www.testorganisation.com")
+    expect(page).to have_summary_list_row("Telephone number", "01234 567890")
+  end
+
+  def when_i_click_to_change_the_region
+    click_link "Change Region"
+  end
+
+  def when_i_change_the_region
+    find("label", text: "Outer London").click
+  end
+
+  def and_i_navigate_back_to_check_your_answers_from_the_region_page
+    click_on "Continue"
+    click_on "Continue"
+    click_on "Continue"
+  end
+
+  def then_i_see_the_check_your_answers_page_with_changed_region
+    expect(page).to have_summary_list_row("Organisation name", "Changed Organisation")
+    expect(page).to have_summary_list_row("Vendor number", "987654321")
+    expect(page).to have_summary_list_row("Claim window", @claim_window_2.name)
+    expect(page).to have_summary_list_row("Region", "Outer London")
+
+    expect(page).to have_h2("Contact details")
+    expect(page).to have_summary_list_row("Address", "123 Test Street Test Town AB12 3CD")
+    expect(page).to have_summary_list_row("Website", "https://www.testorganisation.com")
+    expect(page).to have_summary_list_row("Telephone number", "01234 567890")
+  end
+
+  def when_i_click_to_change_the_address
+    click_link "Change Address"
+  end
+
+  def when_i_change_the_address
+    fill_in "Address line 1", with: "456 Changed Street"
+    fill_in "Town or city", with: "Changed Town"
+    fill_in "Postcode", with: "EF45 6GH"
+  end
+
+  def and_i_navigate_back_to_check_your_answers_from_the_address_page
+    click_on "Continue"
+    click_on "Continue"
+  end
+
+  def then_i_see_the_check_your_answers_page_with_changed_address
+    expect(page).to have_summary_list_row("Organisation name", "Changed Organisation")
+    expect(page).to have_summary_list_row("Vendor number", "987654321")
+    expect(page).to have_summary_list_row("Claim window", @claim_window_2.name)
+    expect(page).to have_summary_list_row("Region", "Outer London")
+
+    expect(page).to have_h2("Contact details")
+    expect(page).to have_summary_list_row("Address", "456 Changed Street Changed Town EF45 6GH")
+    expect(page).to have_summary_list_row("Website", "https://www.testorganisation.com")
+    expect(page).to have_summary_list_row("Telephone number", "01234 567890")
+  end
+
+  def when_i_click_to_change_the_telephone_number
+    click_link "Change Telephone number"
+  end
+
+  def when_i_change_the_telephone_number
+    fill_in "Telephone number", with: "09876 543210"
+  end
+
+  def and_i_navigate_back_to_check_your_answers_from_the_contact_details_page
+    click_on "Continue"
+  end
+
+  def then_i_see_the_check_your_answers_page_with_changed_telephone_number
+    expect(page).to have_summary_list_row("Organisation name", "Changed Organisation")
+    expect(page).to have_summary_list_row("Vendor number", "987654321")
+    expect(page).to have_summary_list_row("Claim window", @claim_window_2.name)
+    expect(page).to have_summary_list_row("Region", "Outer London")
+
+    expect(page).to have_h2("Contact details")
+    expect(page).to have_summary_list_row("Address", "456 Changed Street Changed Town EF45 6GH")
+    expect(page).to have_summary_list_row("Website", "https://www.testorganisation.com")
+    expect(page).to have_summary_list_row("Telephone number", "09876 543210")
+  end
+
+  def when_i_click_to_change_the_website
+    click_link "Change Website"
+  end
+
+  def when_i_change_the_website
+    fill_in "Website", with: "https://www.changedorganisation.com"
+  end
+
+  def and_i_navigate_back_to_check_your_answers_from_the_website_page
+    click_on "Continue"
+  end
+
+  def then_i_see_the_check_your_answers_page_with_changed_website
+    expect(page).to have_summary_list_row("Organisation name", "Changed Organisation")
+    expect(page).to have_summary_list_row("Vendor number", "987654321")
+    expect(page).to have_summary_list_row("Claim window", @claim_window_2.name)
+    expect(page).to have_summary_list_row("Region", "Outer London")
+
+    expect(page).to have_h2("Contact details")
+    expect(page).to have_summary_list_row("Address", "456 Changed Street Changed Town EF45 6GH")
+    expect(page).to have_summary_list_row("Website", "https://www.changedorganisation.com")
+    expect(page).to have_summary_list_row("Telephone number", "09876 543210")
+  end
+
+  def when_i_click_save_organisation
+    click_on "Save organisation"
+  end
+
+  def then_i_see_the_organisations_page
+    expect(page).to have_title("Organisations (1) - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Organisations")
+    expect(page).to have_h1("Organisations (1)")
+    expect(page).to have_link("Add organisation")
+    expect(page).to have_link("Changed Organisation")
+  end
+
+  def and_i_see_the_success_message
+    expect(page).to have_success_banner("Organisation added")
+  end
+end

--- a/spec/validators/unique_identifier_validator_spec.rb
+++ b/spec/validators/unique_identifier_validator_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe UniqueIdentifierValidator do
+  subject(:record) { Validatable.new }
+
+  before do
+    validatable_class = Class.new do
+      include ActiveModel::Validations
+
+      attr_accessor :urn, :vendor_number
+
+      validates_with UniqueIdentifierValidator
+
+      def initialize(urn: nil, vendor_number: nil)
+        @urn = urn
+        @vendor_number = vendor_number
+      end
+    end
+
+    stub_const("Validatable", validatable_class)
+  end
+
+  context "when both urn and vendor_number are blank" do
+    it "adds an error to the base" do
+      record.valid?
+
+      expect(record.errors[:base]).to include("A unique reference number (URN) or vendor number is required")
+    end
+  end
+
+  context "when urn is present" do
+    before do
+      record.urn = "123456789"
+    end
+
+    it "does not add an error" do
+      record.valid?
+
+      expect(record.errors[:base]).to be_empty
+    end
+  end
+
+  context "when vendor_number is present" do
+    before do
+      record.vendor_number = "987654321"
+    end
+
+    it "does not add an error" do
+      record.valid?
+
+      expect(record.errors[:base]).to be_empty
+    end
+  end
+end

--- a/spec/wizards/claims/add_organisation_wizard/address_step_spec.rb
+++ b/spec/wizards/claims/add_organisation_wizard/address_step_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Claims::AddOrganisationWizard::AddressStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Claims::AddOrganisationWizard)
+  end
+  let(:attributes) { nil }
+
+  describe "attributes" do
+    it { is_expected.to have_attributes(address1: nil, address2: nil, town: nil, postcode: nil) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:address1) }
+    it { is_expected.to validate_presence_of(:town) }
+    it { is_expected.to validate_presence_of(:postcode) }
+  end
+end

--- a/spec/wizards/claims/add_organisation_wizard/contact_details_step_spec.rb
+++ b/spec/wizards/claims/add_organisation_wizard/contact_details_step_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Claims::AddOrganisationWizard::ContactDetailsStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Claims::AddOrganisationWizard)
+  end
+  let(:attributes) { nil }
+
+  describe "attributes" do
+    it { is_expected.to have_attributes(telephone: nil, website: nil) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:telephone) }
+    it { is_expected.to validate_presence_of(:website) }
+  end
+end

--- a/spec/wizards/claims/add_organisation_wizard/name_step_spec.rb
+++ b/spec/wizards/claims/add_organisation_wizard/name_step_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe Claims::AddOrganisationWizard::NameStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Claims::AddOrganisationWizard)
+  end
+  let(:attributes) { nil }
+
+  describe "attributes" do
+    it { is_expected.to have_attributes(name: nil) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+  end
+end

--- a/spec/wizards/claims/add_organisation_wizard/region_step_spec.rb
+++ b/spec/wizards/claims/add_organisation_wizard/region_step_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe Claims::AddOrganisationWizard::RegionStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Claims::AddOrganisationWizard)
+  end
+  let(:attributes) { nil }
+
+  describe "attributes" do
+    it { is_expected.to have_attributes(region_id: nil) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:region_id) }
+  end
+
+  describe "#regions" do
+    it "returns all regions" do
+      expect(step.regions).to match_array(Region.all)
+    end
+  end
+end

--- a/spec/wizards/claims/add_organisation_wizard/vendor_number_step_spec.rb
+++ b/spec/wizards/claims/add_organisation_wizard/vendor_number_step_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe Claims::AddOrganisationWizard::VendorNumberStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Claims::AddOrganisationWizard)
+  end
+  let(:attributes) { nil }
+
+  describe "attributes" do
+    it { is_expected.to have_attributes(vendor_number: nil) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:vendor_number) }
+  end
+end

--- a/spec/wizards/claims/add_organisation_wizard_spec.rb
+++ b/spec/wizards/claims/add_organisation_wizard_spec.rb
@@ -1,0 +1,156 @@
+require "rails_helper"
+
+RSpec.describe Claims::AddOrganisationWizard do
+  subject(:wizard) { described_class.new(state:, params:, current_step: nil) }
+
+  let(:state) { {} }
+  let(:params_data) { {} }
+  let(:params) { ActionController::Parameters.new(params_data) }
+
+  describe "#steps" do
+    subject { wizard.steps.keys }
+
+    context "when there are no current or upcoming claim windows" do
+      it { is_expected.to eq(%i[no_claim_window]) }
+    end
+
+    context "when there a current or upcoming claim windows" do
+      let(:current_claim_window) { create(:claim_window, :current) }
+
+      before { current_claim_window }
+
+      context "when an school was selected during the school step" do
+        let!(:school) { create(:school) }
+        let(:state) do
+          {
+            "school" => { "id" => school.id, "name" => school.name },
+          }
+        end
+
+        it { is_expected.to eq %i[name vendor_number claim_window region address contact_details check_your_answers] }
+      end
+    end
+  end
+
+  describe "#organisation" do
+    subject(:organisation) { wizard.organisation }
+
+    let(:current_claim_window) { create(:claim_window, :current) }
+    let(:region) { Region.first }
+    let(:name) { "Test School" }
+    let(:vendor_number) { "123456" }
+    let(:address1) { "123 Test Street" }
+    let(:address2) { "Test House" }
+    let(:postcode) { "AB12 3CD" }
+    let(:town) { "Test Town" }
+    let(:website) { "https://www.testschool.com" }
+    let(:telephone) { "01234 567890" }
+
+    let(:state) do
+      {
+        "claim_window" => { "claim_window_id" => current_claim_window.id },
+        "name" => {
+          "name" => name,
+        },
+        "vendor_number" => {
+          "vendor_number" => vendor_number,
+        },
+        "region" => {
+          "region_id" => region.id,
+        },
+        "address" => {
+          "address1" => address1,
+          "address2" => address2,
+          "postcode" => postcode,
+          "town" => town,
+        },
+        "contact_details" => {
+          "website" => website,
+          "telephone" => telephone,
+        },
+      }
+    end
+
+    it "builds a new organisation" do
+      expect(organisation).to be_a(Claims::School)
+      expect(organisation.name).to eq(name)
+      expect(organisation.vendor_number).to eq(vendor_number)
+      expect(organisation.address1).to eq(address1)
+      expect(organisation.address2).to eq(address2)
+      expect(organisation.postcode).to eq(postcode)
+      expect(organisation.town).to eq(town)
+      expect(organisation.region_id).to eq(region.id)
+      expect(organisation.website).to eq(website)
+      expect(organisation.telephone).to eq(telephone)
+    end
+  end
+
+  describe "#create_organisation" do
+    subject(:create_organisation) { wizard.create_organisation }
+
+    let(:current_claim_window) { create(:claim_window, :current) }
+    let(:region) { Region.first }
+    let(:name) { "Test School" }
+    let(:vendor_number) { "123456" }
+    let(:address1) { "123 Test Street" }
+    let(:address2) { "Test House" }
+    let(:postcode) { "AB12 3CD" }
+    let(:town) { "Test Town" }
+    let(:website) { "https://www.testschool.com" }
+    let(:telephone) { "01234 567890" }
+    let(:state) do
+      {
+        "claim_window" => { "claim_window_id" => current_claim_window.id },
+        "name" => {
+          "name" => name,
+        },
+        "vendor_number" => {
+          "vendor_number" => vendor_number,
+        },
+        "region" => {
+          "region_id" => region.id,
+        },
+        "address" => {
+          "address1" => address1,
+          "address2" => address2,
+          "postcode" => postcode,
+          "town" => town,
+        },
+        "contact_details" => {
+          "website" => website,
+          "telephone" => telephone,
+        },
+      }
+    end
+
+    it "creates a new organisation" do
+      expect { create_organisation }.to change(Claims::School, :count).by(1)
+      organisation = Claims::School.last
+      expect(organisation.name).to eq(name)
+      expect(organisation.vendor_number).to eq(vendor_number)
+      expect(organisation.address1).to eq(address1)
+      expect(organisation.address2).to eq(address2)
+      expect(organisation.postcode).to eq(postcode)
+      expect(organisation.town).to eq(town)
+      expect(organisation.region_id).to eq(region.id)
+      expect(organisation.website).to eq(website)
+      expect(organisation.telephone).to eq(telephone)
+      expect(organisation.eligible_claim_windows).to contain_exactly(current_claim_window)
+    end
+  end
+
+  describe "#claim_window" do
+    subject(:claim_window) { wizard.claim_window }
+
+    let(:current_claim_window) { create(:claim_window, :current) }
+    let(:state) do
+      {
+        "claim_window" => { "claim_window_id" => current_claim_window.id },
+      }
+    end
+
+    it "returns the current claim window" do
+      expect(claim_window).to eq(current_claim_window)
+    end
+  end
+end

--- a/spec/wizards/claims/add_school_wizard_spec.rb
+++ b/spec/wizards/claims/add_school_wizard_spec.rb
@@ -27,11 +27,11 @@ RSpec.describe Claims::AddSchoolWizard do
           }
         end
 
-        it { is_expected.to eq %i[claim_window school check_your_answers] }
+        it { is_expected.to eq %i[school claim_window check_your_answers] }
       end
 
       context "when an school was not selected during the school step" do
-        it { is_expected.to eq %i[claim_window school school_options check_your_answers] }
+        it { is_expected.to eq %i[school school_options claim_window check_your_answers] }
       end
     end
   end


### PR DESCRIPTION
## Context

Adds a new way to add organisations that do not have URN's to the service, this allows organisations such as nurseries to be able to claim for the funding they're entitled to.

## Changes proposed in this pull request

- [x] Adds the Add organisation wizard
- [x] Updates the path of the Add school wizard

## Guidance to review

- Log in as Colin
- Click on "Add organisation"
- Click on "The organisation is not listed"
- Click on "manually add them to service"
- Follow the steps

## Link to Trello card

[Claims design fix: Manual function needed to add school address of schools that do not have an URN or UKPRN](https://trello.com/c/EFTu65vm/504-claims-design-fix-manual-function-needed-to-add-school-address-of-schools-that-do-not-have-an-urn-or-ukprn)

## Screenshots

![image](https://github.com/user-attachments/assets/687cae65-839c-4377-9a13-148213aee004)
![image](https://github.com/user-attachments/assets/e6a520db-d86e-4694-afb2-7be0d6739f09)
![image](https://github.com/user-attachments/assets/1e0569db-829c-41f9-8d0e-0cccb9a53678)
![image](https://github.com/user-attachments/assets/a125b4d5-95be-4f9f-93d9-a4d5bb560d44)
![image](https://github.com/user-attachments/assets/be13926c-41a5-4e5a-a4eb-ec22d6ba69f6)
![image](https://github.com/user-attachments/assets/f7b14b3e-a979-410f-bbb1-99798e800ee4)
![image](https://github.com/user-attachments/assets/eb1a8230-631f-4874-91bb-479f7a4b1b68)
![image](https://github.com/user-attachments/assets/5f350374-1397-4439-8b11-6ad7edd58c8f)

