### PR TITLE
Content changes for green and amber EOI paths

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -24,6 +24,34 @@ class Subject < ApplicationRecord
   has_many :child_subjects, class_name: "Subject", foreign_key: :parent_subject_id, dependent: :destroy
   has_many :placements, dependent: :restrict_with_exception
 
+  STEM_SUBJECTS = [
+    "Biology",
+    "Chemistry",
+    "Computing",
+    "Design and technology",
+    "Mathematics",
+    "Physics",
+  ].freeze
+  LIT_LANG_SUBJECTS = ["English", "Modern Languages"].freeze
+  ART_HUMANITIES_SOCIAL_SUBJECTS = [
+    "Art and design",
+    "Business studies",
+    "Citizenship",
+    "Classics",
+    "Communication and media studies",
+    "Dance",
+    "Drama",
+    "Economics",
+    "Geography",
+    "History",
+    "Music",
+    "Philosophy",
+    "Psychology",
+    "Religious education",
+    "Social sciences",
+  ].freeze
+  HEALTH_PHYSICAL_EDUCATION_SUBJECTS = ["Health and social care", "Physical education"].freeze
+
   enum :subject_area,
        { primary: "primary", secondary: "secondary" },
        validate: true
@@ -32,6 +60,10 @@ class Subject < ApplicationRecord
 
   scope :order_by_name, -> { order(:name) }
   scope :parent_subjects, -> { where(parent_subject_id: nil).order_by_name }
+  scope :stem_subjects, -> { where(name: STEM_SUBJECTS) }
+  scope :lit_lang_subjects, -> { where(name: LIT_LANG_SUBJECTS) }
+  scope :art_humanities_social_subjects, -> { where(name: ART_HUMANITIES_SOCIAL_SUBJECTS) }
+  scope :health_physical_education_subjects, -> { where(name: HEALTH_PHYSICAL_EDUCATION_SUBJECTS) }
 
   def has_child_subjects?
     child_subjects.exists?

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -31,9 +31,16 @@ class Subject < ApplicationRecord
     "Design and technology",
     "Mathematics",
     "Physics",
+    "Science", # TODO: Category unsure
   ].freeze
-  LIT_LANG_SUBJECTS = ["English", "Modern Languages"].freeze
+  LIT_LANG_SUBJECTS = [
+    "English",
+    "Modern Languages",
+    "Latin", # TODO: Category unsure
+  ].freeze
   ART_HUMANITIES_SOCIAL_SUBJECTS = [
+    "Ancient Greek", # TODO: Category unsure
+    "Ancient Hebrew", # TODO: Category unsure
     "Art and design",
     "Business studies",
     "Citizenship",
@@ -50,7 +57,11 @@ class Subject < ApplicationRecord
     "Religious education",
     "Social sciences",
   ].freeze
-  HEALTH_PHYSICAL_EDUCATION_SUBJECTS = ["Health and social care", "Physical education"].freeze
+  HEALTH_PHYSICAL_EDUCATION_SUBJECTS = [
+    "Health and social care",
+    "Physical education",
+    "Physical education with an EBacc subject", # TODO: Category unsure
+  ].freeze
 
   enum :subject_area,
        { primary: "primary", secondary: "secondary" },

--- a/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_actively_looking.html.erb
+++ b/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_actively_looking.html.erb
@@ -14,6 +14,10 @@
   ) %>
 </p>
 
+<p class="govuk-body">
+  <%= t(".assigning_a_provider_is_not_contractual") %>
+</p>
+
 <h2 class="govuk-heading-m">
   <%= t(".manage_your_placements") %>
 </h2>

--- a/app/views/placements/schools/placements/index.html.erb
+++ b/app/views/placements/schools/placements/index.html.erb
@@ -35,7 +35,7 @@
         <%= app_table do |table| %>
           <% table.with_head do |head| %>
             <% head.with_row do |row| %>
-              <% row.with_cell(header: true, text: t(".subject")) %>
+              <% row.with_cell(header: true, text: t(".placement")) %>
               <% row.with_cell(header: true, text: t(".mentor")) %>
               <% row.with_cell(header: true, text: t(".expected_date")) %>
               <% row.with_cell(header: true, text: t(".provider")) %>

--- a/app/views/shared/wizards/placements/multiple_placements_wizard/_check_your_answers.html.erb
+++ b/app/views/shared/wizards/placements/multiple_placements_wizard/_check_your_answers.html.erb
@@ -1,6 +1,8 @@
 <%# locals: { current_step:, wizard:, potential: false } -%>
 
-<h2 class="govuk-heading-m"><%= t(".education_phase") %></h2>
+<h2 class="govuk-heading-m">
+  <%= potential ? t(".potential_education_phase") : t(".education_phase") %>
+</h2>
 
 <%= render "shared/wizards/placements/multiple_placements_wizard/check_your_answers/education_phase_list",
  current_step: %>

--- a/app/views/shared/wizards/placements/multiple_placements_wizard/check_your_answers/_education_phase_list.html.erb
+++ b/app/views/shared/wizards/placements/multiple_placements_wizard/check_your_answers/_education_phase_list.html.erb
@@ -5,7 +5,13 @@
     <% if current_step.phases.include?(Placements::AddHostingInterestWizard::UNKNOWN_OPTION) %>
       <% row.with_value(text: t(".unknown")) %>
     <% else %>
-      <% row.with_value(text: current_step.phases.to_sentence) %>
+      <% row.with_value do %>
+        <%= govuk_list do %>
+          <% current_step.phases.each do |phase| %>
+            <li><%= phase %></li>
+          <% end %>
+        <% end %>
+      <% end %>
     <% end %>
     <% row.with_action(text: t("change"),
                        href: step_path(:phase),

--- a/app/views/wizards/placements/add_hosting_interest_wizard/_appetite_step.html.erb
+++ b/app/views/wizards/placements/add_hosting_interest_wizard/_appetite_step.html.erb
@@ -13,7 +13,8 @@
         :appetite,
         current_step.appetite_options,
         :value, :name, :description,
-        legend: { size: "l", text: t(".title", academic_year_name: @wizard.upcoming_academic_year.name), tag: "h1" }
+        legend: { size: "l", text: t(".title", academic_year_name: @wizard.upcoming_academic_year.name), tag: "h1" },
+        hint: { text: t(".hint") }
       ) %>
 
       <%= f.govuk_submit t(".continue") %>

--- a/app/views/wizards/placements/add_hosting_interest_wizard/_check_your_answers_step.html.erb
+++ b/app/views/wizards/placements/add_hosting_interest_wizard/_check_your_answers_step.html.erb
@@ -17,7 +17,7 @@
         potential: false %>
 
       <% if @wizard.steps[:school_contact].present? %>
-        <h2 class="govuk-heading-m"><%= t(".itt_contact") %></h2>
+        <h2 class="govuk-heading-m"><%= t(".placement_contact") %></h2>
 
         <%= govuk_summary_list(html_attributes: { id: "school_contact" }) do |summary_list| %>
           <% summary_list.with_row do |row| %>

--- a/app/views/wizards/placements/add_hosting_interest_wizard/interested/_phase_step.html.erb
+++ b/app/views/wizards/placements/add_hosting_interest_wizard/interested/_phase_step.html.erb
@@ -9,7 +9,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l"><%= t(".caption") %></span>
-      <%= f.govuk_check_boxes_fieldset(:phases, legend: { size: "l", text: t(".title"), tag: "h1" }) do %>
+      <%= f.govuk_check_boxes_fieldset(:phases, 
+        legend: { size: "l", text: t(".title"), tag: "h1" },
+        hint: { text: t(".hint") }) do %>
         <% current_step.phases_for_selection.each_with_index do |phase, i| %>
           <%= f.govuk_check_box :phases, phase.name,
             label: { text: phase.name },

--- a/app/views/wizards/placements/add_hosting_interest_wizard/interested/_phase_step.html.erb
+++ b/app/views/wizards/placements/add_hosting_interest_wizard/interested/_phase_step.html.erb
@@ -9,7 +9,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l"><%= t(".caption") %></span>
-      <%= f.govuk_check_boxes_fieldset(:phases, 
+      <%= f.govuk_check_boxes_fieldset(:phases,
         legend: { size: "l", text: t(".title"), tag: "h1" },
         hint: { text: t(".hint") }) do %>
         <% current_step.phases_for_selection.each_with_index do |phase, i| %>

--- a/app/views/wizards/placements/add_hosting_interest_wizard/interested/_secondary_child_subject_placement_selection_step.html.erb
+++ b/app/views/wizards/placements/add_hosting_interest_wizard/interested/_secondary_child_subject_placement_selection_step.html.erb
@@ -13,25 +13,30 @@
       <span class="govuk-caption-l"><%= t(".caption") %></span>
       <h1 class="govuk-heading-l">
         <%= t(".title",
-          placement_quantity: @wizard.placement_quantity_for_subject(current_step.subject),
           subject_name: current_step.subject.name) %>
       </h1>
 
-      <h2 class="govuk-heading-m">
-        <%= t(".select_languages_taught") %>
-      </h2>
-      <%= f.govuk_collection_check_boxes(
+      <%= f.govuk_check_boxes_fieldset(
         :child_subject_ids,
-        current_step.child_subjects,
-        :id, :name,
         legend: {
           size: "m",
           text: t(".placement_number",
             placement_number: current_step.selection_number,
             step_count: @wizard.child_subject_placement_step_count),
           tag: "h2",
-}
-      ) %>
+        }
+      ) do %>
+        <% current_step.child_subjects.each_with_index do |subject, i| %>
+          <%= f.govuk_check_box :child_subject_ids, subject.id,
+            label: { text: subject.name },
+            link_errors: i.zero? %>
+        <% end %>
+        <%= f.govuk_check_box_divider %>
+        <%= f.govuk_check_box :child_subject_ids, current_step.unknown_option.value,
+            label: { text: current_step.unknown_option.name },
+            hint: { text: current_step.unknown_option.description },
+            exclusive: true %>
+      <% end %>
 
       <%= f.govuk_submit t(".continue") %>
     </div>

--- a/app/views/wizards/placements/add_hosting_interest_wizard/interested/_secondary_child_subject_placement_selection_step.html.erb
+++ b/app/views/wizards/placements/add_hosting_interest_wizard/interested/_secondary_child_subject_placement_selection_step.html.erb
@@ -24,7 +24,7 @@
             placement_number: current_step.selection_number,
             step_count: @wizard.child_subject_placement_step_count),
           tag: "h2",
-        }
+        },
       ) do %>
         <% current_step.child_subjects.each_with_index do |subject, i| %>
           <%= f.govuk_check_box :child_subject_ids, subject.id,

--- a/app/views/wizards/placements/add_hosting_interest_wizard/interested/_secondary_placement_quantity_known_step.html.erb
+++ b/app/views/wizards/placements/add_hosting_interest_wizard/interested/_secondary_placement_quantity_known_step.html.erb
@@ -14,7 +14,8 @@
             :quantity_known,
             current_step.options_for_selection,
             :name, :name,
-            legend: { size: "l", text: t(".title"), tag: "h1" }
+            legend: { size: "l", text: t(".title"), tag: "h1" },
+            hint: { text: t(".hint") }
           ) %>
 
       <%= f.govuk_submit t(".continue") %>

--- a/app/views/wizards/placements/add_hosting_interest_wizard/interested/_secondary_subject_selection_step.html.erb
+++ b/app/views/wizards/placements/add_hosting_interest_wizard/interested/_secondary_subject_selection_step.html.erb
@@ -15,10 +15,27 @@
         legend: { size: "l", text: t(".title"), tag: "h1" },
         hint: { text: t(".hint") },
       ) do %>
-        <% current_step.subjects_for_selection.each_with_index do |subject, i| %>
+        <p class="govuk-body secondary-text"><%= t(".sharing_info") %></p>
+        <h2 class="govuk-heading-m"><%= t(".stem_subjects") %></h2>
+        <% current_step.stem_subjects.each_with_index do |subject, i| %>
           <%= f.govuk_check_box :subject_ids, subject.id,
             label: { text: subject.name },
             link_errors: i.zero? %>
+        <% end %>
+        <h2 class="govuk-heading-m"><%= t(".lit_lang_subjects") %></h2>
+        <% current_step.lit_lang_subjects.each do |subject| %>
+          <%= f.govuk_check_box :subject_ids, subject.id,
+            label: { text: subject.name } %>
+        <% end %>
+        <h2 class="govuk-heading-m"><%= t(".art_humanities_social_subjects") %></h2>
+        <% current_step.art_humanities_social_subjects.each do |subject| %>
+          <%= f.govuk_check_box :subject_ids, subject.id,
+            label: { text: subject.name } %>
+        <% end %>
+        <h2 class="govuk-heading-m"><%= t(".health_physical_education_subjects") %></h2>
+        <% current_step.health_physical_education_subjects.each do |subject| %>
+          <%= f.govuk_check_box :subject_ids, subject.id,
+            label: { text: subject.name } %>
         <% end %>
         <%= f.govuk_check_box_divider %>
         <%= f.govuk_check_box :subject_ids, current_step.unknown_option.value,

--- a/app/views/wizards/placements/add_hosting_interest_wizard/interested/_year_group_placement_quantity_known_step.html.erb
+++ b/app/views/wizards/placements/add_hosting_interest_wizard/interested/_year_group_placement_quantity_known_step.html.erb
@@ -14,7 +14,8 @@
             :quantity_known,
             current_step.options_for_selection,
             :name, :name,
-            legend: { size: "l", text: t(".title"), tag: "h1" }
+            legend: { size: "l", text: t(".title"), tag: "h1" },
+            hint: { text: t(".hint") }
           ) %>
 
       <%= f.govuk_submit t(".continue") %>

--- a/app/views/wizards/placements/add_hosting_interest_wizard/interested/_year_group_placement_quantity_step.html.erb
+++ b/app/views/wizards/placements/add_hosting_interest_wizard/interested/_year_group_placement_quantity_step.html.erb
@@ -10,7 +10,7 @@
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l"><%= t(".caption") %></span>
       <h1 class="govuk-heading-l"><%= t(".title") %></h1>
