### PR TITLE
Remove placements page from provider interface

### DIFF
--- a/app/controllers/placements/organisations_controller.rb
+++ b/app/controllers/placements/organisations_controller.rb
@@ -32,7 +32,7 @@ class Placements::OrganisationsController < Placements::ApplicationController
     if organisation.is_a?(School)
       placements_school_placements_path(organisation)
     else # Provider
-      placements_provider_placements_path(organisation)
+      placements_provider_find_index_path(organisation)
     end
   end
 end

--- a/app/controllers/placements/providers/placements_controller.rb
+++ b/app/controllers/placements/providers/placements_controller.rb
@@ -3,6 +3,7 @@ class Placements::Providers::PlacementsController < Placements::ApplicationContr
   helper_method :filter_form, :location_coordinates
 
   def index
+    authorize @provider, :index?, policy_class: Placements::Provider::PlacementPolicy
     @current_academic_year = Placements::AcademicYear.current.decorate
     @next_academic_year = @current_academic_year.next.decorate
     @subjects = filter_subjects_by_phase

--- a/app/policies/placements/provider/placement_policy.rb
+++ b/app/policies/placements/provider/placement_policy.rb
@@ -4,4 +4,8 @@ class Placements::Provider::PlacementPolicy < ApplicationPolicy
       scope
     end
   end
+
+  def index?
+    Flipper.enabled?(:show_provider_placements)
+  end
 end

--- a/app/views/placements/providers/_primary_navigation.html.erb
+++ b/app/views/placements/providers/_primary_navigation.html.erb
@@ -7,7 +7,9 @@
 <%= content_for(:primary_navigation_content) do %>
   <%= render PrimaryNavigationComponent.new do |component| %>
     <% component.with_navigation_item t(".find"), placements_provider_find_index_path(provider), current: current_navigation == :find %>
-    <% component.with_navigation_item t(".placements"), placements_provider_placements_path(provider), current: current_navigation == :placements %>
+    <% if Flipper.enabled?(:show_provider_placements) %>
+      <% component.with_navigation_item t(".placements"), placements_provider_placements_path(provider), current: current_navigation == :placements %>
+    <% end %>
     <% component.with_navigation_item t(".schools"), placements_provider_partner_schools_path(provider), current: current_navigation == :partner_schools %>
     <% component.with_navigation_item t(".users"), placements_provider_users_path(provider), current: current_navigation == :users %>
     <% component.with_navigation_item t(".organisation_details"),

--- a/db/migrate/20250422161024_add_hide_placements_flag.rb
+++ b/db/migrate/20250422161024_add_hide_placements_flag.rb
@@ -1,0 +1,5 @@
+class AddHidePlacementsFlag < ActiveRecord::Migration[7.2]
+  def change
+    Flipper.add(:show_provider_placements)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_22_121713) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_22_161024) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -239,6 +239,7 @@ Provider.create!(name: "Test Provider 789", code: "TEST 789")
 # Feature flags
 
 Flipper.add(:bulk_add_placements)
+Flipper.add(:show_provider_placements)
 Flipper.enable(:bulk_add_placements)
 
 Flipper.add(:school_partner_providers)

--- a/spec/requests/placements/providers/placements_spec.rb
+++ b/spec/requests/placements/providers/placements_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe "Placements", service: :placements, type: :request do
   describe "GET /placements" do
     context "when an organisation is present" do
       before do
+        Flipper.add(:show_provider_placements)
+        Flipper.enable(:show_provider_placements)
         get placements_provider_placements_path(provider)
       end
 

--- a/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
+++ b/spec/system/placements/organisations/users/user_removes_other_users_from_organisation_spec.rb
@@ -136,7 +136,6 @@ RSpec.describe "Placements support user removes a user from an organisation", se
 
   def users_is_selected_in_providers_primary_nav
     within(".app-primary-navigation__nav") do
-      expect(page).to have_link "Placements", current: "false"
       expect(page).to have_link "Users", current: "page"
       expect(page).to have_link "Organisation details", current: "false"
     end

--- a/spec/system/placements/organisations/users/user_views_other_users_spec.rb
+++ b/spec/system/placements/organisations/users/user_views_other_users_spec.rb
@@ -103,7 +103,6 @@ RSpec.describe "Placements user views other users in their organisation", servic
 
   def and_users_is_selected_in_providers_primary_nav
     within(".app-primary-navigation__nav") do
