### PR TITLE
Add select all that apply hint

### DIFF
--- a/app/views/wizards/placements/multi_placement_wizard/_phase_step.html.erb
+++ b/app/views/wizards/placements/multi_placement_wizard/_phase_step.html.erb
@@ -13,7 +13,8 @@
         :phases,
         current_step.phases_for_selection,
         :name, :name, :description,
-        legend: { size: "l", text: t(".title"), tag: "h1" }
+        legend: { size: "l", text: t(".title"), tag: "h1" },
+        hint: { text: t(".hint") }
       ) %>
 
       <%= f.govuk_submit t(".continue") %>

--- a/config/locales/en/wizards/placements/add_hosting_interest_wizard.yml
+++ b/config/locales/en/wizards/placements/add_hosting_interest_wizard.yml
@@ -90,7 +90,7 @@ en:
         interested:
           phase_step:
             title: What education phase could you offer placements in?
-            hint: Sharing information on what you may be able to offer helps providers know whether to contact you. It is not a commitment to take a trainee teacher.
+            hint: Select all that apply. Sharing information on what you may be able to offer helps providers know whether to contact you. It is not a commitment to take a trainee teacher.
             caption: Potential placement offer details
             continue: Continue
             options:

--- a/config/locales/en/wizards/placements/multi_placement_wizard.yml
+++ b/config/locales/en/wizards/placements/multi_placement_wizard.yml
@@ -35,6 +35,7 @@ en:
         phase_step:
           caption: Placement details
           title: What education phase can your placements be?
+          hint: Select all that apply
           options:
             primary_description: 3 to 11 years
             secondary_description: 11 to 19 years

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_add_their_hosting_interest_and_bulk_adds_placements_for_the_primary_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_add_their_hosting_interest_and_bulk_adds_placements_for_the_primary_phase_spec.rb
@@ -114,6 +114,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe "School user does not enter a placement quantity",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_does_not_select_a_year_group_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_does_not_select_a_year_group_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe "School user does not select a year group",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe "School user enters a float as a placement quantity",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe "School user enters zero as a placement quantity",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
@@ -177,6 +177,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/school_user_does_not_select_a_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/school_user_does_not_select_a_phase_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe "School user does not select a phases",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
@@ -126,6 +126,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_adds_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_adds_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
@@ -112,6 +112,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
@@ -86,6 +86,7 @@ RSpec.describe "School user does not enter a placement quantity",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
@@ -94,6 +94,7 @@ RSpec.describe "School user does not select a child subjects",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
@@ -199,6 +199,10 @@ RSpec.describe "School user completes the interested journey and declares primar
       text: "What education phase could you offer placements in?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint(
