### PR TITLE
Refactor provider subject filters

### DIFF
--- a/app/controllers/placements/providers/find_controller.rb
+++ b/app/controllers/placements/providers/find_controller.rb
@@ -100,14 +100,9 @@ class Placements::Providers::FindController < Placements::ApplicationController
   end
 
   def filter_subjects_by_phase
-    scope = if filter_form.primary_only?
-              Subject.primary
-            elsif filter_form.secondary_only?
-              Subject.secondary
-            else
-              Subject
-            end
-    scope.order_by_name.select(:id, :name)
+    return Subject.none if filter_form.primary_only?
+
+    Subject.secondary.order_by_name.select(:id, :name)
   end
 
   def placements_last_offered

--- a/app/views/placements/providers/find/_filter.html.erb
+++ b/app/views/placements/providers/find/_filter.html.erb
@@ -150,7 +150,7 @@
           <% end %>
 
           <% if filter_form.subject_ids.present? %>
-            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".subject") %></h3>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".secondary_subject") %></h3>
             <ul class="app-filter-tags">
               <% filter_form.subjects.each do |subject| %>
                 <li>
@@ -268,7 +268,7 @@
             <%= form.govuk_check_boxes_fieldset(
               :subject_ids,
               legend: {
-                text: t(".subject"),
+                text: t(".secondary_subject"),
                 size: "s",
               },
               small: true,

--- a/config/locales/en/placements/providers/find.yml
+++ b/config/locales/en/placements/providers/find.yml
@@ -28,7 +28,7 @@ en:
           school: School
           search_location: Location
           search_by_location: Search by location
-          subject: Subject
+          secondary_subject: Secondary subject
           schools_i_work_with: Schools I work with
           no_schools_i_work_with_html: Record schools you work with on the %{link} so that they display here.
           schools_page: schools page

--- a/spec/system/placements/providers/find/provider_user_filters_schools_by_phase_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_filters_schools_by_phase_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Provider user filters schools by phase", service: :placements, t
     @primary_school = build(:placements_school, phase: "Primary", name: "Springfield Elementary")
     @secondary_school = build(:placements_school, phase: "Secondary", name: "Shelbyville High School")
 
-    @primary_subject = build(:subject, name: "Primary with mathematics", subject_area: "primary")
+    @primary_subject = build(:subject, name: "Primary", subject_area: "primary")
     @springfield_primary_placement = create(:placement, school: @primary_school, subject: @primary_subject)
 
     @secondary_subject = build(:subject, name: "Music", subject_area: "secondary")
@@ -99,7 +99,6 @@ RSpec.describe "Provider user filters schools by phase", service: :placements, t
 
   def and_i_see_only_secondary_subjects_listed_in_the_subjects_filter
     expect(page).to have_unchecked_field("Music")
-    expect(page).not_to have_unchecked_field("Primary with mathematics")
   end
 
   def and_i_see_that_the_secondary_phase_checkbox_is_selected
@@ -115,7 +114,6 @@ RSpec.describe "Provider user filters schools by phase", service: :placements, t
   end
 
   def and_i_see_all_subjects_listed_in_the_subjects_filter
-    expect(page).to have_unchecked_field("Primary with mathematics")
     expect(page).to have_unchecked_field("Music")
   end
 

--- a/spec/system/placements/providers/find/provider_user_filters_schools_by_subject_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_filters_schools_by_subject_spec.rb
@@ -10,18 +10,18 @@ RSpec.describe "Provider user filters schools by subject", service: :placements,
     and_i_see_all_schools
     and_i_see_the_subject_filter
 
-    when_i_select_primary_with_maths_from_the_subject_filter
+    when_i_select_maths_from_the_subject_filter
     and_i_click_on_apply_filters
-    then_i_see_the_primary_school_with_the_maths_placement
-    and_i_do_not_see_the_primary_school_with_the_english_placement
+    then_i_see_the_secondary_school_with_the_maths_placement
+    and_i_do_not_see_the_secondary_school_with_the_english_placement
     and_i_see_my_selected_subject_filter
 
-    when_i_select_primary_with_english_from_the_subject_filter
+    when_i_select_english_from_the_subject_filter
     and_i_click_on_apply_filters
     then_i_see_all_schools
     and_i_see_my_selected_subject_filters
 
-    when_i_click_on_the_primary_with_maths_subject_filter_tag
+    when_i_click_on_the_maths_subject_filter_tag
     then_i_see_the_primary_school_with_the_english_placement
     and_i_do_not_see_the_primary_school_with_the_maths_placement
     and_i_do_not_see_the_primary_with_maths_subject_filter
@@ -36,13 +36,13 @@ RSpec.describe "Provider user filters schools by subject", service: :placements,
   def given_that_schools_exist
     @provider = build(:placements_provider, name: "Aes Sedai Trust")
 
-    @primary_school_with_maths = build(:placements_school, phase: "Primary", name: "Springfield Elementary")
-    @primary_maths_subject = build(:subject, name: "Primary with mathematics", subject_area: "primary")
-    _primary_maths_placement = create(:placement, school: @primary_school_with_maths, subject: @primary_maths_subject)
+    @school_with_maths = build(:placements_school, phase: "Secondary", name: "Springfield Elementary")
+    @maths_subject = build(:subject, name: "Mathematics", subject_area: "secondary")
+    _maths_placement = create(:placement, school: @school_with_maths, subject: @maths_subject)
 
-    @primary_school_with_english = build(:placements_school, phase: "Primary", name: "Hogwarts Elementary")
-    @primary_english_subject = build(:subject, name: "Primary with english", subject_area: "primary")
-    _primary_english_placement = create(:placement, school: @primary_school_with_english, subject: @primary_english_subject)
+    @school_with_english = build(:placements_school, phase: "Secondary", name: "Hogwarts Elementary")
+    @english_subject = build(:subject, name: "English", subject_area: "secondary")
+    _english_placement = create(:placement, school: @school_with_english, subject: @english_subject)
   end
 
   def and_i_am_signed_in
@@ -69,48 +69,48 @@ RSpec.describe "Provider user filters schools by subject", service: :placements,
   alias_method :then_i_see_all_schools, :and_i_see_all_schools
 
   def and_i_see_the_subject_filter
-    expect(page).to have_element(:legend, text: "Subject", class: "govuk-fieldset__legend")
-    expect(page).to have_field("Primary with mathematics", type: :checkbox, checked: false)
-    expect(page).to have_field("Primary with english", type: :checkbox, unchecked: true)
+    expect(page).to have_element(:legend, text: "Secondary subject", class: "govuk-fieldset__legend")
+    expect(page).to have_field("Mathematics", type: :checkbox, checked: false)
+    expect(page).to have_field("English", type: :checkbox, unchecked: true)
   end
 
-  def when_i_select_primary_with_maths_from_the_subject_filter
-    check "Primary with mathematics"
+  def when_i_select_maths_from_the_subject_filter
+    check "Mathematics"
   end
 
   def and_i_click_on_apply_filters
     click_on "Apply filters"
   end
 
-  def then_i_see_the_primary_school_with_the_maths_placement
+  def then_i_see_the_secondary_school_with_the_maths_placement
     expect(page).to have_h2("Springfield Elementary")
   end
 
-  def and_i_do_not_see_the_primary_school_with_the_english_placement
+  def and_i_do_not_see_the_secondary_school_with_the_english_placement
     expect(page).not_to have_h2("Hogwarts Elementary")
   end
 
   def and_i_see_my_selected_subject_filter
-    expect(page).to have_filter_tag("Primary with mathematics")
-    expect(page).to have_checked_field("Primary with mathematics")
-    expect(page).not_to have_filter_tag("Primary with english")
-    expect(page).not_to have_checked_field("Primary with english")
+    expect(page).to have_filter_tag("Mathematics")
+    expect(page).to have_checked_field("Mathematics")
+    expect(page).not_to have_filter_tag("English")
+    expect(page).not_to have_checked_field("English")
   end
 
-  def when_i_select_primary_with_english_from_the_subject_filter
-    check "Primary with english"
+  def when_i_select_english_from_the_subject_filter
+    check "English"
   end
 
   def and_i_see_my_selected_subject_filters
-    expect(page).to have_filter_tag("Primary with mathematics")
-    expect(page).to have_checked_field("Primary with mathematics")
-    expect(page).to have_filter_tag("Primary with english")
-    expect(page).to have_checked_field("Primary with english")
+    expect(page).to have_filter_tag("Mathematics")
+    expect(page).to have_checked_field("Mathematics")
+    expect(page).to have_filter_tag("English")
+    expect(page).to have_checked_field("English")
   end
 
-  def when_i_click_on_the_primary_with_maths_subject_filter_tag
+  def when_i_click_on_the_maths_subject_filter_tag
     within ".app-filter-tags" do
-      click_on "Primary with mathematics"
+      click_on "Mathematics"
     end
   end
 
@@ -123,22 +123,22 @@ RSpec.describe "Provider user filters schools by subject", service: :placements,
   end
 
   def and_i_do_not_see_the_primary_with_maths_subject_filter
-    expect(page).not_to have_filter_tag("Primary with mathematics")
-    expect(page).not_to have_checked_field("Primary with mathematics")
-    expect(page).to have_filter_tag("Primary with english")
-    expect(page).to have_checked_field("Primary with english")
+    expect(page).not_to have_filter_tag("Mathematics")
+    expect(page).not_to have_checked_field("Mathematics")
+    expect(page).to have_filter_tag("English")
+    expect(page).to have_checked_field("English")
   end
 
   def when_i_click_on_the_primary_with_english_subject_filter_tag
     within ".app-filter-tags" do
-      click_on "Primary with english"
+      click_on "English"
     end
   end
 
   def and_i_do_not_see_any_selected_subject_filters
-    expect(page).not_to have_filter_tag("Primary with mathematics")
-    expect(page).not_to have_checked_field("Primary with mathematics")
-    expect(page).not_to have_filter_tag("Primary with english")
-    expect(page).not_to have_checked_field("Primary with english")
+    expect(page).not_to have_filter_tag("Mathematics")
+    expect(page).not_to have_checked_field("Mathematics")
+    expect(page).not_to have_filter_tag("English")
+    expect(page).not_to have_checked_field("English")
   end
 end


### PR DESCRIPTION
## Context

- Refactor subject filters on the Provider "Find" page to show only secondary subjects

## Changes proposed in this pull request

- Remove primary subjects from the subjects list
- Rename the subjects filter to "Secondary subjects"

## Guidance to review

- Sign in as Patricia (Provider user)
- View the Subject filter on the "Find" page
- The filter should now be titled "Secondary subject" and only show Secondary subjects

## Link to Trello card

https://trello.com/c/OSfu9nNA/640-refactor-provider-subjects-filter

## Screenshots

<img width="1386" alt="Screenshot 2025-05-21 at 13 12 17" src="https://github.com/user-attachments/assets/4838c4ec-bc9d-4537-bf11-aea96e901556" />