-      expect(page).to have_link "Placements", current: "false"
       expect(page).to have_link "Users", current: "page"
       expect(page).to have_link "Organisation details", current: "false"
     end

--- a/spec/system/placements/organisations/view_organisations_spec.rb
+++ b/spec/system/placements/organisations/view_organisations_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "View organisations", service: :placements, type: :system do
     when_i_click_on_change_organisation
     i_am_redirected_to_organisation_index
     when_i_click_on_provider_name
-    then_i_see_the_placements_search_page(multi_org_provider)
+    then_i_see_the_find_schools_page(multi_org_provider)
     when_i_click_on_change_organisation
     i_am_redirected_to_organisation_index
   end
@@ -32,7 +32,7 @@ RSpec.describe "View organisations", service: :placements, type: :system do
 
   scenario "I sign in as user Anne with one provider" do
     given_i_am_signed_in_as_a_placements_user(organisations: [one_provider])
-    then_i_see_the_one_provider
+    then_i_see_the_find_schools_page(one_provider)
   end
 
   scenario "I cannot view a school unless it is a placements school" do
@@ -77,14 +77,17 @@ RSpec.describe "View organisations", service: :placements, type: :system do
     click_on "Provider 1"
   end
 
-  def then_i_see_the_placements_search_page(provider)
-    expect(page).to have_current_path placements_provider_placements_path(provider), ignore_query: true
+  def then_i_see_the_find_schools_page(provider)
+    expect(page).to have_current_path placements_provider_find_index_path(provider), ignore_query: true
     within(".app-primary-navigation__nav") do
-      expect(page).to have_link "Placements", current: "page"
+      expect(page).to have_link "Find", current: "page"
       expect(page).to have_link "Schools", current: "false"
       expect(page).to have_link "Users", current: "false"
       expect(page).to have_link "Organisation details", current: "false"
     end
+    expect(page).to have_title("Find schools hosting placements - Manage school placements - GOV.UK")
+    expect(page).to have_h1("Find schools hosting placements")
+    expect(page).to have_h2("Filter")
   end
 
   def then_i_see_the_one_school

--- a/spec/system/placements/providers/partner_schools/add_a_partner_school_spec.rb
+++ b/spec/system/placements/providers/partner_schools/add_a_partner_school_spec.rb
@@ -224,7 +224,6 @@ RSpec.describe "Placements / Providers / Partner schools / Add a partner school"
     nav = page.find(".app-primary-navigation__nav")
 
     within(nav) do
-      expect(page).to have_link "Placements", current: "false"
       expect(page).to have_link "Schools", current: "page"
       expect(page).to have_link "Users", current: "false"
       expect(page).to have_link "Organisation details", current: "false"

--- a/spec/system/placements/providers/partner_schools/add_a_partner_school_without_javascript_spec.rb
+++ b/spec/system/placements/providers/partner_schools/add_a_partner_school_without_javascript_spec.rb
@@ -186,7 +186,6 @@ RSpec.describe "Placements / Providers / Partner schools / Add a partner school 
     nav = page.find(".app-primary-navigation__nav")
 
     within(nav) do
-      expect(page).to have_link "Placements", current: "false"
       expect(page).to have_link "Schools", current: "page"
       expect(page).to have_link "Users", current: "false"
       expect(page).to have_link "Organisation details", current: "false"

--- a/spec/system/placements/providers/partner_schools/remove_a_partner_school_spec.rb
+++ b/spec/system/placements/providers/partner_schools/remove_a_partner_school_spec.rb
@@ -153,7 +153,6 @@ RSpec.describe "Placements / Providers / Partner schools / Remove a partner scho
     nav = page.find(".app-primary-navigation__nav")
 
     within(nav) do
-      expect(page).to have_link "Placements", current: "false"
       expect(page).to have_link "Schools", current: "page"
       expect(page).to have_link "Users", current: "false"
       expect(page).to have_link "Organisation details", current: "false"

