### PR TITLE
Iteration 3 red path changes

### DIFF
--- a/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next.html.erb
+++ b/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next.html.erb
@@ -6,38 +6,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <% if @appetite == "not_open" %>
-
-        <p class="govuk-body"><%= t(".not_open.we_set_your_profile") %></p>
-
-        <p class="govuk-body"><%= t(".not_open.your_contact_details_will_not_be_shown") %></p>
-
-        <h2 class="govuk-heading-m"><%= t(".what_happens_next") %></h2>
-
-        <p class="govuk-body"><%= t(".not_open.we_will_ask_you_again_html", school_url: placements_school_url(@school)) %></p>
-
-        <p class="govuk-body"><%= t(".not_open.if_you_would_like_to_host_placements") %></p>
-
-        <h2 class="govuk-heading-m"><%= t(".not_open.further_help_with_itt") %></h2>
-
-        <p class="govuk-body"><%= t(".not_open.your_hub_or_provider") %></p>
-
-        <p class="govuk-body"><%= t(".not_open.always_keen") %></p>
-
-        <%= tag.p t(".not_open.find_your_nearest") %>
-        <%= govuk_list type: :bullet do %>
-          <%= tag.li govuk_link_to(
-            t(".not_open.teaching_school_hub"),
-            t(".teaching_school_hub_url"),
-            new_tab: true,
-            no_visited_state: true,
-          ) %>
-          <%= tag.li govuk_link_to(
-            t(".not_open.itt_provider"),
-            placements_school_partner_providers_path(@school),
-            new_tab: true,
-            no_visited_state: true,
-          ) %>
-        <% end %>
+        <%= render "placements/schools/hosting_interests/add_hosting_interest/whats_next/not_open", placement_details: @placement_details %>
       <% elsif @appetite == "interested" %>
         <%= render "placements/schools/hosting_interests/add_hosting_interest/whats_next/interested", placement_details: @placement_details %>
       <% else %>

--- a/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_not_open.html.erb
+++ b/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_not_open.html.erb
@@ -1,0 +1,22 @@
+<%= govuk_panel(
+  title_text: t(".panel_title_html"),
+  text: t(".panel_text"),
+) %>
+
+<h1 class="govuk-heading-l govuk-!-margin-top-6">
+  <%= t(".what_happens_next") %>
+</h1>
+
+<p class="govuk-body">
+  <%= t(".we_will_ask_you_again") %>
+</p>
+
+<p class="govuk-body">
+  <%= embedded_link_text(
+    t(".if_you_would_like_to_host_placements",
+      link: govuk_link_to(
+        t(".update_your_placement_preferences"),
+        placements_school_path(@school),
+      )),
+  ) %>
+</p>

--- a/app/views/wizards/placements/add_hosting_interest_wizard/_are_you_sure_step.html.erb
+++ b/app/views/wizards/placements/add_hosting_interest_wizard/_are_you_sure_step.html.erb
@@ -11,9 +11,63 @@
       <span class="govuk-caption-l"><%= t(".caption") %></span>
       <h1 class="govuk-heading-l"><%= t(".title") %></h1>
 
-      <p class="govuk-body"><%= t(".this_will_help_providers") %></p>
-      <p class="govuk-body"><%= t(".your_school_will_show_as") %></p>
-      <p class="govuk-body"><%= t(".we_will_ask_again") %></p>
+      <p class="govuk-body"><%= t(".your_contact_details") %></p>
+      <p class="govuk-body"><%= t(".we_will_ask_you_again") %></p>
+      <p class="govuk-body"><%= t(".your_reason") %></p>
+
+      <h2 class="govuk-heading-m"><%= t(".details") %></h2>
+
+      <%= govuk_summary_list(html_attributes: { id: "reason_for_not_offering" }) do |summary_list| %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".reason_for_not_offering")) %>
+          <% row.with_value do %>
+            <%= govuk_list do %>
+              <% current_step.reasons_not_hosting.each do |reason| %>
+                <% if reason == "Other" %>
+                  <li><%= reason %> - <%= current_step.other_reason_not_hosting %></li>
+                <% else %>
+                  <li><%= reason %></li>
+                <% end %>
+              <% end %>
+            <% end %>
+          <% end %>
+          <% row.with_action(text: t(".change"),
+                             href: step_path(:reason_not_hosting),
+                             visually_hidden_text: t(".reason_for_not_offering"),
+                             classes: ["govuk-link--no-visited-state"]) %>
+        <% end %>
+      <% end %>
+
+      <% if @wizard.steps[:school_contact].present? %>
+        <h2 class="govuk-heading-m"><%= t(".itt_contact") %></h2>
+
+        <%= govuk_summary_list(html_attributes: { id: "school_contact" }) do |summary_list| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: User.human_attribute_name(:first_name)) %>
+            <% row.with_value(text: current_step.school_contact_first_name) %>
+            <% row.with_action(text: t(".change"),
+                               href: step_path(:school_contact),
+                               visually_hidden_text: User.human_attribute_name(:first_name),
+                               classes: ["govuk-link--no-visited-state"]) %>
+          <% end %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: User.human_attribute_name(:last_name)) %>
+            <% row.with_value(text: current_step.school_contact_last_name) %>
+            <% row.with_action(text: t(".change"),
+                               href: step_path(:school_contact),
+                               visually_hidden_text: User.human_attribute_name(:last_name),
+                               classes: ["govuk-link--no-visited-state"]) %>
+          <% end %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: User.human_attribute_name(:email_address)) %>
+            <% row.with_value(text: current_step.school_contact_email_address) %>
+            <% row.with_action(text: t(".change"),
+                               href: step_path(:school_contact),
+                               visually_hidden_text: User.human_attribute_name(:email_address),
+                               classes: ["govuk-link--no-visited-state"]) %>
+          <% end %>
+        <% end %>
+      <% end %>
 
       <%= f.govuk_submit t(".continue") %>
     </div>

--- a/app/views/wizards/placements/add_hosting_interest_wizard/_reason_not_hosting_step.html.erb
+++ b/app/views/wizards/placements/add_hosting_interest_wizard/_reason_not_hosting_step.html.erb
@@ -8,7 +8,11 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= f.govuk_check_boxes_fieldset :reasons_not_hosting, legend: { size: "l", text: t(".title"), tag: "h1" } do %>
+      <span class="govuk-caption-l"><%= t(".caption") %></span>
+
+      <%= f.govuk_check_boxes_fieldset :reasons_not_hosting,
+        legend: { size: "l", text: t(".title"), tag: "h1" },
+        hint: { text: t(".hint") } do %>
         <% current_step.reason_options.each_with_index do |reason_option, i| %>
           <%= f.govuk_check_box :reasons_not_hosting, reason_option.value, label: { text: reason_option.name }, link_errors: i.zero? do %>
             <% if reason_option.name == t(".options.other") %>

--- a/app/views/wizards/placements/add_hosting_interest_wizard/not_open/_school_contact_step.html.erb
+++ b/app/views/wizards/placements/add_hosting_interest_wizard/not_open/_school_contact_step.html.erb
@@ -1,0 +1,34 @@
+<% content_for :page_title, title_with_error_prefix(
+  t(".title"),
+  error: current_step.errors.any?,
+) %>
+
+<%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".caption") %></span>
+      <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+      <p class="govuk-body secondary-text"><%= t(".description") %></p>
+
+      <div class="govuk-form-group">
+        <%= f.govuk_text_field :first_name,
+                               width: 20,
+                               label: { text: User.human_attribute_name(:first_name), size: "s" } %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= f.govuk_text_field :last_name,
+                               width: 20,
+                               label: { text: User.human_attribute_name(:last_name), size: "s" } %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= f.govuk_text_field :email_address, label: { text: User.human_attribute_name(:email_address), size: "s" } %>
+      </div>
+
+      <%= f.govuk_submit t(".continue") %>
+    </div>
+  </div>
+<% end %>

