### PR TITLE
Allow support to remove submitted claims

### DIFF
--- a/app/policies/claims/support/claim_policy.rb
+++ b/app/policies/claims/support/claim_policy.rb
@@ -24,7 +24,7 @@ class Claims::Support::ClaimPolicy < Claims::ApplicationPolicy
   end
 
   def destroy?
-    record.draft?
+    record.draft? || (record.submitted? && user.support_user?)
   end
 
   # TODO: Remove record.draft? and not create drafts for existing drafts

--- a/spec/policies/claims/support/claim_policy_spec.rb
+++ b/spec/policies/claims/support/claim_policy_spec.rb
@@ -512,4 +512,24 @@ describe Claims::Support::ClaimPolicy do
       end
     end
   end
+
+  permissions :destroy? do
+    context "when user has a draft claim" do
+      it "grants access" do
+        expect(claim_policy).to permit(user, draft_claim)
+      end
+    end
+
+    context "when user has a submitted claim" do
+      it "grants access" do
+        expect(claim_policy).to permit(support_user, submitted_claim)
+      end
+    end
+
+    context "when user is not support user" do
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, submitted_claim)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

We have received many support requests for us to remove claims via the production console as schools are making mistakes and noticing them.

The standard process is for the claim to be sent to the ESFA and for them to spot the error and then reject the claim at the end of the academic year, however due to the way the training hours are set up and because schools are recognising their mistakes, it makes logical sense for support to be able to remove these claims and reduce work for people further down the line.

## Changes proposed in this pull request

- [x] Allows support users to remove (destroy) claims which have been submitted
- [x] Does not allow claims which have moved past the submitted state to be removed.

## Guidance to review

- Log is as Anne
- Add a claim
- Log in as Colin
- Select Anne's organisation
- Click into the claim
- Remove the claim

## Link to Trello card

[Allow support users to remove submitted claims](https://trello.com/c/U6doOHfD/632-allow-support-users-to-remove-submitted-claims)

## Screenshots

![image](https://github.com/user-attachments/assets/7a189294-0e55-4f8d-ad6e-8f3b533d6015)
