### PR TITLE
704 when removing last placement redirect user back to eoi flow

### DIFF
--- a/app/controllers/placements/organisations_controller.rb
+++ b/app/controllers/placements/organisations_controller.rb
@@ -30,10 +30,10 @@ class Placements::OrganisationsController < Placements::ApplicationController
 
   def landing_page_path(organisation)
     if organisation.is_a?(School)
-      if organisation.expression_of_interest_completed?
-        placements_school_placements_path(organisation)
-      else
+      if organisation.new_hosting_interest_required?(academic_year: current_user.selected_academic_year)
         new_add_hosting_interest_placements_school_hosting_interests_path(organisation)
+      else
+        placements_school_placements_path(organisation)
       end
     elsif !Flipper.enabled?(:provider_hide_find_placements, organisation) # Provider
       placements_provider_find_index_path(organisation)

--- a/app/controllers/placements/schools/placements_controller.rb
+++ b/app/controllers/placements/schools/placements_controller.rb
@@ -33,10 +33,19 @@ class Placements::Schools::PlacementsController < Placements::ApplicationControl
   def destroy
     authorize @placement
 
-    @placement.destroy!
-    redirect_to index_path, flash: {
-      heading: t(".placement_deleted"),
-    }
+    if @school.last_placement_for_school?(placement: @placement)
+      @school.current_hosting_interest(academic_year: academic_year_scope).destroy!
+      @placement.destroy!
+      redirect_to new_add_hosting_interest_placements_school_hosting_interests_path(@school), flash: {
+        heading: t(".placement_deleted"),
+        body: t(".last_placement_deleted_body"),
+      }
+    else
+      @placement.destroy!
+      redirect_to index_path, flash: {
+        heading: t(".placement_deleted"),
+      }
+    end
   end
 
   def preview; end

--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -83,8 +83,4 @@ class Placement < ApplicationRecord
                      description: I18n.t("placements.schools.placements.year_groups.#{value}_description")
     end
   end
-
-  def last_placement_for_school?
-    school.placements.where.not(id: id).none?
-  end
 end

--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -83,4 +83,8 @@ class Placement < ApplicationRecord
                      description: I18n.t("placements.schools.placements.year_groups.#{value}_description")
     end
   end
+
+  def last_placement_for_school?
+    school.placements.where.not(id: id).none?
+  end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -163,6 +163,10 @@ class School < ApplicationRecord
     hosting_interests.find_by(academic_year:)
   end
 
+  def new_hosting_interest_required?(academic_year:)
+    current_hosting_interest(academic_year:).blank? || !expression_of_interest_completed?
+  end
+
   def available_placements(academic_year:)
     placements.available_placements_for_academic_year(academic_year)
   end
@@ -179,5 +183,9 @@ class School < ApplicationRecord
     return false if potential_placement_details.blank?
 
     potential_placement_details.dig("phase", "phases").include?("SEND")
+  end
+
+  def last_placement_for_school?(placement:)
+    placements.where.not(id: placement.id).where(academic_year: placement.academic_year).none?
   end
 end

--- a/app/views/placements/schools/placements/confirm_remove.html.erb
+++ b/app/views/placements/schools/placements/confirm_remove.html.erb
@@ -13,6 +13,10 @@
 
       <%= simple_format(t(".it_is_your_responsibility")) %>
 
+      <% if @placement.last_placement_for_school? %>
+        <%= govuk_warning_text text t.call(".last_placement_warning") %>
+      <% end %>
+
       <%= govuk_button_to t(".delete_placement"),
         placements_school_placement_path(@school, @placement),
         warning: true,

--- a/app/views/placements/schools/placements/confirm_remove.html.erb
+++ b/app/views/placements/schools/placements/confirm_remove.html.erb
@@ -11,10 +11,10 @@
       <span class="govuk-caption-l"><%= @placement.title %></span>
       <h1 class="govuk-heading-l"><%= t(".are_you_sure") %></h1>
 
-      <%= simple_format(t(".it_is_your_responsibility")) %>
+      <%= simple_format(t(".it_is_your_responsibility"), class: "govuk-body") %>
 
-      <% if @placement.last_placement_for_school? %>
-        <%= govuk_warning_text text t.call(".last_placement_warning") %>
+      <% if @school.last_placement_for_school?(placement: @placement) %>
+        <%= govuk_warning_text text: t(".last_placement_warning") %>
       <% end %>
 
       <%= govuk_button_to t(".delete_placement"),

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -165,6 +165,7 @@ en:
           description: '%{provider_name} must be removed from the placement before you can delete it.'
         destroy:
           placement_deleted: Placement deleted
+          last_placement_deleted_body: You no longer have placement information available. Confirm your placement availability so providers know whether to contact you.
         confirm_unassign_provider:
           page_title: "Are you sure you want to remove %{provider_name} from this placement? - %{subject_names}"
           are_you_sure: Are you sure you want to remove %{provider_name} from this placement?

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -157,6 +157,7 @@ en:
           are_you_sure: Are you sure you want to delete this placement?
           cancel: Cancel
           it_is_your_responsibility: It is your responsibility to make sure that anyone relevant to organising this placement is aware it is being deleted.
+          last_placement_warning: You are deleting your last placement. We will ask you to confirm your placement availability so providers can know whether to contact you.
           delete_placement: Delete placement
         can_not_remove:
           page_title: "You cannot delete this placement - %{subject_names}"

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -104,11 +104,19 @@ FactoryBot.define do
             class: "Placements::School",
             parent: :school, traits: %i[placements] do
       transient do
