### PR TITLE
Add ability to remove providers from placements

### DIFF
--- a/app/controllers/placements/schools/placements_controller.rb
+++ b/app/controllers/placements/schools/placements_controller.rb
@@ -1,7 +1,7 @@
 class Placements::Schools::PlacementsController < Placements::ApplicationController
   before_action :set_school
-  before_action :set_placement, only: %i[show remove destroy preview]
-  before_action :set_decorated_placement, only: %i[show remove preview]
+  before_action :set_placement, only: %i[show remove destroy preview unassign_provider confirm_unassign_provider]
+  before_action :set_decorated_placement, only: %i[show remove preview confirm_unassign_provider]
 
   helper_method :edit_attribute_path, :add_provider_path, :add_mentor_path
 
@@ -35,6 +35,21 @@ class Placements::Schools::PlacementsController < Placements::ApplicationControl
   end
 
   def preview; end
+
+  def confirm_unassign_provider; end
+
+  def unassign_provider
+    provider = @placement.provider
+    @placement.update!(provider: nil)
+    Placements::Placements::NotifyProvider::Remove.call(
+      provider:,
+      placement: @placement,
+    )
+
+    redirect_to placements_school_placement_path(@school, @placement), flash: {
+      heading: t(".success"),
+    }
+  end
 
   private
 

--- a/app/views/placements/schools/placements/_details.html.erb
+++ b/app/views/placements/schools/placements/_details.html.erb
@@ -98,8 +98,8 @@
     <% end %>
     <% if placement.provider.present? %>
       <% row.with_action(
-        text: t(".change"),
-        href: edit_attribute_path(:provider),
+        text: t(".unassign_provider"),
+        href: confirm_unassign_provider_placements_school_placement_path(@school, @placement),
         visually_hidden_text: t(".attributes.placements.provider"),
       ) %>
     <% end %>

--- a/app/views/placements/schools/placements/confirm_unassign_provider.html.erb
+++ b/app/views/placements/schools/placements/confirm_unassign_provider.html.erb
@@ -1,0 +1,26 @@
+<%= content_for :page_title, sanitize(t(".page_title", subject_names: @placement.title, provider_name: @placement.provider_name)) %>
+<%= render "placements/schools/primary_navigation", school: @school, current_navigation: :placements %>
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: placements_school_placement_path(@school, @placement)) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <span class="govuk-caption-l"><%= @placement.title %></span>
+      <h1 class="govuk-heading-l"><%= t(".are_you_sure", provider_name: @placement.provider_name) %></h1>
+
+      <%= govuk_warning_text(text: t(".provider_will_be_sent_an_email", provider_name: @placement.provider_name)) %>
+
+      <%= govuk_button_to t(".unassign_provider"),
+        unassign_provider_placements_school_placement_path(@school, @placement),
+        warning: true,
+        method: :put %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to(t(".cancel"), placements_school_placement_path(@school, @placement), no_visited_state: true) %>
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/wizards/placements/add_placement_wizard/_terms_step.erb
+++ b/app/views/wizards/placements/add_placement_wizard/_terms_step.erb
@@ -19,7 +19,11 @@
             <%= f.govuk_check_box :term_ids, term.id, label: { text: term.name }, link_errors: index.zero? %>
           <% end %>
           <%= f.govuk_check_box_divider %>
-          <%= f.govuk_check_box :term_ids, "any_term", label: { text: t(".any_term") }, checked: current_step.term_ids.include?("any_term"), exclusive: true %>
+          <%= f.govuk_check_box :term_ids,
+            "any_term",
+            label: { text: t(".any_term") },
+            checked: current_step.term_ids.include?("any_term") || current_step.term_ids.blank?,
+            exclusive: true %>
         <% end %>
 
         <%= f.govuk_submit t(".continue") %>

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -121,6 +121,7 @@ en:
           select_a_mentor: Select a mentor
           add_a_mentor: Add a mentor
           assign_a_provider: Assign a provider
+          unassign_provider: Unassign provider
           add_a_partner_provider: Add a partner provider
           not_yet_known: Not yet known
           change: Change
@@ -147,3 +148,12 @@ en:
           description: '%{provider_name} must be removed from the placement before you can delete it.'
         destroy:
           placement_deleted: Placement deleted
