### PR TITLE
Add page to display manually onboarded schools

### DIFF
--- a/app/controllers/claims/support/manually_onboarded_schools_controller.rb
+++ b/app/controllers/claims/support/manually_onboarded_schools_controller.rb
@@ -2,6 +2,6 @@ class Claims::Support::ManuallyOnboardedSchoolsController < Claims::Support::App
   before_action :skip_authorization
 
   def index
-    @manually_onboarded_schools = Claims::School.where.not(manually_onboarded_by_id: nil)
+    @pagy, @manually_onboarded_schools = pagy(Claims::School.where.not(manually_onboarded_by_id: nil).order_by_name)
   end
 end

--- a/app/controllers/claims/support/manually_onboarded_schools_controller.rb
+++ b/app/controllers/claims/support/manually_onboarded_schools_controller.rb
@@ -1,0 +1,7 @@
+class Claims::Support::ManuallyOnboardedSchoolsController < Claims::Support::ApplicationController
+  before_action :skip_authorization
+
+  def index
+    @manually_onboarded_schools = Claims::School.where.not(manually_onboarded_by_id: nil)
+  end
+end

--- a/app/controllers/claims/support/schools/add_school_controller.rb
+++ b/app/controllers/claims/support/schools/add_school_controller.rb
@@ -23,7 +23,7 @@ class Claims::Support::Schools::AddSchoolController < Claims::Support::Applicati
   def set_wizard
     state = session[state_key] ||= {}
     current_step = params[:step]&.to_sym
-    @wizard = Claims::AddSchoolWizard.new(params:, state:, current_step:)
+    @wizard = Claims::AddSchoolWizard.new(current_user:, params:, state:, current_step:)
   end
 
   def authorize_school

--- a/app/views/claims/support/manually_onboarded_schools/index.html.erb
+++ b/app/views/claims/support/manually_onboarded_schools/index.html.erb
@@ -5,39 +5,45 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 
-  <% if @manually_onboarded_schools.exists? %>
-    <%= govuk_table do |table| %>
-      <% table.with_head do |head| %>
-        <% head.with_row do |row| %>
-          <% row.with_cell text: t(".table.headers.school_name") %>
-          <% row.with_cell text: t(".table.headers.onboarded_by") %>
-          <% row.with_cell text: t(".table.headers.eligible_for") %>
-        <% end %>
-      <% end %>
+      <% if @manually_onboarded_schools.exists? %>
+        <%= govuk_table do |table| %>
+          <% table.with_head do |head| %>
+            <% head.with_row do |row| %>
+              <% row.with_cell text: t(".table.headers.school_name") %>
+              <% row.with_cell text: t(".table.headers.onboarded_by") %>
+              <% row.with_cell text: t(".table.headers.eligible_for") %>
+            <% end %>
+          <% end %>
 
-      <% table.with_body do |body| %>
-        <% @manually_onboarded_schools.each do |school| %>
-          <% body.with_row do |row| %>
-            <% row.with_cell text: govuk_link_to(school.name, claims_support_school_path(school)) %>
-            <% row.with_cell text: school.manually_onboarded_by.full_name %>
-            <% row.with_cell do %>
-              <%= govuk_list do %>
-                <% school.eligible_claim_windows.order(starts_on: :desc).each do |claim_window| %>
-                  <% if claim_window.current? %>
-                    <li><strong><%= "#{window_range_display(claim_window.starts_on, claim_window.ends_on)} (current)" %></strong></li>
-                  <% else %>
-                    <li><%= window_range_display(claim_window.starts_on, claim_window.ends_on) %></li>
+          <% table.with_body do |body| %>
+            <% @manually_onboarded_schools.each do |school| %>
+              <% body.with_row do |row| %>
+                <% row.with_cell text: govuk_link_to(school.name, claims_support_school_path(school)) %>
+                <% row.with_cell text: school.manually_onboarded_by.full_name %>
+                <% row.with_cell do %>
+                  <%= govuk_list do %>
+                    <% school.eligible_claim_windows.order(starts_on: :desc).each do |claim_window| %>
+                      <% if claim_window.current? %>
+                        <li>
+                          <strong><%= "#{window_range_display(claim_window.starts_on, claim_window.ends_on)} (current)" %></strong>
+                        </li>
+                      <% else %>
+                        <li><%= window_range_display(claim_window.starts_on, claim_window.ends_on) %></li>
+                      <% end %>
+                    <% end %>
                   <% end %>
                 <% end %>
               <% end %>
             <% end %>
           <% end %>
         <% end %>
