### PR TITLE
Fix claim guidance warning

### DIFF
--- a/app/models/claims/claim_window.rb
+++ b/app/models/claims/claim_window.rb
@@ -35,7 +35,7 @@ class Claims::ClaimWindow < ApplicationRecord
   validate :does_not_start_within_another_claim_window
   validate :does_not_end_within_another_claim_window
 
-  delegate :name, to: :academic_year, prefix: true
+  delegate :name, :starts_on, :ends_on, to: :academic_year, prefix: true
   delegate :past?, to: :ends_on
   delegate :future?, to: :starts_on
 

--- a/app/views/claims/schools/claims/index.html.erb
+++ b/app/views/claims/schools/claims/index.html.erb
@@ -9,7 +9,7 @@
       <% if policy(Claims::Claim.new(school: @school)).create? %>
         <% if @school.mentors.any? %>
           <%= govuk_warning_text do %>
-            <p class="govuk-body"><%= t(".guidance", end_date: l(Claims::ClaimWindow.current.ends_on, format: :long_with_day), start_year: Claims::ClaimWindow.current.starts_on.year, end_year: Claims::ClaimWindow.current.ends_on.year) %></p>
+            <p class="govuk-body"><%= t(".guidance", end_date: l(Claims::ClaimWindow.current.ends_on, format: :long_with_day), start_year: Claims::ClaimWindow.current.academic_year_starts_on.year, end_year: Claims::ClaimWindow.current.academic_year_ends_on.year) %></p>
           <% end %>
 
           <%= govuk_button_link_to(t(".add_claim"), new_add_claim_claims_school_claims_path) %>

--- a/spec/models/claims/claim_window_spec.rb
+++ b/spec/models/claims/claim_window_spec.rb
@@ -72,6 +72,14 @@ RSpec.describe Claims::ClaimWindow, type: :model do
     end
   end
 
+  describe "delegations" do
+    it { is_expected.to delegate_method(:name).to(:academic_year).with_prefix }
+    it { is_expected.to delegate_method(:starts_on).to(:academic_year).with_prefix }
+    it { is_expected.to delegate_method(:ends_on).to(:academic_year).with_prefix }
+    it { is_expected.to delegate_method(:past?).to(:ends_on) }
+    it { is_expected.to delegate_method(:future?).to(:starts_on) }
+  end
+
   describe "#current?" do
     it "returns true if the current date is inclusively within the starts on and ends on dates", freeze: "17 July 2024" do
       on_start_date = build(:claim_window, starts_on: Date.parse("17 July 2024"), ends_on: Date.parse("27 July 2024"))


### PR DESCRIPTION
## Context

The message was using the start and end years from the claim window, rather than the academic year which was causing confusion for users.

## Changes proposed in this pull request

- Replaced the claim window `starts_on` and `ends_on` year for the academic year equivalent
- Delegates `starts_on` and `ends_on` to the academic year with prefix

## Guidance to review

- Log in as Anne
- Check that the warning message references the academic year start and end date

## Link to Trello card

[Typo on CFMT claim journey](https://trello.com/c/fbxy3PZs/628-typo-on-cfmt-claim-journey)

## Screenshots

![image](https://github.com/user-attachments/assets/54ffcccc-8312-4af2-8448-2a76b12e4947)