--- a/spec/system/placements/providers/partner_schools/view_a_partner_school_spec.rb
+++ b/spec/system/placements/providers/partner_schools/view_a_partner_school_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe "Placements / Providers / Partner schools / Views a partner schoo
     nav = page.find(".app-primary-navigation__nav")
 
     within(nav) do
-      expect(page).to have_link "Placements", current: "false"
       expect(page).to have_link "Schools", current: "page"
       expect(page).to have_link "Users", current: "false"
       expect(page).to have_link "Organisation details", current: "false"

--- a/spec/system/placements/providers/partner_schools/view_partner_schools_list_spec.rb
+++ b/spec/system/placements/providers/partner_schools/view_partner_schools_list_spec.rb
@@ -53,7 +53,6 @@ RSpec.describe "Placements / Providers / Partner schools / View a list of partne
     nav = page.find(".app-primary-navigation__nav")
 
     within(nav) do
-      expect(page).to have_link "Placements", current: "false"
       expect(page).to have_link "Schools", current: "page"
       expect(page).to have_link "Users", current: "false"
       expect(page).to have_link "Organisation details", current: "false"

--- a/spec/system/placements/providers/placements/provider_user_filters_placements_by_academic_year_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_filters_placements_by_academic_year_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.describe "Provider user filters placements by academic year", service: :placements, type: :system do
   scenario do
     given_that_placements_exist
+    given_the_show_provider_placements_feature_flag_is_enabled
     and_i_am_signed_in
+    and_i_navigate_to_the_placements_index
 
     when_i_am_on_the_placements_index_page
     then_i_see_the_placement_for_the_current_academic_year
@@ -40,6 +42,17 @@ RSpec.describe "Provider user filters placements by academic year", service: :pl
 
   def and_i_am_signed_in
     sign_in_placements_user(organisations: [@provider])
+  end
+
+  def given_the_show_provider_placements_feature_flag_is_enabled
+    Flipper.add(:show_provider_placements)
+    Flipper.enable(:show_provider_placements)
+  end
+
+  def and_i_navigate_to_the_placements_index
+    within ".app-primary-navigation__nav" do
+      click_on "Placements"
+    end
   end
 
   def when_i_am_on_the_placements_index_page

--- a/spec/system/placements/providers/placements/provider_user_filters_placements_by_expected_date_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_filters_placements_by_expected_date_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.describe "Provider user filters placements by expected date", service: :placements, type: :system do
   scenario do
     given_that_placements_exist
+    given_the_show_provider_placements_feature_flag_is_enabled
     and_i_am_signed_in
+    and_i_navigate_to_the_placements_index
 
     when_i_am_on_the_placements_index_page
     then_i_see_all_placements
@@ -56,6 +58,17 @@ RSpec.describe "Provider user filters placements by expected date", service: :pl
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_h1("Find placements")
     expect(page).to have_h2("Filter")
+  end
+
+  def given_the_show_provider_placements_feature_flag_is_enabled
+    Flipper.add(:show_provider_placements)
+    Flipper.enable(:show_provider_placements)
+  end
+
+  def and_i_navigate_to_the_placements_index
+    within primary_navigation do
+      click_on "Placements"
+    end
   end
 
   def then_i_see_all_placements

--- a/spec/system/placements/providers/placements/provider_user_filters_placements_by_phase_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_filters_placements_by_phase_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.describe "Provider user filters placements by phase", service: :placements, type: :system do
   scenario do
     given_that_placements_exist
+    given_the_show_provider_placements_feature_flag_is_enabled
     and_i_am_signed_in
+    and_i_navigate_to_the_placements_index
 
     when_i_am_on_the_placements_index_page
     then_i_see_all_placements
@@ -57,6 +59,17 @@ RSpec.describe "Provider user filters placements by phase", service: :placements
     @secondary_subject = build(:subject, name: "Music", subject_area: "secondary")
     @shelbyville_secondary_placement = create(:placement, school: @secondary_school, subject: @secondary_subject)
     @ogdenville_secondary_placement = create(:placement, school: @all_through_school, subject: @secondary_subject)
+  end
+
+  def given_the_show_provider_placements_feature_flag_is_enabled
+    Flipper.add(:show_provider_placements)
+    Flipper.enable(:show_provider_placements)
+  end
+
+  def and_i_navigate_to_the_placements_index
+    within primary_navigation do
+      click_on "Placements"
+    end
   end
 
   def and_i_am_signed_in