+      <% else %>
+        <p class="govuk-body"><%= t(".no_schools") %></p>
       <% end %>
-    <% end %>
-  <% else %>
-    <p class="govuk-body"><%= t(".no_schools") %></p>
-  <% end %>
+    </div>
+  </div>
 </div>

--- a/app/views/claims/support/manually_onboarded_schools/index.html.erb
+++ b/app/views/claims/support/manually_onboarded_schools/index.html.erb
@@ -1,0 +1,43 @@
+<% render "claims/support/primary_navigation", current: :settings %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: claims_support_settings_path) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+
+  <% if @manually_onboarded_schools.exists? %>
+    <%= govuk_table do |table| %>
+      <% table.with_head do |head| %>
+        <% head.with_row do |row| %>
+          <% row.with_cell text: t(".table.headers.school_name") %>
+          <% row.with_cell text: t(".table.headers.onboarded_by") %>
+          <% row.with_cell text: t(".table.headers.eligible_for") %>
+        <% end %>
+      <% end %>
+
+      <% table.with_body do |body| %>
+        <% @manually_onboarded_schools.each do |school| %>
+          <% body.with_row do |row| %>
+            <% row.with_cell text: govuk_link_to(school.name, claims_support_school_path(school)) %>
+            <% row.with_cell text: school.manually_onboarded_by.full_name %>
+            <% row.with_cell do %>
+              <%= govuk_list do %>
+                <% school.eligible_claim_windows.order(starts_on: :desc).each do |claim_window| %>
+                  <% if claim_window.current? %>
+                    <li><strong><%= "#{window_range_display(claim_window.starts_on, claim_window.ends_on)} (current)" %></strong></li>
+                  <% else %>
+                    <li><%= window_range_display(claim_window.starts_on, claim_window.ends_on) %></li>
+                  <% end %>
+                <% end %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% else %>
+    <p class="govuk-body"><%= t(".no_schools") %></p>
+  <% end %>
+</div>

--- a/app/views/claims/support/settings/index.html.erb
+++ b/app/views/claims/support/settings/index.html.erb
@@ -13,6 +13,7 @@
         govuk_link_to(t(".claim_windows"), claims_support_claim_windows_path, no_visited_state: true),
         govuk_link_to(t(".onboard_users"), new_onboard_users_claims_support_schools_path, no_visited_state: true),
         govuk_link_to(t(".onboard_schools"), new_onboard_schools_claims_support_schools_path, no_visited_state: true),
+        govuk_link_to(t(".manually_onboarded_schools"), claims_support_manually_onboarded_schools_path, no_visited_state: true),
         govuk_link_to(t(".emails"), claims_support_mailers_path, no_visited_state: true),
         (govuk_link_to(t(".reset_database"), reset_claims_support_database_path, no_visited_state: true) unless HostingEnvironment.env.production?),
         (govuk_link_to(t(".revert_claims_to_submitted"), revert_to_submitted_claims_support_database_databases_claims_path, no_visited_state: true) unless HostingEnvironment.env.production?),

--- a/app/wizards/claims/add_school_wizard.rb
+++ b/app/wizards/claims/add_school_wizard.rb
@@ -1,5 +1,10 @@
 module Claims
   class AddSchoolWizard < BaseWizard
+    def initialize(current_user:, params:, state:, current_step: nil)
+      @current_user = current_user
+      super(state:, params:, current_step:)
+    end
+
     def define_steps
       if claim_windows_exist?
         add_step(SchoolStep)
@@ -17,7 +22,7 @@ module Claims
     end
 
     def onboard_school
-      school.update!(claims_service: true)
+      school.update!(claims_service: true, manually_onboarded_by: current_user)
       school.becomes(Claims::School)
         .eligibilities
         .create!(claim_window:)
@@ -30,6 +35,8 @@ module Claims
     end
 
     private
+
+    attr_reader :current_user
 
     def claim_windows_exist?
       Claims::ClaimWindow.current.present? ||

--- a/config/locales/en/claims/support/manually_onboarded_schools.yml
+++ b/config/locales/en/claims/support/manually_onboarded_schools.yml
@@ -1,0 +1,12 @@
+en:
+  claims:
+    support:
+      manually_onboarded_schools:
+        index:
+          heading: Manually onboarded schools
+          table:
+            headers:
+              school_name: School name
+              onboarded_by: Onboarded by
+              eligible_for: Eligible to claim dates
+          no_schools: No manually onboarded schools found.

