### PR TITLE
Update add placements check your answers inset text to new paragraph

### DIFF
--- a/app/views/wizards/placements/add_placement_wizard/_check_your_answers_step.html.erb
+++ b/app/views/wizards/placements/add_placement_wizard/_check_your_answers_step.html.erb
@@ -13,6 +13,8 @@
         <%= t(".title") %>
       </h1>
 
+      <p class="govuk-body"><%= t(".placement_visible_to_providers_text") %></p>
+
       <%= govuk_summary_list do |summary_list| %>
 
         <% if wizard.steps.include?(:phase) %>
@@ -90,8 +92,6 @@
           <% end %>
         <% end %>
       <% end %>
-
-      <%= govuk_inset_text(text: t(".info_text")) %>
 
       <div class="govuk-button-group">
         <%= f.govuk_submit t(".publish_placement") %>

--- a/config/locales/en/wizards/placements/add_placement_wizard.yml
+++ b/config/locales/en/wizards/placements/add_placement_wizard.yml
@@ -47,6 +47,7 @@ en:
         check_your_answers_step:
           page_title: Check your answers - %{contextual_text}
           title: Check your answers
+          placement_visible_to_providers_text: Publishing your placements will mean they are visible to teacher training providers. They will see your school has available placements.
           phase: Phase
           subject: Subject
           additional_subjects: Additional subjects

--- a/spec/system/placements/schools/placements/all_through_school_user_adds_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/all_through_school_user_adds_a_placement_spec.rb
@@ -378,7 +378,7 @@ RSpec.describe "All-through school user adds a placement", service: :placements,
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_h1("Check your answers")
     expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
-    expect(page).to have_element(:div, text: "When a placement is published, it will be visible to teacher training providers.", class: "govuk-inset-text")
+    expect(page).to have_paragraph("Publishing your placements will mean they are visible to teacher training providers. They will see your school has available placements.")
     expect(page).to have_button("Publish placement")
     expect(page).to have_element(:a, text: "Preview placement", class: "govuk-link")
     expect(page).to have_link("Cancel", href: "/schools/#{@school.id}/placements")

--- a/spec/system/placements/schools/placements/primary_school_user_adds_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/primary_school_user_adds_a_placement_spec.rb
@@ -311,7 +311,7 @@ RSpec.describe "Primary school user adds a placement", service: :placements, typ
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_h1("Check your answers")
     expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
-    expect(page).to have_element(:div, text: "When a placement is published, it will be visible to teacher training providers.", class: "govuk-inset-text")
+    expect(page).to have_paragraph("Publishing your placements will mean they are visible to teacher training providers. They will see your school has available placements.")
     expect(page).to have_button("Publish placement")
     expect(page).to have_element(:a, text: "Preview placement", class: "govuk-link")
     expect(page).to have_link("Cancel", href: "/schools/#{@school.id}/placements")

--- a/spec/system/placements/schools/placements/secondary_school_user_adds_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/secondary_school_user_adds_a_placement_spec.rb
@@ -294,7 +294,7 @@ RSpec.describe "Secondary school user adds a placement", service: :placements, t
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_h1("Check your answers")
     expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
-    expect(page).to have_element(:div, text: "When a placement is published, it will be visible to teacher training providers.", class: "govuk-inset-text")
+    expect(page).to have_paragraph("Publishing your placements will mean they are visible to teacher training providers. They will see your school has available placements.")
     expect(page).to have_button("Publish placement")
     expect(page).to have_element(:a, text: "Preview placement", class: "govuk-link")
     expect(page).to have_link("Cancel", href: "/schools/#{@school.id}/placements")

--- a/spec/system/placements/schools/placements/user_publishes_a_placement_after_preview_spec.rb
+++ b/spec/system/placements/schools/placements/user_publishes_a_placement_after_preview_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe "User publishes a placement after preview", service: :placements,
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_h1("Check your answers")
     expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
