### PR TITLE
Fix flakey internal drafts spec by increasing time without update

### DIFF
--- a/spec/services/claims/claim/remove_internal_drafts_spec.rb
+++ b/spec/services/claims/claim/remove_internal_drafts_spec.rb
@@ -11,7 +11,7 @@ describe Claims::Claim::RemoveInternalDrafts do
 
   describe "#call" do
     it "removes internal draft claims that haven't changed in at least 24 hours" do
-      create(:claim, status: :internal_draft, updated_at: 1.day.ago)
+      create(:claim, status: :internal_draft, updated_at: 25.hours.ago)
 
       expect { service }.to change(Claims::Claim, :count).from(4).to(3)
       expect(Claims::Claim.all).to eq(


### PR DESCRIPTION
## Context

Internal drafts spec was flaking on PR creation. I believe this is down to 1.day.ago being too close to the 24.hours ago check to remove internal drafts. Adding an extra hour buffer should ensure it no longer sporadically fails.
