### PR TITLE
Add primary year group filter

### DIFF
--- a/app/controllers/placements/providers/find_controller.rb
+++ b/app/controllers/placements/providers/find_controller.rb
@@ -81,6 +81,7 @@ class Placements::Providers::FindController < Placements::ApplicationController
       schools_i_work_with_ids: [],
       subject_ids: [],
       phases: [],
+      year_groups: [],
       itt_statuses: [],
       last_offered_placements_academic_year_ids: [],
       trained_mentors: [],

--- a/app/forms/placements/schools/filter_form.rb
+++ b/app/forms/placements/schools/filter_form.rb
@@ -6,6 +6,7 @@ class Placements::Schools::FilterForm < ApplicationForm
   attribute :search_location, default: nil
   attribute :search_by_name, default: nil
   attribute :phases, default: []
+  attribute :year_groups, default: []
   attribute :itt_statuses, default: []
   attribute :last_offered_placements_academic_year_ids, default: []
 
@@ -49,6 +50,7 @@ class Placements::Schools::FilterForm < ApplicationForm
       search_location:,
       search_by_name:,
       phases:,
+      year_groups:,
       itt_statuses:,
       last_offered_placements_academic_year_ids:,
     }
@@ -56,6 +58,12 @@ class Placements::Schools::FilterForm < ApplicationForm
 
   def subjects
     @subjects ||= Subject.where(id: subject_ids).order_by_name
+  end
+
+  def year_group_options
+    @year_group_options || Placement.year_groups_as_options.select do |year_group|
+      year_groups.include?(year_group.value)
+    end
   end
 
   def schools_i_work_with

--- a/app/queries/placements/schools_query.rb
+++ b/app/queries/placements/schools_query.rb
@@ -14,6 +14,7 @@ class Placements::SchoolsQuery < ApplicationQuery
     scope = subject_condition(scope)
     scope = phase_condition(scope)
     scope = last_offered_placements_condition(scope)
+    scope = year_group_condition(scope)
     scope = itt_statuses_condition(scope)
     order_condition(scope)
   end
@@ -44,6 +45,12 @@ class Placements::SchoolsQuery < ApplicationQuery
            scope.left_outer_joins(placements: :additional_subjects)
                 .where(additional_subjects: { id: filter_params[:subject_ids] }),
          )
+  end
+
+  def year_group_condition(scope)
+    return scope if filter_params[:year_groups].blank?
+
+    scope.where(placements: { year_group: filter_params[:year_groups] })
   end
 
   def itt_statuses_condition(scope)

--- a/app/views/placements/providers/find/_filter.html.erb
+++ b/app/views/placements/providers/find/_filter.html.erb
@@ -149,7 +149,7 @@
             </ul>
           <% end %>
 
-          <% if filter_form.year_group_options.present?%>
+          <% if filter_form.year_group_options.present? %>
             <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".primary_year_group") %></h3>
             <ul class="app-filter-tags">
               <% filter_form.year_group_options.each do |year_group| %>

--- a/app/views/placements/providers/find/_filter.html.erb
+++ b/app/views/placements/providers/find/_filter.html.erb
@@ -149,6 +149,25 @@
             </ul>
           <% end %>
 
+          <% if filter_form.year_group_options.present?%>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".primary_year_group") %></h3>
+            <ul class="app-filter-tags">
+              <% filter_form.year_group_options.each do |year_group| %>
+                <li>
+                  <%= govuk_link_to(
+                        year_group.name,
+                        filter_form.index_path_without_filter(
+                          filter: "year_groups",
+                          value: year_group.value,
+                        ),
+                        class: "app-filter__tag",
+                        no_visited_state: true,
+                      ) %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+
           <% if filter_form.subject_ids.present? %>
             <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".subject") %></h3>
             <ul class="app-filter-tags">
@@ -260,6 +279,19 @@
             ) do %>
               <% filter_form.last_offered_placement_options.each do |name, value| %>
                 <%= form.govuk_check_box :last_offered_placements_academic_year_ids, value, label: { text: name } %>
+              <% end %>
+            <% end %>
+          </div>
+
+          <div class="app-filter__option">
+            <%= form.govuk_check_boxes_fieldset(
+              :itt_statuses,
+              legend: { text: t(".primary_year_group"), size: "s" },
+              small: true,
+              multiple: true,
+            ) do %>
+              <% Placement.year_groups_as_options.each do |year_group| %>
+                <%= form.govuk_check_box :year_groups, year_group.value, label: { text: year_group.name } %>
               <% end %>
             <% end %>
           </div>

--- a/config/locales/en/placements/providers/find.yml
+++ b/config/locales/en/placements/providers/find.yml
@@ -53,6 +53,7 @@ en:
           trained_mentors: Trained mentors
           trained_mentors_true_label: "Yes"
           trained_mentors_false_label: "No"
+          primary_year_group: Primary year group
         placements:
           page_title: "%{school_name} - Find"
           placements: Placements

