### PR TITLE
EOI content sweep changes

### DIFF
--- a/app/views/wizards/placements/add_hosting_interest_wizard/_appetite_step.html.erb
+++ b/app/views/wizards/placements/add_hosting_interest_wizard/_appetite_step.html.erb
@@ -8,6 +8,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".caption") %></span>
       <%= f.govuk_collection_radio_buttons(
         :appetite,
         current_step.appetite_options,

--- a/app/views/wizards/placements/add_hosting_interest_wizard/_check_your_answers_step.html.erb
+++ b/app/views/wizards/placements/add_hosting_interest_wizard/_check_your_answers_step.html.erb
@@ -8,6 +8,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".caption") %></span>
       <h1 class="govuk-heading-l"><%= t(".title") %></h1>
 
       <%= render "shared/wizards/placements/multiple_placements_wizard/check_your_answers",

--- a/app/views/wizards/placements/add_hosting_interest_wizard/_school_contact_step.html.erb
+++ b/app/views/wizards/placements/add_hosting_interest_wizard/_school_contact_step.html.erb
@@ -8,6 +8,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".caption") %></span>
       <h1 class="govuk-heading-l"><%= t(".title") %></h1>
       <p class="govuk-body secondary-text"><%= t(".description") %></p>
 

--- a/app/views/wizards/placements/add_hosting_interest_wizard/interested/_phase_step.html.erb
+++ b/app/views/wizards/placements/add_hosting_interest_wizard/interested/_phase_step.html.erb
@@ -8,6 +8,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".caption") %></span>
       <%= f.govuk_check_boxes_fieldset(:phases, legend: { size: "l", text: t(".title"), tag: "h1" }) do %>
         <% current_step.phases_for_selection.each_with_index do |phase, i| %>
           <%= f.govuk_check_box :phases, phase.name,

--- a/app/views/wizards/placements/multi_placement_wizard/_phase_step.html.erb
+++ b/app/views/wizards/placements/multi_placement_wizard/_phase_step.html.erb
@@ -8,6 +8,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".caption") %></span>
       <%= f.govuk_collection_check_boxes(
         :phases,
         current_step.phases_for_selection,

--- a/app/views/wizards/placements/multi_placement_wizard/_secondary_subject_selection_step.html.erb
+++ b/app/views/wizards/placements/multi_placement_wizard/_secondary_subject_selection_step.html.erb
@@ -13,7 +13,8 @@
         :subject_ids,
         current_step.subjects_for_selection,
         :id, :name,
-        legend: { size: "l", text: t(".title"), tag: "h1" }
+        legend: { size: "l", text: t(".title"), tag: "h1" },
+        hint: { text: t(".hint") }
       ) %>
 
       <%= f.govuk_submit t(".continue") %>

--- a/config/locales/en/wizards/placements/add_hosting_interest_wizard.yml
+++ b/config/locales/en/wizards/placements/add_hosting_interest_wizard.yml
@@ -3,6 +3,7 @@ en:
     placements:
       add_hosting_interest_wizard:
         appetite_step:
+          caption: Placement preferences
           title: 
             Can your school offer placements for trainee teachers in this academic year (%{academic_year_name})?
           continue: Continue
@@ -46,6 +47,7 @@ en:
           local_providers: These training providers are local to you and could help.
           find_providers: Find providers near me
         school_contact_step:
+          caption: Contact details
           title: Who should providers contact?
           description: Choose the person best placed to organise ITT placements at your school. This information will be shown on your profile.
           continue: Continue
@@ -53,6 +55,7 @@ en:
           title: Do you know which subjects you would like to host?
           continue: Continue
         check_your_answers_step:
+          caption: Placement details
           title: Check your answers
           continue: Save and continue
           change: Change
@@ -65,7 +68,7 @@ en:
           we_will_ask_again: We will ask you again in 12 months whether you would like to host placements. 
           continue: Continue
         confirm_step:
-          title: Confirm and share your approximate information with providers
+          title: Confirm and share what you may be able to offer
           caption: Potential placement details
           providers_see_you_can_offer_placements:
             Providers will be able to see that you may be able to offer placements for trainee teachers.
@@ -79,6 +82,7 @@ en:
         interested:
           phase_step:
             title: Do you know what phase of education your placements will be?
+            caption: Potential placement offer details
             continue: Continue
             options:
               unknown: I don’t know
@@ -108,7 +112,7 @@ en:
           note_to_providers_step:
             title: 
               Is there anything about your school you would like providers to know? (optional)