--- a/app/wizards/placements/add_hosting_interest_wizard.rb
+++ b/app/wizards/placements/add_hosting_interest_wizard.rb
@@ -18,9 +18,7 @@ module Placements
       when "actively_looking"
         actively_looking_steps
       when "not_open"
-        add_step(ReasonNotHostingStep)
-        add_step(SchoolContactStep)
-        add_step(AreYouSureStep)
+        not_open_steps
       when "interested"
         interested_steps
       end
@@ -161,6 +159,12 @@ module Placements
       add_step(Interested::NoteToProvidersStep)
       add_step(SchoolContactStep)
       add_step(ConfirmStep)
+    end
+
+    def not_open_steps
+      add_step(ReasonNotHostingStep)
+      add_step(NotOpen::SchoolContactStep)
+      add_step(AreYouSureStep)
     end
 
     def year_group_steps

--- a/app/wizards/placements/add_hosting_interest_wizard/are_you_sure_step.rb
+++ b/app/wizards/placements/add_hosting_interest_wizard/are_you_sure_step.rb
@@ -1,2 +1,14 @@
 class Placements::AddHostingInterestWizard::AreYouSureStep < BaseStep
+  delegate :first_name, :last_name, :email_address, to: :school_contact_step, prefix: :school_contact
+  delegate :reasons_not_hosting, :other_reason_not_hosting, to: :reason_not_hosting_step
+
+  private
+
+  def school_contact_step
+    wizard.steps.fetch(:school_contact)
+  end
+
+  def reason_not_hosting_step
+    wizard.steps.fetch(:reason_not_hosting)
+  end
 end

--- a/app/wizards/placements/add_hosting_interest_wizard/not_open/school_contact_step.rb
+++ b/app/wizards/placements/add_hosting_interest_wizard/not_open/school_contact_step.rb
@@ -1,0 +1,2 @@
+class Placements::AddHostingInterestWizard::NotOpen::SchoolContactStep < Placements::AddHostingInterestWizard::SchoolContactStep
+end

--- a/app/wizards/placements/add_hosting_interest_wizard/reason_not_hosting_step.rb
+++ b/app/wizards/placements/add_hosting_interest_wizard/reason_not_hosting_step.rb
@@ -30,15 +30,18 @@ class Placements::AddHostingInterestWizard::ReasonNotHostingStep < BaseStep
     [
       I18n.t("#{locale_path}.options.concerns_about_trainee_quality"),
       I18n.t("#{locale_path}.options.do_not_get_offered_trainees"),
-      I18n.t("#{locale_path}.options.do_not_know_how_to_get_involved"),
       I18n.t("#{locale_path}.options.not_enough_trained_mentors"),
       I18n.t("#{locale_path}.options.number_of_pupils_with_send_needs"),
+      I18n.t("#{locale_path}.options.low_capacity_to_support_trainees"),
       I18n.t("#{locale_path}.options.working_to_improve_our_ofsted_rating"),
-      I18n.t("#{locale_path}.options.other"),
-    ]
+      I18n.t("#{locale_path}.options.do_not_know_how_to_get_involved"),
+    ].sort +
+      [
+        I18n.t("#{locale_path}.options.other"),
+      ]
   end
 
   def locale_path
-    ".wizards.placements.multi_placement_wizard.reason_not_hosting_step"
+    ".wizards.placements.add_hosting_interest_wizard.reason_not_hosting_step"
   end
 end

--- a/config/locales/en/placements/schools/hosting_interests.yml
+++ b/config/locales/en/placements/schools/hosting_interests.yml
@@ -27,19 +27,14 @@ en:
             what_happens_next: What happens next?
             teaching_school_hub_url: https://www.gov.uk/guidance/teaching-school-hubs
             not_open:
-              we_set_your_profile: We’ve set your profile to ‘not looking to host placements this year’.
-              your_contact_details_will_not_be_shown: Your contact details will not be shown to providers looking to place ITT trainees.
-              we_will_ask_you_again_html: 
-                We will ask you again in 12 months whether you would like to host placements. 
-                Make sure your profile has <a href=%{school_url}>up to date contact details of your ITT coordinator.</a>
+              panel_title_html: Confirmed.</br>You are not offering placements
+              panel_text: Your contact details will not be shown to providers
+              what_happens_next: What happens next?
+              we_will_ask_you_again: 
+                We will ask you again in the spring term of the next year to check whether you would like to offer placements.
               if_you_would_like_to_host_placements:
-                If you would like to host placements this year, update your profile to let providers know you’re interested.
-              further_help_with_itt: Further help with ITT
-              your_hub_or_provider: Your teaching school hub or local provider can answer any questions about ITT.
-              always_keen: They are always keen to hear from potential host schools, and can help you in a way that meets the individual needs of your school.
-              find_your_nearest: "Find your nearest:"
-              teaching_school_hub: teaching school hub
-              itt_provider: ITT provider
+                If you would like to host placements this year, %{link} to let providers know you’re interested.
+              update_your_placement_preferences: update your placement preferences
             interested:
               panel_title: Approximate information added
               panel_text: Providers can see that you may offer placements

--- a/config/locales/en/wizards/placements/add_hosting_interest_wizard.yml
+++ b/config/locales/en/wizards/placements/add_hosting_interest_wizard.yml
@@ -23,16 +23,19 @@ en:
           title: Would you like to list some placements to be seen by providers?
           continue: Continue
         reason_not_hosting_step:
-          title: What are your reasons for not taking part in ITT this year?
+          caption: Not offering placements this year
+          title: Tell us why you aren’t able to host this year
+          hint: 
+            Your answers will help Department for Education better understand how to improve managing ITT.
           continue: Continue
-          hint: "Select all that apply"
           options:
             concerns_about_trainee_quality: Concerns about trainee quality
-            do_not_get_offered_trainees: Don't get offered trainees
-            do_not_know_how_to_get_involved: Don't know how to get involved
-            not_enough_trained_mentors: Not enough trained mentors
-            number_of_pupils_with_send_needs: Number of pupils with SEND needs
+            do_not_get_offered_trainees: Not offered appropriate trainees
+            do_not_know_how_to_get_involved: Unsure how to get involved
+            not_enough_trained_mentors: No mentors available due to capacity
+            number_of_pupils_with_send_needs: High number of pupils with SEND needs
             working_to_improve_our_ofsted_rating: Working to improve our OFSTED rating
+            low_capacity_to_support_trainees: Low capacity to support trainees due to staff changes
             other: Other
           tell_us: Tell us your reason
         help_step:
@@ -58,12 +61,18 @@ en:
           change: Change
           itt_contact: ITT contact
         are_you_sure_step:
-          title: Are you sure you do not want to be contacted about placements?
-          caption: Not interested in hosting this year
-          this_will_help_providers: This will help providers know not to contact your school. You can change this at any time.
-          your_school_will_show_as: Your school will show as ‘not looking to host this year’. 
-          we_will_ask_again: We will ask you again in 12 months whether you would like to host placements. 
+          title: Confirm and let providers know you are not offering placements
+          caption: Not offering placements this year
+          your_contact_details: Your contact details and reason will not be shared with providers.
+          we_will_ask_you_again: 
+            We will ask you again in the spring term of the next year to check whether you would like to offer placements.
+          your_reason:
+            Your reason for not offering placements be shared with the Department for Education for reporting purposes.
+          reason_for_not_offering: Reason for not offering
+          details: Details
+          itt_contact: ITT contact
           continue: Continue
+          change: Change
         confirm_step:
           title: Confirm and share your approximate information with providers
           caption: Potential placement details
@@ -134,3 +143,9 @@ en:
             caption: Potential secondary placement details
             continue: Continue
             placement_number: "Placement %{placement_number} of %{step_count}"
+        not_open:
+          school_contact_step:
+            caption: Not offering placements this year
+            title: Who is the preferred contact for next year?
+            description: We will ask in the next academic year about placements. The contact may be you, or someone at your school who coordinates ITT.
+            continue: Continue

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -555,10 +555,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_28_092256) do
     t.string "local_authority_code"
     t.datetime "claims_grant_conditions_accepted_at"
     t.uuid "claims_grant_conditions_accepted_by_id"
