### PR TITLE
Update unavailable tag

### DIFF
--- a/app/components/placement/status_tag_component.rb
+++ b/app/components/placement/status_tag_component.rb
@@ -1,19 +1,44 @@
 class Placement::StatusTagComponent < ApplicationComponent
-  def initialize(placement:, classes: [], html_attributes: {})
+  def initialize(placement:, viewed_by_organisation:, classes: [], html_attributes: {})
     super(classes:, html_attributes:)
 
     @placement = placement
+    @viewed_by_organisation = viewed_by_organisation
   end
 
   private
 
-  attr_reader :placement
+  attr_reader :placement, :viewed_by_organisation
+
+  def status
+    if assigned_to_viewed_by_organisation?
+      { colour: "blue", text: I18n.t("placements.schools.placements.assigned_to_you") }
+    elsif placement_has_provider? && viewed_by_organisation_type == :school
+      { colour: "blue", text: I18n.t("placements.schools.placements.assigned_to_provider") }
+    elsif placement_has_provider?
+      { colour: "red", text: I18n.t("placements.schools.placements.unavailable") }
+    else
+      { colour: "green", text: I18n.t("placements.schools.placements.available") }
+    end
+  end
 
   def status_colour
-    placement.provider.present? ? "orange" : "turquoise"
+    status[:colour]
   end
 
   def status_text
-    placement.provider.present? ? I18n.t("placements.schools.placements.unavailable") : I18n.t("placements.schools.placements.available")
+    status[:text]
+  end
+
+  def assigned_to_viewed_by_organisation?
+    placement_has_provider? && placement.provider.id == viewed_by_organisation.id
+  end
+
+  def placement_has_provider?
+    placement.provider.present?
+  end
+
+  def viewed_by_organisation_type
+    @viewed_by_organisation_type ||= viewed_by_organisation.is_a?(Placements::School) ? :school : :provider
   end
 end

--- a/app/components/placement/summary_component.html.erb
+++ b/app/components/placement/summary_component.html.erb
@@ -5,7 +5,7 @@
     <% end %>
   </h2>
   <div class="app-result-detail">
-    <%= render Placement::StatusTagComponent.new(placement:) %>
+    <%= render Placement::StatusTagComponent.new(placement:, viewed_by_organisation: provider) %>
   </div>
 
   <dl class="app-result-detail">

--- a/app/views/placements/providers/partner_schools/placements/index.html.erb
+++ b/app/views/placements/providers/partner_schools/placements/index.html.erb
@@ -48,7 +48,7 @@
             <% body.with_row do |row| %>
               <% row.with_cell(text: govuk_link_to(placement.title, placements_provider_partner_school_placement_path(@provider, @partner_school, placement), no_visited_state: true)) %>
               <% row.with_cell do %>
-                <%= render Placement::StatusTagComponent.new(placement:) %>
+                <%= render Placement::StatusTagComponent.new(placement:, viewed_by_organisation: @provider) %>
               <% end %>
             <% end %>
           <% end %>

--- a/app/views/placements/providers/partner_schools/placements/show.html.erb
+++ b/app/views/placements/providers/partner_schools/placements/show.html.erb
@@ -7,5 +7,5 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <%= render "shared/placements/placement_details", school: @placement.school, placement: @placement %>
+  <%= render "shared/placements/placement_details", school: @placement.school, placement: @placement, viewed_by_organisation: @provider %>
 </div>

--- a/app/views/placements/providers/placements/show.html.erb
+++ b/app/views/placements/providers/placements/show.html.erb
@@ -6,5 +6,5 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <%= render "shared/placements/placement_details", school: @school, placement: @placement %>
+  <%= render "shared/placements/placement_details", school: @school, placement: @placement, viewed_by_organisation: @provider %>
 </div>

--- a/app/views/placements/schools/placements/_details.html.erb
+++ b/app/views/placements/schools/placements/_details.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (school:, placement:, support: false) -%>
 <div class="govuk-!-margin-top-0 govuk-!-margin-bottom-6">
-  <%= render Placement::StatusTagComponent.new(placement:) %>
+  <%= render Placement::StatusTagComponent.new(placement:, viewed_by_organisation: school) %>
 </div>
 
 <%= govuk_summary_list do |summary_list| %>

--- a/app/views/placements/schools/placements/preview.html.erb
+++ b/app/views/placements/schools/placements/preview.html.erb
@@ -10,5 +10,5 @@
   <%= render(GovukComponent::NotificationBannerComponent.new(title_text: t(".important"))) do |nb|
         nb.with_heading(text: t(".this_is_a_preview"))
       end %>
