### PR TITLE
Assign last placement warning

### DIFF
--- a/app/controllers/placements/schools/placements/edit_placement_controller.rb
+++ b/app/controllers/placements/schools/placements/edit_placement_controller.rb
@@ -35,7 +35,14 @@ class Placements::Schools::Placements::EditPlacementController < Placements::App
   def set_wizard
     state = session[state_key] ||= {}
     current_step = params.fetch(:step).to_sym
-    @wizard = Placements::EditPlacementWizard.new(school:, placement: @placement, state:, params:, current_step:)
+    @wizard = Placements::EditPlacementWizard.new(
+      school:,
+      placement: @placement,
+      state:,
+      params:,
+      current_step:,
+      current_user:,
+    )
   end
 
   def authorize_placement

--- a/app/queries/placements/schools_query.rb
+++ b/app/queries/placements/schools_query.rb
@@ -72,7 +72,8 @@ class Placements::SchoolsQuery < ApplicationQuery
     end
 
     if hosting_interests.include?("filled_placements")
-      conditions << scope.where(hosting_interests: { appetite: "actively_looking" }, placements: { academic_year_id: academic_year.id }).excluding(scope.where(placements: { provider: nil }))
+      conditions << scope.where(hosting_interests: { appetite: "actively_looking" }, placements: { academic_year_id: academic_year.id })
+        .excluding(scope.where(placements: { academic_year_id: academic_year.id, provider: nil }))
     end
 
     conditions.reduce(scope.none) { |combined_scope, condition| combined_scope.or(condition) }

--- a/app/views/wizards/placements/edit_placement_wizard/_assign_last_placement_step.html.erb
+++ b/app/views/wizards/placements/edit_placement_wizard/_assign_last_placement_step.html.erb
@@ -1,0 +1,21 @@
+<% content_for :page_title, title_with_error_prefix(
+  t(".page_title", contextual_text:),
+  error: current_step.errors.any?,
+) %>
+
+<%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
+  <%= f.govuk_error_summary %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <span class="govuk-caption-l"><%= contextual_text %></span>
+      <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+
+      <p class="govuk-body"><%= t(".you_status_will_change") %></p>
+
+      <p class="govuk-body"><%= t(".you_can_add_more_placements") %></p>
+
+      <%= f.govuk_submit t(".assign_provider") %>
+    </div>
+  </div>
+<% end %>

--- a/app/wizards/placements/edit_placement_wizard/assign_last_placement_step.rb
+++ b/app/wizards/placements/edit_placement_wizard/assign_last_placement_step.rb
@@ -1,0 +1,2 @@
+class Placements::EditPlacementWizard::AssignLastPlacementStep < BaseStep
+end

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -55,6 +55,7 @@ en:
               mentors: Mentor updated
               provider: Provider updated
               provider_options: Provider updated
+              assign_last_placement: Provider updated
               year_group: Year group updated
               terms: Expected date updated
           edit:

--- a/config/locales/en/wizards/placements/edit_placement_wizard.yml
+++ b/config/locales/en/wizards/placements/edit_placement_wizard.yml
@@ -14,3 +14,11 @@ en:
         provider_options_step:
           title: "%{organisation_count} results found for ‘%{search_param}’ - %{contextual_text}"
           continue: Continue
+        assign_last_placement_step:
+          page_title: You are assigning your last available placement to a provider - %{contextual_text}
+          title: You are assigning your last available placement to a provider
+          assign_provider: Assign provider
+          you_status_will_change: 
+            Your status will be set to ‘no placements available’. Providers will no longer contact you about available placements.
+          you_can_add_more_placements:
+            You can add more placements at anytime.

--- a/spec/system/placements/schools/placements/primary_school_user_edits_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/primary_school_user_edits_a_placement_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
       partner_providers: [@aes_sedai_provider, @ashaman_provider],
     )
 
-    @primary_english_subject = build(:subject, name: "Primary with english", subject_area: :primary)
+    @primary_subject = build(:subject, name: "Primary", subject_area: :primary)
 
     @autumn_term = build(:placements_term, name: "Autumn term")
     @spring_term = create(:placements_term, name: "Spring term")
@@ -140,10 +140,17 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
     @placement = create(
       :placement,
       school: @springfield_elementary_school,
-      subject: @primary_english_subject,
+      subject: @primary_subject,
       year_group: :year_1,
       academic_year: @next_academic_year,
       terms: [@autumn_term],
+    )
+    _another_placement = create(
+      :placement,
+      school: @springfield_elementary_school,
+      subject: @primary_subject,
+      year_group: :year_5,
+      academic_year: @next_academic_year,
     )
   end
 
@@ -161,18 +168,20 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   alias_method :then_i_see_the_placements_index_page, :when_i_am_on_the_placements_index_page
 
   def then_i_see_my_placement
-    expect(page).to have_element(:td, text: "Primary with english (Year 1)", class: "govuk-table__cell")
-    expect(page).to have_element(:td, text: "Mentor not assigned", class: "govuk-table__cell")
-    expect(page).to have_element(:td, text: "Autumn term", class: "govuk-table__cell")
-    expect(page).to have_element(:td, text: "Provider not assigned", class: "govuk-table__cell")
+    expect(page).to have_table_row({
+      "Placement" => "Primary (Year 1)",
+      "Mentor" => "Mentor not assigned",
+      "Expected date" => "Autumn term",
+      "Provider" => "Provider not assigned",
+    })
   end
 
   def when_i_click_on_my_placement
