### PR TITLE
Content changes for placement provider removal

### DIFF
--- a/app/controllers/placements/schools/placements/edit_placement_controller.rb
+++ b/app/controllers/placements/schools/placements/edit_placement_controller.rb
@@ -67,15 +67,7 @@ class Placements::Schools::Placements::EditPlacementController < Placements::App
   end
 
   def notify_provider(placement)
-    from_provider_id = @wizard.placement.saved_change_to_provider_id.first
     to_provider_id = @wizard.placement.saved_change_to_provider_id.last
-
-    if from_provider_id.present?
-      Placements::Placements::NotifyProvider::Remove.call(
-        provider: Provider.find(from_provider_id),
-        placement:,
-      )
-    end
 
     if to_provider_id.present?
       Placements::Placements::NotifyProvider::Assign.call(

--- a/app/controllers/placements/schools/placements_controller.rb
+++ b/app/controllers/placements/schools/placements_controller.rb
@@ -45,6 +45,11 @@ class Placements::Schools::PlacementsController < Placements::ApplicationControl
       provider:,
       placement: @placement,
     )
+    Placements::Placements::NotifySchool::RemoveProvider.call(
+      school: @school,
+      provider: @provider,
+      placement: @placement,
+    )
 
     redirect_to placements_school_placement_path(@school, @placement), flash: {
       heading: t(".success"),

--- a/app/mailers/placements/school_user_mailer.rb
+++ b/app/mailers/placements/school_user_mailer.rb
@@ -36,4 +36,18 @@ class Placements::SchoolUserMailer < Placements::UserMailer
 
     notify_email to: user.email, subject: t(".subject")
   end
+
+  def placement_provider_removed_notification(user, school, provider, placement)
+    @user_name = user.first_name
+    @school_name = school.name
+
+    @provider_email_address = provider.primary_email_address
+    @provider_name = provider.name
+    @placement_name = placement.decorate.title
+    @placement_url = placements_school_placement_url(school, placement, utm_source: "email", utm_medium: "notification", utm_campaign: "school")
+    @service_name = service_name
+    @sign_in_url = sign_in_url(utm_source: "email", utm_medium: "notification", utm_campaign: "school")
+
+    notify_email to: user.email, subject: t(".subject")
+  end
 end

--- a/app/services/placements/placements/notify_school/remove_provider.rb
+++ b/app/services/placements/placements/notify_school/remove_provider.rb
@@ -1,0 +1,28 @@
+module Placements
+  module Placements
+    module NotifySchool
+      class RemoveProvider < ApplicationService
+        def initialize(school:, provider:, placement:)
+          @school = school
+          @provider = provider
+          @placement = placement
+        end
+
+        def call
+          notify_users
+        end
+
+        private
+
+        def notify_users
+          @school.users.each do |user|
+            ::Placements::SchoolUserMailer
+              .placement_provider_removed_notification(
+                user, @school, @provider, @placement
+              ).deliver_later
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/views/placements/provider_user_mailer/placement_provider_removed_notification.text.erb
+++ b/app/views/placements/provider_user_mailer/placement_provider_removed_notification.text.erb
@@ -6,6 +6,7 @@
 
 ## What happens next?
 You should no longer arrange for a trainee to complete this placement.
+
 If you are assigned to other placements with this school, you will remain assigned unless the school removes you from them.
 
 If you think this is a mistake, contact the school on [<%= @itt_contact_email %>](mailto:<%= @itt_contact_email %>).

--- a/app/views/placements/provider_user_mailer/placement_provider_removed_notification.text.erb
+++ b/app/views/placements/provider_user_mailer/placement_provider_removed_notification.text.erb
@@ -1,15 +1,16 @@
 <%= @user_name %>,
 
-<%= @school_name %> has removed <%= @provider_name %> from the following placement:
+<%= @school_name %> has removed <%= @provider_name %> from a placement.
 
-- [<%= @placement_name %>](<%= @placement_url %>)
-
-You can no longer allocate a trainee onto this placement.
+[<%= @placement_name %>](<%= @placement_url %>)
 
 ## What happens next?
+You should no longer arrange for a trainee to complete this placement.
+If you are assigned to other placements with this school, you will remain assigned unless the school removes you from them.
+
 If you think this is a mistake, contact the school on [<%= @itt_contact_email %>](mailto:<%= @itt_contact_email %>).
 
 ## Your account
-[Sign in to Manage school placements](<%= @sign_in_url %>)
+[Sign in to the Manage school placements service](<%= @sign_in_url %>)
 
 <%= @service_name %> service

--- a/app/views/placements/school_user_mailer/placement_provider_removed_notification.text.erb
+++ b/app/views/placements/school_user_mailer/placement_provider_removed_notification.text.erb
@@ -1,0 +1,13 @@
+<%= @user_name %>,
+
+You removed <%= @provider_name %> from a placement.
+
+[<%= @placement_name %>](<%= @placement_url %>)
+
+## What happens next?
+You must make sure the provider is aware that they should no longer place a trainee with you. Contact them on [<%= @provider_email_address %>](mailto:<%= @provider_email_address %>).
+
+## Your account
+[Sign in to the Manage school placements service](<%= @sign_in_url %>)
+
+<%= @service_name %> service

--- a/app/views/placements/schools/placements/_details.html.erb
+++ b/app/views/placements/schools/placements/_details.html.erb
@@ -98,7 +98,7 @@
     <% end %>
     <% if placement.provider.present? %>
       <% row.with_action(
-        text: t(".unassign_provider"),
+        text: t(".remove"),
         href: confirm_unassign_provider_placements_school_placement_path(@school, @placement),
         visually_hidden_text: t(".attributes.placements.provider"),
       ) %>

--- a/app/views/placements/schools/placements/confirm_unassign_provider.html.erb
+++ b/app/views/placements/schools/placements/confirm_unassign_provider.html.erb
@@ -11,7 +11,11 @@
       <span class="govuk-caption-l"><%= @placement.title %></span>
       <h1 class="govuk-heading-l"><%= t(".are_you_sure", provider_name: @placement.provider_name) %></h1>
 
-      <%= govuk_warning_text(text: t(".provider_will_be_sent_an_email", provider_name: @placement.provider_name)) %>
+      <p class="govuk-body"><%= t(".provider_will_be_sent_an_email") %></p>
+
+      <p class="govuk-body"><%= t(".it_is_your_responsibility") %></p>
+
+      <p class="govuk-body"><%= t(".assign_a_new_provider") %></p>
 
       <%= govuk_button_to t(".unassign_provider"),
         unassign_provider_placements_school_placement_path(@school, @placement),

--- a/config/locales/en/placements/school_user_mailer.yml
+++ b/config/locales/en/placements/school_user_mailer.yml
@@ -9,3 +9,5 @@ en:
         subject: A provider has added you
       partnership_destroyed_notification:
         subject: A provider has removed you
+      placement_provider_removed_notification:
+        subject: You have removed a provider from a placement

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -121,7 +121,7 @@ en:
           select_a_mentor: Select a mentor
           add_a_mentor: Add a mentor
           assign_a_provider: Assign a provider
-          unassign_provider: Unassign provider
+          remove: Remove
           add_a_partner_provider: Add a partner provider
           not_yet_known: Not yet known
           change: Change
@@ -149,11 +149,15 @@ en:
         destroy:
           placement_deleted: Placement deleted
         confirm_unassign_provider:
-          page_title: "Are you sure you want to unassign %{provider_name} from this placement? - %{subject_names}"
-          are_you_sure: Are you sure you want to unassign %{provider_name} from this placement?
-          unassign_provider: Unassign provider
+          page_title: "Are you sure you want to remove %{provider_name} from this placement? - %{subject_names}"
+          are_you_sure: Are you sure you want to remove %{provider_name} from this placement?
+          unassign_provider: Remove provider
           cancel: Cancel
           provider_will_be_sent_an_email:
-            An email will be sent to %{provider_name} to let them know that they are no longer assigned to this placement.
+            We will send an email to let them know they should no longer arrange for a trainee to undertake this placement.
+          it_is_your_responsibility:
+            It is your responsibility to contact the provider separately and tell them this placement is no longer available to them.
+          assign_a_new_provider:
+            You can assign a new provider once you have removed the current provider.
         unassign_provider:
-          success: Provider unassigned
+          success: Provider removed

--- a/spec/mailers/placements/provider_user_mailer_spec.rb
+++ b/spec/mailers/placements/provider_user_mailer_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe Placements::ProviderUserMailer, type: :mailer do
     let(:provider_user) { create(:placements_user, providers: [provider]) }
     let(:school_contact_email) { school.school_contact.email_address }
 
-    it "sends a provider assigned notification email to the user of the provider" do
+    it "sends a provider removed notification email to the user of the provider" do
       expect(placement_provider_removed_notification.to).to contain_exactly(provider_user.email)
       expect(placement_provider_removed_notification.subject).to eq(
         "A school has removed you from a placement",
@@ -280,17 +280,18 @@ RSpec.describe Placements::ProviderUserMailer, type: :mailer do
       expect(placement_provider_removed_notification.body).to have_content <<~EMAIL
         #{provider_user.first_name},
 
-        #{school.name} has removed #{provider.name} from the following placement:
+        #{school.name} has removed #{provider.name} from a placement.
 
-        - [#{placement.decorate.title}](http://placements.localhost/providers/#{provider.id}/placements/#{placement.id}?utm_campaign=provider&utm_medium=notification&utm_source=email)
-
-        You can no longer allocate a trainee onto this placement.
+        [#{placement.decorate.title}](http://placements.localhost/providers/#{provider.id}/placements/#{placement.id}?utm_campaign=provider&utm_medium=notification&utm_source=email)
 
         ## What happens next?
+        You should no longer arrange for a trainee to complete this placement.
+        If you are assigned to other placements with this school, you will remain assigned unless the school removes you from them.
+
         If you think this is a mistake, contact the school on [#{school.school_contact_email_address}](mailto:#{school.school_contact_email_address}).
 
         ## Your account
-        [Sign in to Manage school placements](http://placements.localhost/sign-in?utm_campaign=provider&utm_medium=notification&utm_source=email)
+        [Sign in to the Manage school placements service](http://placements.localhost/sign-in?utm_campaign=provider&utm_medium=notification&utm_source=email)
 
         Manage school placements service
       EMAIL

--- a/spec/mailers/placements/provider_user_mailer_spec.rb
+++ b/spec/mailers/placements/provider_user_mailer_spec.rb
@@ -286,6 +286,7 @@ RSpec.describe Placements::ProviderUserMailer, type: :mailer do
 
         ## What happens next?
         You should no longer arrange for a trainee to complete this placement.
+
         If you are assigned to other placements with this school, you will remain assigned unless the school removes you from them.
 
         If you think this is a mistake, contact the school on [#{school.school_contact_email_address}](mailto:#{school.school_contact_email_address}).

--- a/spec/mailers/previews/placements/provider_user_mailer_preview.rb
+++ b/spec/mailers/previews/placements/provider_user_mailer_preview.rb
@@ -35,7 +35,16 @@ class Placements::ProviderUserMailerPreview < ActionMailer::Preview
   end
 
   def school
-    Placements::School.new(id: stubbed_id, name: "Test School")
+    Placements::School.new(id: stubbed_id, name: "Test School", school_contact:)
+  end
+
+  def school_contact
+    Placements::SchoolContact.new(
+      id: stubbed_id,
+      first_name: "Joe",
+      last_name: "Bloggs",
+      email_address: "joe_bloggs@example.com",
+    )
   end
 
   def provider

--- a/spec/mailers/previews/placements/school_user_mailer_preview.rb
+++ b/spec/mailers/previews/placements/school_user_mailer_preview.rb
@@ -15,6 +15,10 @@ class Placements::SchoolUserMailerPreview < ActionMailer::Preview
     Placements::SchoolUserMailer.partnership_destroyed_notification(user, provider, school)
   end
 
+  def placement_provider_removed_notification
+    Placements::SchoolUserMailer.placement_provider_removed_notification(user, school, provider, placement)
+  end
+
   private
 
   def user
@@ -32,6 +36,14 @@ class Placements::SchoolUserMailerPreview < ActionMailer::Preview
 
   def provider
     PreviewProvider.new(id: stubbed_id, name: "Test Provider")
+  end
+
+  def placement
+    Placement.new(id: stubbed_id, school:, provider:, subject:)
+  end
+
+  def subject
+    Subject.new(id: stubbed_id, name: "English")
   end
 
   def stubbed_id

--- a/spec/services/placements/placements/notify_school/remove_provider_spec.rb
+++ b/spec/services/placements/placements/notify_school/remove_provider_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe Placements::Placements::NotifySchool::RemoveProvider do
+  subject(:notify_school_service) { described_class.call(school:, provider:, placement:) }
+
+  it_behaves_like "a service object" do
+    let(:params) { { school: create(:school), provider: create(:provider), placement: create(:placement) } }
+  end
+
+  describe "#call" do
+    let!(:provider) { create(:placements_provider) }
+    let(:placement) { create(:placement) }
+    let(:school) { create(:placements_school) }
+    let!(:user_1) { create(:placements_user, schools: [school]) }
+    let!(:user_2) { create(:placements_user, schools: [school]) }
+
+    it "sends a notification email to every user belonging to the provider" do
+      expect { notify_school_service }.to have_enqueued_mail(
+        Placements::SchoolUserMailer,
+        :placement_provider_removed_notification,
+      ).with(
+        user_1, school, provider, placement
+      ).and have_enqueued_mail(
+        Placements::SchoolUserMailer,
+        :placement_provider_removed_notification,
+      ).with(
+        user_2, school, provider, placement
+      )
+    end
+  end
+end

--- a/spec/system/placements/schools/placements/primary_school_user_edits_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/primary_school_user_edits_a_placement_spec.rb
@@ -82,11 +82,11 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
     then_i_see_the_placement_details_page_with_aes_sedai_trust
     and_i_see_a_provider_updated_success_message
 
-    when_i_click_on_unassign_provider
+    when_i_click_on_remove
     then_i_see_the_confirmation_page
 
-    when_i_click_on_unassign_provider
-    then_i_see_the_provider_was_successfully_unassigned
+    when_i_click_on_remove_provider
+    then_i_see_the_provider_was_successfully_removed
     and_i_see_the_placement_details_page_with_jane_doe
 
     when_i_click_on_preview_this_placement
@@ -421,13 +421,17 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
     expect(page).to have_success_banner("Provider updated")
   end
 
-  def when_i_click_on_unassign_provider
-    click_on("Unassign provider")
+  def when_i_click_on_remove
+    click_on("Remove")
+  end
+
+  def when_i_click_on_remove_provider
+    click_on("Remove provider")
   end
 
   def then_i_see_the_confirmation_page
     expect(page).to have_title(
-      "Are you sure you want to unassign Aes Sedai Trust from this placement? - Primary with english (Year 2) - Manage school placements - GOV.UK",
+      "Are you sure you want to remove Aes Sedai Trust from this placement? - Primary with english (Year 2) - Manage school placements - GOV.UK",
     )
     expect(page).to have_element(
       :span,
@@ -435,16 +439,28 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
       class: "govuk-caption-l",
     )
     expect(page).to have_h1(
-      "Are you sure you want to unassign Aes Sedai Trust from this placement?",
+      "Are you sure you want to remove Aes Sedai Trust from this placement?",
     )
-    expect(page).to have_warning_text(
-      "An email will be sent to Aes Sedai Trust to let them know that they are no longer assigned to this placement.",
+    expect(page).to have_element(
+      :p,
+      text: "We will send an email to let them know they should no longer arrange for a trainee to undertake this placement.",
+      class: "govuk-body",
     )
-    expect(page).to have_button("Unassign provider", class: "govuk-button--warning")
+    expect(page).to have_element(
+      :p,
+      text: "It is your responsibility to contact the provider separately and tell them this placement is no longer available to them.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "You can assign a new provider once you have removed the current provider.",
+      class: "govuk-body",
+    )
+    expect(page).to have_button("Remove provider", class: "govuk-button--warning")
   end
 
-  def then_i_see_the_provider_was_successfully_unassigned
-    expect(page).to have_success_banner("Provider unassigned")
+  def then_i_see_the_provider_was_successfully_removed
+    expect(page).to have_success_banner("Provider removed")
   end
 
   def when_i_select_the_ashaman_trust

--- a/spec/system/placements/schools/placements/primary_school_user_edits_a_placement_with_javascript_disabled_spec.rb
+++ b/spec/system/placements/schools/placements/primary_school_user_edits_a_placement_with_javascript_disabled_spec.rb
@@ -91,11 +91,11 @@ RSpec.describe "Primary school user edits a placement with javascript disabled",
     then_i_see_the_placement_details_page_with_aes_sedai_trust
     and_i_see_a_provider_updated_success_message
 
-    when_i_click_on_unassign_provider
+    when_i_click_on_remove
     then_i_see_the_confirmation_page
 
-    when_i_click_on_unassign_provider
-    then_i_see_the_provider_was_successfully_unassigned
+    when_i_click_on_remove_provider
+    then_i_see_the_provider_was_successfully_removed
     and_i_see_the_placement_details_page_with_jane_doe
 
     when_i_click_on_preview_this_placement
@@ -416,13 +416,17 @@ RSpec.describe "Primary school user edits a placement with javascript disabled",
     expect(page).to have_success_banner("Provider updated")
   end
 
-  def when_i_click_on_unassign_provider
-    click_on("Unassign provider")
+  def when_i_click_on_remove
+    click_on("Remove")
+  end
+
+  def when_i_click_on_remove_provider
+    click_on("Remove provider")
   end
 
   def then_i_see_the_confirmation_page
     expect(page).to have_title(
-      "Are you sure you want to unassign Aes Sedai Trust from this placement? - Primary with english (Year 2) - Manage school placements - GOV.UK",
+      "Are you sure you want to remove Aes Sedai Trust from this placement? - Primary with english (Year 2) - Manage school placements - GOV.UK",
     )
     expect(page).to have_element(
       :span,
@@ -430,16 +434,28 @@ RSpec.describe "Primary school user edits a placement with javascript disabled",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1(
-      "Are you sure you want to unassign Aes Sedai Trust from this placement?",
+      "Are you sure you want to remove Aes Sedai Trust from this placement?",
     )
-    expect(page).to have_warning_text(
-      "An email will be sent to Aes Sedai Trust to let them know that they are no longer assigned to this placement.",
+    expect(page).to have_element(
+      :p,
+      text: "We will send an email to let them know they should no longer arrange for a trainee to undertake this placement.",
+      class: "govuk-body",
     )
-    expect(page).to have_button("Unassign provider", class: "govuk-button--warning")
+    expect(page).to have_element(
+      :p,
+      text: "It is your responsibility to contact the provider separately and tell them this placement is no longer available to them.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "You can assign a new provider once you have removed the current provider.",
+      class: "govuk-body",
+    )
+    expect(page).to have_button("Remove provider", class: "govuk-button--warning")
   end
 
-  def then_i_see_the_provider_was_successfully_unassigned
-    expect(page).to have_success_banner("Provider unassigned")
+  def then_i_see_the_provider_was_successfully_removed
+    expect(page).to have_success_banner("Provider removed")
   end
 
   def when_i_select_the_aes_sedai_trust

--- a/spec/system/placements/schools/placements/secondary_school_user_edits_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/secondary_school_user_edits_a_placement_spec.rb
@@ -71,11 +71,11 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
     then_i_see_the_placement_details_page_with_aes_sedai_trust
     and_i_see_a_provider_updated_success_message
 
-    when_i_click_on_unassign_provider
+    when_i_click_on_remove
     then_i_see_the_confirmation_page
 
-    when_i_click_on_unassign_provider
-    then_i_see_the_provider_was_successfully_unassigned
+    when_i_click_on_remove_provider
+    then_i_see_the_provider_was_successfully_removed
     and_i_see_the_placement_details_page_with_jane_doe
 
     when_i_click_on_preview_this_placement
@@ -380,13 +380,17 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
     expect(page).to have_success_banner("Provider updated")
   end
 
-  def when_i_click_on_unassign_provider
-    click_on("Unassign provider")
+  def when_i_click_on_remove
+    click_on("Remove")
+  end
+
+  def when_i_click_on_remove_provider
+    click_on("Remove provider")
   end
 
   def then_i_see_the_confirmation_page
     expect(page).to have_title(
-      "Are you sure you want to unassign Aes Sedai Trust from this placement? - English - Manage school placements - GOV.UK",
+      "Are you sure you want to remove Aes Sedai Trust from this placement? - English - Manage school placements - GOV.UK",
     )
     expect(page).to have_element(
       :span,
@@ -394,16 +398,28 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
       class: "govuk-caption-l",
     )
     expect(page).to have_h1(
-      "Are you sure you want to unassign Aes Sedai Trust from this placement?",
+      "Are you sure you want to remove Aes Sedai Trust from this placement?",
     )
-    expect(page).to have_warning_text(
-      "An email will be sent to Aes Sedai Trust to let them know that they are no longer assigned to this placement.",
+    expect(page).to have_element(
+      :p,
+      text: "We will send an email to let them know they should no longer arrange for a trainee to undertake this placement.",
+      class: "govuk-body",
     )
-    expect(page).to have_button("Unassign provider", class: "govuk-button--warning")
+    expect(page).to have_element(
+      :p,
+      text: "It is your responsibility to contact the provider separately and tell them this placement is no longer available to them.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "You can assign a new provider once you have removed the current provider.",
+      class: "govuk-body",
+    )
+    expect(page).to have_button("Remove provider", class: "govuk-button--warning")
   end
 
-  def then_i_see_the_provider_was_successfully_unassigned
-    expect(page).to have_success_banner("Provider unassigned")
+  def then_i_see_the_provider_was_successfully_removed
+    expect(page).to have_success_banner("Provider removed")
   end
 
   def when_i_select_the_ashaman_trust

--- a/spec/system/placements/schools/placements/secondary_school_user_edits_a_placement_with_javascript_disabled_spec.rb
+++ b/spec/system/placements/schools/placements/secondary_school_user_edits_a_placement_with_javascript_disabled_spec.rb
@@ -80,11 +80,11 @@ RSpec.describe "Secondary school user edits a placement with javascript disabled
     then_i_see_the_placement_details_page_with_aes_sedai_trust
     and_i_see_a_provider_updated_success_message
 
-    when_i_click_on_unassign_provider
+    when_i_click_on_remove
     then_i_see_the_confirmation_page
 
-    when_i_click_on_unassign_provider
-    then_i_see_the_provider_was_successfully_unassigned
+    when_i_click_on_remove_provider
+    then_i_see_the_provider_was_successfully_removed
     and_i_see_the_placement_details_page_with_jane_doe
 
     when_i_click_on_preview_this_placement
@@ -379,13 +379,17 @@ RSpec.describe "Secondary school user edits a placement with javascript disabled
     expect(page).to have_success_banner("Provider updated")
   end
 
-  def when_i_click_on_unassign_provider
-    click_on("Unassign provider")
+  def when_i_click_on_remove
+    click_on("Remove")
+  end
+
+  def when_i_click_on_remove_provider
+    click_on("Remove provider")
   end
 
   def then_i_see_the_confirmation_page
     expect(page).to have_title(
-      "Are you sure you want to unassign Aes Sedai Trust from this placement? - English - Manage school placements - GOV.UK",
+      "Are you sure you want to remove Aes Sedai Trust from this placement? - English - Manage school placements - GOV.UK",
     )
     expect(page).to have_element(
       :span,
@@ -393,16 +397,28 @@ RSpec.describe "Secondary school user edits a placement with javascript disabled
       class: "govuk-caption-l",
     )
     expect(page).to have_h1(
-      "Are you sure you want to unassign Aes Sedai Trust from this placement?",
+      "Are you sure you want to remove Aes Sedai Trust from this placement?",
     )
-    expect(page).to have_warning_text(
-      "An email will be sent to Aes Sedai Trust to let them know that they are no longer assigned to this placement.",
+    expect(page).to have_element(
+      :p,
+      text: "We will send an email to let them know they should no longer arrange for a trainee to undertake this placement.",
+      class: "govuk-body",
     )
-    expect(page).to have_button("Unassign provider", class: "govuk-button--warning")
+    expect(page).to have_element(
+      :p,
+      text: "It is your responsibility to contact the provider separately and tell them this placement is no longer available to them.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "You can assign a new provider once you have removed the current provider.",
+      class: "govuk-body",
+    )
+    expect(page).to have_button("Remove provider", class: "govuk-button--warning")
   end
 
-  def then_i_see_the_provider_was_successfully_unassigned
-    expect(page).to have_success_banner("Provider unassigned")
+  def then_i_see_the_provider_was_successfully_removed
+    expect(page).to have_success_banner("Provider removed")
   end
 
   def when_i_select_the_ashaman_trust

--- a/spec/system/placements/support/schools/placements/primary_school_support_user_edits_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/primary_school_support_user_edits_a_placement_spec.rb
@@ -84,11 +84,11 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
     then_i_see_the_placement_details_page_with_aes_sedai_trust
     and_i_see_a_provider_updated_success_message
 
-    when_i_click_on_unassign_provider
+    when_i_click_on_remove
     then_i_see_the_confirmation_page
 
-    when_i_click_on_unassign_provider
-    then_i_see_the_provider_was_successfully_unassigned
+    when_i_click_on_remove_provider
+    then_i_see_the_provider_was_successfully_removed
     and_i_see_the_placement_details_page_with_jane_doe
 
     when_i_click_on_preview_this_placement
@@ -450,13 +450,17 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
     expect(page).to have_success_banner("Provider updated")
   end
 
-  def when_i_click_on_unassign_provider
-    click_on("Unassign provider")
+  def when_i_click_on_remove
+    click_on("Remove")
+  end
+
+  def when_i_click_on_remove_provider
+    click_on("Remove provider")
   end
 
   def then_i_see_the_confirmation_page
     expect(page).to have_title(
-      "Are you sure you want to unassign Aes Sedai Trust from this placement? - Primary with english (Year 2) - Manage school placements - GOV.UK",
+      "Are you sure you want to remove Aes Sedai Trust from this placement? - Primary with english (Year 2) - Manage school placements - GOV.UK",
     )
     expect(page).to have_element(
       :span,
@@ -464,16 +468,28 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
       class: "govuk-caption-l",
     )
     expect(page).to have_h1(
-      "Are you sure you want to unassign Aes Sedai Trust from this placement?",
+      "Are you sure you want to remove Aes Sedai Trust from this placement?",
     )
-    expect(page).to have_warning_text(
-      "An email will be sent to Aes Sedai Trust to let them know that they are no longer assigned to this placement.",
+    expect(page).to have_element(
+      :p,
+      text: "We will send an email to let them know they should no longer arrange for a trainee to undertake this placement.",
+      class: "govuk-body",
     )
-    expect(page).to have_button("Unassign provider", class: "govuk-button--warning")
+    expect(page).to have_element(
+      :p,
+      text: "It is your responsibility to contact the provider separately and tell them this placement is no longer available to them.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "You can assign a new provider once you have removed the current provider.",
+      class: "govuk-body",
+    )
+    expect(page).to have_button("Remove provider", class: "govuk-button--warning")
   end
 
-  def then_i_see_the_provider_was_successfully_unassigned
-    expect(page).to have_success_banner("Provider unassigned")
+  def then_i_see_the_provider_was_successfully_removed
+    expect(page).to have_success_banner("Provider removed")
   end
 
   def when_i_select_the_ashaman_trust

--- a/spec/system/placements/support/schools/placements/secondary_school_support_user_edits_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/secondary_school_support_user_edits_a_placement_spec.rb
@@ -69,11 +69,11 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
     then_i_see_the_placement_details_page_with_aes_sedai_trust
     and_i_see_a_provider_updated_success_message
 
-    when_i_click_on_unassign_provider
+    when_i_click_on_remove
     then_i_see_the_confirmation_page
 
-    when_i_click_on_unassign_provider
-    then_i_see_the_provider_was_successfully_unassigned
+    when_i_click_on_remove_provider
+    then_i_see_the_provider_was_successfully_removed
     and_i_see_the_placement_details_page_with_jane_doe
 
     when_i_click_on_preview_this_placement
@@ -371,13 +371,17 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
     expect(page).to have_success_banner("Provider updated")
   end
 
-  def when_i_click_on_unassign_provider
-    click_on("Unassign provider")
+  def when_i_click_on_remove
+    click_on("Remove")
+  end
+
+  def when_i_click_on_remove_provider
+    click_on("Remove provider")
   end
 
   def then_i_see_the_confirmation_page
     expect(page).to have_title(
-      "Are you sure you want to unassign Aes Sedai Trust from this placement? - English - Manage school placements - GOV.UK",
+      "Are you sure you want to remove Aes Sedai Trust from this placement? - English - Manage school placements - GOV.UK",
     )
     expect(page).to have_element(
       :span,
@@ -385,16 +389,28 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
       class: "govuk-caption-l",
     )
     expect(page).to have_h1(
-      "Are you sure you want to unassign Aes Sedai Trust from this placement?",
+      "Are you sure you want to remove Aes Sedai Trust from this placement?",
     )
-    expect(page).to have_warning_text(
-      "An email will be sent to Aes Sedai Trust to let them know that they are no longer assigned to this placement.",
+    expect(page).to have_element(
+      :p,
+      text: "We will send an email to let them know they should no longer arrange for a trainee to undertake this placement.",
+      class: "govuk-body",
     )
-    expect(page).to have_button("Unassign provider", class: "govuk-button--warning")
+    expect(page).to have_element(
+      :p,
+      text: "It is your responsibility to contact the provider separately and tell them this placement is no longer available to them.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "You can assign a new provider once you have removed the current provider.",
+      class: "govuk-body",
+    )
+    expect(page).to have_button("Remove provider", class: "govuk-button--warning")
   end
 
-  def then_i_see_the_provider_was_successfully_unassigned
-    expect(page).to have_success_banner("Provider unassigned")
+  def then_i_see_the_provider_was_successfully_removed
+    expect(page).to have_success_banner("Provider removed")
   end
 
   def when_i_select_the_ashaman_trust

--- a/spec/system/placements/support/schools/placements/view_placements/support_user_views_a_placement_with_a_provider_spec.rb
+++ b/spec/system/placements/support/schools/placements/view_placements/support_user_views_a_placement_with_a_provider_spec.rb
@@ -104,7 +104,6 @@ RSpec.describe "Support user views a placement with a provider", service: :place
     expect(page).to have_summary_list_row("Expected date", "Any time in the academic year")
     expect(page).to have_link("Change Expected date")
     expect(page).to have_summary_list_row("Mentor", "Select a mentor")
-    expect(page).to have_summary_list_row("Provider", "Best Practice Network")
-    expect(page).to have_link("Unassign provider")
+    expect(page).to have_summary_list_row("Provider", "Best Practice Network", "Remove")
   end
 end

--- a/spec/system/placements/support/schools/placements/view_placements/support_user_views_a_placement_with_a_specific_term_spec.rb
+++ b/spec/system/placements/support/schools/placements/view_placements/support_user_views_a_placement_with_a_specific_term_spec.rb
@@ -105,7 +105,6 @@ RSpec.describe "Support user views a placement with a specific term", service: :
     expect(page).to have_summary_list_row("Expected date", "Autumn term")
     expect(page).to have_link("Change Expected date")
     expect(page).to have_summary_list_row("Mentor", "Select a mentor")
-    expect(page).to have_summary_list_row("Provider", "Best Practice Network")
-    expect(page).to have_link("Unassign provider")
+    expect(page).to have_summary_list_row("Provider", "Best Practice Network", "Remove")
   end
 end


### PR DESCRIPTION
## Context

- Content changes to the placement provider removal pages
- Changes to the email providers receive when removed from the placement
- Added an email to school after removing a provider from a placement

## Link to Trello card

https://trello.com/c/75ALAFzD/596-unassign-provider-from-placement

## Screenshots

![screencapture-placements-localhost-3000-rails-mailers-placements-provider-user-mailer-placement-provider-removed-notification-2025-05-08-14_17_14](https://github.com/user-attachments/assets/e4558a9f-bd1f-43f0-a618-0f66b3521b7b)

![screencapture-placements-localhost-3000-rails-mailers-placements-school-user-mailer-placement-provider-removed-notification-2025-05-08-14_16_58](https://github.com/user-attachments/assets/5c6afbf1-d8e6-4d19-8cbc-50e1471c7b10)


https://github.com/user-attachments/assets/0f17c65b-5762-47a7-804e-5b68bc1b8185

