### PR TITLE
Update select mentor content

### DIFF
--- a/app/views/wizards/placements/add_placement_wizard/_mentors_step.html.erb
+++ b/app/views/wizards/placements/add_placement_wizard/_mentors_step.html.erb
@@ -14,7 +14,7 @@
           legend: { size: "l",
                     text: t(".select_a_mentor"),
                     tag: "h1" },
-          hint: { text: @placement.present? ? t(".hint.published") : t(".hint.unpublished_html") } do %>
+          hint: { text: t(".hint") } do %>
           <% current_step.mentors_for_selection.each_with_index do |mentor, index| %>
             <%= f.govuk_check_box :mentor_ids, mentor.id, label: { text: mentor.full_name }, link_errors: index.zero? %>
           <% end %>

--- a/config/locales/en/wizards/placements/add_placement_wizard.yml
+++ b/config/locales/en/wizards/placements/add_placement_wizard.yml
@@ -29,17 +29,9 @@ en:
           primary: Primary
           continue: Continue
         mentors_step:
-          title: Select a mentor - %{contextual_text}
-          select_a_mentor: Select a mentor
-          hint:
-            unpublished_html: |
-              Some placements may have more than one mentor. 
-              For example, if a mentor works part time.<br>
-              <br>
-              You can change who the mentor is after you have published the placement.
-            published: |
-              Some placements may have more than one mentor. 
-              For example, if a mentor works part time.
+          title: Select who will mentor the trainee - %{contextual_text}
+          select_a_mentor: Select who will mentor the trainee
+          hint: Only your school will be able to see the assigned mentor. Providers will not have access to this information.
           continue: Continue
           mentors: Mentors
           not_known: Not yet known

--- a/spec/system/placements/schools/placements/all_through_school_user_adds_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/all_through_school_user_adds_a_placement_spec.rb
@@ -364,11 +364,11 @@ RSpec.describe "All-through school user adds a placement", service: :placements,
   end
 
   def then_i_see_the_select_a_mentor_page
