### PR TITLE
Revert rate limit addition for prod

### DIFF
--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -54,16 +54,5 @@
           }
         ]
       }
-    },
-    "rate_limit": [
-      {
-        "agent": "all",
-        "priority": 100,
-        "duration": 5,
-        "limit": 350,
-        "selector": "Host",
-        "operator": "GreaterThanOrEqual",
-        "match_values": "0"
-      }
-    ]
+    }
   }


### PR DESCRIPTION
## Context

PR to add rate_limit failed as the terraform module tries to create 2 security-policies with the same name due to the multiple domains.
This will require a fix to the domains module.

## Changes proposed in this pull request

Revert rate-limit setting 

## Guidance to review

make production domains-plan