+        confirm_unassign_provider:
+          page_title: "Are you sure you want to unassign %{provider_name} from this placement? - %{subject_names}"
+          are_you_sure: Are you sure you want to unassign %{provider_name} from this placement?
+          unassign_provider: Unassign provider
+          cancel: Cancel
+          provider_will_be_sent_an_email:
+            An email will be sent to %{provider_name} to let them know that they are no longer assigned to this placement.
+        unassign_provider:
+          success: Provider unassigned

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -91,6 +91,8 @@ scope module: :placements,
 
       resources :placements, only: %i[index show destroy] do
         member do
+          get :confirm_unassign_provider
+          put :unassign_provider
           get :remove
           get "edit", to: "placements/edit_placement#new", as: :new_edit_placement
           get "edit/:state_key/:step", to: "placements/edit_placement#edit", as: :edit_placement

--- a/spec/models/claims/claim_spec.rb
+++ b/spec/models/claims/claim_spec.rb
@@ -164,7 +164,10 @@ RSpec.describe Claims::Claim, type: :model do
 
     describe "#paid_for_current_academic_year" do
       let(:current_academic_year) do
-        AcademicYear.for_date(Date.current) || create(:academic_year, :current)
+        AcademicYear.for_date(Date.current)
+      end
+      let(:historic_academic_year) do
+        AcademicYear.for_date(Date.current - 1.year)
       end
       let(:current_claim_window) do
         create(:claim_window,
@@ -172,10 +175,16 @@ RSpec.describe Claims::Claim, type: :model do
                ends_on: current_academic_year.starts_on + 1.month,
                academic_year: current_academic_year)
       end
+      let(:historic_claim_window) do
+        create(:claim_window,
+               starts_on: historic_academic_year.starts_on + 1.day,
+               ends_on: historic_academic_year.starts_on + 1.month,
+               academic_year: historic_academic_year)
+      end
       let(:current_year_paid_claim) do
         create(:claim, :submitted, status: :paid, claim_window: current_claim_window)
       end
-      let(:another_paid_claim) { create(:claim, :submitted, status: :paid) }
+      let(:another_paid_claim) { create(:claim, :submitted, status: :paid, claim_window: historic_claim_window) }
       let(:current_year_draft_claim) { create(:claim, :draft, claim_window: current_claim_window) }
 
       before do

--- a/spec/system/placements/schools/placements/all_through_school_user_adds_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/all_through_school_user_adds_a_placement_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe "All-through school user adds a placement", service: :placements,
     then_i_see_the_when_could_the_placement_take_place_page
     and_i_see_the_term_dates
 
-    when_i_click_on_continue
+    when_i_unselect_any_time_in_the_academic_year
+    and_i_click_on_continue
     then_i_see_a_validation_error_for_selecting_a_term
 
     when_i_select_autumn_term_and_spring_term
@@ -357,6 +358,7 @@ RSpec.describe "All-through school user adds a placement", service: :placements,
   end
 
   def when_i_select_autumn_term_and_spring_term
+    uncheck "Any time in the academic year"
     check "Autumn term"
     check "Spring term"
   end
@@ -597,5 +599,9 @@ RSpec.describe "All-through school user adds a placement", service: :placements,
       "Expected date" => "Summer term",
       "Provider" => "Provider not assigned",
     })
+  end
+
+  def when_i_unselect_any_time_in_the_academic_year
+    uncheck "Any time in the academic year"
   end
 end

--- a/spec/system/placements/schools/placements/primary_school_user_adds_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/primary_school_user_adds_a_placement_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe "Primary school user adds a placement", service: :placements, typ
     then_i_see_the_when_could_the_placement_take_place_page
     and_i_see_the_term_dates
 
-    when_i_click_on_continue
+    when_i_unselect_any_time_in_the_academic_year
+    and_i_click_on_continue
     then_i_see_a_validation_error_for_selecting_a_term
 
     when_i_select_autumn_term_and_spring_term
@@ -301,6 +302,7 @@ RSpec.describe "Primary school user adds a placement", service: :placements, typ
   end
 
   def when_i_select_autumn_term_and_spring_term
+    uncheck "Any time in the academic year"
     check "Autumn term"
     check "Spring term"
   end
@@ -549,5 +551,9 @@ RSpec.describe "Primary school user adds a placement", service: :placements, typ
       "Expected date" => "Summer term",
       "Provider" => "Provider not assigned",
     })
