### PR TITLE
Remove closed schools when syncing

### DIFF
--- a/app/models/placements/school.rb
+++ b/app/models/placements/school.rb
@@ -78,7 +78,6 @@ class Placements::School < School
   has_many :mentor_memberships
   has_many :mentors, through: :mentor_memberships
 
-  has_many :partnerships, dependent: :destroy
   has_many :partner_providers,
            through: :partnerships,
            source: :provider

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -98,6 +98,8 @@ class School < ApplicationRecord
   has_many :placements
   has_many :academic_years, through: :placements
 
+  has_many :partnerships, class_name: "Placements::Partnership", dependent: :destroy
+
   has_one :school_contact, dependent: :destroy, class_name: "Placements::SchoolContact"
 
   normalizes :email_address, with: ->(value) { value.strip.downcase }

--- a/app/services/gias/csv_importer.rb
+++ b/app/services/gias/csv_importer.rb
@@ -133,6 +133,16 @@ module Gias
       end
 
       Rails.logger.info "GIAS Data Imported!"
+
+      Rails.logger.silence do
+        offboarded_schools_scope = School.where(placements_service: false, claims_service: false).where.missing(:partnerships)
+        onboarded_urns = school_records.pluck(:urn)
+        schools_to_remove = offboarded_schools_scope.where.not(urn: onboarded_urns)
+
+        schools_to_remove.delete_all
+      end
+
+      Rails.logger.info "Schools which have been closed have been purged from the database."
     end
 
     private

--- a/app/services/gias/csv_importer.rb
+++ b/app/services/gias/csv_importer.rb
@@ -135,14 +135,15 @@ module Gias
       Rails.logger.info "GIAS Data Imported!"
 
       Rails.logger.silence do
-        offboarded_schools_scope = School.where(placements_service: false, claims_service: false).where.missing(:partnerships)
-        onboarded_urns = school_records.pluck(:urn)
-        schools_to_remove = offboarded_schools_scope.where.not(urn: onboarded_urns)
+        # Schools which are not part of the claims service, placements service and do not have partnerships
+        inactive_schools_scope = School.where(placements_service: false, claims_service: false).where.missing(:partnerships)
+        # Inactive schools which did not appear in the imported data
+        schools_to_remove = inactive_schools_scope.where.not(urn: school_records.pluck(:urn))
 
         schools_to_remove.delete_all
       end
 
-      Rails.logger.info "Schools which have been closed have been purged from the database."
+      Rails.logger.info "Deleted schools which have been closed from the database."
     end
 
     private

--- a/spec/models/placements/school_spec.rb
+++ b/spec/models/placements/school_spec.rb
@@ -97,10 +97,6 @@ RSpec.describe Placements::School do
       end
     end
 
-    describe "#partnerships" do
-      it { is_expected.to have_many(:partnerships) }
-    end
-
     describe "#partner_providers" do
       it { is_expected.to have_many(:partner_providers).through(:partnerships) }
 

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe School, type: :model do
     it { is_expected.to have_many(:mentor_memberships) }
     it { is_expected.to have_many(:mentors).through(:mentor_memberships) }
     it { is_expected.to have_many(:users).through(:user_memberships) }
+    it { is_expected.to have_many(:partnerships).class_name("Placements::Partnership").dependent(:destroy) }
   end
 
   context "with scopes" do

--- a/spec/services/gias/csv_importer_spec.rb
+++ b/spec/services/gias/csv_importer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Gias::CSVImporter do
 
   it "logs messages to STDOUT" do
     expect(Rails.logger).to receive(:info).with("GIAS Data Imported!")
-    expect(Rails.logger).to receive(:info).with("Schools which have been closed have been purged from the database.")
+    expect(Rails.logger).to receive(:info).with("Deleted schools which have been closed from the database.")
 
     gias_importer
   end


### PR DESCRIPTION
## Context

We exclude closed schools when importing from GIAS but we don’t check if schools have closed and remove them if they were imported whilst they were open. This has caused a few issues with duplicate school names and onboarding the wrong schools.

## Changes proposed in this pull request

- Moves the `partnerships` association to the base school model
- Deletes schools that do not have partnerships or that are onboarded from the service if they have been closed in GIAS

## Guidance to review

This is one you'll need to check out locally to test. You'll need to create a school locally via the console that uses a made up URN e.g. "999999", then run the GIAS import and verify that it has been removed.

## Link to Trello card

[Remove closed schools from the service database](https://trello.com/c/R4DgQihv/663-remove-closed-schools-from-the-service-database)
