### PR TITLE
Add service.gov.uk environment domains

### DIFF
--- a/terraform/application/config/production_app_env.yml
+++ b/terraform/application/config/production_app_env.yml
@@ -4,7 +4,7 @@ HOSTING_ENV: production
 # Primary hostname for the Funding Mentors service
 CLAIMS_HOST: claim-funding-for-mentor-training.education.gov.uk
 # Additional hostnames that may be used – e.g. the CDN origin (comma separated)
-CLAIMS_HOSTS: claim-funding-for-mentor-training.education.gov.uk,track-and-pay-production.teacherservices.cloud,track-and-pay-temp.teacherservices.cloud
+CLAIMS_HOSTS: claim-funding-for-mentor-training.education.gov.uk,claim-funding-for-itt-mentor-training.service.gov.uk,track-and-pay-production.teacherservices.cloud,track-and-pay-temp.teacherservices.cloud
 
 # Primary hostname for the School Placements service
 PLACEMENTS_HOST: manage-school-placements.education.gov.uk

--- a/terraform/application/config/qa_app_env.yml
+++ b/terraform/application/config/qa_app_env.yml
@@ -5,7 +5,7 @@ SKYLIGHT_ENV: qa
 # Primary hostname for the Funding Mentors service
 CLAIMS_HOST: qa.claim-funding-for-mentor-training.education.gov.uk
 # Additional hostnames that may be used – e.g. the CDN origin (comma separated)
-CLAIMS_HOSTS: qa.claim-funding-for-mentor-training.education.gov.uk,track-and-pay-qa.test.teacherservices.cloud
+CLAIMS_HOSTS: qa.claim-funding-for-mentor-training.education.gov.uk,qa.claim-funding-for-itt-mentor-training.service.gov.uk,track-and-pay-qa.test.teacherservices.cloud
 
 # Primary hostname for the School Placements service
 PLACEMENTS_HOST: qa.manage-school-placements.education.gov.uk

--- a/terraform/application/config/sandbox_app_env.yml
+++ b/terraform/application/config/sandbox_app_env.yml
@@ -4,7 +4,7 @@ HOSTING_ENV: sandbox
 # Primary hostname for the Funding Mentors service
 CLAIMS_HOST: sandbox.claim-funding-for-mentor-training.education.gov.uk
 # Additional hostnames that may be used – e.g. the CDN origin (comma separated)
-CLAIMS_HOSTS: sandbox.claim-funding-for-mentor-training.education.gov.uk,track-and-pay-sandbox.teacherservices.cloud
+CLAIMS_HOSTS: sandbox.claim-funding-for-mentor-training.education.gov.uk,sandbox.claim-funding-for-itt-mentor-training.service.gov.uk,track-and-pay-sandbox.teacherservices.cloud
 
 # Primary hostname for the School Placements service
 PLACEMENTS_HOST: sandbox.manage-school-placements.education.gov.uk

--- a/terraform/application/config/staging_app_env.yml
+++ b/terraform/application/config/staging_app_env.yml
@@ -5,7 +5,7 @@ SKYLIGHT_ENV: staging
 # Primary hostname for the Funding Mentors service
 CLAIMS_HOST: staging.claim-funding-for-mentor-training.education.gov.uk
 # Additional hostnames that may be used – e.g. the CDN origin (comma separated)
-CLAIMS_HOSTS: staging.claim-funding-for-mentor-training.education.gov.uk,track-and-pay-staging.test.teacherservices.cloud,track-and-pay-temp.test.teacherservices.cloud
+CLAIMS_HOSTS: staging.claim-funding-for-mentor-training.education.gov.uk,staging.claim-funding-for-itt-mentor-training.service.gov.uk,track-and-pay-staging.test.teacherservices.cloud,track-and-pay-temp.test.teacherservices.cloud
 
 # Primary hostname for the School Placements service
 PLACEMENTS_HOST: staging.manage-school-placements.education.gov.uk

--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -18,6 +18,24 @@
           }
         ]
       },