-            caption: Expression of interest
+            caption: Potential placement details
             continue: Continue
           secondary_subject_selection_step:
             title: Do you know the secondary school subjects you could have placements in?

--- a/config/locales/en/wizards/placements/multi_placement_wizard.yml
+++ b/config/locales/en/wizards/placements/multi_placement_wizard.yml
@@ -33,7 +33,8 @@ en:
           description: Choose the person best placed to organise ITT placements at your school. This information will be shown on your profile.
           continue: Continue
         phase_step:
-          title: What phase of education can your placements be?
+          caption: Placement details
+          title: What education phase can your placements be?
           options:
             primary_description: 3 to 11 years
             secondary_description: 11 to 19 years
@@ -48,8 +49,9 @@ en:
           caption: Placement details
           continue: Continue
         secondary_subject_selection_step:
-          title: Select secondary school subjects
-          caption: Placement details
+          title: Select secondary school subjects you can offer
+          caption: Secondary placement details
+          hint: Subjects are taken from the DfE database of courses. If the subject you would like to host is not here, choose the closest option
           continue: Continue
         primary_placement_quantity_step:
           title: "Primary subjects: Enter the number of placements you would be willing to host"
@@ -57,15 +59,15 @@ en:
           caption: Placement details
           continue: Continue
         secondary_placement_quantity_step:
-          title: "Secondary subjects: Enter the number of placements you would be willing to host"
+          title: Enter the number of secondary school placements you can offer
           enter_approximate: Enter an approximate number if you are unsure
           change_to_specify: You will have a chance to specify the languages later
-          caption: Placement details
+          caption: Secondary placement details
           continue: Continue
         secondary_child_subject_placement_selection_step:
           title: You selected %{placement_quantity} %{subject_name} placements
           select_languages_taught: Select the languages taught on each of these placements
-          caption: Placement details
+          caption: Secondary placement details
           continue: Continue
           placement_number: "Placement %{placement_number} of %{step_count}"
         provider_step:
@@ -108,7 +110,7 @@ en:
           hint: You will be able to enter the number of placements on the next screen
           continue: Continue
         year_group_placement_quantity_step:
