### PR TITLE
Update red path content

### DIFF
--- a/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_not_open.html.erb
+++ b/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_not_open.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_panel(
-  title_text: t(".panel_title_html"),
+  title_text: t(".panel_title"),
   text: t(".panel_text"),
 ) %>
 

--- a/app/views/wizards/placements/add_hosting_interest_wizard/_are_you_sure_step.html.erb
+++ b/app/views/wizards/placements/add_hosting_interest_wizard/_are_you_sure_step.html.erb
@@ -11,8 +11,8 @@
       <span class="govuk-caption-l"><%= t(".caption") %></span>
       <h1 class="govuk-heading-l"><%= t(".title") %></h1>
 
-      <p class="govuk-body"><%= t(".your_contact_details") %></p>
       <p class="govuk-body"><%= t(".we_will_ask_you_again") %></p>
+      <p class="govuk-body"><%= t(".your_contact_details") %></p>
       <p class="govuk-body"><%= t(".your_reason") %></p>
 
       <h2 class="govuk-heading-m"><%= t(".details") %></h2>

--- a/app/views/wizards/placements/add_hosting_interest_wizard/not_open/_school_contact_step.html.erb
+++ b/app/views/wizards/placements/add_hosting_interest_wizard/not_open/_school_contact_step.html.erb
@@ -10,7 +10,8 @@
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l"><%= t(".caption") %></span>
       <h1 class="govuk-heading-l"><%= t(".title") %></h1>
-      <p class="govuk-body secondary-text"><%= t(".description") %></p>
+      <p class="govuk-body secondary-text"><%= t(".we_will_ask_next_year") %></p>
+      <p class="govuk-body secondary-text"><%= t(".choose_the_best_person") %></p>
 
       <div class="govuk-form-group">
         <%= f.govuk_text_field :first_name,

