### PR TITLE
Add key stages to edit placement wizard

### DIFF
--- a/app/views/placements/schools/placements/_details.html.erb
+++ b/app/views/placements/schools/placements/_details.html.erb
@@ -24,6 +24,27 @@
       <% end %>
     <% end %>
   <% end %>
+  <% if placement.send_specific %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key(text: t(".attributes.placements.key_stage")) %>
+      <% row.with_value do %>
+        <% if placement.key_stages.present? %>
+          <%= govuk_list do %>
+            <% placement.key_stages.each do |key_stage| %>
+              <li><%= key_stage.name %></li>
+            <% end %>
+          <% end %>
+        <% else %>
+          <%= I18n.t("placements.schools.placements.not_yet_known") %>
+        <% end %>
+      <% end %>
+      <% row.with_action(
+        text: t(".change"),
+        href: edit_attribute_path(:key_stage),
+        visually_hidden_text: t(".attributes.placements.key_stage"),
+      ) %>
+    <% end %>
+  <% end %>
   <% if placement.year_group.present? %>
     <% summary_list.with_row do |row| %>
       <% row.with_key(text: t(".attributes.placements.year_group")) %>

--- a/app/views/wizards/placements/edit_placement_wizard/_key_stage_step.html.erb
+++ b/app/views/wizards/placements/edit_placement_wizard/_key_stage_step.html.erb
@@ -1,0 +1,31 @@
+<% content_for :page_title, title_with_error_prefix(
+  t(".title"),
+  error: current_step.errors.any?,
+) %>
+
+<%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".caption") %></span>
+     <%= f.govuk_check_boxes_fieldset(
+        :key_stages,
+        legend: { size: "l", text: t(".title"), tag: "h1" },
+      ) do %>
+        <% current_step.key_stages_for_selection.each_with_index do |key_stage, i| %>
+          <%= f.govuk_check_box :key_stages, key_stage.id,
+            label: { text: key_stage.name },
+            link_errors: i.zero? %>
+        <% end %>
+        <%= f.govuk_check_box_divider %>
+        <%= f.govuk_check_box :key_stages, current_step.unknown_option.value,
+            label: { text: current_step.unknown_option.name },
+            hint: { text: current_step.unknown_option.description },
+            exclusive: true %>
+      <% end %>
+
+      <%= f.govuk_submit t(".continue") %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/wizards/placements/edit_placement_wizard/_key_stage_step.html.erb
+++ b/app/views/wizards/placements/edit_placement_wizard/_key_stage_step.html.erb
@@ -22,6 +22,7 @@
         <%= f.govuk_check_box :key_stages, current_step.unknown_option.value,
             label: { text: current_step.unknown_option.name },
             hint: { text: current_step.unknown_option.description },
+            checked: @placement.key_stages.blank?,
             exclusive: true %>
       <% end %>
 

--- a/app/wizards/placements/edit_placement_wizard.rb
+++ b/app/wizards/placements/edit_placement_wizard.rb
@@ -15,6 +15,7 @@ module Placements
       add_step(AddPlacementWizard::YearGroupStep) if current_step == :year_group
       add_step(AddPlacementWizard::MentorsStep) if current_step == :mentors
       add_step(AddPlacementWizard::TermsStep) if current_step == :terms
+      add_step(KeyStageStep) if current_step == :key_stage
     end
 
     def update_placement
@@ -37,6 +38,10 @@ module Placements
         placement.terms = steps[:terms].terms
       end
 
+      if steps[:key_stage].present?
+        placement.key_stages = key_stages
+      end
+
       placement.save!
     end
 
@@ -45,6 +50,19 @@ module Placements
       state["year_group"] = { "year_group" => placement.year_group }
       state["mentors"] = { "mentor_ids" => placement.mentors.ids }
       state["terms"] = { "term_ids" => placement.terms.ids }