-      <p class="govuk-body secondary-text"><%= t(".enter_approximate") %></p>
+      <p class="govuk-body secondary-text"><%= t(".hint") %></p>
 
       <% current_step.year_groups.each do |year_group| %>
         <%= f.govuk_number_field(

--- a/app/views/wizards/placements/multi_placement_wizard/_secondary_child_subject_placement_selection_step.html.erb
+++ b/app/views/wizards/placements/multi_placement_wizard/_secondary_child_subject_placement_selection_step.html.erb
@@ -13,13 +13,9 @@
       <span class="govuk-caption-l"><%= t(".caption") %></span>
       <h1 class="govuk-heading-l">
         <%= t(".title",
-          placement_quantity: @wizard.placement_quantity_for_subject(current_step.subject),
           subject_name: current_step.subject.name) %>
       </h1>
 
-      <h2 class="govuk-heading-m">
-        <%= t(".select_languages_taught") %>
-      </h2>
       <%= f.govuk_collection_check_boxes(
         :child_subject_ids,
         current_step.child_subjects,
@@ -30,7 +26,7 @@
             placement_number: current_step.selection_number,
             step_count: @wizard.child_subject_placement_step_count),
           tag: "h2",
-}
+        }
       ) %>
 
       <%= f.govuk_submit t(".continue") %>

--- a/app/views/wizards/placements/multi_placement_wizard/_secondary_subject_selection_step.html.erb
+++ b/app/views/wizards/placements/multi_placement_wizard/_secondary_subject_selection_step.html.erb
@@ -9,13 +9,33 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l"><%= t(".caption") %></span>
-      <%= f.govuk_collection_check_boxes(
+      <%= f.govuk_check_boxes_fieldset(
         :subject_ids,
-        current_step.subjects_for_selection,
-        :id, :name,
         legend: { size: "l", text: t(".title"), tag: "h1" },
-        hint: { text: t(".hint") }
-      ) %>
+        hint: { text: t(".hint") },
+      ) do %>
+        <h2 class="govuk-heading-m"><%= t(".stem_subjects") %></h2>
+        <% current_step.stem_subjects.each_with_index do |subject, i| %>
+          <%= f.govuk_check_box :subject_ids, subject.id,
+            label: { text: subject.name },
+            link_errors: i.zero? %>
+        <% end %>
+        <h2 class="govuk-heading-m"><%= t(".lit_lang_subjects") %></h2>
+        <% current_step.lit_lang_subjects.each do |subject| %>
+          <%= f.govuk_check_box :subject_ids, subject.id,
+            label: { text: subject.name } %>
+        <% end %>
+        <h2 class="govuk-heading-m"><%= t(".art_humanities_social_subjects") %></h2>
+        <% current_step.art_humanities_social_subjects.each do |subject| %>
+          <%= f.govuk_check_box :subject_ids, subject.id,
+            label: { text: subject.name } %>
+        <% end %>
+        <h2 class="govuk-heading-m"><%= t(".health_physical_education_subjects") %></h2>
+        <% current_step.health_physical_education_subjects.each do |subject| %>
+          <%= f.govuk_check_box :subject_ids, subject.id,
+            label: { text: subject.name } %>
+        <% end %>
+      <% end %>
 
       <%= f.govuk_submit t(".continue") %>
     </div>

--- a/app/wizards/placements/add_hosting_interest_wizard.rb
+++ b/app/wizards/placements/add_hosting_interest_wizard.rb
@@ -39,7 +39,7 @@ module Placements
 
         hosting_interest.save!
 
-        if appetite == "interested"
+        if appetite_interested?
           save_potential_placements_information
         else
           create_placements
@@ -168,7 +168,7 @@ module Placements
     end
 
     def year_group_steps
-      if appetite == "interested"
+      if appetite_interested?
         add_step(Interested::YearGroupSelectionStep)
         return if value_unknown(year_groups)
 
@@ -182,14 +182,8 @@ module Placements
       end
     end
 
-    def primary_subject_steps
-      add_step(MultiPlacementWizard::PrimarySubjectSelectionStep)
-      add_step(MultiPlacementWizard::PrimaryPlacementQuantityStep)
-      # No primary subject have child subjects
-    end
-
     def secondary_subject_steps
-      if appetite == "interested"
+      if appetite_interested?
         add_step(Interested::SecondarySubjectSelectionStep)
         return if value_unknown(selected_secondary_subject_ids)
 
@@ -211,8 +205,7 @@ module Placements
 
           placement_quantity_for_subject(subject).times do |i|
             index = i + 1
