### PR TITLE
Move potential placement details to PII list for tracking

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -173,6 +173,7 @@ shared:
     - claims_grant_conditions_accepted_by_id
     - expression_of_interest_completed
     - vendor_number
+    - potential_placement_details
   :providers:
     - id
     - code

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -132,7 +132,6 @@ shared:
     - walk_travel_duration
     - drive_travel_duration
     - previously_offered_placements
-    - potential_placement_details
   :school_contacts:
     - name
     - email_address

--- a/config/analytics_hidden_pii.yml
+++ b/config/analytics_hidden_pii.yml
@@ -7,3 +7,5 @@ shared:
   users:
     - first_name
     - last_name
+  schools:
+    - potential_placement_details


### PR DESCRIPTION
## Context

We need to track potential placement details to understand how users are using the service.

## Changes proposed in this pull request

- Remove `potential_placement_details` from the blocklist
- Adds `potential_placement_details` to the allow list
- Adds `potential_placement_details` to the PII list

## Guidance to review

- Check that the columns are in the specified files

## Link to Trello card

[Move potential placement details to PII list](https://trello.com/c/nkU6ndjU/695-move-potential-placement-details-to-pii-list)