-    expect(page).to have_title("Select a mentor - Placement details - Manage school placements - GOV.UK")
+    expect(page).to have_title("Select who will mentor the trainee - Placement details - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
-    expect(page).to have_element(:legend, text: "Select a mentor", class: "govuk-fieldset__legend")
-    expect(page).to have_element(:div, text: "Some placements may have more than one mentor. For example, if a mentor works part time. You can change who the mentor is after you have published the placement.", class: "govuk-hint")
+    expect(page).to have_element(:legend, text: "Select who will mentor the trainee", class: "govuk-fieldset__legend")
+    expect(page).to have_element(:div, text: "Only your school will be able to see the assigned mentor. Providers will not have access to this information.", class: "govuk-hint")
     expect(page).to have_element(:span, text: "My mentor is not listed", class: "govuk-details__summary-text")
     expect(page).to have_link("Cancel", href: "/schools/#{@school.id}/placements")
   end

--- a/spec/system/placements/schools/placements/primary_school_user_adds_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/primary_school_user_adds_a_placement_spec.rb
@@ -308,11 +308,11 @@ RSpec.describe "Primary school user adds a placement", service: :placements, typ
   end
 
   def then_i_see_the_select_a_mentor_page
-    expect(page).to have_title("Select a mentor - Placement details - Manage school placements - GOV.UK")
+    expect(page).to have_title("Select who will mentor the trainee - Placement details - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
-    expect(page).to have_element(:legend, text: "Select a mentor", class: "govuk-fieldset__legend")
-    expect(page).to have_element(:div, text: "Some placements may have more than one mentor. For example, if a mentor works part time. You can change who the mentor is after you have published the placement.", class: "govuk-hint")
+    expect(page).to have_element(:legend, text: "Select who will mentor the trainee", class: "govuk-fieldset__legend")
+    expect(page).to have_element(:div, text: "Only your school will be able to see the assigned mentor. Providers will not have access to this information.", class: "govuk-hint")
     expect(page).to have_element(:span, text: "My mentor is not listed", class: "govuk-details__summary-text")
     expect(page).to have_link("Cancel", href: "/schools/#{@school.id}/placements")
   end

--- a/spec/system/placements/schools/placements/primary_school_user_edits_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/primary_school_user_edits_a_placement_spec.rb
@@ -296,11 +296,11 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   end
 
   def then_i_see_the_select_a_mentor_page
-    expect(page).to have_title("Select a mentor - Placement details - Manage school placements - GOV.UK")
+    expect(page).to have_title("Select who will mentor the trainee - Placement details - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
-    expect(page).to have_element(:legend, text: "Select a mentor", class: "govuk-fieldset__legend")
-    expect(page).to have_element(:div, text: "Some placements may have more than one mentor. For example, if a mentor works part time.", class: "govuk-hint")
+    expect(page).to have_element(:legend, text: "Select who will mentor the trainee", class: "govuk-fieldset__legend")
+    expect(page).to have_element(:div, text: "Only your school will be able to see the assigned mentor. Providers will not have access to this information.", class: "govuk-hint")
     expect(page).to have_element(:span, text: "My mentor is not listed", class: "govuk-details__summary-text")
     expect(page).to have_link("Cancel", href: "/schools/#{@springfield_elementary_school.id}/placements/#{@placement.id}")
   end

--- a/spec/system/placements/schools/placements/primary_school_user_edits_a_placement_with_javascript_disabled_spec.rb
+++ b/spec/system/placements/schools/placements/primary_school_user_edits_a_placement_with_javascript_disabled_spec.rb
@@ -307,11 +307,11 @@ RSpec.describe "Primary school user edits a placement with javascript disabled",
   end
 
   def then_i_see_the_select_a_mentor_page
-    expect(page).to have_title("Select a mentor - Placement details - Manage school placements - GOV.UK")
+    expect(page).to have_title("Select who will mentor the trainee - Placement details - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
-    expect(page).to have_element(:legend, text: "Select a mentor", class: "govuk-fieldset__legend")
-    expect(page).to have_element(:div, text: "Some placements may have more than one mentor. For example, if a mentor works part time.", class: "govuk-hint")
+    expect(page).to have_element(:legend, text: "Select who will mentor the trainee", class: "govuk-fieldset__legend")
+    expect(page).to have_element(:div, text: "Only your school will be able to see the assigned mentor. Providers will not have access to this information.", class: "govuk-hint")
     expect(page).to have_element(:span, text: "My mentor is not listed", class: "govuk-details__summary-text")
     expect(page).to have_link("Cancel", href: "/schools/#{@springfield_elementary_school.id}/placements/#{@placement.id}")
   end

--- a/spec/system/placements/schools/placements/secondary_school_user_adds_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/secondary_school_user_adds_a_placement_spec.rb
@@ -254,11 +254,11 @@ RSpec.describe "Secondary school user adds a placement", service: :placements, t
   end
 
   def then_i_see_the_select_a_mentor_page
-    expect(page).to have_title("Select a mentor - Placement details - Manage school placements - GOV.UK")
+    expect(page).to have_title("Select who will mentor the trainee - Placement details - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
-    expect(page).to have_element(:legend, text: "Select a mentor", class: "govuk-fieldset__legend")
-    expect(page).to have_element(:div, text: "Some placements may have more than one mentor. For example, if a mentor works part time. You can change who the mentor is after you have published the placement.", class: "govuk-hint")
+    expect(page).to have_element(:legend, text: "Select who will mentor the trainee", class: "govuk-fieldset__legend")
+    expect(page).to have_element(:div, text: "Only your school will be able to see the assigned mentor. Providers will not have access to this information.", class: "govuk-hint")
     expect(page).to have_element(:span, text: "My mentor is not listed", class: "govuk-details__summary-text")
     expect(page).to have_link("Cancel", href: "/schools/#{@school.id}/placements")
   end

--- a/spec/system/placements/schools/placements/secondary_school_user_edits_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/secondary_school_user_edits_a_placement_spec.rb
@@ -238,11 +238,11 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
   end
 
   def then_i_see_the_select_a_mentor_page
-    expect(page).to have_title("Select a mentor - Placement details - Manage school placements - GOV.UK")
+    expect(page).to have_title("Select who will mentor the trainee - Placement details - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
-    expect(page).to have_element(:legend, text: "Select a mentor", class: "govuk-fieldset__legend")
-    expect(page).to have_element(:div, text: "Some placements may have more than one mentor. For example, if a mentor works part time.", class: "govuk-hint")
+    expect(page).to have_element(:legend, text: "Select who will mentor the trainee", class: "govuk-fieldset__legend")
+    expect(page).to have_element(:div, text: "Only your school will be able to see the assigned mentor. Providers will not have access to this information.", class: "govuk-hint")
     expect(page).to have_element(:span, text: "My mentor is not listed", class: "govuk-details__summary-text")
     expect(page).to have_link("Cancel", href: "/schools/#{@hogwarts_school.id}/placements/#{@placement.id}")
   end

--- a/spec/system/placements/schools/placements/secondary_school_user_edits_a_placement_with_javascript_disabled_spec.rb
+++ b/spec/system/placements/schools/placements/secondary_school_user_edits_a_placement_with_javascript_disabled_spec.rb
@@ -249,11 +249,11 @@ RSpec.describe "Secondary school user edits a placement with javascript disabled
   end
 
   def then_i_see_the_select_a_mentor_page
-    expect(page).to have_title("Select a mentor - Placement details - Manage school placements - GOV.UK")
+    expect(page).to have_title("Select who will mentor the trainee - Placement details - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
-    expect(page).to have_element(:legend, text: "Select a mentor", class: "govuk-fieldset__legend")
-    expect(page).to have_element(:div, text: "Some placements may have more than one mentor. For example, if a mentor works part time.", class: "govuk-hint")
+    expect(page).to have_element(:legend, text: "Select who will mentor the trainee", class: "govuk-fieldset__legend")
+    expect(page).to have_element(:div, text: "Only your school will be able to see the assigned mentor. Providers will not have access to this information.", class: "govuk-hint")
     expect(page).to have_element(:span, text: "My mentor is not listed", class: "govuk-details__summary-text")
     expect(page).to have_link("Cancel", href: "/schools/#{@hogwarts_school.id}/placements/#{@placement.id}")
   end

--- a/spec/system/placements/schools/placements/user_publishes_a_placement_after_preview_spec.rb
+++ b/spec/system/placements/schools/placements/user_publishes_a_placement_after_preview_spec.rb
@@ -140,11 +140,11 @@ RSpec.describe "User publishes a placement after preview", service: :placements,
   end
 
   def then_i_see_the_select_a_mentor_page
-    expect(page).to have_title("Select a mentor - Placement details - Manage school placements - GOV.UK")
+    expect(page).to have_title("Select who will mentor the trainee - Placement details - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
-    expect(page).to have_element(:legend, text: "Select a mentor", class: "govuk-fieldset__legend")
-    expect(page).to have_element(:div, text: "Some placements may have more than one mentor. For example, if a mentor works part time. You can change who the mentor is after you have published the placement.", class: "govuk-hint")
+    expect(page).to have_element(:legend, text: "Select who will mentor the trainee", class: "govuk-fieldset__legend")
+    expect(page).to have_element(:div, text: "Only your school will be able to see the assigned mentor. Providers will not have access to this information.", class: "govuk-hint")
     expect(page).to have_element(:span, text: "My mentor is not listed", class: "govuk-details__summary-text")
     expect(page).to have_link("Cancel", href: "/schools/#{@school.id}/placements")
   end

--- a/spec/system/placements/support/schools/placements/all_through_school_support_user_adds_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/all_through_school_support_user_adds_a_placement_spec.rb
@@ -375,11 +375,11 @@ RSpec.describe "All-through support school user adds a placement", service: :pla
   end
 
   def then_i_see_the_select_a_mentor_page
-    expect(page).to have_title("Select a mentor - Placement details - Manage school placements - GOV.UK")
+    expect(page).to have_title("Select who will mentor the trainee - Placement details - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
-    expect(page).to have_element(:legend, text: "Select a mentor", class: "govuk-fieldset__legend")
-    expect(page).to have_element(:div, text: "Some placements may have more than one mentor. For example, if a mentor works part time. You can change who the mentor is after you have published the placement.", class: "govuk-hint")
+    expect(page).to have_element(:legend, text: "Select who will mentor the trainee", class: "govuk-fieldset__legend")
+    expect(page).to have_element(:div, text: "Only your school will be able to see the assigned mentor. Providers will not have access to this information.", class: "govuk-hint")
     expect(page).to have_element(:span, text: "My mentor is not listed", class: "govuk-details__summary-text")
     expect(page).to have_link("Cancel", href: "/schools/#{@school.id}/placements")
   end

--- a/spec/system/placements/support/schools/placements/primary_school_support_user_adds_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/primary_school_support_user_adds_a_placement_spec.rb
@@ -319,11 +319,11 @@ RSpec.describe "Primary school user adds a placement", service: :placements, typ
   end
 
   def then_i_see_the_select_a_mentor_page
-    expect(page).to have_title("Select a mentor - Placement details - Manage school placements - GOV.UK")
+    expect(page).to have_title("Select who will mentor the trainee - Placement details - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
-    expect(page).to have_element(:legend, text: "Select a mentor", class: "govuk-fieldset__legend")
-    expect(page).to have_element(:div, text: "Some placements may have more than one mentor. For example, if a mentor works part time. You can change who the mentor is after you have published the placement.", class: "govuk-hint")
+    expect(page).to have_element(:legend, text: "Select who will mentor the trainee", class: "govuk-fieldset__legend")
+    expect(page).to have_element(:div, text: "Only your school will be able to see the assigned mentor. Providers will not have access to this information.", class: "govuk-hint")
     expect(page).to have_element(:span, text: "My mentor is not listed", class: "govuk-details__summary-text")
     expect(page).to have_link("Cancel", href: "/schools/#{@school.id}/placements")
   end

--- a/spec/system/placements/support/schools/placements/primary_school_support_user_edits_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/primary_school_support_user_edits_a_placement_spec.rb
@@ -305,11 +305,11 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   end
 
   def then_i_see_the_select_a_mentor_page
-    expect(page).to have_title("Select a mentor - Placement details - Manage school placements - GOV.UK")
+    expect(page).to have_title("Select who will mentor the trainee - Placement details - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
-    expect(page).to have_element(:legend, text: "Select a mentor", class: "govuk-fieldset__legend")
-    expect(page).to have_element(:div, text: "Some placements may have more than one mentor. For example, if a mentor works part time.", class: "govuk-hint")
+    expect(page).to have_element(:legend, text: "Select who will mentor the trainee", class: "govuk-fieldset__legend")
+    expect(page).to have_element(:div, text: "Only your school will be able to see the assigned mentor. Providers will not have access to this information.", class: "govuk-hint")
     expect(page).to have_element(:span, text: "My mentor is not listed", class: "govuk-details__summary-text")
     expect(page).to have_link("Cancel", href: "/schools/#{@springfield_elementary_school.id}/placements/#{@placement.id}")
   end

--- a/spec/system/placements/support/schools/placements/secondary_school_support_user_adds_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/secondary_school_support_user_adds_a_placement_spec.rb
@@ -264,11 +264,11 @@ RSpec.describe "Secondary school user adds a placement", service: :placements, t
   end
 
   def then_i_see_the_select_a_mentor_page
-    expect(page).to have_title("Select a mentor - Placement details - Manage school placements - GOV.UK")
+    expect(page).to have_title("Select who will mentor the trainee - Placement details - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
-    expect(page).to have_element(:legend, text: "Select a mentor", class: "govuk-fieldset__legend")
-    expect(page).to have_element(:div, text: "Some placements may have more than one mentor. For example, if a mentor works part time. You can change who the mentor is after you have published the placement.", class: "govuk-hint")
+    expect(page).to have_element(:legend, text: "Select who will mentor the trainee", class: "govuk-fieldset__legend")
+    expect(page).to have_element(:div, text: "Only your school will be able to see the assigned mentor. Providers will not have access to this information.", class: "govuk-hint")
     expect(page).to have_element(:span, text: "My mentor is not listed", class: "govuk-details__summary-text")
     expect(page).to have_link("Cancel", href: "/schools/#{@school.id}/placements")
   end

--- a/spec/system/placements/support/schools/placements/secondary_school_support_user_edits_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/secondary_school_support_user_edits_a_placement_spec.rb
@@ -229,11 +229,11 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
   end
 
   def then_i_see_the_select_a_mentor_page
-    expect(page).to have_title("Select a mentor - Placement details - Manage school placements - GOV.UK")
+    expect(page).to have_title("Select who will mentor the trainee - Placement details - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
-    expect(page).to have_element(:legend, text: "Select a mentor", class: "govuk-fieldset__legend")
-    expect(page).to have_element(:div, text: "Some placements may have more than one mentor. For example, if a mentor works part time.", class: "govuk-hint")
+    expect(page).to have_element(:legend, text: "Select who will mentor the trainee", class: "govuk-fieldset__legend")
+    expect(page).to have_element(:div, text: "Only your school will be able to see the assigned mentor. Providers will not have access to this information.", class: "govuk-hint")
     expect(page).to have_element(:span, text: "My mentor is not listed", class: "govuk-details__summary-text")
     expect(page).to have_link("Cancel", href: "/schools/#{@hogwarts_school.id}/placements/#{@placement.id}")
   end

--- a/spec/system/placements/support/schools/placements/support_user_publishes_a_placement_after_preview_spec.rb
+++ b/spec/system/placements/support/schools/placements/support_user_publishes_a_placement_after_preview_spec.rb
@@ -146,11 +146,11 @@ RSpec.describe "Support user publishes a placement after preview", service: :pla
   end
 
   def then_i_see_the_select_a_mentor_page
-    expect(page).to have_title("Select a mentor - Placement details - Manage school placements - GOV.UK")
+    expect(page).to have_title("Select who will mentor the trainee - Placement details - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
-    expect(page).to have_element(:legend, text: "Select a mentor", class: "govuk-fieldset__legend")
-    expect(page).to have_element(:div, text: "Some placements may have more than one mentor. For example, if a mentor works part time. You can change who the mentor is after you have published the placement.", class: "govuk-hint")
+    expect(page).to have_element(:legend, text: "Select who will mentor the trainee", class: "govuk-fieldset__legend")
+    expect(page).to have_element(:div, text: "Only your school will be able to see the assigned mentor. Providers will not have access to this information.", class: "govuk-hint")
     expect(page).to have_element(:span, text: "My mentor is not listed", class: "govuk-details__summary-text")
     expect(page).to have_link("Cancel", href: "/schools/#{@school.id}/placements")
   end


### PR DESCRIPTION
## Context

Update the mentor screen as part of the content sweep

## Changes proposed in this pull request

- Change the h1 content
- Change the hint text content

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[Sweep: Change select a mentor screen](https://trello.com/c/O5mUOCTE/586-sweep-change-select-a-mentor-screen)

## Screenshots

![image](https://github.com/user-attachments/assets/fd61cc58-72f5-45ee-89e1-880504291afd)