+  end
+
+  def when_i_unselect_any_time_in_the_academic_year
+    uncheck "Any time in the academic year"
   end
 end

--- a/spec/system/placements/schools/placements/primary_school_user_edits_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/primary_school_user_edits_a_placement_spec.rb
@@ -82,20 +82,18 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
     then_i_see_the_placement_details_page_with_aes_sedai_trust
     and_i_see_a_provider_updated_success_message
 
-    when_i_click_on_change_provider
-    and_i_enter_ashaman_trust
-    then_i_see_a_dropdown_item_for_ashaman_trust
+    when_i_click_on_unassign_provider
+    then_i_see_the_confirmation_page
 
-    when_i_click_on_the_ashaman_trust_dropdown_item
-    and_i_click_on_continue
-    then_i_see_the_placement_details_page_with_the_ashaman_trust
-    and_i_see_a_provider_updated_success_message
+    when_i_click_on_unassign_provider
+    then_i_see_the_provider_was_successfully_unassigned
+    and_i_see_the_placement_details_page_with_jane_doe
 
     when_i_click_on_preview_this_placement
     then_i_see_the_preview_placement_page
 
     when_i_click_on_the_back_link
-    then_i_see_the_placement_details_page_with_the_ashaman_trust
+    then_i_see_the_placement_details_page_with_jane_doe
   end
 
   private
@@ -366,6 +364,8 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
     expect(page).to have_summary_list_row("Provider", "Assign a provider")
     expect(page).to have_element(:div, text: "You can preview this placement as it appears to providers.", class: "govuk-inset-text")
   end
+  alias_method :and_i_see_the_placement_details_page_with_jane_doe,
+               :then_i_see_the_placement_details_page_with_jane_doe
 
   def when_i_click_on_assign_a_provider
     click_on "Assign a provider"
@@ -421,8 +421,30 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
     expect(page).to have_success_banner("Provider updated")
   end
 
-  def when_i_click_on_change_provider
-    click_on("Change Provider")
+  def when_i_click_on_unassign_provider
+    click_on("Unassign provider")
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_title(
+      "Are you sure you want to unassign Aes Sedai Trust from this placement? - Primary with english (Year 2) - Manage school placements - GOV.UK",
+    )
+    expect(page).to have_element(
+      :span,
+      text: "Primary with english (Year 2)",
+      class: "govuk-caption-l",
+    )
+    expect(page).to have_h1(
+      "Are you sure you want to unassign Aes Sedai Trust from this placement?",
+    )
+    expect(page).to have_warning_text(
+      "An email will be sent to Aes Sedai Trust to let them know that they are no longer assigned to this placement.",
+    )
+    expect(page).to have_button("Unassign provider", class: "govuk-button--warning")
+  end
+
+  def then_i_see_the_provider_was_successfully_unassigned
+    expect(page).to have_success_banner("Provider unassigned")
   end
 
   def when_i_select_the_ashaman_trust

--- a/spec/system/placements/schools/placements/primary_school_user_edits_a_placement_with_javascript_disabled_spec.rb
+++ b/spec/system/placements/schools/placements/primary_school_user_edits_a_placement_with_javascript_disabled_spec.rb
@@ -91,21 +91,18 @@ RSpec.describe "Primary school user edits a placement with javascript disabled",
     then_i_see_the_placement_details_page_with_aes_sedai_trust
     and_i_see_a_provider_updated_success_message
 
-    when_i_click_on_change_provider
-    and_i_enter_ashaman_trust
-    and_i_click_on_continue
-    then_i_see_the_provider_options_page_for_ashaman_trust_search
+    when_i_click_on_unassign_provider
+    then_i_see_the_confirmation_page
 
-    when_i_select_the_ashaman_trust
-    and_i_click_on_continue
-    then_i_see_the_placement_details_page_with_the_ashaman_trust
-    and_i_see_a_provider_updated_success_message
+    when_i_click_on_unassign_provider
+    then_i_see_the_provider_was_successfully_unassigned
+    and_i_see_the_placement_details_page_with_jane_doe
 
     when_i_click_on_preview_this_placement
     then_i_see_the_preview_placement_page
 
     when_i_click_on_the_back_link