--- a/app/wizards/placements/add_hosting_interest_wizard/reason_not_hosting_step.rb
+++ b/app/wizards/placements/add_hosting_interest_wizard/reason_not_hosting_step.rb
@@ -29,7 +29,6 @@ class Placements::AddHostingInterestWizard::ReasonNotHostingStep < BaseStep
   def reasons
     [
       I18n.t("#{locale_path}.options.concerns_about_trainee_quality"),
-      I18n.t("#{locale_path}.options.do_not_get_offered_trainees"),
       I18n.t("#{locale_path}.options.not_enough_trained_mentors"),
       I18n.t("#{locale_path}.options.number_of_pupils_with_send_needs"),
       I18n.t("#{locale_path}.options.low_capacity_to_support_trainees"),

--- a/config/locales/en/placements/schools/hosting_interests.yml
+++ b/config/locales/en/placements/schools/hosting_interests.yml
@@ -12,7 +12,7 @@ en:
             heading: 
               actively_looking: Placement information uploaded
               not_open: Your profile has been updated
-              interested: Your status has been updated to ‘interesed in hosting placements’
+              interested: Your status has been updated to ‘interested in hosting placements’
             body:
               actively_looking_html:
                 Providers can see your placement preferences and may contact you to discuss them.<br><br>

--- a/config/locales/en/placements/schools/hosting_interests.yml
+++ b/config/locales/en/placements/schools/hosting_interests.yml
@@ -27,11 +27,11 @@ en:
             what_happens_next: What happens next?
             teaching_school_hub_url: https://www.gov.uk/guidance/teaching-school-hubs
             not_open:
-              panel_title_html: Confirmed.</br>You are not offering placements
+              panel_title: You are not offering placements this year
               panel_text: Your contact details will not be shown to providers
               what_happens_next: What happens next?
-              we_will_ask_you_again: 
-                We will ask you again in the spring term of the next year to check whether you would like to offer placements.
+              we_will_ask_you_again:
+                We will ask in the next academic year whether you are able to offer placements for trainee teachers.
               if_you_would_like_to_host_placements:
                 If you would like to host placements this year, %{link} to let providers know you’re interested.
               update_your_placement_preferences: update your placement preferences

--- a/config/locales/en/wizards/placements/add_hosting_interest_wizard.yml
+++ b/config/locales/en/wizards/placements/add_hosting_interest_wizard.yml
@@ -26,13 +26,12 @@ en:
           continue: Continue
         reason_not_hosting_step:
           caption: Not offering placements this year
-          title: Tell us why you aren’t able to host this year
-          hint: 
-            Your answers will help Department for Education better understand how to improve managing ITT.
+          title: Tell us why you are not able to offer placements for trainee teachers
+          hint:
+            Your answers will be shared with Department for Education to help understand teacher training and recruitment.
           continue: Continue
           options:
-            concerns_about_trainee_quality: Concerns about trainee quality
-            do_not_get_offered_trainees: Not offered appropriate trainees
+            concerns_about_trainee_quality: Trainees we were offered did not meet our expectations
             do_not_know_how_to_get_involved: Unsure how to get involved
             not_enough_trained_mentors: No mentors available due to capacity
             number_of_pupils_with_send_needs: High number of pupils with SEND needs
@@ -67,14 +66,13 @@ en:
         are_you_sure_step:
           title: Confirm and let providers know you are not offering placements
           caption: Not offering placements this year
-          your_contact_details: Your contact details and reason will not be shared with providers.
-          we_will_ask_you_again: 
-            We will ask you again in the spring term of the next year to check whether you would like to offer placements.
+          your_contact_details: No information will be shared with providers.
+          we_will_ask_you_again: We will ask in the next academic year whether you are able to offer placements for trainee teachers.
           your_reason:
-            Your reason for not offering placements be shared with the Department for Education for reporting purposes.
+            Your reason for not offering placements be shared with the Department for Education to help understand teacher training and recruitment.
           reason_for_not_offering: Reason for not offering
           details: Details
-          itt_contact: ITT contact
+          itt_contact: Contact details
           continue: Continue
           change: Change
         confirm_step:
@@ -165,5 +163,6 @@ en:
           school_contact_step:
             caption: Not offering placements this year
             title: Who is the preferred contact for next year?
-            description: We will ask in the next academic year about placements. The contact may be you, or someone at your school who coordinates ITT.
+            we_will_ask_next_year: We will ask in the next academic year whether you are able to offer placements for trainee teachers.
+            choose_the_best_person: Choose the person best placed to organise placements for trainee teachers at your school.
             continue: Continue

--- a/config/locales/en/wizards/placements/add_hosting_interest_wizard.yml
+++ b/config/locales/en/wizards/placements/add_hosting_interest_wizard.yml
@@ -132,7 +132,7 @@ en:
             caption: Potential secondary placement details
             hint: 
               Subjects are taken from the DfE database of courses. If the subject you would like to host is not here, choose the closest option.
-            sharing_info: 
+            sharing_info:
               Sharing information on what you may be able to offer helps providers know whether to contact you. It is not a commitment to take a trainee teacher.
             stem_subjects: Science, technology, engineering and mathematics (STEM)
             lit_lang_subjects: Languages and literature

--- a/config/locales/en/wizards/placements/multi_placement_wizard.yml
+++ b/config/locales/en/wizards/placements/multi_placement_wizard.yml
@@ -10,12 +10,12 @@ en:
           continue: Continue
           hint: "Select all that apply"
           options:
-            concerns_about_trainee_quality: Concerns about trainee quality
-            do_not_get_offered_trainees: Don't get offered trainees
-            do_not_know_how_to_get_involved: Don't know how to get involved
-            not_enough_trained_mentors: Not enough trained mentors
-            number_of_pupils_with_send_needs: Number of pupils with SEND needs
+            concerns_about_trainee_quality: Trainees we were offered did not meet our expectations
+            do_not_know_how_to_get_involved: Unsure how to get involved
+            not_enough_trained_mentors: No mentors available due to capacity
+            number_of_pupils_with_send_needs: High number of pupils with SEND needs
             working_to_improve_our_ofsted_rating: Working to improve our OFSTED rating
+            low_capacity_to_support_trainees: Low capacity to support trainees due to staff changes
             other: Other
           tell_us: Tell us your reason
         help_step:

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe "School user completes the interested journey and declares primar
 
   def then_i_see_my_responses_with_successfully_updated
     expect(page).to have_success_banner(
-      "Your status has been updated to ‘interesed in hosting placements’",
+      "Your status has been updated to ‘interested in hosting placements’",
       "This means providers can see that you’re looking to host placements.",
     )
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_child_subjects_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_child_subjects_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe "School user completes the interested journey without declaring c
 
   def then_i_see_my_responses_with_successfully_updated
     expect(page).to have_success_banner(
-      "Your status has been updated to ‘interesed in hosting placements’",
+      "Your status has been updated to ‘interested in hosting placements’",
       "This means providers can see that you’re looking to host placements.",
     )
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_potential_placement_details_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe "School user completes the interested journey without declaring p
 
   def then_i_see_my_responses_with_successfully_updated
     expect(page).to have_success_banner(
-      "Your status has been updated to ‘interesed in hosting placements’",
+      "Your status has been updated to ‘interested in hosting placements’",
       "This means providers can see that you’re looking to host placements.",
     )
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_quantities_for_potential_placements_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_quantities_for_potential_placements_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe "School user completes the interested journey without declaring q
 
   def then_i_see_my_responses_with_successfully_updated
     expect(page).to have_success_banner(
-      "Your status has been updated to ‘interesed in hosting placements’",
+      "Your status has been updated to ‘interested in hosting placements’",
       "This means providers can see that you’re looking to host placements.",
     )
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_specific_year_groups_or_subjects_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_specific_year_groups_or_subjects_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe "School user completes the interested journey without declaring s
 
   def then_i_see_my_responses_with_successfully_updated
     expect(page).to have_success_banner(
-      "Your status has been updated to ‘interesed in hosting placements’",
+      "Your status has been updated to ‘interested in hosting placements’",
       "This means providers can see that you’re looking to host placements.",
     )
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_does_not_enter_a_reason_when_selecting_other_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_does_not_enter_a_reason_when_selecting_other_spec.rb
@@ -64,19 +64,18 @@ RSpec.describe "School user does not select any reasons not to host",
 
   def then_i_see_the_reasons_for_not_hosting_form
     expect(page).to have_title(
-      "Tell us why you aren’t able to host this year - Manage school placements - GOV.UK",
+      "Tell us why you are not able to offer placements for trainee teachers - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Tell us why you aren’t able to host this year",
+      text: "Tell us why you are not able to offer placements for trainee teachers",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Concerns about trainee quality", type: :checkbox)
+    expect(page).to have_field("Trainees we were offered did not meet our expectations", type: :checkbox)
     expect(page).to have_field("High number of pupils with SEND needs", type: :checkbox)
     expect(page).to have_field("Low capacity to support trainees due to staff changes", type: :checkbox)
     expect(page).to have_field("No mentors available due to capacity", type: :checkbox)
-    expect(page).to have_field("Not offered appropriate trainees", type: :checkbox)
     expect(page).to have_field("Unsure how to get involved", type: :checkbox)
     expect(page).to have_field("Working to improve our OFSTED rating", type: :checkbox)
     expect(page).to have_field("Other", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_does_not_enter_any_school_contact_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_does_not_enter_any_school_contact_details_spec.rb
@@ -68,19 +68,18 @@ RSpec.describe "School user does not enter any school contact details",
 
   def then_i_see_the_reasons_for_not_hosting_form
     expect(page).to have_title(
-      "Tell us why you aren’t able to host this year - Manage school placements - GOV.UK",
+      "Tell us why you are not able to offer placements for trainee teachers - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Tell us why you aren’t able to host this year",
+      text: "Tell us why you are not able to offer placements for trainee teachers",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Concerns about trainee quality", type: :checkbox)
+    expect(page).to have_field("Trainees we were offered did not meet our expectations", type: :checkbox)
     expect(page).to have_field("High number of pupils with SEND needs", type: :checkbox)
     expect(page).to have_field("Low capacity to support trainees due to staff changes", type: :checkbox)
     expect(page).to have_field("No mentors available due to capacity", type: :checkbox)
-    expect(page).to have_field("Not offered appropriate trainees", type: :checkbox)
     expect(page).to have_field("Unsure how to get involved", type: :checkbox)
     expect(page).to have_field("Working to improve our OFSTED rating", type: :checkbox)
     expect(page).to have_field("Other", type: :checkbox)
@@ -102,8 +101,12 @@ RSpec.describe "School user does not enter any school contact details",
     expect(page).to have_h1("Who is the preferred contact for next year?")
     expect(page).to have_element(
       :p,
-      text: "We will ask in the next academic year about placements. " \
-        "The contact may be you, or someone at your school who coordinates ITT.",
+      text: "We will ask in the next academic year whether you are able to offer placements for trainee teachers.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "Choose the person best placed to organise placements for trainee teachers at your school.",
       class: "govuk-body",
     )
 

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_does_not_select_any_reasons_not_to_host_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_does_not_select_any_reasons_not_to_host_spec.rb
@@ -63,19 +63,18 @@ RSpec.describe "School user does not select any reasons not to host",
 
   def then_i_see_the_reasons_for_not_hosting_form
     expect(page).to have_title(
-      "Tell us why you aren’t able to host this year - Manage school placements - GOV.UK",
+      "Tell us why you are not able to offer placements for trainee teachers - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Tell us why you aren’t able to host this year",
+      text: "Tell us why you are not able to offer placements for trainee teachers",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Concerns about trainee quality", type: :checkbox)
+    expect(page).to have_field("Trainees we were offered did not meet our expectations", type: :checkbox)
     expect(page).to have_field("High number of pupils with SEND needs", type: :checkbox)
     expect(page).to have_field("Low capacity to support trainees due to staff changes", type: :checkbox)
     expect(page).to have_field("No mentors available due to capacity", type: :checkbox)
-    expect(page).to have_field("Not offered appropriate trainees", type: :checkbox)
     expect(page).to have_field("Unsure how to get involved", type: :checkbox)
     expect(page).to have_field("Working to improve our OFSTED rating", type: :checkbox)
     expect(page).to have_field("Other", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_enters_another_reason_why_they_are_not_hosting_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_enters_another_reason_why_they_are_not_hosting_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "School user enters another reason why they are not hosting",
 
   def then_i_see_the_reasons_for_not_hosting_form
     expect(page).to have_title(
-      "Tell us why you aren’t able to host this year - Manage school placements - GOV.UK",
+      "Tell us why you are not able to offer placements for trainee teachers - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
@@ -87,14 +87,13 @@ RSpec.describe "School user enters another reason why they are not hosting",
     )
     expect(page).to have_element(
       :legend,
-      text: "Tell us why you aren’t able to host this year",
+      text: "Tell us why you are not able to offer placements for trainee teachers",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Concerns about trainee quality", type: :checkbox)
+    expect(page).to have_field("Trainees we were offered did not meet our expectations", type: :checkbox)
     expect(page).to have_field("High number of pupils with SEND needs", type: :checkbox)
     expect(page).to have_field("Low capacity to support trainees due to staff changes", type: :checkbox)
     expect(page).to have_field("No mentors available due to capacity", type: :checkbox)
-    expect(page).to have_field("Not offered appropriate trainees", type: :checkbox)
     expect(page).to have_field("Unsure how to get involved", type: :checkbox)
     expect(page).to have_field("Working to improve our OFSTED rating", type: :checkbox)
     expect(page).to have_field("Other", type: :checkbox)
@@ -117,8 +116,12 @@ RSpec.describe "School user enters another reason why they are not hosting",
     expect(page).to have_h1("Who is the preferred contact for next year?")
     expect(page).to have_element(
       :p,
-      text: "We will ask in the next academic year about placements. " \
-        "The contact may be you, or someone at your school who coordinates ITT.",
+      text: "We will ask in the next academic year whether you are able to offer placements for trainee teachers.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "Choose the person best placed to organise placements for trainee teachers at your school.",
       class: "govuk-body",
     )
 
@@ -140,8 +143,12 @@ RSpec.describe "School user enters another reason why they are not hosting",
     expect(page).to have_h1("Who is the preferred contact for next year?")
     expect(page).to have_element(
       :p,
-      text: "We will ask in the next academic year about placements. " \
-        "The contact may be you, or someone at your school who coordinates ITT.",
+      text: "We will ask in the next academic year whether you are able to offer placements for trainee teachers.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "Choose the person best placed to organise placements for trainee teachers at your school.",
       class: "govuk-body",
     )
 
@@ -198,17 +205,17 @@ RSpec.describe "School user enters another reason why they are not hosting",
     expect(page).to have_h1("Confirm and let providers know you are not offering placements")
     expect(page).to have_element(
       :p,
-      text: "Your contact details and reason will not be shared with providers.",
+      text: "We will ask in the next academic year whether you are able to offer placements for trainee teachers.",
       class: "govuk-body",
     )
     expect(page).to have_element(
       :p,
-      text: "We will ask you again in the spring term of the next year to check whether you would like to offer placements.",
+      text: "No information will be shared with providers.",
       class: "govuk-body",
     )
     expect(page).to have_element(
       :p,
-      text: "Your reason for not offering placements be shared with the Department for Education for reporting purposes.",
+      text: "Your reason for not offering placements be shared with the Department for Education to help understand teacher training and recruitment.",
       class: "govuk-body",
     )
   end
@@ -221,7 +228,7 @@ RSpec.describe "School user enters another reason why they are not hosting",
   end
 
   def and_i_see_the_entered_school_contact_details
-    expect(page).to have_h2("ITT contact", class: "govuk-heading-m")
+    expect(page).to have_h2("Contact details", class: "govuk-heading-m")
     expect(page).to have_summary_list_row("First name", "Joe")
     expect(page).to have_summary_list_row("Last name", "Bloggs")
     expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")
@@ -233,13 +240,13 @@ RSpec.describe "School user enters another reason why they are not hosting",
 
   def and_i_see_the_whats_next_page
     expect(page).to have_panel(
-      "Confirmed.You are not offering placements",
+      "You are not offering placements this year",
       "Your contact details will not be shown to providers",
     )
     expect(page).to have_h1("What happens next?", class: "govuk-heading-l")
     expect(page).to have_element(
       :p,
-      text: "We will ask you again in the spring term of the next year to check whether you would like to offer placements.",
+      text: "We will ask in the next academic year whether you are able to offer placements for trainee teachers.",
       class: "govuk-body",
     )
     expect(page).to have_element(

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_successfully_completes_the_not_open_journey_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_successfully_completes_the_not_open_journey_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe "School user successfully completes the not open journey",
 
   def then_i_see_the_reasons_for_not_hosting_form
     expect(page).to have_title(
-      "Tell us why you aren’t able to host this year - Manage school placements - GOV.UK",
+      "Tell us why you are not able to offer placements for trainee teachers - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
@@ -109,14 +109,13 @@ RSpec.describe "School user successfully completes the not open journey",
     )
     expect(page).to have_element(
       :legend,
-      text: "Tell us why you aren’t able to host this year",
+      text: "Tell us why you are not able to offer placements for trainee teachers",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Concerns about trainee quality", type: :checkbox)
+    expect(page).to have_field("Trainees we were offered did not meet our expectations", type: :checkbox)
     expect(page).to have_field("High number of pupils with SEND needs", type: :checkbox)
     expect(page).to have_field("Low capacity to support trainees due to staff changes", type: :checkbox)
     expect(page).to have_field("No mentors available due to capacity", type: :checkbox)
-    expect(page).to have_field("Not offered appropriate trainees", type: :checkbox)
     expect(page).to have_field("Unsure how to get involved", type: :checkbox)
     expect(page).to have_field("Working to improve our OFSTED rating", type: :checkbox)
     expect(page).to have_field("Other", type: :checkbox)
@@ -143,8 +142,12 @@ RSpec.describe "School user successfully completes the not open journey",
     expect(page).to have_h1("Who is the preferred contact for next year?")
     expect(page).to have_element(
       :p,
-      text: "We will ask in the next academic year about placements. " \
-        "The contact may be you, or someone at your school who coordinates ITT.",
+      text: "We will ask in the next academic year whether you are able to offer placements for trainee teachers.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "Choose the person best placed to organise placements for trainee teachers at your school.",
       class: "govuk-body",
     )
 
@@ -166,8 +169,12 @@ RSpec.describe "School user successfully completes the not open journey",
     expect(page).to have_h1("Who is the preferred contact for next year?")
     expect(page).to have_element(
       :p,
-      text: "We will ask in the next academic year about placements. " \
-        "The contact may be you, or someone at your school who coordinates ITT.",
+      text: "We will ask in the next academic year whether you are able to offer placements for trainee teachers.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "Choose the person best placed to organise placements for trainee teachers at your school.",
       class: "govuk-body",
     )
     expect(page).to have_field("First name", with: "Joe")
@@ -225,30 +232,30 @@ RSpec.describe "School user successfully completes the not open journey",
     expect(page).to have_h1("Confirm and let providers know you are not offering placements")
     expect(page).to have_element(
       :p,
-      text: "Your contact details and reason will not be shared with providers.",
+      text: "We will ask in the next academic year whether you are able to offer placements for trainee teachers.",
       class: "govuk-body",
     )
     expect(page).to have_element(
       :p,
-      text: "We will ask you again in the spring term of the next year to check whether you would like to offer placements.",
+      text: "No information will be shared with providers.",
       class: "govuk-body",
     )
     expect(page).to have_element(
       :p,
-      text: "Your reason for not offering placements be shared with the Department for Education for reporting purposes.",
+      text: "Your reason for not offering placements be shared with the Department for Education to help understand teacher training and recruitment.",
       class: "govuk-body",
     )
   end
 
   def and_i_see_the_whats_next_page
     expect(page).to have_panel(
-      "Confirmed.You are not offering placements",
+      "You are not offering placements this year",
       "Your contact details will not be shown to providers",
     )
     expect(page).to have_h1("What happens next?", class: "govuk-heading-l")
     expect(page).to have_element(
       :p,
-      text: "We will ask you again in the spring term of the next year to check whether you would like to offer placements.",
+      text: "We will ask in the next academic year whether you are able to offer placements for trainee teachers.",
       class: "govuk-body",
     )
     expect(page).to have_element(
@@ -267,7 +274,7 @@ RSpec.describe "School user successfully completes the not open journey",
   end
 
   def and_i_see_the_entered_school_contact_details
-    expect(page).to have_h2("ITT contact", class: "govuk-heading-m")
+    expect(page).to have_h2("Contact details", class: "govuk-heading-m")
     expect(page).to have_summary_list_row("First name", "Joe")
     expect(page).to have_summary_list_row("Last name", "Bloggs")
     expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe "School user completes the interested journey without declaring p
 
   def then_i_see_my_responses_with_successfully_updated
     expect(page).to have_success_banner(
-      "Your status has been updated to ‘interesed in hosting placements’",
+      "Your status has been updated to ‘interested in hosting placements’",
       "This means providers can see that you’re looking to host placements.",
     )
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_interested/school_user_completes_the_interested_journey_without_declaring_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_interested/school_user_completes_the_interested_journey_without_declaring_potential_placement_details_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe "School user completes the interested journey without declaring p
 
   def then_i_see_my_responses_with_successfully_updated
     expect(page).to have_success_banner(
-      "Your status has been updated to ‘interesed in hosting placements’",
+      "Your status has been updated to ‘interested in hosting placements’",
       "This means providers can see that you’re looking to host placements.",
     )
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_does_not_enter_a_reason_when_selecting_other_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_does_not_enter_a_reason_when_selecting_other_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe "School user does not select any reasons not to host",
 
   def then_i_see_the_reasons_for_not_hosting_form
     expect(page).to have_title(
-      "Tell us why you aren’t able to host this year - Manage school placements - GOV.UK",
+      "Tell us why you are not able to offer placements for trainee teachers - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
@@ -113,14 +113,13 @@ RSpec.describe "School user does not select any reasons not to host",
     )
     expect(page).to have_element(
       :legend,
-      text: "Tell us why you aren’t able to host this year",
+      text: "Tell us why you are not able to offer placements for trainee teachers",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Concerns about trainee quality", type: :checkbox)
+    expect(page).to have_field("Trainees we were offered did not meet our expectations", type: :checkbox)
     expect(page).to have_field("High number of pupils with SEND needs", type: :checkbox)
     expect(page).to have_field("Low capacity to support trainees due to staff changes", type: :checkbox)
     expect(page).to have_field("No mentors available due to capacity", type: :checkbox)
-    expect(page).to have_field("Not offered appropriate trainees", type: :checkbox)
     expect(page).to have_field("Unsure how to get involved", type: :checkbox)
     expect(page).to have_field("Working to improve our OFSTED rating", type: :checkbox)
     expect(page).to have_field("Other", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_does_not_select_any_reasons_not_to_host_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_does_not_select_any_reasons_not_to_host_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "School user does not select any reasons not to host",
 
   def then_i_see_the_reasons_for_not_hosting_form
     expect(page).to have_title(
-      "Tell us why you aren’t able to host this year - Manage school placements - GOV.UK",
+      "Tell us why you are not able to offer placements for trainee teachers - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
@@ -112,14 +112,13 @@ RSpec.describe "School user does not select any reasons not to host",
     )
     expect(page).to have_element(
       :legend,
-      text: "Tell us why you aren’t able to host this year",
+      text: "Tell us why you are not able to offer placements for trainee teachers",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Concerns about trainee quality", type: :checkbox)
     expect(page).to have_field("High number of pupils with SEND needs", type: :checkbox)
     expect(page).to have_field("Low capacity to support trainees due to staff changes", type: :checkbox)
     expect(page).to have_field("No mentors available due to capacity", type: :checkbox)
-    expect(page).to have_field("Not offered appropriate trainees", type: :checkbox)
+    expect(page).to have_field("Trainees we were offered did not meet our expectations", type: :checkbox)
     expect(page).to have_field("Unsure how to get involved", type: :checkbox)
     expect(page).to have_field("Working to improve our OFSTED rating", type: :checkbox)
     expect(page).to have_field("Other", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_enters_another_reason_why_they_are_not_hosting_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_enters_another_reason_why_they_are_not_hosting_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "School user enters another reason why they are not hosting",
 
   def then_i_see_the_reasons_for_not_hosting_form
     expect(page).to have_title(
-      "Tell us why you aren’t able to host this year - Manage school placements - GOV.UK",
+      "Tell us why you are not able to offer placements for trainee teachers - Manage school placements - GOV.UK",
     )
     expect(page).to have_current_item("Organisation details")
     expect(page).to have_element(
@@ -120,14 +120,14 @@ RSpec.describe "School user enters another reason why they are not hosting",
     )
     expect(page).to have_element(
       :legend,
-      text: "Tell us why you aren’t able to host this year",
+      text: "Tell us why you are not able to offer placements for trainee teachers",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Concerns about trainee quality", type: :checkbox)
+    expect(page).to have_element(:div, text: "Your answers will be shared with Department for Education to help understand teacher training and recruitment.", class: "govuk-hint")
+    expect(page).to have_field("Trainees we were offered did not meet our expectations", type: :checkbox)
     expect(page).to have_field("High number of pupils with SEND needs", type: :checkbox)
     expect(page).to have_field("Low capacity to support trainees due to staff changes", type: :checkbox)
     expect(page).to have_field("No mentors available due to capacity", type: :checkbox)
-    expect(page).to have_field("Not offered appropriate trainees", type: :checkbox)
     expect(page).to have_field("Unsure how to get involved", type: :checkbox)
     expect(page).to have_field("Working to improve our OFSTED rating", type: :checkbox)
     expect(page).to have_field("Other", type: :checkbox)
@@ -224,17 +224,17 @@ RSpec.describe "School user enters another reason why they are not hosting",
     expect(page).to have_h1("Confirm and let providers know you are not offering placements")
     expect(page).to have_element(
       :p,
-      text: "Your contact details and reason will not be shared with providers.",
+      text: "Your reason for not offering placements be shared with the Department for Education to help understand teacher training and recruitment.",
       class: "govuk-body",
     )
     expect(page).to have_element(
       :p,
-      text: "We will ask you again in the spring term of the next year to check whether you would like to offer placements.",
+      text: "No information will be shared with providers.",
       class: "govuk-body",
     )
     expect(page).to have_element(
       :p,
-      text: "Your reason for not offering placements be shared with the Department for Education for reporting purposes.",
+      text: "Your reason for not offering placements be shared with the Department for Education to help understand teacher training and recruitment.",
       class: "govuk-body",
     )
   end
@@ -252,13 +252,13 @@ RSpec.describe "School user enters another reason why they are not hosting",
 
   def and_i_see_the_whats_next_page
     expect(page).to have_panel(
-      "Confirmed.You are not offering placements",
+      "You are not offering placements this year",
       "Your contact details will not be shown to providers",
     )
     expect(page).to have_h1("What happens next?", class: "govuk-heading-l")
     expect(page).to have_element(
       :p,
-      text: "We will ask you again in the spring term of the next year to check whether you would like to offer placements.",
+      text: "We will ask in the next academic year whether you are able to offer placements for trainee teachers.",
       class: "govuk-body",
     )
     expect(page).to have_element(

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_successfully_completes_the_not_open_journey_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_successfully_completes_the_not_open_journey_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe "School user successfully completes the not open journey",
 
   def then_i_see_the_reasons_for_not_hosting_form
     expect(page).to have_title(
-      "Tell us why you aren’t able to host this year - Manage school placements - GOV.UK",
+      "Tell us why you are not able to offer placements for trainee teachers - Manage school placements - GOV.UK",
     )
     expect(page).to have_current_item("Organisation details")
     expect(page).to have_element(
@@ -135,14 +135,13 @@ RSpec.describe "School user successfully completes the not open journey",
     )
     expect(page).to have_element(
       :legend,
-      text: "Tell us why you aren’t able to host this year",
+      text: "Tell us why you are not able to offer placements for trainee teachers",
       class: "govuk-fieldset__legend",
     )
-    expect(page).to have_field("Concerns about trainee quality", type: :checkbox)
+    expect(page).to have_field("Trainees we were offered did not meet our expectations", type: :checkbox)
     expect(page).to have_field("High number of pupils with SEND needs", type: :checkbox)
     expect(page).to have_field("Low capacity to support trainees due to staff changes", type: :checkbox)
     expect(page).to have_field("No mentors available due to capacity", type: :checkbox)
-    expect(page).to have_field("Not offered appropriate trainees", type: :checkbox)
     expect(page).to have_field("Unsure how to get involved", type: :checkbox)
     expect(page).to have_field("Working to improve our OFSTED rating", type: :checkbox)
     expect(page).to have_field("Other", type: :checkbox)
@@ -169,8 +168,12 @@ RSpec.describe "School user successfully completes the not open journey",
     expect(page).to have_h1("Who is the preferred contact for next year?")
     expect(page).to have_element(
       :p,
-      text: "We will ask in the next academic year about placements. " \
-        "The contact may be you, or someone at your school who coordinates ITT.",
+      text: "We will ask in the next academic year whether you are able to offer placements for trainee teachers.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "Choose the person best placed to organise placements for trainee teachers at your school.",
       class: "govuk-body",
     )
 
@@ -192,8 +195,12 @@ RSpec.describe "School user successfully completes the not open journey",
     expect(page).to have_h1("Who is the preferred contact for next year?")
     expect(page).to have_element(
       :p,
-      text: "We will ask in the next academic year about placements. " \
-        "The contact may be you, or someone at your school who coordinates ITT.",
+      text: "We will ask in the next academic year whether you are able to offer placements for trainee teachers.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "Choose the person best placed to organise placements for trainee teachers at your school.",
       class: "govuk-body",
     )
     expect(page).to have_field("First name", with: "Joe")
@@ -251,30 +258,30 @@ RSpec.describe "School user successfully completes the not open journey",
     expect(page).to have_h1("Confirm and let providers know you are not offering placements")
     expect(page).to have_element(
       :p,
-      text: "Your contact details and reason will not be shared with providers.",
+      text: "We will ask in the next academic year whether you are able to offer placements for trainee teachers.",
       class: "govuk-body",
     )
     expect(page).to have_element(
       :p,
-      text: "We will ask you again in the spring term of the next year to check whether you would like to offer placements.",
+      text: "No information will be shared with providers.",
       class: "govuk-body",
     )
     expect(page).to have_element(
       :p,
-      text: "Your reason for not offering placements be shared with the Department for Education for reporting purposes.",
+      text: "Your reason for not offering placements be shared with the Department for Education to help understand teacher training and recruitment.",
       class: "govuk-body",
     )
   end
 
   def and_i_see_the_whats_next_page
     expect(page).to have_panel(
-      "Confirmed.You are not offering placements",
+      "You are not offering placements this year",
       "Your contact details will not be shown to providers",
     )
     expect(page).to have_h1("What happens next?", class: "govuk-heading-l")
     expect(page).to have_element(
       :p,
-      text: "We will ask you again in the spring term of the next year to check whether you would like to offer placements.",
+      text: "We will ask in the next academic year whether you are able to offer placements for trainee teachers.",
       class: "govuk-body",
     )
     expect(page).to have_element(
@@ -293,7 +300,7 @@ RSpec.describe "School user successfully completes the not open journey",
   end
 
   def and_i_see_the_entered_school_contact_details
-    expect(page).to have_h2("ITT contact", class: "govuk-heading-m")
+    expect(page).to have_h2("Contact details", class: "govuk-heading-m")
     expect(page).to have_summary_list_row("First name", "Joe")
     expect(page).to have_summary_list_row("Last name", "Bloggs")
     expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")

--- a/spec/wizards/placements/add_hosting_interest_wizard/reason_not_hosting_step_spec.rb
+++ b/spec/wizards/placements/add_hosting_interest_wizard/reason_not_hosting_step_spec.rb
@@ -33,17 +33,13 @@ RSpec.describe Placements::AddHostingInterestWizard::ReasonNotHostingStep, type:
     subject(:reason_options) { step.reason_options }
 
     it "returns struct objects for each reason not to host ITT" do
-      concerns_about_trainee_quality = reason_options[0]
-      high_number_of_pupils_with_send_needs = reason_options[1]
-      low_capacity_to_support_trainees_due_to_staff_changes = reason_options[2]
-      no_mentors_available_due_to_capacity = reason_options[3]
-      not_offered_appropriate_trainees = reason_options[4]
-      unsure_how_to_get_involved = reason_options[5]
-      working_to_improve_our_ofsted_rating = reason_options[6]
-      other = reason_options[7]
-
-      expect(concerns_about_trainee_quality.name).to eq("Concerns about trainee quality")
-      expect(concerns_about_trainee_quality.value).to eq("Concerns about trainee quality")
+      high_number_of_pupils_with_send_needs = reason_options[0]
+      low_capacity_to_support_trainees_due_to_staff_changes = reason_options[1]
+      no_mentors_available_due_to_capacity = reason_options[2]
+      concerns_about_trainee_quality = reason_options[3]
+      unsure_how_to_get_involved = reason_options[4]
+      working_to_improve_our_ofsted_rating = reason_options[5]
+      other = reason_options[6]
 
       expect(high_number_of_pupils_with_send_needs.name).to eq("High number of pupils with SEND needs")
       expect(high_number_of_pupils_with_send_needs.value).to eq("High number of pupils with SEND needs")
@@ -62,8 +58,8 @@ RSpec.describe Placements::AddHostingInterestWizard::ReasonNotHostingStep, type:
         "No mentors available due to capacity",
       )
 
-      expect(not_offered_appropriate_trainees.name).to eq("Not offered appropriate trainees")
-      expect(not_offered_appropriate_trainees.value).to eq("Not offered appropriate trainees")
+      expect(concerns_about_trainee_quality.name).to eq("Trainees we were offered did not meet our expectations")
+      expect(concerns_about_trainee_quality.value).to eq("Trainees we were offered did not meet our expectations")
 
       expect(unsure_how_to_get_involved.name).to eq("Unsure how to get involved")
       expect(unsure_how_to_get_involved.value).to eq("Unsure how to get involved")


### PR DESCRIPTION
## Context

Updates the red path content in line with the latest content sweep.

## Changes proposed in this pull request

- Updates h1's, hints and options for the red path
- Fixes a typo in the interested path

## Guidance to review

- Log in as Anne
- Select "No - I can't offer placements"
- Review each page against the trello card content

## Link to Trello card

[Iteration 4: Content changes to red path](https://trello.com/c/j4skuIaU/592-iteration-4-content-changes-to-red-path)

## Screenshots

![image](https://github.com/user-attachments/assets/bf67a36e-0d20-449d-8c72-3ab5b5d193fe)
![image](https://github.com/user-attachments/assets/d2320b94-e251-4ea1-b6bd-6f5feae197d3)
![image](https://github.com/user-attachments/assets/88b69db0-46db-4503-a299-eae1bdf8533b)
![image](https://github.com/user-attachments/assets/1314ceb1-68c8-43e1-8641-f016737d11f7)
![image](https://github.com/user-attachments/assets/7b7c4c55-6969-4243-90f7-fd93f6006ab3)

