### PR TITLE
Display postcode on provider autocomplete

### DIFF
--- a/app/controllers/api/provider_suggestions_controller.rb
+++ b/app/controllers/api/provider_suggestions_controller.rb
@@ -1,7 +1,7 @@
 class Api::ProviderSuggestionsController < ApplicationController
   def index
     render json: Provider.search_name_urn_ukprn_postcode(query_params)
-                         .select(:id, :name, :code)
+                         .select(:id, :name, :postcode)
                          .limit(50)
   end
 

--- a/app/wizards/claims/add_claim_wizard/provider_step.rb
+++ b/app/wizards/claims/add_claim_wizard/provider_step.rb
@@ -6,6 +6,6 @@ class Claims::AddClaimWizard::ProviderStep < Claims::AddClaimWizard::ProviderSel
   end
 
   def autocomplete_return_attributes_value
-    %w[code]
+    %w[postcode]
   end
 end

--- a/app/wizards/placements/add_organisation_wizard/organisation_step.rb
+++ b/app/wizards/placements/add_organisation_wizard/organisation_step.rb
@@ -13,7 +13,7 @@ class Placements::AddOrganisationWizard::OrganisationStep < Placements::AddOrgan
 
   def autocomplete_return_attributes_value
     if wizard.steps[:organisation_type].provider?
-      %w[code]
+      %w[postcode]
     else
       %w[town postcode]
     end

--- a/app/wizards/placements/add_partnership_wizard/partnership_step.rb
+++ b/app/wizards/placements/add_partnership_wizard/partnership_step.rb
@@ -13,7 +13,7 @@ class Placements::AddPartnershipWizard::PartnershipStep < Placements::AddPartner
 
   def autocomplete_return_attributes_value
     if partner_organisation_model == Provider
-      %w[code]
+      %w[postcode]
     else
       %w[town postcode]
     end

--- a/app/wizards/placements/edit_placement_wizard/provider_step.rb
+++ b/app/wizards/placements/edit_placement_wizard/provider_step.rb
@@ -8,6 +8,6 @@ class Placements::EditPlacementWizard::ProviderStep < Placements::EditPlacementW
   end
 
   def autocomplete_return_attributes_value
-    %w[code]
+    %w[postcode]
   end
 end

--- a/spec/wizards/claims/add_claim_wizard/provider_step_spec.rb
+++ b/spec/wizards/claims/add_claim_wizard/provider_step_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Claims::AddClaimWizard::ProviderStep, type: :model do
   describe "#autocomplete_return_attributes_value" do
     subject { step.autocomplete_return_attributes_value }
 
-    it { is_expected.to contain_exactly("code") }
+    it { is_expected.to contain_exactly("postcode") }
   end
 
   describe "#scope" do

--- a/spec/wizards/placements/add_organisation_wizard/organisation_step_spec.rb
+++ b/spec/wizards/placements/add_organisation_wizard/organisation_step_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Placements::AddOrganisationWizard::OrganisationStep, type: :model
       let(:is_provider) { true }
 
       it "returns the attributes returned by the provider suggestions api" do
-        expect(step.autocomplete_return_attributes_value).to match_array(%w[code])
+        expect(step.autocomplete_return_attributes_value).to match_array(%w[postcode])
       end
     end
   end

--- a/spec/wizards/placements/add_partnership_wizard/partnership_step_spec.rb
+++ b/spec/wizards/placements/add_partnership_wizard/partnership_step_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Placements::AddPartnershipWizard::PartnershipStep, type: :model d
   describe "#autocomplete_return_attributes_value" do
     context "when organisation type is a provider" do
       it "returns the attributes returned by the provider suggestions api" do
-        expect(step.autocomplete_return_attributes_value).to match_array(%w[code])
+        expect(step.autocomplete_return_attributes_value).to match_array(%w[postcode])
       end
     end
 

--- a/spec/wizards/placements/edit_placement_wizard/provider_step_spec.rb
+++ b/spec/wizards/placements/edit_placement_wizard/provider_step_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Placements::EditPlacementWizard::ProviderStep, type: :model do
   describe "#autocomplete_return_attributes_value" do
     subject(:autocomplete_return_attributes_value) { step.autocomplete_return_attributes_value }
 
-    it { is_expected.to contain_exactly("code") }
+    it { is_expected.to contain_exactly("postcode") }
   end
 
   describe "#scope" do


### PR DESCRIPTION
## Context

We currently display a `code` for providers that comes from another service, however this is not widely used or recognised and therefore doesn't work very well as an identifier.

I considered also adding `town` as we do for schools, however this isn't data that we store despite having a field for it.

## Changes proposed in this pull request

- [x] Replaces the code with a postcode

## Guidance to review

- Log in as Anne
- Create a placements
- Assign a provider to a placement
- Search for a provider
- Confirm that the postcode is show next to the provider name

## Link to Trello card

['Organisation name' insufficient when searching for a partner](https://trello.com/c/eSOXNiQj/598-organisation-name-insufficient-when-searching-for-a-partner)

## Screenshots

![image](https://github.com/user-attachments/assets/2eff3368-b186-4bf5-9c8c-8551129a03fa)
