### PR TITLE
Update multi-add-placement content on check your answers page

### DIFF
--- a/app/views/wizards/placements/multi_placement_wizard/_check_your_answers_step.html.erb
+++ b/app/views/wizards/placements/multi_placement_wizard/_check_your_answers_step.html.erb
@@ -10,6 +10,8 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l"><%= t(".title") %></h1>
 
+      <p class="govuk-body"><%= t(".placement_visible_to_providers_text") %></p>
+
       <%= render "shared/wizards/placements/multiple_placements_wizard/check_your_answers",
         current_step:,
         wizard: @wizard,

--- a/config/locales/en/wizards/placements/multi_placement_wizard.yml
+++ b/config/locales/en/wizards/placements/multi_placement_wizard.yml
@@ -79,6 +79,7 @@ en:
           select_all: Select all
         check_your_answers_step:
           title: Check your answers
+          placement_visible_to_providers_text: Publishing your placements will mean they are visible to teacher training providers. They will see your school has available placements.
           continue: Save and continue
           education_phase: Education phase
           phase: Phase

--- a/spec/system/placements/schools/placements/bulk_add_placements/school_user_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/school_user_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
@@ -269,6 +269,7 @@ RSpec.describe "School user bulk adds placements for primary and secondary phase
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_h1("Check your answers")
+    expect(page).to have_paragraph("Publishing your placements will mean they are visible to teacher training providers. They will see your school has available placements.")
 
     expect(page).to have_h2("Education phase")
     expect(page).to have_summary_list_row("Phase", "Primary Secondary")


### PR DESCRIPTION
## Context

Add clarity to who the new placements are visible to on the multi-add-placements check your answers page. 

## Changes proposed in this pull request

Content update. 

## Link to Trello card

https://trello.com/c/mO6vRQFm/702-update-multi-add-placement-content

## Screenshots

<img width="750" alt="Screenshot 2025-06-04 at 15 04 49" src="https://github.com/user-attachments/assets/550e2608-f5b4-4b92-94e1-f8685d494ab9" />
