### PR TITLE
Remove flash message from EOI journeys

### DIFF
--- a/app/controllers/placements/schools/hosting_interests/add_hosting_interest_controller.rb
+++ b/app/controllers/placements/schools/hosting_interests/add_hosting_interest_controller.rb
@@ -19,10 +19,7 @@ class Placements::Schools::HostingInterests::AddHostingInterestController < Plac
       end
       @wizard.reset_state
 
-      redirect_to whats_next_placements_school_hosting_interests_path(@school), flash: {
-        heading: t(".heading.#{appetite}"),
-        body: t(".body.#{appetite}_html"),
-      }
+      redirect_to whats_next_placements_school_hosting_interests_path(@school)
     end
   end
 

--- a/app/controllers/placements/schools/hosting_interests/edit_hosting_interest_controller.rb
+++ b/app/controllers/placements/schools/hosting_interests/edit_hosting_interest_controller.rb
@@ -25,12 +25,7 @@ class Placements::Schools::HostingInterests::EditHostingInterestController < Pla
         session["whats_next"] = @wizard.placements_information
       end
       @wizard.reset_state
-
-      flash_locales_path = "placements.schools.hosting_interests.add_hosting_interest.update"
-      redirect_to whats_next_placements_school_hosting_interests_path(@school), flash: {
-        heading: t("#{flash_locales_path}.heading.#{appetite}"),
-        body: t("#{flash_locales_path}.body.#{appetite}_html"),
-      }
+      redirect_to whats_next_placements_school_hosting_interests_path(@school)
     end
   end
 

--- a/config/locales/en/placements/schools/hosting_interests.yml
+++ b/config/locales/en/placements/schools/hosting_interests.yml
@@ -8,19 +8,6 @@ en:
         add_hosting_interest:
           edit:
             cancel: Cancel
-          update:
-            heading: 
-              actively_looking: Placement information uploaded
-              not_open: Your profile has been updated
-              interested: Your status has been updated to ‘interested in hosting placements’
-            body:
-              actively_looking_html:
-                Providers can see your placement preferences and may contact you to discuss them.<br><br>
-                You can add details to your placements such as expected date and provider.
-              not_open_html: 
-                You can change your profile in <a href="">settings</a> if your circumstances change.
-              interested_html:
-                This means providers can see that you’re looking to host placements.
           whats_next:
             return_to_placements: Return to placements list
             return_to_organisation_details: Return to organisation details

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_add_their_hosting_interest_and_bulk_adds_placements_for_the_primary_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_add_their_hosting_interest_and_bulk_adds_placements_for_the_primary_phase_spec.rb
@@ -34,8 +34,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     then_i_see_the_check_your_answers_page
 
     when_i_click_on_publish_placements
-    then_i_see_my_responses_were_successfully_updated
-    and_i_see_the_whats_next_page
+    then_i_see_the_whats_next_page
     and_i_see_2_reception_primary_placements_have_been_created
     and_i_see_3_year_3_primary_placements_have_been_created
     and_i_see_1_mixed_year_groups_primary_placements_have_been_created
@@ -202,13 +201,6 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     fill_in "Email address", with: "joe_bloggs@example.com"
   end
 
-  def then_i_see_my_responses_were_successfully_updated
-    expect(page).to have_success_banner(
-      "Placement information uploaded",
-      "Providers can see your placement preferences and may contact you to discuss them. You can add details to your placements such as expected date and provider.",
-    )
-  end
-
   def and_the_schools_contact_has_been_updated
     @school_contact = @school.school_contact.reload
     expect(@school_contact.first_name).to eq("Joe")
@@ -250,7 +242,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")
   end
 
-  def and_i_see_the_whats_next_page
+  def then_i_see_the_whats_next_page
     expect(page).to have_title(
       "What happens next? - Manage school placements - GOV.UK",
     )

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
@@ -93,8 +93,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     then_i_see_the_check_your_answers_page
 
     when_i_click_on_publish_placements
-    then_i_see_my_responses_were_successfully_updated
-    and_i_see_the_whats_next_page
+    then_i_see_the_whats_next_page
     and_i_see_2_year_1_primary_placements_have_been_created
     and_i_see_1_english_secondary_placement_has_been_created
     and_i_see_4_mathematics_secondary_placements_have_been_created