+    t.jsonb "potential_placement_details"
     t.string "vendor_number"
     t.boolean "expression_of_interest_completed", default: false
     t.boolean "previously_offered_placements", default: false
-    t.jsonb "potential_placement_details"
     t.index ["claims_grant_conditions_accepted_by_id"], name: "index_schools_on_claims_grant_conditions_accepted_by_id"
     t.index ["claims_service"], name: "index_schools_on_claims_service"
     t.index ["latitude"], name: "index_schools_on_latitude"

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_does_not_enter_a_reason_when_selecting_other_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_does_not_enter_a_reason_when_selecting_other_spec.rb
@@ -33,23 +33,6 @@ RSpec.describe "School user does not select any reasons not to host",
     sign_in_placements_user(organisations: [@school])
   end
 
-  def when_i_am_on_the_placements_index_page
-    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
-    expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Placements")
-    expect(secondary_navigation).to have_current_item("This year (#{@current_academic_year_name}")
-    expect(page).to have_link("Add placement")
-    expect(page).to have_link("Bulk add placements")
-  end
-  alias_method :then_i_am_on_the_placements_index_page,
-               :when_i_am_on_the_placements_index_page
-
-  def when_i_click_on_bulk_add_placements
-    click_on "Bulk add placements"
-  end
-  alias_method :and_i_click_on_bulk_add_placements,
-               :when_i_click_on_bulk_add_placements
-
   def when_i_visit_the_add_hosting_interest_page
     visit new_add_hosting_interest_placements_school_hosting_interests_path(@school)
   end