--- a/config/locales/en/claims/support/settings.yml
+++ b/config/locales/en/claims/support/settings.yml
@@ -11,3 +11,4 @@ en:
           revert_claims_to_submitted: Revert all claims to 'Submitted'
           onboard_users: Onboard users
           onboard_schools: Onboard schools
+          manually_onboarded_schools: Manually onboarded schools

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -283,6 +283,8 @@ scope module: :claims, as: :claims, constraints: {
 
     resources :mailers, only: :index
 
+    resources :manually_onboarded_schools, only: :index
+
     resources :claim_windows do
       get :new_check, path: :check, on: :collection
       get :edit_check, path: :check, on: :member

--- a/spec/components/previews/autocomplete_select_form_component_preview.rb
+++ b/spec/components/previews/autocomplete_select_form_component_preview.rb
@@ -1,6 +1,7 @@
 class AutocompleteSelectFormComponentPreview < ApplicationComponentPreview
   def school_onboarding_form
-    wizard = Claims::AddSchoolWizard.new(state: {}, params: {})
+    current_user = FactoryBot.build(:claims_support_user)
+    wizard = Claims::AddSchoolWizard.new(current_user:, state: {}, params: {})
     step = Claims::AddSchoolWizard::SchoolStep.new(
       wizard:, attributes: {},
     )

--- a/spec/components/previews/options_form_component_preview.rb
+++ b/spec/components/previews/options_form_component_preview.rb
@@ -1,7 +1,8 @@
 class OptionsFormComponentPreview < ApplicationComponentPreview
   def less_than_15_schools
+    current_user = FactoryBot.build(:claims_support_user)
     schools = FactoryBot.build_list(:school, 2)
-    wizard = Claims::AddSchoolWizard.new(state: {}, params: {})
+    wizard = Claims::AddSchoolWizard.new(current_user:, state: {}, params: {})
     step = Claims::AddSchoolWizard::SchoolOptionsStep.new(
       wizard:, attributes: {},
     )
@@ -17,8 +18,9 @@ class OptionsFormComponentPreview < ApplicationComponentPreview
   end
 
   def more_than_15_schools
+    current_user = FactoryBot.build(:claims_support_user)
     schools = FactoryBot.build_list(:school, 16)
-    wizard = Claims::AddSchoolWizard.new(state: {}, params: {})
+    wizard = Claims::AddSchoolWizard.new(current_user:, state: {}, params: {})
     step = Claims::AddSchoolWizard::SchoolOptionsStep.new(
       wizard:, attributes: {},
     )

--- a/spec/system/claims/support/settings/support_user_views_manually_onboarded_schools_spec.rb
+++ b/spec/system/claims/support/settings/support_user_views_manually_onboarded_schools_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe "Support user views manually onboarded schools", service: :claims, type: :system do
+  scenario do
+    given_manually_onboarded_schools_exist
+    and_i_am_signed_in
+    when_i_navigate_to_the_settings_index_page
+    then_i_see_the_manually_onboarded_schools_link
+
+    when_i_click_on_the_manually_onboarded_schools_link
+    then_i_see_the_manually_onboarded_schools_page
+  end
+
+  private
+
+  def given_manually_onboarded_schools_exist
+    @current_claim_window = create(:claim_window, :current)
+    @previous_claim_window = create(:claim_window, :historic)
+
+    @london_onboarding_user = create(:claims_support_user, first_name: "London", last_name: "Onboarder User", email: "london_onboarder@education.gov.uk")
+    @london_school = create(:claims_school, name: "London School", urn: 111_111, manually_onboarded_by: @london_onboarding_user)
+    create(:eligibility, school: @london_school, claim_window: @current_claim_window)
+    create(:eligibility, school: @london_school, claim_window: @previous_claim_window)
+
+    @guildford_onboarding_user = create(:claims_support_user, first_name: "Guildford", last_name: "Onboarder User", email: "guildford_onboarder@education.gov.uk")
+    @guildford_school = create(:claims_school, name: "Guildford School", urn: 222_222, manually_onboarded_by: @guildford_onboarding_user)
+    create(:eligibility, school: @guildford_school, claim_window: @current_claim_window)
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_settings_index_page
+    within(primary_navigation) do
+      click_on "Settings"
+    end
+  end
+
+  def then_i_see_the_manually_onboarded_schools_link
+    expect(page).to have_link("Manually onboarded schools", href: "/support/manually_onboarded_schools")
+  end
+
+  def when_i_click_on_the_manually_onboarded_schools_link
+    click_on "Manually onboarded schools"
+  end
+
+  def then_i_see_the_manually_onboarded_schools_page
+    expect(page).to have_title("Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_link("Settings", href: "/support/settings")
+    expect(page).to have_h1("Manually onboarded schools", class: "govuk-heading-l")
+    expect(page).to have_table_row({
+      "School name" => "London School",
+      "Onboarded by" => "London Onboarder User",
+      "Eligible to claim dates" => "#{I18n.l(@current_claim_window.starts_on, format: :long)} to #{I18n.l(@current_claim_window.ends_on, format: :long)} (current) #{I18n.l(@previous_claim_window.starts_on, format: :long)} to #{I18n.l(@previous_claim_window.ends_on, format: :long)}",
+    })
+    expect(page).to have_table_row({
+      "School name" => "Guildford School",
+      "Onboarded by" => "Guildford Onboarder User",
+      "Eligible to claim dates" => "#{I18n.l(@current_claim_window.starts_on, format: :long)} to #{I18n.l(@current_claim_window.ends_on, format: :long)} (current)",
+    })
+  end
+end

--- a/spec/system/claims/support/settings/support_user_views_manually_onboarded_schools_when_none_are_present_spec.rb
+++ b/spec/system/claims/support/settings/support_user_views_manually_onboarded_schools_when_none_are_present_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe "Support user views manually onboarded schools when none are present", service: :claims, type: :system do
+  scenario do
+    given_i_am_signed_in
+    when_i_navigate_to_the_settings_index_page
+    then_i_see_the_manually_onboarded_schools_link
+
+    when_i_click_on_the_manually_onboarded_schools_link
+    then_i_do_not_see_any_schools
+  end
+
+  private
+
+  def given_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_settings_index_page
+    within(primary_navigation) do
+      click_on "Settings"
+    end
+  end
+
+  def then_i_see_the_manually_onboarded_schools_link
+    expect(page).to have_link("Manually onboarded schools", href: "/support/manually_onboarded_schools")
+  end
+
+  def when_i_click_on_the_manually_onboarded_schools_link
+    click_on "Manually onboarded schools"
+  end
+
+  def then_i_do_not_see_any_schools
+    expect(page).to have_title("Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_link("Settings", href: "/support/settings")
+    expect(page).to have_h1("Manually onboarded schools", class: "govuk-heading-l")
+    expect(page).to have_paragraph("No manually onboarded schools found.")
+  end
+end

--- a/spec/wizards/claims/add_school_wizard_spec.rb
+++ b/spec/wizards/claims/add_school_wizard_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
 RSpec.describe Claims::AddSchoolWizard do
-  subject(:wizard) { described_class.new(state:, params:, current_step: nil) }
+  subject(:wizard) { described_class.new(current_user:, state:, params:, current_step: nil) }
 
+  let(:current_user) { create(:claims_support_user) }
   let(:state) { {} }
   let(:params_data) { {} }
   let(:params) { ActionController::Parameters.new(params_data) }
@@ -67,6 +68,7 @@ RSpec.describe Claims::AddSchoolWizard do
         .and change(Claims::Eligibility, :count).by(1)
 
       school.reload
+      expect(school.manually_onboarded_by).to eq(current_user)
       expect(school.claims_service).to be(true)
       expect(current_claim_window.eligible_schools.ids).to contain_exactly(school.id)
     end


### PR DESCRIPTION
## Context

Claims needs a way to view which schools have been manually onboarded so that they can be cross referenced against whether they should have been.

## Changes proposed in this pull request

- Adds the manually onboarded schools page to the support settings page

## Guidance to review

- Log in as Colin
- Click on settings
- View the Manually onboarded schools page

## Link to Trello card

[Add support console page to view manually onboarded schools](https://trello.com/c/bv50tUj7/710-add-support-console-page-to-view-manually-onboarded-schools)

## Screenshots

![image](https://github.com/user-attachments/assets/e0e816fd-169b-40e4-9971-baae5aadaa9f)
![image](https://github.com/user-attachments/assets/8fbe5881-b938-4233-ba26-e165f846f656)
