### PR TITLE
Update new user email with additional content

### DIFF
--- a/app/mailers/claims/user_mailer.rb
+++ b/app/mailers/claims/user_mailer.rb
@@ -7,9 +7,9 @@ class Claims::UserMailer < Claims::ApplicationMailer
                    user_name: user.first_name,
                    organisation_name: organisation.name,
                    service_name:,
-                   heading: t(".heading"),
                    support_email:,
                    sign_in_url: sign_in_url(utm_source: "email", utm_medium: "notification", utm_campaign: "school"),
+                   sign_in_approver_url: "https://edd-help.signin.education.gov.uk/contact/create-account#:~:text=An%20approver%20is%20someone%20at%20your%20organisation%20responsible,person%2C%20such%20as%20an%20administrator%2C%20manager%2C%20or%20headteacher",
                  )
   end
 

--- a/config/locales/en/claims/user_mailer.yml
+++ b/config/locales/en/claims/user_mailer.yml
@@ -6,17 +6,26 @@ en:
         body: |
           Dear %{user_name},
   
-          You have been invited to join the %{service_name} service for %{organisation_name}.
+          You have been invited to join the %{service_name} service for %{organisation_name} because you are a [DfE-sign approver](%{sign_in_approver_url}) for your organisation.
+
+          If you are not the right person in your organisation to submit funding claims for general mentor training, please:
+
+          - access the service using DfE sign-in and add an appropriate colleague in the Users section
+          - forward this email to the appropriate colleague after adding them as a user
+
+          # Sign in to submit claims
   
-          # %{heading}
-  
-          If you have a DfE Sign-in account, you can use it to sign in:
+          Sign in using DfE sign-in:
   
           [%{sign_in_url}](%{sign_in_url})
   
-          If you need to create a DfE Sign-in account, you can do this after clicking "Sign in using DfE Sign-in"
+          If your colleague needs to create a DfE Sign-in account, they can do this after clicking "Sign in using DfE Sign-in"
   
-          After creating a DfE Sign-in account, you will need to return to this email and [sign in to access the service](%{sign_in_url}).
+          After creating a DfE Sign-in account, they will need to return to this email and [sign in to access the service](%{sign_in_url})
+
+          # Prior to submitting claims
+
+          We recommend confirming with your accredited provider the number of hours you are claiming, as they may be asked to provide evidence to support this claim.
   
           # Give feedback or report a problem
   
@@ -25,7 +34,6 @@ en:
           Regards
   
           %{service_name} team
-        heading: Sign in to submit claims
       user_membership_destroyed_notification:
         subject: You have been removed from %{service_name}
         body: |

--- a/spec/mailers/claims/user_mailer_spec.rb
+++ b/spec/mailers/claims/user_mailer_spec.rb
@@ -4,26 +4,35 @@ RSpec.describe Claims::UserMailer, type: :mailer do
   describe "#user_membership_created_notification" do
     subject(:invite_email) { described_class.user_membership_created_notification(user, organisation) }
 
-    let(:user) { create(:claims_user) }
-    let(:organisation) { create(:claims_school) }
+    let(:user) { create(:claims_user, first_name: "Joe") }
+    let(:organisation) { create(:claims_school, name: "Shelbyville Elementary") }
 
     it "sends the invitation" do
       expect(invite_email.to).to contain_exactly(user.email)
       expect(invite_email.subject).to eq("Invitation to join Claim funding for mentor training")
       expect(invite_email.body).to have_content <<~EMAIL
-        Dear #{user.first_name},
+        Dear Joe,
 
-        You have been invited to join the Claim funding for mentor training service for #{organisation.name}.
+        You have been invited to join the Claim funding for mentor training service for Shelbyville Elementary because you are a [DfE-sign approver](https://edd-help.signin.education.gov.uk/contact/create-account#:~:text=An%20approver%20is%20someone%20at%20your%20organisation%20responsible,person%2C%20such%20as%20an%20administrator%2C%20manager%2C%20or%20headteacher) for your organisation.
+
+        If you are not the right person in your organisation to submit funding claims for general mentor training, please:
+
+        - access the service using DfE sign-in and add an appropriate colleague in the Users section
+        - forward this email to the appropriate colleague after adding them as a user
 
         # Sign in to submit claims
 
-        If you have a DfE Sign-in account, you can use it to sign in:
+        Sign in using DfE sign-in:
 
         [http://claims.localhost/sign-in?utm_campaign=school&utm_medium=notification&utm_source=email](http://claims.localhost/sign-in?utm_campaign=school&utm_medium=notification&utm_source=email)
 
-        If you need to create a DfE Sign-in account, you can do this after clicking "Sign in using DfE Sign-in"
+        If your colleague needs to create a DfE Sign-in account, they can do this after clicking "Sign in using DfE Sign-in"
 
-        After creating a DfE Sign-in account, you will need to return to this email and [sign in to access the service](http://claims.localhost/sign-in?utm_campaign=school&utm_medium=notification&utm_source=email).
+        After creating a DfE Sign-in account, they will need to return to this email and [sign in to access the service](http://claims.localhost/sign-in?utm_campaign=school&utm_medium=notification&utm_source=email)
+
+        # Prior to submitting claims
+
+        We recommend confirming with your accredited provider the number of hours you are claiming, as they may be asked to provide evidence to support this claim.
 
         # Give feedback or report a problem
 


### PR DESCRIPTION
## Context

Update invitation email (in service) for Claim users so they have all the required info to direct users on how to ensure the right person in their school has access to the service.

## Changes proposed in this pull request

Update user mailer content

## Link to Trello card

https://trello.com/c/lB5HJ7YZ/564-update-invitation-email-for-new-users

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