-    then_i_see_the_placement_details_page_with_the_ashaman_trust
+    then_i_see_the_placement_details_page_with_jane_doe
   end
 
   private
@@ -378,6 +375,8 @@ RSpec.describe "Primary school user edits a placement with javascript disabled",
     expect(page).to have_summary_list_row("Provider", "Assign a provider")
     expect(page).to have_element(:div, text: "You can preview this placement as it appears to providers.", class: "govuk-inset-text")
   end
+  alias_method :and_i_see_the_placement_details_page_with_jane_doe,
+               :then_i_see_the_placement_details_page_with_jane_doe
 
   def when_i_click_on_assign_a_provider
     click_on "Assign a provider"
@@ -417,8 +416,30 @@ RSpec.describe "Primary school user edits a placement with javascript disabled",
     expect(page).to have_success_banner("Provider updated")
   end
 
-  def when_i_click_on_change_provider
-    click_on("Change Provider")
+  def when_i_click_on_unassign_provider
+    click_on("Unassign provider")
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_title(
+      "Are you sure you want to unassign Aes Sedai Trust from this placement? - Primary with english (Year 2) - Manage school placements - GOV.UK",
+    )
+    expect(page).to have_element(
+      :span,
+      text: "Primary with english (Year 2)",
+      class: "govuk-caption-l",
+    )
+    expect(page).to have_h1(
+      "Are you sure you want to unassign Aes Sedai Trust from this placement?",
+    )
+    expect(page).to have_warning_text(
+      "An email will be sent to Aes Sedai Trust to let them know that they are no longer assigned to this placement.",
+    )
+    expect(page).to have_button("Unassign provider", class: "govuk-button--warning")
+  end
+
+  def then_i_see_the_provider_was_successfully_unassigned
+    expect(page).to have_success_banner("Provider unassigned")
   end
 
   def when_i_select_the_aes_sedai_trust

--- a/spec/system/placements/schools/placements/secondary_school_user_adds_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/secondary_school_user_adds_a_placement_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe "Secondary school user adds a placement", service: :placements, t
     then_i_see_the_when_could_the_placement_take_place_page
     and_i_see_the_term_dates
 
-    when_i_click_on_continue
+    when_i_unselect_any_time_in_the_academic_year
+    and_i_click_on_continue
     then_i_see_a_validation_error_for_selecting_a_term
 
     when_i_select_autumn_term_and_spring_term
@@ -247,6 +248,7 @@ RSpec.describe "Secondary school user adds a placement", service: :placements, t
   end
 
   def when_i_select_autumn_term_and_spring_term
+    uncheck "Any time in the academic year"
     check "Autumn term"
     check "Spring term"
   end
@@ -462,5 +464,9 @@ RSpec.describe "Secondary school user adds a placement", service: :placements, t
       "Expected date" => "Summer term",
       "Provider" => "Provider not assigned",
     })
+  end
+
+  def when_i_unselect_any_time_in_the_academic_year
+    uncheck "Any time in the academic year"
   end
 end

--- a/spec/system/placements/schools/placements/secondary_school_user_edits_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/secondary_school_user_edits_a_placement_spec.rb
@@ -71,20 +71,18 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
     then_i_see_the_placement_details_page_with_aes_sedai_trust
     and_i_see_a_provider_updated_success_message
 
-    when_i_click_on_change_provider
-    and_i_enter_ashaman_trust
-    then_i_see_a_dropdown_item_for_ashaman_trust
+    when_i_click_on_unassign_provider
+    then_i_see_the_confirmation_page
 
-    when_i_click_on_the_ashaman_trust_dropdown_item
-    and_i_click_on_continue
-    then_i_see_the_placement_details_page_with_the_ashaman_trust
-    and_i_see_a_provider_updated_success_message
+    when_i_click_on_unassign_provider
+    then_i_see_the_provider_was_successfully_unassigned
+    and_i_see_the_placement_details_page_with_jane_doe
 
     when_i_click_on_preview_this_placement
     then_i_see_the_preview_placement_page
 
     when_i_click_on_the_back_link
-    then_i_see_the_placement_details_page_with_the_ashaman_trust
+    then_i_see_the_placement_details_page_with_jane_doe
   end
 
   private
@@ -306,6 +304,8 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
     expect(page).to have_summary_list_row("Provider", "Assign a provider")
     expect(page).to have_element(:div, text: "You can preview this placement as it appears to providers.", class: "govuk-inset-text")
   end