+      state["key_stage"] = { "key_stages" => placement.key_stages.ids }
+    end
+
+    private
+
+    def value_unknown(value)
+      value.include?(AddHostingInterestWizard::UNKNOWN_OPTION)
+    end
+
+    def key_stages
+      return [] if value_unknown(steps[:key_stage].key_stages)
+
+      KeyStage.where(id: steps[:key_stage].key_stages)
     end
   end
 end

--- a/app/wizards/placements/edit_placement_wizard/key_stage_step.rb
+++ b/app/wizards/placements/edit_placement_wizard/key_stage_step.rb
@@ -1,0 +1,38 @@
+class Placements::EditPlacementWizard::KeyStageStep < BaseStep
+  attribute :key_stages, default: []
+
+  validates :key_stages, presence: true
+
+  def key_stages_for_selection
+    Placements::KeyStage.order_by_name
+  end
+
+  def unknown_option
+    @unknown_option ||=
+      OpenStruct.new(
+        value: Placements::AddHostingInterestWizard::UNKNOWN_OPTION,
+        name: I18n.t(
+          "#{unknown_option_locale_path}.unknown",
+        ),
+        description: I18n.t(
+          "#{unknown_option_locale_path}.unknown_description",
+        ),
+      )
+  end
+
+  def key_stages=(value)
+    super normalised_key_stages(value)
+  end
+
+  private
+
+  def normalised_key_stages(selected_key_stages)
+    return [] if selected_key_stages.blank?
+
+    selected_key_stages.reject(&:blank?)
+  end
+
+  def unknown_option_locale_path
+    ".wizards.placements.multi_placement_wizard.key_stage_step.options"
+  end
+end

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -98,6 +98,10 @@ en:
           attributes:
             provider_id:
               blank: Select a provider
+        placements/edit_placement_wizard/key_stage_step:
+          attributes:
+            key_stages:
+              blank: Select a key stage
         placements/add_support_user_wizard/support_user_step:
           attributes:
             first_name:

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -57,6 +57,7 @@ en:
               provider_options: Provider updated
               year_group: Year group updated
               terms: Expected date updated
+              key_stage: Key stage updated
           edit:
             edit_placement: Placement details
             cancel: Cancel
@@ -137,6 +138,7 @@ en:
               mentor: Mentor
               status: Status
               provider: Provider
+              key_stage: Key stage
         confirm_remove:
           page_title: "Are you sure you want to delete this placement? - %{subject_names}"
           are_you_sure: Are you sure you want to delete this placement?

--- a/config/locales/en/wizards/placements/edit_placement_wizard.yml
+++ b/config/locales/en/wizards/placements/edit_placement_wizard.yml
@@ -13,4 +13,11 @@ en:
         provider_options_step:
           title: "%{organisation_count} results found for ‘%{search_param}’ - %{contextual_text}"
           continue: Continue
+        key_stage_step:
+          title: What SEND key stages can you offer placements in?
+          caption: SEND placement details
+          continue: Continue
+          options:
+            unknown: I don’t know
+            unknown_description: You can discuss key stages with providers later
 