@@ -81,19 +64,20 @@ RSpec.describe "School user does not select any reasons not to host",
 
   def then_i_see_the_reasons_for_not_hosting_form
     expect(page).to have_title(
-      "What are your reasons for not taking part in ITT this year? - Manage school placements - GOV.UK",
+      "Tell us why you aren’t able to host this year - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What are your reasons for not taking part in ITT this year?",
+      text: "Tell us why you aren’t able to host this year",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Concerns about trainee quality", type: :checkbox)
-    expect(page).to have_field("Don't get offered trainees", type: :checkbox)
-    expect(page).to have_field("Don't know how to get involved", type: :checkbox)
-    expect(page).to have_field("Not enough trained mentors", type: :checkbox)
-    expect(page).to have_field("Number of pupils with SEND needs", type: :checkbox)
+    expect(page).to have_field("High number of pupils with SEND needs", type: :checkbox)
+    expect(page).to have_field("Low capacity to support trainees due to staff changes", type: :checkbox)
+    expect(page).to have_field("No mentors available due to capacity", type: :checkbox)
+    expect(page).to have_field("Not offered appropriate trainees", type: :checkbox)
+    expect(page).to have_field("Unsure how to get involved", type: :checkbox)
     expect(page).to have_field("Working to improve our OFSTED rating", type: :checkbox)
     expect(page).to have_field("Other", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_does_not_enter_any_school_contact_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_does_not_enter_any_school_contact_details_spec.rb
@@ -37,22 +37,6 @@ RSpec.describe "School user does not enter any school contact details",
     sign_in_placements_user(organisations: [@school])
   end
 
-  def when_i_am_on_the_placements_index_page
-    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
-    expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Placements")
-    expect(secondary_navigation).to have_current_item("This year (#{@current_academic_year_name}")
-    expect(page).to have_link("Bulk add placements")
-  end
-  alias_method :then_i_am_on_the_placements_index_page,
-               :when_i_am_on_the_placements_index_page
-
-  def when_i_click_on_bulk_add_placements
-    click_on "Bulk add placements"
-  end
-  alias_method :and_i_click_on_bulk_add_placements,
-               :when_i_click_on_bulk_add_placements
-
   def when_i_visit_the_add_hosting_interest_page
     visit new_add_hosting_interest_placements_school_hosting_interests_path(@school)
   end
@@ -84,53 +68,45 @@ RSpec.describe "School user does not enter any school contact details",
 
   def then_i_see_the_reasons_for_not_hosting_form
     expect(page).to have_title(
-      "What are your reasons for not taking part in ITT this year? - Manage school placements - GOV.UK",
+      "Tell us why you aren’t able to host this year - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What are your reasons for not taking part in ITT this year?",
+      text: "Tell us why you aren’t able to host this year",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Concerns about trainee quality", type: :checkbox)
-    expect(page).to have_field("Don't get offered trainees", type: :checkbox)
-    expect(page).to have_field("Don't know how to get involved", type: :checkbox)
-    expect(page).to have_field("Not enough trained mentors", type: :checkbox)
-    expect(page).to have_field("Number of pupils with SEND needs", type: :checkbox)
+    expect(page).to have_field("High number of pupils with SEND needs", type: :checkbox)
+    expect(page).to have_field("Low capacity to support trainees due to staff changes", type: :checkbox)
+    expect(page).to have_field("No mentors available due to capacity", type: :checkbox)
+    expect(page).to have_field("Not offered appropriate trainees", type: :checkbox)
+    expect(page).to have_field("Unsure how to get involved", type: :checkbox)
     expect(page).to have_field("Working to improve our OFSTED rating", type: :checkbox)
     expect(page).to have_field("Other", type: :checkbox)
   end
 
   def when_i_select_not_enough_trained_mentors
-    check "Not enough trained mentors"
+    check "No mentors available due to capacity"
   end
 
   def and_i_select_number_of_pupils_with_send_needs
-    check "Number of pupils with SEND needs"
-  end
-
-  def then_i_see_the_help_available_to_you_page
-    expect(page).to have_title(
-      "Help available to you - Manage school placements - GOV.UK",
-    )
-    expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Help available to you")
+    check "High number of pupils with SEND needs"
   end
 
   def then_i_see_the_school_contact_form
     expect(page).to have_title(
-      "Who should providers contact? - Manage school placements - GOV.UK",
+      "Who is the preferred contact for next year? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Who should providers contact?")
+    expect(page).to have_h1("Who is the preferred contact for next year?")
     expect(page).to have_element(
       :p,
-      text: "Choose the person best placed to organise ITT placements at your school. "\
-        "This information will be shown on your profile.",
+      text: "We will ask in the next academic year about placements. " \
+        "The contact may be you, or someone at your school who coordinates ITT.",
       class: "govuk-body",
     )
 
-    @school_contact = @school.school_contact
     expect(page).to have_field("First name")
     expect(page).to have_field("Last name")
     expect(page).to have_field("Email address")

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_does_not_select_any_reasons_not_to_host_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_does_not_select_any_reasons_not_to_host_spec.rb
@@ -32,23 +32,6 @@ RSpec.describe "School user does not select any reasons not to host",
     sign_in_placements_user(organisations: [@school])
   end
 
-  def when_i_am_on_the_placements_index_page
-    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
-    expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Placements")
-    expect(secondary_navigation).to have_current_item("This year (#{@current_academic_year_name}")
-    expect(page).to have_link("Add placement")
-    expect(page).to have_link("Bulk add placements")
-  end
-  alias_method :then_i_am_on_the_placements_index_page,
-               :when_i_am_on_the_placements_index_page
-
-  def when_i_click_on_bulk_add_placements
-    click_on "Bulk add placements"
-  end
-  alias_method :and_i_click_on_bulk_add_placements,
-               :when_i_click_on_bulk_add_placements
-
   def when_i_visit_the_add_hosting_interest_page
     visit new_add_hosting_interest_placements_school_hosting_interests_path(@school)
   end
@@ -80,19 +63,20 @@ RSpec.describe "School user does not select any reasons not to host",
 
   def then_i_see_the_reasons_for_not_hosting_form
     expect(page).to have_title(
-      "What are your reasons for not taking part in ITT this year? - Manage school placements - GOV.UK",
+      "Tell us why you aren’t able to host this year - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What are your reasons for not taking part in ITT this year?",
+      text: "Tell us why you aren’t able to host this year",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Concerns about trainee quality", type: :checkbox)
-    expect(page).to have_field("Don't get offered trainees", type: :checkbox)
-    expect(page).to have_field("Don't know how to get involved", type: :checkbox)
-    expect(page).to have_field("Not enough trained mentors", type: :checkbox)
-    expect(page).to have_field("Number of pupils with SEND needs", type: :checkbox)
+    expect(page).to have_field("High number of pupils with SEND needs", type: :checkbox)
+    expect(page).to have_field("Low capacity to support trainees due to staff changes", type: :checkbox)
+    expect(page).to have_field("No mentors available due to capacity", type: :checkbox)
+    expect(page).to have_field("Not offered appropriate trainees", type: :checkbox)
+    expect(page).to have_field("Unsure how to get involved", type: :checkbox)
     expect(page).to have_field("Working to improve our OFSTED rating", type: :checkbox)
     expect(page).to have_field("Other", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_enters_another_reason_why_they_are_not_hosting_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_enters_another_reason_why_they_are_not_hosting_spec.rb
@@ -22,9 +22,12 @@ RSpec.describe "School user enters another reason why they are not hosting",
     when_i_fill_in_the_school_contact_details
     and_i_click_on_continue
     then_i_see_the_are_you_sure_page
+    and_i_see_the_reason_not_hosting_i_entered
+    and_i_see_the_entered_school_contact_details
 
     when_i_click_on_continue
     then_i_see_my_responses_with_successfully_updated
+    and_i_see_the_whats_next_page
     and_the_schools_contact_has_been_updated
     and_the_schools_hosting_interest_for_the_next_year_is_updated
   end
@@ -42,23 +45,6 @@ RSpec.describe "School user enters another reason why they are not hosting",
     @school = create(:placements_school)
     sign_in_placements_user(organisations: [@school])
   end
-
-  def when_i_am_on_the_placements_index_page
-    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
-    expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Placements")
-    expect(secondary_navigation).to have_current_item("This year (#{@current_academic_year_name}")
-    expect(page).to have_link("Add placement")
-    expect(page).to have_link("Bulk add placements")
-  end
-  alias_method :then_i_am_on_the_placements_index_page,
-               :when_i_am_on_the_placements_index_page
-
-  def when_i_click_on_bulk_add_placements
-    click_on "Bulk add placements"
-  end
-  alias_method :and_i_click_on_bulk_add_placements,
-               :when_i_click_on_bulk_add_placements
 
   def when_i_visit_the_add_hosting_interest_page
     visit new_add_hosting_interest_placements_school_hosting_interests_path(@school)
@@ -91,45 +77,48 @@ RSpec.describe "School user enters another reason why they are not hosting",
 
   def then_i_see_the_reasons_for_not_hosting_form
     expect(page).to have_title(
-      "What are your reasons for not taking part in ITT this year? - Manage school placements - GOV.UK",
+      "Tell us why you aren’t able to host this year - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
+      :span,
+      text: "Not offering placements this year",
+      class: "govuk-caption-l",
+    )
+    expect(page).to have_element(
       :legend,
-      text: "What are your reasons for not taking part in ITT this year?",
+      text: "Tell us why you aren’t able to host this year",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Not enough trained mentors", type: :checkbox)
-    expect(page).to have_field("Number of pupils with SEND needs", type: :checkbox)
+    expect(page).to have_field("Concerns about trainee quality", type: :checkbox)
+    expect(page).to have_field("High number of pupils with SEND needs", type: :checkbox)
+    expect(page).to have_field("Low capacity to support trainees due to staff changes", type: :checkbox)
+    expect(page).to have_field("No mentors available due to capacity", type: :checkbox)
+    expect(page).to have_field("Not offered appropriate trainees", type: :checkbox)
+    expect(page).to have_field("Unsure how to get involved", type: :checkbox)
     expect(page).to have_field("Working to improve our OFSTED rating", type: :checkbox)
+    expect(page).to have_field("Other", type: :checkbox)
   end
 
   def when_i_select_other
     check "Other"
   end
 
-  def and_i_select_number_of_pupils_with_send_needs
-    check "Number of pupils with SEND needs"
-  end
-
-  def then_i_see_the_help_available_to_you_page
-    expect(page).to have_title(
-      "Help available to you - Manage school placements - GOV.UK",
-    )
-    expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Help available to you")
-  end
-
   def then_i_see_the_school_contact_form
     expect(page).to have_title(
-      "Who should providers contact? - Manage school placements - GOV.UK",
+      "Who is the preferred contact for next year? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Who should providers contact?")
+    expect(page).to have_element(
+      :span,
+      text: "Not offering placements this year",
+      class: "govuk-caption-l",
+    )
+    expect(page).to have_h1("Who is the preferred contact for next year?")
     expect(page).to have_element(
       :p,
-      text: "Choose the person best placed to organise ITT placements at your school. "\
-        "This information will be shown on your profile.",
+      text: "We will ask in the next academic year about placements. " \
+        "The contact may be you, or someone at your school who coordinates ITT.",
       class: "govuk-body",
     )
 
@@ -140,18 +129,22 @@ RSpec.describe "School user enters another reason why they are not hosting",
 
   def then_i_see_the_school_contact_form_prefilled_with_my_inputs
     expect(page).to have_title(
-      "Who should providers contact? - Manage school placements - GOV.UK",
+      "Who is the preferred contact for next year? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Who should providers contact?")
+    expect(page).to have_element(
+      :span,
+      text: "Not offering placements this year",
+      class: "govuk-caption-l",
+    )
+    expect(page).to have_h1("Who is the preferred contact for next year?")
     expect(page).to have_element(
       :p,
-      text: "Choose the person best placed to organise ITT placements at your school. "\
-        "This information will be shown on your profile.",
+      text: "We will ask in the next academic year about placements. " \
+        "The contact may be you, or someone at your school who coordinates ITT.",
       class: "govuk-body",
     )
 
-    @school_contact = @school.school_contact
     expect(page).to have_field("First name", with: "Joe")
     expect(page).to have_field("Last name", with: "Bloggs")
     expect(page).to have_field("Email address", with: "joe_bloggs@example.com")
@@ -194,17 +187,66 @@ RSpec.describe "School user enters another reason why they are not hosting",
 
   def then_i_see_the_are_you_sure_page
     expect(page).to have_title(
-      "Are you sure you do not want to be contacted about placements? - Manage school placements - GOV.UK",
+      "Confirm and let providers know you are not offering placements - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Are you sure you do not want to be contacted about placements?")
     expect(page).to have_element(
       :span,
-      text: "Not interested in hosting this year",
+      text: "Not offering placements this year",
+      class: "govuk-caption-l",
     )
+    expect(page).to have_h1("Confirm and let providers know you are not offering placements")
+    expect(page).to have_element(
+      :p,
+      text: "Your contact details and reason will not be shared with providers.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "We will ask you again in the spring term of the next year to check whether you would like to offer placements.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "Your reason for not offering placements be shared with the Department for Education for reporting purposes.",
+      class: "govuk-body",
+    )
+  end
+
+  def and_i_see_the_reason_not_hosting_i_entered
+    expect(page).to have_summary_list_row(
+      "Reason for not offering",
+      "Other - Some other reason",
+    )
+  end
+
+  def and_i_see_the_entered_school_contact_details
+    expect(page).to have_h2("ITT contact", class: "govuk-heading-m")
+    expect(page).to have_summary_list_row("First name", "Joe")
+    expect(page).to have_summary_list_row("Last name", "Bloggs")
+    expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")
   end
 
   def and_i_enter_another_reason
     fill_in "Tell us your reason", with: "Some other reason"
+  end
+
+  def and_i_see_the_whats_next_page
+    expect(page).to have_panel(
+      "Confirmed.You are not offering placements",
+      "Your contact details will not be shown to providers",
+    )
+    expect(page).to have_h1("What happens next?", class: "govuk-heading-l")
+    expect(page).to have_element(
+      :p,
+      text: "We will ask you again in the spring term of the next year to check whether you would like to offer placements.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "If you would like to host placements this year, update your placement preferences to let providers know you’re interested.",
+      class: "govuk-body",
+    )
+    expect(page).to have_link("update your placement preferences", href: placements_school_path(@school))
   end
 end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_successfully_completes_the_not_open_journey_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_successfully_completes_the_not_open_journey_spec.rb
@@ -44,9 +44,12 @@ RSpec.describe "School user successfully completes the not open journey",
     when_i_fill_in_the_school_contact_details
     and_i_click_on_continue
     then_i_see_the_are_you_sure_page
+    and_i_see_the_reason_not_hosting_i_entered
+    and_i_see_the_entered_school_contact_details
 
     when_i_click_on_continue
     then_i_see_my_responses_with_successfully_updated
+    and_i_see_the_whats_next_page
     and_the_schools_contact_has_been_updated
     and_the_schools_hosting_interest_for_the_next_year_is_updated
   end
@@ -64,23 +67,6 @@ RSpec.describe "School user successfully completes the not open journey",
     @school = create(:placements_school)
     sign_in_placements_user(organisations: [@school])
   end
-
-  def when_i_am_on_the_placements_index_page
-    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
-    expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Placements")
-    expect(secondary_navigation).to have_current_item("This year (#{@current_academic_year_name}")
-    expect(page).to have_link("Add placement")
-    expect(page).to have_link("Bulk add placements")
-  end
-  alias_method :then_i_am_on_the_placements_index_page,
-               :when_i_am_on_the_placements_index_page
-
-  def when_i_click_on_bulk_add_placements
-    click_on "Bulk add placements"
-  end
-  alias_method :and_i_click_on_bulk_add_placements,
-               :when_i_click_on_bulk_add_placements
 
   def when_i_visit_the_add_hosting_interest_page
     visit new_add_hosting_interest_placements_school_hosting_interests_path(@school)
@@ -113,49 +99,55 @@ RSpec.describe "School user successfully completes the not open journey",
 
   def then_i_see_the_reasons_for_not_hosting_form
     expect(page).to have_title(
-      "What are your reasons for not taking part in ITT this year? - Manage school placements - GOV.UK",
+      "Tell us why you aren’t able to host this year - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
+      :span,
+      text: "Not offering placements this year",
+      class: "govuk-caption-l",
+    )
+    expect(page).to have_element(
       :legend,
-      text: "What are your reasons for not taking part in ITT this year?",
+      text: "Tell us why you aren’t able to host this year",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Not enough trained mentors", type: :checkbox)
-    expect(page).to have_field("Number of pupils with SEND needs", type: :checkbox)
+    expect(page).to have_field("Concerns about trainee quality", type: :checkbox)
+    expect(page).to have_field("High number of pupils with SEND needs", type: :checkbox)
+    expect(page).to have_field("Low capacity to support trainees due to staff changes", type: :checkbox)
+    expect(page).to have_field("No mentors available due to capacity", type: :checkbox)
+    expect(page).to have_field("Not offered appropriate trainees", type: :checkbox)
+    expect(page).to have_field("Unsure how to get involved", type: :checkbox)
     expect(page).to have_field("Working to improve our OFSTED rating", type: :checkbox)
+    expect(page).to have_field("Other", type: :checkbox)
   end
 
   def when_i_select_not_enough_trained_mentors
-    check "Not enough trained mentors"
+    check "No mentors available due to capacity"
   end
 
   def and_i_select_number_of_pupils_with_send_needs
-    check "Number of pupils with SEND needs"
-  end
-
-  def then_i_see_the_help_available_to_you_page
-    expect(page).to have_title(
-      "Help available to you - Manage school placements - GOV.UK",
-    )
-    expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Help available to you")
+    check "High number of pupils with SEND needs"
   end
 
   def then_i_see_the_school_contact_form
     expect(page).to have_title(
-      "Who should providers contact? - Manage school placements - GOV.UK",
+      "Who is the preferred contact for next year? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Who should providers contact?")
+    expect(page).to have_element(
+      :span,
+      text: "Not offering placements this year",
+      class: "govuk-caption-l",
+    )
+    expect(page).to have_h1("Who is the preferred contact for next year?")
     expect(page).to have_element(
       :p,
-      text: "Choose the person best placed to organise ITT placements at your school. "\
-        "This information will be shown on your profile.",
+      text: "We will ask in the next academic year about placements. " \
+        "The contact may be you, or someone at your school who coordinates ITT.",
       class: "govuk-body",
     )
 
-    @school_contact = @school.school_contact
     expect(page).to have_field("First name")
     expect(page).to have_field("Last name")
     expect(page).to have_field("Email address")
@@ -163,17 +155,21 @@ RSpec.describe "School user successfully completes the not open journey",
 
   def then_i_see_the_school_contact_form_prefilled_with_my_inputs
     expect(page).to have_title(
-      "Who should providers contact? - Manage school placements - GOV.UK",
+      "Who is the preferred contact for next year? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Who should providers contact?")
+    expect(page).to have_element(
+      :span,
+      text: "Not offering placements this year",
+      class: "govuk-caption-l",
+    )
+    expect(page).to have_h1("Who is the preferred contact for next year?")
     expect(page).to have_element(
       :p,
-      text: "Choose the person best placed to organise ITT placements at your school. "\
-        "This information will be shown on your profile.",
+      text: "We will ask in the next academic year about placements. " \
+        "The contact may be you, or someone at your school who coordinates ITT.",
       class: "govuk-body",
     )
-
     expect(page).to have_field("First name", with: "Joe")
     expect(page).to have_field("Last name", with: "Bloggs")
     expect(page).to have_field("Email address", with: "joe_bloggs@example.com")
@@ -211,20 +207,69 @@ RSpec.describe "School user successfully completes the not open journey",
     hosting_interest = @school.hosting_interests.for_academic_year(@next_academic_year).last
     expect(hosting_interest.appetite).to eq("not_open")
     expect(hosting_interest.reasons_not_hosting).to contain_exactly(
-      "Not enough trained mentors",
-      "Number of pupils with SEND needs",
+      "No mentors available due to capacity",
+      "High number of pupils with SEND needs",
     )
   end
 
   def then_i_see_the_are_you_sure_page
     expect(page).to have_title(
-      "Are you sure you do not want to be contacted about placements? - Manage school placements - GOV.UK",
+      "Confirm and let providers know you are not offering placements - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Are you sure you do not want to be contacted about placements?")
     expect(page).to have_element(
       :span,
-      text: "Not interested in hosting this year",
+      text: "Not offering placements this year",
+      class: "govuk-caption-l",
     )
+    expect(page).to have_h1("Confirm and let providers know you are not offering placements")
+    expect(page).to have_element(
+      :p,
+      text: "Your contact details and reason will not be shared with providers.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "We will ask you again in the spring term of the next year to check whether you would like to offer placements.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "Your reason for not offering placements be shared with the Department for Education for reporting purposes.",
+      class: "govuk-body",
+    )
+  end
+
+  def and_i_see_the_whats_next_page
+    expect(page).to have_panel(
+      "Confirmed.You are not offering placements",
+      "Your contact details will not be shown to providers",
+    )
+    expect(page).to have_h1("What happens next?", class: "govuk-heading-l")
+    expect(page).to have_element(
+      :p,
+      text: "We will ask you again in the spring term of the next year to check whether you would like to offer placements.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "If you would like to host placements this year, update your placement preferences to let providers know you’re interested.",
+      class: "govuk-body",
+    )
+    expect(page).to have_link("update your placement preferences", href: placements_school_path(@school))
+  end
+
+  def and_i_see_the_reason_not_hosting_i_entered
+    expect(page).to have_summary_list_row(
+      "Reason for not offering",
+      "High number of pupils with SEND needs No mentors available due to capacity",
+    )
+  end
+
+  def and_i_see_the_entered_school_contact_details
+    expect(page).to have_h2("ITT contact", class: "govuk-heading-m")
+    expect(page).to have_summary_list_row("First name", "Joe")
+    expect(page).to have_summary_list_row("Last name", "Bloggs")
+    expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")
   end
 end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_does_not_enter_a_reason_when_selecting_other_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_does_not_enter_a_reason_when_selecting_other_spec.rb
@@ -103,19 +103,25 @@ RSpec.describe "School user does not select any reasons not to host",
 
   def then_i_see_the_reasons_for_not_hosting_form
     expect(page).to have_title(
-      "What are your reasons for not taking part in ITT this year? - Manage school placements - GOV.UK",
+      "Tell us why you aren’t able to host this year - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
+      :span,
+      text: "Not offering placements this year",
+      class: "govuk-caption-l",
+    )
+    expect(page).to have_element(
       :legend,
-      text: "What are your reasons for not taking part in ITT this year?",
+      text: "Tell us why you aren’t able to host this year",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Concerns about trainee quality", type: :checkbox)
-    expect(page).to have_field("Don't get offered trainees", type: :checkbox)
-    expect(page).to have_field("Don't know how to get involved", type: :checkbox)
-    expect(page).to have_field("Not enough trained mentors", type: :checkbox)
-    expect(page).to have_field("Number of pupils with SEND needs", type: :checkbox)
+    expect(page).to have_field("High number of pupils with SEND needs", type: :checkbox)
+    expect(page).to have_field("Low capacity to support trainees due to staff changes", type: :checkbox)
+    expect(page).to have_field("No mentors available due to capacity", type: :checkbox)
+    expect(page).to have_field("Not offered appropriate trainees", type: :checkbox)
+    expect(page).to have_field("Unsure how to get involved", type: :checkbox)
     expect(page).to have_field("Working to improve our OFSTED rating", type: :checkbox)
     expect(page).to have_field("Other", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_does_not_select_any_reasons_not_to_host_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_does_not_select_any_reasons_not_to_host_spec.rb
@@ -102,19 +102,25 @@ RSpec.describe "School user does not select any reasons not to host",
 
   def then_i_see_the_reasons_for_not_hosting_form
     expect(page).to have_title(
-      "What are your reasons for not taking part in ITT this year? - Manage school placements - GOV.UK",
+      "Tell us why you aren’t able to host this year - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
+      :span,
+      text: "Not offering placements this year",
+      class: "govuk-caption-l",
+    )
+    expect(page).to have_element(
       :legend,
-      text: "What are your reasons for not taking part in ITT this year?",
+      text: "Tell us why you aren’t able to host this year",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Concerns about trainee quality", type: :checkbox)
-    expect(page).to have_field("Don't get offered trainees", type: :checkbox)
-    expect(page).to have_field("Don't know how to get involved", type: :checkbox)
-    expect(page).to have_field("Not enough trained mentors", type: :checkbox)
-    expect(page).to have_field("Number of pupils with SEND needs", type: :checkbox)
+    expect(page).to have_field("High number of pupils with SEND needs", type: :checkbox)
+    expect(page).to have_field("Low capacity to support trainees due to staff changes", type: :checkbox)
+    expect(page).to have_field("No mentors available due to capacity", type: :checkbox)
+    expect(page).to have_field("Not offered appropriate trainees", type: :checkbox)
+    expect(page).to have_field("Unsure how to get involved", type: :checkbox)
     expect(page).to have_field("Working to improve our OFSTED rating", type: :checkbox)
     expect(page).to have_field("Other", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_enters_another_reason_why_they_are_not_hosting_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_enters_another_reason_why_they_are_not_hosting_spec.rb
@@ -23,9 +23,11 @@ RSpec.describe "School user enters another reason why they are not hosting",
     and_i_enter_another_reason
     and_i_click_on_continue
     then_i_see_the_are_you_sure_page
+    and_i_see_the_reason_not_hosting_i_entered
 
     when_i_click_on_continue
     then_i_see_my_responses_with_successfully_updated
+    and_i_see_the_whats_next_page
     and_the_schools_hosting_interest_for_the_next_year_is_updated
   end
 
@@ -108,45 +110,48 @@ RSpec.describe "School user enters another reason why they are not hosting",
 
   def then_i_see_the_reasons_for_not_hosting_form
     expect(page).to have_title(
-      "What are your reasons for not taking part in ITT this year? - Manage school placements - GOV.UK",
+      "Tell us why you aren’t able to host this year - Manage school placements - GOV.UK",
     )
-    expect(primary_navigation).to have_current_item("Organisation details")
+    expect(page).to have_current_item("Organisation details")
+    expect(page).to have_element(
+      :span,
+      text: "Not offering placements this year",
+      class: "govuk-caption-l",
+    )
     expect(page).to have_element(
       :legend,
-      text: "What are your reasons for not taking part in ITT this year?",
+      text: "Tell us why you aren’t able to host this year",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Not enough trained mentors", type: :checkbox)
-    expect(page).to have_field("Number of pupils with SEND needs", type: :checkbox)
+    expect(page).to have_field("Concerns about trainee quality", type: :checkbox)
+    expect(page).to have_field("High number of pupils with SEND needs", type: :checkbox)
+    expect(page).to have_field("Low capacity to support trainees due to staff changes", type: :checkbox)
+    expect(page).to have_field("No mentors available due to capacity", type: :checkbox)
+    expect(page).to have_field("Not offered appropriate trainees", type: :checkbox)
+    expect(page).to have_field("Unsure how to get involved", type: :checkbox)
     expect(page).to have_field("Working to improve our OFSTED rating", type: :checkbox)
+    expect(page).to have_field("Other", type: :checkbox)
   end
 
   def when_i_select_other
     check "Other"
   end
 
-  def and_i_select_number_of_pupils_with_send_needs
-    check "Number of pupils with SEND needs"
-  end
-
-  def then_i_see_the_help_available_to_you_page
-    expect(page).to have_title(
-      "Help available to you - Manage school placements - GOV.UK",
-    )
-    expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("Help available to you")
-  end
-
   def then_i_see_the_school_contact_form
     expect(page).to have_title(
-      "Who should providers contact? - Manage school placements - GOV.UK",
+      "Who is the preferred contact for next year? - Manage school placements - GOV.UK",
     )
-    expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("Who should providers contact?")
+    expect(page).to have_current_item("Organisation details")
+    expect(page).to have_element(
+      :span,
+      text: "Not offering placements this year",
+      class: "govuk-caption-l",
+    )
+    expect(page).to have_h1("Who is the preferred contact for next year?")
     expect(page).to have_element(
       :p,
-      text: "Choose the person best placed to organise ITT placements at your school. "\
-        "This information will be shown on your profile.",
+      text: "We will ask in the next academic year about placements. " \
+        "The contact may be you, or someone at your school who coordinates ITT.",
       class: "govuk-body",
     )
 
@@ -157,18 +162,22 @@ RSpec.describe "School user enters another reason why they are not hosting",
 
   def then_i_see_the_school_contact_form_prefilled_with_my_inputs
     expect(page).to have_title(
-      "Who should providers contact? - Manage school placements - GOV.UK",
+      "Who is the preferred contact for next year? - Manage school placements - GOV.UK",
     )
-    expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("Who should providers contact?")
+    expect(page).to have_current_item("Organisation details")
+    expect(page).to have_element(
+      :span,
+      text: "Not offering placements this year",
+      class: "govuk-caption-l",
+    )
+    expect(page).to have_h1("Who is the preferred contact for next year?")
     expect(page).to have_element(
       :p,
-      text: "Choose the person best placed to organise ITT placements at your school. "\
-        "This information will be shown on your profile.",
+      text: "We will ask in the next academic year about placements. " \
+        "The contact may be you, or someone at your school who coordinates ITT.",
       class: "govuk-body",
     )
 
-    @school_contact = @school.school_contact
     expect(page).to have_field("First name", with: "Joe")
     expect(page).to have_field("Last name", with: "Bloggs")
     expect(page).to have_field("Email address", with: "joe_bloggs@example.com")
@@ -195,13 +204,6 @@ RSpec.describe "School user enters another reason why they are not hosting",
     )
   end
 
-  def and_the_schools_contact_has_been_updated
-    @school_contact = @school.school_contact.reload
-    expect(@school_contact.first_name).to eq("Joe")
-    expect(@school_contact.last_name).to eq("Bloggs")
-    expect(@school_contact.email_address).to eq("joe_bloggs@example.com")
-  end
-
   def and_the_schools_hosting_interest_for_the_next_year_is_updated
     hosting_interest = @school.hosting_interests.for_academic_year(@next_academic_year).last
     expect(hosting_interest.appetite).to eq("not_open")
@@ -211,17 +213,59 @@ RSpec.describe "School user enters another reason why they are not hosting",
 
   def then_i_see_the_are_you_sure_page
     expect(page).to have_title(
-      "Are you sure you do not want to be contacted about placements? - Manage school placements - GOV.UK",
+      "Confirm and let providers know you are not offering placements - Manage school placements - GOV.UK",
     )
-    expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("Are you sure you do not want to be contacted about placements?")
+    expect(page).to have_current_item("Organisation details")
     expect(page).to have_element(
       :span,
-      text: "Not interested in hosting this year",
+      text: "Not offering placements this year",
+      class: "govuk-caption-l",
+    )
+    expect(page).to have_h1("Confirm and let providers know you are not offering placements")
+    expect(page).to have_element(
+      :p,
+      text: "Your contact details and reason will not be shared with providers.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "We will ask you again in the spring term of the next year to check whether you would like to offer placements.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "Your reason for not offering placements be shared with the Department for Education for reporting purposes.",
+      class: "govuk-body",
+    )
+  end
+
+  def and_i_see_the_reason_not_hosting_i_entered
+    expect(page).to have_summary_list_row(
+      "Reason for not offering",
+      "Other - Some other reason",
     )
   end
 
   def and_i_enter_another_reason
     fill_in "Tell us your reason", with: "Some other reason"
+  end
+
+  def and_i_see_the_whats_next_page
+    expect(page).to have_panel(
+      "Confirmed.You are not offering placements",
+      "Your contact details will not be shown to providers",
+    )
+    expect(page).to have_h1("What happens next?", class: "govuk-heading-l")
+    expect(page).to have_element(
+      :p,
+      text: "We will ask you again in the spring term of the next year to check whether you would like to offer placements.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "If you would like to host placements this year, update your placement preferences to let providers know you’re interested.",
+      class: "govuk-body",
+    )
+    expect(page).to have_link("update your placement preferences", href: placements_school_path(@school))
   end
 end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_successfully_completes_the_not_open_journey_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_successfully_completes_the_not_open_journey_spec.rb
@@ -38,9 +38,11 @@ RSpec.describe "School user successfully completes the not open journey",
     and_i_select_number_of_pupils_with_send_needs
     and_i_click_on_continue
     then_i_see_the_are_you_sure_page
+    and_i_see_the_reason_not_hosting_i_entered
 
     when_i_click_on_continue
     then_i_see_my_responses_with_successfully_updated
+    and_i_see_the_whats_next_page
     and_the_schools_hosting_interest_for_the_next_year_is_updated
   end
 
@@ -123,49 +125,55 @@ RSpec.describe "School user successfully completes the not open journey",
 
   def then_i_see_the_reasons_for_not_hosting_form
     expect(page).to have_title(
-      "What are your reasons for not taking part in ITT this year? - Manage school placements - GOV.UK",
+      "Tell us why you aren’t able to host this year - Manage school placements - GOV.UK",
     )
-    expect(primary_navigation).to have_current_item("Organisation details")
+    expect(page).to have_current_item("Organisation details")
+    expect(page).to have_element(
+      :span,
+      text: "Not offering placements this year",
+      class: "govuk-caption-l",
+    )
     expect(page).to have_element(
       :legend,
-      text: "What are your reasons for not taking part in ITT this year?",
+      text: "Tell us why you aren’t able to host this year",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Not enough trained mentors", type: :checkbox)
-    expect(page).to have_field("Number of pupils with SEND needs", type: :checkbox)
+    expect(page).to have_field("Concerns about trainee quality", type: :checkbox)
+    expect(page).to have_field("High number of pupils with SEND needs", type: :checkbox)
+    expect(page).to have_field("Low capacity to support trainees due to staff changes", type: :checkbox)
+    expect(page).to have_field("No mentors available due to capacity", type: :checkbox)
+    expect(page).to have_field("Not offered appropriate trainees", type: :checkbox)
+    expect(page).to have_field("Unsure how to get involved", type: :checkbox)
     expect(page).to have_field("Working to improve our OFSTED rating", type: :checkbox)
+    expect(page).to have_field("Other", type: :checkbox)
   end
 
   def when_i_select_not_enough_trained_mentors
-    check "Not enough trained mentors"
+    check "No mentors available due to capacity"
   end
 
   def and_i_select_number_of_pupils_with_send_needs
-    check "Number of pupils with SEND needs"
-  end
-
-  def then_i_see_the_help_available_to_you_page
-    expect(page).to have_title(
-      "Help available to you - Manage school placements - GOV.UK",
-    )
-    expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("Help available to you")
+    check "High number of pupils with SEND needs"
   end
 
   def then_i_see_the_school_contact_form
     expect(page).to have_title(
-      "Who should providers contact? - Manage school placements - GOV.UK",
+      "Who is the preferred contact for next year? - Manage school placements - GOV.UK",
     )
-    expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("Who should providers contact?")
+    expect(page).to have_current_item("Organisation details")
+    expect(page).to have_element(
+      :span,
+      text: "Not offering placements this year",
+      class: "govuk-caption-l",
+    )
+    expect(page).to have_h1("Who is the preferred contact for next year?")
     expect(page).to have_element(
       :p,
-      text: "Choose the person best placed to organise ITT placements at your school. "\
-        "This information will be shown on your profile.",
+      text: "We will ask in the next academic year about placements. " \
+        "The contact may be you, or someone at your school who coordinates ITT.",
       class: "govuk-body",
     )
 
-    @school_contact = @school.school_contact
     expect(page).to have_field("First name")
     expect(page).to have_field("Last name")
     expect(page).to have_field("Email address")
@@ -173,17 +181,21 @@ RSpec.describe "School user successfully completes the not open journey",
 
   def then_i_see_the_school_contact_form_prefilled_with_my_inputs
     expect(page).to have_title(
-      "Who should providers contact? - Manage school placements - GOV.UK",
+      "Who is the preferred contact for next year? - Manage school placements - GOV.UK",
     )
-    expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("Who should providers contact?")
+    expect(page).to have_current_item("Organisation details")
+    expect(page).to have_element(
+      :span,
+      text: "Not offering placements this year",
+      class: "govuk-caption-l",
+    )
+    expect(page).to have_h1("Who is the preferred contact for next year?")
     expect(page).to have_element(
       :p,
-      text: "Choose the person best placed to organise ITT placements at your school. "\
-        "This information will be shown on your profile.",
+      text: "We will ask in the next academic year about placements. " \
+        "The contact may be you, or someone at your school who coordinates ITT.",
       class: "govuk-body",
     )
-
     expect(page).to have_field("First name", with: "Joe")
     expect(page).to have_field("Last name", with: "Bloggs")
     expect(page).to have_field("Email address", with: "joe_bloggs@example.com")
@@ -221,20 +233,69 @@ RSpec.describe "School user successfully completes the not open journey",
     hosting_interest = @school.hosting_interests.for_academic_year(@next_academic_year).last
     expect(hosting_interest.appetite).to eq("not_open")
     expect(hosting_interest.reasons_not_hosting).to contain_exactly(
-      "Not enough trained mentors",
-      "Number of pupils with SEND needs",
+      "No mentors available due to capacity",
+      "High number of pupils with SEND needs",
     )
   end
 
   def then_i_see_the_are_you_sure_page
     expect(page).to have_title(
-      "Are you sure you do not want to be contacted about placements? - Manage school placements - GOV.UK",
+      "Confirm and let providers know you are not offering placements - Manage school placements - GOV.UK",
     )
-    expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("Are you sure you do not want to be contacted about placements?")
+    expect(page).to have_current_item("Organisation details")
     expect(page).to have_element(
       :span,
-      text: "Not interested in hosting this year",
+      text: "Not offering placements this year",
+      class: "govuk-caption-l",
     )
+    expect(page).to have_h1("Confirm and let providers know you are not offering placements")
+    expect(page).to have_element(
+      :p,
+      text: "Your contact details and reason will not be shared with providers.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "We will ask you again in the spring term of the next year to check whether you would like to offer placements.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "Your reason for not offering placements be shared with the Department for Education for reporting purposes.",
+      class: "govuk-body",
+    )
+  end
+
+  def and_i_see_the_whats_next_page
+    expect(page).to have_panel(
+      "Confirmed.You are not offering placements",
+      "Your contact details will not be shown to providers",
+    )
+    expect(page).to have_h1("What happens next?", class: "govuk-heading-l")
+    expect(page).to have_element(
+      :p,
+      text: "We will ask you again in the spring term of the next year to check whether you would like to offer placements.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "If you would like to host placements this year, update your placement preferences to let providers know you’re interested.",
+      class: "govuk-body",
+    )
+    expect(page).to have_link("update your placement preferences", href: placements_school_path(@school))
+  end
+
+  def and_i_see_the_reason_not_hosting_i_entered
+    expect(page).to have_summary_list_row(
+      "Reason for not offering",
+      "High number of pupils with SEND needs No mentors available due to capacity",
+    )
+  end
+
+  def and_i_see_the_entered_school_contact_details
+    expect(page).to have_h2("ITT contact", class: "govuk-heading-m")
+    expect(page).to have_summary_list_row("First name", "Joe")
+    expect(page).to have_summary_list_row("Last name", "Bloggs")
+    expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")
   end
 end

--- a/spec/wizards/placements/add_hosting_interest_wizard/are_you_sure_step_spec.rb
+++ b/spec/wizards/placements/add_hosting_interest_wizard/are_you_sure_step_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe Placements::AddHostingInterestWizard::AreYouSureStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Placements::AddHostingInterestWizard).tap do |mock_wizard|
+      allow(mock_wizard).to receive(:school).and_return(school)
+    end
+  end
+
+  let(:attributes) { nil }
+  let!(:school) { create(:placements_school) }
+
+  describe "delegations" do
+    it { is_expected.to delegate_method(:reasons_not_hosting).to(:reason_not_hosting_step) }
+    it { is_expected.to delegate_method(:other_reason_not_hosting).to(:reason_not_hosting_step) }
+    it { is_expected.to delegate_method(:first_name).to(:school_contact_step).with_prefix(:school_contact) }
+    it { is_expected.to delegate_method(:last_name).to(:school_contact_step).with_prefix(:school_contact) }
+    it { is_expected.to delegate_method(:email_address).to(:school_contact_step).with_prefix(:school_contact) }
+  end
+end

--- a/spec/wizards/placements/add_hosting_interest_wizard/reason_not_hosting_step_spec.rb
+++ b/spec/wizards/placements/add_hosting_interest_wizard/reason_not_hosting_step_spec.rb
@@ -34,27 +34,39 @@ RSpec.describe Placements::AddHostingInterestWizard::ReasonNotHostingStep, type:
 
     it "returns struct objects for each reason not to host ITT" do
       concerns_about_trainee_quality = reason_options[0]
-      do_not_get_offered_trainees = reason_options[1]
-      do_not_know_how_to_get_involved = reason_options[2]
-      not_enough_trained_mentors = reason_options[3]
-      number_of_pupils_with_send_needs = reason_options[4]
-      working_to_improve_our_ofsted_rating = reason_options[5]
-      other = reason_options[6]
+      high_number_of_pupils_with_send_needs = reason_options[1]
+      low_capacity_to_support_trainees_due_to_staff_changes = reason_options[2]
+      no_mentors_available_due_to_capacity = reason_options[3]
+      not_offered_appropriate_trainees = reason_options[4]
+      unsure_how_to_get_involved = reason_options[5]
+      working_to_improve_our_ofsted_rating = reason_options[6]
+      other = reason_options[7]
 
       expect(concerns_about_trainee_quality.name).to eq("Concerns about trainee quality")
       expect(concerns_about_trainee_quality.value).to eq("Concerns about trainee quality")
 
-      expect(do_not_get_offered_trainees.name).to eq("Don't get offered trainees")
-      expect(do_not_get_offered_trainees.value).to eq("Don't get offered trainees")
+      expect(high_number_of_pupils_with_send_needs.name).to eq("High number of pupils with SEND needs")
+      expect(high_number_of_pupils_with_send_needs.value).to eq("High number of pupils with SEND needs")
 
-      expect(do_not_know_how_to_get_involved.name).to eq("Don't know how to get involved")
-      expect(do_not_know_how_to_get_involved.value).to eq("Don't know how to get involved")
+      expect(low_capacity_to_support_trainees_due_to_staff_changes.name).to eq(
+        "Low capacity to support trainees due to staff changes",
+      )
+      expect(low_capacity_to_support_trainees_due_to_staff_changes.value).to eq(
+        "Low capacity to support trainees due to staff changes",
+      )
 
-      expect(not_enough_trained_mentors.name).to eq("Not enough trained mentors")
-      expect(not_enough_trained_mentors.value).to eq("Not enough trained mentors")
+      expect(no_mentors_available_due_to_capacity.name).to eq(
+        "No mentors available due to capacity",
+      )
+      expect(no_mentors_available_due_to_capacity.value).to eq(
+        "No mentors available due to capacity",
+      )
 
-      expect(number_of_pupils_with_send_needs.name).to eq("Number of pupils with SEND needs")
-      expect(number_of_pupils_with_send_needs.value).to eq("Number of pupils with SEND needs")
+      expect(not_offered_appropriate_trainees.name).to eq("Not offered appropriate trainees")
+      expect(not_offered_appropriate_trainees.value).to eq("Not offered appropriate trainees")
+
+      expect(unsure_how_to_get_involved.name).to eq("Unsure how to get involved")
+      expect(unsure_how_to_get_involved.value).to eq("Unsure how to get involved")
 
       expect(working_to_improve_our_ofsted_rating.name).to eq("Working to improve our OFSTED rating")
       expect(working_to_improve_our_ofsted_rating.value).to eq("Working to improve our OFSTED rating")


### PR DESCRIPTION
## Context

- Changes to the Red (Not open) path of EOI, as requested in https://www.figma.com/design/9eMfPnPEONmEPvimD3CYpz/MSP-Concepts?node-id=63713-34520&t=r3iQPZpM6zsQQv1o-0

## Changes proposed in this pull request

- Changes to the content of the EOI Wizards, as requested in https://www.figma.com/design/9eMfPnPEONmEPvimD3CYpz/MSP-Concepts?node-id=63713-34520&t=r3iQPZpM6zsQQv1o-0

## Guidance to review

- Sign in as Anne (School User)
- Once on the EOI page, select "No - I can’t offer placements"
- Complete the journey, making sure that the content matches that requested in https://www.figma.com/design/9eMfPnPEONmEPvimD3CYpz/MSP-Concepts?node-id=63713-34520&t=r3iQPZpM6zsQQv1o-0

## Link to Trello card

https://trello.com/c/IhDgfjDK/576-development-work-for-red-path-eoi-iteration-3

## Screenshots

https://github.com/user-attachments/assets/28883fa2-11ac-4268-b8f3-fe5a65bf4381