-  <%= render "shared/placements/placement_details", school: @placement.school, placement: @placement %>
+  <%= render "shared/placements/placement_details", school: @placement.school, placement: @placement, viewed_by_organisation: @school %>
 </div>

--- a/app/views/shared/placements/_placement_details.html.erb
+++ b/app/views/shared/placements/_placement_details.html.erb
@@ -3,7 +3,7 @@
   <%= placement.title %>
 </h1>
 <div class="govuk-!-margin-top-0 govuk-!-margin-bottom-6">
-  <%= render Placement::StatusTagComponent.new(placement:) %>
+  <%= render Placement::StatusTagComponent.new(placement:, viewed_by_organisation:) %>
 </div>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/wizards/placements/add_placement_wizard/_preview_placement_step.html.erb
+++ b/app/views/wizards/placements/add_placement_wizard/_preview_placement_step.html.erb
@@ -8,7 +8,7 @@
   <%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
     <%= f.govuk_error_summary %>
 
-    <%= render "shared/placements/placement_details", school: wizard.school.decorate, placement: current_step.placement.decorate %>
+    <%= render "shared/placements/placement_details", school: wizard.school.decorate, placement: current_step.placement.decorate, viewed_by_organisation: wizard.school %>
 
     <div class="govuk-button-group">
       <%= f.govuk_submit t(".publish_placement") %>

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -88,6 +88,8 @@ en:
           mixed_year_groups_description: ""
         available: Available
         unavailable: Unavailable
+        assigned_to_provider: Assigned to provider
+        assigned_to_you: Assigned to you
         index:
             page_title: Placements
             placements: Placements

--- a/spec/components/placement/status_tag_component_spec.rb
+++ b/spec/components/placement/status_tag_component_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Placement::StatusTagComponent, type: :component do
   subject(:component) do
-    described_class.new(placement:)
+    described_class.new(placement:, viewed_by_organisation:)
   end
 
   let(:placement) { create(:placement) }
@@ -11,33 +11,87 @@ RSpec.describe Placement::StatusTagComponent, type: :component do
     placement
   end
 
-  context "when the placement does not have a provider" do
-    it "renders the status as available" do
-      render_inline(component)
+  context "when viewed by a school" do
+    let(:viewed_by_organisation) { create(:placements_school) }
 
-      expect(page).to have_content("Available")
+    context "when the placement does not have a provider" do
+      it "renders the status as available" do
+        render_inline(component)
+
+        expect(page).to have_content("Available")
+      end
+
+      it "renders the status as green" do
+        render_inline(component)
+
+        expect(page).to have_css(".govuk-tag--green")
+      end
     end
 
-    it "renders the status as turquoise" do
-      render_inline(component)
+    context "when the placement has a provider" do
+      let(:placement) { create(:placement, provider: create(:provider)) }
 
-      expect(page).to have_css(".govuk-tag--turquoise")
+      it "renders the status as assigned to provider" do
+        render_inline(component)
+
+        expect(page).to have_content("Assigned to provider")
+      end
+
+      it "renders the status as blue" do
+        render_inline(component)
+
+        expect(page).to have_css(".govuk-tag--blue")
+      end
     end
   end
 
-  context "when the placement has a provider" do
-    let(:placement) { create(:placement, provider: create(:provider)) }
+  context "when viewed by a provider" do
+    let(:viewed_by_organisation) { create(:placements_provider) }
 
-    it "renders the status as unavailable" do
-      render_inline(component)
+    context "when the placement does not have a provider" do
+      it "renders the status as available" do
+        render_inline(component)
 
-      expect(page).to have_content("Unavailable")
+        expect(page).to have_content("Available")
+      end
+
+      it "renders the status as green" do
+        render_inline(component)
+
+        expect(page).to have_css(".govuk-tag--green")
+      end
     end
 
-    it "renders the status as orange" do
-      render_inline(component)
+    context "when the placement has a provider" do
+      let(:placement) { create(:placement, provider: create(:placements_provider)) }
 
-      expect(page).to have_css(".govuk-tag--orange")
+      it "renders the status as unavailable" do
+        render_inline(component)
+
+        expect(page).to have_content("Unavailable")
+      end
+
+      it "renders the status as red" do
+        render_inline(component)
+
+        expect(page).to have_css(".govuk-tag--red")
+      end
+    end
+
+    context "when the placement is assigned to the organisation" do
+      let(:placement) { create(:placement, provider: viewed_by_organisation) }
+
+      it "renders the status as assigned to you" do
+        render_inline(component)
+
+        expect(page).to have_content("Assigned to you")
+      end
+
+      it "renders the status as blue" do
+        render_inline(component)
+
+        expect(page).to have_css(".govuk-tag--blue")
+      end
     end
   end
 end