+  alias_method :and_i_see_the_placement_details_page_with_jane_doe,
+               :then_i_see_the_placement_details_page_with_jane_doe
 
   def when_i_click_on_assign_a_provider
     click_on "Assign a provider"
@@ -380,8 +380,30 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
     expect(page).to have_success_banner("Provider updated")
   end
 
-  def when_i_click_on_change_provider
-    click_on("Change Provider")
+  def when_i_click_on_unassign_provider
+    click_on("Unassign provider")
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_title(
+      "Are you sure you want to unassign Aes Sedai Trust from this placement? - English - Manage school placements - GOV.UK",
+    )
+    expect(page).to have_element(
+      :span,
+      text: "English",
+      class: "govuk-caption-l",
+    )
+    expect(page).to have_h1(
+      "Are you sure you want to unassign Aes Sedai Trust from this placement?",
+    )
+    expect(page).to have_warning_text(
+      "An email will be sent to Aes Sedai Trust to let them know that they are no longer assigned to this placement.",
+    )
+    expect(page).to have_button("Unassign provider", class: "govuk-button--warning")
+  end
+
+  def then_i_see_the_provider_was_successfully_unassigned
+    expect(page).to have_success_banner("Provider unassigned")
   end
 
   def when_i_select_the_ashaman_trust

--- a/spec/system/placements/schools/placements/secondary_school_user_edits_a_placement_with_javascript_disabled_spec.rb
+++ b/spec/system/placements/schools/placements/secondary_school_user_edits_a_placement_with_javascript_disabled_spec.rb
@@ -80,21 +80,18 @@ RSpec.describe "Secondary school user edits a placement with javascript disabled
     then_i_see_the_placement_details_page_with_aes_sedai_trust
     and_i_see_a_provider_updated_success_message
 
-    when_i_click_on_change_provider
-    and_i_enter_ashaman_trust
-    and_i_click_on_continue
-    then_i_see_the_provider_options_page_for_ashaman_trust_search
+    when_i_click_on_unassign_provider
+    then_i_see_the_confirmation_page
 
-    when_i_select_the_ashaman_trust
-    and_i_click_on_continue
-    then_i_see_the_placement_details_page_with_the_ashaman_trust
-    and_i_see_a_provider_updated_success_message
+    when_i_click_on_unassign_provider
+    then_i_see_the_provider_was_successfully_unassigned
+    and_i_see_the_placement_details_page_with_jane_doe
 
     when_i_click_on_preview_this_placement
     then_i_see_the_preview_placement_page
 
     when_i_click_on_the_back_link
-    then_i_see_the_placement_details_page_with_the_ashaman_trust
+    then_i_see_the_placement_details_page_with_jane_doe
   end
 
   private
@@ -318,6 +315,8 @@ RSpec.describe "Secondary school user edits a placement with javascript disabled
     expect(page).to have_summary_list_row("Provider", "Assign a provider")
     expect(page).to have_element(:div, text: "You can preview this placement as it appears to providers.", class: "govuk-inset-text")
   end
+  alias_method :and_i_see_the_placement_details_page_with_jane_doe,
+               :then_i_see_the_placement_details_page_with_jane_doe
 
   def when_i_click_on_assign_a_provider
     click_on "Assign a provider"
@@ -380,8 +379,30 @@ RSpec.describe "Secondary school user edits a placement with javascript disabled
     expect(page).to have_success_banner("Provider updated")
   end
 
-  def when_i_click_on_change_provider
-    click_on("Change Provider")
+  def when_i_click_on_unassign_provider
+    click_on("Unassign provider")
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_title(
+      "Are you sure you want to unassign Aes Sedai Trust from this placement? - English - Manage school placements - GOV.UK",
+    )
+    expect(page).to have_element(
+      :span,
+      text: "English",
+      class: "govuk-caption-l",
+    )
+    expect(page).to have_h1(
+      "Are you sure you want to unassign Aes Sedai Trust from this placement?",
+    )
+    expect(page).to have_warning_text(
+      "An email will be sent to Aes Sedai Trust to let them know that they are no longer assigned to this placement.",
+    )
+    expect(page).to have_button("Unassign provider", class: "govuk-button--warning")
+  end
+
+  def then_i_see_the_provider_was_successfully_unassigned
+    expect(page).to have_success_banner("Provider unassigned")
   end
 
   def when_i_select_the_ashaman_trust

