### PR TITLE
Add daily Slack roundup schedule

### DIFF
--- a/config/scheduled_jobs.yml
+++ b/config/scheduled_jobs.yml
@@ -45,4 +45,9 @@ send_entity_table_checks_to_bigquery:
 trim_expired_sessions:
   cron: "15 * * * *" # Every hour at quarter past
   class: "TrimExpiredSessionsJob"
-  description: Trim old sessions from the database
+  description: "Trim old sessions from the database"
+
+send_claims_slack_daily_roundup:
+    cron: "0 16 * * *" # Every day at 16:00
+    class: "Claims::Slack::DailyRoundupJob"
+    description: "Sends a daily roundup Slack message"


### PR DESCRIPTION
## Context

We need to schedule this job to run every day.

## Changes proposed in this pull request

- Adds the `Claims::Slack::DailyRoundupJob` to the schedule at 16:00 each day

## Guidance to review

- Review the yaml and make sure it matches with the above ☝️ 

## Link to Trello card

[Add daily claims roundup schedule](https://trello.com/c/6ymaqyZ7/643-add-daily-claims-roundup-schedule)