--- a/spec/components/previews/placement/status_tag_component_preview.rb
+++ b/spec/components/previews/placement/status_tag_component_preview.rb
@@ -3,7 +3,7 @@ class Placement::StatusTagComponentPreview < ApplicationComponentPreview
     school = FactoryBot.build(:placements_school, with_school_contact: false)
     placement = FactoryBot.build(:placement, school:)
 
-    render(Placement::StatusTagComponent.new(placement:))
+    render(Placement::StatusTagComponent.new(placement:, organisation: school))
   end
 
   def placement_with_provider
@@ -11,6 +11,6 @@ class Placement::StatusTagComponentPreview < ApplicationComponentPreview
     school = FactoryBot.build(:placements_school, with_school_contact: false)
     placement = FactoryBot.build(:placement, school:, provider:)
 
-    render(Placement::StatusTagComponent.new(placement:))
+    render(Placement::StatusTagComponent.new(placement:, organisation: school))
   end
 end

--- a/spec/system/placements/schools/placements/primary_school_user_edits_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/primary_school_user_edits_a_placement_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   def then_i_see_the_placement_details_page
     expect(page).to have_title("Primary with english (Year 1) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 1")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
@@ -239,7 +239,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   def then_i_see_the_placement_details_page_with_my_updated_year_group
     expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 2")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
