### PR TITLE
Update placements invitation email

### DIFF
--- a/app/views/placements/school_user_mailer/user_membership_created_notification.text.erb
+++ b/app/views/placements/school_user_mailer/user_membership_created_notification.text.erb
@@ -1,8 +1,10 @@
-<%= @user_name %>,
+Dear <%= @user_name %>,
 
-You have been invited to join the <%= @service_name %> service for <%= @organisation_name %>.
+You now have access to the <%= @service_name %> service for <%= @organisation_name %>.
 
-This service allows you to publish and manage placements at your school. You can assign your preferred providers to fulfil your placements with suitable trainees.
+Please sign-in this week to record your school's preferences for offering placements for trainee teachers.
+
+It is important to do this so teacher training providers know whether to contact you, and to ensure you do not miss out on getting trainee teachers in your school.
 
 [Sign in to Manage school placements](<%= @sign_in_url %>)
 
@@ -10,4 +12,8 @@ If you do not have DfE Sign-in, create an account. You can then return to this e
 
 If you need help or have feedback for us, contact [<%= @support_email %>](mailto:<%= @support_email %>).
 
+Thank you.
+
 <%= @service_name %> service
+
+Department for Education

--- a/config/locales/en/placements/school_user_mailer.yml
+++ b/config/locales/en/placements/school_user_mailer.yml
@@ -2,7 +2,7 @@ en:
   placements:
     school_user_mailer:
       user_membership_created_notification:
-        subject: Invitation to join %{service_name}
+        subject: "ACTION NEEDED: Sign-in to the %{service_name} service"
       user_membership_destroyed_notification:
         subject: You have been removed from %{service_name}
       partnership_created_notification:

--- a/spec/mailers/placements/school_user_mailer_spec.rb
+++ b/spec/mailers/placements/school_user_mailer_spec.rb
@@ -9,13 +9,15 @@ RSpec.describe Placements::SchoolUserMailer, type: :mailer do
 
     it "sends invitation email" do
       expect(invite_email.to).to contain_exactly(user.email)
-      expect(invite_email.subject).to eq("Invitation to join Manage school placements")
+      expect(invite_email.subject).to eq("ACTION NEEDED: Sign-in to the Manage school placements service")
       expect(invite_email.body).to have_content <<~EMAIL
-        #{user.first_name},
+        Dear #{user.first_name},
 
-        You have been invited to join the Manage school placements service for #{organisation.name}.
+        You now have access to the Manage school placements service for #{organisation.name}.
 