+        hosting_interests { [] }
+        with_hosting_interest { true }
         with_school_contact { true }
       end
 
       after(:build) do |school, evaluator|
         create(:school_contact, school:) if evaluator.with_school_contact
+
+        if evaluator.hosting_interests.present?
+          school.hosting_interests.concat(evaluator.hosting_interests)
+        elsif evaluator.with_hosting_interest
+          create(:hosting_interest, school:, academic_year: Placements::AcademicYear.current.next)
+        end
       end
     end
   end

--- a/spec/models/placements/school_spec.rb
+++ b/spec/models/placements/school_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Placements::School do
     end
 
     context "when there are multiple hosting interests" do
-      let(:current_hosting_interest) { build(:hosting_interest) }
+      let(:current_hosting_interest) { build(:hosting_interest, academic_year: academic_year) }
       let(:previous_hosting_interest) { build(:hosting_interest, academic_year: academic_year.previous) }
       let(:hosting_interests) { [current_hosting_interest, previous_hosting_interest] }
 

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -249,4 +249,25 @@ RSpec.describe School, type: :model do
       end
     end
   end
+
+  describe "#last_placement_for_school?" do
+    let(:school) { create(:placements_school) }
+    let(:current_academic_year) { create(:placements_academic_year, :current) }
+    let(:placement) { create(:placement, school: school, academic_year: current_academic_year) }
+    let(:last_placement_for_school?) { school.last_placement_for_school?(placement: placement) }
+
+    it "returns true when no other placements exist for the school" do
+      expect(last_placement_for_school?).to be(true)
+    end
+
+    it "returns true when a placement exists for the school in a previous academic year" do
+      create(:placement, school: school, academic_year: create(:placements_academic_year, :previous))
+      expect(last_placement_for_school?).to be(true)
+    end
+
+    it "returns false when another placement exists for the school in the current academic year" do
+      create(:placement, school: school, academic_year: current_academic_year)
+      expect(last_placement_for_school?).to be(false)
+    end
+  end
 end

--- a/spec/policies/placements/school_policy_spec.rb
+++ b/spec/policies/placements/school_policy_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Placements::SchoolPolicy do
     let(:selected_academic_year) { Placements::AcademicYear.current.next }
     let(:current_user) { create(:placements_user, schools: [school], selected_academic_year:) }
     let(:school) do
-      build(:placements_school, potential_placement_details:)
+      build(:placements_school, with_hosting_interest: false, potential_placement_details:)
     end
     let(:potential_placement_details) { nil }
     let(:hosting_interest) do

--- a/spec/queries/placements/schools_query_spec.rb
+++ b/spec/queries/placements/schools_query_spec.rb
@@ -8,6 +8,7 @@ describe Placements::SchoolsQuery do
   let(:query_school) do
     create(
       :placements_school,
+      with_hosting_interest: false,
       name: "London Primary School",
       phase: "All-through",
       minimum_age: "4",
@@ -23,7 +24,7 @@ describe Placements::SchoolsQuery do
     )
   end
   let(:non_query_school) do
-    create(:placements_school, name: "York Secondary School", latitude: 29.732613, longitude: 105.448063)
+    create(:placements_school, with_hosting_interest: false, name: "York Secondary School", latitude: 29.732613, longitude: 105.448063)
   end
   let(:academic_year) { Placements::AcademicYear.current }
   let(:placement) { create(:placement, school: query_school, academic_year:, year_group:) }

--- a/spec/support/govuk_component_matchers.rb
+++ b/spec/support/govuk_component_matchers.rb
@@ -124,6 +124,15 @@ module GovukComponentMatchers
     end
   end
 
+  matcher :have_inset_text do |text|
+    match do |page|
+      page.find("div[class^='govuk-inset-text']", text:)
+      true
+    rescue Capybara::ElementNotFound
+      false
+    end
+  end
+
   matcher :have_hint do |text|
     match do |page|
       page.find("div[class^='govuk-hint']", text:)

--- a/spec/system/placements/academic_years/multi_organisation_user_changes_their_selected_academic_year_spec.rb
+++ b/spec/system/placements/academic_years/multi_organisation_user_changes_their_selected_academic_year_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe "School user changes their selected academic year",
     @current_academic_year = Placements::AcademicYear.current
     @next_academic_year = @current_academic_year.next
 