--- a/spec/system/placements/schools/placements/user_publishes_a_placement_after_preview_spec.rb
+++ b/spec/system/placements/schools/placements/user_publishes_a_placement_after_preview_spec.rb
@@ -134,6 +134,7 @@ RSpec.describe "User publishes a placement after preview", service: :placements,
   end
 
   def when_i_select_autumn_term_and_spring_term
+    uncheck "Any time in the academic year"
     check "Autumn term"
     check "Spring term"
   end

--- a/spec/system/placements/support/schools/placements/all_through_school_support_user_adds_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/all_through_school_support_user_adds_a_placement_spec.rb
@@ -52,7 +52,8 @@ RSpec.describe "All-through support school user adds a placement", service: :pla
     then_i_see_the_when_could_the_placement_take_place_page
     and_i_see_the_term_dates
 
-    when_i_click_on_continue
+    when_i_unselect_any_time_in_the_academic_year
+    and_i_click_on_continue
     then_i_see_a_validation_error_for_selecting_a_term
 
     when_i_select_autumn_term_and_spring_term
@@ -368,6 +369,7 @@ RSpec.describe "All-through support school user adds a placement", service: :pla
   end
 
   def when_i_select_autumn_term_and_spring_term
+    uncheck "Any time in the academic year"
     check "Autumn term"
     check "Spring term"
   end
@@ -602,5 +604,9 @@ RSpec.describe "All-through support school user adds a placement", service: :pla
     expect(page).to have_element(:td, text: "Jane Doe", class: "govuk-table__cell")
     expect(page).to have_element(:td, text: "Summer term", class: "govuk-table__cell")
     expect(page).to have_element(:td, text: "Provider not assigned", class: "govuk-table__cell")
+  end
+
+  def when_i_unselect_any_time_in_the_academic_year
+    uncheck "Any time in the academic year"
   end
 end

--- a/spec/system/placements/support/schools/placements/primary_school_support_user_adds_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/primary_school_support_user_adds_a_placement_spec.rb
@@ -44,7 +44,8 @@ RSpec.describe "Primary school user adds a placement", service: :placements, typ
     then_i_see_the_when_could_the_placement_take_place_page
     and_i_see_the_term_dates
 
-    when_i_click_on_continue
+    when_i_unselect_any_time_in_the_academic_year
+    and_i_click_on_continue
     then_i_see_a_validation_error_for_selecting_a_term
 
     when_i_select_autumn_term_and_spring_term
@@ -312,6 +313,7 @@ RSpec.describe "Primary school user adds a placement", service: :placements, typ
   end
 
   def when_i_select_autumn_term_and_spring_term
+    uncheck "Any time in the academic year"
     check "Autumn term"
     check "Spring term"
   end
@@ -558,5 +560,9 @@ RSpec.describe "Primary school user adds a placement", service: :placements, typ
     expect(page).to have_element(:td, text: "Jane Doe", class: "govuk-table__cell")
     expect(page).to have_element(:td, text: "Summer term", class: "govuk-table__cell")
     expect(page).to have_element(:td, text: "Provider not assigned", class: "govuk-table__cell")
+  end
+
+  def when_i_unselect_any_time_in_the_academic_year
+    uncheck "Any time in the academic year"
   end
 end

--- a/spec/system/placements/support/schools/placements/primary_school_support_user_edits_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/primary_school_support_user_edits_a_placement_spec.rb
@@ -84,20 +84,18 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
     then_i_see_the_placement_details_page_with_aes_sedai_trust
     and_i_see_a_provider_updated_success_message
 
-    when_i_click_on_change_provider
-    and_i_enter_ashaman_trust
-    then_i_see_a_dropdown_item_for_ashaman_trust
+    when_i_click_on_unassign_provider
+    then_i_see_the_confirmation_page
 
-    when_i_click_on_the_ashaman_trust_dropdown_item
-    and_i_click_on_continue
-    then_i_see_the_placement_details_page_with_the_ashaman_trust
-    and_i_see_a_provider_updated_success_message
+    when_i_click_on_unassign_provider
+    then_i_see_the_provider_was_successfully_unassigned
+    and_i_see_the_placement_details_page_with_jane_doe
 
     when_i_click_on_preview_this_placement
     then_i_see_the_preview_placement_page
 
     when_i_click_on_the_back_link