@@ -319,13 +318,6 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     fill_in "Email address", with: "joe_bloggs@example.com"
   end
 
-  def then_i_see_my_responses_were_successfully_updated
-    expect(page).to have_success_banner(
-      "Placement information uploaded",
-      "Providers can see your placement preferences and may contact you to discuss them. You can add details to your placements such as expected date and provider.",
-    )
-  end
-
   def and_the_schools_contact_has_been_updated
     @school_contact.reload
     expect(@school_contact.first_name).to eq("Joe")
@@ -365,7 +357,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")
   end
 
-  def and_i_see_the_whats_next_page
+  def then_i_see_the_whats_next_page
     expect(page).to have_title(
       "What happens next? - Manage school placements - GOV.UK",
     )

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
@@ -43,8 +43,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     then_i_see_the_check_your_answers_page
 
     when_i_click_on_publish_placements
-    then_i_see_my_responses_were_successfully_updated
-    and_i_see_the_whats_next_page
+    then_i_see_the_whats_next_page
     and_i_see_2_secondary_placements_for_modern_languages_have_been_created
     and_the_schools_contact_has_been_updated
     and_the_schools_hosting_interest_for_the_next_year_is_updated
@@ -228,13 +227,6 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     fill_in "Email address", with: "joe_bloggs@example.com"
   end
 
-  def then_i_see_my_responses_were_successfully_updated
-    expect(page).to have_success_banner(
-      "Placement information uploaded",
-      "Providers can see your placement preferences and may contact you to discuss them. You can add details to your placements such as expected date and provider.",
-    )
-  end
-
   def and_the_schools_contact_has_been_updated
     @school_contact = @school.school_contact.reload
     expect(@school_contact.first_name).to eq("Joe")
@@ -288,7 +280,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")
   end
 
-  def and_i_see_the_whats_next_page
+  def then_i_see_the_whats_next_page
     expect(page).to have_title(
       "What happens next? - Manage school placements - GOV.UK",
     )

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_adds_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_adds_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
@@ -33,8 +33,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     then_i_see_the_check_your_answers_page
 
     when_i_click_on_publish_placements
-    then_i_see_my_responses_were_successfully_updated
-    and_i_see_the_whats_next_page
+    then_i_see_the_whats_next_page
     and_i_see_1_secondary_placement_for_english_have_been_created
     and_i_see_4_secondary_placements_for_mathematics_have_been_created
     and_the_schools_contact_has_been_updated
@@ -184,13 +183,6 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     fill_in "Email address", with: "joe_bloggs@example.com"
   end
 
-  def then_i_see_my_responses_were_successfully_updated
-    expect(page).to have_success_banner(
-      "Placement information uploaded",
-      "Providers can see your placement preferences and may contact you to discuss them. You can add details to your placements such as expected date and provider.",
-    )
-  end
-
   def and_the_schools_contact_has_been_updated
     @school_contact = @school.school_contact.reload
     expect(@school_contact.first_name).to eq("Joe")
@@ -245,7 +237,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")
   end
 
-  def and_i_see_the_whats_next_page
+  def then_i_see_the_whats_next_page
     expect(page).to have_title(
       "What happens next? - Manage school placements - GOV.UK",
     )

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
@@ -59,8 +59,7 @@ RSpec.describe "School user completes the interested journey and declares primar
     and_i_see_the_message_to_provider_i_entered
 
     when_i_click_on_confirm
-    then_i_see_my_responses_with_successfully_updated
-    and_i_see_the_whats_next_page
+    then_i_see_the_whats_next_page
     and_the_schools_contact_has_been_updated
     and_the_schools_hosting_interest_for_the_next_year_is_updated
     and_the_schools_potential_placement_details_have_been_updated
@@ -160,13 +159,6 @@ RSpec.describe "School user completes the interested journey and declares primar
     fill_in "Email address", with: "joe_bloggs@example.com"
   end
 