+    @current_year_hosting_interest = create(:hosting_interest, school: @springfield_school, academic_year: @current_academic_year)
+
     @current_academic_year_placements = create(
       :placement,
       school: @springfield_school,

--- a/spec/system/placements/academic_years/school_user_changes_their_selected_academic_year_spec.rb
+++ b/spec/system/placements/academic_years/school_user_changes_their_selected_academic_year_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe "School user changes their selected academic year",
     @current_academic_year = Placements::AcademicYear.current
     @next_academic_year = @current_academic_year.next
 
+    @current_year_hosting_interest = create(:hosting_interest, school: @school, academic_year: @current_academic_year)
+
     @current_academic_year_placements = create(
       :placement,
       school: @school,

--- a/spec/system/placements/academic_years/support_user_changes_their_selected_academic_year_spec.rb
+++ b/spec/system/placements/academic_years/support_user_changes_their_selected_academic_year_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe "Support user changes their selected academic year",
     @current_academic_year = Placements::AcademicYear.current
     @next_academic_year = @current_academic_year.next
 
+    @current_year_hosting_interest = create(:hosting_interest, school: @springfield_school, academic_year: @current_academic_year)
+
     @current_academic_year_placements = create(
       :placement,
       school: @springfield_school,

--- a/spec/system/placements/providers/find/provider_user_filters_by_schools_to_show_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_filters_by_schools_to_show_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe "Provider user filters schools by schools I work with", service: 
     @school_with_completed_eoi = create(:placements_school, name: "Springfield Elementary")
     @school_without_eoi = create(
       :placements_school,
+      with_hosting_interest: false,
       expression_of_interest_completed: false,
       name: "Hogwarts Elementary",
     )
@@ -35,7 +36,6 @@ RSpec.describe "Provider user filters schools by schools I work with", service: 
       name: "Brixton Academy",
       expression_of_interest_completed: false,
     )
-    create(:hosting_interest, school: @school_with_hosting_interest)
   end
 
   def and_i_am_signed_in

--- a/spec/system/placements/providers/find/provider_user_views_a_school_which_is_not_onboarded_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_views_a_school_which_is_not_onboarded_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Provider user views a school which is not onboarded", service: :
 
   def given_that_schools_exist
     @provider = build(:placements_provider, name: "Aes Sedai Trust")
-    @not_onboarded_school = create(:placements_school, phase: "Secondary", name: "Shelbyville High School")
+    @not_onboarded_school = create(:placements_school, with_hosting_interest: false, phase: "Secondary", name: "Shelbyville High School")
   end
 
   def and_i_am_signed_in

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_send_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_send_potential_placement_details_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "School user completes the interested journey and declares primar
   end
 
   def and_i_am_signed_in
-    @school = create(:placements_school, with_school_contact: false)
+    @school = create(:placements_school, with_school_contact: false, with_hosting_interest: false)
     sign_in_placements_user(organisations: [@school])
   end
 

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "School user does not enter a placement quantity",
   end
 
   def and_a_school_exists_with_a_hosting_interest
-    @school = create(:placements_school)
+    @school = create(:placements_school, with_hosting_interest: false)
     @hosting_interest = create(
       :hosting_interest,
       school: @school,

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_does_not_select_a_year_group_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_does_not_select_a_year_group_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "School user does not select a year group",
   end
 
   def and_a_school_exists_with_a_hosting_interest
-    @school = create(:placements_school)
+    @school = create(:placements_school, with_hosting_interest: false)
     @hosting_interest = create(
       :hosting_interest,
       school: @school,

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_the_primary_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_the_primary_phase_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
   end
 
   def and_a_school_exists_with_a_hosting_interest
-    @school = create(:placements_school)
+    @school = create(:placements_school, with_hosting_interest: false)
     @hosting_interest = create(
       :hosting_interest,
       school: @school,

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "School user enters a float as a placement quantity",
   end
 
   def and_a_school_exists_with_a_hosting_interest
-    @school = create(:placements_school)
+    @school = create(:placements_school, with_hosting_interest: false)
     @hosting_interest = create(
       :hosting_interest,
       school: @school,

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "School user enters zero as a placement quantity",
   end
 
   def and_a_school_exists_with_a_hosting_interest
-    @school = create(:placements_school)
+    @school = create(:placements_school, with_hosting_interest: false)
     @hosting_interest = create(
       :hosting_interest,
       school: @school,

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/school_user_does_not_select_a_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/school_user_does_not_select_a_phase_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "School user does not select a phases",
   end
 
   def and_a_school_exists_with_a_hosting_interest
-    @school = create(:placements_school)
+    @school = create(:placements_school, with_hosting_interest: false)
     @hosting_interest = create(
       :hosting_interest,
       school: @school,

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
   end
 
   def and_a_school_exists_with_a_hosting_interest
-    @school = create(:placements_school)
+    @school = create(:placements_school, with_hosting_interest: false)
     @hosting_interest = create(
       :hosting_interest,
       school: @school,

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/school_user_edits_their_hosting_interest_while_having_assigned_placements_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/school_user_edits_their_hosting_interest_while_having_assigned_placements_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "School user edits their hosting interest while having assigned p
   end
 
   def and_a_school_exists_with_a_hosting_interest
-    @school = create(:placements_school)
+    @school = create(:placements_school, with_hosting_interest: false)
     @hosting_interest = create(
       :hosting_interest,
       school: @school,

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_does_not_enter_a_placement_quantity_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
   end
 
   def and_a_school_exists_with_a_hosting_interest
-    @school = create(:placements_school)
+    @school = create(:placements_school, with_hosting_interest: false)
     @hosting_interest = create(
       :hosting_interest,
       school: @school,

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "School user does not select a child subjects",
   end
 
   def and_a_school_exists_with_a_hosting_interest
-    @school = create(:placements_school)
+    @school = create(:placements_school, with_hosting_interest: false)
     @hosting_interest = create(
       :hosting_interest,
       school: @school,

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
   end
 
   def and_a_school_exists_with_a_hosting_interest
-    @school = create(:placements_school)
+    @school = create(:placements_school, with_hosting_interest: false)
     @hosting_interest = create(
       :hosting_interest,
       school: @school,

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
   end
 
   def and_a_school_exists_with_a_hosting_interest
-    @school = create(:placements_school)
+    @school = create(:placements_school, with_hosting_interest: false)
     @hosting_interest = create(
       :hosting_interest,
       school: @school,

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_edits_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_edits_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
   end
 
   def and_a_school_exists_with_a_hosting_interest
-    @school = create(:placements_school)
+    @school = create(:placements_school, with_hosting_interest: false)
     @hosting_interest = create(
       :hosting_interest,
       school: @school,

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_enters_a_float_as_a_placement_quantity_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
   end
 
   def and_a_school_exists_with_a_hosting_interest
-    @school = create(:placements_school)
+    @school = create(:placements_school, with_hosting_interest: false)
     @hosting_interest = create(
       :hosting_interest,
       school: @school,

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_enters_zero_as_a_placement_quantity_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "School user bulk adds placements for the secondary phase",
   end
 
   def and_a_school_exists_with_a_hosting_interest
-    @school = create(:placements_school)
+    @school = create(:placements_school, with_hosting_interest: false)
     @hosting_interest = create(
       :hosting_interest,
       school: @school,

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/send_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_the_send_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/send_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_the_send_phase_spec.rb
@@ -71,12 +71,11 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
   end
 
   def and_a_school_exists_with_a_hosting_interest
-    @school = create(:placements_school)
-    @hosting_interest = create(
+    @hosting_interest = build(
       :hosting_interest,
-      school: @school,
       academic_year: @next_academic_year,
     )
+    @school = create(:placements_school, hosting_interests: [@hosting_interest])
   end
 
   def and_i_am_signed_in

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "School user completes the interested journey and declares primar
   end
 
   def and_a_school_exists_with_a_hosting_interest
-    @school = create(:placements_school)
+    @school = create(:placements_school, with_hosting_interest: false)
     @hosting_interest = create(
       :hosting_interest,
       school: @school,

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_send_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_send_potential_placement_details_spec.rb
@@ -70,12 +70,12 @@ RSpec.describe "School user completes the interested journey and declares SEND p
   end
 
   def and_a_school_exists_with_a_hosting_interest
-    @school = create(:placements_school)
-    @hosting_interest = create(
+    @hosting_interest = build(
       :hosting_interest,
       school: @school,
       academic_year: @next_academic_year,
     )
+    @school = create(:placements_school, hosting_interests: [@hosting_interest])
   end
 
   def and_i_am_signed_in

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_potential_placement_details_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "School user completes the interested journey without declaring p
   end
 
   def and_a_school_exists_with_a_hosting_interest
-    @school = create(:placements_school)
+    @school = create(:placements_school, with_hosting_interest: false)
     @hosting_interest = create(
       :hosting_interest,
       school: @school,

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_interested/school_user_edits_their_hosting_interest_while_having_unassigned_placements_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_interested/school_user_edits_their_hosting_interest_while_having_unassigned_placements_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "School user edits their hosting interest while having unassigned
   end
 
   def and_a_school_exists_with_a_hosting_interest
-    @school = create(:placements_school)
+    @school = create(:placements_school, with_hosting_interest: false)
     @hosting_interest = create(
       :hosting_interest,
       school: @school,

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_not_open/school_user_does_not_enter_a_reason_when_selecting_other_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_not_open/school_user_does_not_enter_a_reason_when_selecting_other_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "School user does not select any reasons not to host",
   end
 
   def and_a_school_exists_with_a_hosting_interest
-    @school = create(:placements_school)
+    @school = create(:placements_school, with_hosting_interest: false)
     @hosting_interest = create(
       :hosting_interest,
       school: @school,

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_not_open/school_user_does_not_select_any_reasons_not_to_host_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_not_open/school_user_does_not_select_any_reasons_not_to_host_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "School user does not select any reasons not to host",
   end
 
   def and_a_school_exists_with_a_hosting_interest
-    @school = create(:placements_school)
+    @school = create(:placements_school, with_hosting_interest: false)
     @hosting_interest = create(
       :hosting_interest,
       school: @school,

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_not_open/school_user_enters_another_reason_why_they_are_not_hosting_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_not_open/school_user_enters_another_reason_why_they_are_not_hosting_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "School user enters another reason why they are not hosting",
   end
 
   def and_a_school_exists_with_a_hosting_interest
-    @school = create(:placements_school)
+    @school = create(:placements_school, with_hosting_interest: false)
     @hosting_interest = create(
       :hosting_interest,
       school: @school,

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_not_open/school_user_successfully_completes_the_not_open_journey_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_not_open/school_user_successfully_completes_the_not_open_journey_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "School user successfully completes the not open journey",
   end
 
   def and_a_school_exists_with_a_hosting_interest
-    @school = create(:placements_school)
+    @school = create(:placements_school, with_hosting_interest: false)
     @hosting_interest = create(
       :hosting_interest,
       school: @school,

--- a/spec/system/placements/schools/placements/school_user_views_and_deletes_the_last_placement_spec.rb
+++ b/spec/system/placements/schools/placements/school_user_views_and_deletes_the_last_placement_spec.rb
@@ -19,9 +19,8 @@ RSpec.describe "School user views and deletes a placement", service: :placements
 
     when_i_click_on_the_delete_placement_link
     and_i_click_on_the_delete_placement_button
-    then_i_see_the_placements_index_page
+    then_i_see_the_expression_of_interest_page
     and_i_see_a_success_message
-    and_my_placement_has_been_deleted
   end
 
   private
@@ -46,7 +45,6 @@ RSpec.describe "School user views and deletes a placement", service: :placements
     )
 
     @primary_english_subject = build(:subject, name: "Primary with english", subject_area: :primary)
-    @primary_maths_subject = build(:subject, name: "Primary with mathematics", subject_area: :primary)
 
     @autumn_term = build(:placements_term, name: "Autumn term")
     @spring_term = create(:placements_term, name: "Spring term")
@@ -60,14 +58,6 @@ RSpec.describe "School user views and deletes a placement", service: :placements
       school: @springfield_elementary_school,
       subject: @primary_english_subject,
       year_group: :year_1,
-      academic_year: @next_academic_year,
-      terms: [@autumn_term],
-    )
-    @second_placement = create(
-      :placement,
-      school: @springfield_elementary_school,
-      subject: @primary_maths_subject,
-      year_group: :year_2,
       academic_year: @next_academic_year,
       terms: [@autumn_term],
     )
@@ -87,10 +77,6 @@ RSpec.describe "School user views and deletes a placement", service: :placements
   alias_method :then_i_see_the_placements_index_page, :when_i_am_on_the_placements_index_page
 
   def then_i_see_my_placement
-    expect(page).to have_table_row({ "Placement": "Primary with mathematics (Year 2)",
-                                     "Mentor": "Mentor not assigned",
-                                     "Expected date": "Autumn term",
-                                     "Provider": "Provider not assigned" })
     expect(page).to have_table_row({ "Placement": "Primary with english (Year 1)",
                                      "Mentor": "Mentor not assigned",
                                      "Expected date": "Autumn term",
@@ -136,21 +122,22 @@ RSpec.describe "School user views and deletes a placement", service: :placements
     click_on "Delete placement"
   end
 
-  def then_i_see_the_placements_index_page
-    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
+  def then_i_see_the_expression_of_interest_page
+    expect(page).to have_title(
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
+    )
     expect(primary_navigation).to have_current_item("Placements")
-    expect(page).to have_h1("Placements")
-    expect(page).to have_link("Add placement", class: "govuk-button")
+    expect(page).to have_element(
+      :legend,
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Yes - I can offer placements", type: :radio)
+    expect(page).to have_field("Maybe - I’m not sure yet", type: :radio)
+    expect(page).to have_field("No - I can’t offer placements", type: :radio)
   end
 
   def and_i_see_a_success_message
-    expect(page).to have_success_banner("Placement deleted")
-  end
-
-  def and_my_placement_has_been_deleted
-    expect(page).not_to have_table_row({ "Placement": "Primary with english (Year 1)",
-                                         "Mentor": "Mentor not assigned",
-                                         "Expected date": "Autumn term",
-                                         "Provider": "Provider not assigned" })
+    expect(page).to have_success_banner("Placement deleted", "You no longer have placement information available. Confirm your placement availability so providers know whether to contact you.")
   end
 end

--- a/spec/system/placements/schools/placements/school_user_views_the_placements_index_when_not_hosting_placements_spec.rb
+++ b/spec/system/placements/schools/placements/school_user_views_the_placements_index_when_not_hosting_placements_spec.rb
@@ -12,8 +12,14 @@ RSpec.describe "School user views the placements index when not hosting placemen
   private
 
   def given_a_school_exists_with_a_hosting_interest_not_open_to_hosting
-    @springfield_elementary_school = build(
+    @hosting_interest = build(
+      :hosting_interest,
+      :for_next_year,
+      appetite: "not_open",
+    )
+    @springfield_elementary_school = create(
       :placements_school,
+      hosting_interests: @hosting_interest,
       name: "Springfield Elementary",
       address1: "Westgate Street",
       address2: "Hackney",
@@ -28,13 +34,6 @@ RSpec.describe "School user views the placements index when not hosting placemen
       urban_or_rural: "(England/Wales) Urban major conurbation",
       percentage_free_school_meals: 15,
       rating: "Outstanding",
-    )
-
-    @hosting_interest = create(
-      :hosting_interest,
-      :for_next_year,
-      school: @springfield_elementary_school,
-      appetite: "not_open",
     )
   end
 

--- a/spec/system/placements/schools/potential_placements/convert_potential_placements/school_user_converts_their_potential_primary_and_secondary_placements_spec.rb
+++ b/spec/system/placements/schools/potential_placements/convert_potential_placements/school_user_converts_their_potential_primary_and_secondary_placements_spec.rb
@@ -72,13 +72,12 @@ RSpec.describe "School user converts their potential primary and secondary place
       "secondary_placement_quantity" => { "english" => 1, "science" => 2 },
       "year_group_placement_quantity" => { "year_2" => 1, "year_3" => 2 },
     }
-    @school = create(:placements_school, potential_placement_details:)
-    @hosting_interest = create(
+    @hosting_interest = build(
       :hosting_interest,
-      school: @school,
       academic_year: @next_academic_year,
       appetite: "interested",
     )
+    @school = create(:placements_school, hosting_interests: @hosting_interest, potential_placement_details:)
   end
 
   def and_i_am_signed_in

--- a/spec/system/placements/schools/potential_placements/convert_potential_placements/school_user_converts_their_potential_send_placements_spec.rb
+++ b/spec/system/placements/schools/potential_placements/convert_potential_placements/school_user_converts_their_potential_send_placements_spec.rb
@@ -59,6 +59,11 @@ RSpec.describe "School user converts their potential SEND placements",
   end
 
   def and_a_school_exists_with_a_hosting_interest_and_potential_placement_details
+    @hosting_interest = build(
+      :hosting_interest,
+      academic_year: @next_academic_year,
+      appetite: "interested",
+    )
     potential_placement_details = {
       "phase" => { "phases" => %w[Primary Secondary] },
       "note_to_providers" => { "note" => "Interested in offering placements at the provider's request" },
@@ -69,13 +74,7 @@ RSpec.describe "School user converts their potential SEND placements",
       "key_stage_selection" => { "key_stage_ids" => [@key_stage_2.id, @key_stage_5.id] },
       "key_stage_placement_quantity" => { "key_stage_2" => 2, "key_stage_5" => 1 },
     }
-    @school = create(:placements_school, potential_placement_details:)
-    @hosting_interest = create(
-      :hosting_interest,
-      school: @school,
-      academic_year: @next_academic_year,
-      appetite: "interested",
-    )
+    @school = create(:placements_school, hosting_interests: [@hosting_interest], potential_placement_details:)
   end
 
   def and_i_am_signed_in

--- a/spec/system/placements/schools/potential_placements/convert_potential_placements/school_user_manually_adds_placements_instead_of_converting_potential_placements_spec.rb
+++ b/spec/system/placements/schools/potential_placements/convert_potential_placements/school_user_manually_adds_placements_instead_of_converting_potential_placements_spec.rb
@@ -125,13 +125,12 @@ RSpec.describe "School user manually adds placements instead of converting poten
       "secondary_placement_quantity" => { "english" => 1, "science" => 2 },
       "year_group_placement_quantity" => { "year_2" => 1, "year_3" => 2 },
     }
-    @school = create(:placements_school, potential_placement_details:)
-    @hosting_interest = create(
+    @hosting_interest = build(
       :hosting_interest,
-      school: @school,
       academic_year: @next_academic_year,
       appetite: "interested",
     )
+    @school = create(:placements_school, hosting_interests: @hosting_interest, potential_placement_details:)
   end
 
   def and_i_am_signed_in

--- a/spec/system/placements/schools/potential_placements/school_user_does_not_select_a_phase_spec.rb
+++ b/spec/system/placements/schools/potential_placements/school_user_does_not_select_a_phase_spec.rb
@@ -46,13 +46,12 @@ RSpec.describe "School user does not select a phase",
       "secondary_placement_quantity" => { "english" => 1, "science" => 2 },
       "year_group_placement_quantity" => { "year_2" => 1, "year_3" => 2 },
     }
-    @school = create(:placements_school, potential_placement_details:)
-    @hosting_interest = create(
+    @hosting_interest = build(
       :hosting_interest,
-      school: @school,
       academic_year: @next_academic_year,
       appetite: "interested",
     )
+    @school = create(:placements_school, hosting_interests: @hosting_interest, potential_placement_details:)
   end
 
   def and_i_am_signed_in

--- a/spec/system/placements/schools/potential_placements/school_user_updates_their_schools_message_to_provider_spec.rb
+++ b/spec/system/placements/schools/potential_placements/school_user_updates_their_schools_message_to_provider_spec.rb
@@ -52,13 +52,12 @@ RSpec.describe "School user updates their school's message to provider",
       "secondary_placement_quantity" => { "english" => 1, "science" => 2 },
       "year_group_placement_quantity" => { "year_2" => 1, "year_3" => 2 },
     }
-    @school = create(:placements_school, potential_placement_details:)
-    @hosting_interest = create(
+    @hosting_interest = build(
       :hosting_interest,
-      school: @school,
       academic_year: @next_academic_year,
       appetite: "interested",
     )
+    @school = create(:placements_school, hosting_interests: @hosting_interest, potential_placement_details:)
   end
 
   def and_i_am_signed_in

--- a/spec/system/placements/schools/potential_placements/school_user_updates_their_schools_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/potential_placements/school_user_updates_their_schools_potential_placement_details_spec.rb
@@ -91,13 +91,12 @@ RSpec.describe "School user updates their school's potential placement details",
       "secondary_placement_quantity" => { "english" => 1, "science" => 2 },
       "year_group_placement_quantity" => { "year_2" => 1, "year_3" => 2 },
     }
-    @school = create(:placements_school, potential_placement_details:)
-    @hosting_interest = create(
+    @hosting_interest = build(
       :hosting_interest,
-      school: @school,
       academic_year: @next_academic_year,
       appetite: "interested",
     )
+    @school = create(:placements_school, hosting_interests: @hosting_interest, potential_placement_details:)
   end
 
   def and_i_am_signed_in

--- a/spec/system/placements/schools/potential_placements/school_user_updates_their_schools_primary_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/potential_placements/school_user_updates_their_schools_primary_potential_placement_details_spec.rb
@@ -86,13 +86,12 @@ RSpec.describe "School user updates their school's primary potential placement d
       "secondary_placement_quantity" => { "english" => 1, "science" => 2 },
       "year_group_placement_quantity" => { "year_2" => 1, "year_3" => 2 },
     }
-    @school = create(:placements_school, potential_placement_details:)
-    @hosting_interest = create(
+    @hosting_interest = build(
       :hosting_interest,
-      school: @school,
       academic_year: @next_academic_year,
       appetite: "interested",
     )
+    @school = create(:placements_school, hosting_interests: @hosting_interest, potential_placement_details:)
   end
 
   def and_i_am_signed_in

--- a/spec/system/placements/schools/potential_placements/school_user_updates_their_schools_secondary_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/potential_placements/school_user_updates_their_schools_secondary_potential_placement_details_spec.rb
@@ -69,13 +69,12 @@ RSpec.describe "School user updates their school's secondary potential placement
       "secondary_placement_quantity" => { "english" => 1, "science" => 2 },
       "year_group_placement_quantity" => { "year_2" => 1, "year_3" => 2 },
     }
-    @school = create(:placements_school, potential_placement_details:)
-    @hosting_interest = create(
+    @hosting_interest = build(
       :hosting_interest,
-      school: @school,
       academic_year: @next_academic_year,
       appetite: "interested",
     )
+    @school = create(:placements_school, hosting_interests: @hosting_interest, potential_placement_details:)
   end
 
   def and_i_am_signed_in

--- a/spec/system/placements/support/schools/placements/school_support_user_views_and_deletes_a_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/school_support_user_views_and_deletes_a_placement_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe "School support user views and deletes a placement", service: :pl
     )
 
     @primary_english_subject = build(:subject, name: "Primary with english", subject_area: :primary)
+    @primary_maths_subject = build(:subject, name: "Primary with mathematics", subject_area: :primary)
 
     @autumn_term = build(:placements_term, name: "Autumn term")
     @spring_term = create(:placements_term, name: "Spring term")
@@ -61,6 +62,14 @@ RSpec.describe "School support user views and deletes a placement", service: :pl
       school: @springfield_elementary_school,
       subject: @primary_english_subject,
       year_group: :year_1,
+      academic_year: @next_academic_year,
+      terms: [@autumn_term],
+    )
+    @second_placement = create(
+      :placement,
+      school: @springfield_elementary_school,
+      subject: @primary_maths_subject,
+      year_group: :year_2,
       academic_year: @next_academic_year,
       terms: [@autumn_term],
     )
@@ -89,10 +98,14 @@ RSpec.describe "School support user views and deletes a placement", service: :pl
   alias_method :then_i_see_the_placements_index_page, :when_i_am_on_the_placements_index_page
 
   def and_i_see_my_placement
-    expect(page).to have_element(:td, text: "Primary with english (Year 1)", class: "govuk-table__cell")
-    expect(page).to have_element(:td, text: "Mentor not assigned", class: "govuk-table__cell")
-    expect(page).to have_element(:td, text: "Autumn term", class: "govuk-table__cell")
-    expect(page).to have_element(:td, text: "Provider not assigned", class: "govuk-table__cell")
+    expect(page).to have_table_row({ "Placement": "Primary with mathematics (Year 2)",
+                                     "Mentor": "Mentor not assigned",
+                                     "Expected date": "Autumn term",
+                                     "Provider": "Provider not assigned" })
+    expect(page).to have_table_row({ "Placement": "Primary with english (Year 1)",
+                                     "Mentor": "Mentor not assigned",
+                                     "Expected date": "Autumn term",
+                                     "Provider": "Provider not assigned" })
   end
 
   def when_i_click_on_my_placement
@@ -146,9 +159,9 @@ RSpec.describe "School support user views and deletes a placement", service: :pl
   end
 
   def and_my_placement_has_been_deleted
-    expect(page).not_to have_element(:td, text: "Primary with english (Year 1)", class: "govuk-table__cell")
-    expect(page).not_to have_element(:td, text: "Mentor not assigned", class: "govuk-table__cell")
-    expect(page).not_to have_element(:td, text: "Autumn term", class: "govuk-table__cell")
-    expect(page).not_to have_element(:td, text: "Provider not assigned", class: "govuk-table__cell")
+    expect(page).not_to have_table_row({ "Placement": "Primary with english (Year 1)",
+                                         "Mentor": "Mentor not assigned",
+                                         "Expected date": "Autumn term",
+                                         "Provider": "Provider not assigned" })
   end
 end

--- a/spec/system/placements/support/schools/placements/school_support_user_views_and_deletes_the_last_placement_spec.rb
+++ b/spec/system/placements/support/schools/placements/school_support_user_views_and_deletes_the_last_placement_spec.rb
@@ -1,12 +1,14 @@
 require "rails_helper"
 
-RSpec.describe "School user views and deletes a placement", service: :placements, type: :system do
+RSpec.describe "School support user views and deletes a placement", service: :placements, type: :system do
   scenario do
     given_that_placements_exist
     and_i_am_signed_in
 
-    when_i_am_on_the_placements_index_page
-    then_i_see_my_placement
+    when_i_am_on_the_organisations_index_page
+    and_i_select_springfield_elementary
+    then_i_see_the_placements_index_page
+    and_i_see_my_placement
 
     when_i_click_on_my_placement
     then_i_see_the_placement_details_page
@@ -19,9 +21,8 @@ RSpec.describe "School user views and deletes a placement", service: :placements
 
     when_i_click_on_the_delete_placement_link
     and_i_click_on_the_delete_placement_button
-    then_i_see_the_placements_index_page
+    then_i_see_the_expression_of_interest_page
     and_i_see_a_success_message
-    and_my_placement_has_been_deleted
   end
 
   private
@@ -46,7 +47,6 @@ RSpec.describe "School user views and deletes a placement", service: :placements
     )
 
     @primary_english_subject = build(:subject, name: "Primary with english", subject_area: :primary)
-    @primary_maths_subject = build(:subject, name: "Primary with mathematics", subject_area: :primary)
 
     @autumn_term = build(:placements_term, name: "Autumn term")
     @spring_term = create(:placements_term, name: "Spring term")
@@ -63,18 +63,19 @@ RSpec.describe "School user views and deletes a placement", service: :placements
       academic_year: @next_academic_year,
       terms: [@autumn_term],
     )
-    @second_placement = create(
-      :placement,
-      school: @springfield_elementary_school,
-      subject: @primary_maths_subject,
-      year_group: :year_2,
-      academic_year: @next_academic_year,
-      terms: [@autumn_term],
-    )
   end
 
   def and_i_am_signed_in
-    sign_in_placements_user(organisations: [@springfield_elementary_school])
+    sign_in_placements_support_user
+  end
+
+  def when_i_am_on_the_organisations_index_page
+    expect(page).to have_title("Organisations (1) - Manage school placements - GOV.UK")
+    expect(page).to have_h1("Organisations (1)")
+  end
+
+  def and_i_select_springfield_elementary
+    click_on "Springfield Elementary"
   end
 
   def when_i_am_on_the_placements_index_page
@@ -86,11 +87,7 @@ RSpec.describe "School user views and deletes a placement", service: :placements
 
   alias_method :then_i_see_the_placements_index_page, :when_i_am_on_the_placements_index_page
 
-  def then_i_see_my_placement
-    expect(page).to have_table_row({ "Placement": "Primary with mathematics (Year 2)",
-                                     "Mentor": "Mentor not assigned",
-                                     "Expected date": "Autumn term",
-                                     "Provider": "Provider not assigned" })
+  def and_i_see_my_placement
     expect(page).to have_table_row({ "Placement": "Primary with english (Year 1)",
                                      "Mentor": "Mentor not assigned",
                                      "Expected date": "Autumn term",
@@ -143,14 +140,22 @@ RSpec.describe "School user views and deletes a placement", service: :placements
     expect(page).to have_link("Add placement", class: "govuk-button")
   end
 
-  def and_i_see_a_success_message
-    expect(page).to have_success_banner("Placement deleted")
+  def then_i_see_the_expression_of_interest_page
+    expect(page).to have_title(
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Yes - I can offer placements", type: :radio)
+    expect(page).to have_field("Maybe - I’m not sure yet", type: :radio)
+    expect(page).to have_field("No - I can’t offer placements", type: :radio)
   end
 
-  def and_my_placement_has_been_deleted
-    expect(page).not_to have_table_row({ "Placement": "Primary with english (Year 1)",
-                                         "Mentor": "Mentor not assigned",
-                                         "Expected date": "Autumn term",
-                                         "Provider": "Provider not assigned" })
+  def and_i_see_a_success_message
+    expect(page).to have_success_banner("Placement deleted", "You no longer have placement information available. Confirm your placement availability so providers know whether to contact you.")
   end
 end

--- a/spec/wizards/placements/add_hosting_interest_wizard_spec.rb
+++ b/spec/wizards/placements/add_hosting_interest_wizard_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Placements::AddHostingInterestWizard do
   subject(:wizard) { described_class.new(state:, params:, school:, current_step:, current_user:) }
 
-  let(:school) { create(:placements_school) }
+  let(:school) { create(:placements_school, with_hosting_interest: false) }
   let(:state) { {} }
   let(:params_data) { {} }
   let(:params) { ActionController::Parameters.new(params_data) }
@@ -340,7 +340,7 @@ RSpec.describe Placements::AddHostingInterestWizard do
 
         context "when school has no hosting interest for the next academic year" do
           context "when school has no school contact assigned" do
-            let(:school) { create(:placements_school, with_school_contact: false) }
+            let(:school) { create(:placements_school, with_hosting_interest: false, with_school_contact: false) }
 
             it "creates hosting interest for the next academic year, assigns the appetite,
               reasons not hosting and creates a school contact" do

--- a/spec/wizards/placements/edit_hosting_interest_wizard_spec.rb
+++ b/spec/wizards/placements/edit_hosting_interest_wizard_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Placements::EditHostingInterestWizard do
   end
 
   let(:academic_year) { Placements::AcademicYear.current.next }
-  let(:school) { create(:placements_school) }
+  let(:school) { create(:placements_school, with_hosting_interest: false) }
   let(:hosting_interest) do
     create(
       :hosting_interest,
@@ -366,7 +366,7 @@ RSpec.describe Placements::EditHostingInterestWizard do
         end
 
         context "when school has no hosting interest for the next academic year" do
-          let(:school) { create(:placements_school, with_school_contact: false) }
+          let(:school) { create(:placements_school, with_hosting_interest: false, with_school_contact: false) }
 
           it "creates hosting interest for the next academic year, assigns the appetite,
             and reasons not hosting" do
@@ -495,7 +495,7 @@ RSpec.describe Placements::EditHostingInterestWizard do
     subject(:setup_state) { wizard.setup_state }
 
     context "when the school has a hosting interest for the next academic year" do
-      let(:school) { create(:placements_school) }
+      let(:school) { create(:placements_school, with_hosting_interest: false) }
       let(:hosting_interest) do
         create(:hosting_interest,
                school:,


### PR DESCRIPTION
## Context

When the final placement is deleted the user should know that their school appears as not accepting placements. The school should be aware of this and given the opportunity to update their expression of interest.

## Changes proposed in this pull request

Add warning text to Are you sure you want to delete this placement? page

When the final placement is removed destroy their hosting interest record

Add new logic that redirects the user to the EoI flow, this can be added to the exsiting redirect if they’ve not completed the EoI flow, but now we should also render EoI if they don’t have a hosting interest against their organisation OR if they haven’t completed the flow before.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Qmr142Ul/704-when-removing-last-placement-redirect-user-back-to-eoi-flow