--- a/spec/system/placements/schools/placements/school_user_edits_a_send_placement_key_stage_to_unknown_spec.rb
+++ b/spec/system/placements/schools/placements/school_user_edits_a_send_placement_key_stage_to_unknown_spec.rb
@@ -1,0 +1,156 @@
+require "rails_helper"
+
+RSpec.describe "School user edits a send placement key stages", service: :placements, type: :system do
+  scenario do
+    given_key_stages_exist
+    and_that_placements_exist
+    and_i_am_signed_in
+
+    when_i_am_on_the_placements_index_page
+    then_i_see_my_placement
+
+    when_i_click_on_my_placement
+    then_i_see_the_placement_details_page
+
+    when_i_click_on_change_key_stage
+    then_i_see_the_key_stage_form
+
+    when_i_select_i_dont_know
+    and_i_click_on_continue
+    then_i_see_the_placement_details_page_with_my_updated_key_stage
+    and_i_see_a_key_stage_updated_success_message
+  end
+
+  private
+
+  def and_that_placements_exist
+    @springfield_elementary_school = build(
+      :placements_school,
+      name: "Springfield Elementary",
+      address1: "Westgate Street",
+      address2: "Hackney",
+      postcode: "E8 3RL",
+      group: "Local authority maintained schools",
+      phase: "Primary",
+      gender: "Mixed",
+      minimum_age: 3,
+      maximum_age: 11,
+      religious_character: "Does not apply",
+      admissions_policy: "Not applicable",
+      urban_or_rural: "(England/Wales) Urban major conurbation",
+      percentage_free_school_meals: 15,
+      rating: "Outstanding",
+    )
+
+    @autumn_term = build(:placements_term, name: "Autumn term")
+
+    @next_academic_year = Placements::AcademicYear.current.next
+    @next_academic_year_name = @next_academic_year.name
+
+    @placement = create(
+      :placement,
+      :send,
+      school: @springfield_elementary_school,
+      subject: @primary_english_subject,
+      year_group: :year_1,
+      academic_year: @next_academic_year,
+      terms: [@autumn_term],
+      key_stages: [@key_stage_2, @key_stage_5],
+    )
+  end
+
+  def given_key_stages_exist
+    @early_years = create(:key_stage, name: "Early years")
+    @key_stage_1 = create(:key_stage, name: "Key stage 1")
+    @key_stage_2 = create(:key_stage, name: "Key stage 2")
+    @key_stage_3 = create(:key_stage, name: "Key stage 3")
+    @key_stage_4 = create(:key_stage, name: "Key stage 4")
+    @key_stage_5 = create(:key_stage, name: "Key stage 5")
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@springfield_elementary_school])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Placements")
+    expect(page).to have_element(:a, text: "Add placement", class: "govuk-button")
+  end
+
+  alias_method :then_i_see_the_placements_index_page, :when_i_am_on_the_placements_index_page
+
+  def then_i_see_my_placement
+    expect(page).to have_element(:td, text: "SEND (Key stage 2, Key stage 5)", class: "govuk-table__cell")
+    expect(page).to have_element(:td, text: "Mentor not assigned", class: "govuk-table__cell")
+    expect(page).to have_element(:td, text: "Autumn term", class: "govuk-table__cell")
+    expect(page).to have_element(:td, text: "Provider not assigned", class: "govuk-table__cell")
+  end
+
+  def when_i_click_on_my_placement
+    click_on "SEND"
+  end
+
+  def then_i_see_the_placement_details_page
+    expect(page).to have_title("SEND (Key stage 2, Key stage 5) - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_summary_list_row("Key stage", "Key stage 2 Key stage 5")
+    expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
+    expect(page).to have_summary_list_row("Expected date", "Autumn term")
+    expect(page).to have_summary_list_row("Mentor", "Add a mentor")
+    expect(page).to have_summary_list_row("Provider", "Assign a provider")
+    expect(page).to have_element(:div, text: "You can preview this placement as it appears to providers.", class: "govuk-inset-text")
+    expect(page).to have_link("Delete placement", href: "/schools/#{@springfield_elementary_school.id}/placements/#{@placement.id}/remove")
+  end
+
+  def when_i_click_on_change_key_stage
+    click_on "Change Key stage"
+  end
+
+  def then_i_see_the_key_stage_form
+    expect(page).to have_title(
+      "What SEND key stages can you offer placements in? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "What SEND key stages can you offer placements in?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_element(:span, text: "SEND placement details", class: "govuk-caption-l")
+    expect(page).to have_field("Early year", type: :checkbox)
+    expect(page).to have_field("Key stage 1", type: :checkbox)
+    expect(page).to have_field("Key stage 2", type: :checkbox)
+    expect(page).to have_field("Key stage 3", type: :checkbox)
+    expect(page).to have_field("Key stage 4", type: :checkbox)
+    expect(page).to have_field("Key stage 5", type: :checkbox)
+    expect(page).to have_field("I don’t know", type: :checkbox)
+  end
+
+  def when_i_select_i_dont_know
+    check "I don’t know"
+  end
+
+  def and_i_see_a_key_stage_updated_success_message
+    expect(page).to have_success_banner("Key stage updated")
+  end
+
+  def then_i_see_the_placement_details_page_with_my_updated_key_stage
+    expect(page).to have_title("SEND - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_summary_list_row("Key stage", "Not yet known")
+    expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
+    expect(page).to have_summary_list_row("Expected date", "Autumn term")
+    expect(page).to have_summary_list_row("Mentor", "Add a mentor")
+    expect(page).to have_summary_list_row("Provider", "Assign a provider")
+    expect(page).to have_element(:div, text: "You can preview this placement as it appears to providers.", class: "govuk-inset-text")
+    expect(page).to have_link("Delete placement", href: "/schools/#{@springfield_elementary_school.id}/placements/#{@placement.id}/remove")
+  end
+
+  def and_i_click_on_continue
+    click_on "Continue"
+  end
+end

--- a/spec/system/placements/schools/placements/school_user_edits_a_send_placement_key_stages_spec.rb
+++ b/spec/system/placements/schools/placements/school_user_edits_a_send_placement_key_stages_spec.rb
@@ -1,0 +1,160 @@
+require "rails_helper"
+
+RSpec.describe "School user edits a send placement key stages", service: :placements, type: :system do
+  scenario do
+    given_that_placements_exist
+    and_key_stages_exist
+    and_i_am_signed_in
+
+    when_i_am_on_the_placements_index_page
+    then_i_see_my_placement
+
+    when_i_click_on_my_placement
+    then_i_see_the_placement_details_page
+
+    when_i_click_on_change_key_stage
+    then_i_see_the_key_stage_form
+
+    when_i_select_key_stage_2
+    and_i_select_key_stage_5
+    and_i_click_on_continue
+    then_i_see_the_placement_details_page_with_my_updated_key_stage
+    and_i_see_a_key_stage_updated_success_message
+  end
+
+  private
+
+  def given_that_placements_exist
+    @springfield_elementary_school = build(
+      :placements_school,
+      name: "Springfield Elementary",
+      address1: "Westgate Street",
+      address2: "Hackney",
+      postcode: "E8 3RL",
+      group: "Local authority maintained schools",
+      phase: "Primary",
+      gender: "Mixed",
+      minimum_age: 3,
+      maximum_age: 11,
+      religious_character: "Does not apply",
+      admissions_policy: "Not applicable",
+      urban_or_rural: "(England/Wales) Urban major conurbation",
+      percentage_free_school_meals: 15,
+      rating: "Outstanding",
+    )
+
+    @autumn_term = build(:placements_term, name: "Autumn term")
+
+    @next_academic_year = Placements::AcademicYear.current.next
+    @next_academic_year_name = @next_academic_year.name
+
+    @placement = create(
+      :placement,
+      :send,
+      school: @springfield_elementary_school,
+      subject: @primary_english_subject,
+      year_group: :year_1,
+      academic_year: @next_academic_year,
+      terms: [@autumn_term],
+    )
+  end
+
+  def and_key_stages_exist
+    @early_years = create(:key_stage, name: "Early years")
+    @key_stage_1 = create(:key_stage, name: "Key stage 1")
+    @key_stage_2 = create(:key_stage, name: "Key stage 2")
+    @key_stage_3 = create(:key_stage, name: "Key stage 3")
+    @key_stage_4 = create(:key_stage, name: "Key stage 4")
+    @key_stage_5 = create(:key_stage, name: "Key stage 5")
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@springfield_elementary_school])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Placements")
+    expect(page).to have_element(:a, text: "Add placement", class: "govuk-button")
+  end
+
+  alias_method :then_i_see_the_placements_index_page, :when_i_am_on_the_placements_index_page
+
+  def then_i_see_my_placement
+    expect(page).to have_element(:td, text: "SEND", class: "govuk-table__cell")
+    expect(page).to have_element(:td, text: "Mentor not assigned", class: "govuk-table__cell")
+    expect(page).to have_element(:td, text: "Autumn term", class: "govuk-table__cell")
+    expect(page).to have_element(:td, text: "Provider not assigned", class: "govuk-table__cell")
+  end
+
+  def when_i_click_on_my_placement
+    click_on "SEND"
+  end
+
+  def then_i_see_the_placement_details_page
+    expect(page).to have_title("SEND - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_summary_list_row("Key stage", "Not yet known")
+    expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
+    expect(page).to have_summary_list_row("Expected date", "Autumn term")
+    expect(page).to have_summary_list_row("Mentor", "Add a mentor")
+    expect(page).to have_summary_list_row("Provider", "Assign a provider")
+    expect(page).to have_element(:div, text: "You can preview this placement as it appears to providers.", class: "govuk-inset-text")
+    expect(page).to have_link("Delete placement", href: "/schools/#{@springfield_elementary_school.id}/placements/#{@placement.id}/remove")
+  end
+
+  def when_i_click_on_change_key_stage
+    click_on "Change Key stage"
+  end
+
+  def then_i_see_the_key_stage_form
+    expect(page).to have_title(
+      "What SEND key stages can you offer placements in? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "What SEND key stages can you offer placements in?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_element(:span, text: "SEND placement details", class: "govuk-caption-l")
+    expect(page).to have_field("Early year", type: :checkbox)
+    expect(page).to have_field("Key stage 1", type: :checkbox)
+    expect(page).to have_field("Key stage 2", type: :checkbox)
+    expect(page).to have_field("Key stage 3", type: :checkbox)
+    expect(page).to have_field("Key stage 4", type: :checkbox)
+    expect(page).to have_field("Key stage 5", type: :checkbox)
+    expect(page).to have_field("I don’t know", type: :checkbox)
+  end
+
+  def when_i_select_key_stage_2
+    check "Key stage 2"
+  end
+
+  def and_i_select_key_stage_5
+    check "Key stage 5"
+  end
+
+  def and_i_see_a_key_stage_updated_success_message
+    expect(page).to have_success_banner("Key stage updated")
+  end
+
+  def then_i_see_the_placement_details_page_with_my_updated_key_stage
+    expect(page).to have_title("SEND (Key stage 2, Key stage 5) - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_summary_list_row("Key stage", "Key stage 2 Key stage 5")
+    expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
+    expect(page).to have_summary_list_row("Expected date", "Autumn term")
+    expect(page).to have_summary_list_row("Mentor", "Add a mentor")
+    expect(page).to have_summary_list_row("Provider", "Assign a provider")
+    expect(page).to have_element(:div, text: "You can preview this placement as it appears to providers.", class: "govuk-inset-text")
+    expect(page).to have_link("Delete placement", href: "/schools/#{@springfield_elementary_school.id}/placements/#{@placement.id}/remove")
+  end
+
+  def and_i_click_on_continue
+    click_on "Continue"
+  end
+end

--- a/spec/wizards/placements/edit_placement_wizard/key_stage_step_spec.rb
+++ b/spec/wizards/placements/edit_placement_wizard/key_stage_step_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+RSpec.describe Placements::EditPlacementWizard::KeyStageStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Placements::EditPlacementWizard).tap do |mock_wizard|
+      allow(mock_wizard).to receive(:school).and_return(school)
+    end
+  end
+
+  let(:attributes) { nil }
+  let!(:school) { create(:placements_school) }
+
+  describe "attributes" do
+    it { is_expected.to have_attributes(key_stages: []) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:key_stages) }
+  end
+
+  describe "#key_stages_for_selection" do
+    subject(:key_stages_for_selection) { step.key_stages_for_selection }
+
+    let!(:early_years) { create(:key_stage, name: "Early years") }
+    let!(:key_stage_1) { create(:key_stage, name: "Key stage 1") }
+    let!(:key_stage_2) { create(:key_stage, name: "Key stage 2") }
+    let!(:key_stage_3) { create(:key_stage, name: "Key stage 3") }
+    let!(:key_stage_4) { create(:key_stage, name: "Key stage 4") }
+    let!(:key_stage_5) { create(:key_stage, name: "Key stage 5") }
+
+    it "returns the list of key stages ordered by name" do
+      expect(key_stages_for_selection).to eq(
+        [
+          early_years,
+          key_stage_1,
+          key_stage_2,
+          key_stage_3,
+          key_stage_4,
+          key_stage_5,
+        ],
+      )
+    end
+  end
+
+  describe "#key_stages" do
+    subject(:key_stages) { step.key_stages }
+
+    let(:early_years) { create(:key_stage, name: "Early years") }
+    let(:key_stage_1) { create(:key_stage, name: "Key stage 1") }
+    let!(:key_stage_2) { create(:key_stage, name: "Key stage 2") }
+    let(:key_stage_3) { create(:key_stage, name: "Key stage 3") }
+    let(:key_stage_4) { create(:key_stage, name: "Key stage 4") }
+    let!(:key_stage_5) { create(:key_stage, name: "Key stage 5") }
+
+    before do
+      early_years
+      key_stage_1
+      key_stage_3
+      key_stage_4
+    end
+
+    context "when key_stages is blank" do
+      it "returns an empty array" do
+        expect(key_stages).to eq([])
+      end
+    end
+
+    context "when the key_stages attribute contains a blank element" do
+      let(:attributes) { { key_stages: [key_stage_2.id, nil] } }
+
+      it "removes the nil element from the key_stages attribute" do
+        expect(key_stages).to contain_exactly(key_stage_2.id)
+      end
+    end
+
+    context "when the key_stages attribute contains no blank elements" do
+      let(:attributes) { { key_stages: [key_stage_2.id, key_stage_5.id] } }
+
+      it "returns the phases attribute unchanged" do
+        expect(key_stages).to contain_exactly(
+          key_stage_2.id, key_stage_5.id
+        )
+      end
+    end
+  end
+end

--- a/spec/wizards/placements/edit_placement_wizard_spec.rb
+++ b/spec/wizards/placements/edit_placement_wizard_spec.rb
@@ -52,6 +52,12 @@ RSpec.describe Placements::EditPlacementWizard do
 
       it { is_expected.to eq %i[terms] }
     end
+
+    context "with the key_stage step" do
+      let(:current_step) { :key_stage }
+
+      it { is_expected.to eq %i[key_stage] }
+    end
   end
 
   describe "#update_placement" do
@@ -156,6 +162,22 @@ RSpec.describe Placements::EditPlacementWizard do
 
         it "updates the placement" do
           expect(placement.terms).to contain_exactly(selected_term)
+        end
+      end
+
+      context "when the step is key_stages" do
+        let(:current_step) { :key_stage }
+        let(:key_stage_2) { create(:key_stage, name: "Key stage 2") }
+        let(:key_stage_5) { create(:key_stage, name: "Key stage 5") }
+
+        let(:state) do
+          {
+            "key_stage" => { "key_stages" => [key_stage_2, key_stage_5] },
+          }
+        end
+
+        it "updates the placement" do
+          expect(placement.key_stages).to contain_exactly(key_stage_2, key_stage_5)
         end
       end
     end


### PR DESCRIPTION
## Context

- Add `key_stage` to the EditPlacementWizard

## Changes proposed in this pull request

- Add `key_stage` step to the EditPlacementWizard

## Guidance to review

- Sign in as Anne (School user)
⚠️ You will need a SEND placement for this test ⚠️ 
- Click on the SEND placement
- Click "Change" to change the key stages
- Select new key stages
- Click "Continue"
- Your placement key stages have been changed.

## Link to Trello card

https://trello.com/c/UYS8SApw/635-add-the-ability-to-edit-key-stages-on-a-placement

## Screenshots

https://github.com/user-attachments/assets/c639f08b-447e-48d1-bb45-a9363fca6c60


