### PR TITLE
Add image build workflow

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -31,6 +31,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           context: .
           snyk-token: ${{ secrets.SNYK_TOKEN }}
+          max-cache: true
 
   deploy_review:
     name: Deploy to review environment

--- a/.github/workflows/build_nocache.yml
+++ b/.github/workflows/build_nocache.yml
@@ -1,0 +1,37 @@
+name: Build No Cache
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 12 * * 0"
+    # Will run once a week on Sunday afternoon
+
+jobs:
+  build-no-cache:
+    outputs:
+      docker-image-tag: ${{ steps.build-image.outputs.tag }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout
+
+      - name: Build without cache and push docker image
+        id: build-image
+        uses: DFE-Digital/github-actions/build-docker-image@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          context: .
+          reuse-cache: false
+          snyk-token: ${{ secrets.SNYK_TOKEN }}
+          max-cache: true
+
+      - name: Notify slack on failure
+        uses: rtCamp/action-slack-notify@master
+        if: ${{ failure() }}
+        env:
+          SLACK_USERNAME: CI Deployment
+          SLACK_COLOR: failure
+          SLACK_ICON_EMOJI: ":github-logo:"
+          SLACK_TITLE: "Build failure"
+          SLACK_MESSAGE: ":alert: Rebuild docker cache failure :sadparrot:"
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
### Context
Use a standard workflow for building container images without using image cache

### Changes proposed in this pull request
Add a new github actions workflow for building images without using image cache

### Guidance to review
Check the workflow - https://github.com/DFE-Digital/itt-mentor-services/actions/runs/15437953594/job/43448692751?pr=1612

### Trello card 
https://trello.com/c/ktsJEPED/2326-use-build-docker-image-github-action


### Checklist
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
