### PR TITLE
Stop provider importer re-importing NIoT organisations

### DIFF
--- a/app/services/publish_teacher_training/provider/importer.rb
+++ b/app/services/publish_teacher_training/provider/importer.rb
@@ -25,6 +25,34 @@ module PublishTeacherTraining
 
       private
 
+      # NIoT has multiple organisations in other services, however we only want one in this service, the one we've
+      # chosen has the code 2N2, these are the ones we want to ignore
+      NIOT_CODES_TO_IGNORE = %w[
+        1YF
+        21J
+        1GV
+        2HE
+        24P
+        1MN
+        1TZ
+        5J5
+        7K9
+        L06
+        2P4
+        21P
+        1FE
+        3P4
+        3L4
+        2H7
+        2A6
+        4W2
+        4L1
+        4L3
+        4C2
+        5A6
+        2U6
+      ].freeze
+
       def invalid?(provider_attributes)
         provider_attributes["name"].blank? || provider_attributes["provider_type"].blank? ||
           provider_attributes["code"].blank?
@@ -36,6 +64,7 @@ module PublishTeacherTraining
           provider_attributes = provider_details["attributes"]
           @invalid_records << "Provider with code #{provider_attributes["code"]} is invalid" if invalid?(provider_attributes)
           next if invalid?(provider_attributes)
+          next if NIOT_CODES_TO_IGNORE.include?(provider_attributes["code"])
 
           @records << {
             code: provider_attributes["code"],

--- a/spec/services/publish_teacher_training/provider/importer_spec.rb
+++ b/spec/services/publish_teacher_training/provider/importer_spec.rb
@@ -5,6 +5,36 @@ RSpec.describe PublishTeacherTraining::Provider::Importer do
 
   it_behaves_like "a service object"
 
+  describe ".NIOT_CODES_TO_IGNORE" do
+    it "contains the correct values" do
+      expect(described_class::NIOT_CODES_TO_IGNORE).to match_array(%w[
+        1YF
+        21J
+        1GV
+        2HE
+        24P
+        1MN
+        1TZ
+        5J5
+        7K9
+        L06
+        2P4
+        21P
+        1FE
+        3P4
+        3L4
+        2H7
+        2A6
+        4W2
+        4L1
+        4L3
+        4C2
+        5A6
+        2U6
+      ])
+    end
+  end
+
   context "with only providers in API response which don't exist" do
     before do
       non_existing_providers_request
@@ -12,7 +42,7 @@ RSpec.describe PublishTeacherTraining::Provider::Importer do
 
     it "creates new provider records for responses" do
       expect { importer }.to change(Provider, :count).by(3)
-        .and change(ProviderEmailAddress, :count).by(2)
+                                                     .and change(ProviderEmailAddress, :count).by(2)
       expect(
         Provider.find_by(
           name: "Provider 1",
@@ -41,6 +71,18 @@ RSpec.describe PublishTeacherTraining::Provider::Importer do
         ),
       ).to be_present
     end
+
+    it "does not import the NIoT providers" do
+      expect(
+        Provider.find_by(
+          name: "NIoT",
+          code: "L06",
+          provider_type: :scitt,
+          latitude: 56.68806439999999,
+          longitude: -1.853286,
+        ),
+      ).not_to be_present
+    end
   end
 
   context "with providers in API response which pre-exist" do
@@ -54,7 +96,7 @@ RSpec.describe PublishTeacherTraining::Provider::Importer do
     it "creates new provider records for responses which don't already exist or are valid,
       and updates any pre-existing providers" do
       expect { importer }.to change(Provider, :count).by(1)
-        .and change(ProviderEmailAddress, :count).by(2)
+                                                     .and change(ProviderEmailAddress, :count).by(2)
       new_provider = Provider.find_by(
         name: "Provider 1",
         code: "Prov1",
@@ -144,6 +186,17 @@ RSpec.describe PublishTeacherTraining::Provider::Importer do
               "provider_type" => "lead_school",
               "email" => "provider_3@example.com",
               "latitude" => 53.68806439999999,
+              "longitude" => -1.853286,
+            },
+          },
+          {
+            "id" => 456,
+            "attributes" => {
+              "name" => "NIoT",
+              "code" => "L06",
+              "provider_type" => "scitt",
+              "email" => "niot@example.com",
+              "latitude" => 56.68806439999999,
               "longitude" => -1.853286,
             },
           },


### PR DESCRIPTION
## Context

We are importing NIoT several times but should only import them once, this is due to legacy data held by other services.

## Changes proposed in this pull request

- Add a constant array of the NIoT codes we do not want to store
- Skip the provider in the import if they match these codes

## Guidance to review

- Review the list of codes against the Trello card

## Link to Trello card

[Remove NIoT duplicates](https://trello.com/c/vsFTSvqi/716-remove-niot-duplicates)
