### PR TITLE
Resolve issue with placements showing Date not added

### DIFF
--- a/app/views/placements/schools/placements/index.html.erb
+++ b/app/views/placements/schools/placements/index.html.erb
@@ -53,10 +53,7 @@
                   text: placement.mentors.present? ? placement.mentor_names : t(".mentor_not_assigned"),
                   html_attributes: { class: table_text_class(placement.mentor_names) },
                 ) %>
-                <% row.with_cell(
-                  text: placement.terms.present? ? placement.term_names : t(".date_not_added"),
-                  html_attributes: { class: (placement.terms.blank? ? "secondary-text" : "") },
-                ) %>
+                <% row.with_cell(text: placement.term_names) %>
                 <% row.with_cell(
                   text: placement.provider.present? ? placement.provider_name : t(".provider_not_assigned"),
                   html_attributes: { class: table_text_class(placement.provider_name) },

--- a/spec/system/placements/schools/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/schools/placements/view_placements_list_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Placement school user views a list of placements", service: :pla
       given_a_placement_exists_with_multiple_mentors
       given_i_am_signed_in_as_a_placements_user(organisations: [school])
       then_i_see_placement_details({
-        "Expected date" => "Date not added",
+        "Expected date" => "Any time in the academic year",
         "Mentor" => "Bart Simpson and Lisa Simpson",
         "Subject" => "Biology",
         "Provider" => "Provider not assigned",
@@ -32,7 +32,7 @@ RSpec.describe "Placement school user views a list of placements", service: :pla
       given_a_placement_exists
       given_i_am_signed_in_as_a_placements_user(organisations: [school])
       then_i_see_placement_details({
-        "Expected date" => "Date not added",
+        "Expected date" => "Any time in the academic year",
         "Mentor" => "Mentor not assigned",
         "Subject" => "Biology",
         "Provider" => "Provider not assigned",
@@ -43,7 +43,7 @@ RSpec.describe "Placement school user views a list of placements", service: :pla
       given_a_placement_exists_with_a_provider
       given_i_am_signed_in_as_a_placements_user(organisations: [school])
       then_i_see_placement_details({
-        "Expected date" => "Date not added",
+        "Expected date" => "Any time in the academic year",
         "Mentor" => "Mentor not assigned",
         "Subject" => "Biology",
         "Provider" => "Springfield University",

--- a/spec/system/placements/support/schools/placements/view_placements/support_user_views_a_placement_with_a_mentor_assigned_spec.rb
+++ b/spec/system/placements/support/schools/placements/view_placements/support_user_views_a_placement_with_a_mentor_assigned_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "Support user views a placement with a mentor assigned", service:
     expect(page).to have_table_row({
       "Subject" => "Primary with english (Year 1)",
       "Mentor" => "Jane Doe and John Smith",
-      "Expected date" => "Date not added",
+      "Expected date" => "Any time in the academic year",
       "Provider" => "Provider not assigned",
     })
   end

--- a/spec/system/placements/support/schools/placements/view_placements/support_user_views_a_placement_with_a_provider_spec.rb
+++ b/spec/system/placements/support/schools/placements/view_placements/support_user_views_a_placement_with_a_provider_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "Support user views a placement with a provider", service: :place
     expect(page).to have_table_row({
       "Subject" => "Primary with english (Year 1)",
       "Mentor" => "Mentor not assigned",
-      "Expected date" => "Date not added",
+      "Expected date" => "Any time in the academic year",
       "Provider" => "Best Practice Network",
     })
   end


### PR DESCRIPTION
## Context

- Return placements index to show "Any time in the academic year" instead of "Date not added"

## Changes proposed in this pull request

- Return placements index to show "Any time in the academic year" instead of "Date not added"

## Link to Trello card

https://trello.com/c/1biA1NVk/595-full-journey-card-template

## Screenshots

![Screenshot 2025-05-07 at 15 39 42](https://github.com/user-attachments/assets/e6a215cf-2c76-49a7-b1a5-153e9a627d4e)