-    click_on "Primary with english (Year 1)"
+    click_on "Primary (Year 1)"
   end
 
   def then_i_see_the_placement_details_page
-    expect(page).to have_title("Primary with english (Year 1) - Manage school placements - GOV.UK")
+    expect(page).to have_title("Primary (Year 1) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
@@ -237,7 +246,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   end
 
   def then_i_see_the_placement_details_page_with_my_updated_year_group
-    expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
+    expect(page).to have_title("Primary (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
@@ -260,7 +269,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
     expect(page).to have_h1("Placements")
     expect(page).to have_element(:a, text: "Add placement", class: "govuk-button")
     expect(page).to have_table_row({
-      "Placement" => "Primary with english (Year 2)",
+      "Placement" => "Primary (Year 2)",
       "Mentor" => "Mentor not assigned",
       "Expected date" => "Autumn term",
       "Provider" => "Provider not assigned",
@@ -268,7 +277,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   end
 
   def when_i_click_on_my_placement_with_updated_year_group
-    click_on "Primary with english (Year 2)"
+    click_on "Primary (Year 2)"
   end
 
   def when_i_click_on_change_expected_date
@@ -296,7 +305,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   end
 
   def then_i_see_the_placement_details_page_with_my_updated_term
-    expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
+    expect(page).to have_title("Primary (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:strong, text: "Available", class: "govuk-tag govuk-tag--green")
     expect(page).to have_summary_list_row("Subject", "Primary")
@@ -348,7 +357,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   end
 
   def then_i_see_the_placement_details_page_with_john_smith
-    expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
+    expect(page).to have_title("Primary (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:strong, text: "Available", class: "govuk-tag govuk-tag--green")
     expect(page).to have_summary_list_row("Subject", "Primary")
@@ -427,7 +436,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   end
 
   def then_i_see_the_placement_details_page_with_aes_sedai_trust
-    expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
+    expect(page).to have_title("Primary (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_tag("Assigned to provider", "blue")
     expect(page).to have_summary_list_row("Subject", "Primary")
@@ -453,11 +462,11 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
 
   def then_i_see_the_confirmation_page
     expect(page).to have_title(
-      "Are you sure you want to remove Aes Sedai Trust from this placement? - Primary with english (Year 2) - Manage school placements - GOV.UK",
+      "Are you sure you want to remove Aes Sedai Trust from this placement? - Primary (Year 2) - Manage school placements - GOV.UK",
     )
     expect(page).to have_element(
       :span,
-      text: "Primary with english (Year 2)",
+      text: "Primary (Year 2)",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1(
@@ -490,7 +499,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   end
 
   def then_i_see_the_placement_details_page_with_the_ashaman_trust
-    expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
+    expect(page).to have_title("Primary (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_tag("Unavailable", "orange")
     expect(page).to have_summary_list_row("Subject", "Primary")
@@ -507,9 +516,9 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   end
 
   def then_i_see_the_preview_placement_page
-    expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
+    expect(page).to have_title("Primary (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Placement - Springfield Elementary\nPrimary with english (Year 2)")
+    expect(page).to have_h1("Placement - Springfield Elementary\nPrimary (Year 2)")
     expect(page).to have_important_banner("This is a preview of how your placement appears to teacher training providers.")
     expect(page).to have_h2("Placement dates")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")

--- a/spec/system/placements/schools/placements/primary_school_user_edits_a_placement_with_javascript_disabled_spec.rb
+++ b/spec/system/placements/schools/placements/primary_school_user_edits_a_placement_with_javascript_disabled_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe "Primary school user edits a placement with javascript disabled",
       partner_providers: [@aes_sedai_provider, @ashaman_provider],
     )
 
-    @primary_english_subject = build(:subject, name: "Primary with english", subject_area: :primary)
+    @primary_subject = build(:subject, name: "Primary", subject_area: :primary)
 
     @autumn_term = build(:placements_term, name: "Autumn term")
     @spring_term = create(:placements_term, name: "Spring term")
@@ -145,10 +145,17 @@ RSpec.describe "Primary school user edits a placement with javascript disabled",
     @placement = create(
       :placement,
       school: @springfield_elementary_school,
-      subject: @primary_english_subject,
+      subject: @primary_subject,
       year_group: :year_1,
       academic_year: @next_academic_year,
       terms: [@autumn_term],
+    )
+    _another_placement = create(
+      :placement,
+      school: @springfield_elementary_school,
+      subject: @primary_subject,
+      year_group: :year_5,
+      academic_year: @next_academic_year,
     )
   end
 
@@ -166,18 +173,20 @@ RSpec.describe "Primary school user edits a placement with javascript disabled",
   alias_method :then_i_see_the_placements_index_page, :when_i_am_on_the_placements_index_page
 
   def then_i_see_my_placement
-    expect(page).to have_element(:td, text: "Primary with english (Year 1)", class: "govuk-table__cell")
-    expect(page).to have_element(:td, text: "Mentor not assigned", class: "govuk-table__cell")
-    expect(page).to have_element(:td, text: "Autumn term", class: "govuk-table__cell")
-    expect(page).to have_element(:td, text: "Provider not assigned", class: "govuk-table__cell")
+    expect(page).to have_table_row({
+      "Placement" => "Primary (Year 1)",
+      "Mentor" => "Mentor not assigned",
+      "Expected date" => "Autumn term",
+      "Provider" => "Provider not assigned",
+    })
   end
 
   def when_i_click_on_my_placement
-    click_on "Primary with english (Year 1)"
+    click_on "Primary (Year 1)"
   end
 
   def then_i_see_the_placement_details_page
-    expect(page).to have_title("Primary with english (Year 1) - Manage school placements - GOV.UK")
+    expect(page).to have_title("Primary (Year 1) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
@@ -244,7 +253,7 @@ RSpec.describe "Primary school user edits a placement with javascript disabled",
                :and_i_click_on_continue
 
   def then_i_see_the_placement_details_page_with_my_updated_year_group
-    expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
+    expect(page).to have_title("Primary (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
@@ -285,7 +294,7 @@ RSpec.describe "Primary school user edits a placement with javascript disabled",
   end
 
   def then_i_see_the_placement_details_page_with_my_updated_term
-    expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
+    expect(page).to have_title("Primary (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:strong, text: "Available", class: "govuk-tag govuk-tag--green")
     expect(page).to have_summary_list_row("Subject", "Primary")
@@ -337,7 +346,7 @@ RSpec.describe "Primary school user edits a placement with javascript disabled",
   end
 
   def then_i_see_the_placement_details_page_with_john_smith
-    expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
+    expect(page).to have_title("Primary (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:strong, text: "Available", class: "govuk-tag govuk-tag--green")
     expect(page).to have_summary_list_row("Subject", "Primary")
@@ -400,7 +409,7 @@ RSpec.describe "Primary school user edits a placement with javascript disabled",
   end
 
   def then_i_see_the_placement_details_page_with_aes_sedai_trust
-    expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
+    expect(page).to have_title("Primary (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_tag("Assigned to provider", "blue")
     expect(page).to have_summary_list_row("Subject", "Primary")
@@ -426,11 +435,11 @@ RSpec.describe "Primary school user edits a placement with javascript disabled",
 
   def then_i_see_the_confirmation_page
     expect(page).to have_title(
-      "Are you sure you want to remove Aes Sedai Trust from this placement? - Primary with english (Year 2) - Manage school placements - GOV.UK",
+      "Are you sure you want to remove Aes Sedai Trust from this placement? - Primary (Year 2) - Manage school placements - GOV.UK",
     )
     expect(page).to have_element(
       :span,
-      text: "Primary with english (Year 2)",
+      text: "Primary (Year 2)",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1(
@@ -467,7 +476,7 @@ RSpec.describe "Primary school user edits a placement with javascript disabled",
   end
 
   def then_i_see_the_placement_details_page_with_the_ashaman_trust
-    expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
+    expect(page).to have_title("Primary (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_tag("Unavailable", "orange")
     expect(page).to have_summary_list_row("Subject", "Primary")
@@ -484,9 +493,9 @@ RSpec.describe "Primary school user edits a placement with javascript disabled",
   end
 
   def then_i_see_the_preview_placement_page
-    expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
+    expect(page).to have_title("Primary (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Placement - Springfield Elementary Primary with english (Year 2)")
+    expect(page).to have_h1("Placement - Springfield Elementary Primary (Year 2)")
     expect(page).to have_important_banner("This is a preview of how your placement appears to teacher training providers.")
     expect(page).to have_h2("Placement dates")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")

--- a/spec/system/placements/schools/placements/school_user_assigns_a_provider_to_the_schools_last_available_placement_spec.rb
+++ b/spec/system/placements/schools/placements/school_user_assigns_a_provider_to_the_schools_last_available_placement_spec.rb
@@ -1,0 +1,183 @@
+require "rails_helper"
+
+RSpec.describe "School user assigns a provider to the school's last available placement",
+               :js,
+               service: :placements,
+               type: :system do
+  scenario do
+    given_that_placements_exist
+    and_i_am_signed_in
+
+    when_i_am_on_the_placements_index_page
+    then_i_see_my_placement
+
+    when_i_click_on_my_placement
+    then_i_see_the_placement_details_page
+
+    when_i_click_on_assign_a_provider
+    and_i_enter_aes_sedai_trust
+    then_i_see_a_dropdown_item_for_aes_sedai_trust
+
+    when_i_click_on_the_aes_sedai_trust_dropdown_item
+    and_i_click_on_continue
+    then_i_see_the_assigning_the_last_placement_page
+
+    when_i_click_on_assign_provider
+    then_i_see_the_placement_details_page_with_aes_sedai_trust
+    and_i_see_a_provider_updated_success_message
+  end
+
+  private
+
+  def given_that_placements_exist
+    @aes_sedai_provider = build(:placements_provider, name: "Aes Sedai Trust", code: "111", postcode: "BR11RP")
+    @ashaman_provider = build(:placements_provider, name: "Ashaman Trust")
+
+    @springfield_elementary_school = build(
+      :placements_school,
+      name: "Springfield Elementary",
+      address1: "Westgate Street",
+      address2: "Hackney",
+      postcode: "E8 3RL",
+      group: "Local authority maintained schools",
+      phase: "Primary",
+      gender: "Mixed",
+      minimum_age: 3,
+      maximum_age: 11,
+      religious_character: "Does not apply",
+      admissions_policy: "Not applicable",
+      urban_or_rural: "(England/Wales) Urban major conurbation",
+      percentage_free_school_meals: 15,
+      rating: "Outstanding",
+      partner_providers: [@aes_sedai_provider, @ashaman_provider],
+    )
+
+    @primary_subject = build(:subject, name: "Primary", subject_area: :primary)
+
+    @autumn_term = build(:placements_term, name: "Autumn term")
+    @spring_term = create(:placements_term, name: "Spring term")
+    @summer_term = create(:placements_term, name: "Summer term")
+
+    @mentor_john_smith = create(:placements_mentor, first_name: "John", last_name: "Smith", schools: [@springfield_elementary_school])
+    @mentor_jane_doe = create(:placements_mentor, first_name: "Jane", last_name: "Doe", schools: [@springfield_elementary_school])
+
+    @next_academic_year = Placements::AcademicYear.current.next
+    @next_academic_year_name = @next_academic_year.name
+
+    @placement = create(
+      :placement,
+      school: @springfield_elementary_school,
+      subject: @primary_subject,
+      year_group: :year_1,
+      academic_year: @next_academic_year,
+      terms: [@autumn_term],
+    )
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@springfield_elementary_school])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Placements")
+    expect(page).to have_element(:a, text: "Add placement", class: "govuk-button")
+  end
+
+  alias_method :then_i_see_the_placements_index_page, :when_i_am_on_the_placements_index_page
+
+  def then_i_see_my_placement
+    expect(page).to have_table_row({
+      "Placement" => "Primary (Year 1)",
+      "Mentor" => "Mentor not assigned",
+      "Expected date" => "Autumn term",
+      "Provider" => "Provider not assigned",
+    })
+  end
+
+  def when_i_click_on_my_placement
+    click_on "Primary (Year 1)"
+  end
+
+  def then_i_see_the_placement_details_page
+    expect(page).to have_title("Primary (Year 1) - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_tag("Available", "green")
+    expect(page).to have_summary_list_row("Subject", "Primary")
+    expect(page).to have_summary_list_row("Year group", "Year 1")
+    expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
+    expect(page).to have_summary_list_row("Expected date", "Autumn term")
+    expect(page).to have_summary_list_row("Mentor", "Select a mentor")
+    expect(page).to have_summary_list_row("Provider", "Assign a provider")
+    expect(page).to have_element(:div, text: "You can preview this placement as it appears to providers.", class: "govuk-inset-text")
+    expect(page).to have_link("Delete placement", href: "/schools/#{@springfield_elementary_school.id}/placements/#{@placement.id}/remove")
+  end
+
+  def when_i_click_on_assign_a_provider
+    click_on "Assign a provider"
+  end
+
+  def then_i_see_the_select_a_provider_page
+    expect(page).to have_title("Select a provider - Placement details - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:label, text: "Select a provider", class: "govuk-label--l")
+    expect(page).to have_button("Continue")
+    expect(page).to have_link("Cancel", href: "/schools/#{@springfield_elementary_school.id}/placements/#{@placement.id}")
+  end
+
+  def and_i_enter_aes_sedai_trust
+    fill_in "Select a provider", with: "Aes Sedai Trust"
+  end
+
+  def then_i_see_a_dropdown_item_for_aes_sedai_trust
+    expect(page).to have_css(".autocomplete__option", text: "Aes Sedai Trust (BR11RP, 111)", wait: 10)
+  end
+
+  def when_i_click_on_the_aes_sedai_trust_dropdown_item
+    page.find(".autocomplete__option", text: "Aes Sedai Trust").click
+  end
+
+  def and_i_click_on_continue
+    click_on "Continue"
+  end
+
+  def then_i_see_the_assigning_the_last_placement_page
+    expect(page).to have_title(
+      "You are assigning your last available placement to a provider - Placement details - Manage school placements - GOV.UK",
+    )
+    expect(page).to have_span_caption("Placement details")
+    expect(page).to have_h1("You are assigning your last available placement to a provider")
+    expect(page).to have_paragraph(
+      "Your status will be set to ‘no placements available’. Providers will no longer contact you about available placements.",
+    )
+    expect(page).to have_paragraph("You can add more placements at anytime.")
+    expect(page).to have_button("Assign provider", class: "govuk-button")
+    expect(page).to have_link(
+      "Cancel",
+      href: placements_school_placement_path(@springfield_elementary_school, @placement),
+    )
+  end
+
+  def when_i_click_on_assign_provider
+    click_on "Assign provider"
+  end
+
+  def then_i_see_the_placement_details_page_with_aes_sedai_trust
+    expect(page).to have_title("Primary (Year 1) - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_tag("Assigned to provider", "blue")
+    expect(page).to have_summary_list_row("Subject", "Primary")
+    expect(page).to have_summary_list_row("Year group", "Year 1")
+    expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
+    expect(page).to have_summary_list_row("Expected date", "Autumn term")
+    expect(page).to have_summary_list_row("Mentor", "Select a mentor")
+    expect(page).to have_summary_list_row("Provider", "Aes Sedai Trust")
+    expect(page).to have_element(:div, text: "You can preview this placement as it appears to providers.", class: "govuk-inset-text")
+  end
+
+  def and_i_see_a_provider_updated_success_message
+    expect(page).to have_success_banner("Provider updated")
+  end
+end

--- a/spec/system/placements/schools/placements/secondary_school_user_edits_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/secondary_school_user_edits_a_placement_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
     )
 
     @secondary_english_subject = build(:subject, name: "English", subject_area: :secondary)
+    @secondary_science_subject = build(:subject, name: "Science", subject_area: :secondary)
 
     @autumn_term = build(:placements_term, name: "Autumn term")
     @spring_term = create(:placements_term, name: "Spring term")
@@ -128,6 +129,12 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
       subject: @secondary_english_subject,
       academic_year: @next_academic_year,
       terms: [@autumn_term],
+    )
+    _another_placement = create(
+      :placement,
+      school: @hogwarts_school,
+      subject: @secondary_science_subject,
+      academic_year: @next_academic_year,
     )
   end
 
@@ -152,10 +159,12 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
   end
 
   def and_i_see_my_placement
-    expect(page).to have_element(:td, text: "English", class: "govuk-table__cell")
-    expect(page).to have_element(:td, text: "Mentor not assigned", class: "govuk-table__cell")
-    expect(page).to have_element(:td, text: "Autumn term", class: "govuk-table__cell")
-    expect(page).to have_element(:td, text: "Provider not assigned", class: "govuk-table__cell")
+    expect(page).to have_table_row({
+      "Placement" => "English",
+      "Mentor" => "Mentor not assigned",
+      "Expected date" => "Autumn term",
+      "Provider" => "Provider not assigned",
+    })
   end
 
   def when_i_click_on_my_placement

--- a/spec/system/placements/schools/placements/secondary_school_user_edits_a_placement_with_javascript_disabled_spec.rb
+++ b/spec/system/placements/schools/placements/secondary_school_user_edits_a_placement_with_javascript_disabled_spec.rb
@@ -120,6 +120,7 @@ RSpec.describe "Secondary school user edits a placement with javascript disabled
     )
 
     @secondary_english_subject = build(:subject, name: "English", subject_area: :secondary)
+    @secondary_science_subject = build(:subject, name: "Science", subject_area: :secondary)
 
     @autumn_term = build(:placements_term, name: "Autumn term")
     @spring_term = create(:placements_term, name: "Spring term")
@@ -137,6 +138,12 @@ RSpec.describe "Secondary school user edits a placement with javascript disabled
       subject: @secondary_english_subject,
       academic_year: @next_academic_year,
       terms: [@autumn_term],
+    )
+    _another_placement = create(
+      :placement,
+      school: @hogwarts_school,
+      subject: @secondary_science_subject,
+      academic_year: @next_academic_year,
     )
   end
 
@@ -161,10 +168,12 @@ RSpec.describe "Secondary school user edits a placement with javascript disabled
   end
 
   def and_i_see_my_placement
-    expect(page).to have_element(:td, text: "English", class: "govuk-table__cell")
-    expect(page).to have_element(:td, text: "Mentor not assigned", class: "govuk-table__cell")
-    expect(page).to have_element(:td, text: "Autumn term", class: "govuk-table__cell")
-    expect(page).to have_element(:td, text: "Provider not assigned", class: "govuk-table__cell")
+    expect(page).to have_table_row({
+      "Placement" => "English",
+      "Mentor" => "Mentor not assigned",
+      "Expected date" => "Autumn term",
+      "Provider" => "Provider not assigned",
+    })
   end
 
   def when_i_click_on_my_placement

--- a/spec/system/placements/support/schools/placements/primary_school_support_user_edits_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/primary_school_support_user_edits_a_placement_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
       partner_providers: [@aes_sedai_provider, @ashaman_provider],
     )
 
-    @primary_english_subject = build(:subject, name: "Primary with english", subject_area: :primary)
+    @primary_subject = build(:subject, name: "Primary", subject_area: :primary)
 
     @autumn_term = build(:placements_term, name: "Autumn term")
     @spring_term = create(:placements_term, name: "Spring term")
@@ -138,10 +138,17 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
     @placement = create(
       :placement,
       school: @springfield_elementary_school,
-      subject: @primary_english_subject,
+      subject: @primary_subject,
       year_group: :year_1,
       academic_year: @next_academic_year,
       terms: [@autumn_term],
+    )
+    _another_placement = create(
+      :placement,
+      school: @springfield_elementary_school,
+      subject: @primary_subject,
+      year_group: :year_5,
+      academic_year: @next_academic_year,
     )
   end
 
@@ -166,18 +173,20 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   end
 
   def and_i_see_my_placement
-    expect(page).to have_element(:td, text: "Primary with english (Year 1)", class: "govuk-table__cell")
-    expect(page).to have_element(:td, text: "Mentor not assigned", class: "govuk-table__cell")
-    expect(page).to have_element(:td, text: "Autumn term", class: "govuk-table__cell")
-    expect(page).to have_element(:td, text: "Provider not assigned", class: "govuk-table__cell")
+    expect(page).to have_table_row({
+      "Placement" => "Primary (Year 1)",
+      "Mentor" => "Mentor not assigned",
+      "Expected date" => "Autumn term",
+      "Provider" => "Provider not assigned",
+    })
   end
 
   def when_i_click_on_my_placement
-    click_on "Primary with english (Year 1)"
+    click_on "Primary (Year 1)"
   end
 
   def then_i_see_the_placement_details_page
-    expect(page).to have_title("Primary with english (Year 1) - Manage school placements - GOV.UK")
+    expect(page).to have_title("Primary (Year 1) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
@@ -242,7 +251,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   end
 
   def then_i_see_the_placement_details_page_with_my_updated_year_group
-    expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
+    expect(page).to have_title("Primary (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
@@ -283,7 +292,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   end
 
   def then_i_see_the_placement_details_page_with_my_updated_term
-    expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
+    expect(page).to have_title("Primary (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
@@ -335,7 +344,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   end
 
   def then_i_see_the_placement_details_page_with_john_smith
-    expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
+    expect(page).to have_title("Primary (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_tag("Available", "green")
     expect(page).to have_summary_list_row("Subject", "Primary")
@@ -434,7 +443,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   end
 
   def then_i_see_the_placement_details_page_with_aes_sedai_trust
-    expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
+    expect(page).to have_title("Primary (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_tag("Assigned to provider", "blue")
     expect(page).to have_summary_list_row("Subject", "Primary")
@@ -460,11 +469,11 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
 
   def then_i_see_the_confirmation_page
     expect(page).to have_title(
-      "Are you sure you want to remove Aes Sedai Trust from this placement? - Primary with english (Year 2) - Manage school placements - GOV.UK",
+      "Are you sure you want to remove Aes Sedai Trust from this placement? - Primary (Year 2) - Manage school placements - GOV.UK",
     )
     expect(page).to have_element(
       :span,
-      text: "Primary with english (Year 2)",
+      text: "Primary (Year 2)",
       class: "govuk-caption-l",
     )
     expect(page).to have_h1(
@@ -497,7 +506,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   end
 
   def then_i_see_the_placement_details_page_with_the_ashaman_trust
-    expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
+    expect(page).to have_title("Primary (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_tag("Unavailable", "orange")
     expect(page).to have_summary_list_row("Subject", "Primary")
@@ -514,9 +523,9 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
   end
 
   def then_i_see_the_preview_placement_page
-    expect(page).to have_title("Primary with english (Year 2) - Manage school placements - GOV.UK")
+    expect(page).to have_title("Primary (Year 2) - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Placement - Springfield Elementary\nPrimary with english (Year 2)")
+    expect(page).to have_h1("Placement - Springfield Elementary\nPrimary (Year 2)")
     expect(page).to have_important_banner("This is a preview of how your placement appears to teacher training providers.")
     expect(page).to have_h2("Placement dates")
     expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")

--- a/spec/system/placements/support/schools/placements/secondary_school_support_user_edits_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/secondary_school_support_user_edits_a_placement_spec.rb
@@ -5,8 +5,10 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
     given_that_placements_exist
     and_i_am_signed_in
 
-    when_i_am_on_the_placements_index_page
-    then_i_see_my_placement
+    when_i_am_on_the_organisations_index_page
+    and_i_select_hogwarts
+    then_i_see_the_placements_index_page
+    and_i_see_my_placement
 
     when_i_click_on_my_placement
     then_i_see_the_placement_details_page
@@ -109,6 +111,7 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
     )
 
     @secondary_english_subject = build(:subject, name: "English", subject_area: :secondary)
+    @secondary_science_subject = build(:subject, name: "Science", subject_area: :secondary)
 
     @autumn_term = build(:placements_term, name: "Autumn term")
     @spring_term = create(:placements_term, name: "Spring term")
@@ -127,10 +130,25 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
       academic_year: @next_academic_year,
       terms: [@autumn_term],
     )
+    _another_placement = create(
+      :placement,
+      school: @hogwarts_school,
+      subject: @secondary_science_subject,
+      academic_year: @next_academic_year,
+    )
   end
 
   def and_i_am_signed_in
-    sign_in_placements_user(organisations: [@hogwarts_school])
+    sign_in_placements_support_user
+  end
+
+  def when_i_am_on_the_organisations_index_page
+    expect(page).to have_title("Organisations (3) - Manage school placements - GOV.UK")
+    expect(page).to have_h1("Organisations (3)")
+  end
+
+  def and_i_select_hogwarts
+    click_on "Hogwarts"
   end
 
   def when_i_am_on_the_placements_index_page
@@ -142,11 +160,13 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
 
   alias_method :then_i_see_the_placements_index_page, :when_i_am_on_the_placements_index_page
 
-  def then_i_see_my_placement
-    expect(page).to have_element(:td, text: "English", class: "govuk-table__cell")
-    expect(page).to have_element(:td, text: "Mentor not assigned", class: "govuk-table__cell")
-    expect(page).to have_element(:td, text: "Autumn term", class: "govuk-table__cell")
-    expect(page).to have_element(:td, text: "Provider not assigned", class: "govuk-table__cell")
+  def and_i_see_my_placement
+    expect(page).to have_table_row({
+      "Placement" => "English",
+      "Mentor" => "Mentor not assigned",
+      "Expected date" => "Autumn term",
+      "Provider" => "Provider not assigned",
+    })
   end
 
   def when_i_click_on_my_placement

--- a/spec/system/placements/support/schools/placements/support_user_assigns_a_provider_to_the_schools_last_available_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/support_user_assigns_a_provider_to_the_schools_last_available_placement_spec.rb
@@ -1,0 +1,194 @@
+require "rails_helper"
+
+RSpec.describe "Support user assigns a provider to the schools last available placement",
+               :js,
+               service: :placements,
+               type: :system do
+  scenario do
+    given_that_placements_exist
+    and_i_am_signed_in
+
+    when_i_am_on_the_organisations_index_page
+    and_i_select_springfield_elementary
+    then_i_see_the_placements_index_page
+    and_i_see_my_placement
+
+    when_i_click_on_my_placement
+    then_i_see_the_placement_details_page
+
+    when_i_click_on_assign_a_provider
+    and_i_enter_aes_sedai_trust
+    then_i_see_a_dropdown_item_for_aes_sedai_trust
+
+    when_i_click_on_the_aes_sedai_trust_dropdown_item
+    and_i_click_on_continue
+    then_i_see_the_assigning_the_last_placement_page
+
+    when_i_click_on_assign_provider
+    then_i_see_the_placement_details_page_with_aes_sedai_trust
+    and_i_see_a_provider_updated_success_message
+  end
+
+  private
+
+  def given_that_placements_exist
+    @aes_sedai_provider = build(:placements_provider, name: "Aes Sedai Trust", code: "111", postcode: "BR11RP")
+    @ashaman_provider = build(:placements_provider, name: "Ashaman Trust")
+
+    @springfield_elementary_school = build(
+      :placements_school,
+      name: "Springfield Elementary",
+      address1: "Westgate Street",
+      address2: "Hackney",
+      postcode: "E8 3RL",
+      group: "Local authority maintained schools",
+      phase: "Primary",
+      gender: "Mixed",
+      minimum_age: 3,
+      maximum_age: 11,
+      religious_character: "Does not apply",
+      admissions_policy: "Not applicable",
+      urban_or_rural: "(England/Wales) Urban major conurbation",
+      percentage_free_school_meals: 15,
+      rating: "Outstanding",
+      partner_providers: [@aes_sedai_provider, @ashaman_provider],
+    )
+
+    @primary_subject = build(:subject, name: "Primary", subject_area: :primary)
+
+    @autumn_term = build(:placements_term, name: "Autumn term")
+    @spring_term = create(:placements_term, name: "Spring term")
+    @summer_term = create(:placements_term, name: "Summer term")
+
+    @mentor_john_smith = create(:placements_mentor, first_name: "John", last_name: "Smith", schools: [@springfield_elementary_school])
+    @mentor_jane_doe = create(:placements_mentor, first_name: "Jane", last_name: "Doe", schools: [@springfield_elementary_school])
+
+    @next_academic_year = Placements::AcademicYear.current.next
+    @next_academic_year_name = @next_academic_year.name
+
+    @placement = create(
+      :placement,
+      school: @springfield_elementary_school,
+      subject: @primary_subject,
+      year_group: :year_1,
+      academic_year: @next_academic_year,
+      terms: [@autumn_term],
+    )
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_support_user
+  end
+
+  def when_i_am_on_the_organisations_index_page
+    expect(page).to have_title("Organisations (3) - Manage school placements - GOV.UK")
+    expect(page).to have_h1("Organisations (3)")
+  end
+
+  def and_i_select_springfield_elementary
+    click_on "Springfield Elementary"
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Placements")
+    expect(page).to have_element(:a, text: "Add placement", class: "govuk-button")
+  end
+
+  alias_method :then_i_see_the_placements_index_page, :when_i_am_on_the_placements_index_page
+
+  def and_i_see_my_placement
+    expect(page).to have_table_row({
+      "Placement" => "Primary (Year 1)",
+      "Mentor" => "Mentor not assigned",
+      "Expected date" => "Autumn term",
+      "Provider" => "Provider not assigned",
+    })
+  end
+
+  def when_i_click_on_my_placement
+    click_on "Primary (Year 1)"
+  end
+
+  def then_i_see_the_placement_details_page
+    expect(page).to have_title("Primary (Year 1) - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_tag("Available", "green")
+    expect(page).to have_summary_list_row("Subject", "Primary")
+    expect(page).to have_summary_list_row("Year group", "Year 1")
+    expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
+    expect(page).to have_summary_list_row("Expected date", "Autumn term")
+    expect(page).to have_summary_list_row("Mentor", "Select a mentor")
+    expect(page).to have_summary_list_row("Provider", "Assign a provider")
+    expect(page).to have_element(:div, text: "You can preview this placement as it appears to providers.", class: "govuk-inset-text")
+    expect(page).to have_link("Delete placement", href: "/schools/#{@springfield_elementary_school.id}/placements/#{@placement.id}/remove")
+  end
+
+  def when_i_click_on_assign_a_provider
+    click_on "Assign a provider"
+  end
+
+  def then_i_see_the_select_a_provider_page
+    expect(page).to have_title("Select a provider - Placement details - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
+    expect(page).to have_element(:label, text: "Select a provider", class: "govuk-label--l")
+    expect(page).to have_button("Continue")
+    expect(page).to have_link("Cancel", href: "/schools/#{@springfield_elementary_school.id}/placements/#{@placement.id}")
+  end
+
+  def and_i_enter_aes_sedai_trust
+    fill_in "Select a provider", with: "Aes Sedai Trust"
+  end
+
+  def then_i_see_a_dropdown_item_for_aes_sedai_trust
+    expect(page).to have_css(".autocomplete__option", text: "Aes Sedai Trust (BR11RP, 111)", wait: 10)
+  end
+
+  def when_i_click_on_the_aes_sedai_trust_dropdown_item
+    page.find(".autocomplete__option", text: "Aes Sedai Trust").click
+  end
+
+  def and_i_click_on_continue
+    click_on "Continue"
+  end
+
+  def then_i_see_the_assigning_the_last_placement_page
+    expect(page).to have_title(
+      "You are assigning your last available placement to a provider - Placement details - Manage school placements - GOV.UK",
+    )
+    expect(page).to have_span_caption("Placement details")
+    expect(page).to have_h1("You are assigning your last available placement to a provider")
+    expect(page).to have_paragraph(
+      "Your status will be set to ‘no placements available’. Providers will no longer contact you about available placements.",
+    )
+    expect(page).to have_paragraph("You can add more placements at anytime.")
+    expect(page).to have_button("Assign provider", class: "govuk-button")
+    expect(page).to have_link(
+      "Cancel",
+      href: placements_school_placement_path(@springfield_elementary_school, @placement),
+    )
+  end
+
+  def when_i_click_on_assign_provider
+    click_on "Assign provider"
+  end
+
+  def then_i_see_the_placement_details_page_with_aes_sedai_trust
+    expect(page).to have_title("Primary (Year 1) - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_tag("Assigned to provider", "blue")
+    expect(page).to have_summary_list_row("Subject", "Primary")
+    expect(page).to have_summary_list_row("Year group", "Year 1")
+    expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
+    expect(page).to have_summary_list_row("Expected date", "Autumn term")
+    expect(page).to have_summary_list_row("Mentor", "Select a mentor")
+    expect(page).to have_summary_list_row("Provider", "Aes Sedai Trust")
+    expect(page).to have_element(:div, text: "You can preview this placement as it appears to providers.", class: "govuk-inset-text")
+  end
+
+  def and_i_see_a_provider_updated_success_message
+    expect(page).to have_success_banner("Provider updated")
+  end
+end

--- a/spec/wizards/placements/edit_placement_wizard_spec.rb
+++ b/spec/wizards/placements/edit_placement_wizard_spec.rb
@@ -1,15 +1,16 @@
 require "rails_helper"
 
 RSpec.describe Placements::EditPlacementWizard do
-  subject(:wizard) { described_class.new(state:, placement:, params:, school:, current_step:) }
+  subject(:wizard) { described_class.new(state:, placement:, params:, school:, current_step:, current_user:) }
 
   let(:school) { build(:placements_school, :primary, mentors:, partner_providers:) }
-  let(:placement) { create(:placement, school:) }
+  let(:placement) { create(:placement, school:, academic_year: current_user.selected_academic_year) }
   let(:state) { {} }
   let(:params_data) { { id: placement.id } }
   let(:params) { ActionController::Parameters.new(params_data) }
   let(:mentors) { build_list(:placements_mentor, 5) }
   let(:partner_providers) { build_list(:provider, 5) }
+  let(:current_user) { create(:placements_user, schools: [school]) }
 
   describe "#steps" do
     subject { wizard.steps.keys }
@@ -27,10 +28,16 @@ RSpec.describe Placements::EditPlacementWizard do
           }
         end
 
-        it { is_expected.to eq %i[provider] }
+        it { is_expected.to eq %i[provider assign_last_placement] }
       end
 
       context "when provider id is not set in the provider step" do
+        it { is_expected.to eq %i[provider provider_options assign_last_placement] }
+      end
+
+      context "when the this placement is not the last unassigned placement" do
+        before { create(:placement, school:, academic_year: current_user.selected_academic_year) }
+
         it { is_expected.to eq %i[provider provider_options] }
       end
     end


### PR DESCRIPTION
## Context

- Add a warning to users when the last unassigned placement is assigned to a provider.

## Changes proposed in this pull request

- Add a new AssignLastPlacementStep to the EditPlacementWizard

## Guidance to review

- Sign in as Anne (School user)
- (Assuming you have only 1 placement NOT assigned to a provider)
- Click on the last available placement
- Click "Assign a provider"
- Assign a provider and click continue
- You should see an additional warning page

## Link to Trello card

https://trello.com/c/oEEl3veB/703-when-removing-provider-from-last-assigned-placement-warn-user-about-their-status

## Screenshots


