### PR TITLE
Persist filter params

### DIFF
--- a/app/controllers/placements/providers/find_controller.rb
+++ b/app/controllers/placements/providers/find_controller.rb
@@ -2,6 +2,7 @@ class Placements::Providers::FindController < Placements::ApplicationController
   before_action :set_provider
   before_action :selected_academic_year
   before_action :load_placements_and_subjects, only: %i[placements placement_information school_details]
+  before_action :store_filter_params, only: %i[index]
   helper_method :filter_form, :location_coordinates
 
   def index
@@ -119,5 +120,9 @@ class Placements::Providers::FindController < Placements::ApplicationController
 
   def selected_academic_year
     @selected_academic_year ||= current_user.selected_academic_year
+  end
+
+  def store_filter_params
+    session["find_filter_params"] = { filters: filter_params }
   end
 end

--- a/app/views/placements/providers/find/_details_navigation.html.erb
+++ b/app/views/placements/providers/find/_details_navigation.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (school:, academic_year:, provider:, unfilled_subjects:, filled_subjects: -%>
 <%= content_for(:before_content) do %>
-  <%= govuk_back_link(href: placements_provider_find_index_path(provider)) %>
+  <%= govuk_back_link(href: placements_provider_find_index_path(provider, session["find_filter_params"])) %>
 <% end %>
 
 <h1 class="govuk-heading-l">


### PR DESCRIPTION
## Context

- When clicking the `Back` link (as a provider on the placement show page), the filters persist when going back.

## Changes proposed in this pull request

- Store filter params in a session.
- Use the session to assign the filters to the back link.

## Guidance to review

- Sign in as Patricia (Provider user)
- Navigate to the "Find" page
- Select and apply some filters
- Click on one of the school links to view placement information
- Click the "Back" link at the top of the page to return to the "Find" page
- The filters previously selected should have persisted.

## Link to Trello card

https://trello.com/c/WcR9ZA4K/601-filter-preferences-are-not-consistent-when-moving-between-school-results-pages

## Screenshots

https://github.com/user-attachments/assets/3ad90170-cd41-41a6-ad49-cb8fe783955a