--- a/spec/system/placements/providers/placements/provider_user_filters_placements_by_placements_to_show_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_filters_placements_by_placements_to_show_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.describe "Provider user filters placements by placements to show", service: :placements, type: :system do
   scenario do
     given_that_placements_exist
+    given_the_show_provider_placements_feature_flag_is_enabled
     and_i_am_signed_in
+    and_i_navigate_to_the_placements_index
 
     when_i_am_on_the_placements_index_page
     then_i_see_the_available_placement
@@ -37,6 +39,17 @@ RSpec.describe "Provider user filters placements by placements to show", service
     @primary_science_subject = build(:subject, name: "Primary with science", subject_area: "primary")
     _assigned_placement = create(:placement, school: @primary_school, subject: @primary_science_subject,
                                              provider: @provider)
+  end
+
+  def given_the_show_provider_placements_feature_flag_is_enabled
+    Flipper.add(:show_provider_placements)
+    Flipper.enable(:show_provider_placements)
+  end
+
+  def and_i_navigate_to_the_placements_index
+    within primary_navigation do
+      click_on "Placements"
+    end
   end
 
   def and_i_am_signed_in

--- a/spec/system/placements/providers/placements/provider_user_filters_placements_by_primary_year_group_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_filters_placements_by_primary_year_group_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.describe "Provider user filters placements by primary year group", service: :placements, type: :system do
   scenario do
     given_that_placements_exist
+    given_the_show_provider_placements_feature_flag_is_enabled
     and_i_am_signed_in
+    and_i_navigate_to_the_placements_index
 
     when_i_am_on_the_placements_index_page
     then_i_see_all_placements
@@ -47,6 +49,17 @@ RSpec.describe "Provider user filters placements by primary year group", service
 
   def and_i_am_signed_in
     sign_in_placements_user(organisations: [@provider])
+  end
+
+  def given_the_show_provider_placements_feature_flag_is_enabled
+    Flipper.add(:show_provider_placements)
+    Flipper.enable(:show_provider_placements)
+  end
+
+  def and_i_navigate_to_the_placements_index
+    within primary_navigation do
+      click_on "Placements"
+    end
   end
 
   def when_i_am_on_the_placements_index_page

--- a/spec/system/placements/providers/placements/provider_user_filters_placements_by_school_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_filters_placements_by_school_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.describe "Provider user filters placements by school", service: :placements, type: :system do
   scenario do
     given_that_placements_exist
+    given_the_show_provider_placements_feature_flag_is_enabled
     and_i_am_signed_in
+    and_i_navigate_to_the_placements_index
 
     when_i_am_on_the_placements_index_page
     then_i_see_all_placements
@@ -46,6 +48,17 @@ RSpec.describe "Provider user filters placements by school", service: :placement
 
   def and_i_am_signed_in
     sign_in_placements_user(organisations: [@provider])
+  end
+
+  def given_the_show_provider_placements_feature_flag_is_enabled
+    Flipper.add(:show_provider_placements)
+    Flipper.enable(:show_provider_placements)
+  end
+
+  def and_i_navigate_to_the_placements_index
+    within primary_navigation do
+      click_on "Placements"
+    end
   end
 
   def when_i_am_on_the_placements_index_page

--- a/spec/system/placements/providers/placements/provider_user_filters_placements_by_schools_i_work_with_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_filters_placements_by_schools_i_work_with_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.describe "Provider user filters placements by schools I work with", service: :placements, type: :system do
   scenario do
     given_that_placements_exist
+    given_the_show_provider_placements_feature_flag_is_enabled
     and_i_am_signed_in
+    and_i_navigate_to_the_placements_index
 
     when_i_am_on_the_placements_index_page
     then_i_see_all_placements
@@ -38,6 +40,17 @@ RSpec.describe "Provider user filters placements by schools I work with", servic
 
   def and_i_am_signed_in
     sign_in_placements_user(organisations: [@provider])
+  end
+
+  def given_the_show_provider_placements_feature_flag_is_enabled
+    Flipper.add(:show_provider_placements)
+    Flipper.enable(:show_provider_placements)
+  end
+
+  def and_i_navigate_to_the_placements_index
+    within primary_navigation do
+      click_on "Placements"
+    end
   end
 
   def when_i_am_on_the_placements_index_page