+      "Select all that apply. Sharing information on what you may be able to offer helps providers know whether to contact you." \
+        " It is not a commitment to take a trainee teacher.",
+    )
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
     expect(page).to have_field("I don’t know", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_child_subjects_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_child_subjects_spec.rb
@@ -190,6 +190,10 @@ RSpec.describe "School user completes the interested journey without declaring c
       text: "What education phase could you offer placements in?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint(
+      "Select all that apply. Sharing information on what you may be able to offer helps providers know whether to contact you." \
+        " It is not a commitment to take a trainee teacher.",
+    )
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
     expect(page).to have_field("I don’t know", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_potential_placement_details_spec.rb
@@ -161,6 +161,10 @@ RSpec.describe "School user completes the interested journey without declaring p
       text: "What education phase could you offer placements in?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint(
+      "Select all that apply. Sharing information on what you may be able to offer helps providers know whether to contact you." \
+        " It is not a commitment to take a trainee teacher.",
+    )
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
     expect(page).to have_field("I don’t know", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_quantities_for_potential_placements_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_quantities_for_potential_placements_spec.rb
@@ -191,6 +191,10 @@ RSpec.describe "School user completes the interested journey without declaring q
       text: "What education phase could you offer placements in?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint(
+      "Select all that apply. Sharing information on what you may be able to offer helps providers know whether to contact you." \
+        " It is not a commitment to take a trainee teacher.",
+    )
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
     expect(page).to have_field("I don’t know", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_specific_year_groups_or_subjects_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_specific_year_groups_or_subjects_spec.rb
@@ -182,6 +182,10 @@ RSpec.describe "School user completes the interested journey without declaring s
       text: "What education phase could you offer placements in?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint(
+      "Select all that apply. Sharing information on what you may be able to offer helps providers know whether to contact you." \
+        " It is not a commitment to take a trainee teacher.",
+    )
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
     expect(page).to have_field("I don’t know", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_does_not_enter_any_school_contact_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_does_not_enter_any_school_contact_details_spec.rb
@@ -119,6 +119,10 @@ RSpec.describe "School user does not enter any school contact details",
       text: "What education phase could you offer placements in?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint(
+      "Select all that apply. Sharing information on what you may be able to offer helps providers know whether to contact you." \
+        " It is not a commitment to take a trainee teacher.",
+    )
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
     expect(page).to have_field("I don’t know", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
@@ -123,6 +123,7 @@ RSpec.describe "School user does not enter a placement quantity",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_does_not_select_a_year_group_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_does_not_select_a_year_group_spec.rb
@@ -119,6 +119,7 @@ RSpec.describe "School user does not select a year group",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_the_primary_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_the_primary_phase_spec.rb
@@ -139,6 +139,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
@@ -124,6 +124,7 @@ RSpec.describe "School user enters a float as a placement quantity",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/primary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
@@ -126,6 +126,7 @@ RSpec.describe "School user enters zero as a placement quantity",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/school_user_does_not_select_a_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/school_user_does_not_select_a_phase_spec.rb
@@ -119,6 +119,7 @@ RSpec.describe "School user does not select a phases",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
@@ -195,6 +195,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
@@ -125,6 +125,7 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
@@ -133,6 +133,7 @@ RSpec.describe "School user does not select a child subjects",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
@@ -162,6 +162,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_edits_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_edits_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
@@ -142,6 +142,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
@@ -126,6 +126,7 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_actively_looking/secondary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
@@ -126,6 +126,7 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
@@ -20,8 +20,6 @@ RSpec.describe "School user completes the interested journey without declaring p
     and_i_click_on_continue
     then_i_see_the_phase_known_page
 
-    then_i_see_the_phase_known_page
-
     when_i_select_primary
     and_i_select_secondary
     and_i_click_on_continue
@@ -210,6 +208,10 @@ RSpec.describe "School user completes the interested journey without declaring p
       :legend,
       text: "What education phase could you offer placements in?",
       class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_hint(
+      "Select all that apply. Sharing information on what you may be able to offer helps providers know whether to contact you." \
+        " It is not a commitment to take a trainee teacher.",
     )
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_interested/school_user_completes_the_interested_journey_without_declaring_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interst/appetite_interested/school_user_completes_the_interested_journey_without_declaring_potential_placement_details_spec.rb
@@ -170,6 +170,10 @@ RSpec.describe "School user completes the interested journey without declaring p
       text: "What education phase could you offer placements in?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint(
+      "Select all that apply. Sharing information on what you may be able to offer helps providers know whether to contact you." \
+        " It is not a commitment to take a trainee teacher.",
+    )
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
     expect(page).to have_field("I don’t know", type: :checkbox)

--- a/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_bulk_adds_placements_for_the_primary_phase_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_bulk_adds_placements_for_the_primary_phase_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe "School user bulk adds placements for the primary phases",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe "School user does not enter a placement quantity",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_does_not_select_a_year_group_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_does_not_select_a_year_group_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe "School user does not select a year group",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe "School user enters a float as a placement quantity",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe "School user enters zero as a placement quantity",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/placements/bulk_add_placements/school_user_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/school_user_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
@@ -131,6 +131,7 @@ RSpec.describe "School user bulk adds placements for primary and secondary phase
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/placements/bulk_add_placements/school_user_does_not_select_a_phase_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/school_user_does_not_select_a_phase_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe "School user does not select a phases",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_adds_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_adds_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe "School user does not select a child subjects",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end

--- a/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
       text: "What education phase can your placements be?",
       class: "govuk-fieldset__legend",
     )
+    expect(page).to have_hint("Select all that apply")
     expect(page).to have_field("Primary", type: :checkbox)
     expect(page).to have_field("Secondary", type: :checkbox)
   end


### PR DESCRIPTION
## Context

- Add "Select all that apply" hint text to phase steps of HostingInterests and MultiPlacement Wizards

## Guidance to review

- Sign in as Anne (School user)
- Navigate to Edit your hosting interest if EOI does not appear on loading.
- Select "Yes - I can offer placements"
- Check the hint text appears.
- Click "Back"
- Select "Maybe - I’m not sure yet"
- Check the hint text appears.

## Link to Trello card

https://trello.com/c/DqiztNFW/693-add-select-all-that-apply-to-the-phase-of-education-for-green-path-and-amber-path

## Screenshots

_Green path_

![screencapture-placements-localhost-3000-schools-00099662-671e-42d4-8547-112c8d8c43c1-hosting-interests-new-3b95345f-ebe9-4b6c-9cbf-6aaf0c219962-phase-2025-06-05-10_50_11](https://github.com/user-attachments/assets/00ac75a0-f957-4e9c-8a38-2aa526f75227)

_Amber path_

![screencapture-placements-localhost-3000-schools-00099662-671e-42d4-8547-112c8d8c43c1-hosting-interests-new-3b95345f-ebe9-4b6c-9cbf-6aaf0c219962-phase-2025-06-05-10_50_23](https://github.com/user-attachments/assets/5827e10e-6bc0-447c-8c58-15af84a4f65c)
