### PR TITLE
Update the .env files to use new publish API url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ DATABASE_URL=postgres://postgres:$POSTGRES_PASSWORD@localhost:5432
 # EXTERNAL SERVICES
 GOVUK_NOTIFY_API_KEY=
 GIAS_CSV_BASE_URL=https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public
-PUBLISH_BASE_URL=https://www.publish-teacher-training-courses.service.gov.uk
+PUBLISH_BASE_URL=https://api.publish-teacher-training-courses.service.gov.uk
 DFE_SIGN_IN_ISSUER_URL=https://dev-oidc.signin.education.gov.uk
 
 TEACHING_RECORD_BASE_URL=https://preprod.teacher-qualifications-api.education.gov.uk

--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,3 @@
 SIGN_IN_METHOD=persona
 GIAS_CSV_BASE_URL=https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public
-PUBLISH_BASE_URL=https://www.publish-teacher-training-courses.service.gov.uk
+PUBLISH_BASE_URL=https://api.publish-teacher-training-courses.service.gov.uk

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,5 @@
 HOSTING_ENV=test
-PUBLISH_BASE_URL=https://www.publish-teacher-training-courses.service.gov.uk
+PUBLISH_BASE_URL=https://api.publish-teacher-training-courses.service.gov.uk
 GOVUK_NOTIFY_API_KEY=
 SIGN_IN_METHOD=dfe-sign-in
 DFE_SIGN_IN_ISSUER_URL=https://dev-oidc.signin.education.gov.uk

--- a/spec/jobs/publish_teacher_training/provider/sync_all_job_spec.rb
+++ b/spec/jobs/publish_teacher_training/provider/sync_all_job_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe PublishTeacherTraining::Provider::SyncAllJob, type: :job do
     before do
       stub_request(
         :get,
-        "https://www.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/current/providers",
+        "https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/current/providers",
       ).to_return(
         status: 200,
         body: {

--- a/spec/jobs/publish_teacher_training/subject/sync_all_job_spec.rb
+++ b/spec/jobs/publish_teacher_training/subject/sync_all_job_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe PublishTeacherTraining::Subject::SyncAllJob, type: :job do
   def success_stub_request
     stub_request(
       :get,
-      "https://www.publish-teacher-training-courses.service.gov.uk/api/public/v1/subject_areas?include=subjects",
+      "https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/subject_areas?include=subjects",
     ).to_return(
       status: 200,
       body: response_body.to_json,
@@ -58,7 +58,7 @@ RSpec.describe PublishTeacherTraining::Subject::SyncAllJob, type: :job do
   def failure_stub_request
     stub_request(
       :get,
-      "https://www.publish-teacher-training-courses.service.gov.uk/api/public/v1/subject_areas?include=subjects",
+      "https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/subject_areas?include=subjects",
     ).to_return(
       status: 200,
       body: invalid_response_body.to_json,

--- a/spec/services/publish_teacher_training/provider/api_spec.rb
+++ b/spec/services/publish_teacher_training/provider/api_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PublishTeacherTraining::Provider::Api do
   before do
     stub_request(
       :get,
-      "https://www.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/current/providers",
+      "https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/current/providers",
     ).to_return(
       status: 200,
       body: {

--- a/spec/services/publish_teacher_training/provider/importer_spec.rb
+++ b/spec/services/publish_teacher_training/provider/importer_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe PublishTeacherTraining::Provider::Importer do
   private
 
   def publish_url
-    "https://www.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/current/providers"
+    "https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/current/providers"
   end
 
   def non_existing_providers_request

--- a/spec/services/publish_teacher_training/subject/api_spec.rb
+++ b/spec/services/publish_teacher_training/subject/api_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe PublishTeacherTraining::Subject::Api do
   def success_stub_request
     stub_request(
       :get,
-      "https://www.publish-teacher-training-courses.service.gov.uk/api/public/v1/subject_areas?include=subjects",
+      "https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/subject_areas?include=subjects",
     ).to_return(
       status: 200,
       body: response_body.to_json,

--- a/spec/services/publish_teacher_training/subject/import_spec.rb
+++ b/spec/services/publish_teacher_training/subject/import_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe PublishTeacherTraining::Subject::Import do
   def success_stub_request
     stub_request(
       :get,
-      "https://www.publish-teacher-training-courses.service.gov.uk/api/public/v1/subject_areas?include=subjects",
+      "https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/subject_areas?include=subjects",
     ).to_return(
       status: 200,
       body: response_body.to_json,
@@ -68,7 +68,7 @@ RSpec.describe PublishTeacherTraining::Subject::Import do
   def failure_stub_request
     stub_request(
       :get,
-      "https://www.publish-teacher-training-courses.service.gov.uk/api/public/v1/subject_areas?include=subjects",
+      "https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/subject_areas?include=subjects",
     ).to_return(
       status: 200,
       body: invalid_response_body.to_json,

--- a/spec/tasks/subject_data_spec.rb
+++ b/spec/tasks/subject_data_spec.rb
@@ -22,7 +22,7 @@ describe "subject_data" do
   def success_stub_request
     stub_request(
       :get,
-      "https://www.publish-teacher-training-courses.service.gov.uk/api/public/v1/subject_areas?include=subjects",
+      "https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/subject_areas?include=subjects",
     ).to_return(
       status: 200,
       body: response_body.to_json,


### PR DESCRIPTION
## Context

The publish API changed the URL they use, as a result it stopped workijng for us

## Changes proposed in this pull request

- Updates the publish API url

## Guidance to review

- Drop your database
- Set it up again
- Run migrations
- Run seeds
- Everything should work without error again

## Link to Trello card

[Update Publish API URL](https://trello.com/c/Uecc0VYo/650-update-publish-api-url)