--- a/spec/system/placements/providers/placements/provider_user_filters_placements_by_search_by_location_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_filters_placements_by_search_by_location_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.describe "Provider user filters placements by search by location", service: :placements, type: :system do
   scenario do
     given_that_placements_exist
+    given_the_show_provider_placements_feature_flag_is_enabled
     and_i_am_signed_in
+    and_i_navigate_to_the_placements_index
 
     when_i_am_on_the_placements_index_page
     then_i_see_all_placements
@@ -47,6 +49,17 @@ RSpec.describe "Provider user filters placements by search by location", service
 
   def and_i_am_signed_in
     sign_in_placements_user(organisations: [@provider])
+  end
+
+  def given_the_show_provider_placements_feature_flag_is_enabled
+    Flipper.add(:show_provider_placements)
+    Flipper.enable(:show_provider_placements)
+  end
+
+  def and_i_navigate_to_the_placements_index
+    within primary_navigation do
+      click_on "Placements"
+    end
   end
 
   def when_i_am_on_the_placements_index_page

--- a/spec/system/placements/providers/placements/provider_user_filters_placements_by_subject_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_filters_placements_by_subject_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.describe "Provider user filters placements by subject", service: :placements, type: :system do
   scenario do
     given_that_placements_exist
+    given_the_show_provider_placements_feature_flag_is_enabled
     and_i_am_signed_in
+    and_i_navigate_to_the_placements_index
 
     when_i_am_on_the_placements_index_page
     then_i_see_all_placements
@@ -45,6 +47,17 @@ RSpec.describe "Provider user filters placements by subject", service: :placemen
 
   def and_i_am_signed_in
     sign_in_placements_user(organisations: [@provider])
+  end
+
+  def given_the_show_provider_placements_feature_flag_is_enabled
+    Flipper.add(:show_provider_placements)
+    Flipper.enable(:show_provider_placements)
+  end
+
+  def and_i_navigate_to_the_placements_index
+    within primary_navigation do
+      click_on "Placements"
+    end
   end
 
   def when_i_am_on_the_placements_index_page

--- a/spec/system/placements/providers/placements/provider_user_filters_placements_with_multiple_filters_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_filters_placements_with_multiple_filters_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.describe "Provider user filters placements with multiple filters", service: :placements, type: :system do
   scenario do
     given_that_placements_exist
+    given_the_show_provider_placements_feature_flag_is_enabled
     and_i_am_signed_in
+    and_i_navigate_to_the_placements_index
 
     when_i_am_on_the_placements_index_page
     then_i_see_all_placements
@@ -38,6 +40,17 @@ RSpec.describe "Provider user filters placements with multiple filters", service
 
   def and_i_am_signed_in
     sign_in_placements_user(organisations: [@provider])
+  end
+
+  def given_the_show_provider_placements_feature_flag_is_enabled
+    Flipper.add(:show_provider_placements)
+    Flipper.enable(:show_provider_placements)
+  end
+
+  def and_i_navigate_to_the_placements_index
+    within primary_navigation do
+      click_on "Placements"
+    end
   end
 
   def when_i_am_on_the_placements_index_page

