### PR TITLE
Add text to onboarding email about pilot

### DIFF
--- a/app/views/placements/school_user_mailer/user_membership_created_notification.text.erb
+++ b/app/views/placements/school_user_mailer/user_membership_created_notification.text.erb
@@ -21,6 +21,8 @@ After creating a DfE sign-in account, they will need to return to this email to 
 
 ## Give feedback or report a problem
 
+This is a pilot service for schools and teacher training providers in Leeds and Essex.
+
 If you need help or have feedback for us, contact [<%= @support_email %>](mailto:<%= @support_email %>).
 
 Thank you.

--- a/spec/mailers/placements/school_user_mailer_spec.rb
+++ b/spec/mailers/placements/school_user_mailer_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe Placements::SchoolUserMailer, type: :mailer do
 
         ## Give feedback or report a problem
 
+        This is a pilot service for schools and teacher training providers in Leeds and Essex.
+
         If you need help or have feedback for us, contact [Manage.SchoolPlacements@education.gov.uk](mailto:Manage.SchoolPlacements@education.gov.uk).
 
         Thank you.


### PR DESCRIPTION
## Context

- Request made to add "This is a pilot service for schools and teacher training providers in Leeds and Essex." to onboarding email

## Link to Trello card

https://trello.com/c/4jd0WEWB/546-onboard-all-schools-in-essex-to-the-service

## Screenshots

<img width="413" alt="Screenshot 2025-05-15 at 14 05 50" src="https://github.com/user-attachments/assets/6135ea8a-e7cd-40ac-bc47-4aa6721d48d7" />

