### PR TITLE
Add ingress rate limits

### DIFF
--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -54,5 +54,16 @@
           }
         ]
       }
-    }
+    },
+    "rate_limit": [
+      {
+        "agent": "all",
+        "priority": 100,
+        "duration": 5,
+        "limit": 350,
+        "selector": "Host",
+        "operator": "GreaterThanOrEqual",
+        "match_values": "0"
+      }
+    ]
   }

--- a/terraform/domains/environment_domains/config/qa.tfvars.json
+++ b/terraform/domains/environment_domains/config/qa.tfvars.json
@@ -36,5 +36,16 @@
         "environment_short": "qa",
         "origin_hostname": "manage-school-placements-qa.test.teacherservices.cloud"
       }
-    }
+    },
+    "rate_limit": [
+      {
+        "agent": "all",
+        "priority": 100,
+        "duration": 5,
+        "limit": 250,
+        "selector": "Host",
+        "operator": "GreaterThanOrEqual",
+        "match_values": "0"
+      }
+    ]
 }

--- a/terraform/domains/environment_domains/config/sandbox.tfvars.json
+++ b/terraform/domains/environment_domains/config/sandbox.tfvars.json
@@ -36,5 +36,16 @@
         "environment_short": "sandbox",
         "origin_hostname": "manage-school-placements-sandbox.teacherservices.cloud"
       }
-    }
+    },
+    "rate_limit": [
+      {
+        "agent": "all",
+        "priority": 100,
+        "duration": 5,
+        "limit": 250,
+        "selector": "Host",
+        "operator": "GreaterThanOrEqual",
+        "match_values": "0"
+      }
+    ]
   }

--- a/terraform/domains/environment_domains/config/staging.tfvars.json
+++ b/terraform/domains/environment_domains/config/staging.tfvars.json
@@ -36,5 +36,16 @@
         "environment_short": "staging",
         "origin_hostname": "manage-school-placements-staging.test.teacherservices.cloud"
       }
-    }
+    },
+    "rate_limit": [
+      {
+        "agent": "all",
+        "priority": 100,
+        "duration": 5,
+        "limit": 250,
+        "selector": "Host",
+        "operator": "GreaterThanOrEqual",
+        "match_values": "0"
+      }
+    ]
 }


### PR DESCRIPTION
### Context

Configure rate limiting for all environments

### Changes proposed in this pull request

Add global rate limit per IP for 5 minute intervals
Value for production global rate set from checking ingress logs for the last 4 weeks and is more than double any 10 minute period in that time.

### Guidance to review

make env domains-plan

### Link to Trello card

https://trello.com/c/rmljcE5W/2345-add-rate-limiting-for-services