--- a/spec/system/placements/providers/placements/provider_user_prevented_from_viewing_placements_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_prevented_from_viewing_placements_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+RSpec.describe "Provider user attempts to navigate to placements", service: :placements, type: :system do
+  scenario "When the show provider placements feature flag is disabled" do
+    given_that_placements_exist
+    given_there_is_a_show_providers_feature_flag
+    when_the_show_provider_placements_feature_flag_is_disabled
+    and_i_am_signed_in
+
+    then_i_see_the_find_schools_page
+    and_there_is_no_placements_tab_in_the_navigation_window
+
+    when_i_attempt_to_navigate_to_the_placements_page
+    then_i_am_prevented_from_doing_so
+  end
+
+  private
+
+  def given_that_placements_exist
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+    @primary_school = build(:placements_school, phase: "Primary", name: "Springfield Elementary")
+    @autumn_term = build(:placements_term, :autumn)
+
+    @primary_maths_subject = build(:subject, name: "Primary with mathematics", subject_area: "primary")
+    _primary_maths_placement = create(:placement, school: @primary_school, subject: @primary_maths_subject,
+                                                  terms: [@autumn_term])
+
+    @primary_english_subject = build(:subject, name: "Primary with english", subject_area: "primary")
+    _primary_english_placement = create(:placement, school: @primary_school, subject: @primary_english_subject,
+                                                    terms: [@autumn_term])
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def given_there_is_a_show_providers_feature_flag
+    Flipper.add(:show_provider_placements)
+  end
+
+  def when_the_show_provider_placements_feature_flag_is_enabled
+    Flipper.enable(:show_provider_placements)
+  end
+
+  def when_the_show_provider_placements_feature_flag_is_disabled
+    Flipper.disable(:show_provider_placements)
+  end
+
+  def then_i_see_the_find_schools_page
+    expect(page).to have_title("Find schools hosting placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Find schools hosting placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def and_there_is_no_placements_tab_in_the_navigation_window
+    within primary_navigation do
+      expect(page).not_to have_link "Placements", current: "false"
+      expect(page).to have_link "Find", current: "page"
+      expect(page).to have_link "Schools", current: "false"
+      expect(page).to have_link "Users", current: "false"
+      expect(page).to have_link "Organisation details", current: "false"
+    end
+  end
+
+  def when_i_attempt_to_navigate_to_the_placements_page
+    visit placements_provider_placements_path(@provider)
+  end
+
+  def then_i_am_prevented_from_doing_so
+    expect(page).to have_title("Manage school placements")
+    expect(page).to have_important_banner("You cannot perform this action")
+  end
+end

--- a/spec/system/placements/providers/placements/provider_user_searches_for_school_filter_option_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_searches_for_school_filter_option_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.describe "Provider user searchers for a school filter option", :js, service: :placements, type: :system do
   scenario do
     given_that_school_filter_options_exist
+    given_the_show_provider_placements_feature_flag_is_enabled
     and_i_am_signed_in
+    and_i_navigate_to_the_placements_index
 
     when_i_am_on_the_placements_index_page
     then_i_see_the_school_filter
@@ -26,6 +28,17 @@ RSpec.describe "Provider user searchers for a school filter option", :js, servic
 
   def and_i_am_signed_in
     sign_in_placements_user(organisations: [@provider])
+  end
+
+  def given_the_show_provider_placements_feature_flag_is_enabled
+    Flipper.add(:show_provider_placements)
+    Flipper.enable(:show_provider_placements)
+  end
+
+  def and_i_navigate_to_the_placements_index
+    within primary_navigation do
+      click_on "Placements"
+    end
   end
 
   def when_i_am_on_the_placements_index_page

--- a/spec/system/placements/providers/placements/provider_user_searches_for_subject_filter_option_spec.rb
+++ b/spec/system/placements/providers/placements/provider_user_searches_for_subject_filter_option_spec.rb
@@ -2,8 +2,10 @@ require "rails_helper"
 
 RSpec.describe "Provider user searchers for a subject filter option", :js, service: :placements, type: :system do
   scenario do
+    given_the_show_provider_placements_feature_flag_is_enabled
     given_that_subject_filter_options_exist
     and_i_am_signed_in
+    and_i_navigate_to_the_placements_index
 
     when_i_am_on_the_placements_index_page
     then_i_see_the_subject_filter
@@ -26,6 +28,17 @@ RSpec.describe "Provider user searchers for a subject filter option", :js, servi
 
   def and_i_am_signed_in
     sign_in_placements_user(organisations: [@provider])
+  end
+
+  def given_the_show_provider_placements_feature_flag_is_enabled
+    Flipper.add(:show_provider_placements)
+    Flipper.enable(:show_provider_placements)
+  end
+
+  def and_i_navigate_to_the_placements_index
+    within primary_navigation do
+      click_on "Placements"
+    end
   end
 
   def when_i_am_on_the_placements_index_page

--- a/spec/system/placements/providers/placements/view_a_placement_spec.rb
+++ b/spec/system/placements/providers/placements/view_a_placement_spec.rb
@@ -33,7 +33,10 @@ RSpec.describe "Placements / Providers / Placements / View a placement",
     create(:placement, subject: placement_subject, school:, additional_subjects:, academic_year:, terms:)
   end
 
-  before { given_i_am_signed_in_as_a_placements_user(organisations: [provider]) }
+  before do
+    given_i_am_signed_in_as_a_placements_user(organisations: [provider])
+    given_the_show_provider_placements_feature_flag_is_enabled
+  end
 
   context "when the placement has a subject without child subjects" do
     let(:placement_subject) { subject_1 }
@@ -68,6 +71,11 @@ RSpec.describe "Placements / Providers / Placements / View a placement",
   end
 
   private
+
+  def given_the_show_provider_placements_feature_flag_is_enabled
+    Flipper.add(:show_provider_placements)
+    Flipper.enable(:show_provider_placements)
+  end
 
   def when_i_visit_the_placement_show_page
     visit placements_provider_placement_path(provider, placement)

--- a/spec/system/placements/providers/remembering_the_current_provider_spec.rb
+++ b/spec/system/placements/providers/remembering_the_current_provider_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe "Remembering the current provider", service: :placements, type: :
 
     when_i_click_on "The Chalkboard Champions"
     then_my_current_provider_is "The Chalkboard Champions"
-    when_i_click_on "Placements"
+    when_i_click_on "Find"
     then_my_current_provider_is "The Chalkboard Champions"
 
     when_i_click_on "Change organisation"
     and_i_click_on "Ctrl + Alt + Teach"
     then_my_current_provider_is "Ctrl + Alt + Teach"
-    when_i_click_on "Placements"
+    when_i_click_on "Find"
     then_my_current_provider_is "Ctrl + Alt + Teach"
   end
 

--- a/spec/system/placements/providers/view_provider_details_spec.rb
+++ b/spec/system/placements/providers/view_provider_details_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe "Placements / Providers / View provider details", service: :place
     nav = page.find(".app-primary-navigation__nav")
 
     within(nav) do
-      expect(page).to have_link "Placements", current: "false"
       expect(page).to have_link "Users", current: "false"
       expect(page).to have_link "Organisation details", current: "page"
       expect(page).to have_link "Schools", current: "false"

--- a/spec/system/placements/sign_in_as_a_placements_user_spec.rb
+++ b/spec/system/placements/sign_in_as_a_placements_user_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
     scenario "I sign in as a provider user and see the placements list page" do
       given_i_am_signed_in_as_a_placements_user(organisations: [organisation])
       then_i_dont_get_redirected_to_support_organisations
-      then_i_can_see_the_placements_page
+      then_i_can_see_the_find_schools_page
     end
   end
 
@@ -184,7 +184,7 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
           then_i_am_redirected_to_the_provider_users_page(organisation)
           when_i_visit_the placements_root_path
           and_i_click_on "Start now"
-          then_i_can_see_the_placements_page
+          then_i_can_see_the_find_schools_page
         end
       end
 
@@ -316,8 +316,8 @@ RSpec.describe "Sign In as a Placements User", service: :placements, type: :syst
     expect(page).to have_current_path(placements_school_placements_path(organisation))
   end
 
-  def then_i_can_see_the_placements_page
-    expect(page).to have_current_path(placements_provider_placements_path(organisation))
+  def then_i_can_see_the_find_schools_page
+    expect(page).to have_current_path(placements_provider_find_index_path(organisation))
   end
 
   def and_i_see_an_empty_organsations_page


### PR DESCRIPTION
Add show_provider_placements feature flag so that this functionality may be re-enabled in future

## Context

When accessing the service as a provider the landing page is ‘Find a placement’

Note that we are not removing the logic for the time being but a fair few system specs are going to break as they’ll use this page as a “jumping off” point. Replace the physical “click on navigation” action for these specs with the path instead.

Once we’ve launched the private beta we’ll assess if we can chop this logic entirely. We should also add a policy that blocks users accessing these pages via URL’s (that can be stubbed in the specs)

## Changes proposed in this pull request

Add feature flag to show provider placements. When it is set to false; the placements page will not be visible.

## Guidance to review

Run the review app and try to navigate the pages with/without the feature flag.

## Link to Trello card

(https://trello.com/c/Ck4VbN9n/524-remove-find-a-placement-page-from-the-provider-view)

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