-            prefix = appetite == "interested" ? Interested : MultiPlacementWizard
-            add_step(prefix::SecondaryChildSubjectPlacementSelectionStep,
+            add_step(step_prefix::SecondaryChildSubjectPlacementSelectionStep,
                      {
                        selection_id: "#{subject.name_as_attribute}_#{index}",
                        selection_number: index,
@@ -320,6 +313,18 @@ module Placements
       }
 
       @school.update!(potential_placement_details:)
+    end
+
+    def appetite_interested?
+      @appetite_interested ||= appetite == "interested"
+    end
+
+    def step_prefix
+      @step_prefix ||= if appetite_interested?
+                         Interested
+                       else
+                         MultiPlacementWizard
+                       end
     end
   end
 end

--- a/app/wizards/placements/add_hosting_interest_wizard.rb
+++ b/app/wizards/placements/add_hosting_interest_wizard.rb
@@ -211,7 +211,8 @@ module Placements
 
           placement_quantity_for_subject(subject).times do |i|
             index = i + 1
-            add_step(MultiPlacementWizard::SecondaryChildSubjectPlacementSelectionStep,
+            prefix = appetite == "interested" ? Interested : MultiPlacementWizard
+            add_step(prefix::SecondaryChildSubjectPlacementSelectionStep,
                      {
                        selection_id: "#{subject.name_as_attribute}_#{index}",
                        selection_number: index,

--- a/app/wizards/placements/add_hosting_interest_wizard/interested/secondary_child_subject_placement_selection_step.rb
+++ b/app/wizards/placements/add_hosting_interest_wizard/interested/secondary_child_subject_placement_selection_step.rb
@@ -1,2 +1,17 @@
 class Placements::AddHostingInterestWizard::Interested::SecondaryChildSubjectPlacementSelectionStep < Placements::MultiPlacementWizard::SecondaryChildSubjectPlacementSelectionStep
+  def unknown_option
+    @unknown_option ||=
+      OpenStruct.new(
+        value: Placements::AddHostingInterestWizard::UNKNOWN_OPTION,
+        name: I18n.t(
+          "#{unknown_option_locale_path}.unknown",
+        ),
+      )
+  end
+
+  private
+
+  def unknown_option_locale_path
+    ".wizards.placements.add_hosting_interest_wizard.interested.secondary_child_subject_placement_selection_step.options"
+  end
 end

--- a/app/wizards/placements/multi_placement_wizard/secondary_subject_selection_step.rb
+++ b/app/wizards/placements/multi_placement_wizard/secondary_subject_selection_step.rb
@@ -1,4 +1,8 @@
 class Placements::MultiPlacementWizard::SecondarySubjectSelectionStep < Placements::MultiPlacementWizard::SubjectSelectionStep
+  delegate :stem_subjects, :lit_lang_subjects,
+           :art_humanities_social_subjects, :health_physical_education_subjects,
+           to: :subjects_for_selection
+
   private
 
   def phase

--- a/app/wizards/placements/multi_placement_wizard/subject_selection_step.rb
+++ b/app/wizards/placements/multi_placement_wizard/subject_selection_step.rb
@@ -4,7 +4,7 @@ class Placements::MultiPlacementWizard::SubjectSelectionStep < BaseStep
   validates :subject_ids, presence: true
 
   def subjects_for_selection
-    {
+    @subjects_for_selection ||= {
       Placements::School::PRIMARY_PHASE => Subject.parent_subjects.primary,
       Placements::School::SECONDARY_PHASE => Subject.parent_subjects.secondary,
     }.fetch phase

--- a/config/locales/en/placements/schools/hosting_interests.yml
+++ b/config/locales/en/placements/schools/hosting_interests.yml
@@ -36,17 +36,17 @@ en:
                 If you would like to host placements this year, %{link} to let providers know you’re interested.
               update_your_placement_preferences: update your placement preferences
             interested:
-              panel_title: Approximate information added
+              panel_title: Information added
               panel_text: Providers can see that you may offer placements
-              what_happens_next: What happens next?
+              what_happens_next: What happens next
               providers_can_contact_you:
                 Providers who are looking for schools to work with can contact you on %{mailto}.
               once_you_know_which_placements:
-                Once you know which placements you can offer, you can %{link} to help providers know what trainees you need.
-              add_placements: add placements
-              potential_placement_information: Potential placement information
-              potential_primary_placements: Potential primary placements
-              potential_secondary_placements: Potential secondary placements
+                Once you are sure which placements your school can offer, %{link}. Doing so will mean you will be able to assign providers to them.
+              add_placements: add your placements
+              potential_placement_information: Your potential placements
+              potential_primary_placements: Potential primary school placements
+              potential_secondary_placements: Potential secondary school placements
             primary_placements_list:
               year_group: Year group
               number_of_placements: Number of placements
@@ -68,11 +68,13 @@ en:
               primary_placements: Primary placements
               secondary_placements: Secondary placements
               manage_your_placements: Manage your placements
-              you_can_edit_placements: You can %{link} at any time.
-              edit_your_placements: edit your placements
-              editing_them: "Editing them allows you to:"
+              you_can_edit_placements: "%{link} to change or remove information."
+              edit_your_placements: Edit your placements
+              editing_them: "For each individual placement, you can:"
               editing_options:
-                - assign a provider
                 - add an expected date
-                - change or remove any information
+                - assign a provider
                 - assign a mentor - only your school will be able to see mentor information
+              assigning_a_provider_is_not_contractual:
+                Assigning a provider to a placement in this service is not a contractual agreement for a trainee to be placed in your school.
+                An agreement must be made between you and the provider outside this service. 

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -98,7 +98,7 @@ en:
             you_must_add_itt_placement_contact: |
               Before you add a placement, you must %{link_to} so that the teacher training providers can contact you.
             add_itt_placement_contact: add a placement contact
-            subject: Subject
+            placement: Placement
             mentor: Mentor
             expected_date: Expected date
             provider: Provider

--- a/config/locales/en/shared/wizards/placements/multiple_placements_wizard.yml
+++ b/config/locales/en/shared/wizards/placements/multiple_placements_wizard.yml
@@ -5,6 +5,7 @@ en:
         multiple_placements_wizard:
           check_your_answers:
             education_phase: Education phase
+            potential_education_phase: Potential education phase
             placements: Placements
             year_group: Year group
             number_of_placements: Number of placements

--- a/config/locales/en/wizards/placements/add_hosting_interest_wizard.yml
+++ b/config/locales/en/wizards/placements/add_hosting_interest_wizard.yml
@@ -144,7 +144,7 @@ en:
             options:
               unknown: I don’t know
           secondary_placement_quantity_known_step:
-            title: Do you know how many secondary  school placements you may be willing to offer?
+            title: Do you know how many secondary school placements you may be willing to offer?
             hint: Sharing information on what you may be able to offer helps providers know whether to contact you. It is not a commitment to take a trainee teacher.
             caption: Potential secondary placement details
             continue: Continue

--- a/config/locales/en/wizards/placements/add_hosting_interest_wizard.yml
+++ b/config/locales/en/wizards/placements/add_hosting_interest_wizard.yml
@@ -5,18 +5,19 @@ en:
         appetite_step:
           caption: Placement preferences
           title: 
-            Can your school offer placements for trainee teachers in this academic year (%{academic_year_name})?
+            Can your school offer placements for trainee teachers in the academic year %{academic_year_name}?
           continue: Continue
+          hint: You can change your answers any time after completing the questions.
           options:
             actively_looking:
               name: Yes - I can offer placements
-              description: Record the placements you can offer. You can edit your placements any time.
+              description: Share the placements you can offer
             interested:
               name: Maybe - I’m not sure yet
-              description: Providers can contact you to discuss potential placements.
+              description: Share what you can potentially offer
             not_open: 
               name: No - I can’t offer placements
-              description: Tell us why your school cannot offer placements. Your contact details will not be shown to providers.
+              description: Tell us why you cannot offer placements
             already_organised:
               name: Placements already organised with providers
               description: We'll show any providers who search for you that you're at capacity
@@ -52,7 +53,7 @@ en:
         school_contact_step:
           caption: Contact details
           title: Who should providers contact?
-          description: Choose the person best placed to organise ITT placements at your school. This information will be shown on your profile.
+          description: Choose the person best placed to organise placements for trainee teachers at your school
           continue: Continue
         subjects_known_step:
           title: Do you know which subjects you would like to host?
@@ -60,9 +61,9 @@ en:
         check_your_answers_step:
           caption: Placement details
           title: Check your answers
-          continue: Save and continue
+          continue: Publish placements
           change: Change
-          itt_contact: ITT contact
+          placement_contact: Placement contact
         are_you_sure_step:
           title: Confirm and let providers know you are not offering placements
           caption: Not offering placements this year
@@ -82,7 +83,7 @@ en:
           providers_see_you_can_offer_placements:
             Providers will be able to see that you may be able to offer placements for trainee teachers.
           providers_can_see_approximate_info:
-            They will be able to see your approximate information and will be able to use your email to contact you.
+            They will be able to see your potential placement details and will be able to use your email to contact you.
           your_information: Your information
           additional_information: Additional information
           message_to_providers: Message to providers
@@ -90,15 +91,16 @@ en:
           change: Change
         interested:
           phase_step:
-            title: Do you know what phase of education your placements will be?
+            title: What education phase could you offer placements in?
+            hint: Sharing information on what you may be able to offer helps providers know whether to contact you. It is not a commitment to take a trainee teacher.
             caption: Potential placement offer details
             continue: Continue
             options:
               unknown: I don’t know
               unknown_description: A phase of education will not be recorded
           year_group_selection_step:
-            title: Do you know what primary school year groups you would be willing to host placements in?
-            hint: You will be able to enter the number of placements on the next screen
+            title: What year groups could you offer placements in?
+            hint: Sharing information on what you may be able to offer helps providers know whether to contact you. It is not a commitment to take a trainee teacher.
             caption: Potential primary placement details
             continue: Continue
             options:
@@ -110,11 +112,15 @@ en:
               "no": "No"
           year_group_placement_quantity_known_step:
             title: 
-              Do you know the number of primary placements you would be willing to host in each year group?
+              Do you know how many placements could you offer for each primary school year group?
+            hint:
+              Sharing information on what you may be able to offer helps providers know whether to contact you. It is not a commitment to take a trainee teacher.
             caption: Potential primary placement details
             continue: Continue
           year_group_placement_quantity_step:
-            title: How many primary placements you would be willing to host in each year group?
+            title: How many placements could you offer for each year group?
+            hint:
+              Sharing information on what you may be able to offer helps providers know whether to contact you. It is not a commitment to take a trainee teacher.
             caption: Potential primary placement details
             enter_approximate: Enter an approximate number if you are unsure
             continue: Continue
@@ -124,29 +130,37 @@ en:
             caption: Potential placement details
             continue: Continue
           secondary_subject_selection_step:
-            title: Do you know the secondary school subjects you could have placements in?
+            title: What subjects could you offer placements in?
             caption: Potential secondary placement details
             hint: 
-              Subjects are taken from the DfE database of courses. If the subject you would like to host is not here, choose the closest option
+              Subjects are taken from the DfE database of courses. If the subject you would like to host is not here, choose the closest option.
+            sharing_info: 
+              Sharing information on what you may be able to offer helps providers know whether to contact you. It is not a commitment to take a trainee teacher.
+            stem_subjects: Science, technology, engineering and mathematics (STEM)
+            lit_lang_subjects: Languages and literature
+            art_humanities_social_subjects: Arts, humanities and social sciences
+            health_physical_education_subjects: Health and physical education
             continue: Continue
             options:
               unknown: I don’t know
           secondary_placement_quantity_known_step:
-            title: Do you know the number of secondary placements you would be willing to host?
+            title: Do you know how many secondary  school placements you may be willing to offer?
+            hint: Sharing information on what you may be able to offer helps providers know whether to contact you. It is not a commitment to take a trainee teacher.
             caption: Potential secondary placement details
             continue: Continue
           secondary_placement_quantity_step:
-            title: How many secondary placements you would be willing to host in each subject?
+            title: How many placements could you offer for each subject?
             caption: Potential secondary placement details
             enter_approximate: Enter an approximate number if you are unsure
             change_to_specify: You will have a chance to specify the languages later
             continue: Continue
           secondary_child_subject_placement_selection_step:
-            title: You selected %{placement_quantity} %{subject_name} placements
-            select_languages_taught: Select the languages taught on each of these placements
+            title: What languages are taught on your %{subject_name} placement offers?
             caption: Potential secondary placement details
             continue: Continue
             placement_number: "Placement %{placement_number} of %{step_count}"
+            options:
+              unknown: Not sure yet
         not_open:
           school_contact_step:
             caption: Not offering placements this year

--- a/config/locales/en/wizards/placements/multi_placement_wizard.yml
+++ b/config/locales/en/wizards/placements/multi_placement_wizard.yml
@@ -49,9 +49,13 @@ en:
           caption: Placement details
           continue: Continue
         secondary_subject_selection_step:
-          title: Select secondary school subjects you can offer
+          title: What secondary school subjects can you offer placements in?
           caption: Secondary placement details
           hint: Subjects are taken from the DfE database of courses. If the subject you would like to host is not here, choose the closest option
+          stem_subjects: Science, technology, engineering and mathematics (STEM)
+          lit_lang_subjects: Languages and literature
+          art_humanities_social_subjects: Arts, humanities and social sciences
+          health_physical_education_subjects: Health and physical education
           continue: Continue
         primary_placement_quantity_step:
           title: "Primary subjects: Enter the number of placements you would be willing to host"
@@ -59,14 +63,13 @@ en:
           caption: Placement details
           continue: Continue
         secondary_placement_quantity_step:
-          title: Enter the number of secondary school placements you can offer
+          title: How many placements can you offer for each subject?
           enter_approximate: Enter an approximate number if you are unsure
           change_to_specify: You will have a chance to specify the languages later
           caption: Secondary placement details
           continue: Continue
         secondary_child_subject_placement_selection_step:
-          title: You selected %{placement_quantity} %{subject_name} placements
-          select_languages_taught: Select the languages taught on each of these placements
+          title: What languages are taught on your %{subject_name} placement offers?
           caption: Secondary placement details
           continue: Continue
           placement_number: "Placement %{placement_number} of %{step_count}"
@@ -105,7 +108,7 @@ en:
             You haven’t added any placement information so providers cannot see any of your preferences.
           continue: Continue
         year_group_selection_step:
-          title: Select primary school year groups you can offer
+          title: What primary school year groups can you offer placements in?
           caption: Primary placement details
           hint: You will be able to enter the number of placements on the next screen
           continue: Continue

--- a/spec/system/placements/academic_years/multi_organisation_user_changes_their_selected_academic_year_spec.rb
+++ b/spec/system/placements/academic_years/multi_organisation_user_changes_their_selected_academic_year_spec.rb
@@ -82,13 +82,13 @@ RSpec.describe "School user changes their selected academic year",
 
   def and_i_see_the_placements_for_the_next_academic_year
     expect(page).to have_table_row(
-      "Subject" => "Science",
+      "Placement" => "Science",
     )
   end
 
   def and_i_do_not_see_placements_for_this_academic_year
     expect(page).not_to have_table_row(
-      "Subject" => "English",
+      "Placement" => "English",
     )
   end
 
@@ -130,13 +130,13 @@ RSpec.describe "School user changes their selected academic year",
 
   def and_i_see_the_placements_for_this_academic_year
     expect(page).to have_table_row(
-      "Subject" => "English",
+      "Placement" => "English",
     )
   end
 
   def and_i_do_not_see_placements_for_the_next_academic_year
     expect(page).not_to have_table_row(
-      "Subject" => "Science",
+      "Placement" => "Science",
     )
   end
 end

--- a/spec/system/placements/academic_years/school_user_changes_their_selected_academic_year_spec.rb
+++ b/spec/system/placements/academic_years/school_user_changes_their_selected_academic_year_spec.rb
@@ -62,13 +62,13 @@ RSpec.describe "School user changes their selected academic year",
 
   def and_i_see_the_placements_for_the_next_academic_year
     expect(page).to have_table_row(
-      "Subject" => "Science",
+      "Placement" => "Science",
     )
   end
 
   def and_i_do_not_see_placements_for_this_academic_year
     expect(page).not_to have_table_row(
-      "Subject" => "English",
+      "Placement" => "English",
     )
   end
 
@@ -110,13 +110,13 @@ RSpec.describe "School user changes their selected academic year",
 
   def and_i_see_the_placements_for_this_academic_year
     expect(page).to have_table_row(
-      "Subject" => "English",
+      "Placement" => "English",
     )
   end
 
   def and_i_do_not_see_placements_for_the_next_academic_year
     expect(page).not_to have_table_row(
-      "Subject" => "Science",
+      "Placement" => "Science",
     )
   end
 end

--- a/spec/system/placements/academic_years/support_user_changes_their_selected_academic_year_spec.rb
+++ b/spec/system/placements/academic_years/support_user_changes_their_selected_academic_year_spec.rb
@@ -82,13 +82,13 @@ RSpec.describe "Support user changes their selected academic year",
 
   def and_i_see_the_placements_for_the_next_academic_year
     expect(page).to have_table_row(
-      "Subject" => "Science",
+      "Placement" => "Science",
     )
   end
 
   def and_i_do_not_see_placements_for_this_academic_year
     expect(page).not_to have_table_row(
-      "Subject" => "English",
+      "Placement" => "English",
     )
   end
 
@@ -130,13 +130,13 @@ RSpec.describe "Support user changes their selected academic year",
 
   def and_i_see_the_placements_for_this_academic_year
     expect(page).to have_table_row(
-      "Subject" => "English",
+      "Placement" => "English",
     )
   end
 
   def and_i_do_not_see_placements_for_the_next_academic_year
     expect(page).not_to have_table_row(
-      "Subject" => "Science",
+      "Placement" => "Science",
     )
   end
 end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_add_their_hosting_interest_and_bulk_adds_placements_for_the_primary_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_add_their_hosting_interest_and_bulk_adds_placements_for_the_primary_phase_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     and_i_click_on_continue
     then_i_see_the_check_your_answers_page
 
-    when_i_click_save_and_continue
+    when_i_click_on_publish_placements
     then_i_see_my_responses_were_successfully_updated
     and_i_see_the_whats_next_page
     and_i_see_2_reception_primary_placements_have_been_created
@@ -82,12 +82,12 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -129,12 +129,12 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_primary_year_group_selection_form
     expect(page).to have_title(
-      "Select primary school year groups you can offer - Manage school placements - GOV.UK",
+      "What primary school year groups can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select primary school year groups you can offer",
+      text: "What primary school year groups can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")
@@ -187,8 +187,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_element(
       :p,
-      text: "Choose the person best placed to organise ITT placements at your school. "\
-        "This information will be shown on your profile.",
+      text: "Choose the person best placed to organise placements for trainee teachers at your school",
       class: "govuk-body",
     )
 
@@ -226,8 +225,8 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     click_on "Next year (#{@next_academic_year.name})"
   end
 
-  def when_i_click_save_and_continue
-    click_on "Save and continue"
+  def when_i_click_on_publish_placements
+    click_on "Publish placements"
   end
 
   def then_i_see_the_check_your_answers_page
@@ -245,7 +244,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     expect(page).to have_summary_list_row("Year 3", "3")
     expect(page).to have_summary_list_row("Mixed year group", "1")
 
-    expect(page).to have_h2("ITT contact")
+    expect(page).to have_h2("Placement contact")
     expect(page).to have_summary_list_row("First name", "Joe")
     expect(page).to have_summary_list_row("Last name", "Bloggs")
     expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")
@@ -285,7 +284,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
   end
 
   def when_i_click_on_edit_your_placements
-    click_on "edit your placements"
+    click_on "Edit your placements"
   end
 
   def and_i_see_2_primary_placements_for_reception

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
@@ -67,12 +67,12 @@ RSpec.describe "School user does not enter a placement quantity",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -110,12 +110,12 @@ RSpec.describe "School user does not enter a placement quantity",
 
   def then_i_see_the_primary_year_group_selection_form
     expect(page).to have_title(
-      "Select primary school year groups you can offer - Manage school placements - GOV.UK",
+      "What primary school year groups can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select primary school year groups you can offer",
+      text: "What primary school year groups can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_does_not_select_a_year_group_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_does_not_select_a_year_group_spec.rb
@@ -47,12 +47,12 @@ RSpec.describe "School user does not select a year group",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -90,12 +90,12 @@ RSpec.describe "School user does not select a year group",
 
   def then_i_see_the_primary_year_group_selection_form
     expect(page).to have_title(
-      "Select primary school year groups you can offer - Manage school placements - GOV.UK",
+      "What primary school year groups can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select primary school year groups you can offer",
+      text: "What primary school year groups can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
@@ -52,12 +52,12 @@ RSpec.describe "School user enters a float as a placement quantity",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -95,12 +95,12 @@ RSpec.describe "School user enters a float as a placement quantity",
 
   def then_i_see_the_primary_year_group_selection_form
     expect(page).to have_title(
-      "Select primary school year groups you can offer - Manage school placements - GOV.UK",
+      "What primary school year groups can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select primary school year groups you can offer",
+      text: "What primary school year groups can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
@@ -52,12 +52,12 @@ RSpec.describe "School user enters zero as a placement quantity",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -95,12 +95,12 @@ RSpec.describe "School user enters zero as a placement quantity",
 
   def then_i_see_the_primary_year_group_selection_form
     expect(page).to have_title(
-      "Select primary school year groups you can offer - Manage school placements - GOV.UK",
+      "hat primary school year groups can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select primary school year groups you can offer",
+      text: "What primary school year groups can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "School user enters zero as a placement quantity",
 
   def then_i_see_the_primary_year_group_selection_form
     expect(page).to have_title(
-      "hat primary school year groups can you offer placements in? - Manage school placements - GOV.UK",
+      "What primary school year groups can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     and_i_click_on_continue
     then_i_see_the_check_your_answers_page
 
-    when_i_click_save_and_continue
+    when_i_click_on_publish_placements
     then_i_see_my_responses_were_successfully_updated
     and_i_see_the_whats_next_page
     and_i_see_2_year_1_primary_placements_have_been_created
@@ -145,12 +145,12 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -192,12 +192,12 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_primary_year_group_selection_form
     expect(page).to have_title(
-      "Select primary school year groups you can offer - Manage school placements - GOV.UK",
+      "What primary school year groups can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select primary school year groups you can offer",
+      text: "What primary school year groups can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")
@@ -232,12 +232,12 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
+      "What secondary school subjects can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects you can offer",
+      text: "What secondary school subjects can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
@@ -256,10 +256,10 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
+      "How many placements can you offer for each subject? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements can you offer for each subject?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
     expect(page).to have_field("Mathematics", type: :number)
@@ -278,8 +278,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_element(
       :p,
-      text: "Choose the person best placed to organise ITT placements at your school. "\
-        "This information will be shown on your profile.",
+      text: "Choose the person best placed to organise placements for trainee teachers at your school",
       class: "govuk-body",
     )
 
@@ -296,8 +295,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_element(
       :p,
-      text: "Choose the person best placed to organise ITT placements at your school. "\
-        "This information will be shown on your profile.",
+      text: "Choose the person best placed to organise placements for trainee teachers at your school",
       class: "govuk-body",
     )
 
@@ -340,8 +338,8 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     expect(hosting_interest.appetite).to eq("actively_looking")
   end
 
-  def when_i_click_save_and_continue
-    click_on "Save and continue"
+  def when_i_click_on_publish_placements
+    click_on "Publish placements"
   end
 
   def then_i_see_the_check_your_answers_page
@@ -352,7 +350,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     expect(page).to have_h1("Check your answers")
 
     expect(page).to have_h2("Education phase")
-    expect(page).to have_summary_list_row("Phase", "Primary and Secondary")
+    expect(page).to have_summary_list_row("Phase", "Primary Secondary")
 
     expect(page).to have_h2("Primary placements")
     expect(page).to have_summary_list_row("Year 1", "2")
@@ -361,7 +359,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     expect(page).to have_summary_list_row("English", "1")
     expect(page).to have_summary_list_row("Mathematics", "4")
 
-    expect(page).to have_h2("ITT contact")
+    expect(page).to have_h2("Placement contact")
     expect(page).to have_summary_list_row("First name", "Joe")
     expect(page).to have_summary_list_row("Last name", "Bloggs")
     expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")
@@ -401,7 +399,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
   end
 
   def when_i_click_on_edit_your_placements
-    click_on "edit your placements"
+    click_on "Edit your placements"
   end
 
   def and_i_see_2_primary_placements_for_year_1

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/school_user_does_not_select_a_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/school_user_does_not_select_a_phase_spec.rb
@@ -47,12 +47,12 @@ RSpec.describe "School user does not select a phases",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     and_i_click_on_continue
     then_i_see_the_check_your_answers_page
 
-    when_i_click_save_and_continue
+    when_i_click_on_publish_placements
     then_i_see_my_responses_were_successfully_updated
     and_i_see_the_whats_next_page
     and_i_see_2_secondary_placements_for_modern_languages_have_been_created
@@ -61,7 +61,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     @english = create(:subject, :secondary, name: "English")
     @mathematics = create(:subject, :secondary, name: "Mathematics")
     @science = create(:subject, :secondary, name: "Science")
-    @modern_languages = create(:subject, :secondary, name: "Modern languages")
+    @modern_languages = create(:subject, :secondary, name: "Modern Languages")
     @french = create(:subject, :secondary, name: "French", parent_subject: @modern_languages)
     @spanish = create(:subject, :secondary, name: "Spanish", parent_subject: @modern_languages)
     @russian = create(:subject, :secondary, name: "Russian", parent_subject: @modern_languages)
@@ -90,12 +90,12 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -137,51 +137,47 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
+      "What secondary school subjects can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects you can offer",
+      text: "What secondary school subjects can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
-    expect(page).to have_field("Modern languages", type: :checkbox)
+    expect(page).to have_field("Modern Languages", type: :checkbox)
   end
 
   def when_i_select_modern_languages
-    check "Modern languages"
+    check "Modern Languages"
   end
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
+      "How many placements can you offer for each subject? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements can you offer for each subject?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
-    expect(page).to have_field("Modern languages", type: :number)
+    expect(page).to have_field("Modern Languages", type: :number)
   end
 
   def when_i_fill_in_the_number_of_secondary_placements_i_require
-    fill_in "Modern languages", with: 2
+    fill_in "Modern Languages", with: 2
   end
 
   def then_i_see_the_subject_selection_for_modern_languages_form
     expect(page).to have_title(
-      "You selected 2 Modern languages placements - Manage school placements - GOV.UK",
+      "What languages are taught on your Modern Languages placement offers? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_h1(
-      "You selected 2 Modern languages placements",
+      "What languages are taught on your Modern Languages placement offers?",
       class: "govuk-heading-l",
-    )
-    expect(page).to have_h2(
-      "Select the languages taught on each of these placements",
-      class: "govuk-heading-m",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("French", type: :checkbox)
@@ -217,8 +213,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_element(
       :p,
-      text: "Choose the person best placed to organise ITT placements at your school. "\
-        "This information will be shown on your profile.",
+      text: "Choose the person best placed to organise placements for trainee teachers at your school",
       class: "govuk-body",
     )
 
@@ -270,8 +265,8 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     )
   end
 
-  def when_i_click_save_and_continue
-    click_on "Save and continue"
+  def when_i_click_on_publish_placements
+    click_on "Publish placements"
   end
 
   def then_i_see_the_check_your_answers_page
@@ -285,9 +280,9 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     expect(page).to have_summary_list_row("Phase", "Secondary")
 
     expect(page).to have_h2("Secondary placements")
-    expect(page).to have_summary_list_row("Modern languages", "2")
+    expect(page).to have_summary_list_row("Modern Languages", "2")
 
-    expect(page).to have_h2("ITT contact")
+    expect(page).to have_h2("Placement contact")
     expect(page).to have_summary_list_row("First name", "Joe")
     expect(page).to have_summary_list_row("Last name", "Bloggs")
     expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")
@@ -315,10 +310,10 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
   end
 
   def and_i_see_2_secondary_placements_for_modern_languages_have_been_created
-    expect(page).to have_summary_list_row("Modern languages", "2")
+    expect(page).to have_summary_list_row("Modern Languages", "2")
   end
 
   def when_i_click_on_edit_your_placements
-    click_on "edit your placements"
+    click_on "Edit your placements"
   end
 end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_adds_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_adds_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     and_i_click_on_continue
     then_i_see_the_check_your_answers_page
 
-    when_i_click_save_and_continue
+    when_i_click_on_publish_placements
     then_i_see_my_responses_were_successfully_updated
     and_i_see_the_whats_next_page
     and_i_see_1_secondary_placement_for_english_have_been_created
@@ -76,12 +76,12 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -123,12 +123,12 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
+      "What secondary school subjects can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects you can offer",
+      text: "What secondary school subjects can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
@@ -147,10 +147,10 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
+      "How many placements can you offer for each subject? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements can you offer for each subject?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
     expect(page).to have_field("Mathematics", type: :number)
@@ -169,8 +169,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_element(
       :p,
-      text: "Choose the person best placed to organise ITT placements at your school. "\
-        "This information will be shown on your profile.",
+      text: "Choose the person best placed to organise placements for trainee teachers at your school",
       class: "govuk-body",
     )
 
@@ -222,8 +221,8 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     )
   end
 
-  def when_i_click_save_and_continue
-    click_on "Save and continue"
+  def when_i_click_on_publish_placements
+    click_on "Publish placements"
   end
 
   def then_i_see_the_check_your_answers_page
@@ -240,7 +239,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     expect(page).to have_summary_list_row("English", "1")
     expect(page).to have_summary_list_row("Mathematics", "4")
 
-    expect(page).to have_h2("ITT contact")
+    expect(page).to have_h2(" contact")
     expect(page).to have_summary_list_row("First name", "Joe")
     expect(page).to have_summary_list_row("Last name", "Bloggs")
     expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")
@@ -276,6 +275,6 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
   end
 
   def when_i_click_on_edit_your_placements
-    click_on "edit your placements"
+    click_on "Edit your placements"
   end
 end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
@@ -53,12 +53,12 @@ RSpec.describe "School user does not enter a placement quantity",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -96,12 +96,12 @@ RSpec.describe "School user does not enter a placement quantity",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
+      "What secondary school subjects can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects you can offer",
+      text: "What secondary school subjects can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
@@ -116,10 +116,10 @@ RSpec.describe "School user does not enter a placement quantity",
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
+      "How many placements can you offer for each subject? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements can you offer for each subject?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "School user does not select a child subjects",
     @english = create(:subject, :secondary, name: "English")
     @mathematics = create(:subject, :secondary, name: "Mathematics")
     @science = create(:subject, :secondary, name: "Science")
-    @modern_languages = create(:subject, :secondary, name: "Modern languages")
+    @modern_languages = create(:subject, :secondary, name: "Modern Languages")
     @french = create(:subject, :secondary, name: "French", parent_subject: @modern_languages)
     @spanish = create(:subject, :secondary, name: "Spanish", parent_subject: @modern_languages)
     @russian = create(:subject, :secondary, name: "Russian", parent_subject: @modern_languages)
@@ -61,12 +61,12 @@ RSpec.describe "School user does not select a child subjects",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -104,51 +104,47 @@ RSpec.describe "School user does not select a child subjects",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
+      "What secondary school subjects can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects you can offer",
+      text: "What secondary school subjects can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
-    expect(page).to have_field("Modern languages", type: :checkbox)
+    expect(page).to have_field("Modern Languages", type: :checkbox)
   end
 
   def when_i_select_modern_languages
-    check "Modern languages"
+    check "Modern Languages"
   end
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
+      "How many placements can you offer for each subject? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements can you offer for each subject?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
-    expect(page).to have_field("Modern languages", type: :number)
+    expect(page).to have_field("Modern Languages", type: :number)
   end
 
   def when_i_fill_in_the_number_of_secondary_placements_i_require
-    fill_in "Modern languages", with: 1
+    fill_in "Modern Languages", with: 1
   end
 
   def then_i_see_the_subject_selection_for_modern_languages_form
     expect(page).to have_title(
-      "You selected 1 Modern languages placements - Manage school placements - GOV.UK",
+      "What languages are taught on your Modern Languages placement offers? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_h1(
-      "You selected 1 Modern languages placements",
+      "What languages are taught on your Modern Languages placement offers?",
       class: "govuk-heading-l",
-    )
-    expect(page).to have_h2(
-      "Select the languages taught on each of these placements",
-      class: "govuk-heading-m",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("French", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
@@ -49,12 +49,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -92,12 +92,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
+      "What secondary school subjects can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects you can offer",
+      text: "What secondary school subjects can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
@@ -54,12 +54,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -97,12 +97,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
+      "What secondary school subjects can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects you can offer",
+      text: "What secondary school subjects can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
@@ -117,10 +117,10 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
+      "How many placements can you offer for each subject? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements can you offer for each subject?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
@@ -54,12 +54,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -97,12 +97,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
+      "What secondary school subjects can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects you can offer",
+      text: "What secondary school subjects can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
@@ -117,10 +117,10 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
+      "How many placements can you offer for each subject? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements can you offer for each subject?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
@@ -94,12 +94,12 @@ RSpec.describe "School user completes the interested journey and declares primar
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -132,7 +132,7 @@ RSpec.describe "School user completes the interested journey and declares primar
     )
     expect(page).to have_element(
       :p,
-      text: "They will be able to see your approximate information and will be able to use your email to contact you.",
+      text: "They will be able to see your potential placement details and will be able to use your email to contact you.",
       class: "govuk-body",
     )
   end
@@ -145,8 +145,7 @@ RSpec.describe "School user completes the interested journey and declares primar
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_element(
       :p,
-      text: "Choose the person best placed to organise ITT placements at your school. "\
-        "This information will be shown on your profile.",
+      text: "Choose the person best placed to organise placements for trainee teachers at your school",
       class: "govuk-body",
     )
 
@@ -182,10 +181,10 @@ RSpec.describe "School user completes the interested journey and declares primar
 
   def and_i_see_the_whats_next_page
     expect(page).to have_panel(
-      "Approximate information added",
+      "Information added",
       "Providers can see that you may offer placements",
     )
-    expect(page).to have_h1("What happens next?", class: "govuk-heading-l")
+    expect(page).to have_h1("What happens next", class: "govuk-heading-l")
     expect(page).to have_element(
       :p,
       text: "Providers who are looking for schools to work with can contact you on joe_bloggs@example.com.",
@@ -193,19 +192,19 @@ RSpec.describe "School user completes the interested journey and declares primar
     )
     expect(page).to have_element(
       :p,
-      text: "Once you know which placements you can offer, you can add placements to help providers know what trainees you need.",
+      text: "Once you are sure which placements your school can offer, add your placements. Doing so will mean you will be able to assign providers to them.",
       class: "govuk-body",
     )
-    expect(page).to have_link("add placements", href: placements_school_placements_path(@school))
+    expect(page).to have_link("add your placements", href: placements_school_placements_path(@school))
   end
 
   def then_i_see_the_phase_known_page
     expect(page).to have_title(
-      "Do you know what phase of education your placements will be? - Manage school placements - GOV.UK",
+      "What education phase could you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(page).to have_element(
       :legend,
-      text: "Do you know what phase of education your placements will be?",
+      text: "What education phase could you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -241,8 +240,8 @@ RSpec.describe "School user completes the interested journey and declares primar
   end
 
   def and_i_see_the_education_phases_i_selected
-    expect(page).to have_h2("Education phase", class: "govuk-heading-m")
-    expect(page).to have_summary_list_row("Phase", "Primary and Secondary")
+    expect(page).to have_h2("Potential education phase", class: "govuk-heading-m")
+    expect(page).to have_summary_list_row("Phase", "Primary Secondary")
   end
 
   def and_i_see_the_message_to_provider_i_entered
@@ -290,12 +289,12 @@ RSpec.describe "School user completes the interested journey and declares primar
 
   def then_i_see_the_primary_year_group_selection_form
     expect(page).to have_title(
-      "Do you know what primary school year groups you would be willing to host placements in? - Manage school placements - GOV.UK",
+      "What year groups could you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Do you know what primary school year groups you would be willing to host placements in?",
+      text: "What year groups could you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Potential primary placement details", class: "govuk-caption-l")
@@ -317,10 +316,10 @@ RSpec.describe "School user completes the interested journey and declares primar
 
   def then_i_see_the_primary_placement_quantity_form
     expect(page).to have_title(
-      "How many primary placements you would be willing to host in each year group? - Manage school placements - GOV.UK",
+      "How many placements could you offer for each year group? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("How many primary placements you would be willing to host in each year group?", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements could you offer for each year group?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Potential primary placement details", class: "govuk-caption-l")
     expect(page).to have_field("Year 1", type: :number)
   end
@@ -331,13 +330,13 @@ RSpec.describe "School user completes the interested journey and declares primar
 
   def then_i_see_the_primary_placement_quantity_known_page
     expect(page).to have_title(
-      "Do you know the number of primary placements you would be willing to host in each year group? - Manage school placements - GOV.UK",
+      "Do you know how many placements could you offer for each primary school year group? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:span, text: "Potential primary placement details", class: "govuk-caption-l")
     expect(page).to have_element(
       :legend,
-      text: "Do you know the number of primary placements you would be willing to host in each year group?",
+      text: "Do you know how many placements could you offer for each primary school year group?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes", type: :radio)
@@ -350,12 +349,12 @@ RSpec.describe "School user completes the interested journey and declares primar
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Do you know the secondary school subjects you could have placements in? - Manage school placements - GOV.UK",
+      "What subjects could you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Do you know the secondary school subjects you could have placements in?",
+      text: "What subjects could you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Potential secondary placement details", class: "govuk-caption-l")
@@ -375,10 +374,10 @@ RSpec.describe "School user completes the interested journey and declares primar
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "How many secondary placements you would be willing to host in each subject? - Manage school placements - GOV.UK",
+      "How many placements could you offer for each subject? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("How many secondary placements you would be willing to host in each subject?", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements could you offer for each subject?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Potential secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
     expect(page).to have_field("Mathematics", type: :number)
@@ -391,13 +390,13 @@ RSpec.describe "School user completes the interested journey and declares primar
 
   def then_i_see_the_secondary_placement_quantity_known_page
     expect(page).to have_title(
-      "Do you know the number of secondary placements you would be willing to host? - Manage school placements - GOV.UK",
+      "Do you know how many secondary school placements you may be willing to offer? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:span, text: "Potential secondary placement details", class: "govuk-caption-l")
     expect(page).to have_element(
       :legend,
-      text: "Do you know the number of secondary placements you would be willing to host?",
+      text: "Do you know how many secondary school placements you may be willing to offer?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes", type: :radio)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_quantities_for_potential_placements_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_quantities_for_potential_placements_spec.rb
@@ -86,12 +86,12 @@ RSpec.describe "School user completes the interested journey without declaring q
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -124,7 +124,7 @@ RSpec.describe "School user completes the interested journey without declaring q
     )
     expect(page).to have_element(
       :p,
-      text: "They will be able to see your approximate information and will be able to use your email to contact you.",
+      text: "They will be able to see your potential placement details and will be able to use your email to contact you.",
       class: "govuk-body",
     )
   end
@@ -137,8 +137,7 @@ RSpec.describe "School user completes the interested journey without declaring q
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_element(
       :p,
-      text: "Choose the person best placed to organise ITT placements at your school. "\
-        "This information will be shown on your profile.",
+      text: "Choose the person best placed to organise placements for trainee teachers at your school",
       class: "govuk-body",
     )
 
@@ -174,10 +173,10 @@ RSpec.describe "School user completes the interested journey without declaring q
 
   def and_i_see_the_whats_next_page
     expect(page).to have_panel(
-      "Approximate information added",
+      "Information added",
       "Providers can see that you may offer placements",
     )
-    expect(page).to have_h1("What happens next?", class: "govuk-heading-l")
+    expect(page).to have_h1("What happens next", class: "govuk-heading-l")
     expect(page).to have_element(
       :p,
       text: "Providers who are looking for schools to work with can contact you on joe_bloggs@example.com.",
@@ -185,19 +184,19 @@ RSpec.describe "School user completes the interested journey without declaring q
     )
     expect(page).to have_element(
       :p,
-      text: "Once you know which placements you can offer, you can add placements to help providers know what trainees you need.",
+      text: "Once you are sure which placements your school can offer, add your placements. Doing so will mean you will be able to assign providers to them.",
       class: "govuk-body",
     )
-    expect(page).to have_link("add placements", href: placements_school_placements_path(@school))
+    expect(page).to have_link("add your placements", href: placements_school_placements_path(@school))
   end
 
   def then_i_see_the_phase_known_page
     expect(page).to have_title(
-      "Do you know what phase of education your placements will be? - Manage school placements - GOV.UK",
+      "What education phase could you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(page).to have_element(
       :legend,
-      text: "Do you know what phase of education your placements will be?",
+      text: "What education phase could you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -233,8 +232,8 @@ RSpec.describe "School user completes the interested journey without declaring q
   end
 
   def and_i_see_the_education_phases_i_selected
-    expect(page).to have_h2("Education phase", class: "govuk-heading-m")
-    expect(page).to have_summary_list_row("Phase", "Primary and Secondary")
+    expect(page).to have_h2("Potential education phase", class: "govuk-heading-m")
+    expect(page).to have_summary_list_row("Phase", "Primary Secondary")
   end
 
   def and_i_see_the_message_to_provider_i_entered
@@ -278,12 +277,12 @@ RSpec.describe "School user completes the interested journey without declaring q
 
   def then_i_see_the_primary_year_group_selection_form
     expect(page).to have_title(
-      "Do you know what primary school year groups you would be willing to host placements in? - Manage school placements - GOV.UK",
+      "What year groups could you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Do you know what primary school year groups you would be willing to host placements in?",
+      text: "What year groups could you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Potential primary placement details", class: "govuk-caption-l")
@@ -305,13 +304,13 @@ RSpec.describe "School user completes the interested journey without declaring q
 
   def then_i_see_the_primary_placement_quantity_known_page
     expect(page).to have_title(
-      "Do you know the number of primary placements you would be willing to host in each year group? - Manage school placements - GOV.UK",
+      "Do you know how many placements could you offer for each primary school year group? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:span, text: "Potential primary placement details", class: "govuk-caption-l")
     expect(page).to have_element(
       :legend,
-      text: "Do you know the number of primary placements you would be willing to host in each year group?",
+      text: "Do you know how many placements could you offer for each primary school year group?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes", type: :radio)
@@ -324,12 +323,12 @@ RSpec.describe "School user completes the interested journey without declaring q
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Do you know the secondary school subjects you could have placements in? - Manage school placements - GOV.UK",
+      "What subjects could you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Do you know the secondary school subjects you could have placements in?",
+      text: "What subjects could you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Potential secondary placement details", class: "govuk-caption-l")
@@ -349,13 +348,13 @@ RSpec.describe "School user completes the interested journey without declaring q
 
   def then_i_see_the_secondary_placement_quantity_known_page
     expect(page).to have_title(
-      "Do you know the number of secondary placements you would be willing to host? - Manage school placements - GOV.UK",
+      "Do you know how many secondary school placements you may be willing to offer? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:span, text: "Potential secondary placement details", class: "govuk-caption-l")
     expect(page).to have_element(
       :legend,
-      text: "Do you know the number of secondary placements you would be willing to host?",
+      text: "Do you know how many secondary school placements you may be willing to offer?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes", type: :radio)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_specific_year_groups_or_subjects_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_specific_year_groups_or_subjects_spec.rb
@@ -77,12 +77,12 @@ RSpec.describe "School user completes the interested journey without declaring s
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -115,7 +115,7 @@ RSpec.describe "School user completes the interested journey without declaring s
     )
     expect(page).to have_element(
       :p,
-      text: "They will be able to see your approximate information and will be able to use your email to contact you.",
+      text: "They will be able to see your potential placement details and will be able to use your email to contact you.",
       class: "govuk-body",
     )
   end
@@ -128,8 +128,7 @@ RSpec.describe "School user completes the interested journey without declaring s
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_element(
       :p,
-      text: "Choose the person best placed to organise ITT placements at your school. "\
-        "This information will be shown on your profile.",
+      text: "Choose the person best placed to organise placements for trainee teachers at your school",
       class: "govuk-body",
     )
 
@@ -165,10 +164,10 @@ RSpec.describe "School user completes the interested journey without declaring s
 
   def and_i_see_the_whats_next_page
     expect(page).to have_panel(
-      "Approximate information added",
+      "Information added",
       "Providers can see that you may offer placements",
     )
-    expect(page).to have_h1("What happens next?", class: "govuk-heading-l")
+    expect(page).to have_h1("What happens next", class: "govuk-heading-l")
     expect(page).to have_element(
       :p,
       text: "Providers who are looking for schools to work with can contact you on joe_bloggs@example.com.",
@@ -176,19 +175,19 @@ RSpec.describe "School user completes the interested journey without declaring s
     )
     expect(page).to have_element(
       :p,
-      text: "Once you know which placements you can offer, you can add placements to help providers know what trainees you need.",
+      text: "Once you are sure which placements your school can offer, add your placements. Doing so will mean you will be able to assign providers to them.",
       class: "govuk-body",
     )
-    expect(page).to have_link("add placements", href: placements_school_placements_path(@school))
+    expect(page).to have_link("add your placements", href: placements_school_placements_path(@school))
   end
 
   def then_i_see_the_phase_known_page
     expect(page).to have_title(
-      "Do you know what phase of education your placements will be? - Manage school placements - GOV.UK",
+      "What education phase could you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(page).to have_element(
       :legend,
-      text: "Do you know what phase of education your placements will be?",
+      text: "What education phase could you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -224,8 +223,8 @@ RSpec.describe "School user completes the interested journey without declaring s
   end
 
   def and_i_see_the_education_phases_i_selected
-    expect(page).to have_h2("Education phase", class: "govuk-heading-m")
-    expect(page).to have_summary_list_row("Phase", "Primary and Secondary")
+    expect(page).to have_h2("Potential education phase", class: "govuk-heading-m")
+    expect(page).to have_summary_list_row("Phase", "Primary Secondary")
   end
 
   def and_i_see_the_message_to_provider_i_entered
@@ -269,12 +268,12 @@ RSpec.describe "School user completes the interested journey without declaring s
 
   def then_i_see_the_primary_year_group_selection_form
     expect(page).to have_title(
-      "Do you know what primary school year groups you would be willing to host placements in? - Manage school placements - GOV.UK",
+      "What year groups could you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Do you know what primary school year groups you would be willing to host placements in?",
+      text: "What year groups could you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Potential primary placement details", class: "govuk-caption-l")
@@ -296,10 +295,10 @@ RSpec.describe "School user completes the interested journey without declaring s
 
   def then_i_see_the_primary_placement_quantity_form
     expect(page).to have_title(
-      "How many primary placements you would be willing to host in each year group? - Manage school placements - GOV.UK",
+      "How many placements could you offer for each year group? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("How many primary placements you would be willing to host in each year group?", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements could you offer for each year group?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Potential primary placement details", class: "govuk-caption-l")
     expect(page).to have_field("Year 1", type: :number)
   end
@@ -310,13 +309,13 @@ RSpec.describe "School user completes the interested journey without declaring s
 
   def then_i_see_the_primary_placement_quantity_known_page
     expect(page).to have_title(
-      "Do you know the number of primary placements you would be willing to host in each year group? - Manage school placements - GOV.UK",
+      "Do you know how many placements could you offer for each primary school year group? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:span, text: "Potential primary placement details", class: "govuk-caption-l")
     expect(page).to have_element(
       :legend,
-      text: "Do you know the number of primary placements you would be willing to host in each year group?",
+      text: "Do you know how many placements could you offer for each primary school year group?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes", type: :radio)
@@ -329,12 +328,12 @@ RSpec.describe "School user completes the interested journey without declaring s
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Do you know the secondary school subjects you could have placements in? - Manage school placements - GOV.UK",
+      "What subjects could you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Do you know the secondary school subjects you could have placements in?",
+      text: "What subjects could you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Potential secondary placement details", class: "govuk-caption-l")
@@ -354,10 +353,10 @@ RSpec.describe "School user completes the interested journey without declaring s
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "How many secondary placements you would be willing to host in each subject? - Manage school placements - GOV.UK",
+      "How many placements could you offer for each subject? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("How many secondary placements you would be willing to host in each subject?", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements could you offer for each subject?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Potential secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
     expect(page).to have_field("Mathematics", type: :number)
@@ -370,13 +369,13 @@ RSpec.describe "School user completes the interested journey without declaring s
 
   def then_i_see_the_secondary_placement_quantity_known_page
     expect(page).to have_title(
-      "Do you know the number of secondary placements you would be willing to host? - Manage school placements - GOV.UK",
+      "Do you know how many secondary school placements you may be willing to offer? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:span, text: "Potential secondary placement details", class: "govuk-caption-l")
     expect(page).to have_element(
       :legend,
-      text: "Do you know the number of secondary placements you would be willing to host?",
+      text: "Do you know how many secondary school placements you may be willing to offer?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes", type: :radio)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_does_not_enter_any_school_contact_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_does_not_enter_any_school_contact_details_spec.rb
@@ -44,12 +44,12 @@ RSpec.describe "School user does not enter any school contact details",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -82,7 +82,7 @@ RSpec.describe "School user does not enter any school contact details",
     )
     expect(page).to have_element(
       :p,
-      text: "They will be able to see your approximate information and will be able to use your email to contact you.",
+      text: "They will be able to see your potential placement details and will be able to use your email to contact you.",
       class: "govuk-body",
     )
   end
@@ -95,8 +95,7 @@ RSpec.describe "School user does not enter any school contact details",
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_element(
       :p,
-      text: "Choose the person best placed to organise ITT placements at your school. "\
-        "This information will be shown on your profile.",
+      text: "Choose the person best placed to organise placements for trainee teachers at your school",
       class: "govuk-body",
     )
 
@@ -113,11 +112,11 @@ RSpec.describe "School user does not enter any school contact details",
 
   def then_i_see_the_phase_known_page
     expect(page).to have_title(
-      "Do you know what phase of education your placements will be? - Manage school placements - GOV.UK",
+      "What education phase could you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(page).to have_element(
       :legend,
-      text: "Do you know what phase of education your placements will be?",
+      text: "What education phase could you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_does_not_enter_a_reason_when_selecting_other_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_does_not_enter_a_reason_when_selecting_other_spec.rb
@@ -39,12 +39,12 @@ RSpec.describe "School user does not select any reasons not to host",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_does_not_enter_any_school_contact_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_does_not_enter_any_school_contact_details_spec.rb
@@ -43,12 +43,12 @@ RSpec.describe "School user does not enter any school contact details",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_does_not_select_any_reasons_not_to_host_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_does_not_select_any_reasons_not_to_host_spec.rb
@@ -38,12 +38,12 @@ RSpec.describe "School user does not select any reasons not to host",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_enters_another_reason_why_they_are_not_hosting_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_enters_another_reason_why_they_are_not_hosting_spec.rb
@@ -52,12 +52,12 @@ RSpec.describe "School user enters another reason why they are not hosting",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_successfully_completes_the_not_open_journey_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_successfully_completes_the_not_open_journey_spec.rb
@@ -74,12 +74,12 @@ RSpec.describe "School user successfully completes the not open journey",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/school_user_does_not_select_an_appetite_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/school_user_does_not_select_an_appetite_spec.rb
@@ -51,12 +51,12 @@ RSpec.describe "School user does not select an appetite",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
@@ -90,12 +90,12 @@ RSpec.describe "School user does not enter a placement quantity",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -133,12 +133,12 @@ RSpec.describe "School user does not enter a placement quantity",
 
   def then_i_see_the_primary_year_group_selection_form
     expect(page).to have_title(
-      "Select primary school year groups you can offer - Manage school placements - GOV.UK",
+      "What primary school year groups can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Select primary school year groups you can offer",
+      text: "What primary school year groups can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_does_not_select_a_year_group_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_does_not_select_a_year_group_spec.rb
@@ -86,12 +86,12 @@ RSpec.describe "School user does not select a year group",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -129,12 +129,12 @@ RSpec.describe "School user does not select a year group",
 
   def then_i_see_the_primary_year_group_selection_form
     expect(page).to have_title(
-      "Select primary school year groups you can offer - Manage school placements - GOV.UK",
+      "What primary school year groups can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Select primary school year groups you can offer",
+      text: "What primary school year groups can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_the_primary_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_the_primary_phase_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     and_i_click_on_continue
     then_i_see_the_check_your_answers_page
 
-    when_i_click_save_and_continue
+    when_i_click_on_publish_placements
     then_i_see_my_responses_were_successfully_updated
     and_i_see_the_whats_next_page
     and_i_see_2_reception_primary_placements_have_been_created
@@ -107,12 +107,12 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -154,12 +154,12 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_primary_year_group_selection_form
     expect(page).to have_title(
-      "Select primary school year groups you can offer - Manage school placements - GOV.UK",
+      "What primary school year groups can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Select primary school year groups you can offer",
+      text: "What primary school year groups can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")
@@ -212,8 +212,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_element(
       :p,
-      text: "Choose the person best placed to organise ITT placements at your school. "\
-        "This information will be shown on your profile.",
+      text: "Choose the person best placed to organise placements for trainee teachers at your school",
       class: "govuk-body",
     )
 
@@ -247,8 +246,8 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     expect(hosting_interest.appetite).to eq("actively_looking")
   end
 
-  def when_i_click_save_and_continue
-    click_on "Save and continue"
+  def when_i_click_on_publish_placements
+    click_on "Publish placements"
   end
 
   def then_i_see_the_check_your_answers_page
@@ -301,7 +300,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
   end
 
   def when_i_click_on_edit_your_placements
-    click_on "edit your placements"
+    click_on "Edit your placements"
   end
 
   def and_i_see_2_primary_placements_for_reception

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
@@ -91,12 +91,12 @@ RSpec.describe "School user enters a float as a placement quantity",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -134,12 +134,12 @@ RSpec.describe "School user enters a float as a placement quantity",
 
   def then_i_see_the_primary_year_group_selection_form
     expect(page).to have_title(
-      "Select primary school year groups you can offer - Manage school placements - GOV.UK",
+      "What primary school year groups can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Select primary school year groups you can offer",
+      text: "What primary school year groups can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
@@ -93,12 +93,12 @@ RSpec.describe "School user enters zero as a placement quantity",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -136,12 +136,12 @@ RSpec.describe "School user enters zero as a placement quantity",
 
   def then_i_see_the_primary_year_group_selection_form
     expect(page).to have_title(
-      "Select primary school year groups you can offer - Manage school placements - GOV.UK",
+      "What primary school year groups can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Select primary school year groups you can offer",
+      text: "What primary school year groups can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/school_user_does_not_select_a_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/school_user_does_not_select_a_phase_spec.rb
@@ -86,12 +86,12 @@ RSpec.describe "School user does not select a phases",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     and_i_click_on_continue
     then_i_see_the_check_your_answers_page
 
-    when_i_click_save_and_continue
+    when_i_click_on_publish_placements
     then_i_see_my_responses_with_successfully_updated
     and_i_see_the_whats_next_page
     and_i_see_2_year_1_primary_placements_have_been_created
@@ -163,12 +163,12 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -210,12 +210,12 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_primary_year_group_selection_form
     expect(page).to have_title(
-      "Select primary school year groups you can offer - Manage school placements - GOV.UK",
+      "What primary school year groups can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Select primary school year groups you can offer",
+      text: "What primary school year groups can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")
@@ -250,12 +250,12 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
+      "What secondary school subjects can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects you can offer",
+      text: "What secondary school subjects can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
@@ -274,10 +274,10 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
+      "How many placements can you offer for each subject? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements can you offer for each subject?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
     expect(page).to have_field("Mathematics", type: :number)
@@ -296,8 +296,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_element(
       :p,
-      text: "Choose the person best placed to organise ITT placements at your school. "\
-        "This information will be shown on your profile.",
+      text: "Choose the person best placed to organise placements for trainee teachers at your school",
       class: "govuk-body",
     )
 
@@ -314,8 +313,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_element(
       :p,
-      text: "Choose the person best placed to organise ITT placements at your school. "\
-        "This information will be shown on your profile.",
+      text: "Choose the person best placed to organise placements for trainee teachers at your school",
       class: "govuk-body",
     )
 
@@ -414,8 +412,8 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     expect(page).to have_field("Test Provider 789", type: :checkbox)
   end
 
-  def when_i_click_save_and_continue
-    click_on "Save and continue"
+  def when_i_click_on_publish_placements
+    click_on "Publish placements"
   end
 
   def then_i_see_the_check_your_answers_page
@@ -426,7 +424,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     expect(page).to have_h1("Check your answers")
 
     expect(page).to have_h2("Education phase")
-    expect(page).to have_summary_list_row("Phase", "Primary and Secondary")
+    expect(page).to have_summary_list_row("Phase", "Primary Secondary")
 
     expect(page).to have_h2("Primary placements")
     expect(page).to have_summary_list_row("Year 1", "2")
@@ -470,7 +468,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
   end
 
   def when_i_click_on_edit_your_placements
-    click_on "edit your placements"
+    click_on "Edit your placements"
   end
 
   def and_i_see_2_primary_placements_for_year_1

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
@@ -92,12 +92,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -135,12 +135,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
+      "What secondary school subjects can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects you can offer",
+      text: "What secondary school subjects can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
@@ -155,10 +155,10 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
+      "How many placements can you offer for each subject? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements can you offer for each subject?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "School user does not select a child subjects",
     @english = create(:subject, :secondary, name: "English")
     @mathematics = create(:subject, :secondary, name: "Mathematics")
     @science = create(:subject, :secondary, name: "Science")
-    @modern_languages = create(:subject, :secondary, name: "Modern languages")
+    @modern_languages = create(:subject, :secondary, name: "Modern Languages")
     @french = create(:subject, :secondary, name: "French", parent_subject: @modern_languages)
     @spanish = create(:subject, :secondary, name: "Spanish", parent_subject: @modern_languages)
     @russian = create(:subject, :secondary, name: "Russian", parent_subject: @modern_languages)
@@ -100,12 +100,12 @@ RSpec.describe "School user does not select a child subjects",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -143,51 +143,47 @@ RSpec.describe "School user does not select a child subjects",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
+      "What secondary school subjects can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects you can offer",
+      text: "What secondary school subjects can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
-    expect(page).to have_field("Modern languages", type: :checkbox)
+    expect(page).to have_field("Modern Languages", type: :checkbox)
   end
 
   def when_i_select_modern_languages
-    check "Modern languages"
+    check "Modern Languages"
   end
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
+      "How many placements can you offer for each subject? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements can you offer for each subject?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
-    expect(page).to have_field("Modern languages", type: :number)
+    expect(page).to have_field("Modern Languages", type: :number)
   end
 
   def when_i_fill_in_the_number_of_secondary_placements_i_require
-    fill_in "Modern languages", with: 1
+    fill_in "Modern Languages", with: 1
   end
 
   def then_i_see_the_subject_selection_for_modern_languages_form
     expect(page).to have_title(
-      "You selected 1 Modern languages placements - Manage school placements - GOV.UK",
+      "What languages are taught on your Modern Languages placement offers? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_h1(
-      "You selected 1 Modern languages placements",
+      "What languages are taught on your Modern Languages placement offers?",
       class: "govuk-heading-l",
-    )
-    expect(page).to have_h2(
-      "Select the languages taught on each of these placements",
-      class: "govuk-heading-m",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("French", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
@@ -88,12 +88,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -131,12 +131,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
+      "What secondary school subjects can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects you can offer",
+      text: "What secondary school subjects can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     and_i_click_on_continue
     then_i_see_the_check_your_answers_page
 
-    when_i_click_save_and_continue
+    when_i_click_on_publish_placements
     then_i_see_my_responses_with_successfully_updated
     and_i_see_the_whats_next_page
     and_i_see_2_secondary_placements_for_modern_languages_have_been_created
@@ -62,7 +62,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     @english = create(:subject, :secondary, name: "English")
     @mathematics = create(:subject, :secondary, name: "Mathematics")
     @science = create(:subject, :secondary, name: "Science")
-    @modern_languages = create(:subject, :secondary, name: "Modern languages")
+    @modern_languages = create(:subject, :secondary, name: "Modern Languages")
     @french = create(:subject, :secondary, name: "French", parent_subject: @modern_languages)
     @spanish = create(:subject, :secondary, name: "Spanish", parent_subject: @modern_languages)
     @russian = create(:subject, :secondary, name: "Russian", parent_subject: @modern_languages)
@@ -126,12 +126,12 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -173,51 +173,47 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
+      "What secondary school subjects can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects you can offer",
+      text: "What secondary school subjects can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
-    expect(page).to have_field("Modern languages", type: :checkbox)
+    expect(page).to have_field("Modern Languages", type: :checkbox)
   end
 
   def when_i_select_modern_languages
-    check "Modern languages"
+    check "Modern Languages"
   end
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
+      "How many placements can you offer for each subject? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements can you offer for each subject?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
-    expect(page).to have_field("Modern languages", type: :number)
+    expect(page).to have_field("Modern Languages", type: :number)
   end
 
   def when_i_fill_in_the_number_of_secondary_placements_i_require
-    fill_in "Modern languages", with: 2
+    fill_in "Modern Languages", with: 2
   end
 
   def then_i_see_the_subject_selection_for_modern_languages_form
     expect(page).to have_title(
-      "You selected 2 Modern languages placements - Manage school placements - GOV.UK",
+      "What languages are taught on your Modern Languages placement offers? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_h1(
-      "You selected 2 Modern languages placements",
+      "What languages are taught on your Modern Languages placement offers?",
       class: "govuk-heading-l",
-    )
-    expect(page).to have_h2(
-      "Select the languages taught on each of these placements",
-      class: "govuk-heading-m",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("French", type: :checkbox)
@@ -253,8 +249,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_element(
       :p,
-      text: "Choose the person best placed to organise ITT placements at your school. "\
-        "This information will be shown on your profile.",
+      text: "Choose the person best placed to organise placements for trainee teachers at your school",
       class: "govuk-body",
     )
 
@@ -310,8 +305,8 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     )
   end
 
-  def when_i_click_save_and_continue
-    click_on "Save and continue"
+  def when_i_click_on_publish_placements
+    click_on "Publish placements"
   end
 
   def then_i_see_the_check_your_answers_page
@@ -325,7 +320,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     expect(page).to have_summary_list_row("Phase", "Secondary")
 
     expect(page).to have_h2("Secondary placements")
-    expect(page).to have_summary_list_row("Modern languages", "2")
+    expect(page).to have_summary_list_row("Modern Languages", "2")
   end
 
   def and_i_see_the_whats_next_page
@@ -350,11 +345,11 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
   end
 
   def and_i_see_2_secondary_placements_for_modern_languages_have_been_created
-    expect(page).to have_summary_list_row("Modern languages", "2")
+    expect(page).to have_summary_list_row("Modern Languages", "2")
   end
 
   def when_i_click_on_edit_your_placements
-    click_on "edit your placements"
+    click_on "Edit your placements"
   end
 
   def when_i_am_on_the_placements_index_page

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_edits_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_edits_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     and_i_click_on_continue
     then_i_see_the_check_your_answers_page
 
-    when_i_click_save_and_continue
+    when_i_click_on_publish_placements
     then_i_see_my_responses_with_successfully_updated
     and_i_see_the_whats_next_page
     and_i_see_1_english_secondary_placement_has_been_created
@@ -106,12 +106,12 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -153,12 +153,12 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
+      "What secondary school subjects can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects you can offer",
+      text: "What secondary school subjects can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
@@ -177,10 +177,10 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
+      "How many placements can you offer for each subject? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements can you offer for each subject?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
     expect(page).to have_field("Mathematics", type: :number)
@@ -199,8 +199,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     expect(page).to have_h1("Who should providers contact?")
     expect(page).to have_element(
       :p,
-      text: "Choose the person best placed to organise ITT placements at your school. "\
-        "This information will be shown on your profile.",
+      text: "Choose the person best placed to organise placements for trainee teachers at your school",
       class: "govuk-body",
     )
 
@@ -254,8 +253,8 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     expect(page).to have_field("Test Provider 789", type: :checkbox)
   end
 
-  def when_i_click_save_and_continue
-    click_on "Save and continue"
+  def when_i_click_on_publish_placements
+    click_on "Publish placements"
   end
 
   def then_i_see_the_check_your_answers_page
@@ -305,7 +304,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
   end
 
   def when_i_click_on_edit_your_placements
-    click_on "edit your placements"
+    click_on "Edit your placements"
   end
 
   def when_i_am_on_the_placements_index_page

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
@@ -93,12 +93,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -136,12 +136,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
+      "What secondary school subjects can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects you can offer",
+      text: "What secondary school subjects can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
@@ -156,10 +156,10 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
+      "How many placements can you offer for each subject? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements can you offer for each subject?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
@@ -93,12 +93,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -136,12 +136,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
+      "What secondary school subjects can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects you can offer",
+      text: "What secondary school subjects can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
@@ -156,10 +156,10 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
+      "How many placements can you offer for each subject? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
-    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements can you offer for each subject?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
@@ -129,12 +129,12 @@ RSpec.describe "School user completes the interested journey without declaring p
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -167,7 +167,7 @@ RSpec.describe "School user completes the interested journey without declaring p
     )
     expect(page).to have_element(
       :p,
-      text: "They will be able to see your approximate information and will be able to use your email to contact you.",
+      text: "They will be able to see your potential placement details and will be able to use your email to contact you.",
       class: "govuk-body",
     )
   end
@@ -193,10 +193,10 @@ RSpec.describe "School user completes the interested journey without declaring p
 
   def and_i_see_the_whats_next_page
     expect(page).to have_panel(
-      "Approximate information added",
+      "Information added",
       "Providers can see that you may offer placements",
     )
-    expect(page).to have_h1("What happens next?", class: "govuk-heading-l")
+    expect(page).to have_h1("What happens next", class: "govuk-heading-l")
     expect(page).to have_element(
       :p,
       text: "Providers who are looking for schools to work with can contact you on #{@school.school_contact_email_address}.",
@@ -204,19 +204,19 @@ RSpec.describe "School user completes the interested journey without declaring p
     )
     expect(page).to have_element(
       :p,
-      text: "Once you know which placements you can offer, you can add placements to help providers know what trainees you need.",
+      text: "Once you are sure which placements your school can offer, add your placements. Doing so will mean you will be able to assign providers to them.",
       class: "govuk-body",
     )
-    expect(page).to have_link("add placements", href: placements_school_placements_path(@school))
+    expect(page).to have_link("add your placements", href: placements_school_placements_path(@school))
   end
 
   def then_i_see_the_phase_known_page
     expect(page).to have_title(
-      "Do you know what phase of education your placements will be? - Manage school placements - GOV.UK",
+      "What education phase could you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(page).to have_element(
       :legend,
-      text: "Do you know what phase of education your placements will be?",
+      text: "What education phase could you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -252,8 +252,8 @@ RSpec.describe "School user completes the interested journey without declaring p
   end
 
   def and_i_see_the_education_phases_i_selected
-    expect(page).to have_h2("Education phase", class: "govuk-heading-m")
-    expect(page).to have_summary_list_row("Phase", "Primary and Secondary")
+    expect(page).to have_h2("Potential education phase", class: "govuk-heading-m")
+    expect(page).to have_summary_list_row("Phase", "Primary Secondary")
   end
 
   def and_i_see_the_message_to_provider_i_entered
@@ -301,12 +301,12 @@ RSpec.describe "School user completes the interested journey without declaring p
 
   def then_i_see_the_primary_year_group_selection_form
     expect(page).to have_title(
-      "Do you know what primary school year groups you would be willing to host placements in? - Manage school placements - GOV.UK",
+      "What year groups could you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(page).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Do you know what primary school year groups you would be willing to host placements in?",
+      text: "What year groups could you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Potential primary placement details", class: "govuk-caption-l")
@@ -328,10 +328,10 @@ RSpec.describe "School user completes the interested journey without declaring p
 
   def then_i_see_the_primary_placement_quantity_form
     expect(page).to have_title(
-      "How many primary placements you would be willing to host in each year group? - Manage school placements - GOV.UK",
+      "How many placements could you offer for each year group? - Manage school placements - GOV.UK",
     )
     expect(page).to have_current_item("Organisation details")
-    expect(page).to have_h1("How many primary placements you would be willing to host in each year group?", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements could you offer for each year group?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Potential primary placement details", class: "govuk-caption-l")
     expect(page).to have_field("Year 1", type: :number)
   end
@@ -342,13 +342,13 @@ RSpec.describe "School user completes the interested journey without declaring p
 
   def then_i_see_the_primary_placement_quantity_known_page
     expect(page).to have_title(
-      "Do you know the number of primary placements you would be willing to host in each year group? - Manage school placements - GOV.UK",
+      "Do you know how many placements could you offer for each primary school year group? - Manage school placements - GOV.UK",
     )
     expect(page).to have_current_item("Organisation details")
     expect(page).to have_element(:span, text: "Potential primary placement details", class: "govuk-caption-l")
     expect(page).to have_element(
       :legend,
-      text: "Do you know the number of primary placements you would be willing to host in each year group?",
+      text: "Do you know how many placements could you offer for each primary school year group?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes", type: :radio)
@@ -361,12 +361,12 @@ RSpec.describe "School user completes the interested journey without declaring p
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Do you know the secondary school subjects you could have placements in? - Manage school placements - GOV.UK",
+      "What subjects could you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(page).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Do you know the secondary school subjects you could have placements in?",
+      text: "What subjects could you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Potential secondary placement details", class: "govuk-caption-l")
@@ -386,10 +386,10 @@ RSpec.describe "School user completes the interested journey without declaring p
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "How many secondary placements you would be willing to host in each subject? - Manage school placements - GOV.UK",
+      "How many placements could you offer for each subject? - Manage school placements - GOV.UK",
     )
     expect(page).to have_current_item("Organisation details")
-    expect(page).to have_h1("How many secondary placements you would be willing to host in each subject?", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements could you offer for each subject?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Potential secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
     expect(page).to have_field("Mathematics", type: :number)
@@ -402,13 +402,13 @@ RSpec.describe "School user completes the interested journey without declaring p
 
   def then_i_see_the_secondary_placement_quantity_known_page
     expect(page).to have_title(
-      "Do you know the number of secondary placements you would be willing to host? - Manage school placements - GOV.UK",
+      "Do you know how many secondary school placements you may be willing to offer? - Manage school placements - GOV.UK",
     )
     expect(page).to have_current_item("Organisation details")
     expect(page).to have_element(:span, text: "Potential secondary placement details", class: "govuk-caption-l")
     expect(page).to have_element(
       :legend,
-      text: "Do you know the number of secondary placements you would be willing to host?",
+      text: "Do you know how many secondary school placements you may be willing to offer?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes", type: :radio)

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_interested/school_user_completes_the_interested_journey_without_declaring_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_interested/school_user_completes_the_interested_journey_without_declaring_potential_placement_details_spec.rb
@@ -89,12 +89,12 @@ RSpec.describe "School user completes the interested journey without declaring p
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)
@@ -127,7 +127,7 @@ RSpec.describe "School user completes the interested journey without declaring p
     )
     expect(page).to have_element(
       :p,
-      text: "They will be able to see your approximate information and will be able to use your email to contact you.",
+      text: "They will be able to see your potential placement details and will be able to use your email to contact you.",
       class: "govuk-body",
     )
   end
@@ -152,10 +152,10 @@ RSpec.describe "School user completes the interested journey without declaring p
 
   def and_i_see_the_whats_next_page
     expect(page).to have_panel(
-      "Approximate information added",
+      "Information added",
       "Providers can see that you may offer placements",
     )
-    expect(page).to have_h1("What happens next?", class: "govuk-heading-l")
+    expect(page).to have_h1("What happens next", class: "govuk-heading-l")
     expect(page).to have_element(
       :p,
       text: "Providers who are looking for schools to work with can contact you on #{@school.school_contact_email_address}.",
@@ -163,19 +163,19 @@ RSpec.describe "School user completes the interested journey without declaring p
     )
     expect(page).to have_element(
       :p,
-      text: "Once you know which placements you can offer, you can add placements to help providers know what trainees you need.",
+      text: "Once you are sure which placements your school can offer, add your placements. Doing so will mean you will be able to assign providers to them.",
       class: "govuk-body",
     )
-    expect(page).to have_link("add placements", href: placements_school_placements_path(@school))
+    expect(page).to have_link("add your placements", href: placements_school_placements_path(@school))
   end
 
   def then_i_see_the_phase_known_page
     expect(page).to have_title(
-      "Do you know what phase of education your placements will be? - Manage school placements - GOV.UK",
+      "What education phase could you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(page).to have_element(
       :legend,
-      text: "Do you know what phase of education your placements will be?",
+      text: "What education phase could you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Primary", type: :checkbox)
@@ -203,7 +203,7 @@ RSpec.describe "School user completes the interested journey without declaring p
   end
 
   def and_i_see_the_education_phase_is_not_known
-    expect(page).to have_h2("Education phase", class: "govuk-heading-m")
+    expect(page).to have_h2("Potential education phase", class: "govuk-heading-m")
     expect(page).to have_summary_list_row("Phase", "I don’t know")
   end
 

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_does_not_enter_a_reason_when_selecting_other_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_does_not_enter_a_reason_when_selecting_other_spec.rb
@@ -78,12 +78,12 @@ RSpec.describe "School user does not select any reasons not to host",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_does_not_select_any_reasons_not_to_host_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_does_not_select_any_reasons_not_to_host_spec.rb
@@ -77,12 +77,12 @@ RSpec.describe "School user does not select any reasons not to host",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_enters_another_reason_why_they_are_not_hosting_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_enters_another_reason_why_they_are_not_hosting_spec.rb
@@ -85,12 +85,12 @@ RSpec.describe "School user enters another reason why they are not hosting",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_successfully_completes_the_not_open_journey_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_successfully_completes_the_not_open_journey_spec.rb
@@ -100,12 +100,12 @@ RSpec.describe "School user successfully completes the not open journey",
 
   def then_i_see_the_appetite_form
     expect(page).to have_title(
-      "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})? - Manage school placements - GOV.UK",
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_element(
       :legend,
-      text: "Can your school offer placements for trainee teachers in this academic year (#{@next_academic_year_name})?",
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes - I can offer placements", type: :radio)

--- a/spec/system/placements/schools/placements/all_through_school_user_adds_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/all_through_school_user_adds_a_placement_spec.rb
@@ -594,7 +594,7 @@ RSpec.describe "All-through school user adds a placement", service: :placements,
 
   def and_i_see_my_placement
     expect(page).to have_table_row({
-      "Subject" => "Mathematics",
+      "Placement" => "Mathematics",
       "Mentor" => "Jane Doe",
       "Expected date" => "Summer term",
       "Provider" => "Provider not assigned",

--- a/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_bulk_adds_placements_for_the_primary_phase_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_bulk_adds_placements_for_the_primary_phase_spec.rb
@@ -92,12 +92,12 @@ RSpec.describe "School user bulk adds placements for the primary phases",
 
   def then_i_see_the_primary_year_group_selection_form
     expect(page).to have_title(
-      "Select primary school year groups you can offer - Manage school placements - GOV.UK",
+      "What primary school year groups can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select primary school year groups you can offer",
+      text: "What primary school year groups can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")

--- a/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
@@ -83,12 +83,12 @@ RSpec.describe "School user does not enter a placement quantity",
 
   def then_i_see_the_primary_year_group_selection_form
     expect(page).to have_title(
-      "Select primary school year groups you can offer - Manage school placements - GOV.UK",
+      "What primary school year groups can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select primary school year groups you can offer",
+      text: "What primary school year groups can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")

--- a/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_does_not_select_a_year_group_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_does_not_select_a_year_group_spec.rb
@@ -79,12 +79,12 @@ RSpec.describe "School user does not select a year group",
 
   def then_i_see_the_primary_year_group_selection_form
     expect(page).to have_title(
-      "Select primary school year groups you can offer - Manage school placements - GOV.UK",
+      "What primary school year groups can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select primary school year groups you can offer",
+      text: "What primary school year groups can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")

--- a/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
@@ -84,12 +84,12 @@ RSpec.describe "School user enters a float as a placement quantity",
 
   def then_i_see_the_primary_year_group_selection_form
     expect(page).to have_title(
-      "Select primary school year groups you can offer - Manage school placements - GOV.UK",
+      "What primary school year groups can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select primary school year groups you can offer",
+      text: "What primary school year groups can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")

--- a/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
@@ -86,12 +86,12 @@ RSpec.describe "School user enters zero as a placement quantity",
 
   def then_i_see_the_primary_year_group_selection_form
     expect(page).to have_title(
-      "Select primary school year groups you can offer - Manage school placements - GOV.UK",
+      "What primary school year groups can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select primary school year groups you can offer",
+      text: "What primary school year groups can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")

--- a/spec/system/placements/schools/placements/bulk_add_placements/school_user_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/school_user_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
@@ -145,12 +145,12 @@ RSpec.describe "School user bulk adds placements for primary and secondary phase
 
   def then_i_see_the_primary_year_group_selection_form
     expect(page).to have_title(
-      "Select primary school year groups you can offer - Manage school placements - GOV.UK",
+      "What primary school year groups can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select primary school year groups you can offer",
+      text: "What primary school year groups can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Primary placement details", class: "govuk-caption-l")
@@ -185,12 +185,12 @@ RSpec.describe "School user bulk adds placements for primary and secondary phase
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
+      "What secondary school subjects can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects you can offer",
+      text: "What secondary school subjects can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
@@ -209,10 +209,10 @@ RSpec.describe "School user bulk adds placements for primary and secondary phase
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
+      "How many placements can you offer for each subject? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements can you offer for each subject?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
     expect(page).to have_field("Mathematics", type: :number)
@@ -271,7 +271,7 @@ RSpec.describe "School user bulk adds placements for primary and secondary phase
     expect(page).to have_h1("Check your answers")
 
     expect(page).to have_h2("Education phase")
-    expect(page).to have_summary_list_row("Phase", "Primary and Secondary")
+    expect(page).to have_summary_list_row("Phase", "Primary Secondary")
 
     expect(page).to have_h2("Primary placements")
     expect(page).to have_summary_list_row("Year 1", "2")

--- a/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     @english = create(:subject, :secondary, name: "English")
     @mathematics = create(:subject, :secondary, name: "Mathematics")
     @science = create(:subject, :secondary, name: "Science")
-    @modern_languages = create(:subject, :secondary, name: "Modern languages")
+    @modern_languages = create(:subject, :secondary, name: "Modern Languages")
     @french = create(:subject, :secondary, name: "French", parent_subject: @modern_languages)
     @spanish = create(:subject, :secondary, name: "Spanish", parent_subject: @modern_languages)
     @russian = create(:subject, :secondary, name: "Russian", parent_subject: @modern_languages)
@@ -112,51 +112,47 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
+      "What secondary school subjects can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects you can offer",
+      text: "What secondary school subjects can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
-    expect(page).to have_field("Modern languages", type: :checkbox)
+    expect(page).to have_field("Modern Languages", type: :checkbox)
   end
 
   def when_i_select_modern_languages
-    check "Modern languages"
+    check "Modern Languages"
   end
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
+      "How many placements can you offer for each subject? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements can you offer for each subject?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
-    expect(page).to have_field("Modern languages", type: :number)
+    expect(page).to have_field("Modern Languages", type: :number)
   end
 
   def when_i_fill_in_the_number_of_secondary_placements_i_require
-    fill_in "Modern languages", with: 2
+    fill_in "Modern Languages", with: 2
   end
 
   def then_i_see_the_subject_selection_for_modern_languages_form
     expect(page).to have_title(
-      "You selected 2 Modern languages placements - Manage school placements - GOV.UK",
+      "What languages are taught on your Modern Languages placement offers? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_h1(
-      "You selected 2 Modern languages placements",
+      "What languages are taught on your Modern Languages placement offers?",
       class: "govuk-heading-l",
-    )
-    expect(page).to have_h2(
-      "Select the languages taught on each of these placements",
-      class: "govuk-heading-m",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("French", type: :checkbox)
@@ -224,6 +220,6 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     expect(page).to have_summary_list_row("Phase", "Secondary")
 
     expect(page).to have_h2("Secondary placements")
-    expect(page).to have_summary_list_row("Modern languages", "2")
+    expect(page).to have_summary_list_row("Modern Languages", "2")
   end
 end

--- a/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_adds_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_adds_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
@@ -92,12 +92,12 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
+      "What secondary school subjects can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects you can offer",
+      text: "What secondary school subjects can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
@@ -116,10 +116,10 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
+      "How many placements can you offer for each subject? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements can you offer for each subject?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
     expect(page).to have_field("Mathematics", type: :number)

--- a/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
@@ -85,12 +85,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
+      "What secondary school subjects can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects you can offer",
+      text: "What secondary school subjects can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
@@ -105,10 +105,10 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
+      "How many placements can you offer for each subject? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements can you offer for each subject?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
   end

--- a/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "School user does not select a child subjects",
     @english = create(:subject, :secondary, name: "English")
     @mathematics = create(:subject, :secondary, name: "Mathematics")
     @science = create(:subject, :secondary, name: "Science")
-    @modern_languages = create(:subject, :secondary, name: "Modern languages")
+    @modern_languages = create(:subject, :secondary, name: "Modern Languages")
     @french = create(:subject, :secondary, name: "French", parent_subject: @modern_languages)
     @spanish = create(:subject, :secondary, name: "Spanish", parent_subject: @modern_languages)
     @russian = create(:subject, :secondary, name: "Russian", parent_subject: @modern_languages)
@@ -93,51 +93,47 @@ RSpec.describe "School user does not select a child subjects",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
+      "What secondary school subjects can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects you can offer",
+      text: "What secondary school subjects can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :checkbox)
     expect(page).to have_field("Mathematics", type: :checkbox)
     expect(page).to have_field("Science", type: :checkbox)
-    expect(page).to have_field("Modern languages", type: :checkbox)
+    expect(page).to have_field("Modern Languages", type: :checkbox)
   end
 
   def when_i_select_modern_languages
-    check "Modern languages"
+    check "Modern Languages"
   end
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
+      "How many placements can you offer for each subject? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements can you offer for each subject?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
-    expect(page).to have_field("Modern languages", type: :number)
+    expect(page).to have_field("Modern Languages", type: :number)
   end
 
   def when_i_fill_in_the_number_of_secondary_placements_i_require
-    fill_in "Modern languages", with: 1
+    fill_in "Modern Languages", with: 1
   end
 
   def then_i_see_the_subject_selection_for_modern_languages_form
     expect(page).to have_title(
-      "You selected 1 Modern languages placements - Manage school placements - GOV.UK",
+      "What languages are taught on your Modern Languages placement offers? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_h1(
-      "You selected 1 Modern languages placements",
+      "What languages are taught on your Modern Languages placement offers?",
       class: "govuk-heading-l",
-    )
-    expect(page).to have_h2(
-      "Select the languages taught on each of these placements",
-      class: "govuk-heading-m",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("French", type: :checkbox)

--- a/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
@@ -81,12 +81,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
+      "What secondary school subjects can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects you can offer",
+      text: "What secondary school subjects can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")

--- a/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
@@ -86,12 +86,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
+      "What secondary school subjects can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects you can offer",
+      text: "What secondary school subjects can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
@@ -106,10 +106,10 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
+      "How many placements can you offer for each subject? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements can you offer for each subject?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
   end

--- a/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
@@ -86,12 +86,12 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_selection_form
     expect(page).to have_title(
-      "Select secondary school subjects you can offer - Manage school placements - GOV.UK",
+      "What secondary school subjects can you offer placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(
       :legend,
-      text: "Select secondary school subjects you can offer",
+      text: "What secondary school subjects can you offer placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
@@ -106,10 +106,10 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
 
   def then_i_see_the_secondary_subject_placement_quantity_form
     expect(page).to have_title(
-      "Enter the number of secondary school placements you can offer - Manage school placements - GOV.UK",
+      "How many placements can you offer for each subject? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Enter the number of secondary school placements you can offer", class: "govuk-heading-l")
+    expect(page).to have_h1("How many placements can you offer for each subject?", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Secondary placement details", class: "govuk-caption-l")
     expect(page).to have_field("English", type: :number)
   end

--- a/spec/system/placements/schools/placements/primary_school_user_adds_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/primary_school_user_adds_a_placement_spec.rb
@@ -546,7 +546,7 @@ RSpec.describe "Primary school user adds a placement", service: :placements, typ
 
   def and_i_see_my_placement
     expect(page).to have_table_row({
-      "Subject" => "Primary with mathematics (Year 2)",
+      "Placement" => "Primary with mathematics (Year 2)",
       "Mentor" => "Jane Doe",
       "Expected date" => "Summer term",
       "Provider" => "Provider not assigned",

--- a/spec/system/placements/schools/placements/secondary_school_user_adds_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/secondary_school_user_adds_a_placement_spec.rb
@@ -459,7 +459,7 @@ RSpec.describe "Secondary school user adds a placement", service: :placements, t
 
   def and_i_see_my_placement
     expect(page).to have_table_row({
-      "Subject" => "Mathematics",
+      "Placement" => "Mathematics",
       "Mentor" => "Jane Doe",
       "Expected date" => "Summer term",
       "Provider" => "Provider not assigned",

--- a/spec/system/placements/schools/placements/user_publishes_a_placement_after_preview_spec.rb
+++ b/spec/system/placements/schools/placements/user_publishes_a_placement_after_preview_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe "User publishes a placement after preview", service: :placements,
 
   def and_i_see_my_placement
     expect(page).to have_table_row({
-      "Subject" => "English",
+      "Placement" => "English",
       "Mentor" => "John Smith",
       "Expected date" => "Autumn term, Spring term",
       "Provider" => "Provider not assigned",

--- a/spec/system/placements/schools/placements/view_placements_list_spec.rb
+++ b/spec/system/placements/schools/placements/view_placements_list_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Placement school user views a list of placements", service: :pla
       then_i_see_placement_details({
         "Expected date" => "Any time in the academic year",
         "Mentor" => "Bart Simpson and Lisa Simpson",
-        "Subject" => "Biology",
+        "Placement" => "Biology",
         "Provider" => "Provider not assigned",
       })
     end
@@ -34,7 +34,7 @@ RSpec.describe "Placement school user views a list of placements", service: :pla
       then_i_see_placement_details({
         "Expected date" => "Any time in the academic year",
         "Mentor" => "Mentor not assigned",
-        "Subject" => "Biology",
+        "Placement" => "Biology",
         "Provider" => "Provider not assigned",
       })
     end
@@ -45,7 +45,7 @@ RSpec.describe "Placement school user views a list of placements", service: :pla
       then_i_see_placement_details({
         "Expected date" => "Any time in the academic year",
         "Mentor" => "Mentor not assigned",
-        "Subject" => "Biology",
+        "Placement" => "Biology",
         "Provider" => "Springfield University",
       })
     end
@@ -57,7 +57,7 @@ RSpec.describe "Placement school user views a list of placements", service: :pla
       then_i_see_placement_details({
         "Expected date" => "Autumn term",
         "Mentor" => "Mentor not assigned",
-        "Subject" => "Biology",
+        "Placement" => "Biology",
         "Provider" => "Provider not assigned",
       })
     end

--- a/spec/system/placements/schools/school_user_logs_in_for_the_first_time_spec.rb
+++ b/spec/system/placements/schools/school_user_logs_in_for_the_first_time_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe "School user logs in for the first time", service: :placements, t
   end
 
   def then_i_see_the_appetite_page
-    expect(page).to have_title("Can your school offer placements for trainee teachers in this academic year (#{@academic_year.name})? - Manage school placements - GOV.UK")
+    expect(page).to have_title("Can your school offer placements for trainee teachers in the academic year #{@academic_year.name}? - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_element(:h1, text: "Can your school offer placements for trainee teachers in this academic year (#{@academic_year.name})?", class: "govuk-fieldset__heading")
+    expect(page).to have_element(:h1, text: "Can your school offer placements for trainee teachers in the academic year #{@academic_year.name}?", class: "govuk-fieldset__heading")
   end
 
   def when_i_click_on_the_users_tab

--- a/spec/system/placements/support/schools/placements/view_placements/support_user_views_a_placement_with_a_mentor_assigned_spec.rb
+++ b/spec/system/placements/support/schools/placements/view_placements/support_user_views_a_placement_with_a_mentor_assigned_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "Support user views a placement with a mentor assigned", service:
 
   def and_i_see_the_placement_for_primary_with_english
     expect(page).to have_table_row({
-      "Subject" => "Primary with english (Year 1)",
+      "Placement" => "Primary with english (Year 1)",
       "Mentor" => "Jane Doe and John Smith",
       "Expected date" => "Any time in the academic year",
       "Provider" => "Provider not assigned",

--- a/spec/system/placements/support/schools/placements/view_placements/support_user_views_a_placement_with_a_provider_spec.rb
+++ b/spec/system/placements/support/schools/placements/view_placements/support_user_views_a_placement_with_a_provider_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "Support user views a placement with a provider", service: :place
 
   def and_i_see_the_placement_for_primary_with_english
     expect(page).to have_table_row({
-      "Subject" => "Primary with english (Year 1)",
+      "Placement" => "Primary with english (Year 1)",
       "Mentor" => "Mentor not assigned",
       "Expected date" => "Any time in the academic year",
       "Provider" => "Best Practice Network",

--- a/spec/system/placements/support/schools/placements/view_placements/support_user_views_a_placement_with_a_specific_term_spec.rb
+++ b/spec/system/placements/support/schools/placements/view_placements/support_user_views_a_placement_with_a_specific_term_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "Support user views a placement with a specific term", service: :
 
   def and_i_see_the_placement_for_primary_with_english
     expect(page).to have_table_row({
-      "Subject" => "Primary with english (Year 1)",
+      "Placement" => "Primary with english (Year 1)",
       "Mentor" => "Mentor not assigned",
       "Expected date" => "Autumn term",
       "Provider" => "Best Practice Network",

--- a/spec/wizards/placements/add_hosting_interest_wizard/appetite_step_spec.rb
+++ b/spec/wizards/placements/add_hosting_interest_wizard/appetite_step_spec.rb
@@ -38,19 +38,19 @@ RSpec.describe Placements::AddHostingInterestWizard::AppetiteStep, type: :model 
       expect(actively_looking.value).to eq("actively_looking")
       expect(actively_looking.name).to eq("Yes - I can offer placements")
       expect(actively_looking.description).to eq(
-        "Record the placements you can offer. You can edit your placements any time.",
+        "Share the placements you can offer",
       )
 
       expect(interested.value).to eq("interested")
       expect(interested.name).to eq("Maybe - I’m not sure yet")
       expect(interested.description).to eq(
-        "Providers can contact you to discuss potential placements.",
+        "Share what you can potentially offer",
       )
 
       expect(not_open.value).to eq("not_open")
       expect(not_open.name).to eq("No - I can’t offer placements")
       expect(not_open.description).to eq(
-        "Tell us why your school cannot offer placements. Your contact details will not be shown to providers.",
+        "Tell us why you cannot offer placements",
       )
     end
   end


### PR DESCRIPTION
## Context

- Content changes to the EOI Green and Amber paths

## Guidance to review

- Sign in as Anne (School user)
- Complete the hosting interest journeys (Green and Amber paths), ensure all pages match the requested changes in the figma diagrams. https://www.figma.com/design/9eMfPnPEONmEPvimD3CYpz/MSP-Concepts?node-id=63974-37027&t=GMnmv6FzQXXonWBW-0

## Link to Trello card

https://trello.com/c/RZAVbESR/590-iteration-4-content-changes-to-green-path
https://trello.com/c/QLPi4O82/591-iteration-4-content-changes-to-amber-path
https://trello.com/c/OE5wuo4c/593-iteration-4-content-changes-to-can-you-offer-placements-screen

## Screenshots

![screencapture-placements-localhost-3000-schools-0000f772-410b-4940-adbb-1b0e700846c5-hosting-interests-new-83430d54-a6a3-492a-b00b-f199f5201277-appetite-2025-05-09-15_49_49](https://github.com/user-attachments/assets/dc1642f3-dbbc-47e9-b1aa-b8e76f86d61e)


https://github.com/user-attachments/assets/325fd3a3-2d72-4f26-8c86-44bc8a377581


https://github.com/user-attachments/assets/44784937-7b59-4fc3-9084-08468a3d9ec2


