### PR TITLE
Add warning component when assigning a provider to a placement

### DIFF
--- a/app/components/autocomplete_select_form_component.html.erb
+++ b/app/components/autocomplete_select_form_component.html.erb
@@ -29,6 +29,10 @@
         </div>
       <% end %>
 
+      <% if warning_text.present? %>
+        <%= govuk_warning_text text: warning_text %>
+      <% end %>
+
       <%= f.govuk_submit t(".continue") %>
     </div>
   </div>

--- a/app/components/autocomplete_select_form_component.rb
+++ b/app/components/autocomplete_select_form_component.rb
@@ -1,11 +1,11 @@
 class AutocompleteSelectFormComponent < ApplicationComponent
-  attr_reader :model, :scope, :url, :method, :data, :input, :hint
+  attr_reader :model, :scope, :url, :method, :warning_text, :data, :input, :hint
 
   # data: { :turbo, :controller, :autocomplete_path_value,
   #         :autocomplete_return_attributes_value, :input_name }
   # input: { :field_name, :value, :label, :hint, :caption, :previous_search }
 
-  def initialize(model:, scope:, url:, method: :get, data: {},
+  def initialize(model:, scope:, url:, method: :get, warning_text: nil, data: {},
                  input: {}, classes: [], html_attributes: {})
     super(classes:, html_attributes:)
 
@@ -13,6 +13,7 @@ class AutocompleteSelectFormComponent < ApplicationComponent
     @scope = scope
     @url = url
     @method = method
+    @warning_text = warning_text
     @data = data
     @input = input
 

--- a/app/views/wizards/placements/edit_placement_wizard/_provider_step.html.erb
+++ b/app/views/wizards/placements/edit_placement_wizard/_provider_step.html.erb
@@ -8,6 +8,7 @@
   scope: current_step.scope,
   url: current_step_path,
   method: :put,
+  warning_text: t(".not_contractual_agreement"),
   data: {
     autocomplete_path_value: current_step.autocomplete_path_value,
     autocomplete_return_attributes_value: current_step.autocomplete_return_attributes_value,

--- a/config/locales/en/wizards/placements/edit_placement_wizard.yml
+++ b/config/locales/en/wizards/placements/edit_placement_wizard.yml
@@ -10,7 +10,7 @@ en:
           help_with_providers: My provider is not listed
           you_need_to_add_a_provider: You must %{link} before they can be assigned to a specific placement.
           add_a_provider: add providers to your school's profile
+          not_contractual_agreement: Assigning a provider is not a contractual agreement for the provider to place a trainee at your school. You must liaise with this provider to arrange the placement.
         provider_options_step:
           title: "%{organisation_count} results found for ‘%{search_param}’ - %{contextual_text}"
           continue: Continue
-

--- a/spec/components/autocomplete_select_form_component_spec.rb
+++ b/spec/components/autocomplete_select_form_component_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe AutocompleteSelectFormComponent, type: :component do
       url:,
       data:,
       input:,
+      warning_text:,
     )
   end
 
@@ -16,6 +17,7 @@ RSpec.describe AutocompleteSelectFormComponent, type: :component do
     let(:scope) { :form }
     let(:url) { "" }
     let(:input) { {} }
+    let(:warning_text) { nil }
 
     describe "data attribute validation" do
       context "when not given a autocomplete_path_value attribute" do
@@ -79,6 +81,7 @@ RSpec.describe AutocompleteSelectFormComponent, type: :component do
         previous_search: nil,
       }
     end
+    let(:warning_text) { nil }
 
     it "returns an autocomplete select form for onboarding schools" do
       render_inline(component)
@@ -92,6 +95,37 @@ RSpec.describe AutocompleteSelectFormComponent, type: :component do
       expect(page.find(".govuk-caption-l")).to have_content("Add organisation")
       expect(page).to have_field("school-id-field")
       page.find("div[data-input-name='school[name]']")
+    end
+  end
+
+  context "with warning text" do
+    let(:model) { instance_double(BaseStep, errors: {}) }
+    let(:scope) { :school }
+    let(:url) { "" }
+    let(:data) do
+      {
+        turbo: false,
+        controller: "autocomplete",
+        autocomplete_path_value: "/api/school_suggestions",
+        autocomplete_return_attributes_value: %w[town postcode],
+        input_name: "school[name]",
+      }
+    end
+    let(:input) do
+      {
+        field_name: :id,
+        value: nil,
+        label: "Enter a school name, URN or postcode",
+        caption: "Add organisation",
+        previous_search: nil,
+      }
+    end
+    let(:warning_text) { "This is a warning" }
+
+    it "displays the warning text" do
+      render_inline(component)
+
+      expect(page).to have_content(warning_text)
     end
   end
 end


### PR DESCRIPTION
## Context

As part of the content sweep it was identiifed that we should clarify what adding a provider means for users.

## Changes proposed in this pull request

- Adds an optional warning component to the autocomplete component.

## Guidance to review

- Log in as Anne
- Add a placement
- Assign a provider to the placement
- Confirm the warning component is visible

## Link to Trello card

[Sweep: Change warning component on 'select a provider' screen
](https://trello.com/c/0NUJSkuj/585-sweep-change-warning-component-on-select-a-provider-screen)
## Screenshots

![image](https://github.com/user-attachments/assets/c8b1d7db-74eb-48b5-b52d-e027de9f22ba)