@@ -298,7 +298,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   def then_i_see_the_placement_details_page_with_my_updated_term
     expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_element(:strong, text: "Available", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_element(:strong, text: "Available", class: "govuk-tag govuk-tag--green")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 2")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
@@ -350,7 +350,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   def then_i_see_the_placement_details_page_with_john_smith
     expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_element(:strong, text: "Available", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_element(:strong, text: "Available", class: "govuk-tag govuk-tag--green")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 2")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
@@ -377,7 +377,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   end
 
   def then_i_see_the_placement_details_page_with_jane_doe
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 2")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
@@ -429,7 +429,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   def then_i_see_the_placement_details_page_with_aes_sedai_trust
     expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Unavailable", "orange")
+    expect(page).to have_tag("Assigned to provider", "blue")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 2")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")

--- a/spec/system/placements/schools/placements/primary_school_user_edits_a_placement_with_javascript_disabled_spec.rb
+++ b/spec/system/placements/schools/placements/primary_school_user_edits_a_placement_with_javascript_disabled_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe "Primary school user edits a placement with javascript disabled",
   def then_i_see_the_placement_details_page
     expect(page).to have_title("Primary with english (Year 1) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 1")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
@@ -246,7 +246,7 @@ RSpec.describe "Primary school user edits a placement with javascript disabled",
   def then_i_see_the_placement_details_page_with_my_updated_year_group
     expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 2")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
@@ -287,7 +287,7 @@ RSpec.describe "Primary school user edits a placement with javascript disabled",
   def then_i_see_the_placement_details_page_with_my_updated_term
     expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_element(:strong, text: "Available", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_element(:strong, text: "Available", class: "govuk-tag govuk-tag--green")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 2")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
@@ -339,7 +339,7 @@ RSpec.describe "Primary school user edits a placement with javascript disabled",
   def then_i_see_the_placement_details_page_with_john_smith
     expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_element(:strong, text: "Available", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_element(:strong, text: "Available", class: "govuk-tag govuk-tag--green")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 2")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
@@ -366,7 +366,7 @@ RSpec.describe "Primary school user edits a placement with javascript disabled",
   end
 
   def then_i_see_the_placement_details_page_with_jane_doe
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 2")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
@@ -402,7 +402,7 @@ RSpec.describe "Primary school user edits a placement with javascript disabled",
   def then_i_see_the_placement_details_page_with_aes_sedai_trust
     expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Unavailable", "orange")
+    expect(page).to have_tag("Assigned to provider", "blue")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 2")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")

--- a/spec/system/placements/schools/placements/school_user_edits_a_placement_with_no_mentors_spec.rb
+++ b/spec/system/placements/schools/placements/school_user_edits_a_placement_with_no_mentors_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "School user edits a placement with no mentors", service: :placem
   def then_i_see_the_placement_details_page
     expect(page).to have_title("Primary with english (Year 1) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 1")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
@@ -172,7 +172,7 @@ RSpec.describe "School user edits a placement with no mentors", service: :placem
   def then_i_see_the_placement_details_page_with_assign_a_mentor_text
     expect(page).to have_title("Primary with english (Year 1) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 1")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")

--- a/spec/system/placements/schools/placements/school_user_views_and_deletes_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/school_user_views_and_deletes_a_placement_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe "School user views and deletes a placement", service: :placements
   def then_i_see_the_placement_details_page
     expect(page).to have_title("Primary with english (Year 1) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 1")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")

--- a/spec/system/placements/schools/placements/school_user_views_and_deletes_a_placement_with_partner_provider_spec.rb
+++ b/spec/system/placements/schools/placements/school_user_views_and_deletes_a_placement_with_partner_provider_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "School user views and deletes a placement with a partner provide
   def then_i_see_the_placement_details_page
     expect(page).to have_title("Primary with english (Year 1) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Unavailable", "orange")
+    expect(page).to have_tag("Assigned to provider", "blue")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 1")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")

--- a/spec/system/placements/schools/placements/secondary_school_user_edits_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/secondary_school_user_edits_a_placement_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
   def then_i_see_the_placement_details_page
     expect(page).to have_title("English - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "English")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
     expect(page).to have_summary_list_row("Expected date", "Autumn term")
@@ -219,7 +219,7 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
   def then_i_see_the_placement_details_page_with_my_updated_term
     expect(page).to have_title("English - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "English")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
     expect(page).to have_summary_list_row("Expected date", "Autumn term, Summer term")
@@ -270,7 +270,7 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
   def then_i_see_the_placement_details_page_with_john_smith
     expect(page).to have_title("English - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "English")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
     expect(page).to have_summary_list_row("Expected date", "Autumn term, Summer term")
@@ -296,7 +296,7 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
   end
 
   def then_i_see_the_placement_details_page_with_jane_doe
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "English")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
     expect(page).to have_summary_list_row("Expected date", "Autumn term, Summer term")
@@ -367,7 +367,7 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
   def then_i_see_the_placement_details_page_with_aes_sedai_trust
     expect(page).to have_title("English - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Unavailable", "orange")
+    expect(page).to have_tag("Assigned to provider", "blue")
     expect(page).to have_summary_list_row("Subject", "English")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
     expect(page).to have_summary_list_row("Expected date", "Autumn term, Summer term")

--- a/spec/system/placements/schools/placements/secondary_school_user_edits_a_placement_with_javascript_disabled_spec.rb
+++ b/spec/system/placements/schools/placements/secondary_school_user_edits_a_placement_with_javascript_disabled_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe "Secondary school user edits a placement with javascript disabled
   def then_i_see_the_placement_details_page
     expect(page).to have_title("English - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "English")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
     expect(page).to have_summary_list_row("Expected date", "Autumn term")
@@ -230,7 +230,7 @@ RSpec.describe "Secondary school user edits a placement with javascript disabled
   def then_i_see_the_placement_details_page_with_my_updated_term
     expect(page).to have_title("English - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "English")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
     expect(page).to have_summary_list_row("Expected date", "Autumn term, Summer term")
@@ -281,7 +281,7 @@ RSpec.describe "Secondary school user edits a placement with javascript disabled
   def then_i_see_the_placement_details_page_with_john_smith
     expect(page).to have_title("English - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "English")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
     expect(page).to have_summary_list_row("Expected date", "Autumn term, Summer term")
@@ -307,7 +307,7 @@ RSpec.describe "Secondary school user edits a placement with javascript disabled
   end
 
   def then_i_see_the_placement_details_page_with_jane_doe
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "English")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
     expect(page).to have_summary_list_row("Expected date", "Autumn term, Summer term")
@@ -366,7 +366,7 @@ RSpec.describe "Secondary school user edits a placement with javascript disabled
   def then_i_see_the_placement_details_page_with_aes_sedai_trust
     expect(page).to have_title("English - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Unavailable", "orange")
+    expect(page).to have_tag("Assigned to provider", "blue")
     expect(page).to have_summary_list_row("Subject", "English")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
     expect(page).to have_summary_list_row("Expected date", "Autumn term, Summer term")

--- a/spec/system/placements/support/schools/placements/primary_school_support_user_edits_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/primary_school_support_user_edits_a_placement_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   def then_i_see_the_placement_details_page
     expect(page).to have_title("Primary with english (Year 1) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 1")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
@@ -244,7 +244,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   def then_i_see_the_placement_details_page_with_my_updated_year_group
     expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 2")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
@@ -285,7 +285,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   def then_i_see_the_placement_details_page_with_my_updated_term
     expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 2")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
@@ -337,7 +337,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   def then_i_see_the_placement_details_page_with_john_smith
     expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 2")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
@@ -364,7 +364,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   end
 
   def then_i_see_the_placement_details_page_with_jane_doe
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 2")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
@@ -436,7 +436,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   def then_i_see_the_placement_details_page_with_aes_sedai_trust
     expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Unavailable", "orange")
+    expect(page).to have_tag("Assigned to provider", "blue")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 2")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")

--- a/spec/system/placements/support/schools/placements/school_support_user_edits_a_placement_with_no_mentors_spec.rb
+++ b/spec/system/placements/support/schools/placements/school_support_user_edits_a_placement_with_no_mentors_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe "School support user edits a placement with no mentors", service:
   def then_i_see_the_placement_details_page
     expect(page).to have_title("Primary with english (Year 1) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 1")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
@@ -183,7 +183,7 @@ RSpec.describe "School support user edits a placement with no mentors", service:
   def then_i_see_the_placement_details_page_with_assign_a_mentor_text
     expect(page).to have_title("Primary with english (Year 1) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 1")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")

--- a/spec/system/placements/support/schools/placements/school_support_user_views_and_deletes_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/school_support_user_views_and_deletes_a_placement_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "School support user views and deletes a placement", service: :pl
   def then_i_see_the_placement_details_page
     expect(page).to have_title("Primary with english (Year 1) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 1")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")

--- a/spec/system/placements/support/schools/placements/school_support_user_views_and_deletes_a_placement_with_partner_provider_spec.rb
+++ b/spec/system/placements/support/schools/placements/school_support_user_views_and_deletes_a_placement_with_partner_provider_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe "School support user views and deletes a placement with a partner
   def then_i_see_the_placement_details_page
     expect(page).to have_title("Primary with english (Year 1) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Unavailable", "orange")
+    expect(page).to have_tag("Assigned to provider", "blue")
     expect(page).to have_summary_list_row("Subject", "Primary")
     expect(page).to have_summary_list_row("Year group", "Year 1")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")

--- a/spec/system/placements/support/schools/placements/secondary_school_support_user_edits_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/secondary_school_support_user_edits_a_placement_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
   def then_i_see_the_placement_details_page
     expect(page).to have_title("English - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_tag("Available", "turquoise")
+    expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "English")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
     expect(page).to have_summary_list_row("Expected date", "Autumn term")
@@ -210,7 +210,7 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
   def then_i_see_the_placement_details_page_with_my_updated_term
     expect(page).to have_title("English - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_element(:strong, text: "Available", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_element(:strong, text: "Available", class: "govuk-tag govuk-tag--green")
     expect(page).to have_summary_list_row("Subject", "English")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
     expect(page).to have_summary_list_row("Expected date", "Autumn term, Summer term")
@@ -261,7 +261,7 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
   def then_i_see_the_placement_details_page_with_john_smith
     expect(page).to have_title("English - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_element(:strong, text: "Available", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_element(:strong, text: "Available", class: "govuk-tag govuk-tag--green")
     expect(page).to have_summary_list_row("Subject", "English")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
     expect(page).to have_summary_list_row("Expected date", "Autumn term, Summer term")
@@ -287,7 +287,7 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
   end
 
   def then_i_see_the_placement_details_page_with_jane_doe
-    expect(page).to have_element(:strong, text: "Available", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_element(:strong, text: "Available", class: "govuk-tag govuk-tag--green")
     expect(page).to have_summary_list_row("Subject", "English")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
     expect(page).to have_summary_list_row("Expected date", "Autumn term, Summer term")
@@ -358,7 +358,7 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
   def then_i_see_the_placement_details_page_with_aes_sedai_trust
     expect(page).to have_title("English - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_element(:strong, text: "Unavailable", class: "govuk-tag govuk-tag--orange")
+    expect(page).to have_element(:strong, text: "Assigned to provider", class: "govuk-tag govuk-tag--blue")
     expect(page).to have_summary_list_row("Subject", "English")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
     expect(page).to have_summary_list_row("Expected date", "Autumn term, Summer term")


### PR DESCRIPTION
## Context

When a placement was assigned to a provider it would display as "Unavailable" when the provider was viewing the placement. This led to confusion and as a team we agreed this needed to be resolved.

## Changes proposed in this pull request

- Adds new functionality to the status tag to conditonally render school and provider views


## Link to Trello card

['Unavailable' tag causing confusion for assigned placements](https://trello.com/c/TXTSV5wn/599-unavailable-tag-causing-confusion-for-assigned-placements)

## Screenshots

![image](https://github.com/user-attachments/assets/75802d30-5bdc-4b3a-9eff-e75c9767e264)
![image](https://github.com/user-attachments/assets/34f8c3e7-9ac0-4b3e-be00-d05dfe3c281f)
![image](https://github.com/user-attachments/assets/d8ca66a0-5096-4896-9698-6ba2f4f28bdf)