-    then_i_see_the_placement_details_page_with_the_ashaman_trust
+    then_i_see_the_placement_details_page_with_jane_doe
   end
 
   private
@@ -375,6 +373,8 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
     expect(page).to have_summary_list_row("Provider", "Assign a provider")
     expect(page).to have_element(:div, text: "You can preview this placement as it appears to providers.", class: "govuk-inset-text")
   end
+  alias_method :and_i_see_the_placement_details_page_with_jane_doe,
+               :then_i_see_the_placement_details_page_with_jane_doe
 
   def when_i_click_on_assign_a_provider
     click_on "Assign a provider"
@@ -450,8 +450,30 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
     expect(page).to have_success_banner("Provider updated")
   end
 
-  def when_i_click_on_change_provider
-    click_on("Change Provider")
+  def when_i_click_on_unassign_provider
+    click_on("Unassign provider")
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_title(
+      "Are you sure you want to unassign Aes Sedai Trust from this placement? - Primary with english (Year 2) - Manage school placements - GOV.UK",
+    )
+    expect(page).to have_element(
+      :span,
+      text: "Primary with english (Year 2)",
+      class: "govuk-caption-l",
+    )
+    expect(page).to have_h1(
+      "Are you sure you want to unassign Aes Sedai Trust from this placement?",
+    )
+    expect(page).to have_warning_text(
+      "An email will be sent to Aes Sedai Trust to let them know that they are no longer assigned to this placement.",
+    )
+    expect(page).to have_button("Unassign provider", class: "govuk-button--warning")
+  end
+
+  def then_i_see_the_provider_was_successfully_unassigned
+    expect(page).to have_success_banner("Provider unassigned")
   end
 
   def when_i_select_the_ashaman_trust

--- a/spec/system/placements/support/schools/placements/secondary_school_support_user_adds_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/secondary_school_support_user_adds_a_placement_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe "Secondary school user adds a placement", service: :placements, t
     then_i_see_the_when_could_the_placement_take_place_page
     and_i_see_the_term_dates
 
-    when_i_click_on_continue
+    when_i_unselect_any_time_in_the_academic_year
+    and_i_click_on_continue
     then_i_see_a_validation_error_for_selecting_a_term
 
     when_i_select_autumn_term_and_spring_term
@@ -257,6 +258,7 @@ RSpec.describe "Secondary school user adds a placement", service: :placements, t
   end
 
   def when_i_select_autumn_term_and_spring_term
+    uncheck "Any time in the academic year"
     check "Autumn term"
     check "Spring term"
   end
@@ -470,5 +472,9 @@ RSpec.describe "Secondary school user adds a placement", service: :placements, t
     expect(page).to have_element(:td, text: "Jane Doe", class: "govuk-table__cell")
     expect(page).to have_element(:td, text: "Summer term", class: "govuk-table__cell")
     expect(page).to have_element(:td, text: "Provider not assigned", class: "govuk-table__cell")
+  end
+
+  def when_i_unselect_any_time_in_the_academic_year
+    uncheck "Any time in the academic year"
   end
 end

--- a/spec/system/placements/support/schools/placements/secondary_school_support_user_edits_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/secondary_school_support_user_edits_a_placement_spec.rb
@@ -69,20 +69,18 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
     then_i_see_the_placement_details_page_with_aes_sedai_trust
     and_i_see_a_provider_updated_success_message
 
-    when_i_click_on_change_provider
-    and_i_enter_ashaman_trust
-    then_i_see_a_dropdown_item_for_ashaman_trust
+    when_i_click_on_unassign_provider
+    then_i_see_the_confirmation_page
 
-    when_i_click_on_the_ashaman_trust_dropdown_item
-    and_i_click_on_continue
-    then_i_see_the_placement_details_page_with_the_ashaman_trust
-    and_i_see_a_provider_updated_success_message
+    when_i_click_on_unassign_provider
+    then_i_see_the_provider_was_successfully_unassigned
+    and_i_see_the_placement_details_page_with_jane_doe
 
     when_i_click_on_preview_this_placement
     then_i_see_the_preview_placement_page
 
     when_i_click_on_the_back_link
