### PR TITLE
Remove unnecessary through association in providers for claims

### DIFF
--- a/app/models/claims/provider.rb
+++ b/app/models/claims/provider.rb
@@ -43,7 +43,7 @@ class Claims::Provider < Provider
   ].freeze
 
   has_many :mentor_trainings
-  has_many :claims, through: :mentor_trainings
+  has_many :claims
 
   scope :private_beta_providers, -> { where(name: PRIVATE_BETA_PROVIDERS) }
 end

--- a/spec/models/claims/provider_spec.rb
+++ b/spec/models/claims/provider_spec.rb
@@ -41,7 +41,7 @@ require "rails_helper"
 RSpec.describe Claims::Provider, type: :model do
   context "with associations" do
     it { is_expected.to have_many(:mentor_trainings) }
-    it { is_expected.to have_many(:claims).through(:mentor_trainings) }
+    it { is_expected.to have_many(:claims) }
   end
 
   describe "scopes" do


### PR DESCRIPTION
## Context

- Remove unnecessary `through` association between `providers` and `claims` 

## Link to Trello card

https://trello.com/c/XUsra1qh/685-update-claimsprovider-claims-association