-            title: How many primary placements you would be willing to host in each year group?
+            title: Enter the number of primary school placements you can offer
             caption: Primary placement details
             enter_approximate: Enter an approximate number if you are unsure
             continue: Continue

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_add_their_hosting_interest_and_bulk_adds_placements_for_the_primary_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_add_their_hosting_interest_and_bulk_adds_placements_for_the_primary_phase_spec.rb
@@ -107,12 +107,12 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -163,10 +163,10 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_primary_placement_quantity_form
     expect(page).to have_title(
-      "How many primary placements you would be willing to host in each year group? - Manage school placements - GOV.UK",
+      "Enter the number of primary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("How many primary placements you would be willing to host in each year group?", class: "govuk-heading-l")
+    expect(page).to have_h1("Enter the number of primary school placements you can offer", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")
     expect(page).to have_field("Reception", type: :number)
     expect(page).to have_field("Year 3", type: :number)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
@@ -92,12 +92,12 @@ RSpec.describe "School user does not enter a placement quantity",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -136,10 +136,10 @@ RSpec.describe "School user does not enter a placement quantity",
 
   def then_i_see_the_primary_placement_quantity_form
     expect(page).to have_title(
-      "How many primary placements you would be willing to host in each year group? - Manage school placements - GOV.UK",
+      "Enter the number of primary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("How many primary placements you would be willing to host in each year group?", class: "govuk-heading-l")
+    expect(page).to have_h1("Enter the number of primary school placements you can offer", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")
     expect(page).to have_field("Year 1", type: :number)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_does_not_select_a_year_group_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_does_not_select_a_year_group_spec.rb
@@ -72,12 +72,12 @@ RSpec.describe "School user does not select a year group",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
@@ -77,12 +77,12 @@ RSpec.describe "School user enters a float as a placement quantity",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -121,10 +121,10 @@ RSpec.describe "School user enters a float as a placement quantity",
 
   def then_i_see_the_primary_placement_quantity_form
     expect(page).to have_title(
-      "How many primary placements you would be willing to host in each year group? - Manage school placements - GOV.UK",
+      "Enter the number of primary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("How many primary placements you would be willing to host in each year group?", class: "govuk-heading-l")
+    expect(page).to have_h1("Enter the number of primary school placements you can offer", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")
     expect(page).to have_field("Year 1", type: :number)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
@@ -77,12 +77,12 @@ RSpec.describe "School user enters zero as a placement quantity",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -121,10 +121,10 @@ RSpec.describe "School user enters zero as a placement quantity",
 
   def then_i_see_the_primary_placement_quantity_form
     expect(page).to have_title(
-      "How many primary placements you would be willing to host in each year group? - Manage school placements - GOV.UK",
+      "Enter the number of primary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("How many primary placements you would be willing to host in each year group?", class: "govuk-heading-l")
+    expect(page).to have_h1("Enter the number of primary school placements you can offer", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")
     expect(page).to have_field("Year 1", type: :number)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
@@ -170,12 +170,12 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -218,10 +218,10 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_primary_placement_quantity_form
     expect(page).to have_title(
-      "How many primary placements you would be willing to host in each year group? - Manage school placements - GOV.UK",
+      "Enter the number of primary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("How many primary placements you would be willing to host in each year group?", class: "govuk-heading-l")
+    expect(page).to have_h1("Enter the number of primary school placements you can offer", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")
     expect(page).to have_field("Year 1", type: :number)
   end
@@ -232,15 +232,15 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects - Manage school placements - GOV.UK",
+      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects",
+      text: "Select secondary school subjects you can offer",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
@@ -256,11 +256,11 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Secondary subjects: Enter the number of placements you would be willing to host - Manage school placements - GOV.UK",
+      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Secondary subjects: Enter the number of placements you would be willing to host", class: "govuk-heading-l")
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
     expect(page).to have_field("Mathematics", type: :number)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/school_user_does_not_select_a_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/school_user_does_not_select_a_phase_spec.rb
@@ -72,12 +72,12 @@ RSpec.describe "School user does not select a phases",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
@@ -119,12 +119,12 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -137,15 +137,15 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects - Manage school placements - GOV.UK",
+      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects",
+      text: "Select secondary school subjects you can offer",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
@@ -158,11 +158,11 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Secondary subjects: Enter the number of placements you would be willing to host - Manage school placements - GOV.UK",
+      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Secondary subjects: Enter the number of placements you would be willing to host", class: "govuk-heading-l")
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("Modern languages", type: :number)
   end
 
@@ -183,7 +183,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
       "Select the languages taught on each of these placements",
       class: "govuk-heading-m",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("French", type: :checkbox)
     expect(page).to have_field("Spanish", type: :checkbox)
     expect(page).to have_field("Russian", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_adds_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_adds_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
@@ -105,12 +105,12 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -123,15 +123,15 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects - Manage school placements - GOV.UK",
+      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects",
+      text: "Select secondary school subjects you can offer",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
@@ -147,11 +147,11 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Secondary subjects: Enter the number of placements you would be willing to host - Manage school placements - GOV.UK",
+      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Secondary subjects: Enter the number of placements you would be willing to host", class: "govuk-heading-l")
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
     expect(page).to have_field("Mathematics", type: :number)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
@@ -78,12 +78,12 @@ RSpec.describe "School user does not enter a placement quantity",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -96,15 +96,15 @@ RSpec.describe "School user does not enter a placement quantity",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects - Manage school placements - GOV.UK",
+      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects",
+      text: "Select secondary school subjects you can offer",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
@@ -116,11 +116,11 @@ RSpec.describe "School user does not enter a placement quantity",
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Secondary subjects: Enter the number of placements you would be willing to host - Manage school placements - GOV.UK",
+      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Secondary subjects: Enter the number of placements you would be willing to host", class: "govuk-heading-l")
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
   end
 

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
@@ -86,12 +86,12 @@ RSpec.describe "School user does not select a child subjects",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -104,15 +104,15 @@ RSpec.describe "School user does not select a child subjects",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects - Manage school placements - GOV.UK",
+      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects",
+      text: "Select secondary school subjects you can offer",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
@@ -125,11 +125,11 @@ RSpec.describe "School user does not select a child subjects",
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Secondary subjects: Enter the number of placements you would be willing to host - Manage school placements - GOV.UK",
+      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Secondary subjects: Enter the number of placements you would be willing to host", class: "govuk-heading-l")
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("Modern languages", type: :number)
   end
 
@@ -150,7 +150,7 @@ RSpec.describe "School user does not select a child subjects",
       "Select the languages taught on each of these placements",
       class: "govuk-heading-m",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("French", type: :checkbox)
     expect(page).to have_field("Spanish", type: :checkbox)
     expect(page).to have_field("Russian", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
@@ -74,12 +74,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -92,15 +92,15 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects - Manage school placements - GOV.UK",
+      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects",
+      text: "Select secondary school subjects you can offer",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
@@ -79,12 +79,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -97,15 +97,15 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects - Manage school placements - GOV.UK",
+      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects",
+      text: "Select secondary school subjects you can offer",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
@@ -117,11 +117,11 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Secondary subjects: Enter the number of placements you would be willing to host - Manage school placements - GOV.UK",
+      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Secondary subjects: Enter the number of placements you would be willing to host", class: "govuk-heading-l")
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
   end
 

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
@@ -79,12 +79,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -97,15 +97,15 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects - Manage school placements - GOV.UK",
+      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects",
+      text: "Select secondary school subjects you can offer",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
@@ -117,11 +117,11 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Secondary subjects: Enter the number of placements you would be willing to host - Manage school placements - GOV.UK",
+      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Secondary subjects: Enter the number of placements you would be willing to host", class: "govuk-heading-l")
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
   end
 

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
@@ -120,10 +120,10 @@ RSpec.describe "School user completes the interested journey and declares primar
 
   def then_i_see_the_confirmation_page
     expect(page).to have_title(
-      "Confirm and share your approximate information with providers - Manage school placements - GOV.UK",
+      "Confirm and share what you may be able to offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Confirm and share your approximate information with providers", class: "govuk-heading-l")
+    expect(page).to have_h1("Confirm and share what you may be able to offer", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Potential placement details", class: "govuk-caption-l")
     expect(page).to have_element(
       :p,
@@ -223,7 +223,7 @@ RSpec.describe "School user completes the interested journey and declares primar
     )
     expect(page).to have_element(
       :span,
-      text: "Expression of interest",
+      text: "Potential placement details",
       class: "govuk-caption-l",
     )
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_potential_placement_details_spec.rb
@@ -82,10 +82,10 @@ RSpec.describe "School user completes the interested journey without declaring p
 
   def then_i_see_the_confirmation_page
     expect(page).to have_title(
-      "Confirm and share your approximate information with providers - Manage school placements - GOV.UK",
+      "Confirm and share what you may be able to offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Confirm and share your approximate information with providers", class: "govuk-heading-l")
+    expect(page).to have_h1("Confirm and share what you may be able to offer", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Potential placement details", class: "govuk-caption-l")
     expect(page).to have_element(
       :p,
@@ -189,7 +189,7 @@ RSpec.describe "School user completes the interested journey without declaring p
     )
     expect(page).to have_element(
       :span,
-      text: "Expression of interest",
+      text: "Potential placement details",
       class: "govuk-caption-l",
     )
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_quantities_for_potential_placements_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_quantities_for_potential_placements_spec.rb
@@ -112,10 +112,10 @@ RSpec.describe "School user completes the interested journey without declaring q
 
   def then_i_see_the_confirmation_page
     expect(page).to have_title(
-      "Confirm and share your approximate information with providers - Manage school placements - GOV.UK",
+      "Confirm and share what you may be able to offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Confirm and share your approximate information with providers", class: "govuk-heading-l")
+    expect(page).to have_h1("Confirm and share what you may be able to offer", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Potential placement details", class: "govuk-caption-l")
     expect(page).to have_element(
       :p,
@@ -215,7 +215,7 @@ RSpec.describe "School user completes the interested journey without declaring q
     )
     expect(page).to have_element(
       :span,
-      text: "Expression of interest",
+      text: "Potential placement details",
       class: "govuk-caption-l",
     )
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_specific_year_groups_or_subjects_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_specific_year_groups_or_subjects_spec.rb
@@ -103,10 +103,10 @@ RSpec.describe "School user completes the interested journey without declaring s
 
   def then_i_see_the_confirmation_page
     expect(page).to have_title(
-      "Confirm and share your approximate information with providers - Manage school placements - GOV.UK",
+      "Confirm and share what you may be able to offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Confirm and share your approximate information with providers", class: "govuk-heading-l")
+    expect(page).to have_h1("Confirm and share what you may be able to offer", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Potential placement details", class: "govuk-caption-l")
     expect(page).to have_element(
       :p,
@@ -206,7 +206,7 @@ RSpec.describe "School user completes the interested journey without declaring s
     )
     expect(page).to have_element(
       :span,
-      text: "Expression of interest",
+      text: "Potential placement details",
       class: "govuk-caption-l",
     )
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_does_not_enter_any_school_contact_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_does_not_enter_any_school_contact_details_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe "School user does not enter any school contact details",
     )
     expect(page).to have_element(
       :span,
-      text: "Expression of interest",
+      text: "Potential placement details",
       class: "govuk-caption-l",
     )
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
@@ -115,12 +115,12 @@ RSpec.describe "School user does not enter a placement quantity",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -159,10 +159,10 @@ RSpec.describe "School user does not enter a placement quantity",
 
   def then_i_see_the_primary_placement_quantity_form
     expect(page).to have_title(
-      "How many primary placements you would be willing to host in each year group? - Manage school placements - GOV.UK",
+      "Enter the number of primary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("How many primary placements you would be willing to host in each year group?", class: "govuk-heading-l")
+    expect(page).to have_h1("Enter the number of primary school placements you can offer", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")
     expect(page).to have_field("Year 1", type: :number)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_does_not_select_a_year_group_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_does_not_select_a_year_group_spec.rb
@@ -111,12 +111,12 @@ RSpec.describe "School user does not select a year group",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_the_primary_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_the_primary_phase_spec.rb
@@ -132,12 +132,12 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -188,10 +188,10 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_primary_placement_quantity_form
     expect(page).to have_title(
-      "How many primary placements you would be willing to host in each year group? - Manage school placements - GOV.UK",
+      "Enter the number of primary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("How many primary placements you would be willing to host in each year group?", class: "govuk-heading-l")
+    expect(page).to have_h1("Enter the number of primary school placements you can offer", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")
     expect(page).to have_field("Reception", type: :number)
     expect(page).to have_field("Year 3", type: :number)

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
@@ -116,12 +116,12 @@ RSpec.describe "School user enters a float as a placement quantity",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -160,10 +160,10 @@ RSpec.describe "School user enters a float as a placement quantity",
 
   def then_i_see_the_primary_placement_quantity_form
     expect(page).to have_title(
-      "How many primary placements you would be willing to host in each year group? - Manage school placements - GOV.UK",
+      "Enter the number of primary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("How many primary placements you would be willing to host in each year group?", class: "govuk-heading-l")
+    expect(page).to have_h1("Enter the number of primary school placements you can offer", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")
     expect(page).to have_field("Year 1", type: :number)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
@@ -118,12 +118,12 @@ RSpec.describe "School user enters zero as a placement quantity",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -162,10 +162,10 @@ RSpec.describe "School user enters zero as a placement quantity",
 
   def then_i_see_the_primary_placement_quantity_form
     expect(page).to have_title(
-      "How many primary placements you would be willing to host in each year group? - Manage school placements - GOV.UK",
+      "Enter the number of primary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("How many primary placements you would be willing to host in each year group?", class: "govuk-heading-l")
+    expect(page).to have_h1("Enter the number of primary school placements you can offer", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")
     expect(page).to have_field("Year 1", type: :number)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/school_user_does_not_select_a_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/school_user_does_not_select_a_phase_spec.rb
@@ -111,12 +111,12 @@ RSpec.describe "School user does not select a phases",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
@@ -188,12 +188,12 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -236,10 +236,10 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_primary_placement_quantity_form
     expect(page).to have_title(
-      "How many primary placements you would be willing to host in each year group? - Manage school placements - GOV.UK",
+      "Enter the number of primary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("How many primary placements you would be willing to host in each year group?", class: "govuk-heading-l")
+    expect(page).to have_h1("Enter the number of primary school placements you can offer", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")
     expect(page).to have_field("Year 1", type: :number)
   end
@@ -250,15 +250,15 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects - Manage school placements - GOV.UK",
+      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects",
+      text: "Select secondary school subjects you can offer",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
@@ -274,11 +274,11 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Secondary subjects: Enter the number of placements you would be willing to host - Manage school placements - GOV.UK",
+      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("Secondary subjects: Enter the number of placements you would be willing to host", class: "govuk-heading-l")
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
     expect(page).to have_field("Mathematics", type: :number)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
@@ -117,12 +117,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -135,15 +135,15 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects - Manage school placements - GOV.UK",
+      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects",
+      text: "Select secondary school subjects you can offer",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
@@ -155,11 +155,11 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Secondary subjects: Enter the number of placements you would be willing to host - Manage school placements - GOV.UK",
+      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("Secondary subjects: Enter the number of placements you would be willing to host", class: "govuk-heading-l")
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
   end
 

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
@@ -125,12 +125,12 @@ RSpec.describe "School user does not select a child subjects",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -143,15 +143,15 @@ RSpec.describe "School user does not select a child subjects",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects - Manage school placements - GOV.UK",
+      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects",
+      text: "Select secondary school subjects you can offer",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
@@ -164,11 +164,11 @@ RSpec.describe "School user does not select a child subjects",
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Secondary subjects: Enter the number of placements you would be willing to host - Manage school placements - GOV.UK",
+      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("Secondary subjects: Enter the number of placements you would be willing to host", class: "govuk-heading-l")
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("Modern languages", type: :number)
   end
 
@@ -189,7 +189,7 @@ RSpec.describe "School user does not select a child subjects",
       "Select the languages taught on each of these placements",
       class: "govuk-heading-m",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("French", type: :checkbox)
     expect(page).to have_field("Spanish", type: :checkbox)
     expect(page).to have_field("Russian", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
@@ -113,12 +113,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -131,15 +131,15 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects - Manage school placements - GOV.UK",
+      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects",
+      text: "Select secondary school subjects you can offer",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
@@ -155,12 +155,12 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -173,15 +173,15 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects - Manage school placements - GOV.UK",
+      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects",
+      text: "Select secondary school subjects you can offer",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
@@ -194,11 +194,11 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Secondary subjects: Enter the number of placements you would be willing to host - Manage school placements - GOV.UK",
+      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("Secondary subjects: Enter the number of placements you would be willing to host", class: "govuk-heading-l")
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("Modern languages", type: :number)
   end
 
@@ -219,7 +219,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
       "Select the languages taught on each of these placements",
       class: "govuk-heading-m",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("French", type: :checkbox)
     expect(page).to have_field("Spanish", type: :checkbox)
     expect(page).to have_field("Russian", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_edits_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_edits_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
@@ -135,12 +135,12 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -153,15 +153,15 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects - Manage school placements - GOV.UK",
+      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects",
+      text: "Select secondary school subjects you can offer",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
@@ -177,11 +177,11 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Secondary subjects: Enter the number of placements you would be willing to host - Manage school placements - GOV.UK",
+      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("Secondary subjects: Enter the number of placements you would be willing to host", class: "govuk-heading-l")
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
     expect(page).to have_field("Mathematics", type: :number)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
@@ -118,12 +118,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -136,15 +136,15 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects - Manage school placements - GOV.UK",
+      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects",
+      text: "Select secondary school subjects you can offer",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
@@ -156,11 +156,11 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Secondary subjects: Enter the number of placements you would be willing to host - Manage school placements - GOV.UK",
+      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("Secondary subjects: Enter the number of placements you would be willing to host", class: "govuk-heading-l")
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
   end
 

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
@@ -118,12 +118,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -136,15 +136,15 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects - Manage school placements - GOV.UK",
+      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects",
+      text: "Select secondary school subjects you can offer",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
@@ -156,11 +156,11 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Secondary subjects: Enter the number of placements you would be willing to host - Manage school placements - GOV.UK",
+      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("Secondary subjects: Enter the number of placements you would be willing to host", class: "govuk-heading-l")
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
   end
 

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
@@ -155,10 +155,10 @@ RSpec.describe "School user completes the interested journey without declaring p
 
   def then_i_see_the_confirmation_page
     expect(page).to have_title(
-      "Confirm and share your approximate information with providers - Manage school placements - GOV.UK",
+      "Confirm and share what you may be able to offer - Manage school placements - GOV.UK",
     )
     expect(page).to have_current_item("Organisation details")
-    expect(page).to have_h1("Confirm and share your approximate information with providers", class: "govuk-heading-l")
+    expect(page).to have_h1("Confirm and share what you may be able to offer", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Potential placement details", class: "govuk-caption-l")
     expect(page).to have_element(
       :p,
@@ -234,7 +234,7 @@ RSpec.describe "School user completes the interested journey without declaring p
     )
     expect(page).to have_element(
       :span,
-      text: "Expression of interest",
+      text: "Potential placement details",
       class: "govuk-caption-l",
     )
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_interested/school_user_completes_the_interested_journey_without_declaring_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_interested/school_user_completes_the_interested_journey_without_declaring_potential_placement_details_spec.rb
@@ -115,10 +115,10 @@ RSpec.describe "School user completes the interested journey without declaring p
 
   def then_i_see_the_confirmation_page
     expect(page).to have_title(
-      "Confirm and share your approximate information with providers - Manage school placements - GOV.UK",
+      "Confirm and share what you may be able to offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("Confirm and share your approximate information with providers", class: "govuk-heading-l")
+    expect(page).to have_h1("Confirm and share what you may be able to offer", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Potential placement details", class: "govuk-caption-l")
     expect(page).to have_element(
       :p,
@@ -197,7 +197,7 @@ RSpec.describe "School user completes the interested journey without declaring p
     )
     expect(page).to have_element(
       :span,
-      text: "Expression of interest",
+      text: "Potential placement details",
       class: "govuk-caption-l",
     )
   end

--- a/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_bulk_adds_placements_for_the_primary_phase_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_bulk_adds_placements_for_the_primary_phase_spec.rb
@@ -74,12 +74,12 @@ RSpec.describe "School user bulk adds placements for the primary phases",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -126,10 +126,10 @@ RSpec.describe "School user bulk adds placements for the primary phases",
 
   def then_i_see_the_primary_placement_quantity_form
     expect(page).to have_title(
-      "How many primary placements you would be willing to host in each year group? - Manage school placements - GOV.UK",
+      "Enter the number of primary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("How many primary placements you would be willing to host in each year group?", class: "govuk-heading-l")
+    expect(page).to have_h1("Enter the number of primary school placements you can offer", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")
     expect(page).to have_field("Reception", type: :number)
     expect(page).to have_field("Year 3", type: :number)

--- a/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
@@ -65,12 +65,12 @@ RSpec.describe "School user does not enter a placement quantity",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -109,10 +109,10 @@ RSpec.describe "School user does not enter a placement quantity",
 
   def then_i_see_the_primary_placement_quantity_form
     expect(page).to have_title(
-      "How many primary placements you would be willing to host in each year group? - Manage school placements - GOV.UK",
+      "Enter the number of primary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("How many primary placements you would be willing to host in each year group?", class: "govuk-heading-l")
+    expect(page).to have_h1("Enter the number of primary school placements you can offer", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")
     expect(page).to have_field("Year 1", type: :number)
   end

--- a/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_does_not_select_a_year_group_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_does_not_select_a_year_group_spec.rb
@@ -61,12 +61,12 @@ RSpec.describe "School user does not select a year group",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)

--- a/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
@@ -66,12 +66,12 @@ RSpec.describe "School user enters a float as a placement quantity",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -110,10 +110,10 @@ RSpec.describe "School user enters a float as a placement quantity",
 
   def then_i_see_the_primary_placement_quantity_form
     expect(page).to have_title(
-      "How many primary placements you would be willing to host in each year group? - Manage school placements - GOV.UK",
+      "Enter the number of primary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("How many primary placements you would be willing to host in each year group?", class: "govuk-heading-l")
+    expect(page).to have_h1("Enter the number of primary school placements you can offer", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")
     expect(page).to have_field("Year 1", type: :number)
   end

--- a/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
@@ -68,12 +68,12 @@ RSpec.describe "School user enters zero as a placement quantity",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -112,10 +112,10 @@ RSpec.describe "School user enters zero as a placement quantity",
 
   def then_i_see_the_primary_placement_quantity_form
     expect(page).to have_title(
-      "How many primary placements you would be willing to host in each year group? - Manage school placements - GOV.UK",
+      "Enter the number of primary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("How many primary placements you would be willing to host in each year group?", class: "govuk-heading-l")
+    expect(page).to have_h1("Enter the number of primary school placements you can offer", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")
     expect(page).to have_field("Year 1", type: :number)
   end

--- a/spec/system/placements/schools/placements/bulk_add_placements/school_user_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/school_user_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
@@ -123,12 +123,12 @@ RSpec.describe "School user bulk adds placements for primary and secondary phase
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -171,10 +171,10 @@ RSpec.describe "School user bulk adds placements for primary and secondary phase
 
   def then_i_see_the_primary_placement_quantity_form
     expect(page).to have_title(
-      "How many primary placements you would be willing to host in each year group? - Manage school placements - GOV.UK",
+      "Enter the number of primary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("How many primary placements you would be willing to host in each year group?", class: "govuk-heading-l")
+    expect(page).to have_h1("Enter the number of primary school placements you can offer", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")
     expect(page).to have_field("Year 1", type: :number)
   end
@@ -185,15 +185,15 @@ RSpec.describe "School user bulk adds placements for primary and secondary phase
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects - Manage school placements - GOV.UK",
+      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects",
+      text: "Select secondary school subjects you can offer",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
@@ -209,11 +209,11 @@ RSpec.describe "School user bulk adds placements for primary and secondary phase
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Secondary subjects: Enter the number of placements you would be willing to host - Manage school placements - GOV.UK",
+      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Secondary subjects: Enter the number of placements you would be willing to host", class: "govuk-heading-l")
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
     expect(page).to have_field("Mathematics", type: :number)
   end

--- a/spec/system/placements/schools/placements/bulk_add_placements/school_user_does_not_select_a_phase_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/school_user_does_not_select_a_phase_spec.rb
@@ -61,12 +61,12 @@ RSpec.describe "School user does not select a phases",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)

--- a/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
@@ -94,12 +94,12 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -112,15 +112,15 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects - Manage school placements - GOV.UK",
+      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects",
+      text: "Select secondary school subjects you can offer",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
@@ -133,11 +133,11 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Secondary subjects: Enter the number of placements you would be willing to host - Manage school placements - GOV.UK",
+      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Secondary subjects: Enter the number of placements you would be willing to host", class: "govuk-heading-l")
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("Modern languages", type: :number)
   end
 
@@ -158,7 +158,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
       "Select the languages taught on each of these placements",
       class: "govuk-heading-m",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("French", type: :checkbox)
     expect(page).to have_field("Spanish", type: :checkbox)
     expect(page).to have_field("Russian", type: :checkbox)

--- a/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_adds_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_adds_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
@@ -74,12 +74,12 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -92,15 +92,15 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects - Manage school placements - GOV.UK",
+      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects",
+      text: "Select secondary school subjects you can offer",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
@@ -116,11 +116,11 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Secondary subjects: Enter the number of placements you would be willing to host - Manage school placements - GOV.UK",
+      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Secondary subjects: Enter the number of placements you would be willing to host", class: "govuk-heading-l")
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
     expect(page).to have_field("Mathematics", type: :number)
   end

--- a/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
@@ -67,12 +67,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -85,15 +85,15 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects - Manage school placements - GOV.UK",
+      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects",
+      text: "Select secondary school subjects you can offer",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
@@ -105,11 +105,11 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Secondary subjects: Enter the number of placements you would be willing to host - Manage school placements - GOV.UK",
+      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Secondary subjects: Enter the number of placements you would be willing to host", class: "govuk-heading-l")
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
   end
 

--- a/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
@@ -75,12 +75,12 @@ RSpec.describe "School user does not select a child subjects",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -93,15 +93,15 @@ RSpec.describe "School user does not select a child subjects",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects - Manage school placements - GOV.UK",
+      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects",
+      text: "Select secondary school subjects you can offer",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
@@ -114,11 +114,11 @@ RSpec.describe "School user does not select a child subjects",
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Secondary subjects: Enter the number of placements you would be willing to host - Manage school placements - GOV.UK",
+      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Secondary subjects: Enter the number of placements you would be willing to host", class: "govuk-heading-l")
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("Modern languages", type: :number)
   end
 
@@ -139,7 +139,7 @@ RSpec.describe "School user does not select a child subjects",
       "Select the languages taught on each of these placements",
       class: "govuk-heading-m",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("French", type: :checkbox)
     expect(page).to have_field("Spanish", type: :checkbox)
     expect(page).to have_field("Russian", type: :checkbox)

--- a/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
@@ -63,12 +63,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -81,15 +81,15 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects - Manage school placements - GOV.UK",
+      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects",
+      text: "Select secondary school subjects you can offer",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)

--- a/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
@@ -68,12 +68,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -86,15 +86,15 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects - Manage school placements - GOV.UK",
+      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects",
+      text: "Select secondary school subjects you can offer",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
@@ -106,11 +106,11 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Secondary subjects: Enter the number of placements you would be willing to host - Manage school placements - GOV.UK",
+      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Secondary subjects: Enter the number of placements you would be willing to host", class: "govuk-heading-l")
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
   end
 

--- a/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
@@ -68,12 +68,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_phase_form
     expect(page).to have_title(
-      "What phase of education can your placements be? - Manage school placements - GOV.UK",
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "What phase of education can your placements be?",
+      text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -86,15 +86,15 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects - Manage school placements - GOV.UK",
+      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects",
+      text: "Select secondary school subjects you can offer",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
@@ -106,11 +106,11 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Secondary subjects: Enter the number of placements you would be willing to host - Manage school placements - GOV.UK",
+      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Secondary subjects: Enter the number of placements you would be willing to host", class: "govuk-heading-l")
-    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
   end
 


### PR DESCRIPTION
## Context

- Content sweep to ensure the EOI paths contain the correct text.

## Changes proposed in this pull request

- Content changes to align with the figma https://www.figma.com/design/9eMfPnPEONmEPvimD3CYpz/MSP-Concepts?node-id=63713-43535&t=kjLrKGOHllVOlCIZ-0

## Guidance to review

- Sign in as Anne (School user)
- Complete the Hosting Interest flows (make sure the content matches the figma) (except for the education step and confirm step, which match the final figma.)