--- a/spec/forms/placements/schools/filter_form_spec.rb
+++ b/spec/forms/placements/schools/filter_form_spec.rb
@@ -259,6 +259,7 @@ describe Placements::Schools::FilterForm, type: :model do
           search_location: nil,
           search_by_name: nil,
           phases: [],
+          year_groups: [],
           itt_statuses: [],
           last_offered_placements_academic_year_ids: [],
         },

--- a/spec/queries/placements/schools_query_spec.rb
+++ b/spec/queries/placements/schools_query_spec.rb
@@ -26,7 +26,8 @@ describe Placements::SchoolsQuery do
     create(:placements_school, name: "York Secondary School", latitude: 29.732613, longitude: 105.448063)
   end
   let(:academic_year) { Placements::AcademicYear.current }
-  let(:placement) { create(:placement, school: query_school, academic_year:) }
+  let(:placement) { create(:placement, school: query_school, academic_year:, year_group:) }
+  let(:year_group) { nil }
 
   before do
     query_school
@@ -87,6 +88,18 @@ describe Placements::SchoolsQuery do
 
     context "when filtering by phase" do
       let(:params) { { filters: { phases: [query_school.phase] } } }
+
+      it "returns the filtered schools" do
+        expect(query.call).to include(query_school)
+        expect(query.call).not_to include(non_query_school)
+      end
+    end
+
+    context "when filtering by year group" do
+      before { placement }
+
+      let(:year_group) { "year_1" }
+      let(:params) { { filters: { year_groups: %w[year_1] } } }
 
       it "returns the filtered schools" do
         expect(query.call).to include(query_school)

