### PR TITLE
Add deliver now to daily round up job

### DIFF
--- a/app/jobs/claims/slack/daily_roundup_job.rb
+++ b/app/jobs/claims/slack/daily_roundup_job.rb
@@ -13,7 +13,7 @@ class Claims::Slack::DailyRoundupJob < ApplicationJob
       school_count: new_schools.count,
       provider_count: new_providers.count,
       total_claims_count: total_claims,
-    )
+    ).deliver_now
   end
 
   private

--- a/spec/jobs/claims/slack/daily_roundup_job_spec.rb
+++ b/spec/jobs/claims/slack/daily_roundup_job_spec.rb
@@ -7,11 +7,14 @@ RSpec.describe Claims::Slack::DailyRoundupJob, type: :job do
     let(:yesterday_claims) { create_list(:claim, 2, claim_window:, created_at: Time.current.yesterday.change(hour: 16)) }
     let(:slack_notifier) { instance_double(Claims::ClaimSlackNotifier) }
 
+    let(:slack_message) { instance_double(SlackNotifier::Message, deliver_now: true) }
+
     before do
       claims
       yesterday_claims
+
       allow(Claims::ClaimSlackNotifier).to receive(:new).and_return(slack_notifier)
-      allow(slack_notifier).to receive(:claim_submitted_notification)
+      allow(slack_notifier).to receive(:claim_submitted_notification).and_return(slack_message)
     end
 
     it "sends the daily claims notification" do
@@ -23,6 +26,8 @@ RSpec.describe Claims::Slack::DailyRoundupJob, type: :job do
         provider_count: 0,
         total_claims_count: 5,
       )
+
+      expect(slack_message).to have_received(:deliver_now)
     end
   end
 end


### PR DESCRIPTION
## Context

The slack job that is supposed to send a slack message requires a deliver now in order to send the message. This isnt present and though the message was formed; it was never being sent. This should ensure that the message sends normally now.

## Changes proposed in this pull request

Add deliver_now to the daily round up job.

## Guidance to review

After adding the CLAIMS_SLACK_WEBHOOK_URL to your environment (dm me if you dont have access to it).

This change can be tested by opening a rails console and running:

Claims::Slack::DailyRoundupJob.perform_now

The message should be sent to the slack channel #twd_funding_mentors_beta

Then delete deliver_now from the perform method of Claims::Slack::DailyRoundupJob and run the above command again. 

Only with the deliver now command present will the slack message send.

## Link to Trello card

https://trello.com/c/r3bxzLAz/692-fix-claims-slack-notifier-why-doesnt-it-work

## Screenshots

Here is the ouput this morning:

<img width="674" alt="Screenshot 2025-06-16 at 11 08 38" src="https://github.com/user-attachments/assets/d2750de0-211d-46d7-aeae-d1ada8409dc6" />