-        This service allows you to publish and manage placements at your school. You can assign your preferred providers to fulfil your placements with suitable trainees.
+        Please sign-in this week to record your school's preferences for offering placements for trainee teachers.
+
+        It is important to do this so teacher training providers know whether to contact you, and to ensure you do not miss out on getting trainee teachers in your school.
 
         [Sign in to Manage school placements](http://placements.localhost/sign-in?utm_campaign=school&utm_medium=notification&utm_source=email)
 
@@ -23,7 +25,11 @@ RSpec.describe Placements::SchoolUserMailer, type: :mailer do
 
         If you need help or have feedback for us, contact [Manage.SchoolPlacements@education.gov.uk](mailto:Manage.SchoolPlacements@education.gov.uk).
 
+        Thank you.
+
         Manage school placements service
+
+        Department for Education
       EMAIL
     end
 
@@ -33,7 +39,7 @@ RSpec.describe Placements::SchoolUserMailer, type: :mailer do
       end
 
       it "does not prepend the hosting environment to the subject" do
-        expect(invite_email.subject).to eq("Invitation to join Manage school placements")
+        expect(invite_email.subject).to eq("ACTION NEEDED: Sign-in to the Manage school placements service")
       end
     end
 
@@ -43,7 +49,7 @@ RSpec.describe Placements::SchoolUserMailer, type: :mailer do
       end
 
       it "prepends the hosting environment to the subject" do
-        expect(invite_email.subject).to eq("[STAGING] Invitation to join Manage school placements")
+        expect(invite_email.subject).to eq("[STAGING] ACTION NEEDED: Sign-in to the Manage school placements service")
       end
     end
   end

--- a/spec/system/placements/organisations/users/add_users_spec.rb
+++ b/spec/system/placements/organisations/users/add_users_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Placements users invite other users to organisations", service: 
         and_user_is_selected_in_provider_primary_navigation
         when_i_click_confirm
         then_the_user_is_added
-        and_an_email_is_sent("firsty_lasty@email.co.uk", one_provider)
+        and_an_email_is_sent("firsty_lasty@email.co.uk", :provider)
         and_user_is_selected_in_provider_primary_navigation
       end
     end
@@ -52,7 +52,7 @@ RSpec.describe "Placements users invite other users to organisations", service: 
         and_user_is_selected_in_school_primary_navigation
         when_i_click_confirm
         then_the_user_is_added
-        and_an_email_is_sent("firsty_lasty@email.co.uk", one_school)
+        and_an_email_is_sent("firsty_lasty@email.co.uk", :school)
       end
     end
   end
@@ -68,7 +68,7 @@ RSpec.describe "Placements users invite other users to organisations", service: 
       when_i_change_organisation(another_school)
       and_i_try_to_add_the_user
       then_the_user_is_added_successfully(another_school)
-      and_an_email_is_sent(new_user.email, another_school)
+      and_an_email_is_sent(new_user.email, :school)
       when_i_change_organisation(one_provider)
       and_i_try_to_add_the_user
       then_the_user_is_added_successfully(one_provider)
@@ -269,14 +269,18 @@ RSpec.describe "Placements users invite other users to organisations", service: 
     expect(primary_navigation).to have_current_item("Users")
   end
 
-  def email_invite_notification(email, _organisation)
+  def email_invite_notification(email, organisation_type)
     ActionMailer::Base.deliveries.find do |delivery|
-      delivery.to.include?(email) && delivery.subject == "Invitation to join Manage school placements"
+      if organisation_type == :school
+        delivery.to.include?(email) && delivery.subject == "ACTION NEEDED: Sign-in to the Manage school placements service"
+      else
+        delivery.to.include?(email) && delivery.subject == "Invitation to join Manage school placements"
+      end
     end
   end
 
-  def and_an_email_is_sent(email, organisation)
-    invite_email = email_invite_notification(email, organisation)
+  def and_an_email_is_sent(email, organisation_type)
+    invite_email = email_invite_notification(email, organisation_type)
 
     expect(invite_email).not_to be_nil
   end

--- a/spec/system/placements/support/users/school_users/add_user/support_user_adds_a_new_user_to_a_school_spec.rb
+++ b/spec/system/placements/support/users/school_users/add_user/support_user_adds_a_new_user_to_a_school_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe "Support user adds a new user to a school", service: :placements,
   def and_susan_storm_is_sent_an_email
     email = ActionMailer::Base.deliveries.find do |delivery|
       delivery.to.include?("susan_storm@example.com") &&
-        delivery.subject == "Invitation to join Manage school placements"
+        delivery.subject == "ACTION NEEDED: Sign-in to the Manage school placements service"
     end
     expect(email).not_to be_nil
   end

--- a/spec/system/placements/support/users/school_users/add_user/support_user_adds_an_existing_user_to_a_school_spec.rb
+++ b/spec/system/placements/support/users/school_users/add_user/support_user_adds_an_existing_user_to_a_school_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe "Support user adds an existing user to a school", service: :place
   def and_susan_storm_is_sent_an_email
     email = ActionMailer::Base.deliveries.find do |delivery|
       delivery.to.include?("susan_storm@example.com") &&
-        delivery.subject == "Invitation to join Manage school placements"
+        delivery.subject == "ACTION NEEDED: Sign-in to the Manage school placements service"
     end
     expect(email).not_to be_nil
   end


### PR DESCRIPTION
## Context

We want to improve our content for new users to the service

## Changes proposed in this pull request

- Updates the placements service invitation email content

## Guidance to review

- Log in as Colin
- Click on Settings
- Click on Emails
- Click on [user_membership_created_notification (opens in new tab)](http://placements.localhost:3000/rails/mailers/placements/school_user_mailer/user_membership_created_notification)

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Screenshots

![image](https://github.com/user-attachments/assets/2df5d817-4fee-4883-aadd-1e15ef49047a)