--- a/spec/system/placements/providers/find/provider_user_filters_schools_by_year_groups_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_filters_schools_by_year_groups_spec.rb
@@ -1,0 +1,182 @@
+require "rails_helper"
+
+RSpec.describe "Provider user filters schools by year groups", service: :placements, type: :system do
+  scenario do
+    given_that_schools_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_find_schools_page
+    then_i_see_the_find_schools_page
+    and_i_see_all_schools
+    and_i_see_the_year_group_filter
+
+    when_i_select_year_1_from_the_year_group_filter
+    and_i_click_on_apply_filters
+    then_i_see_the_springfield_elementary_school
+    and_i_do_not_see_the_hogwarts_elementary_school
+    and_i_only_see_the_year_1_filter_selected
+
+    when_i_select_year_2_from_the_from_the_year_group
+    and_i_click_on_apply_filters
+    then_i_see_all_schools
+    and_i_only_see_the_year_1_and_year_2_filters_selected
+
+    when_i_click_on_the_year_1_filter_tag
+    then_i_see_the_hogwarts_elementary_school
+    and_i_do_not_see_the_springfield_elementary_school
+    and_i_do_not_see_the_year_1_filter_tag
+
+    when_i_click_on_the_year_2_filter_tag
+    then_i_see_all_schools
+    and_i_do_not_see_any_year_group_filters
+  end
+
+  private
+
+  def given_that_schools_exist
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+    @primary_subject = build(:subject, name: "Primary", subject_area: "primary")
+
+    @year_1_primary_school = build(:placements_school, phase: "Primary", name: "Springfield Elementary", partner_providers: [@provider])
+    _year_1_placement = create(:placement, school: @year_1_primary_school, subject: @primary_subject, year_group: "year_1")
+
+    @year_2_primary_school = build(:placements_school, phase: "Primary", name: "Hogwarts Elementary", partner_providers: [@provider])
+    _year_2_placement = create(:placement, school: @year_2_primary_school, subject: @primary_subject, year_group: "year_2")
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_navigate_to_the_find_schools_page
+    within ".app-primary-navigation__nav" do
+      click_on "Find"
+    end
+  end
+
+  def then_i_see_the_find_schools_page
+    expect(page).to have_title("Find schools hosting placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Find schools hosting placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def and_i_see_all_schools
+    expect(page).to have_h2("Springfield Elementary")
+    expect(page).to have_h2("Hogwarts Elementary")
+  end
+  alias_method :then_i_see_all_schools, :and_i_see_all_schools
+
+  def and_i_see_the_year_group_filter
+    expect(page).to have_element(:legend, text: "Primary year group", class: "govuk-fieldset__legend")
+    expect(page).to have_field("Nursery", type: :checkbox, unchecked: true)
+    expect(page).to have_field("Reception", type: :checkbox, unchecked: true)
+    expect(page).to have_field("Year 1", type: :checkbox, unchecked: true)
+    expect(page).to have_field("Year 2", type: :checkbox, unchecked: true)
+    expect(page).to have_field("Year 3", type: :checkbox, unchecked: true)
+    expect(page).to have_field("Year 4", type: :checkbox, unchecked: true)
+    expect(page).to have_field("Year 5", type: :checkbox, unchecked: true)
+    expect(page).to have_field("Mixed year groups", type: :checkbox, unchecked: true)
+  end
+
+  def when_i_select_year_1_from_the_year_group_filter
+    check "Year 1"
+  end
+
+  def and_i_click_on_apply_filters
+    click_on "Apply filters"
+  end
+
+  def then_i_see_the_springfield_elementary_school
+    expect(page).to have_h2("Springfield Elementary")
+  end
+
+  def and_i_do_not_see_the_hogwarts_elementary_school
+    expect(page).not_to have_h2("Hogwarts Elementary")
+  end
+
+  def and_i_only_see_the_year_1_filter_selected
+    expect(page).to have_filter_tag("Year 1")
+    expect(page).to have_checked_field("Year 1")
+
+    expect(page).not_to have_filter_tag("Nursery")
+    expect(page).not_to have_checked_field("Nursery")
+    expect(page).not_to have_filter_tag("Reception")
+    expect(page).not_to have_checked_field("Reception")
+    expect(page).not_to have_filter_tag("Year 2")
+    expect(page).not_to have_checked_field("Year 2")
+    expect(page).not_to have_filter_tag("Year 3")
+    expect(page).not_to have_checked_field("Year 3")
+    expect(page).not_to have_filter_tag("Year 4")
+    expect(page).not_to have_checked_field("Year 4")
+    expect(page).not_to have_filter_tag("Year 5")
+    expect(page).not_to have_checked_field("Year 5")
+    expect(page).not_to have_filter_tag("Mixed year groups")
+    expect(page).not_to have_checked_field("Mixed year groups")
+  end
+
+  def when_i_select_year_2_from_the_from_the_year_group
+    check "Year 2"
+  end
+
+  def and_i_only_see_the_year_1_and_year_2_filters_selected
+    expect(page).to have_filter_tag("Year 1")
+    expect(page).to have_checked_field("Year 1")
+    expect(page).to have_filter_tag("Year 2")
+    expect(page).to have_checked_field("Year 2")
+
+    expect(page).not_to have_filter_tag("Nursery")
+    expect(page).not_to have_checked_field("Nursery")
+    expect(page).not_to have_filter_tag("Reception")
+    expect(page).not_to have_checked_field("Reception")
+    expect(page).not_to have_filter_tag("Year 3")
+    expect(page).not_to have_checked_field("Year 3")
+    expect(page).not_to have_filter_tag("Year 4")
+    expect(page).not_to have_checked_field("Year 4")
+    expect(page).not_to have_filter_tag("Year 5")
+    expect(page).not_to have_checked_field("Year 5")
+    expect(page).not_to have_filter_tag("Mixed year groups")
+    expect(page).not_to have_checked_field("Mixed year groups")
+  end
+
+  def and_i_see_my_selected_schools_i_work_with_filters
+    expect(page).to have_filter_tag("Springfield Elementary")
+    expect(page).to have_checked_field("Springfield Elementary")
+    expect(page).to have_filter_tag("Hogwarts Elementary")
+    expect(page).to have_checked_field("Hogwarts Elementary")
+  end
+
+  def then_i_see_the_hogwarts_elementary_school
+    expect(page).to have_h2("Hogwarts Elementary")
+  end
+
+  def and_i_do_not_see_the_springfield_elementary_school
+    expect(page).not_to have_h2("Springfield Elementary")
+  end
+
+  def when_i_click_on_the_year_1_filter_tag
+    within ".app-filter-tags" do
+      click_on "Year 1"
+    end
+  end
+
+  def when_i_click_on_the_year_2_filter_tag
+    within ".app-filter-tags" do
+      click_on "Year 2"
+    end
+  end
+
+  def and_i_do_not_see_the_year_1_filter_tag
+    expect(page).not_to have_filter_tag("Year 1")
+    expect(page).not_to have_checked_field("Year 1")
+    expect(page).to have_filter_tag("Year 2")
+    expect(page).to have_checked_field("Year 2")
+  end
+
+  def and_i_do_not_see_any_year_group_filters
+    expect(page).not_to have_filter_tag("Year 1")
+    expect(page).not_to have_checked_field("Year 1")
+    expect(page).not_to have_filter_tag("Year 2")
+    expect(page).not_to have_checked_field("Year 2")
+  end
+end


### PR DESCRIPTION
## Context

- Add "Primary year group" filter to Provider "Find" page

## Changes proposed in this pull request

- Add `year_groups` to `Placements::Schools::FilterForm`
- Add "Primary year group" filter to Provider "Find" page

## Guidance to review

- Sign in as Patricia (Provider user)
- Navigate to the "Find" page
- Find the "Primary year group" filter
- (Assuming you have primary placements) Filter for a placement with a specific year group

## Link to Trello card

https://trello.com/c/37qzQGe1/642-add-primary-year-group-filter

## Screenshots

https://github.com/user-attachments/assets/9bf5360b-4281-4486-8d91-ee252643edca