-    expect(page).to have_element(:div, text: "When a placement is published, it will be visible to teacher training providers.", class: "govuk-inset-text")
+    expect(page).to have_paragraph("Publishing your placements will mean they are visible to teacher training providers. They will see your school has available placements.")
     expect(page).to have_button("Publish placement")
     expect(page).to have_element(:a, text: "Preview placement", class: "govuk-link")
     expect(page).to have_link("Cancel", href: "/schools/#{@school.id}/placements")

--- a/spec/system/placements/support/schools/placements/all_through_school_support_user_adds_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/all_through_school_support_user_adds_a_placement_spec.rb
@@ -387,7 +387,7 @@ RSpec.describe "All-through support school user adds a placement", service: :pla
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_h1("Check your answers")
     expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
-    expect(page).to have_element(:div, text: "When a placement is published, it will be visible to teacher training providers.", class: "govuk-inset-text")
+    expect(page).to have_paragraph("Publishing your placements will mean they are visible to teacher training providers. They will see your school has available placements.")
     expect(page).to have_button("Publish placement")
     expect(page).to have_element(:a, text: "Preview placement", class: "govuk-link")
     expect(page).to have_link("Cancel", href: "/schools/#{@school.id}/placements")

--- a/spec/system/placements/support/schools/placements/primary_school_support_user_adds_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/primary_school_support_user_adds_a_placement_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe "Primary school user adds a placement", service: :placements, typ
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_h1("Check your answers")
     expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
-    expect(page).to have_element(:div, text: "When a placement is published, it will be visible to teacher training providers.", class: "govuk-inset-text")
+    expect(page).to have_paragraph("Publishing your placements will mean they are visible to teacher training providers. They will see your school has available placements.")
     expect(page).to have_button("Publish placement")
     expect(page).to have_element(:a, text: "Preview placement", class: "govuk-link")
     expect(page).to have_link("Cancel", href: "/schools/#{@school.id}/placements")

--- a/spec/system/placements/support/schools/placements/secondary_school_support_user_adds_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/secondary_school_support_user_adds_a_placement_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe "Secondary school user adds a placement", service: :placements, t
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_h1("Check your answers")
     expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
-    expect(page).to have_element(:div, text: "When a placement is published, it will be visible to teacher training providers.", class: "govuk-inset-text")
+    expect(page).to have_paragraph("Publishing your placements will mean they are visible to teacher training providers. They will see your school has available placements.")
     expect(page).to have_button("Publish placement")
     expect(page).to have_element(:a, text: "Preview placement", class: "govuk-link")
     expect(page).to have_link("Cancel", href: "/schools/#{@school.id}/placements")

--- a/spec/system/placements/support/schools/placements/support_user_publishes_a_placement_after_preview_spec.rb
+++ b/spec/system/placements/support/schools/placements/support_user_publishes_a_placement_after_preview_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe "Support user publishes a placement after preview", service: :pla
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_h1("Check your answers")
     expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
-    expect(page).to have_element(:div, text: "When a placement is published, it will be visible to teacher training providers.", class: "govuk-inset-text")
+    expect(page).to have_paragraph("Publishing your placements will mean they are visible to teacher training providers. They will see your school has available placements.")
     expect(page).to have_button("Publish placement")
     expect(page).to have_element(:a, text: "Preview placement", class: "govuk-link")
     expect(page).to have_link("Cancel", href: "/schools/#{@school.id}/placements")


### PR DESCRIPTION
## Context

Remove old inset text message and replace it with a paragraph at the top of the page to reflect the changes to the multi-placement wizard. This content change makes it more clear to a school user who can view their placement once published.

## Changes proposed in this pull request

Add new content in screenshot. 

## Guidance to review
Check that the paragraph appears in the check your answers flow of the add placement wizard.

## Link to Trello card

https://trello.com/c/P7LpGnMb/701-update-add-placement-content

## Screenshots

<img width="751" alt="Screenshot 2025-06-04 at 16 08 09" src="https://github.com/user-attachments/assets/17c44211-edda-4d4e-b334-489f86506047" />