-  def then_i_see_my_responses_with_successfully_updated
-    expect(page).to have_success_banner(
-      "Your status has been updated to ‘interested in hosting placements’",
-      "This means providers can see that you’re looking to host placements.",
-    )
-  end
-
   def and_the_schools_contact_has_been_updated
     school_contact = @school.school_contact
     expect(school_contact.first_name).to eq("Joe")
@@ -179,7 +171,7 @@ RSpec.describe "School user completes the interested journey and declares primar
     expect(hosting_interest.appetite).to eq("interested")
   end
 
-  def and_i_see_the_whats_next_page
+  def then_i_see_the_whats_next_page
     expect(page).to have_panel(
       "Information added",
       "Providers can see that you may offer placements",

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_child_subjects_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_child_subjects_spec.rb
@@ -48,8 +48,7 @@ RSpec.describe "School user completes the interested journey without declaring c
     and_i_see_the_message_to_provider_i_entered
 
     when_i_click_on_confirm
-    then_i_see_my_responses_with_successfully_updated
-    and_i_see_the_whats_next_page
+    then_i_see_the_whats_next_page
     and_the_schools_contact_has_been_updated
     and_the_schools_hosting_interest_for_the_next_year_is_updated
     and_the_schools_potential_placement_details_have_been_updated
@@ -151,13 +150,6 @@ RSpec.describe "School user completes the interested journey without declaring c
     fill_in "Email address", with: "joe_bloggs@example.com"
   end
 
-  def then_i_see_my_responses_with_successfully_updated
-    expect(page).to have_success_banner(
-      "Your status has been updated to ‘interested in hosting placements’",
-      "This means providers can see that you’re looking to host placements.",
-    )
-  end
-
   def and_the_schools_contact_has_been_updated
     school_contact = @school.school_contact
     expect(school_contact.first_name).to eq("Joe")
@@ -170,7 +162,7 @@ RSpec.describe "School user completes the interested journey without declaring c
     expect(hosting_interest.appetite).to eq("interested")
   end
 
-  def and_i_see_the_whats_next_page
+  def then_i_see_the_whats_next_page
     expect(page).to have_panel(
       "Information added",
       "Providers can see that you may offer placements",

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_potential_placement_details_spec.rb
@@ -29,8 +29,7 @@ RSpec.describe "School user completes the interested journey without declaring p
     and_i_see_the_message_to_provider_is_empty
 
     when_i_click_on_confirm
-    then_i_see_my_responses_with_successfully_updated
-    and_i_see_the_whats_next_page
+    then_i_see_the_whats_next_page
     and_the_schools_contact_has_been_updated
     and_the_schools_hosting_interest_for_the_next_year_is_updated
     and_the_schools_potential_placement_details_have_been_updated
@@ -122,13 +121,6 @@ RSpec.describe "School user completes the interested journey without declaring p
     fill_in "Email address", with: "joe_bloggs@example.com"
   end
 
-  def then_i_see_my_responses_with_successfully_updated
-    expect(page).to have_success_banner(
-      "Your status has been updated to ‘interested in hosting placements’",
-      "This means providers can see that you’re looking to host placements.",
-    )
-  end
-
   def and_the_schools_contact_has_been_updated
     school_contact = @school.school_contact
     expect(school_contact.first_name).to eq("Joe")
@@ -141,7 +133,7 @@ RSpec.describe "School user completes the interested journey without declaring p
     expect(hosting_interest.appetite).to eq("interested")
   end
 
-  def and_i_see_the_whats_next_page
+  def then_i_see_the_whats_next_page
     expect(page).to have_panel(
       "Information added",
       "Providers can see that you may offer placements",

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_quantities_for_potential_placements_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_quantities_for_potential_placements_spec.rb
@@ -51,8 +51,7 @@ RSpec.describe "School user completes the interested journey without declaring q
     and_i_see_the_message_to_provider_i_entered
 
     when_i_click_on_confirm
-    then_i_see_my_responses_with_successfully_updated
-    and_i_see_the_whats_next_page
+    then_i_see_the_whats_next_page
     and_the_schools_contact_has_been_updated
     and_the_schools_hosting_interest_for_the_next_year_is_updated
     and_the_schools_potential_placement_details_have_been_updated
@@ -152,13 +151,6 @@ RSpec.describe "School user completes the interested journey without declaring q
     fill_in "Email address", with: "joe_bloggs@example.com"
   end
 
-  def then_i_see_my_responses_with_successfully_updated
-    expect(page).to have_success_banner(
-      "Your status has been updated to ‘interested in hosting placements’",
-      "This means providers can see that you’re looking to host placements.",
-    )
-  end
-
   def and_the_schools_contact_has_been_updated
     school_contact = @school.school_contact
     expect(school_contact.first_name).to eq("Joe")
@@ -171,7 +163,7 @@ RSpec.describe "School user completes the interested journey without declaring q
     expect(hosting_interest.appetite).to eq("interested")
   end
 
-  def and_i_see_the_whats_next_page
+  def then_i_see_the_whats_next_page
     expect(page).to have_panel(
       "Information added",
       "Providers can see that you may offer placements",

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_specific_year_groups_or_subjects_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_specific_year_groups_or_subjects_spec.rb
@@ -42,8 +42,7 @@ RSpec.describe "School user completes the interested journey without declaring s
     and_i_see_the_message_to_provider_i_entered
 
     when_i_click_on_confirm
-    then_i_see_my_responses_with_successfully_updated
-    and_i_see_the_whats_next_page
+    then_i_see_the_whats_next_page
     and_the_schools_contact_has_been_updated
     and_the_schools_hosting_interest_for_the_next_year_is_updated
     and_the_schools_potential_placement_details_have_been_updated
@@ -143,13 +142,6 @@ RSpec.describe "School user completes the interested journey without declaring s
     fill_in "Email address", with: "joe_bloggs@example.com"
   end
 
-  def then_i_see_my_responses_with_successfully_updated
-    expect(page).to have_success_banner(
-      "Your status has been updated to ‘interested in hosting placements’",
-      "This means providers can see that you’re looking to host placements.",
-    )
-  end
-
   def and_the_schools_contact_has_been_updated
     school_contact = @school.school_contact
     expect(school_contact.first_name).to eq("Joe")
@@ -162,7 +154,7 @@ RSpec.describe "School user completes the interested journey without declaring s
     expect(hosting_interest.appetite).to eq("interested")
   end
 
-  def and_i_see_the_whats_next_page
+  def then_i_see_the_whats_next_page
     expect(page).to have_panel(
       "Information added",
       "Providers can see that you may offer placements",

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_enters_another_reason_why_they_are_not_hosting_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_enters_another_reason_why_they_are_not_hosting_spec.rb
@@ -26,8 +26,7 @@ RSpec.describe "School user enters another reason why they are not hosting",
     and_i_see_the_entered_school_contact_details
 
     when_i_click_on_continue
-    then_i_see_my_responses_with_successfully_updated
-    and_i_see_the_whats_next_page
+    then_i_see_the_whats_next_page
     and_the_schools_contact_has_been_updated
     and_the_schools_hosting_interest_for_the_next_year_is_updated
   end
@@ -171,13 +170,6 @@ RSpec.describe "School user enters another reason why they are not hosting",
     fill_in "Email address", with: "joe_bloggs@example.com"
   end
 
-  def then_i_see_my_responses_with_successfully_updated
-    expect(page).to have_success_banner(
-      "Your profile has been updated",
-      "You can change your profile in settings if your circumstances change.",
-    )
-  end
-
   def and_the_schools_contact_has_been_updated
     @school_contact = @school.school_contact.reload
     expect(@school_contact.first_name).to eq("Joe")
@@ -238,7 +230,7 @@ RSpec.describe "School user enters another reason why they are not hosting",
     fill_in "Tell us your reason", with: "Some other reason"
   end
 
-  def and_i_see_the_whats_next_page
+  def then_i_see_the_whats_next_page
     expect(page).to have_panel(
       "You are not offering placements this year",
       "Your contact details will not be shown to providers",

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_successfully_completes_the_not_open_journey_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_not_open/school_user_successfully_completes_the_not_open_journey_spec.rb
@@ -48,8 +48,7 @@ RSpec.describe "School user successfully completes the not open journey",
     and_i_see_the_entered_school_contact_details
 
     when_i_click_on_continue
-    then_i_see_my_responses_with_successfully_updated
-    and_i_see_the_whats_next_page
+    then_i_see_the_whats_next_page
     and_the_schools_contact_has_been_updated
     and_the_schools_hosting_interest_for_the_next_year_is_updated
   end
@@ -196,13 +195,6 @@ RSpec.describe "School user successfully completes the not open journey",
     fill_in "Email address", with: "joe_bloggs@example.com"
   end
 
-  def then_i_see_my_responses_with_successfully_updated
-    expect(page).to have_success_banner(
-      "Your profile has been updated",
-      "You can change your profile in settings if your circumstances change.",
-    )
-  end
-
   def and_the_schools_contact_has_been_updated
     @school_contact = @school.school_contact.reload
     expect(@school_contact.first_name).to eq("Joe")
@@ -247,7 +239,7 @@ RSpec.describe "School user successfully completes the not open journey",
     )
   end
 
-  def and_i_see_the_whats_next_page
+  def then_i_see_the_whats_next_page
     expect(page).to have_panel(
       "You are not offering placements this year",
       "Your contact details will not be shown to providers",

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_the_primary_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_the_primary_phase_spec.rb
@@ -35,8 +35,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     then_i_see_the_check_your_answers_page
 
     when_i_click_on_publish_placements
-    then_i_see_my_responses_were_successfully_updated
-    and_i_see_the_whats_next_page
+    then_i_see_the_whats_next_page
     and_i_see_2_reception_primary_placements_have_been_created
     and_i_see_3_year_3_primary_placements_have_been_created
     and_the_schools_hosting_interest_for_the_next_year_is_updated
@@ -227,13 +226,6 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     fill_in "Email address", with: "joe_bloggs@example.com"
   end
 
-  def then_i_see_my_responses_were_successfully_updated
-    expect(page).to have_success_banner(
-      "Placement information uploaded",
-      "Providers can see your placement preferences and may contact you to discuss them. You can add details to your placements such as expected date and provider.",
-    )
-  end
-
   def and_the_schools_contact_has_been_updated
     @school_contact = @school.school_contact.reload
     expect(@school_contact.first_name).to eq("Joe")
@@ -266,7 +258,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     expect(page).to have_summary_list_row("Mixed year group", "1")
   end
 
-  def and_i_see_the_whats_next_page
+  def then_i_see_the_whats_next_page
     expect(page).to have_title(
       "What happens next? - Manage school placements - GOV.UK",
     )

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
@@ -87,8 +87,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     then_i_see_the_check_your_answers_page
 
     when_i_click_on_publish_placements
-    then_i_see_my_responses_with_successfully_updated
-    and_i_see_the_whats_next_page
+    then_i_see_the_whats_next_page
     and_i_see_2_year_1_primary_placements_have_been_created
     and_i_see_1_english_secondary_placement_has_been_created
     and_i_see_4_mathematics_secondary_placements_have_been_created
@@ -337,13 +336,6 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     fill_in "Email address", with: "joe_bloggs@example.com"
   end
 
-  def then_i_see_my_responses_with_successfully_updated
-    expect(page).to have_success_banner(
-      "Placement information uploaded",
-      "Providers can see your placement preferences and may contact you to discuss them. You can add details to your placements such as expected date and provider.",
-    )
-  end
-
   def and_the_schools_contact_has_been_updated
     @school_contact.reload
     expect(@school_contact.first_name).to eq("Joe")
@@ -434,7 +426,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     expect(page).to have_summary_list_row("Mathematics", "4")
   end
 
-  def and_i_see_the_whats_next_page
+  def then_i_see_the_whats_next_page
     expect(page).to have_title(
       "What happens next? - Manage school placements - GOV.UK",
     )

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
@@ -45,8 +45,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     then_i_see_the_check_your_answers_page
 
     when_i_click_on_publish_placements
-    then_i_see_my_responses_with_successfully_updated
-    and_i_see_the_whats_next_page
+    then_i_see_the_whats_next_page
     and_i_see_2_secondary_placements_for_modern_languages_have_been_created
 
     when_i_click_on_edit_your_placements
@@ -264,13 +263,6 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     fill_in "Email address", with: "joe_bloggs@example.com"
   end
 
-  def then_i_see_my_responses_with_successfully_updated
-    expect(page).to have_success_banner(
-      "Placement information uploaded",
-      "Providers can see your placement preferences and may contact you to discuss them. You can add details to your placements such as expected date and provider.",
-    )
-  end
-
   def and_the_schools_contact_has_been_updated
     @school_contact = @school.school_contact.reload
     expect(@school_contact.first_name).to eq("Joe")
@@ -323,7 +315,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     expect(page).to have_summary_list_row("Modern Languages", "2")
   end
 
-  def and_i_see_the_whats_next_page
+  def then_i_see_the_whats_next_page
     expect(page).to have_title(
       "What happens next? - Manage school placements - GOV.UK",
     )

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_edits_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_edits_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
@@ -34,8 +34,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     then_i_see_the_check_your_answers_page
 
     when_i_click_on_publish_placements
-    then_i_see_my_responses_with_successfully_updated
-    and_i_see_the_whats_next_page
+    then_i_see_the_whats_next_page
     and_i_see_1_english_secondary_placement_has_been_created
     and_i_see_4_mathematics_secondary_placements_have_been_created
 
@@ -214,13 +213,6 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     fill_in "Email address", with: "joe_bloggs@example.com"
   end
 
-  def then_i_see_my_responses_with_successfully_updated
-    expect(page).to have_success_banner(
-      "Placement information uploaded",
-      "Providers can see your placement preferences and may contact you to discuss them. You can add details to your placements such as expected date and provider.",
-    )
-  end
-
   def and_the_schools_contact_has_been_updated
     @school_contact = @school.school_contact.reload
     expect(@school_contact.first_name).to eq("Joe")
@@ -274,7 +266,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     expect(page).not_to have_h2("Providers")
   end
 
-  def and_i_see_the_whats_next_page
+  def then_i_see_the_whats_next_page
     expect(page).to have_title(
       "What happens next? - Manage school placements - GOV.UK",
     )

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
@@ -61,8 +61,7 @@ RSpec.describe "School user completes the interested journey without declaring p
     and_i_see_the_message_to_provider_i_entered
 
     when_i_click_on_confirm
-    then_i_see_my_responses_with_successfully_updated
-    and_i_see_the_whats_next_page
+    then_i_see_the_whats_next_page
     and_the_schools_hosting_interest_for_the_next_year_is_updated
     and_the_schools_potential_placement_details_have_been_updated
   end
@@ -172,13 +171,6 @@ RSpec.describe "School user completes the interested journey without declaring p
     )
   end
 
-  def then_i_see_my_responses_with_successfully_updated
-    expect(page).to have_success_banner(
-      "Your status has been updated to ‘interested in hosting placements’",
-      "This means providers can see that you’re looking to host placements.",
-    )
-  end
-
   def and_the_schools_contact_has_been_updated
     school_contact = @school.school_contact
     expect(school_contact.first_name).to eq("Joe")
@@ -191,7 +183,7 @@ RSpec.describe "School user completes the interested journey without declaring p
     expect(hosting_interest.appetite).to eq("interested")
   end
 
-  def and_i_see_the_whats_next_page
+  def then_i_see_the_whats_next_page
     expect(page).to have_panel(
       "Information added",
       "Providers can see that you may offer placements",

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_interested/school_user_completes_the_interested_journey_without_declaring_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_interested/school_user_completes_the_interested_journey_without_declaring_potential_placement_details_spec.rb
@@ -29,8 +29,7 @@ RSpec.describe "School user completes the interested journey without declaring p
     and_i_see_the_message_to_provider_is_empty
 
     when_i_click_on_confirm
-    then_i_see_my_responses_with_successfully_updated
-    and_i_see_the_whats_next_page
+    then_i_see_the_whats_next_page
     and_the_schools_hosting_interest_for_the_next_year_is_updated
     and_the_schools_potential_placement_details_have_been_updated
   end
@@ -138,19 +137,12 @@ RSpec.describe "School user completes the interested journey without declaring p
     fill_in "Email address", with: "joe_bloggs@example.com"
   end
 
-  def then_i_see_my_responses_with_successfully_updated
-    expect(page).to have_success_banner(
-      "Your status has been updated to ‘interested in hosting placements’",
-      "This means providers can see that you’re looking to host placements.",
-    )
-  end
-
   def and_the_schools_hosting_interest_for_the_next_year_is_updated
     hosting_interest = @school.hosting_interests.for_academic_year(@next_academic_year).last
     expect(hosting_interest.appetite).to eq("interested")
   end
 
-  def and_i_see_the_whats_next_page
+  def then_i_see_the_whats_next_page
     expect(page).to have_panel(
       "Information added",
       "Providers can see that you may offer placements",

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_enters_another_reason_why_they_are_not_hosting_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_enters_another_reason_why_they_are_not_hosting_spec.rb
@@ -26,8 +26,7 @@ RSpec.describe "School user enters another reason why they are not hosting",
     and_i_see_the_reason_not_hosting_i_entered
 
     when_i_click_on_continue
-    then_i_see_my_responses_with_successfully_updated
-    and_i_see_the_whats_next_page
+    then_i_see_the_whats_next_page
     and_the_schools_hosting_interest_for_the_next_year_is_updated
   end
 
@@ -197,13 +196,6 @@ RSpec.describe "School user enters another reason why they are not hosting",
     fill_in "Email address", with: "joe_bloggs@example.com"
   end
 
-  def then_i_see_my_responses_with_successfully_updated
-    expect(page).to have_success_banner(
-      "Your profile has been updated",
-      "You can change your profile in settings if your circumstances change.",
-    )
-  end
-
   def and_the_schools_hosting_interest_for_the_next_year_is_updated
     hosting_interest = @school.hosting_interests.for_academic_year(@next_academic_year).last
     expect(hosting_interest.appetite).to eq("not_open")
@@ -250,7 +242,7 @@ RSpec.describe "School user enters another reason why they are not hosting",
     fill_in "Tell us your reason", with: "Some other reason"
   end
 
-  def and_i_see_the_whats_next_page
+  def then_i_see_the_whats_next_page
     expect(page).to have_panel(
       "You are not offering placements this year",
       "Your contact details will not be shown to providers",

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_successfully_completes_the_not_open_journey_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_not_open/school_user_successfully_completes_the_not_open_journey_spec.rb
@@ -41,8 +41,7 @@ RSpec.describe "School user successfully completes the not open journey",
     and_i_see_the_reason_not_hosting_i_entered
 
     when_i_click_on_continue
-    then_i_see_my_responses_with_successfully_updated
-    and_i_see_the_whats_next_page
+    then_i_see_the_whats_next_page
     and_the_schools_hosting_interest_for_the_next_year_is_updated
   end
 
@@ -222,13 +221,6 @@ RSpec.describe "School user successfully completes the not open journey",
     fill_in "Email address", with: "joe_bloggs@example.com"
   end
 
-  def then_i_see_my_responses_with_successfully_updated
-    expect(page).to have_success_banner(
-      "Your profile has been updated",
-      "You can change your profile in settings if your circumstances change.",
-    )
-  end
-
   def and_the_schools_contact_has_been_updated
     @school_contact = @school.school_contact.reload
     expect(@school_contact.first_name).to eq("Joe")
@@ -273,7 +265,7 @@ RSpec.describe "School user successfully completes the not open journey",
     )
   end
 
-  def and_i_see_the_whats_next_page
+  def then_i_see_the_whats_next_page
     expect(page).to have_panel(
       "You are not offering placements this year",
       "Your contact details will not be shown to providers",


### PR DESCRIPTION
Remove unused translations, amend tests to no longer expect success banners

Given we have the “What’s next“ pages, the flash messages are no longer needed.

Remove flash message from the add + update EOI journeys and update specs to no longer expect success banners. Remove translations that are no longer in use. 

## Changes proposed in this pull request

Remove flash messages and amend specs.

## Guidance to review

## Link to Trello card

https://trello.com/c/DCMUnXvl/624-remove-eoi-success-flash-banners

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