+      "claim-funding-for-itt-mentor-training.service.gov.uk": {
+        "front_door_name": "s189p01-ittmssvc-domains-fd",
+        "resource_group_name": "s189p01-ittmsdomains-rg",
+        "domains": [
+          "apex", "www"
+        ],
+        "cached_paths": [
+          "/assets/*"
+        ],
+        "environment_short": "pd",
+        "origin_hostname": "track-and-pay-production.teacherservices.cloud",
+        "redirect_rules": [
+          {
+            "from-domain": "www",
+            "to-domain": "claim-funding-for-itt-mentor-training.service.gov.uk"
+          }
+        ]
+      },
       "manage-school-placements.education.gov.uk": {
         "front_door_name": "s189p01-ittmssp-domains-fd",
         "resource_group_name": "s189p01-ittmsdomains-rg",

--- a/terraform/domains/environment_domains/config/qa.tfvars.json
+++ b/terraform/domains/environment_domains/config/qa.tfvars.json
@@ -12,6 +12,18 @@
         "environment_short": "qa",
         "origin_hostname": "track-and-pay-qa.test.teacherservices.cloud"
       },
+      "claim-funding-for-itt-mentor-training.service.gov.uk": {
+        "front_door_name": "s189p01-ittmssvc-domains-fd",
+        "resource_group_name": "s189p01-ittmsdomains-rg",
+        "domains": [
+          "qa"
+        ],
+        "cached_paths": [
+          "/assets/*"
+        ],
+        "environment_short": "qa",
+        "origin_hostname": "track-and-pay-qa.test.teacherservices.cloud"
+      },
       "manage-school-placements.education.gov.uk": {
         "front_door_name": "s189p01-ittmssp-domains-fd",
         "resource_group_name": "s189p01-ittmsdomains-rg",

--- a/terraform/domains/environment_domains/config/sandbox.tfvars.json
+++ b/terraform/domains/environment_domains/config/sandbox.tfvars.json
@@ -12,6 +12,18 @@
         "environment_short": "sb",
         "origin_hostname": "track-and-pay-sandbox.teacherservices.cloud"
       },
+      "claim-funding-for-itt-mentor-training.service.gov.uk": {
+        "front_door_name": "s189p01-ittmssvc-domains-fd",
+        "resource_group_name": "s189p01-ittmsdomains-rg",
+        "domains": [
+          "sandbox"
+        ],
+        "cached_paths": [
+          "/assets/*"
+        ],
+        "environment_short": "sb",
+        "origin_hostname": "track-and-pay-sandbox.teacherservices.cloud"
+      },
       "manage-school-placements.education.gov.uk": {
         "front_door_name": "s189p01-ittmssp-domains-fd",
         "resource_group_name": "s189p01-ittmsdomains-rg",

--- a/terraform/domains/environment_domains/config/staging.tfvars.json
+++ b/terraform/domains/environment_domains/config/staging.tfvars.json
@@ -12,6 +12,18 @@
         "environment_short": "stg",
         "origin_hostname": "track-and-pay-staging.test.teacherservices.cloud"
       },
+      "claim-funding-for-itt-mentor-training.service.gov.uk": {
+        "front_door_name": "s189p01-ittmssvc-domains-fd",
+        "resource_group_name": "s189p01-ittmsdomains-rg",
+        "domains": [
+          "staging"
+        ],
+        "cached_paths": [
+          "/assets/*"
+        ],
+        "environment_short": "stg",
+        "origin_hostname": "track-and-pay-staging.test.teacherservices.cloud"
+      },
       "manage-school-placements.education.gov.uk": {
         "front_door_name": "s189p01-ittmssp-domains-fd",
         "resource_group_name": "s189p01-ittmsdomains-rg",


### PR DESCRIPTION
## Context

Now that we have the claim-funding-for-itt-mentor-training service.gov.uk zone and it has been delegated, we need to create the environment sub domains.

## Changes proposed in this pull request

Added subdomains for qa, staging, sandbox and production

## Guidance to review

make qa|staging|sandbox|production domains-plan

## Link to Trello card

https://trello.com/c/Y3u8I72m/2315-create-claim-funding-service-domain