-    then_i_see_the_placement_details_page_with_the_ashaman_trust
+    then_i_see_the_placement_details_page_with_jane_doe
   end
 
   private
@@ -297,6 +295,8 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
     expect(page).to have_summary_list_row("Provider", "Assign a provider")
     expect(page).to have_element(:div, text: "You can preview this placement as it appears to providers.", class: "govuk-inset-text")
   end
+  alias_method :and_i_see_the_placement_details_page_with_jane_doe,
+               :then_i_see_the_placement_details_page_with_jane_doe
 
   def when_i_click_on_assign_a_provider
     click_on "Assign a provider"
@@ -371,8 +371,30 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
     expect(page).to have_success_banner("Provider updated")
   end
 
-  def when_i_click_on_change_provider
-    click_on("Change Provider")
+  def when_i_click_on_unassign_provider
+    click_on("Unassign provider")
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_title(
+      "Are you sure you want to unassign Aes Sedai Trust from this placement? - English - Manage school placements - GOV.UK",
+    )
+    expect(page).to have_element(
+      :span,
+      text: "English",
+      class: "govuk-caption-l",
+    )
+    expect(page).to have_h1(
+      "Are you sure you want to unassign Aes Sedai Trust from this placement?",
+    )
+    expect(page).to have_warning_text(
+      "An email will be sent to Aes Sedai Trust to let them know that they are no longer assigned to this placement.",
+    )
+    expect(page).to have_button("Unassign provider", class: "govuk-button--warning")
+  end
+
+  def then_i_see_the_provider_was_successfully_unassigned
+    expect(page).to have_success_banner("Provider unassigned")
   end
 
   def when_i_select_the_ashaman_trust

--- a/spec/system/placements/support/schools/placements/support_user_publishes_a_placement_after_preview_spec.rb
+++ b/spec/system/placements/support/schools/placements/support_user_publishes_a_placement_after_preview_spec.rb
@@ -140,6 +140,7 @@ RSpec.describe "Support user publishes a placement after preview", service: :pla
   end
 
   def when_i_select_autumn_term_and_spring_term
+    uncheck "Any time in the academic year"
     check "Autumn term"
     check "Spring term"
   end

--- a/spec/system/placements/support/schools/placements/view_placements/support_user_views_a_placement_with_a_provider_spec.rb
+++ b/spec/system/placements/support/schools/placements/view_placements/support_user_views_a_placement_with_a_provider_spec.rb
@@ -105,6 +105,6 @@ RSpec.describe "Support user views a placement with a provider", service: :place
     expect(page).to have_link("Change Expected date")
     expect(page).to have_summary_list_row("Mentor", "Select a mentor")
     expect(page).to have_summary_list_row("Provider", "Best Practice Network")
-    expect(page).to have_link("Change Provider")
+    expect(page).to have_link("Unassign provider")
   end
 end

--- a/spec/system/placements/support/schools/placements/view_placements/support_user_views_a_placement_with_a_specific_term_spec.rb
+++ b/spec/system/placements/support/schools/placements/view_placements/support_user_views_a_placement_with_a_specific_term_spec.rb
@@ -106,6 +106,6 @@ RSpec.describe "Support user views a placement with a specific term", service: :
     expect(page).to have_link("Change Expected date")
     expect(page).to have_summary_list_row("Mentor", "Select a mentor")
     expect(page).to have_summary_list_row("Provider", "Best Practice Network")
-    expect(page).to have_link("Change Provider")
+    expect(page).to have_link("Unassign provider")
   end
 end


### PR DESCRIPTION
## Context

- School users can now remove providers from their placements.

## Changes proposed in this pull request

- Add controllers/routes/views so school users can remove providers from their placements.

## Guidance to review

- Sign in as Anne (School user)
⚠️ You will need a placement assigned to a provider ⚠️ 
- Click on the Placement assigned to a provider
- You should see a link "Unassign provider"
- Clicking "Unassign provider" will take you to a confirm page
- Clicking "Unassign provider" on the confirm page will remove the provider from the placement.

## Link to Trello card

https://trello.com/c/riEuU3Aq/588-fixes-for-expected-date-showing-date-not-added-and-unassigning-a-provider

## Screenshots

https://github.com/user-attachments/assets/95bba0b2-2669-448b-92f7-a897ebe83558


