### PR TITLE
Add send options to EOI flows

### DIFF
--- a/app/controllers/placements/schools/hosting_interests/add_hosting_interest_controller.rb
+++ b/app/controllers/placements/schools/hosting_interests/add_hosting_interest_controller.rb
@@ -14,9 +14,8 @@ class Placements::Schools::HostingInterests::AddHostingInterestController < Plac
     else
       @wizard.update_hosting_interest
       school.reload
-      if appetite == "actively_looking"
-        session["whats_next"] = @wizard.placements_information
-      end
+      session["whats_next"] = nil
+      session["whats_next"] = @wizard.placements_information if appetite == "actively_looking"
       @wizard.reset_state
 
       redirect_to whats_next_placements_school_hosting_interests_path(@school)

--- a/app/controllers/placements/schools/hosting_interests/edit_hosting_interest_controller.rb
+++ b/app/controllers/placements/schools/hosting_interests/edit_hosting_interest_controller.rb
@@ -20,10 +20,10 @@ class Placements::Schools::HostingInterests::EditHostingInterestController < Pla
     else
       @wizard.update_hosting_interest
       school.reload
-      if appetite == "actively_looking"
-        session["whats_next"] = @wizard.placements_information
-      end
+      session["whats_next"] = nil
+      session["whats_next"] = @wizard.placements_information if appetite == "actively_looking"
       @wizard.reset_state
+
       redirect_to whats_next_placements_school_hosting_interests_path(@school)
     end
   end

--- a/app/decorators/placement_decorator.rb
+++ b/app/decorators/placement_decorator.rb
@@ -14,14 +14,18 @@ class PlacementDecorator < Draper::Decorator
   end
 
   def title
-    placement_title = if additional_subjects.present?
-                        additional_subject_names
-                      else
-                        subject_name
-                      end
-    return placement_title if year_group.blank?
+    if send_specific?
+      "#{I18n.t("placements.schools.placements.send")} (#{key_stage.name})"
+    else
+      placement_title = if additional_subjects.present?
+                          additional_subject_names
+                        else
+                          subject_name
+                        end
+      return placement_title if year_group.blank?
 
-    "#{placement_title} (#{I18n.t("placements.schools.placements.year_groups.#{year_group}")})"
+      "#{placement_title} (#{I18n.t("placements.schools.placements.year_groups.#{year_group}")})"
+    end
   end
 
   def school_level

--- a/app/decorators/placement_decorator.rb
+++ b/app/decorators/placement_decorator.rb
@@ -4,6 +4,7 @@ class PlacementDecorator < Draper::Decorator
   decorates_association :academic_year
 
   delegate :name, to: :subject, prefix: true, allow_nil: true
+  delegate :name, to: :key_stage, prefix: true, allow_nil: true
 
   def mentor_names
     if mentors.any?

--- a/app/helpers/placements/potential_placement_helper.rb
+++ b/app/helpers/placements/potential_placement_helper.rb
@@ -1,0 +1,48 @@
+module Placements::PotentialPlacementHelper
+  def potential_placement_details_viewable?(placement_details)
+    @potential_placement_details_viewable ||= potential_placement_year_group_selection(placement_details).present? ||
+      potential_placement_subject_id_selection(placement_details).present? ||
+      potential_placement_key_stage_id_selection(placement_details).present?
+  end
+
+  def selected_placement_details(placement_details:, phase:)
+    case phase
+    when :primary
+      if placement_detail_unknown(potential_placement_year_group_selection(placement_details))
+        Placements::AddHostingInterestWizard::UNKNOWN_OPTION
+      else
+        potential_placement_year_group_selection(placement_details)
+      end
+    when :secondary
+      if placement_detail_unknown(potential_placement_subject_id_selection(placement_details))
+        Placements::AddHostingInterestWizard::UNKNOWN_OPTION
+      else
+        Subject.where(id: potential_placement_subject_id_selection(placement_details))
+      end
+    when :send
+      if placement_detail_unknown(potential_placement_key_stage_id_selection(placement_details))
+        Placements::AddHostingInterestWizard::UNKNOWN_OPTION
+      else
+        Placements::KeyStage.where(id: potential_placement_key_stage_id_selection(placement_details))
+      end
+    else
+      []
+    end
+  end
+
+  def potential_placement_year_group_selection(placement_details)
+    @potential_placement_year_group_selection ||= placement_details.dig("year_group_selection", "year_groups")
+  end
+
+  def potential_placement_subject_id_selection(placement_details)
+    @potential_placement_subject_id_selection ||= placement_details.dig("secondary_subject_selection", "subject_ids")
+  end
+
+  def potential_placement_key_stage_id_selection(placement_details)
+    @potential_placement_key_stage_id_selection ||= placement_details.dig("key_stage_selection", "key_stage_ids")
+  end
+
+  def placement_detail_unknown(value)
+    value.include?(Placements::AddHostingInterestWizard::UNKNOWN_OPTION)
+  end
+end

--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -35,8 +35,9 @@ class Placement < ApplicationRecord
   belongs_to :academic_year, class_name: "Placements::AcademicYear"
   belongs_to :school, class_name: "Placements::School"
   belongs_to :provider, class_name: "::Provider", optional: true
-  belongs_to :subject, class_name: "::Subject"
+  belongs_to :subject, class_name: "::Subject", optional: true
   belongs_to :creator, optional: true, polymorphic: true
+  belongs_to :key_stage, class_name: "Placements::KeyStage", optional: true
 
   accepts_nested_attributes_for :mentors, allow_destroy: true
 
@@ -54,6 +55,8 @@ class Placement < ApplicationRecord
   }, validate: { allow_nil: true }
 
   validates :school, presence: true
+  validates :subject, presence: true, if: -> { !send_specific }
+  validates :key_stage, presence: true, if: -> { send_specific }
 
   delegate :name, to: :provider, prefix: true, allow_nil: true
   delegate :has_child_subjects?, to: :subject, allow_nil: true, prefix: true

--- a/app/models/placements/key_stage.rb
+++ b/app/models/placements/key_stage.rb
@@ -1,0 +1,40 @@
+# == Schema Information
+#
+# Table name: key_stages
+#
+#  id         :uuid             not null, primary key
+#  name       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class Placements::KeyStage < ApplicationRecord
+  EARLY_YEARS = "Early years".freeze
+  KEY_STAGE_1 = "Key stage 1".freeze
+  KEY_STAGE_2 = "Key stage 2".freeze
+  KEY_STAGE_3 = "Key stage 3".freeze
+  KEY_STAGE_4 = "Key stage 4".freeze
+  KEY_STAGE_5 = "Key stage 5".freeze
+  MIXED_KEY_STAGES = "Mixed key stages".freeze
+
+  VALID_NAMES = [
+    EARLY_YEARS,
+    KEY_STAGE_1,
+    KEY_STAGE_2,
+    KEY_STAGE_3,
+    KEY_STAGE_4,
+    KEY_STAGE_5,
+    MIXED_KEY_STAGES,
+  ].freeze
+
+  has_many :placement_key_stages, class_name: "Placements::PlacementKeyStage"
+  has_many :placements, through: :placement_key_stages
+
+  validates :name, presence: true, inclusion: { in: VALID_NAMES }
+
+  scope :order_by_name, -> { order(name: :asc) }
+
+  def name_as_attribute
+    name.parameterize(separator: "_").to_sym
+  end
+end

--- a/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_actively_looking.html.erb
+++ b/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_actively_looking.html.erb
@@ -40,14 +40,12 @@
   <% end %>
 <% end %>
 
-<% if placement_details.dig("year_group_selection", "year_groups").present? ||
-  placement_details.dig("secondary_subject_selection", "subject_ids").present? ||
-  placement_details.dig("key_stage_selection", "key_stage_ids").present? %>
+<% if potential_placement_details_viewable?(placement_details) %>
   <h2 class="govuk-heading-m">
     <%= t(".your_placements_offers") %>
   </h2>
 
-  <% if placement_details.dig("year_group_selection", "year_groups").present? %>
+  <% if potential_placement_year_group_selection(placement_details).present? %>
     <h3 class="govuk-heading-s">
       <%= t(".primary_placements") %>
     </h3>
@@ -56,7 +54,7 @@
       placement_details: placement_details, action_link: nil %>
   <% end %>
 
-  <% if placement_details.dig("secondary_subject_selection", "subject_ids").present? %>
+  <% if potential_placement_subject_id_selection(placement_details).present? %>
     <h3 class="govuk-heading-s">
       <%= t(".secondary_placements") %>
     </h3>
@@ -65,7 +63,7 @@
       placement_details: placement_details, action_link: nil %>
   <% end %>
 
-  <% if placement_details.dig("key_stage_selection", "key_stage_ids").present? %>
+  <% if potential_placement_key_stage_id_selection(placement_details).present? %>
     <h3 class="govuk-heading-s">
       <%= t(".send_placements") %>
     </h3>

--- a/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_actively_looking.html.erb
+++ b/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_actively_looking.html.erb
@@ -41,26 +41,36 @@
 <% end %>
 
 <% if placement_details.dig("year_group_selection", "year_groups").present? ||
-  placement_details.dig("secondary_subject_selection", "subject_ids").present? %>
+  placement_details.dig("secondary_subject_selection", "subject_ids").present? ||
+  placement_details.dig("key_stage_selection", "key_stage_ids").present? %>
   <h2 class="govuk-heading-m">
     <%= t(".your_placements_offers") %>
   </h2>
 
   <% if placement_details.dig("year_group_selection", "year_groups").present? %>
-    <h2 class="govuk-heading-m">
+    <h3 class="govuk-heading-s">
       <%= t(".primary_placements") %>
-    </h2>
+    </h3>
 
     <%= render "placements/schools/hosting_interests/add_hosting_interest/whats_next/primary_placements_list",
       placement_details: placement_details, action_link: nil %>
   <% end %>
 
   <% if placement_details.dig("secondary_subject_selection", "subject_ids").present? %>
-    <h2 class="govuk-heading-m">
+    <h3 class="govuk-heading-s">
       <%= t(".secondary_placements") %>
-    </h2>
+    </h3>
 
     <%= render "placements/schools/hosting_interests/add_hosting_interest/whats_next/secondary_placements_list",
+      placement_details: placement_details, action_link: nil %>
+  <% end %>
+
+  <% if placement_details.dig("key_stage_selection", "key_stage_ids").present? %>
+    <h3 class="govuk-heading-s">
+      <%= t(".send_placements") %>
+    </h3>
+
+    <%= render "placements/schools/hosting_interests/add_hosting_interest/whats_next/send_placements_list",
       placement_details: placement_details, action_link: nil %>
   <% end %>
 <% end %>

--- a/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_interested.html.erb
+++ b/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_interested.html.erb
@@ -26,7 +26,8 @@
 </p>
 
 <% if placement_details.dig("year_group_selection", "year_groups").present? ||
-  placement_details.dig("secondary_subject_selection", "subject_ids").present? %>
+  placement_details.dig("secondary_subject_selection", "subject_ids").present? ||
+  placement_details.dig("key_stage_selection", "key_stage_ids").present? %>
   <h2 class="govuk-heading-m">
     <%= t(".potential_placement_information") %>
   </h2>
@@ -46,6 +47,15 @@
     </h2>
 
     <%= render "placements/schools/hosting_interests/add_hosting_interest/whats_next/secondary_placements_list",
+      placement_details: placement_details, action_link: nil %>
+  <% end %>
+
+  <% if placement_details.dig("key_stage_selection", "key_stage_ids").present? %>
+    <h3 class="govuk-heading-s">
+      <%= t(".potential_send_placements") %>
+    </h3>
+
+    <%= render "placements/schools/hosting_interests/add_hosting_interest/whats_next/send_placements_list",
       placement_details: placement_details, action_link: nil %>
   <% end %>
 <% end %>

--- a/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_interested.html.erb
+++ b/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_interested.html.erb
@@ -25,14 +25,12 @@
   ) %>
 </p>
 
-<% if placement_details.dig("year_group_selection", "year_groups").present? ||
-  placement_details.dig("secondary_subject_selection", "subject_ids").present? ||
-  placement_details.dig("key_stage_selection", "key_stage_ids").present? %>
+<% if potential_placement_details_viewable?(placement_details) %>
   <h2 class="govuk-heading-m">
     <%= t(".potential_placement_information") %>
   </h2>
 
-  <% if placement_details.dig("year_group_selection", "year_groups").present? %>
+  <% if potential_placement_year_group_selection(placement_details).present? %>
     <h2 class="govuk-heading-m">
       <%= t(".potential_primary_placements") %>
     </h2>
@@ -41,7 +39,7 @@
       placement_details: placement_details, action_link: nil %>
   <% end %>
 
-  <% if placement_details.dig("secondary_subject_selection", "subject_ids").present? %>
+  <% if potential_placement_subject_id_selection(placement_details).present? %>
     <h2 class="govuk-heading-m">
       <%= t(".potential_secondary_placements") %>
     </h2>
@@ -50,7 +48,7 @@
       placement_details: placement_details, action_link: nil %>
   <% end %>
 
-  <% if placement_details.dig("key_stage_selection", "key_stage_ids").present? %>
+  <% if potential_placement_key_stage_id_selection(placement_details).present? %>
     <h3 class="govuk-heading-s">
       <%= t(".potential_send_placements") %>
     </h3>

--- a/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_primary_placements_list.html.erb
+++ b/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_primary_placements_list.html.erb
@@ -15,13 +15,10 @@
     <% end %>
   <% end %>
 
-  <% placement_details.dig("year_group_selection", "year_groups").each do |year_group| %>
-    <% if year_group == Placements::AddHostingInterestWizard::UNKNOWN_OPTION %>
-      <% summary_list.with_row do |row| %>
-        <% row.with_key(text: t(".unknown")) %>
-        <% row.with_value(text: t(".not_entered")) %>
-      <% end %>
-    <% else %>
+  <% if placement_detail_unknown(potential_placement_year_group_selection(placement_details)) %>
+    <%= render "placements/schools/hosting_interests/add_hosting_interest/whats_next/unknown", summary_list: %>
+  <% else %>
+    <% selected_placement_details(placement_details:, phase: :primary).each do |year_group| %>
       <% summary_list.with_row do |row| %>
         <% row.with_key(text: t("placements.schools.placements.year_groups.#{year_group}")) %>
         <% row.with_value do %>

--- a/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_secondary_placements_list.html.erb
+++ b/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_secondary_placements_list.html.erb
@@ -1,5 +1,5 @@
 <%# locals: { placement_details: nil, action_link: nil } -%>
-<%= govuk_summary_list(html_attributes: { id: "primary_placements" }, actions: action_link.present?) do |summary_list| %>
+<%= govuk_summary_list(html_attributes: { id: "secondary_placements" }, actions: action_link.present?) do |summary_list| %>
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: t(".subject")) %>
     <% row.with_value do %>

--- a/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_secondary_placements_list.html.erb
+++ b/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_secondary_placements_list.html.erb
@@ -15,14 +15,10 @@
     <% end %>
   <% end %>
 
-  <% placement_details.dig("secondary_subject_selection", "subject_ids").each do |subject_id| %>
-    <% if subject_id == Placements::AddHostingInterestWizard::UNKNOWN_OPTION %>
-      <% summary_list.with_row do |row| %>
-        <% row.with_key(text: t(".unknown")) %>
-        <% row.with_value(text: t(".not_entered")) %>
-      <% end %>
-    <% else %>
-      <% subject = Subject.find(subject_id) %>
+  <% if placement_detail_unknown(potential_placement_subject_id_selection(placement_details)) %>
+    <%= render "placements/schools/hosting_interests/add_hosting_interest/whats_next/unknown", summary_list: %>
+  <% else %>
+    <% selected_placement_details(placement_details:, phase: :secondary).each do |subject| %>
       <% summary_list.with_row do |row| %>
         <% row.with_key(text: subject.name) %>
         <% row.with_value do %>

--- a/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_send_placements_list.html.erb
+++ b/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_send_placements_list.html.erb
@@ -15,14 +15,10 @@
     <% end %>
   <% end %>
 
-  <% placement_details.dig("key_stage_selection", "key_stage_ids").each do |key_stage_id| %>
-    <% if key_stage_id == Placements::AddHostingInterestWizard::UNKNOWN_OPTION %>
-      <% summary_list.with_row do |row| %>
-        <% row.with_key(text: t(".unknown")) %>
-        <% row.with_value(text: t(".not_entered")) %>
-      <% end %>
-    <% else %>
-      <% key_stage = Placements::KeyStage.find(key_stage_id) %>
+  <% if placement_detail_unknown(potential_placement_key_stage_id_selection(placement_details)) %>
+    <%= render "placements/schools/hosting_interests/add_hosting_interest/whats_next/unknown", summary_list: %>
+  <% else %>
+    <% selected_placement_details(placement_details:, phase: :send).each do |key_stage| %>
       <% summary_list.with_row do |row| %>
         <% row.with_key(text: key_stage.name) %>
         <% row.with_value do %>

--- a/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_send_placements_list.html.erb
+++ b/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_send_placements_list.html.erb
@@ -1,0 +1,34 @@
+<%# locals: { placement_details: nil, action_link: nil } -%>
+<%= govuk_summary_list(html_attributes: { id: "send_placements" }, actions: action_link.present?) do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t(".key_stage")) %>
+    <% row.with_value do %>
+      <strong><%= t(".number_of_placements") %></strong>
+    <% end %>
+    <% if action_link.present? %>
+      <% row.with_action(
+        text: t(".change"),
+        href: action_link,
+        visually_hidden_text: t(".key_stage"),
+        classes: ["govuk-link--no-visited-state"],
+      ) %>
+    <% end %>
+  <% end %>
+
+  <% placement_details.dig("key_stage_selection", "key_stage_ids").each do |key_stage_id| %>
+    <% if key_stage_id == Placements::AddHostingInterestWizard::UNKNOWN_OPTION %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: t(".unknown")) %>
+        <% row.with_value(text: t(".not_entered")) %>
+      <% end %>
+    <% else %>
+      <% key_stage = Placements::KeyStage.find(key_stage_id) %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: key_stage.name) %>
+        <% row.with_value do %>
+          <%= placement_details.dig("key_stage_placement_quantity", key_stage.name_as_attribute.to_s).to_i %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_unknown.html.erb
+++ b/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_unknown.html.erb
@@ -1,0 +1,5 @@
+<%# locals: { summary_list: } -%>
+<% summary_list.with_row do |row| %>
+  <% row.with_key(text: t(".unknown")) %>
+  <% row.with_value(text: t(".not_entered")) %>
+<% end %>

--- a/app/views/placements/schools/placements/_details.html.erb
+++ b/app/views/placements/schools/placements/_details.html.erb
@@ -10,10 +10,12 @@
       <% row.with_value(text: placement.school_level) %>
     <% end %>
   <% end %>
-  <% summary_list.with_row do |row| %>
-    <% row.with_key(text: t(".attributes.placements.subject")) %>
-    <% row.with_value do %>
-      <% placement.subject_name %>
+  <% if placement.subject.present? %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key(text: t(".attributes.placements.subject")) %>
+      <% row.with_value do %>
+        <% placement.subject_name %>
+      <% end %>
     <% end %>
   <% end %>
   <% if placement.subject_has_child_subjects? %>
@@ -22,6 +24,19 @@
       <% row.with_value do %>
         <% placement.additional_subject_names %>
       <% end %>
+    <% end %>
+  <% end %>
+   <% if placement.key_stage.present? %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key(text: t(".attributes.placements.key_stage")) %>
+      <% row.with_value do %>
+        <% placement.key_stage_name %>
+      <% end %>
+      <% row.with_action(
+        text: t(".change"),
+        href: edit_attribute_path(:key_stage),
+        visually_hidden_text: t(".attributes.placements.key_stage"),
+      ) %>
     <% end %>
   <% end %>
   <% if placement.year_group.present? %>

--- a/app/views/placements/schools/potential_placements/_details.html.erb
+++ b/app/views/placements/schools/potential_placements/_details.html.erb
@@ -41,10 +41,8 @@
         <% end %>
       <% end %>
 
-      <% if placement_details.dig("year_group_selection", "year_groups").present? ||
-        placement_details.dig("secondary_subject_selection", "subject_ids").present? ||
-        placement_details.dig("key_stage_selection", "key_stage_ids").present? %>
-        <% if placement_details.dig("year_group_selection", "year_groups").present? %>
+      <% if potential_placement_details_viewable?(placement_details) %>
+        <% if potential_placement_year_group_selection(placement_details).present? %>
           <h3 class="govuk-heading-s">
             <%= t(".potential_primary_placements") %>
           </h3>
@@ -58,7 +56,7 @@
             ) %>
         <% end %>
 
-        <% if placement_details.dig("secondary_subject_selection", "subject_ids").present? %>
+        <% if potential_placement_subject_id_selection(placement_details).present? %>
           <h3 class="govuk-heading-s">
             <%= t(".potential_secondary_placements") %>
           </h3>
@@ -72,7 +70,7 @@
             ) %>
         <% end %>
 
-        <% if placement_details.dig("key_stage_selection", "key_stage_ids").present? %>
+        <% if potential_placement_key_stage_id_selection(placement_details).present? %>
           <h3 class="govuk-heading-s">
             <%= t(".potential_send_placements") %>
           </h3>

--- a/app/views/placements/schools/potential_placements/_details.html.erb
+++ b/app/views/placements/schools/potential_placements/_details.html.erb
@@ -42,7 +42,8 @@
       <% end %>
 
       <% if placement_details.dig("year_group_selection", "year_groups").present? ||
-        placement_details.dig("secondary_subject_selection", "subject_ids").present? %>
+        placement_details.dig("secondary_subject_selection", "subject_ids").present? ||
+        placement_details.dig("key_stage_selection", "key_stage_ids").present? %>
         <% if placement_details.dig("year_group_selection", "year_groups").present? %>
           <h3 class="govuk-heading-s">
             <%= t(".potential_primary_placements") %>
@@ -68,6 +69,20 @@
               school,
               step: :secondary_subject_selection,
               state_key: :secondary_subject_selection,
+            ) %>
+        <% end %>
+
+        <% if placement_details.dig("key_stage_selection", "key_stage_ids").present? %>
+          <h3 class="govuk-heading-s">
+            <%= t(".potential_send_placements") %>
+          </h3>
+
+          <%= render "placements/schools/hosting_interests/add_hosting_interest/whats_next/send_placements_list",
+            placement_details: placement_details,
+            action_link: edit_potential_placements_placements_school_potential_placements_path(
+              school,
+              step: :key_stage_selection,
+              state_key: :key_stage_selection,
             ) %>
         <% end %>
       <% end %>

--- a/app/views/shared/wizards/placements/multiple_placements_wizard/_check_your_answers.html.erb
+++ b/app/views/shared/wizards/placements/multiple_placements_wizard/_check_your_answers.html.erb
@@ -24,3 +24,12 @@
   <%= render "shared/wizards/placements/multiple_placements_wizard/check_your_answers/secondary_placements_list",
     wizard:, current_step: %>
 <% end %>
+
+<% if current_step.selected_key_stages.present? %>
+  <h2 class="govuk-heading-m">
+    <%= potential ? t(".potential_send_placements") : t(".send_placements") %>
+  </h2>
+
+  <%= render "shared/wizards/placements/multiple_placements_wizard/check_your_answers/send_placements_list",
+    wizard:, current_step: %>
+<% end %>

--- a/app/views/shared/wizards/placements/multiple_placements_wizard/check_your_answers/_send_placements_list.html.erb
+++ b/app/views/shared/wizards/placements/multiple_placements_wizard/check_your_answers/_send_placements_list.html.erb
@@ -1,0 +1,28 @@
+<%# locals: { wizard:, current_step: } -%>
+<%= govuk_summary_list(html_attributes: { id: "send_placements" }) do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t(".key_stage")) %>
+    <% row.with_value do %>
+      <strong><%= t(".number_of_placements") %></strong>
+    <% end %>
+    <% row.with_action(text: t("change"),
+                       href: step_path(:key_stage_selection),
+                       visually_hidden_text: t(".send_placements"),
+                       classes: ["govuk-link--no-visited-state"]) %>
+  <% end %>
+
+  <% current_step.selected_key_stages.each do |key_stage| %>
+    <% if key_stage == Placements::AddHostingInterestWizard::UNKNOWN_OPTION %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: t(".unknown")) %>
+        <% row.with_value(text: t(".not_entered")) %>
+      <% end %>
+    <% else %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: key_stage.name) %>
+        <% placement_quantity = wizard.placement_quantity_for_key_stage(key_stage) %>
+        <% row.with_value(text: placement_quantity.zero? ? t(".not_entered") : placement_quantity) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/wizards/placements/add_hosting_interest_wizard/interested/_key_stage_placement_quantity_known_step.html.erb
+++ b/app/views/wizards/placements/add_hosting_interest_wizard/interested/_key_stage_placement_quantity_known_step.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title, title_with_error_prefix(
+  t(".title"),
+  error: current_step.errors.any?,
+) %>
+
+<%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".caption") %></span>
+
+      <%= f.govuk_collection_radio_buttons(
+            :quantity_known,
+            current_step.options_for_selection,
+            :name, :name,
+            legend: { size: "l", text: t(".title"), tag: "h1" },
+            hint: { text: t(".hint") }
+          ) %>
+
+      <%= f.govuk_submit t(".continue") %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/wizards/placements/add_hosting_interest_wizard/interested/_key_stage_placement_quantity_step.html.erb
+++ b/app/views/wizards/placements/add_hosting_interest_wizard/interested/_key_stage_placement_quantity_step.html.erb
@@ -10,6 +10,7 @@
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l"><%= t(".caption") %></span>
       <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+      <p class="govuk-body secondary-text"><%= t(".enter_approximate") %></p>
       <p class="govuk-body secondary-text"><%= t(".hint") %></p>
 
       <% current_step.key_stages.each do |key_stage| %>

--- a/app/views/wizards/placements/add_hosting_interest_wizard/interested/_key_stage_placement_quantity_step.html.erb
+++ b/app/views/wizards/placements/add_hosting_interest_wizard/interested/_key_stage_placement_quantity_step.html.erb
@@ -1,0 +1,27 @@
+<% content_for :page_title, title_with_error_prefix(
+  t(".title"),
+  error: current_step.errors.any?,
+) %>
+
+<%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".caption") %></span>
+      <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+      <p class="govuk-body secondary-text"><%= t(".hint") %></p>
+
+      <% current_step.key_stages.each do |key_stage| %>
+        <%= f.govuk_number_field(
+          key_stage.name_as_attribute,
+          class: "govuk-input--width-2",
+          min: 1,
+          label: { text: key_stage.name, class: "govuk-!-font-weight-bold" },
+        ) %>
+      <% end %>
+
+      <%= f.govuk_submit t(".continue") %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/wizards/placements/add_hosting_interest_wizard/interested/_key_stage_selection_step.html.erb
+++ b/app/views/wizards/placements/add_hosting_interest_wizard/interested/_key_stage_selection_step.html.erb
@@ -1,0 +1,34 @@
+<% content_for :page_title, title_with_error_prefix(
+  t(".title"),
+  error: current_step.errors.any?,
+) %>
+
+<%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".caption") %></span>
+     <%= f.govuk_check_boxes_fieldset(
+        :key_stage_ids,
+        legend: { size: "l", text: t(".title"), tag: "h1" },
+        hint: { text: t(".hint") },
+      ) do %>
+        <% current_step.key_stages_for_selection.each_with_index do |key_stage, i| %>
+          <%= f.govuk_check_box :key_stage_ids, key_stage.id,
+            label: { text: key_stage.name },
+            link_errors: i.zero? %>
+        <% end %>
+        <%= f.govuk_check_box_divider %>
+        <%= f.govuk_check_box :key_stage_ids, current_step.mixed_key_stage_option.id,
+            label: { text: current_step.mixed_key_stage_option.name } %>
+        <%= f.govuk_check_box_divider %>
+        <%= f.govuk_check_box :key_stage_ids, current_step.unknown_option.value,
+            label: { text: current_step.unknown_option.name },
+            hint: { text: current_step.unknown_option.description } %>
+      <% end %>
+
+      <%= f.govuk_submit t(".continue") %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/wizards/placements/add_hosting_interest_wizard/interested/_phase_step.html.erb
+++ b/app/views/wizards/placements/add_hosting_interest_wizard/interested/_phase_step.html.erb
@@ -13,7 +13,7 @@
         legend: { size: "l", text: t(".title"), tag: "h1" },
         hint: { text: t(".hint") }) do %>
         <% current_step.phases_for_selection.each_with_index do |phase, i| %>
-          <%= f.govuk_check_box :phases, phase.name,
+          <%= f.govuk_check_box :phases, phase.value,
             label: { text: phase.name },
             hint: { text: phase.description },
             link_errors: i.zero? %>

--- a/app/views/wizards/placements/convert_potential_placement_wizard/_select_placement_step.html.erb
+++ b/app/views/wizards/placements/convert_potential_placement_wizard/_select_placement_step.html.erb
@@ -42,6 +42,21 @@
         <% end %>
       <% end %>
 
+      <% if current_step.key_stages.present? %>
+        <%= f.govuk_check_boxes_fieldset(:key_stage_ids,
+          legend: { size: "m", text: t(".send_placements"), tag: "h2" }) do %>
+          <% current_step.key_stages.each_with_index do |key_stage, i| %>
+            <%= f.govuk_check_box :key_stage_ids, key_stage.id,
+              label: { text: key_stage.name },
+              hint: {
+                text: t(".number_of_placements",
+                count: current_step.placement_count(phase: :send, key: key_stage.name_as_attribute.to_s)),
+              },
+              link_errors: i.zero? %>
+          <% end %>
+        <% end %>
+      <% end %>
+
       <%= f.govuk_submit t(".publish_placements") %>
     </div>
   </div>

--- a/app/views/wizards/placements/edit_placement_wizard/_key_stage_step.html.erb
+++ b/app/views/wizards/placements/edit_placement_wizard/_key_stage_step.html.erb
@@ -1,0 +1,29 @@
+<% content_for :page_title, title_with_error_prefix(
+  t(".title", contextual_text:),
+  error: current_step.errors.any?,
+) %>
+
+<%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= contextual_text %></span>
+     <%= f.govuk_radio_buttons_fieldset(
+        :key_stage_id,
+        legend: { size: "l", text: t(".select_a_key_stage"), tag: "h1" },
+      ) do %>
+        <% current_step.key_stages_for_selection.each_with_index do |key_stage, i| %>
+          <%= f.govuk_radio_button :key_stage_id, key_stage.id,
+            label: { text: key_stage.name },
+            link_errors: i.zero? %>
+        <% end %>
+        <%= f.govuk_radio_divider %>
+        <%= f.govuk_radio_button :key_stage_id, current_step.mixed_key_stage_option.id,
+            label: { text: current_step.mixed_key_stage_option.name } %>
+      <% end %>
+
+      <%= f.govuk_submit t(".continue") %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/wizards/placements/multi_placement_wizard/_key_stage_placement_quantity_step.html.erb
+++ b/app/views/wizards/placements/multi_placement_wizard/_key_stage_placement_quantity_step.html.erb
@@ -1,0 +1,27 @@
+<% content_for :page_title, title_with_error_prefix(
+  t(".title"),
+  error: current_step.errors.any?,
+) %>
+
+<%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".caption") %></span>
+      <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+      <p class="govuk-body secondary-text"><%= t(".enter_approximate") %></p>
+
+      <% current_step.key_stages.each do |key_stage| %>
+        <%= f.govuk_number_field(
+          key_stage.name_as_attribute,
+          class: "govuk-input--width-2",
+          min: 1,
+          label: { text: key_stage.name, class: "govuk-!-font-weight-bold" },
+        ) %>
+      <% end %>
+
+      <%= f.govuk_submit t(".continue") %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/wizards/placements/multi_placement_wizard/_key_stage_selection_step.html.erb
+++ b/app/views/wizards/placements/multi_placement_wizard/_key_stage_selection_step.html.erb
@@ -1,0 +1,30 @@
+<% content_for :page_title, title_with_error_prefix(
+  t(".title"),
+  error: current_step.errors.any?,
+) %>
+
+<%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".caption") %></span>
+     <%= f.govuk_check_boxes_fieldset(
+        :key_stage_ids,
+        legend: { size: "l", text: t(".title"), tag: "h1" },
+        hint: { text: t(".hint") },
+      ) do %>
+        <% current_step.key_stages_for_selection.each_with_index do |key_stage, i| %>
+          <%= f.govuk_check_box :key_stage_ids, key_stage.id,
+            label: { text: key_stage.name },
+            link_errors: i.zero? %>
+        <% end %>
+        <%= f.govuk_check_box_divider %>
+        <%= f.govuk_check_box :key_stage_ids, current_step.mixed_key_stage_option.id,
+            label: { text: current_step.mixed_key_stage_option.name } %>
+      <% end %>
+
+      <%= f.govuk_submit t(".continue") %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/wizards/placements/multi_placement_wizard/_phase_step.html.erb
+++ b/app/views/wizards/placements/multi_placement_wizard/_phase_step.html.erb
@@ -12,7 +12,7 @@
       <%= f.govuk_collection_check_boxes(
         :phases,
         current_step.phases_for_selection,
-        :name, :name, :description,
+        :value, :name, :description,
         legend: { size: "l", text: t(".title"), tag: "h1" },
         hint: { text: t(".hint") }
       ) %>

--- a/app/wizards/placements/add_hosting_interest_wizard/check_your_answers_step.rb
+++ b/app/wizards/placements/add_hosting_interest_wizard/check_your_answers_step.rb
@@ -1,6 +1,6 @@
 class Placements::AddHostingInterestWizard::CheckYourAnswersStep < BaseStep
   delegate :phases, to: :phase_step
-  delegate :year_groups, :selected_secondary_subjects, :selected_providers, to: :wizard
+  delegate :year_groups, :selected_secondary_subjects, :selected_providers, :selected_key_stages, to: :wizard
   delegate :first_name, :last_name, :email_address, to: :school_contact_step, prefix: :school_contact
 
   private

--- a/app/wizards/placements/add_hosting_interest_wizard/confirm_step.rb
+++ b/app/wizards/placements/add_hosting_interest_wizard/confirm_step.rb
@@ -1,6 +1,6 @@
 class Placements::AddHostingInterestWizard::ConfirmStep < BaseStep
   delegate :phases, to: :phase_step
-  delegate :year_groups, :selected_secondary_subjects, :selected_providers, to: :wizard
+  delegate :year_groups, :selected_secondary_subjects, :selected_providers, :selected_key_stages, to: :wizard
   delegate :first_name, :last_name, :email_address, to: :school_contact_step, prefix: :school_contact
   delegate :note, to: :note_to_providers_step
 

--- a/app/wizards/placements/add_hosting_interest_wizard/interested/key_stage_placement_quantity_known_step.rb
+++ b/app/wizards/placements/add_hosting_interest_wizard/interested/key_stage_placement_quantity_known_step.rb
@@ -1,0 +1,2 @@
+class Placements::AddHostingInterestWizard::Interested::KeyStagePlacementQuantityKnownStep < Placements::AddHostingInterestWizard::Interested::PlacementQuantityKnownStep
+end

--- a/app/wizards/placements/add_hosting_interest_wizard/interested/key_stage_placement_quantity_step.rb
+++ b/app/wizards/placements/add_hosting_interest_wizard/interested/key_stage_placement_quantity_step.rb
@@ -1,0 +1,2 @@
+class Placements::AddHostingInterestWizard::Interested::KeyStagePlacementQuantityStep < Placements::MultiPlacementWizard::KeyStagePlacementQuantityStep
+end

--- a/app/wizards/placements/add_hosting_interest_wizard/interested/key_stage_selection_step.rb
+++ b/app/wizards/placements/add_hosting_interest_wizard/interested/key_stage_selection_step.rb
@@ -1,0 +1,20 @@
+class Placements::AddHostingInterestWizard::Interested::KeyStageSelectionStep < Placements::MultiPlacementWizard::KeyStageSelectionStep
+  def unknown_option
+    @unknown_option ||=
+      OpenStruct.new(
+        value: Placements::AddHostingInterestWizard::UNKNOWN_OPTION,
+        name: I18n.t(
+          "#{unknown_option_locale_path}.unknown",
+        ),
+        description: I18n.t(
+          "#{unknown_option_locale_path}.unknown_description",
+        ),
+      )
+  end
+
+  private
+
+  def unknown_option_locale_path
+    ".wizards.placements.add_hosting_interest_wizard.interested.key_stage_selection_step.options"
+  end
+end

--- a/app/wizards/placements/add_hosting_interest_wizard/interested/placement_quantity_known_step.rb
+++ b/app/wizards/placements/add_hosting_interest_wizard/interested/placement_quantity_known_step.rb
@@ -5,7 +5,7 @@ class Placements::AddHostingInterestWizard::Interested::PlacementQuantityKnownSt
   NO = "No".freeze
   QUANTITY_KNOWN_OPTIONS = [YES, NO].freeze
 
-  validates :quantity_known, presence: true, inclusion: QUANTITY_KNOWN_OPTIONS
+  validates :quantity_known, presence: true, inclusion: { in: QUANTITY_KNOWN_OPTIONS }
 
   def options_for_selection
     QUANTITY_KNOWN_OPTIONS.map do |option|

--- a/app/wizards/placements/add_hosting_interest_wizard/list_placements_step.rb
+++ b/app/wizards/placements/add_hosting_interest_wizard/list_placements_step.rb
@@ -5,7 +5,7 @@ class Placements::AddHostingInterestWizard::ListPlacementsStep < BaseStep
   NO = "No".freeze
   LIST_PLACEMENTS = [YES, NO].freeze
 
-  validates :list_placements, presence: true, inclusion: LIST_PLACEMENTS
+  validates :list_placements, presence: true, inclusion: { in: LIST_PLACEMENTS }
 
   def responses_for_selection
     [

--- a/app/wizards/placements/add_hosting_interest_wizard/subjects_known_step.rb
+++ b/app/wizards/placements/add_hosting_interest_wizard/subjects_known_step.rb
@@ -5,7 +5,7 @@ class Placements::AddHostingInterestWizard::SubjectsKnownStep < BaseStep
   NO = "No".freeze
   VALID_SUBJECTS_KNOWN = [YES, NO].freeze
 
-  validates :subjects_known, presence: true, inclusion: VALID_SUBJECTS_KNOWN
+  validates :subjects_known, presence: true, inclusion: { in: VALID_SUBJECTS_KNOWN }
 
   def responses_for_selection
     [

--- a/app/wizards/placements/convert_potential_placement_wizard/select_placement_step.rb
+++ b/app/wizards/placements/convert_potential_placement_wizard/select_placement_step.rb
@@ -3,9 +3,11 @@ class Placements::ConvertPotentialPlacementWizard::SelectPlacementStep < BaseSte
 
   attribute :year_groups, default: []
   attribute :subject_ids, default: []
+  attribute :key_stage_ids, default: []
 
-  validates :year_groups, presence: true, if: -> { primary_year_groups.present? && subject_ids.blank? }
-  validates :subject_ids, presence: true, if: -> { secondary_subjects.present? && year_groups.blank? }
+  validates :year_groups, presence: true, if: -> { primary_year_groups.present? && subject_ids.blank? && key_stage_ids.blank? }
+  validates :subject_ids, presence: true, if: -> { secondary_subjects.present? && year_groups.blank? && key_stage_ids.blank? }
+  validates :key_stage_ids, presence: true, if: -> { key_stages.present? && year_groups.blank? && subject_ids.blank? }
 
   def primary_year_groups
     return [] if potential_placement_details.dig("year_group_selection", "year_groups").blank?
@@ -21,11 +23,21 @@ class Placements::ConvertPotentialPlacementWizard::SelectPlacementStep < BaseSte
     )
   end
 
+  def key_stages
+    @key_stages ||= Placements::KeyStage.where(
+      id: potential_placement_details.dig("key_stage_selection", "key_stage_ids"),
+    )
+  end
+
   def subject_ids=(value)
     super normalised_values(value)
   end
 
   def year_groups=(value)
+    super normalised_values(value)
+  end
+
+  def key_stage_ids=(value)
     super normalised_values(value)
   end
 

--- a/app/wizards/placements/edit_hosting_interest_wizard.rb
+++ b/app/wizards/placements/edit_hosting_interest_wizard.rb
@@ -87,11 +87,16 @@ module Placements
 
     def interested_steps
       add_step(Interested::PhaseStep)
-      if phases.include?(::Placements::School::PRIMARY_PHASE)
+      if primary_phase?
         year_group_steps
       end
-      if phases.include?(::Placements::School::SECONDARY_PHASE)
+
+      if secondary_phase?
         secondary_subject_steps
+      end
+
+      if send_specific?
+        send_steps
       end
       add_step(Interested::NoteToProvidersStep)
       add_step(ConfirmStep)

--- a/app/wizards/placements/edit_placement_wizard.rb
+++ b/app/wizards/placements/edit_placement_wizard.rb
@@ -22,6 +22,7 @@ module Placements
       add_step(AddPlacementWizard::YearGroupStep) if current_step == :year_group
       add_step(AddPlacementWizard::MentorsStep) if current_step == :mentors
       add_step(AddPlacementWizard::TermsStep) if current_step == :terms
+      add_step(KeyStageStep) if current_step == :key_stage
     end
 
     def update_placement
@@ -44,6 +45,10 @@ module Placements
         placement.terms = steps[:terms].terms
       end
 
+      if steps[:key_stage].present?
+        placement.key_stage = steps[:key_stage].key_stage
+      end
+
       placement.save!
     end
 
@@ -52,6 +57,7 @@ module Placements
       state["year_group"] = { "year_group" => placement.year_group }
       state["mentors"] = { "mentor_ids" => placement.mentors.ids }
       state["terms"] = { "term_ids" => placement.terms.ids }
+      state["key_stage"] = { "key_stage_id" => placement.key_stage_id }
     end
   end
 end

--- a/app/wizards/placements/edit_placement_wizard/key_stage_step.rb
+++ b/app/wizards/placements/edit_placement_wizard/key_stage_step.rb
@@ -1,0 +1,23 @@
+class Placements::EditPlacementWizard::KeyStageStep < BaseStep
+  attribute :key_stage_id
+
+  validates :key_stage_id, presence: true, inclusion: { in: ->(step) { step.key_stage_ids } }
+
+  MIXED_KEY_STAGES = "Mixed key stages".freeze
+
+  def key_stages_for_selection
+    Placements::KeyStage.where.not(name: MIXED_KEY_STAGES).order_by_name
+  end
+
+  def mixed_key_stage_option
+    Placements::KeyStage.find_by(name: MIXED_KEY_STAGES)
+  end
+
+  def key_stage
+    @key_stage ||= Placements::KeyStage.find(key_stage_id)
+  end
+
+  def key_stage_ids
+    Placements::KeyStage.ids
+  end
+end

--- a/app/wizards/placements/edit_potential_placements_wizard.rb
+++ b/app/wizards/placements/edit_potential_placements_wizard.rb
@@ -7,12 +7,18 @@ module Placements
     def define_steps
       setup_state if state.blank?
       add_step(Interested::PhaseStep)
-      if phases.include?(::Placements::School::PRIMARY_PHASE)
+      if primary_phase?
         year_group_steps
       end
-      if phases.include?(::Placements::School::SECONDARY_PHASE)
+
+      if secondary_phase?
         secondary_subject_steps
       end
+
+      if send_specific?
+        send_steps
+      end
+
       add_step(Interested::NoteToProvidersStep)
       add_step(ConfirmStep)
     end
@@ -23,6 +29,7 @@ module Placements
 
     def setup_state
       state["phase"] = potential_placement_details["phase"]
+      # Primary placement steps
       state["year_group_selection"] = potential_placement_details["year_group_selection"]
       state["year_group_placement_quantity_known"] = if potential_placement_details["year_group_placement_quantity"].present?
                                                        { "quantity_known" => "Yes" }
@@ -32,6 +39,7 @@ module Placements
       if potential_placement_details["year_group_placement_quantity"].present?
         state["year_group_placement_quantity"] = potential_placement_details["year_group_placement_quantity"]
       end
+      # Secondary placement steps
       state["secondary_subject_selection"] = potential_placement_details["secondary_subject_selection"]
       state["secondary_placement_quantity_known"] = if potential_placement_details["secondary_placement_quantity"].present?
                                                       { "quantity_known" => "Yes" }
@@ -41,6 +49,17 @@ module Placements
       if potential_placement_details["secondary_placement_quantity"].present?
         state["secondary_placement_quantity"] = potential_placement_details["secondary_placement_quantity"]
       end
+      # SEND
+      state["key_stage_selection"] = potential_placement_details["key_stage_selection"]
+      state["key_stage_placement_quantity_known"] = if potential_placement_details["key_stage_placement_quantity"].present?
+                                                      { "quantity_known" => "Yes" }
+                                                    else
+                                                      { "quantity_known" => "No" }
+                                                    end
+      if potential_placement_details["key_stage_placement_quantity"].present?
+        state["key_stage_placement_quantity"] = potential_placement_details["key_stage_placement_quantity"]
+      end
+
       state["note_to_providers"] = potential_placement_details["note_to_providers"]
     end
 

--- a/app/wizards/placements/multi_placement_wizard/check_your_answers_step.rb
+++ b/app/wizards/placements/multi_placement_wizard/check_your_answers_step.rb
@@ -1,6 +1,7 @@
 class Placements::MultiPlacementWizard::CheckYourAnswersStep < BaseStep
   delegate :phases, to: :phase_step
-  delegate :year_groups, :selected_secondary_subjects, :selected_providers, to: :wizard
+  delegate :year_groups, :selected_secondary_subjects, :selected_providers,
+           :selected_key_stages, to: :wizard
 
   private
 

--- a/app/wizards/placements/multi_placement_wizard/key_stage_placement_quantity_step.rb
+++ b/app/wizards/placements/multi_placement_wizard/key_stage_placement_quantity_step.rb
@@ -1,0 +1,54 @@
+class Placements::MultiPlacementWizard::KeyStagePlacementQuantityStep < BaseStep
+  validate :valid_quantities
+
+  delegate :selected_key_stages, to: :wizard
+
+  def initialize(wizard:, attributes:)
+    define_key_stage_attributes(
+      selected_key_stages: wizard.selected_key_stages,
+      attributes: attributes,
+    )
+
+    super(
+      wizard:,
+      attributes: attributes&.select do |k, _v|
+        wizard.selected_key_stages
+        .map(&:name_as_attribute)
+        .include?(k)
+      end
+    )
+  end
+
+  def key_stages
+    selected_key_stages
+  end
+
+  def valid_quantities
+    key_stages.each do |key_stage|
+      key_stage_attribute = key_stage.name_as_attribute
+      key_stage_quantity = try(key_stage_attribute)
+
+      errors.add(key_stage_attribute, :blank, message: "#{key_stage.name} can't be blank") if key_stage_quantity.blank?
+      errors.add(key_stage_attribute, :not_an_integer, message: "#{key_stage.name} must be a whole number") unless (key_stage_quantity.to_f % 1).zero?
+      errors.add(key_stage_attribute, :greater_than, message: "#{key_stage.name} must be greater than 0") unless key_stage_quantity.to_i.positive?
+    end
+  end
+
+  def assigned_variables
+    key_stages.map { |attribute|
+      { attribute.name_as_attribute.to_s => instance_variable_get("@#{attribute.name_as_attribute}") }
+    }.reduce({}, :merge)
+  end
+
+  private
+
+  def define_key_stage_attributes(selected_key_stages:, attributes:)
+    selected_key_stages.each do |key_stage|
+      singleton_class.class_eval { attr_accessor key_stage.name_as_attribute }
+      instance_variable_set(
+        "@#{key_stage.name_as_attribute}",
+        attributes.blank? ? nil : attributes[key_stage.name_as_attribute.to_s],
+      )
+    end
+  end
+end

--- a/app/wizards/placements/multi_placement_wizard/key_stage_selection_step.rb
+++ b/app/wizards/placements/multi_placement_wizard/key_stage_selection_step.rb
@@ -1,0 +1,27 @@
+class Placements::MultiPlacementWizard::KeyStageSelectionStep < BaseStep
+  attribute :key_stage_ids, default: []
+
+  validates :key_stage_ids, presence: true
+
+  MIXED_KEY_STAGES = "Mixed key stages".freeze
+
+  def key_stages_for_selection
+    Placements::KeyStage.where.not(name: MIXED_KEY_STAGES).order_by_name
+  end
+
+  def mixed_key_stage_option
+    Placements::KeyStage.find_by(name: MIXED_KEY_STAGES)
+  end
+
+  def key_stage_ids=(value)
+    super normalised_key_stage_ids(value)
+  end
+
+  private
+
+  def normalised_key_stage_ids(selected_key_stage_ids)
+    return [] if selected_key_stage_ids.blank?
+
+    selected_key_stage_ids.reject(&:blank?)
+  end
+end

--- a/app/wizards/placements/multi_placement_wizard/phase_step.rb
+++ b/app/wizards/placements/multi_placement_wizard/phase_step.rb
@@ -3,20 +3,25 @@ class Placements::MultiPlacementWizard::PhaseStep < BaseStep
 
   validates :phases, presence: true
 
+  SEND = "SEND".freeze
+
   def phases_for_selection
     [
       OpenStruct.new(
         name: Placements::School::PRIMARY_PHASE,
+        value: Placements::School::PRIMARY_PHASE,
         description: I18n.t("#{locale_path}.options.#{Placements::School::PRIMARY_PHASE.downcase}_description"),
       ),
       OpenStruct.new(
         name: Placements::School::SECONDARY_PHASE,
+        value: Placements::School::SECONDARY_PHASE,
         description: I18n.t("#{locale_path}.options.#{Placements::School::SECONDARY_PHASE.downcase}_description"),
       ),
-      # OpenStruct.new(
-      #   name: I18n.t("#{locale_path}.options.send"),
-      #   description: I18n.t("#{locale_path}.options.send_description"),
-      # ),
+      OpenStruct.new(
+        name: I18n.t("#{locale_path}.options.send"),
+        value: SEND,
+        description: I18n.t("#{locale_path}.options.send_description"),
+      ),
     ]
   end
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -204,6 +204,13 @@ shared:
     - academic_year_id
     - creator_id
     - creator_type
+    - send_specific
+    - key_stage_id
+  :key_stages:
+    - id
+    - name
+    - created_at
+    - updated_at
   :school_contacts:
     - id
     - school_id

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -403,6 +403,8 @@ en:
               blank: Primary placements can't be blank
             subject_ids:
               blank: Secondary placements can't be blank
+            key_stage_ids:
+              blank: SEND placements can't be blank
         placements/multi_placement_wizard/key_stage_selection_step:
           attributes:
             key_stage_ids:

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -403,4 +403,7 @@ en:
               blank: Primary placements can't be blank
             subject_ids:
               blank: Secondary placements can't be blank
-
+        placements/multi_placement_wizard/key_stage_selection_step:
+          attributes:
+            key_stage_ids:
+               blank: Please select a key stage

--- a/config/locales/en/placements/schools/hosting_interests.yml
+++ b/config/locales/en/placements/schools/hosting_interests.yml
@@ -34,6 +34,7 @@ en:
               potential_placement_information: Your potential placements
               potential_primary_placements: Potential primary school placements
               potential_secondary_placements: Potential secondary school placements
+              potential_send_placements: Potential SEND placements
             primary_placements_list:
               year_group: Year group
               number_of_placements: Number of placements
@@ -42,6 +43,12 @@ en:
               change: Change
             secondary_placements_list:
               subject: Subject
+              number_of_placements: Number of placements
+              unknown: I don’t know
+              not_entered: Not entered
+              change: Change
+            send_placements_list:
+              key_stage: Key stage
               number_of_placements: Number of placements
               unknown: I don’t know
               not_entered: Not entered
@@ -56,6 +63,7 @@ en:
               your_placements_offers: Your placements offers
               primary_placements: Primary placements
               secondary_placements: Secondary placements
+              send_placements: SEND placements
               manage_your_placements: Manage your placements
               you_can_edit_placements: "%{link} to change or remove information."
               edit_your_placements: Edit your placements

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -61,6 +61,7 @@ en:
               assign_last_placement: Provider updated
               year_group: Year group updated
               terms: Expected date updated
+              key_stage: Key stage updated
           edit:
             edit_placement: Placement details
             cancel: Cancel
@@ -150,6 +151,7 @@ en:
               mentor: Mentor
               status: Status
               provider: Provider
+              key_stage: Key stage
         confirm_remove:
           page_title: "Are you sure you want to delete this placement? - %{subject_names}"
           are_you_sure: Are you sure you want to delete this placement?

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -71,6 +71,7 @@ en:
           summer: Summer
           any_term: Any time in the academic year
         not_yet_known: Not yet known
+        send: SEND
         year_groups:
           nursery: Nursery
           nursery_description: 3 to 4 years

--- a/config/locales/en/placements/schools/potential_placements.yml
+++ b/config/locales/en/placements/schools/potential_placements.yml
@@ -27,6 +27,7 @@ en:
           potential_phases: Potential phases
           potential_primary_placements: Potential primary placements
           potential_secondary_placements: Potential secondary placements
+          potential_send_placements: Potential SEND placements
           additional_information: Additional information
           message_to_providers: Message to providers
           change: Change

--- a/config/locales/en/shared/wizards/placements/multiple_placements_wizard.yml
+++ b/config/locales/en/shared/wizards/placements/multiple_placements_wizard.yml
@@ -13,6 +13,8 @@ en:
             potential_primary_placements: Potential primary placements
             secondary_placements: Secondary placements
             potential_secondary_placements: Potential secondary placements
+            send_placements: SEND placements
+            potential_send_placements: Potential SEND placements
             not_entered: Not entered
             change: Change
             education_phase_list:
@@ -28,6 +30,12 @@ en:
               secondary_placements: Secondary placements
               number_of_placements: Number of placements
               subject: Subject
+              not_entered: Not entered
+              unknown: I don’t know
+            send_placements_list:
+              send_placements: SEND placements
+              number_of_placements: Number of placements
+              key_stage: Key stage
               not_entered: Not entered
               unknown: I don’t know
 

--- a/config/locales/en/wizards/placements/add_hosting_interest_wizard.yml
+++ b/config/locales/en/wizards/placements/add_hosting_interest_wizard.yml
@@ -159,6 +159,30 @@ en:
             placement_number: "Placement %{placement_number} of %{step_count}"
             options:
               unknown: Not sure yet
+          key_stage_placement_quantity_step:
+            title: How many placements could you offer for each key stage?
+            caption: Potential SEND placement details
+            hint:
+              Sharing information on what you may be able to offer helps providers know whether to contact you.
+              It is not a commitment to take a trainee teacher.
+            continue: Continue
+          key_stage_placement_quantity_known_step:
+            title: Do you know how many placement you could offer each SEND key stage?
+            caption: Potential SEND placement details
+            hint:
+              Sharing information on what you may be able to offer helps providers know whether to contact you.
+              It is not a commitment to take a trainee teacher.
+            continue: Continue
+          key_stage_selection_step:
+            title: What key stages could you offer placements in?
+            caption: Potential SEND placement details
+            hint:
+              Sharing information on what you may be able to offer helps providers know whether to contact you.
+              It is not a commitment to take a trainee teacher.
+            continue: Continue
+            options:
+              unknown: I don’t know
+              unknown_description: A key stage will not be recorded
         not_open:
           school_contact_step:
             caption: Not offering placements this year

--- a/config/locales/en/wizards/placements/add_hosting_interest_wizard.yml
+++ b/config/locales/en/wizards/placements/add_hosting_interest_wizard.yml
@@ -162,21 +162,23 @@ en:
           key_stage_placement_quantity_step:
             title: How many placements could you offer for each key stage?
             caption: Potential SEND placement details
+            enter_approximate: Enter an approximate number if you are unsure
             hint:
               Sharing information on what you may be able to offer helps providers know whether to contact you.
               It is not a commitment to take a trainee teacher.
             continue: Continue
           key_stage_placement_quantity_known_step:
-            title: Do you know how many placement you could offer each SEND key stage?
+            title: Do you know how many placements you could offer for each key stage?
             caption: Potential SEND placement details
             hint:
               Sharing information on what you may be able to offer helps providers know whether to contact you.
               It is not a commitment to take a trainee teacher.
             continue: Continue
           key_stage_selection_step:
-            title: What key stages could you offer placements in?
+            title: What key stages could you offer SEND placements in?
             caption: Potential SEND placement details
             hint:
+              Select all that apply. 
               Sharing information on what you may be able to offer helps providers know whether to contact you.
               It is not a commitment to take a trainee teacher.
             continue: Continue

--- a/config/locales/en/wizards/placements/convert_potential_placement_wizard.yml
+++ b/config/locales/en/wizards/placements/convert_potential_placement_wizard.yml
@@ -24,6 +24,7 @@ en:
             You can add or edit placements any time after publishing them.
           primary_placements: Primary placements
           secondary_placements: Secondary placements
+          send_placements: SEND placements
           number_of_placements:
             one: "%{count} placement"
             other: "%{count} placements"

--- a/config/locales/en/wizards/placements/edit_placement_wizard.yml
+++ b/config/locales/en/wizards/placements/edit_placement_wizard.yml
@@ -22,3 +22,7 @@ en:
             Your status will be set to ‘no placements available’. Providers will no longer contact you about available placements.
           you_can_add_more_placements:
             You can add more placements at anytime.
+        key_stage_step:
+          title: Select a key stage - %{contextual_text}
+          select_a_key_stage: Select a key stage
+          continue: Continue

--- a/config/locales/en/wizards/placements/multi_placement_wizard.yml
+++ b/config/locales/en/wizards/placements/multi_placement_wizard.yml
@@ -120,12 +120,12 @@ en:
           enter_approximate: Enter an approximate number if you are unsure
           continue: Continue
         key_stage_placement_quantity_step:
-          title: How many SEND placements can you offer?
+          title: Enter the number of SEND placements you can offer
           caption: SEND placement details
           enter_approximate: Enter an approximate number if you are unsure
           continue: Continue
         key_stage_selection_step:
-          title: What SEND key stages can you offer placements in?
+          title: What key stages can you offer SEND placements in?
           caption: SEND placement details
           hint: Select all that apply
           continue: Continue

--- a/config/locales/en/wizards/placements/multi_placement_wizard.yml
+++ b/config/locales/en/wizards/placements/multi_placement_wizard.yml
@@ -40,7 +40,7 @@ en:
             primary_description: 3 to 11 years
             secondary_description: 11 to 19 years
             send: Special educational needs and disabilities (SEND) specific
-            send_description: You will be able to select year groups
+            send_description: You will be able to select key stages
           continue: Continue
         subjects_known_step:
           title: Do you know which subjects you would like to host?
@@ -115,7 +115,20 @@ en:
           hint: You will be able to enter the number of placements on the next screen
           continue: Continue
         year_group_placement_quantity_step:
-            title: Enter the number of primary school placements you can offer
-            caption: Primary placement details
-            enter_approximate: Enter an approximate number if you are unsure
-            continue: Continue
+          title: Enter the number of primary school placements you can offer
+          caption: Primary placement details
+          enter_approximate: Enter an approximate number if you are unsure
+          continue: Continue
+        key_stage_placement_quantity_step:
+          title: How many SEND placements can you offer?
+          caption: SEND placement details
+          enter_approximate: Enter an approximate number if you are unsure
+          continue: Continue
+        key_stage_selection_step:
+          title: What SEND key stages can you offer placements in?
+          caption: SEND placement details
+          hint: Select all that apply
+          continue: Continue
+          options:
+            unknown: I don’t know
+            unknown_description: You can discuss key stages with providers later

--- a/db/migrate/20250617154411_create_key_stages.rb
+++ b/db/migrate/20250617154411_create_key_stages.rb
@@ -1,0 +1,9 @@
+class CreateKeyStages < ActiveRecord::Migration[8.0]
+  def change
+    create_table :key_stages, id: :uuid do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250617154619_generate_key_stages.rb
+++ b/db/migrate/20250617154619_generate_key_stages.rb
@@ -1,0 +1,11 @@
+class GenerateKeyStages < ActiveRecord::Migration[8.0]
+  def up
+    Placements::KeyStage::VALID_NAMES.each do |name|
+      Placements::KeyStage.find_or_create_by!(name:)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20250617154722_add_send_to_placements.rb
+++ b/db/migrate/20250617154722_add_send_to_placements.rb
@@ -1,0 +1,8 @@
+class AddSendToPlacements < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :placements, :send_specific, :boolean, default: false
+    add_reference :placements, :key_stage, type: :uuid, index: { algorithm: :concurrently }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_02_132426) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_17_154722) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -287,6 +287,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_02_132426) do
     t.index ["school_id"], name: "index_hosting_interests_on_school_id"
   end
 
+  create_table "key_stages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "mentor_memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "type", null: false
     t.uuid "mentor_id", null: false
@@ -411,8 +417,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_02_132426) do
     t.uuid "academic_year_id", null: false
     t.string "creator_type"
     t.uuid "creator_id"
+    t.boolean "send_specific", default: false
+    t.uuid "key_stage_id"
     t.index ["academic_year_id"], name: "index_placements_on_academic_year_id"
     t.index ["creator_type", "creator_id"], name: "index_placements_on_creator"
+    t.index ["key_stage_id"], name: "index_placements_on_key_stage_id"
     t.index ["provider_id"], name: "index_placements_on_provider_id"
     t.index ["school_id"], name: "index_placements_on_school_id"
     t.index ["subject_id"], name: "index_placements_on_subject_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -236,6 +236,10 @@ Provider.create!(name: "Test Provider 123", code: "TEST 123")
 Provider.create!(name: "Test Provider 456", code: "TEST 456")
 Provider.create!(name: "Test Provider 789", code: "TEST 789")
 
+Placements::KeyStage::VALID_NAMES.each do |name|
+  Placements::KeyStage.find_or_create_by!(name:)
+end
+
 # Feature flags
 
 Flipper.add(:school_partner_providers)

--- a/spec/decorators/placement_decorator_spec.rb
+++ b/spec/decorators/placement_decorator_spec.rb
@@ -72,6 +72,15 @@ RSpec.describe PlacementDecorator do
         expect(placement.decorate.title).to eq("Maths (Year 1)")
       end
     end
+
+    context "when the placement is SEND specific" do
+      it "returns SEND, followed by the key stages in brackets" do
+        key_stage_1 = build(:key_stage, name: "Key stage 1")
+        placement = create(:placement, :send, key_stage: key_stage_1)
+
+        expect(placement.decorate.title).to eq("SEND (Key stage 1)")
+      end
+    end
   end
 
   describe "#school_level" do

--- a/spec/factories/placements.rb
+++ b/spec/factories/placements.rb
@@ -29,5 +29,10 @@ FactoryBot.define do
 
     association :school, factory: :placements_school
     association :subject, factory: :subject
+
+    trait :send do
+      subject { nil }
+      send_specific { true }
+    end
   end
 end

--- a/spec/factories/placements/key_stages.rb
+++ b/spec/factories/placements/key_stages.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :key_stage, class: "Placements::KeyStage" do
+  end
+end

--- a/spec/helpers/placements/potential_placement_helper_spec.rb
+++ b/spec/helpers/placements/potential_placement_helper_spec.rb
@@ -1,0 +1,235 @@
+require "rails_helper"
+
+RSpec.describe Placements::PotentialPlacementHelper do
+  let(:english) { create(:subject, :secondary, name: "English") }
+  let(:science) { create(:subject, :secondary, name: "Science") }
+  let(:key_stage_1) { create(:key_stage, name: "Key stage 1") }
+  let(:mixed_key_stages) { create(:key_stage, name: "Mixed key stages") }
+
+  describe "#potential_placement_details_viewable?" do
+    subject(:potential_placement_details_viewable) do
+      potential_placement_details_viewable?(placement_details)
+    end
+
+    context "when potential placements details are not present" do
+      let(:placement_details) { {} }
+
+      it "returns false" do
+        expect(potential_placement_details_viewable).to be(false)
+      end
+    end
+
+    context "when potential placement details include year groups" do
+      let(:placement_details) do
+        {
+          "year_group_selection" => { "year_groups" => %w[year_2 year_3] },
+        }
+      end
+
+      it "returns true" do
+        expect(potential_placement_details_viewable).to be(true)
+      end
+    end
+
+    context "when potential placement details include subject IDs" do
+      let(:placement_details) do
+        {
+          "secondary_subject_selection" => { "subject_ids" => [english.id, science.id] },
+        }
+      end
+
+      it "returns true" do
+        expect(potential_placement_details_viewable).to be(true)
+      end
+    end
+
+    context "when potential placement details include key stage IDs" do
+      let(:placement_details) do
+        {
+          "key_stage_selection" => { "key_stage_ids" => [key_stage_1.id, mixed_key_stages.id] },
+        }
+      end
+
+      it "returns true" do
+        expect(potential_placement_details_viewable).to be(true)
+      end
+    end
+  end
+
+  describe "selected_placement_details" do
+    context "when phase is primary" do
+      let(:phase) { :primary }
+
+      context "when the year groups do not contain 'unknown'" do
+        let(:placement_details) do
+          {
+            "year_group_selection" => { "year_groups" => %w[year_2 year_3] },
+          }
+        end
+
+        it "returns the selected year groups" do
+          expect(
+            selected_placement_details(placement_details:, phase:),
+          ).to contain_exactly("year_2", "year_3")
+        end
+      end
+
+      context "when the year groups do contain 'unknown'" do
+        let(:placement_details) do
+          {
+            "year_group_selection" => { "year_groups" => %w[unknown] },
+          }
+        end
+
+        it "returns unknown" do
+          expect(
+            selected_placement_details(placement_details:, phase:),
+          ).to eq("unknown")
+        end
+      end
+    end
+
+    context "when phase is secondary" do
+      let(:mathematics) { create(:subject, :secondary, name: "Mathematics") }
+
+      let(:phase) { :secondary }
+
+      context "when the subject IDs do not contain 'unknown'" do
+        let(:placement_details) do
+          {
+            "secondary_subject_selection" => { "subject_ids" => [english.id, science.id] },
+          }
+        end
+
+        it "returns the selected subjects" do
+          expect(
+            selected_placement_details(placement_details:, phase:),
+          ).to contain_exactly(english, science)
+        end
+      end
+
+      context "when the subject IDs do contain 'unknown'" do
+        let(:placement_details) do
+          {
+            "secondary_subject_selection" => { "subject_ids" => %w[unknown] },
+          }
+        end
+
+        it "returns unknown" do
+          expect(
+            selected_placement_details(placement_details:, phase:),
+          ).to eq("unknown")
+        end
+      end
+    end
+
+    context "when phase is send" do
+      let(:key_stage_2) { create(:key_stage, name: "Key stage 2") }
+
+      let(:phase) { :send }
+
+      context "when the key stage IDs do not contain 'unknown'" do
+        let(:placement_details) do
+          {
+            "key_stage_selection" => { "key_stage_ids" => [key_stage_1.id, mixed_key_stages.id] },
+          }
+        end
+
+        it "returns the selected subjects" do
+          expect(
+            selected_placement_details(placement_details:, phase:),
+          ).to contain_exactly(key_stage_1, mixed_key_stages)
+        end
+      end
+
+      context "when the key stage IDs do" do
+        let(:placement_details) do
+          {
+            "key_stage_selection" => { "key_stage_ids" => %w[unknown] },
+          }
+        end
+
+        it "returns unknown" do
+          expect(
+            selected_placement_details(placement_details:, phase:),
+          ).to eq("unknown")
+        end
+      end
+    end
+
+    context "when the phase is random" do
+      let(:placement_details) do
+        {
+          "year_group_selection" => { "year_groups" => %w[year_2 year_3] },
+          "secondary_subject_selection" => { "subject_ids" => [english.id, science.id] },
+          "key_stage_selection" => { "key_stage_ids" => [key_stage_1.id, mixed_key_stages.id] },
+        }
+      end
+      let(:phase) { :random }
+
+      it "returns an empty array" do
+        expect(selected_placement_details(placement_details:, phase:)).to eq([])
+      end
+    end
+  end
+
+  describe "#potential_placement_year_group_selection" do
+    let(:placement_details) do
+      {
+        "year_group_selection" => { "year_groups" => %w[year_2 year_3] },
+        "secondary_subject_selection" => { "subject_ids" => [english.id, science.id] },
+        "key_stage_selection" => { "key_stage_ids" => [key_stage_1.id, mixed_key_stages.id] },
+      }
+    end
+
+    it "returns the selected year groups" do
+      expect(potential_placement_year_group_selection(placement_details)).to contain_exactly("year_2", "year_3")
+    end
+  end
+
+  describe "#potential_placement_subject_id_selection" do
+    let(:placement_details) do
+      {
+        "year_group_selection" => { "year_groups" => %w[year_2 year_3] },
+        "secondary_subject_selection" => { "subject_ids" => [english.id, science.id] },
+        "key_stage_selection" => { "key_stage_ids" => [key_stage_1.id, mixed_key_stages.id] },
+      }
+    end
+
+    it "returns the selected subject IDs" do
+      expect(
+        potential_placement_subject_id_selection(placement_details),
+      ).to contain_exactly(english.id, science.id)
+    end
+  end
+
+  describe "#potential_placement_key_stage_id_selection" do
+    let(:placement_details) do
+      {
+        "year_group_selection" => { "year_groups" => %w[year_2 year_3] },
+        "secondary_subject_selection" => { "subject_ids" => [english.id, science.id] },
+        "key_stage_selection" => { "key_stage_ids" => [key_stage_1.id, mixed_key_stages.id] },
+      }
+    end
+
+    it "returns the selected subject IDs" do
+      expect(
+        potential_placement_key_stage_id_selection(placement_details),
+      ).to contain_exactly(key_stage_1.id, mixed_key_stages.id)
+    end
+  end
+
+  describe "#placement_detail_unknown" do
+    context "when the value is not unknown" do
+      it "returns false" do
+        expect(placement_detail_unknown("something")).to be(false)
+      end
+    end
+
+    context "when the value is unknown" do
+      it "returns false" do
+        expect(placement_detail_unknown("unknown")).to be(true)
+      end
+    end
+  end
+end

--- a/spec/models/placement_spec.rb
+++ b/spec/models/placement_spec.rb
@@ -38,8 +38,22 @@ RSpec.describe Placement, type: :model do
     it { is_expected.to belong_to(:academic_year).class_name("Placements::AcademicYear") }
     it { is_expected.to belong_to(:school).class_name("Placements::School") }
     it { is_expected.to belong_to(:provider).class_name("::Provider").optional }
-    it { is_expected.to belong_to(:subject).class_name("::Subject") }
+
     it { is_expected.to belong_to(:creator).optional }
+
+    describe "#subject" do
+      let!(:a_subject) { create(:subject) }
+      let(:placement) { create(:placement, subject: a_subject) }
+
+      it { expect(placement.subject).to eq(a_subject) }
+    end
+
+    describe "key_stage" do
+      let!(:key_stage) { create(:key_stage, name: "Key stage 1") }
+      let(:placement) { create(:placement, :send, key_stage:) }
+
+      it { expect(placement.key_stage).to eq(key_stage) }
+    end
 
     describe "#creator" do
       let(:placement) { build(:placement, creator:) }

--- a/spec/models/placements/key_stage_spec.rb
+++ b/spec/models/placements/key_stage_spec.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: key_stages
+#
+#  id         :uuid             not null, primary key
+#  name       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+require "rails_helper"
+
+RSpec.describe Placements::KeyStage, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_add_their_hosting_interest_and_bulk_adds_placements_for_the_primary_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_add_their_hosting_interest_and_bulk_adds_placements_for_the_primary_phase_spec.rb
@@ -260,8 +260,8 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     )
     expect(page).to have_h2("Manage your placements", class: "govuk-heading-m")
     expect(page).to have_h2("Your placements offer", class: "govuk-heading-m")
-    expect(page).to have_h2("Primary placements", class: "govuk-heading-m")
-    expect(page).not_to have_h2("Secondary placements", class: "govuk-heading-m")
+    expect(page).to have_h3("Primary placements", class: "govuk-heading-s")
+    expect(page).not_to have_h3("Secondary placements", class: "govuk-heading-s")
   end
 
   def and_i_see_2_reception_primary_placements_have_been_created

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
@@ -375,8 +375,8 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     )
     expect(page).to have_h2("Manage your placements", class: "govuk-heading-m")
     expect(page).to have_h2("Your placements offer", class: "govuk-heading-m")
-    expect(page).to have_h2("Primary placements", class: "govuk-heading-m")
-    expect(page).to have_h2("Secondary placements", class: "govuk-heading-m")
+    expect(page).to have_h3("Primary placements", class: "govuk-heading-s")
+    expect(page).to have_h3("Secondary placements", class: "govuk-heading-s")
   end
 
   def and_i_see_2_year_1_primary_placements_have_been_created

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
@@ -298,8 +298,8 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     )
     expect(page).to have_h2("Manage your placements", class: "govuk-heading-m")
     expect(page).to have_h2("Your placements offer", class: "govuk-heading-m")
-    expect(page).not_to have_h2("Primary placements", class: "govuk-heading-m")
-    expect(page).to have_h2("Secondary placements", class: "govuk-heading-m")
+    expect(page).not_to have_h3("Primary placements", class: "govuk-heading-s")
+    expect(page).to have_h3("Secondary placements", class: "govuk-heading-s")
   end
 
   def and_i_see_2_secondary_placements_for_modern_languages_have_been_created

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_adds_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_adds_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
@@ -255,8 +255,8 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     )
     expect(page).to have_h2("Manage your placements", class: "govuk-heading-m")
     expect(page).to have_h2("Your placements offer", class: "govuk-heading-m")
-    expect(page).not_to have_h2("Primary placements", class: "govuk-heading-m")
-    expect(page).to have_h2("Secondary placements", class: "govuk-heading-m")
+    expect(page).not_to have_h3("Primary placements", class: "govuk-heading-s")
+    expect(page).to have_h3("Secondary placements", class: "govuk-heading-s")
   end
 
   def and_i_see_1_secondary_placement_for_english_have_been_created

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/send_only/school_user_adds_their_hosting_interest_and_bulk_adds_send_placements_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/send_only/school_user_adds_their_hosting_interest_and_bulk_adds_send_placements_spec.rb
@@ -117,13 +117,13 @@ RSpec.describe "School user add their hosting interest and bulk adds send placem
 
   def then_i_see_the_key_stage_selection_form
     expect(page).to have_title(
-      "What SEND key stages can you offer placements in? - Manage school placements - GOV.UK",
+      "What key stages can you offer SEND placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_span_caption("SEND placement details")
     expect(page).to have_element(
       :legend,
-      text: "What SEND key stages can you offer placements in?",
+      text: "What key stages can you offer SEND placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Early year", type: :checkbox)
@@ -145,11 +145,11 @@ RSpec.describe "School user add their hosting interest and bulk adds send placem
 
   def then_i_see_the_key_stage_placement_quantity_form
     expect(page).to have_title(
-      "How many SEND placements can you offer? - Manage school placements - GOV.UK",
+      "Enter the number of SEND placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_span_caption("SEND placement details")
-    expect(page).to have_h1("How many SEND placements can you offer?", class: "govuk-heading-l")
+    expect(page).to have_h1("Enter the number of SEND placements you can offer", class: "govuk-heading-l")
     expect(page).to have_field("Key stage 2", type: :number)
     expect(page).to have_field("Key stage 5", type: :number)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/send_only/school_user_adds_their_hosting_interest_and_bulk_adds_send_placements_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/send_only/school_user_adds_their_hosting_interest_and_bulk_adds_send_placements_spec.rb
@@ -1,0 +1,281 @@
+require "rails_helper"
+
+RSpec.describe "School user add their hosting interest and bulk adds send placements",
+               service: :placements,
+               type: :system do
+  scenario do
+    given_key_stages_exist
+    and_academic_years_exist
+    and_i_am_signed_in
+
+    when_i_visit_the_add_hosting_interest_page
+    then_i_see_the_appetite_form
+
+    when_i_select_actively_looking_to_host_placements
+    and_i_click_on_continue
+    then_i_see_the_phase_form
+
+    when_i_select_send
+    and_i_click_on_continue
+    then_i_see_the_key_stage_selection_form
+
+    when_i_select_key_stage_2
+    and_i_select_key_stage_5
+    and_i_click_on_continue
+    then_i_see_the_key_stage_placement_quantity_form
+
+    when_i_fill_in_the_number_of_send_placements_i_require
+    and_i_click_on_continue
+    then_i_see_the_school_contact_form
+
+    when_i_fill_in_the_school_contact_details
+    and_i_click_on_continue
+    then_i_see_the_check_your_answers_page
+
+    when_i_click_on_publish_placements
+    then_i_see_the_whats_next_page
+    and_i_see_a_send_placement_for_key_stage_2_has_been_created
+    and_i_see_two_send_placements_for_key_stage_5_have_been_created
+
+    when_i_click_on_edit_your_placements
+    then_i_am_on_the_placements_index_page
+    and_i_see_1_send_placement_for_key_stage_2
+    and_i_see_2_send_placement_for_key_stage_5
+  end
+
+  private
+
+  def given_key_stages_exist
+    @early_years = create(:key_stage, name: "Early years")
+    @key_stage_1 = create(:key_stage, name: "Key stage 1")
+    @key_stage_2 = create(:key_stage, name: "Key stage 2")
+    @key_stage_3 = create(:key_stage, name: "Key stage 3")
+    @key_stage_4 = create(:key_stage, name: "Key stage 4")
+    @key_stage_5 = create(:key_stage, name: "Key stage 5")
+    @mixed_key_stages = create(:key_stage, name: "Mixed key stages")
+  end
+
+  def and_academic_years_exist
+    current_academic_year = Placements::AcademicYear.current
+    @current_academic_year_name = current_academic_year.name
+    @next_academic_year = current_academic_year.next
+    @next_academic_year_name = @next_academic_year.name
+  end
+
+  def and_i_am_signed_in
+    @school = create(:placements_school)
+    sign_in_placements_user(organisations: [@school])
+  end
+
+  def when_i_visit_the_add_hosting_interest_page
+    visit new_add_hosting_interest_placements_school_hosting_interests_path(@school)
+  end
+
+  def then_i_see_the_appetite_form
+    expect(page).to have_title(
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Yes - I can offer placements", type: :radio)
+    expect(page).to have_field("Maybe - I’m not sure yet", type: :radio)
+    expect(page).to have_field("No - I can’t offer placements", type: :radio)
+  end
+
+  def when_i_select_actively_looking_to_host_placements
+    choose "Yes - I can offer placements"
+  end
+
+  def when_i_click_on_continue
+    click_on "Continue"
+  end
+  alias_method :and_i_click_on_continue,
+               :when_i_click_on_continue
+
+  def then_i_see_the_phase_form
+    expect(page).to have_title(
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "What education phase can your placements be?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Primary", type: :checkbox)
+    expect(page).to have_field("Secondary", type: :checkbox)
+    expect(page).to have_field("Special educational needs and disabilities (SEND) specific", type: :checkbox)
+  end
+
+  def when_i_select_send
+    check "Special educational needs and disabilities (SEND) specific"
+  end
+
+  def then_i_see_the_key_stage_selection_form
+    expect(page).to have_title(
+      "What SEND key stages can you offer placements in? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_span_caption("SEND placement details")
+    expect(page).to have_element(
+      :legend,
+      text: "What SEND key stages can you offer placements in?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Early year", type: :checkbox)
+    expect(page).to have_field("Key stage 1", type: :checkbox)
+    expect(page).to have_field("Key stage 2", type: :checkbox)
+    expect(page).to have_field("Key stage 3", type: :checkbox)
+    expect(page).to have_field("Key stage 4", type: :checkbox)
+    expect(page).to have_field("Key stage 5", type: :checkbox)
+    expect(page).to have_field("Mixed key stages", type: :checkbox)
+  end
+
+  def when_i_select_key_stage_2
+    check "Key stage 2"
+  end
+
+  def and_i_select_key_stage_5
+    check "Key stage 5"
+  end
+
+  def then_i_see_the_key_stage_placement_quantity_form
+    expect(page).to have_title(
+      "How many SEND placements can you offer? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_span_caption("SEND placement details")
+    expect(page).to have_h1("How many SEND placements can you offer?", class: "govuk-heading-l")
+    expect(page).to have_field("Key stage 2", type: :number)
+    expect(page).to have_field("Key stage 5", type: :number)
+  end
+
+  def when_i_fill_in_the_number_of_send_placements_i_require
+    fill_in "Key stage 2", with: 1
+    fill_in "Key stage 5", with: 2
+  end
+
+  def then_i_see_the_school_contact_form
+    expect(page).to have_title(
+      "Who should providers contact? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Who should providers contact?")
+    expect(page).to have_element(
+      :p,
+      text: "Choose the person best placed to organise placements for trainee teachers at your school",
+      class: "govuk-body",
+    )
+
+    expect(page).to have_field("First name")
+    expect(page).to have_field("Last name")
+    expect(page).to have_field("Email address")
+  end
+
+  def when_i_fill_in_the_school_contact_details
+    fill_in "First name", with: "Joe"
+    fill_in "Last name", with: "Bloggs"
+    fill_in "Email address", with: "joe_bloggs@example.com"
+  end
+
+  def and_the_schools_contact_has_been_updated
+    @school_contact = @school.school_contact.reload
+    expect(@school_contact.first_name).to eq("Joe")
+    expect(@school_contact.last_name).to eq("Bloggs")
+    expect(@school_contact.email_address).to eq("joe_bloggs@example.com")
+  end
+
+  def and_the_schools_hosting_interest_for_the_next_year_is_updated
+    hosting_interest = @school.hosting_interests.for_academic_year(@next_academic_year).last
+    expect(hosting_interest.appetite).to eq("actively_looking")
+  end
+
+  def then_i_see_the_check_your_answers_page
+    expect(page).to have_title(
+      "Check your answers - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Check your answers")
+
+    expect(page).to have_h2("Education phase")
+    expect(page).to have_summary_list_row("Phase", "SEND")
+
+    expect(page).to have_h2("SEND placements")
+    expect(page).to have_summary_list_row("Key stage 2", "1")
+    expect(page).to have_summary_list_row("Key stage 5", "2")
+
+    expect(page).to have_h2("Placement contact")
+    expect(page).to have_summary_list_row("First name", "Joe")
+    expect(page).to have_summary_list_row("Last name", "Bloggs")
+    expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")
+  end
+
+  def when_i_click_on_publish_placements
+    click_on "Publish placements"
+  end
+
+  def then_i_see_the_whats_next_page
+    expect(page).to have_title(
+      "What happens next? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_panel(
+      "Placement information added",
+      "Providers can see that you have placements available",
+    )
+    expect(page).to have_h1("What happens next?", class: "govuk-heading-l")
+    expect(page).to have_element(
+      :p,
+      text: "Providers will be able to contact you on joe_bloggs@example.com about your placement offers. After these discussions you can then decide whether to assign a provider to your placements.",
+      class: "govuk-body",
+    )
+    expect(page).to have_h2("Manage your placements", class: "govuk-heading-m")
+    expect(page).to have_h2("Your placements offer", class: "govuk-heading-m")
+    expect(page).not_to have_h3("Primary placements", class: "govuk-heading-s")
+    expect(page).not_to have_h3("Secondary placements", class: "govuk-heading-s")
+    expect(page).to have_h3("SEND placements", class: "govuk-heading-s")
+  end
+
+  def and_i_see_a_send_placement_for_key_stage_2_has_been_created
+    expect(page).to have_summary_list_row("Key stage 2", "1")
+  end
+
+  def and_i_see_two_send_placements_for_key_stage_5_have_been_created
+    expect(page).to have_summary_list_row("Key stage 5", "2")
+  end
+
+  def when_i_click_on_edit_your_placements
+    click_on "Edit your placements"
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Placements")
+    expect(page).to have_link("Add multiple placements")
+  end
+  alias_method :then_i_am_on_the_placements_index_page,
+               :when_i_am_on_the_placements_index_page
+
+  def and_i_see_1_send_placement_for_key_stage_2
+    expect(page).to have_link(
+      "SEND (Key stage 2)",
+      class: "govuk-link govuk-link--no-visited-state",
+      match: :prefer_exact,
+      count: 1,
+    )
+  end
+
+  def and_i_see_2_send_placement_for_key_stage_5
+    expect(page).to have_link(
+      "SEND (Key stage 5)",
+      class: "govuk-link govuk-link--no-visited-state",
+      match: :prefer_exact,
+      count: 2,
+    )
+  end
+end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/send_only/school_user_does_not_enter_a_key_stage_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/send_only/school_user_does_not_enter_a_key_stage_quantity_spec.rb
@@ -1,0 +1,154 @@
+require "rails_helper"
+
+RSpec.describe "School user does not enter a key stage quantity",
+               service: :placements,
+               type: :system do
+  scenario do
+    given_key_stages_exist
+    and_academic_years_exist
+    and_i_am_signed_in
+
+    when_i_visit_the_add_hosting_interest_page
+    then_i_see_the_appetite_form
+
+    when_i_select_actively_looking_to_host_placements
+    and_i_click_on_continue
+    then_i_see_the_phase_form
+
+    when_i_select_send
+    and_i_click_on_continue
+    then_i_see_the_key_stage_selection_form
+
+    when_i_select_key_stage_2
+    and_i_select_key_stage_5
+    and_i_click_on_continue
+    then_i_see_the_key_stage_placement_quantity_form
+
+    when_i_click_on_continue
+    then_i_see_a_validation_error_for_not_entering_a_quantity_for_key_stage_2
+    and_i_see_a_validation_error_for_not_entering_a_quantity_for_key_stage_5
+  end
+
+  private
+
+  def given_key_stages_exist
+    @early_years = create(:key_stage, name: "Early years")
+    @key_stage_1 = create(:key_stage, name: "Key stage 1")
+    @key_stage_2 = create(:key_stage, name: "Key stage 2")
+    @key_stage_3 = create(:key_stage, name: "Key stage 3")
+    @key_stage_4 = create(:key_stage, name: "Key stage 4")
+    @key_stage_5 = create(:key_stage, name: "Key stage 5")
+    @mixed_key_stages = create(:key_stage, name: "Mixed key stages")
+  end
+
+  def and_academic_years_exist
+    current_academic_year = Placements::AcademicYear.current
+    @current_academic_year_name = current_academic_year.name
+    @next_academic_year = current_academic_year.next
+    @next_academic_year_name = @next_academic_year.name
+  end
+
+  def and_i_am_signed_in
+    @school = create(:placements_school)
+    sign_in_placements_user(organisations: [@school])
+  end
+
+  def when_i_visit_the_add_hosting_interest_page
+    visit new_add_hosting_interest_placements_school_hosting_interests_path(@school)
+  end
+
+  def then_i_see_the_appetite_form
+    expect(page).to have_title(
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Yes - I can offer placements", type: :radio)
+    expect(page).to have_field("Maybe - I’m not sure yet", type: :radio)
+    expect(page).to have_field("No - I can’t offer placements", type: :radio)
+  end
+
+  def when_i_select_actively_looking_to_host_placements
+    choose "Yes - I can offer placements"
+  end
+
+  def when_i_click_on_continue
+    click_on "Continue"
+  end
+  alias_method :and_i_click_on_continue,
+               :when_i_click_on_continue
+
+  def then_i_see_the_phase_form
+    expect(page).to have_title(
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "What education phase can your placements be?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Primary", type: :checkbox)
+    expect(page).to have_field("Secondary", type: :checkbox)
+    expect(page).to have_field("Special educational needs and disabilities (SEND) specific", type: :checkbox)
+  end
+
+  def when_i_select_send
+    check "Special educational needs and disabilities (SEND) specific"
+  end
+
+  def then_i_see_the_key_stage_selection_form
+    expect(page).to have_title(
+      "What SEND key stages can you offer placements in? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_span_caption("SEND placement details")
+    expect(page).to have_element(
+      :legend,
+      text: "What SEND key stages can you offer placements in?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Early year", type: :checkbox)
+    expect(page).to have_field("Key stage 1", type: :checkbox)
+    expect(page).to have_field("Key stage 2", type: :checkbox)
+    expect(page).to have_field("Key stage 3", type: :checkbox)
+    expect(page).to have_field("Key stage 4", type: :checkbox)
+    expect(page).to have_field("Key stage 5", type: :checkbox)
+    expect(page).to have_field("Mixed key stages", type: :checkbox)
+  end
+
+  def when_i_select_key_stage_2
+    check "Key stage 2"
+  end
+
+  def and_i_select_key_stage_5
+    check "Key stage 5"
+  end
+
+  def then_i_see_the_key_stage_placement_quantity_form
+    expect(page).to have_title(
+      "How many SEND placements can you offer? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_span_caption("SEND placement details")
+    expect(page).to have_h1("How many SEND placements can you offer?", class: "govuk-heading-l")
+    expect(page).to have_field("Key stage 2", type: :number)
+    expect(page).to have_field("Key stage 5", type: :number)
+  end
+
+  def then_i_see_a_validation_error_for_not_entering_a_quantity_for_key_stage_2
+    expect(page).to have_validation_error(
+      "Key stage 2 can't be blank",
+    )
+  end
+
+  def and_i_see_a_validation_error_for_not_entering_a_quantity_for_key_stage_5
+    expect(page).to have_validation_error(
+      "Key stage 5 can't be blank",
+    )
+  end
+end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/send_only/school_user_does_not_enter_a_key_stage_quantity_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/send_only/school_user_does_not_enter_a_key_stage_quantity_spec.rb
@@ -103,13 +103,13 @@ RSpec.describe "School user does not enter a key stage quantity",
 
   def then_i_see_the_key_stage_selection_form
     expect(page).to have_title(
-      "What SEND key stages can you offer placements in? - Manage school placements - GOV.UK",
+      "What key stages can you offer SEND placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_span_caption("SEND placement details")
     expect(page).to have_element(
       :legend,
-      text: "What SEND key stages can you offer placements in?",
+      text: "What key stages can you offer SEND placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Early year", type: :checkbox)
@@ -131,11 +131,11 @@ RSpec.describe "School user does not enter a key stage quantity",
 
   def then_i_see_the_key_stage_placement_quantity_form
     expect(page).to have_title(
-      "How many SEND placements can you offer? - Manage school placements - GOV.UK",
+      "Enter the number of SEND placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_span_caption("SEND placement details")
-    expect(page).to have_h1("How many SEND placements can you offer?", class: "govuk-heading-l")
+    expect(page).to have_h1("Enter the number of SEND placements you can offer", class: "govuk-heading-l")
     expect(page).to have_field("Key stage 2", type: :number)
     expect(page).to have_field("Key stage 5", type: :number)
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/send_only/school_user_does_not_select_a_key_stage_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/send_only/school_user_does_not_select_a_key_stage_spec.rb
@@ -97,13 +97,13 @@ RSpec.describe "School user does not select a key stage",
 
   def then_i_see_the_key_stage_selection_form
     expect(page).to have_title(
-      "What SEND key stages can you offer placements in? - Manage school placements - GOV.UK",
+      "What key stages can you offer SEND placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_span_caption("SEND placement details")
     expect(page).to have_element(
       :legend,
-      text: "What SEND key stages can you offer placements in?",
+      text: "What key stages can you offer SEND placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Early year", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/send_only/school_user_does_not_select_a_key_stage_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_actively_looking/send_only/school_user_does_not_select_a_key_stage_spec.rb
@@ -1,0 +1,123 @@
+require "rails_helper"
+
+RSpec.describe "School user does not select a key stage",
+               service: :placements,
+               type: :system do
+  scenario do
+    given_key_stages_exist
+    and_academic_years_exist
+    and_i_am_signed_in
+
+    when_i_visit_the_add_hosting_interest_page
+    then_i_see_the_appetite_form
+
+    when_i_select_actively_looking_to_host_placements
+    and_i_click_on_continue
+    then_i_see_the_phase_form
+
+    when_i_select_send
+    and_i_click_on_continue
+    then_i_see_the_key_stage_selection_form
+
+    when_i_click_on_continue
+    then_i_see_a_validation_error_for_not_selecting_a_key_stage
+  end
+
+  private
+
+  def given_key_stages_exist
+    @early_years = create(:key_stage, name: "Early years")
+    @key_stage_1 = create(:key_stage, name: "Key stage 1")
+    @key_stage_2 = create(:key_stage, name: "Key stage 2")
+    @key_stage_3 = create(:key_stage, name: "Key stage 3")
+    @key_stage_4 = create(:key_stage, name: "Key stage 4")
+    @key_stage_5 = create(:key_stage, name: "Key stage 5")
+    @mixed_key_stages = create(:key_stage, name: "Mixed key stages")
+  end
+
+  def and_academic_years_exist
+    current_academic_year = Placements::AcademicYear.current
+    @current_academic_year_name = current_academic_year.name
+    @next_academic_year = current_academic_year.next
+    @next_academic_year_name = @next_academic_year.name
+  end
+
+  def and_i_am_signed_in
+    @school = create(:placements_school)
+    sign_in_placements_user(organisations: [@school])
+  end
+
+  def when_i_visit_the_add_hosting_interest_page
+    visit new_add_hosting_interest_placements_school_hosting_interests_path(@school)
+  end
+
+  def then_i_see_the_appetite_form
+    expect(page).to have_title(
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Yes - I can offer placements", type: :radio)
+    expect(page).to have_field("Maybe - I’m not sure yet", type: :radio)
+    expect(page).to have_field("No - I can’t offer placements", type: :radio)
+  end
+
+  def when_i_select_actively_looking_to_host_placements
+    choose "Yes - I can offer placements"
+  end
+
+  def when_i_click_on_continue
+    click_on "Continue"
+  end
+  alias_method :and_i_click_on_continue,
+               :when_i_click_on_continue
+
+  def then_i_see_the_phase_form
+    expect(page).to have_title(
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "What education phase can your placements be?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Primary", type: :checkbox)
+    expect(page).to have_field("Secondary", type: :checkbox)
+    expect(page).to have_field("Special educational needs and disabilities (SEND) specific", type: :checkbox)
+  end
+
+  def when_i_select_send
+    check "Special educational needs and disabilities (SEND) specific"
+  end
+
+  def then_i_see_the_key_stage_selection_form
+    expect(page).to have_title(
+      "What SEND key stages can you offer placements in? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_span_caption("SEND placement details")
+    expect(page).to have_element(
+      :legend,
+      text: "What SEND key stages can you offer placements in?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Early year", type: :checkbox)
+    expect(page).to have_field("Key stage 1", type: :checkbox)
+    expect(page).to have_field("Key stage 2", type: :checkbox)
+    expect(page).to have_field("Key stage 3", type: :checkbox)
+    expect(page).to have_field("Key stage 4", type: :checkbox)
+    expect(page).to have_field("Key stage 5", type: :checkbox)
+    expect(page).to have_field("Mixed key stages", type: :checkbox)
+  end
+
+  def then_i_see_a_validation_error_for_not_selecting_a_key_stage
+    expect(page).to have_validation_error(
+      "Please select a key stage",
+    )
+  end
+end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_send_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_send_potential_placement_details_spec.rb
@@ -1,0 +1,333 @@
+require "rails_helper"
+
+RSpec.describe "School user completes the interested journey and declares primary and secondary potential placement details",
+               service: :placements,
+               type: :system do
+  scenario do
+    given_academic_years_exist
+    and_key_stages_exist
+    and_i_am_signed_in
+
+    when_i_visit_the_add_hosting_interest_page
+    then_i_see_the_appetite_form
+
+    when_i_select_interested_in_hosting_placements
+    and_i_click_on_continue
+    then_i_see_the_phase_known_page
+
+    when_i_select_send
+    and_i_click_on_continue
+    then_i_see_the_key_stage_selection_form
+
+    when_i_select_key_stage_2
+    and_i_select_key_stage_5
+    and_i_click_on_continue
+    then_i_see_the_key_stage_placement_quantity_known_page
+
+    when_i_select_yes
+    and_i_click_on_continue
+    then_i_see_the_key_stage_placement_quantity_form
+
+    when_i_fill_in_the_number_of_send_placements_i_require
+    and_i_click_on_continue
+    then_i_see_the_provider_note_page
+
+    when_i_enter_a_note_to_the_provider
+    and_i_click_on_continue
+    then_i_see_the_school_contact_form
+
+    when_i_fill_in_the_school_contact_details
+    and_i_click_on_continue
+    then_i_see_the_confirmation_page
+    and_i_see_the_entered_school_contact_details
+    and_i_see_the_education_phases_i_selected
+    and_i_see_the_potential_send_placement_details_i_entered
+    and_i_see_the_message_to_provider_i_entered
+
+    when_i_click_on_confirm
+    then_i_see_the_whats_next_page
+    and_the_schools_contact_has_been_updated
+    and_the_schools_hosting_interest_for_the_next_year_is_updated
+    and_the_schools_potential_placement_details_have_been_updated
+  end
+
+  private
+
+  def given_academic_years_exist
+    current_academic_year = Placements::AcademicYear.current
+    @current_academic_year_name = current_academic_year.name
+    @next_academic_year = current_academic_year.next
+    @next_academic_year_name = @next_academic_year.name
+  end
+
+  def and_key_stages_exist
+    @early_years = create(:key_stage, name: "Early years")
+    @key_stage_1 = create(:key_stage, name: "Key stage 1")
+    @key_stage_2 = create(:key_stage, name: "Key stage 2")
+    @key_stage_3 = create(:key_stage, name: "Key stage 3")
+    @key_stage_4 = create(:key_stage, name: "Key stage 4")
+    @key_stage_5 = create(:key_stage, name: "Key stage 5")
+    @mixed_key_stages = create(:key_stage, name: "Mixed key stages")
+  end
+
+  def and_i_am_signed_in
+    @school = create(:placements_school, with_school_contact: false)
+    sign_in_placements_user(organisations: [@school])
+  end
+
+  def when_i_visit_the_add_hosting_interest_page
+    visit new_add_hosting_interest_placements_school_hosting_interests_path(@school)
+  end
+
+  def then_i_see_the_appetite_form
+    expect(page).to have_title(
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Yes - I can offer placements", type: :radio)
+    expect(page).to have_field("Maybe - I’m not sure yet", type: :radio)
+    expect(page).to have_field("No - I can’t offer placements", type: :radio)
+  end
+
+  def when_i_select_interested_in_hosting_placements
+    choose "Maybe - I’m not sure yet"
+  end
+
+  def when_i_click_on_continue
+    click_on "Continue"
+  end
+
+  alias_method :and_i_click_on_continue,
+               :when_i_click_on_continue
+
+  def then_i_see_the_phase_known_page
+    expect(page).to have_title(
+      "What education phase could you offer placements in? - Manage school placements - GOV.UK",
+    )
+    expect(page).to have_element(
+      :legend,
+      text: "What education phase could you offer placements in?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_hint(
+      "Select all that apply. Sharing information on what you may be able to offer helps providers know whether to contact you." \
+        " It is not a commitment to take a trainee teacher.",
+    )
+    expect(page).to have_field("Primary", type: :checkbox)
+    expect(page).to have_field("Secondary", type: :checkbox)
+    expect(page).to have_field("Special educational needs and disabilities (SEND) specific", type: :checkbox)
+    expect(page).to have_field("I don’t know", type: :checkbox)
+  end
+
+  def when_i_select_send
+    check "Special educational needs and disabilities (SEND) specific"
+  end
+
+  def then_i_see_the_key_stage_selection_form
+    expect(page).to have_title(
+      "What key stages could you offer placements in? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_span_caption("Potential SEND placement details")
+    expect(page).to have_element(
+      :legend,
+      text: "What key stages could you offer placements in?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Early year", type: :checkbox)
+    expect(page).to have_field("Key stage 1", type: :checkbox)
+    expect(page).to have_field("Key stage 2", type: :checkbox)
+    expect(page).to have_field("Key stage 3", type: :checkbox)
+    expect(page).to have_field("Key stage 4", type: :checkbox)
+    expect(page).to have_field("Key stage 5", type: :checkbox)
+    expect(page).to have_field("Mixed key stages", type: :checkbox)
+  end
+
+  def when_i_select_key_stage_2
+    check "Key stage 2"
+  end
+
+  def and_i_select_key_stage_5
+    check "Key stage 5"
+  end
+
+  def then_i_see_the_key_stage_placement_quantity_known_page
+    expect(page).to have_title(
+      "Do you know how many placement you could offer each SEND key stage? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_span_caption("Potential SEND placement details")
+    expect(page).to have_element(
+      :legend,
+      text: "Do you know how many placement you could offer each SEND key stage?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Yes", type: :radio)
+    expect(page).to have_field("No", type: :radio)
+  end
+
+  def when_i_select_yes
+    choose "Yes"
+  end
+
+  def then_i_see_the_key_stage_placement_quantity_form
+    expect(page).to have_title(
+      "How many placements could you offer for each key stage? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_span_caption("Potential SEND placement details")
+    expect(page).to have_h1("How many placements could you offer for each key stage?", class: "govuk-heading-l")
+    expect(page).to have_field("Key stage 2", type: :number)
+    expect(page).to have_field("Key stage 5", type: :number)
+  end
+
+  def when_i_fill_in_the_number_of_send_placements_i_require
+    fill_in "Key stage 2", with: 1
+    fill_in "Key stage 5", with: 2
+  end
+
+  def then_i_see_the_provider_note_page
+    expect(page).to have_title(
+      "Is there anything about your school you would like providers to know? (optional) - Manage school placements - GOV.UK",
+    )
+    expect(page).to have_element(
+      :label,
+      text: "Is there anything about your school you would like providers to know? (optional)",
+    )
+    expect(page).to have_element(
+      :span,
+      text: "Potential placement details",
+      class: "govuk-caption-l",
+    )
+  end
+
+  def when_i_enter_a_note_to_the_provider
+    fill_in "Is there anything about your school you would like providers to know? (optional)", with:
+      "We are open to hosting additional placements at the provider's request."
+  end
+
+  def then_i_see_the_school_contact_form
+    expect(page).to have_title(
+      "Who should providers contact? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Who should providers contact?")
+    expect(page).to have_element(
+      :p,
+      text: "Choose the person best placed to organise placements for trainee teachers at your school",
+      class: "govuk-body",
+    )
+
+    expect(page).to have_field("First name")
+    expect(page).to have_field("Last name")
+    expect(page).to have_field("Email address")
+  end
+
+  def when_i_fill_in_the_school_contact_details
+    fill_in "First name", with: "Joe"
+    fill_in "Last name", with: "Bloggs"
+    fill_in "Email address", with: "joe_bloggs@example.com"
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_title(
+      "Confirm and share what you may be able to offer - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Confirm and share what you may be able to offer", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Potential placement details", class: "govuk-caption-l")
+    expect(page).to have_element(
+      :p,
+      text: "Providers will be able to see that you may be able to offer placements for trainee teachers.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "They will be able to see your potential placement details and will be able to use your email to contact you.",
+      class: "govuk-body",
+    )
+  end
+
+  def and_i_see_the_entered_school_contact_details
+    expect(page).to have_h2("Your information", class: "govuk-heading-m")
+    expect(page).to have_summary_list_row("First name", "Joe")
+    expect(page).to have_summary_list_row("Last name", "Bloggs")
+    expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")
+  end
+
+  def and_i_see_the_education_phases_i_selected
+    expect(page).to have_h2("Potential education phase", class: "govuk-heading-m")
+    expect(page).to have_summary_list_row("Phase", "SEND")
+  end
+
+  def and_i_see_the_message_to_provider_i_entered
+    expect(page).to have_h2("Additional information", class: "govuk-heading-m")
+    expect(page).to have_summary_list_row(
+      "Message to providers",
+      "We are open to hosting additional placements at the provider's request.",
+    )
+  end
+
+  def and_i_see_the_potential_send_placement_details_i_entered
+    expect(page).to have_h2("Potential SEND placements", class: "govuk-heading-m")
+    expect(page).to have_summary_list_row("Key stage 2", "1")
+    expect(page).to have_summary_list_row("Key stage 5", "2")
+  end
+
+  def when_i_click_on_confirm
+    click_on "Confirm"
+  end
+
+  def then_i_see_the_whats_next_page
+    expect(page).to have_panel(
+      "Information added",
+      "Providers can see that you may offer placements",
+    )
+    expect(page).to have_h1("What happens next", class: "govuk-heading-l")
+    expect(page).to have_element(
+      :p,
+      text: "Providers who are looking for schools to work with can contact you on joe_bloggs@example.com.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "Once you are sure which placements your school can offer, add your placements. Doing so will mean you will be able to assign providers to them.",
+      class: "govuk-body",
+    )
+    expect(page).to have_link("add your placements", href: placements_school_placements_path(@school))
+  end
+
+  def and_the_schools_contact_has_been_updated
+    school_contact = @school.school_contact
+    expect(school_contact.first_name).to eq("Joe")
+    expect(school_contact.last_name).to eq("Bloggs")
+    expect(school_contact.email_address).to eq("joe_bloggs@example.com")
+  end
+
+  def and_the_schools_hosting_interest_for_the_next_year_is_updated
+    hosting_interest = @school.hosting_interests.for_academic_year(@next_academic_year).last
+    expect(hosting_interest.appetite).to eq("interested")
+  end
+
+  def and_the_schools_potential_placement_details_have_been_updated
+    potential_placement_details = @school.reload.potential_placement_details
+
+    expect(potential_placement_details["phase"]).to eq({ "phases" => %w[SEND] })
+    expect(
+      potential_placement_details.dig("key_stage_selection", "key_stage_ids").sort,
+    ).to eq(
+      [@key_stage_2.id, @key_stage_5.id].sort,
+    )
+    expect(potential_placement_details["key_stage_placement_quantity"]).to eq(
+      { "key_stage_2" => 1, "key_stage_5" => 2 },
+    )
+    expect(potential_placement_details["note_to_providers"]).to eq(
+      { "note" => "We are open to hosting additional placements at the provider's request." },
+    )
+  end
+end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_send_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_send_potential_placement_details_spec.rb
@@ -130,13 +130,13 @@ RSpec.describe "School user completes the interested journey and declares primar
 
   def then_i_see_the_key_stage_selection_form
     expect(page).to have_title(
-      "What key stages could you offer placements in? - Manage school placements - GOV.UK",
+      "What key stages could you offer SEND placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_span_caption("Potential SEND placement details")
     expect(page).to have_element(
       :legend,
-      text: "What key stages could you offer placements in?",
+      text: "What key stages could you offer SEND placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Early year", type: :checkbox)
@@ -158,13 +158,13 @@ RSpec.describe "School user completes the interested journey and declares primar
 
   def then_i_see_the_key_stage_placement_quantity_known_page
     expect(page).to have_title(
-      "Do you know how many placement you could offer each SEND key stage? - Manage school placements - GOV.UK",
+      "Do you know how many placements you could offer for each key stage? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_span_caption("Potential SEND placement details")
     expect(page).to have_element(
       :legend,
-      text: "Do you know how many placement you could offer each SEND key stage?",
+      text: "Do you know how many placements you could offer for each key stage?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes", type: :radio)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_quantities_for_potential_placements_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_quantities_for_potential_placements_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "School user completes the interested journey without declaring q
   scenario do
     given_academic_years_exist
     and_subjects_exist
+    and_key_stages_exist
     and_i_am_signed_in
 
     when_i_visit_the_add_hosting_interest_page
@@ -17,6 +18,7 @@ RSpec.describe "School user completes the interested journey without declaring q
 
     when_i_select_primary
     and_i_select_secondary
+    and_i_select_send
     and_i_click_on_continue
     then_i_see_the_primary_year_group_selection_form
 
@@ -35,6 +37,15 @@ RSpec.describe "School user completes the interested journey without declaring q
 
     when_i_select_no
     and_i_click_on_continue
+    then_i_see_the_key_stage_selection_form
+
+    when_i_select_key_stage_2
+    and_i_select_key_stage_5
+    and_i_click_on_continue
+    then_i_see_the_key_stage_placement_quantity_known_page
+
+    when_i_select_no
+    and_i_click_on_continue
     then_i_see_the_provider_note_page
 
     when_i_enter_a_note_to_the_provider
@@ -48,6 +59,7 @@ RSpec.describe "School user completes the interested journey without declaring q
     and_i_see_the_education_phases_i_selected
     and_i_see_the_potential_primary_placement_details_with_no_quantities
     and_i_see_the_potential_secondary_placement_details_with_no_quantities
+    and_i_see_the_potential_send_placement_details_with_no_quantities
     and_i_see_the_message_to_provider_i_entered
 
     when_i_click_on_confirm
@@ -72,6 +84,16 @@ RSpec.describe "School user completes the interested journey without declaring q
     @english = create(:subject, :secondary, name: "English")
     @mathematics = create(:subject, :secondary, name: "Mathematics")
     @science = create(:subject, :secondary, name: "Science")
+  end
+
+  def and_key_stages_exist
+    @early_years = create(:key_stage, name: "Early years")
+    @key_stage_1 = create(:key_stage, name: "Key stage 1")
+    @key_stage_2 = create(:key_stage, name: "Key stage 2")
+    @key_stage_3 = create(:key_stage, name: "Key stage 3")
+    @key_stage_4 = create(:key_stage, name: "Key stage 4")
+    @key_stage_5 = create(:key_stage, name: "Key stage 5")
+    @mixed_key_stages = create(:key_stage, name: "Mixed key stages")
   end
 
   def and_i_am_signed_in
@@ -247,7 +269,7 @@ RSpec.describe "School user completes the interested journey without declaring q
   def and_the_schools_potential_placement_details_have_been_updated
     potential_placement_details = @school.reload.potential_placement_details
 
-    expect(potential_placement_details["phase"]).to eq({ "phases" => %w[Primary Secondary] })
+    expect(potential_placement_details["phase"]).to eq({ "phases" => %w[Primary Secondary SEND] })
     expect(potential_placement_details["year_group_selection"]).to eq(
       { "year_groups" => %w[year_1] },
     )
@@ -258,6 +280,12 @@ RSpec.describe "School user completes the interested journey without declaring q
       [@english.id, @mathematics.id].sort,
     )
     expect(potential_placement_details["secondary_placement_quantity"]).to be_nil
+    expect(
+      potential_placement_details.dig("key_stage_selection", "key_stage_ids").sort,
+    ).to eq(
+      [@key_stage_2.id, @key_stage_5.id].sort,
+    )
+    expect(potential_placement_details["key_stage_placement_quantity"]).to be_nil
     expect(potential_placement_details["note_to_providers"]).to eq(
       { "note" => "We are open to hosting additional placements at the provider's request." },
     )
@@ -269,6 +297,10 @@ RSpec.describe "School user completes the interested journey without declaring q
 
   def and_i_select_secondary
     check "Secondary"
+  end
+
+  def and_i_select_send
+    check "Special educational needs and disabilities (SEND) specific"
   end
 
   def then_i_see_the_primary_year_group_selection_form
@@ -366,5 +398,55 @@ RSpec.describe "School user completes the interested journey without declaring q
     expect(page).to have_h2("Potential secondary placements", class: "govuk-heading-m")
     expect(page).to have_summary_list_row("English", "Not entered")
     expect(page).to have_summary_list_row("Mathematics", "Not entered")
+  end
+
+  def and_i_see_the_potential_send_placement_details_with_no_quantities
+    expect(page).to have_h2("Potential SEND placements", class: "govuk-heading-m")
+    expect(page).to have_summary_list_row("Key stage 2", "Not entered")
+    expect(page).to have_summary_list_row("Key stage 5", "Not entered")
+  end
+
+  def then_i_see_the_key_stage_selection_form
+    expect(page).to have_title(
+      "What key stages could you offer placements in? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_span_caption("Potential SEND placement details")
+    expect(page).to have_element(
+      :legend,
+      text: "What key stages could you offer placements in?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Early year", type: :checkbox)
+    expect(page).to have_field("Key stage 1", type: :checkbox)
+    expect(page).to have_field("Key stage 2", type: :checkbox)
+    expect(page).to have_field("Key stage 3", type: :checkbox)
+    expect(page).to have_field("Key stage 4", type: :checkbox)
+    expect(page).to have_field("Key stage 5", type: :checkbox)
+    expect(page).to have_field("Mixed key stages", type: :checkbox)
+    expect(page).to have_field("I don’t know", type: :checkbox)
+  end
+
+  def when_i_select_key_stage_2
+    check "Key stage 2"
+  end
+
+  def and_i_select_key_stage_5
+    check "Key stage 5"
+  end
+
+  def then_i_see_the_key_stage_placement_quantity_known_page
+    expect(page).to have_title(
+      "Do you know how many placement you could offer each SEND key stage? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_span_caption("Potential SEND placement details")
+    expect(page).to have_element(
+      :legend,
+      text: "Do you know how many placement you could offer each SEND key stage?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Yes", type: :radio)
+    expect(page).to have_field("No", type: :radio)
   end
 end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_quantities_for_potential_placements_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_quantities_for_potential_placements_spec.rb
@@ -408,13 +408,13 @@ RSpec.describe "School user completes the interested journey without declaring q
 
   def then_i_see_the_key_stage_selection_form
     expect(page).to have_title(
-      "What key stages could you offer placements in? - Manage school placements - GOV.UK",
+      "What key stages could you offer SEND placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_span_caption("Potential SEND placement details")
     expect(page).to have_element(
       :legend,
-      text: "What key stages could you offer placements in?",
+      text: "What key stages could you offer SEND placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Early year", type: :checkbox)
@@ -437,13 +437,13 @@ RSpec.describe "School user completes the interested journey without declaring q
 
   def then_i_see_the_key_stage_placement_quantity_known_page
     expect(page).to have_title(
-      "Do you know how many placement you could offer each SEND key stage? - Manage school placements - GOV.UK",
+      "Do you know how many placements you could offer for each key stage? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_span_caption("Potential SEND placement details")
     expect(page).to have_element(
       :legend,
-      text: "Do you know how many placement you could offer each SEND key stage?",
+      text: "Do you know how many placements you could offer for each key stage?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes", type: :radio)

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_specific_year_groups_or_subjects_or_key_stages_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_without_declaring_specific_year_groups_or_subjects_or_key_stages_spec.rb
@@ -428,13 +428,13 @@ RSpec.describe "School user completes the interested journey without declaring s
 
   def then_i_see_the_key_stage_selection_form
     expect(page).to have_title(
-      "What key stages could you offer placements in? - Manage school placements - GOV.UK",
+      "What key stages could you offer SEND placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_span_caption("Potential SEND placement details")
     expect(page).to have_element(
       :legend,
-      text: "What key stages could you offer placements in?",
+      text: "What key stages could you offer SEND placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Early year", type: :checkbox)

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_the_primary_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/primary_phase_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_the_primary_phase_spec.rb
@@ -276,8 +276,8 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     )
     expect(page).to have_h2("Manage your placements", class: "govuk-heading-m")
     expect(page).to have_h2("Your placements offer", class: "govuk-heading-m")
-    expect(page).to have_h2("Primary placements", class: "govuk-heading-m")
-    expect(page).not_to have_h2("Secondary placements", class: "govuk-heading-m")
+    expect(page).to have_h3("Primary placements", class: "govuk-heading-s")
+    expect(page).not_to have_h3("Secondary placements", class: "govuk-heading-s")
   end
 
   def and_i_see_2_reception_primary_placements_have_been_created

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
@@ -444,8 +444,8 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     )
     expect(page).to have_h2("Manage your placements", class: "govuk-heading-m")
     expect(page).to have_h2("Your placements offer", class: "govuk-heading-m")
-    expect(page).to have_h2("Primary placements", class: "govuk-heading-m")
-    expect(page).to have_h2("Secondary placements", class: "govuk-heading-m")
+    expect(page).to have_h3("Primary placements", class: "govuk-heading-s")
+    expect(page).to have_h3("Secondary placements", class: "govuk-heading-s")
   end
 
   def and_i_see_2_year_1_primary_placements_have_been_created

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
@@ -333,8 +333,8 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     )
     expect(page).to have_h2("Manage your placements", class: "govuk-heading-m")
     expect(page).to have_h2("Your placements offer", class: "govuk-heading-m")
-    expect(page).not_to have_h2("Primary placements", class: "govuk-heading-m")
-    expect(page).to have_h2("Secondary placements", class: "govuk-heading-m")
+    expect(page).not_to have_h3("Primary placements", class: "govuk-heading-s")
+    expect(page).to have_h3("Secondary placements", class: "govuk-heading-s")
   end
 
   def and_i_see_2_secondary_placements_for_modern_languages_have_been_created

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_edits_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/secondary_phase_only/school_user_edits_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
@@ -284,8 +284,8 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
     )
     expect(page).to have_h2("Manage your placements", class: "govuk-heading-m")
     expect(page).to have_h2("Your placements offer", class: "govuk-heading-m")
-    expect(page).not_to have_h2("Primary placements", class: "govuk-heading-m")
-    expect(page).to have_h2("Secondary placements", class: "govuk-heading-m")
+    expect(page).not_to have_h3("Primary placements", class: "govuk-heading-s")
+    expect(page).to have_h3("Secondary placements", class: "govuk-heading-s")
   end
 
   def and_i_see_1_english_secondary_placement_has_been_created

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/send_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_the_send_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/send_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_the_send_phase_spec.rb
@@ -1,0 +1,322 @@
+require "rails_helper"
+
+RSpec.describe "School user edits their hosting interest and bulk adds placements for the SEND phase",
+               service: :placements,
+               type: :system do
+  scenario do
+    given_subjects_exist
+    and_academic_years_exist
+    and_key_stages_exist
+    and_a_school_exists_with_a_hosting_interest
+    and_i_am_signed_in
+
+    when_i_navigate_to_organisation_details
+    then_i_see_the_organisation_details_page
+    and_i_see_the_hosting_interest_for_the_next_academic_year
+
+    when_i_click_on_change_hosting_status
+    then_i_see_the_appetite_form
+
+    when_i_select_actively_looking_to_host_placements
+    and_i_click_on_continue
+    then_i_see_the_phase_form
+
+    when_i_select_send
+    and_i_click_on_continue
+    then_i_see_the_key_stage_selection_form
+
+    when_i_select_key_stage_2
+    and_i_select_key_stage_5
+    and_i_click_on_continue
+    then_i_see_the_key_stage_placement_quantity_form
+
+    when_i_fill_in_the_number_of_send_placements_i_require
+    and_i_click_on_continue
+    then_i_see_the_check_your_answers_page
+
+    when_i_click_on_publish_placements
+    then_i_see_the_whats_next_page
+    and_i_see_a_send_placement_for_key_stage_2_has_been_created
+    and_i_see_two_send_placements_for_key_stage_5_have_been_created
+
+    when_i_click_on_edit_your_placements
+    then_i_am_on_the_placements_index_page
+    and_i_see_1_send_placement_for_key_stage_2
+    and_i_see_2_send_placement_for_key_stage_5
+  end
+
+  private
+
+  def given_subjects_exist
+    @english = create(:subject, :secondary, name: "English")
+    @mathematics = create(:subject, :secondary, name: "Mathematics")
+    @science = create(:subject, :secondary, name: "Science")
+  end
+
+  def and_academic_years_exist
+    current_academic_year = Placements::AcademicYear.current
+    @current_academic_year_name = current_academic_year.name
+    @next_academic_year = current_academic_year.next
+    @next_academic_year_name = @next_academic_year.name
+  end
+
+  def and_key_stages_exist
+    @early_years = create(:key_stage, name: "Early years")
+    @key_stage_1 = create(:key_stage, name: "Key stage 1")
+    @key_stage_2 = create(:key_stage, name: "Key stage 2")
+    @key_stage_3 = create(:key_stage, name: "Key stage 3")
+    @key_stage_4 = create(:key_stage, name: "Key stage 4")
+    @key_stage_5 = create(:key_stage, name: "Key stage 5")
+    @mixed_key_stages = create(:key_stage, name: "Mixed key stages")
+  end
+
+  def and_a_school_exists_with_a_hosting_interest
+    @school = create(:placements_school)
+    @hosting_interest = create(
+      :hosting_interest,
+      school: @school,
+      academic_year: @next_academic_year,
+    )
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@school])
+  end
+
+  def when_i_navigate_to_organisation_details
+    within(primary_navigation) do
+      click_on "Organisation details"
+    end
+  end
+
+  def then_i_see_the_organisation_details_page
+    expect(page).to have_current_item("Organisation details")
+    expect(page).to have_title(
+      "Organisation details - Manage school placements - GOV.UK",
+    )
+    expect(page).to have_h1(@school.name)
+    expect(page).to have_h2("Hosting status")
+    expect(page).to have_element(
+      :p,
+      text: "This status indicates to providers whether you intend to host placements.",
+      class: "govuk-body",
+    )
+  end
+
+  def and_i_see_the_hosting_interest_for_the_next_academic_year
+    expect(page).to have_summary_list_row(
+      "Status", "Open to hosting"
+    )
+  end
+
+  def when_i_click_on_change_hosting_status
+    click_on "Change Hosting status"
+  end
+
+  def then_i_see_the_appetite_form
+    expect(page).to have_title(
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Organisation details")
+    expect(page).to have_element(
+      :legend,
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Yes - I can offer placements", type: :radio)
+    expect(page).to have_field("Maybe - I’m not sure yet", type: :radio)
+    expect(page).to have_field("No - I can’t offer placements", type: :radio)
+  end
+
+  def when_i_select_actively_looking_to_host_placements
+    choose "Yes - I can offer placements"
+  end
+
+  def when_i_click_on_continue
+    click_on "Continue"
+  end
+  alias_method :and_i_click_on_continue,
+               :when_i_click_on_continue
+
+  def when_i_visit_the_add_hosting_interest_page
+    visit new_add_hosting_interest_placements_school_hosting_interests_path(@school)
+  end
+
+  def then_i_see_the_phase_form
+    expect(page).to have_title(
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Organisation details")
+    expect(page).to have_element(
+      :legend,
+      text: "What education phase can your placements be?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_hint("Select all that apply")
+    expect(page).to have_field("Primary", type: :checkbox)
+    expect(page).to have_field("Secondary", type: :checkbox)
+  end
+
+  def when_i_select_send
+    check "Special educational needs and disabilities (SEND) specific"
+  end
+
+  def then_i_see_the_key_stage_selection_form
+    expect(page).to have_title(
+      "What SEND key stages can you offer placements in? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Organisation details")
+    expect(page).to have_span_caption("SEND placement details")
+    expect(page).to have_element(
+      :legend,
+      text: "What SEND key stages can you offer placements in?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Early year", type: :checkbox)
+    expect(page).to have_field("Key stage 1", type: :checkbox)
+    expect(page).to have_field("Key stage 2", type: :checkbox)
+    expect(page).to have_field("Key stage 3", type: :checkbox)
+    expect(page).to have_field("Key stage 4", type: :checkbox)
+    expect(page).to have_field("Key stage 5", type: :checkbox)
+    expect(page).to have_field("Mixed key stages", type: :checkbox)
+  end
+
+  def when_i_select_key_stage_2
+    check "Key stage 2"
+  end
+
+  def and_i_select_key_stage_5
+    check "Key stage 5"
+  end
+
+  def then_i_see_the_key_stage_placement_quantity_form
+    expect(page).to have_title(
+      "How many SEND placements can you offer? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Organisation details")
+    expect(page).to have_span_caption("SEND placement details")
+    expect(page).to have_h1("How many SEND placements can you offer?", class: "govuk-heading-l")
+    expect(page).to have_field("Key stage 2", type: :number)
+    expect(page).to have_field("Key stage 5", type: :number)
+  end
+
+  def when_i_fill_in_the_number_of_send_placements_i_require
+    fill_in "Key stage 2", with: 1
+    fill_in "Key stage 5", with: 2
+  end
+
+  def then_i_see_the_school_contact_form
+    expect(page).to have_title(
+      "Who should providers contact? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Organisation details")
+    expect(page).to have_h1("Who should providers contact?")
+    expect(page).to have_element(
+      :p,
+      text: "Choose the person best placed to organise placements for trainee teachers at your school",
+      class: "govuk-body",
+    )
+
+    expect(page).to have_field("First name")
+    expect(page).to have_field("Last name")
+    expect(page).to have_field("Email address")
+  end
+
+  def when_i_fill_in_the_school_contact_details
+    fill_in "First name", with: "Joe"
+    fill_in "Last name", with: "Bloggs"
+    fill_in "Email address", with: "joe_bloggs@example.com"
+  end
+
+  def and_the_schools_contact_has_been_updated
+    @school_contact = @school.school_contact.reload
+    expect(@school_contact.first_name).to eq("Joe")
+    expect(@school_contact.last_name).to eq("Bloggs")
+    expect(@school_contact.email_address).to eq("joe_bloggs@example.com")
+  end
+
+  def and_the_schools_hosting_interest_for_the_next_year_is_updated
+    hosting_interest = @school.hosting_interests.for_academic_year(@next_academic_year).last
+    expect(hosting_interest.appetite).to eq("actively_looking")
+  end
+
+  def when_i_click_on_publish_placements
+    click_on "Publish placements"
+  end
+
+  def then_i_see_the_check_your_answers_page
+    expect(page).to have_title(
+      "Check your answers - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Organisation details")
+    expect(page).to have_h1("Check your answers")
+
+    expect(page).to have_h2("Education phase")
+    expect(page).to have_summary_list_row("Phase", "SEND")
+
+    expect(page).to have_h2("SEND placements")
+    expect(page).to have_summary_list_row("Key stage 2", "1")
+    expect(page).to have_summary_list_row("Key stage 5", "2")
+  end
+
+  def then_i_see_the_whats_next_page
+    expect(page).to have_title(
+      "What happens next? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Organisation details")
+    expect(page).to have_panel(
+      "Placement information added",
+      "Providers can see that you have placements available",
+    )
+    expect(page).to have_h1("What happens next?", class: "govuk-heading-l")
+    expect(page).to have_element(
+      :p,
+      text: "Providers will be able to contact you on #{@school.school_contact_email_address} about your placement offers. After these discussions you can then decide whether to assign a provider to your placements.",
+      class: "govuk-body",
+    )
+    expect(page).to have_h2("Manage your placements", class: "govuk-heading-m")
+    expect(page).to have_h2("Your placements offer", class: "govuk-heading-m")
+    expect(page).not_to have_h3("Primary placements", class: "govuk-heading-s")
+    expect(page).not_to have_h3("Secondary placements", class: "govuk-heading-s")
+    expect(page).to have_h3("SEND placements", class: "govuk-heading-s")
+  end
+
+  def and_i_see_a_send_placement_for_key_stage_2_has_been_created
+    expect(page).to have_summary_list_row("Key stage 2", "1")
+  end
+
+  def and_i_see_two_send_placements_for_key_stage_5_have_been_created
+    expect(page).to have_summary_list_row("Key stage 5", "2")
+  end
+
+  def when_i_click_on_edit_your_placements
+    click_on "Edit your placements"
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Placements")
+    expect(page).to have_link("Add multiple placements")
+  end
+  alias_method :then_i_am_on_the_placements_index_page,
+               :when_i_am_on_the_placements_index_page
+
+  def and_i_see_1_send_placement_for_key_stage_2
+    expect(page).to have_link(
+      "SEND (Key stage 2)",
+      class: "govuk-link govuk-link--no-visited-state",
+      match: :prefer_exact,
+      count: 1,
+    )
+  end
+
+  def and_i_see_2_send_placement_for_key_stage_5
+    expect(page).to have_link(
+      "SEND (Key stage 5)",
+      class: "govuk-link govuk-link--no-visited-state",
+      match: :prefer_exact,
+      count: 2,
+    )
+  end
+end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/send_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_the_send_phase_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_actively_looking/send_only/school_user_edits_their_hosting_interest_and_bulk_adds_placements_for_the_send_phase_spec.rb
@@ -163,13 +163,13 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_key_stage_selection_form
     expect(page).to have_title(
-      "What SEND key stages can you offer placements in? - Manage school placements - GOV.UK",
+      "What key stages can you offer SEND placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_span_caption("SEND placement details")
     expect(page).to have_element(
       :legend,
-      text: "What SEND key stages can you offer placements in?",
+      text: "What key stages can you offer SEND placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Early year", type: :checkbox)
@@ -191,11 +191,11 @@ RSpec.describe "School user edits their hosting interest and bulk adds placement
 
   def then_i_see_the_key_stage_placement_quantity_form
     expect(page).to have_title(
-      "How many SEND placements can you offer? - Manage school placements - GOV.UK",
+      "Enter the number of SEND placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_span_caption("SEND placement details")
-    expect(page).to have_h1("How many SEND placements can you offer?", class: "govuk-heading-l")
+    expect(page).to have_h1("Enter the number of SEND placements you can offer", class: "govuk-heading-l")
     expect(page).to have_field("Key stage 2", type: :number)
     expect(page).to have_field("Key stage 5", type: :number)
   end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "School user completes the interested journey without declaring potential placement details",
+RSpec.describe "School user completes the interested journey and declares primary and secondary potential placement details",
                service: :placements,
                type: :system do
   scenario do

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_send_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_send_potential_placement_details_spec.rb
@@ -1,0 +1,342 @@
+require "rails_helper"
+
+RSpec.describe "School user completes the interested journey and declares SEND potential placement details",
+               service: :placements,
+               type: :system do
+  scenario do
+    given_academic_years_exist
+    and_key_stages_exist
+    and_a_school_exists_with_a_hosting_interest
+    and_i_am_signed_in
+
+    when_i_navigate_to_organisation_details
+    then_i_see_the_organisation_details_page
+    and_i_see_the_hosting_interest_for_the_next_academic_year
+
+    when_i_click_on_change_hosting_status
+    then_i_see_the_appetite_form
+
+    when_i_select_interested_in_hosting_placements
+    and_i_click_on_continue
+    then_i_see_the_phase_known_page
+
+    when_i_select_send
+    and_i_click_on_continue
+    then_i_see_the_key_stage_selection_form
+
+    when_i_select_key_stage_2
+    and_i_select_key_stage_5
+    and_i_click_on_continue
+    then_i_see_the_key_stage_placement_quantity_known_page
+
+    when_i_select_yes
+    and_i_click_on_continue
+    then_i_see_the_key_stage_placement_quantity_form
+
+    when_i_fill_in_the_number_of_send_placements_i_require
+    and_i_click_on_continue
+    then_i_see_the_provider_note_page
+
+    when_i_enter_a_note_to_the_provider
+    and_i_click_on_continue
+    then_i_see_the_confirmation_page
+    and_i_see_the_education_phases_i_selected
+    and_i_see_the_potential_send_placement_details_i_entered
+    and_i_see_the_message_to_provider_i_entered
+
+    when_i_click_on_confirm
+    then_i_see_the_whats_next_page
+    and_the_schools_hosting_interest_for_the_next_year_is_updated
+    and_the_schools_potential_placement_details_have_been_updated
+  end
+
+  private
+
+  def given_academic_years_exist
+    current_academic_year = Placements::AcademicYear.current
+    @current_academic_year_name = current_academic_year.name
+    @next_academic_year = current_academic_year.next
+    @next_academic_year_name = @next_academic_year.name
+  end
+
+  def and_key_stages_exist
+    @early_years = create(:key_stage, name: "Early years")
+    @key_stage_1 = create(:key_stage, name: "Key stage 1")
+    @key_stage_2 = create(:key_stage, name: "Key stage 2")
+    @key_stage_3 = create(:key_stage, name: "Key stage 3")
+    @key_stage_4 = create(:key_stage, name: "Key stage 4")
+    @key_stage_5 = create(:key_stage, name: "Key stage 5")
+    @mixed_key_stages = create(:key_stage, name: "Mixed key stages")
+  end
+
+  def and_a_school_exists_with_a_hosting_interest
+    @school = create(:placements_school)
+    @hosting_interest = create(
+      :hosting_interest,
+      school: @school,
+      academic_year: @next_academic_year,
+    )
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@school])
+  end
+
+  def when_i_navigate_to_organisation_details
+    within(primary_navigation) do
+      click_on "Organisation details"
+    end
+  end
+
+  def then_i_see_the_organisation_details_page
+    expect(page).to have_current_item("Organisation details")
+    expect(page).to have_title(
+      "Organisation details - Manage school placements - GOV.UK",
+    )
+    expect(page).to have_h1(@school.name)
+    expect(page).to have_h2("Hosting status")
+    expect(page).to have_element(
+      :p,
+      text: "This status indicates to providers whether you intend to host placements.",
+      class: "govuk-body",
+    )
+  end
+
+  def and_i_see_the_hosting_interest_for_the_next_academic_year
+    expect(page).to have_summary_list_row(
+      "Status", "Open to hosting"
+    )
+  end
+
+  def when_i_click_on_change_hosting_status
+    click_on "Change Hosting status"
+  end
+
+  def then_i_see_the_appetite_form
+    expect(page).to have_title(
+      "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Organisation details")
+    expect(page).to have_element(
+      :legend,
+      text: "Can your school offer placements for trainee teachers in the academic year #{@next_academic_year_name}?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Yes - I can offer placements", type: :radio)
+    expect(page).to have_field("Maybe - I’m not sure yet", type: :radio)
+    expect(page).to have_field("No - I can’t offer placements", type: :radio)
+  end
+
+  def when_i_select_interested_in_hosting_placements
+    choose "Maybe - I’m not sure yet"
+  end
+
+  def when_i_click_on_continue
+    click_on "Continue"
+  end
+
+  alias_method :and_i_click_on_continue,
+               :when_i_click_on_continue
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_title(
+      "Confirm and share what you may be able to offer - Manage school placements - GOV.UK",
+    )
+    expect(page).to have_current_item("Organisation details")
+    expect(page).to have_h1("Confirm and share what you may be able to offer", class: "govuk-heading-l")
+    expect(page).to have_element(:span, text: "Potential placement details", class: "govuk-caption-l")
+    expect(page).to have_element(
+      :p,
+      text: "Providers will be able to see that you may be able to offer placements for trainee teachers.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "They will be able to see your potential placement details and will be able to use your email to contact you.",
+      class: "govuk-body",
+    )
+  end
+
+  def and_the_schools_contact_has_been_updated
+    school_contact = @school.school_contact
+    expect(school_contact.first_name).to eq("Joe")
+    expect(school_contact.last_name).to eq("Bloggs")
+    expect(school_contact.email_address).to eq("joe_bloggs@example.com")
+  end
+
+  def and_the_schools_hosting_interest_for_the_next_year_is_updated
+    hosting_interest = @school.hosting_interests.for_academic_year(@next_academic_year).last
+    expect(hosting_interest.appetite).to eq("interested")
+  end
+
+  def then_i_see_the_whats_next_page
+    expect(page).to have_panel(
+      "Information added",
+      "Providers can see that you may offer placements",
+    )
+    expect(page).to have_h1("What happens next", class: "govuk-heading-l")
+    expect(page).to have_element(
+      :p,
+      text: "Providers who are looking for schools to work with can contact you on #{@school.school_contact_email_address}.",
+      class: "govuk-body",
+    )
+    expect(page).to have_element(
+      :p,
+      text: "Once you are sure which placements your school can offer, add your placements. Doing so will mean you will be able to assign providers to them.",
+      class: "govuk-body",
+    )
+    expect(page).to have_link("add your placements", href: placements_school_placements_path(@school))
+  end
+
+  def then_i_see_the_phase_known_page
+    expect(page).to have_title(
+      "What education phase could you offer placements in? - Manage school placements - GOV.UK",
+    )
+    expect(page).to have_element(
+      :legend,
+      text: "What education phase could you offer placements in?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_hint(
+      "Select all that apply. Sharing information on what you may be able to offer helps providers know whether to contact you." \
+        " It is not a commitment to take a trainee teacher.",
+    )
+    expect(page).to have_field("Primary", type: :checkbox)
+    expect(page).to have_field("Secondary", type: :checkbox)
+    expect(page).to have_field("I don’t know", type: :checkbox)
+  end
+
+  def then_i_see_the_provider_note_page
+    expect(page).to have_title(
+      "Is there anything about your school you would like providers to know? (optional) - Manage school placements - GOV.UK",
+    )
+    expect(page).to have_element(
+      :label,
+      text: "Is there anything about your school you would like providers to know? (optional)",
+    )
+    expect(page).to have_element(
+      :span,
+      text: "Potential placement details",
+      class: "govuk-caption-l",
+    )
+  end
+
+  def when_i_enter_a_note_to_the_provider
+    fill_in "Is there anything about your school you would like providers to know? (optional)", with:
+      "We are open to hosting additional placements at the provider's request."
+  end
+
+  def and_i_see_the_entered_school_contact_details
+    expect(page).to have_h2("Your information", class: "govuk-heading-m")
+    expect(page).to have_summary_list_row("First name", "Joe")
+    expect(page).to have_summary_list_row("Last name", "Bloggs")
+    expect(page).to have_summary_list_row("Email address", "joe_bloggs@example.com")
+  end
+
+  def and_i_see_the_education_phases_i_selected
+    expect(page).to have_h2("Potential education phase", class: "govuk-heading-m")
+    expect(page).to have_summary_list_row("Phase", "SEND")
+  end
+
+  def and_i_see_the_message_to_provider_i_entered
+    expect(page).to have_h2("Additional information", class: "govuk-heading-m")
+    expect(page).to have_summary_list_row(
+      "Message to providers",
+      "We are open to hosting additional placements at the provider's request.",
+    )
+  end
+
+  def when_i_click_on_confirm
+    click_on "Confirm"
+  end
+
+  def and_the_schools_potential_placement_details_have_been_updated
+    potential_placement_details = @school.reload.potential_placement_details
+
+    expect(potential_placement_details["phase"]).to eq({ "phases" => %w[SEND] })
+    expect(
+      potential_placement_details.dig("key_stage_selection", "key_stage_ids").sort,
+    ).to eq(
+      [@key_stage_2.id, @key_stage_5.id].sort,
+    )
+    expect(potential_placement_details["key_stage_placement_quantity"]).to eq(
+      { "key_stage_2" => 1, "key_stage_5" => 2 },
+    )
+    expect(potential_placement_details["note_to_providers"]).to eq(
+      { "note" => "We are open to hosting additional placements at the provider's request." },
+    )
+  end
+
+  def when_i_select_send
+    check "Special educational needs and disabilities (SEND) specific"
+  end
+
+  def then_i_see_the_key_stage_selection_form
+    expect(page).to have_title(
+      "What key stages could you offer placements in? - Manage school placements - GOV.UK",
+    )
+    expect(page).to have_current_item("Organisation details")
+    expect(page).to have_span_caption("Potential SEND placement details")
+    expect(page).to have_element(
+      :legend,
+      text: "What key stages could you offer placements in?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Early year", type: :checkbox)
+    expect(page).to have_field("Key stage 1", type: :checkbox)
+    expect(page).to have_field("Key stage 2", type: :checkbox)
+    expect(page).to have_field("Key stage 3", type: :checkbox)
+    expect(page).to have_field("Key stage 4", type: :checkbox)
+    expect(page).to have_field("Key stage 5", type: :checkbox)
+    expect(page).to have_field("Mixed key stages", type: :checkbox)
+  end
+
+  def when_i_select_key_stage_2
+    check "Key stage 2"
+  end
+
+  def and_i_select_key_stage_5
+    check "Key stage 5"
+  end
+
+  def then_i_see_the_key_stage_placement_quantity_known_page
+    expect(page).to have_title(
+      "Do you know how many placement you could offer each SEND key stage? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Organisation details")
+    expect(page).to have_span_caption("Potential SEND placement details")
+    expect(page).to have_element(
+      :legend,
+      text: "Do you know how many placement you could offer each SEND key stage?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Yes", type: :radio)
+    expect(page).to have_field("No", type: :radio)
+  end
+
+  def when_i_select_yes
+    choose "Yes"
+  end
+
+  def then_i_see_the_key_stage_placement_quantity_form
+    expect(page).to have_title(
+      "How many placements could you offer for each key stage? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Organisation details")
+    expect(page).to have_span_caption("Potential SEND placement details")
+    expect(page).to have_h1("How many placements could you offer for each key stage?", class: "govuk-heading-l")
+    expect(page).to have_field("Key stage 2", type: :number)
+    expect(page).to have_field("Key stage 5", type: :number)
+  end
+
+  def when_i_fill_in_the_number_of_send_placements_i_require
+    fill_in "Key stage 2", with: 1
+    fill_in "Key stage 5", with: 2
+  end
+
+  def and_i_see_the_potential_send_placement_details_i_entered
+    expect(page).to have_h2("Potential SEND placements", class: "govuk-heading-m")
+    expect(page).to have_summary_list_row("Key stage 2", "1")
+    expect(page).to have_summary_list_row("Key stage 5", "2")
+  end
+end

--- a/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_send_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/edit_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_send_potential_placement_details_spec.rb
@@ -273,13 +273,13 @@ RSpec.describe "School user completes the interested journey and declares SEND p
 
   def then_i_see_the_key_stage_selection_form
     expect(page).to have_title(
-      "What key stages could you offer placements in? - Manage school placements - GOV.UK",
+      "What key stages could you offer SEND placements in? - Manage school placements - GOV.UK",
     )
     expect(page).to have_current_item("Organisation details")
     expect(page).to have_span_caption("Potential SEND placement details")
     expect(page).to have_element(
       :legend,
-      text: "What key stages could you offer placements in?",
+      text: "What key stages could you offer SEND placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Early year", type: :checkbox)
@@ -301,13 +301,13 @@ RSpec.describe "School user completes the interested journey and declares SEND p
 
   def then_i_see_the_key_stage_placement_quantity_known_page
     expect(page).to have_title(
-      "Do you know how many placement you could offer each SEND key stage? - Manage school placements - GOV.UK",
+      "Do you know how many placements you could offer for each key stage? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Organisation details")
     expect(page).to have_span_caption("Potential SEND placement details")
     expect(page).to have_element(
       :legend,
-      text: "Do you know how many placement you could offer each SEND key stage?",
+      text: "Do you know how many placements you could offer for each key stage?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Yes", type: :radio)

--- a/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_bulk_adds_placements_for_the_primary_phase_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/primary_phase_only/school_user_bulk_adds_placements_for_the_primary_phase_spec.rb
@@ -198,8 +198,8 @@ RSpec.describe "School user bulk adds placements for the primary phases",
     )
     expect(page).to have_h2("Manage your placements", class: "govuk-heading-m")
     expect(page).to have_h2("Your placements offer", class: "govuk-heading-m")
-    expect(page).to have_h2("Primary placements", class: "govuk-heading-m")
-    expect(page).not_to have_h2("Secondary placements", class: "govuk-heading-m")
+    expect(page).to have_h3("Primary placements", class: "govuk-heading-s")
+    expect(page).not_to have_h3("Secondary placements", class: "govuk-heading-s")
   end
 
   def when_i_click_on_edit_your_placements

--- a/spec/system/placements/schools/placements/bulk_add_placements/school_user_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/school_user_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
@@ -299,8 +299,8 @@ RSpec.describe "School user bulk adds placements for primary and secondary phase
     )
     expect(page).to have_h2("Manage your placements", class: "govuk-heading-m")
     expect(page).to have_h2("Your placements offer", class: "govuk-heading-m")
-    expect(page).to have_h2("Primary placements", class: "govuk-heading-m")
-    expect(page).to have_h2("Secondary placements", class: "govuk-heading-m")
+    expect(page).to have_h3("Primary placements", class: "govuk-heading-s")
+    expect(page).to have_h3("Secondary placements", class: "govuk-heading-s")
   end
 
   def when_i_click_on_edit_your_placements

--- a/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_adds_their_hosting_interest_and_bulk_adds_placements_for_a_subject_with_child_subjects_spec.rb
@@ -238,8 +238,8 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     )
     expect(page).to have_h2("Manage your placements", class: "govuk-heading-m")
     expect(page).to have_h2("Your placements offer", class: "govuk-heading-m")
-    expect(page).not_to have_h2("Primary placements", class: "govuk-heading-m")
-    expect(page).to have_h2("Secondary placements", class: "govuk-heading-m")
+    expect(page).not_to have_h3("Primary placements", class: "govuk-heading-m")
+    expect(page).to have_h3("Secondary placements", class: "govuk-heading-m")
   end
 
   def when_i_click_on_edit_your_placements

--- a/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_adds_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/secondary_phase_only/school_user_adds_ther_hosting_interest_and_bulk_adds_placements_for_the_secondary_phase_spec.rb
@@ -199,8 +199,8 @@ RSpec.describe "School user adds their hosting interest and bulk adds placements
     )
     expect(page).to have_h2("Manage your placements", class: "govuk-heading-m")
     expect(page).to have_h2("Your placements offer", class: "govuk-heading-m")
-    expect(page).not_to have_h2("Primary placements", class: "govuk-heading-m")
-    expect(page).to have_h2("Secondary placements", class: "govuk-heading-m")
+    expect(page).not_to have_h3("Primary placements", class: "govuk-heading-s")
+    expect(page).to have_h3("Secondary placements", class: "govuk-heading-s")
   end
 
   def when_i_click_on_edit_your_placements

--- a/spec/system/placements/schools/placements/bulk_add_placements/send_only/school_user_bulk_adds_placements_for_the_send_phase_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/send_only/school_user_bulk_adds_placements_for_the_send_phase_spec.rb
@@ -1,0 +1,224 @@
+require "rails_helper"
+
+RSpec.describe "School user bulk adds placements for the send phase",
+               service: :placements,
+               type: :system do
+  scenario do
+    given_key_stages_exist
+    and_academic_years_exist
+    and_i_am_signed_in
+
+    when_i_am_on_the_placements_index_page
+    and_i_click_on_add_multiple_placements
+    then_i_see_the_phase_form
+
+    when_i_select_send
+    and_i_click_on_continue
+    then_i_see_the_key_stage_selection_form
+
+    when_i_select_key_stage_2
+    and_i_select_key_stage_5
+    and_i_click_on_continue
+    then_i_see_the_key_stage_placement_quantity_form
+
+    when_i_fill_in_the_number_of_send_placements_i_require
+    and_i_click_on_continue
+    then_i_see_the_check_your_answers_page
+
+    when_i_click_on_publish_placements
+    then_i_see_the_whats_next_page
+    and_i_see_a_send_placement_for_key_stage_2_has_been_created
+    and_i_see_two_send_placements_for_key_stage_5_have_been_created
+
+    when_i_click_on_edit_your_placements
+    then_i_am_on_the_placements_index_page
+    and_i_see_1_send_placement_for_key_stage_2
+    and_i_see_2_send_placement_for_key_stage_5
+  end
+
+  private
+
+  def given_key_stages_exist
+    @early_years = create(:key_stage, name: "Early years")
+    @key_stage_1 = create(:key_stage, name: "Key stage 1")
+    @key_stage_2 = create(:key_stage, name: "Key stage 2")
+    @key_stage_3 = create(:key_stage, name: "Key stage 3")
+    @key_stage_4 = create(:key_stage, name: "Key stage 4")
+    @key_stage_5 = create(:key_stage, name: "Key stage 5")
+    @mixed_key_stages = create(:key_stage, name: "Mixed key stages")
+  end
+
+  def and_academic_years_exist
+    current_academic_year = Placements::AcademicYear.current
+    @current_academic_year_name = current_academic_year.name
+    @next_academic_year = current_academic_year.next
+    @next_academic_year_name = @next_academic_year.name
+  end
+
+  def and_i_am_signed_in
+    @school = create(:placements_school)
+    sign_in_placements_user(organisations: [@school])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Placements")
+    expect(page).to have_link("Add multiple placements")
+  end
+  alias_method :then_i_am_on_the_placements_index_page,
+               :when_i_am_on_the_placements_index_page
+
+  def when_i_click_on_add_multiple_placements
+    click_on "Add multiple placements"
+  end
+  alias_method :and_i_click_on_add_multiple_placements,
+               :when_i_click_on_add_multiple_placements
+
+  def when_i_click_on_continue
+    click_on "Continue"
+  end
+  alias_method :and_i_click_on_continue,
+               :when_i_click_on_continue
+
+  def then_i_see_the_phase_form
+    expect(page).to have_title(
+      "What education phase can your placements be? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_element(
+      :legend,
+      text: "What education phase can your placements be?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Primary", type: :checkbox)
+    expect(page).to have_field("Secondary", type: :checkbox)
+    expect(page).to have_field("Special educational needs and disabilities (SEND) specific", type: :checkbox)
+  end
+
+  def when_i_select_send
+    check "Special educational needs and disabilities (SEND) specific"
+  end
+
+  def then_i_see_the_key_stage_selection_form
+    expect(page).to have_title(
+      "What SEND key stages can you offer placements in? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_span_caption("SEND placement details")
+    expect(page).to have_element(
+      :legend,
+      text: "What SEND key stages can you offer placements in?",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_field("Early year", type: :checkbox)
+    expect(page).to have_field("Key stage 1", type: :checkbox)
+    expect(page).to have_field("Key stage 2", type: :checkbox)
+    expect(page).to have_field("Key stage 3", type: :checkbox)
+    expect(page).to have_field("Key stage 4", type: :checkbox)
+    expect(page).to have_field("Key stage 5", type: :checkbox)
+    expect(page).to have_field("Mixed key stages", type: :checkbox)
+  end
+
+  def when_i_select_key_stage_2
+    check "Key stage 2"
+  end
+
+  def and_i_select_key_stage_5
+    check "Key stage 5"
+  end
+
+  def then_i_see_the_key_stage_placement_quantity_form
+    expect(page).to have_title(
+      "How many SEND placements can you offer? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_span_caption("SEND placement details")
+    expect(page).to have_h1("How many SEND placements can you offer?", class: "govuk-heading-l")
+    expect(page).to have_field("Key stage 2", type: :number)
+    expect(page).to have_field("Key stage 5", type: :number)
+  end
+
+  def when_i_fill_in_the_number_of_send_placements_i_require
+    fill_in "Key stage 2", with: 1
+    fill_in "Key stage 5", with: 2
+  end
+
+  def then_i_see_my_responses_were_successfully_updated
+    expect(page).to have_success_banner(
+      "Placements added",
+      "Providers can see your placements and may contact you to discuss them. You can add details to your placements such as expected date and provider.",
+    )
+  end
+
+  def when_i_click_on_publish_placements
+    click_on "Publish placements"
+  end
+
+  def then_i_see_the_check_your_answers_page
+    expect(page).to have_title(
+      "Check your answers - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Check your answers")
+
+    expect(page).to have_h2("Education phase")
+    expect(page).to have_summary_list_row("Phase", "SEND")
+
+    expect(page).to have_h2("SEND placements")
+    expect(page).to have_summary_list_row("Key stage 2", "1")
+    expect(page).to have_summary_list_row("Key stage 5", "2")
+  end
+
+  def then_i_see_the_whats_next_page
+    expect(page).to have_title(
+      "What happens next? - Manage school placements - GOV.UK",
+    )
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_panel(
+      "Placement information added",
+      "Providers can see that you have placements available",
+    )
+    expect(page).to have_h1("What happens next?", class: "govuk-heading-l")
+    expect(page).to have_element(
+      :p,
+      text: "Providers will be able to contact you on #{@school.school_contact_email_address} about your placement offers. After these discussions you can then decide whether to assign a provider to your placements.",
+      class: "govuk-body",
+    )
+    expect(page).to have_h2("Manage your placements", class: "govuk-heading-m")
+    expect(page).to have_h2("Your placements offer", class: "govuk-heading-m")
+    expect(page).not_to have_h3("Primary placements", class: "govuk-heading-s")
+    expect(page).not_to have_h3("Secondary placements", class: "govuk-heading-s")
+    expect(page).to have_h3("SEND placements", class: "govuk-heading-s")
+  end
+
+  def when_i_click_on_edit_your_placements
+    click_on "Edit your placements"
+  end
+
+  def and_i_see_1_send_placement_for_key_stage_2
+    expect(page).to have_link(
+      "SEND (Key stage 2)",
+      class: "govuk-link govuk-link--no-visited-state",
+      match: :prefer_exact,
+      count: 1,
+    )
+  end
+
+  def and_i_see_2_send_placement_for_key_stage_5
+    expect(page).to have_link(
+      "SEND (Key stage 5)",
+      class: "govuk-link govuk-link--no-visited-state",
+      match: :prefer_exact,
+      count: 2,
+    )
+  end
+
+  def and_i_see_a_send_placement_for_key_stage_2_has_been_created
+    expect(page).to have_summary_list_row("Key stage 2", "1")
+  end
+
+  def and_i_see_two_send_placements_for_key_stage_5_have_been_created
+    expect(page).to have_summary_list_row("Key stage 5", "2")
+  end
+end

--- a/spec/system/placements/schools/placements/bulk_add_placements/send_only/school_user_bulk_adds_placements_for_the_send_phase_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/send_only/school_user_bulk_adds_placements_for_the_send_phase_spec.rb
@@ -102,13 +102,13 @@ RSpec.describe "School user bulk adds placements for the send phase",
 
   def then_i_see_the_key_stage_selection_form
     expect(page).to have_title(
-      "What SEND key stages can you offer placements in? - Manage school placements - GOV.UK",
+      "What key stages can you offer SEND placements in? - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_span_caption("SEND placement details")
     expect(page).to have_element(
       :legend,
-      text: "What SEND key stages can you offer placements in?",
+      text: "What key stages can you offer SEND placements in?",
       class: "govuk-fieldset__legend",
     )
     expect(page).to have_field("Early year", type: :checkbox)
@@ -130,11 +130,11 @@ RSpec.describe "School user bulk adds placements for the send phase",
 
   def then_i_see_the_key_stage_placement_quantity_form
     expect(page).to have_title(
-      "How many SEND placements can you offer? - Manage school placements - GOV.UK",
+      "Enter the number of SEND placements you can offer - Manage school placements - GOV.UK",
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_span_caption("SEND placement details")
-    expect(page).to have_h1("How many SEND placements can you offer?", class: "govuk-heading-l")
+    expect(page).to have_h1("Enter the number of SEND placements you can offer", class: "govuk-heading-l")
     expect(page).to have_field("Key stage 2", type: :number)
     expect(page).to have_field("Key stage 5", type: :number)
   end

--- a/spec/system/placements/schools/placements/school_user_edits_a_send_placement_spec.rb
+++ b/spec/system/placements/schools/placements/school_user_edits_a_send_placement_spec.rb
@@ -1,0 +1,137 @@
+require "rails_helper"
+
+RSpec.describe "Primary school user edits a placement", service: :placements, type: :system do
+  scenario do
+    given_key_stages_exists
+    and_a_placement_exist
+    and_i_am_signed_in
+
+    when_i_am_on_the_placements_index_page
+    then_i_see_my_placement
+
+    when_i_click_on_my_placement
+    then_i_see_the_placement_details_page
+
+    when_i_click_on_change_key_stage
+    then_i_see_the_select_a_key_stage_page
+    and_i_see_the_key_stage_options
+
+    when_i_select_key_stage_5
+    and_i_click_on_continue
+    then_i_see_the_placement_details_page_with_my_updated_key_stage
+    and_i_see_a_key_stage_updated_success_message
+  end
+
+  private
+
+  def given_key_stages_exists
+    @early_years = create(:key_stage, name: "Early years")
+    @key_stage_1 = create(:key_stage, name: "Key stage 1")
+    @key_stage_2 = create(:key_stage, name: "Key stage 2")
+    @key_stage_3 = create(:key_stage, name: "Key stage 3")
+    @key_stage_4 = create(:key_stage, name: "Key stage 4")
+    @key_stage_5 = create(:key_stage, name: "Key stage 5")
+    @mixed_key_stages = create(:key_stage, name: "Mixed key stages")
+  end
+
+  def and_a_placement_exist
+    @school = create(:placements_school, :primary)
+
+    @next_academic_year = Placements::AcademicYear.current.next
+    @next_academic_year_name = @next_academic_year.name
+
+    @send_placement = create(
+      :placement,
+      :send,
+      key_stage: @key_stage_1,
+      school: @school,
+      academic_year: @next_academic_year,
+    )
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@school])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Placements")
+    expect(page).to have_element(:a, text: "Add placement", class: "govuk-button")
+  end
+
+  def then_i_see_my_placement
+    expect(page).to have_table_row({
+      "Placement" => "SEND (Key stage 1)",
+      "Mentor" => "Mentor not assigned",
+      "Expected date" => "Any time in the academic year",
+      "Provider" => "Provider not assigned",
+    })
+  end
+
+  def when_i_click_on_my_placement
+    click_on "SEND (Key stage 1)"
+  end
+
+  def then_i_see_the_placement_details_page
+    expect(page).to have_title("SEND (Key stage 1) - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_tag("Available", "green")
+    expect(page).to have_summary_list_row("Key stage", "Key stage 1")
+    expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
+    expect(page).to have_summary_list_row("Expected date", "Any time in the academic year")
+    expect(page).to have_summary_list_row("Mentor", "Add a mentor")
+    expect(page).to have_summary_list_row("Provider", "Assign a provider")
+    expect(page).to have_element(:div, text: "You can preview this placement as it appears to providers.", class: "govuk-inset-text")
+    expect(page).to have_link("Delete placement", href: "/schools/#{@school.id}/placements/#{@send_placement.id}/remove")
+  end
+
+  def when_i_click_on_change_key_stage
+    click_on "Change Key stage"
+  end
+
+  def then_i_see_the_select_a_key_stage_page
+    expect(page).to have_title("Select a key stage - Placement details - Manage school placements - GOV.UK")
+    expect(page).to have_element(
+      :legend,
+      text: "Select a key stage",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_link("Cancel", href: "/schools/#{@school.id}/placements/#{@send_placement.id}")
+  end
+
+  def and_i_see_the_key_stage_options
+    expect(page).to have_field("Early years", type: :radio)
+    expect(page).to have_field("Key stage 1", type: :radio, checked: true)
+    expect(page).to have_field("Key stage 2", type: :radio)
+    expect(page).to have_field("Key stage 3", type: :radio)
+    expect(page).to have_field("Key stage 4", type: :radio)
+    expect(page).to have_field("Key stage 5", type: :radio)
+    expect(page).to have_field("Mixed key stages", type: :radio)
+  end
+
+  def when_i_select_key_stage_5
+    choose "Key stage 5"
+  end
+
+  def and_i_click_on_continue
+    click_on "Continue"
+  end
+
+  def then_i_see_the_placement_details_page_with_my_updated_key_stage
+    expect(page).to have_title("SEND (Key stage 5) - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_tag("Available", "green")
+    expect(page).to have_summary_list_row("Key stage", "Key stage 5")
+    expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
+    expect(page).to have_summary_list_row("Expected date", "Any time in the academic year")
+    expect(page).to have_summary_list_row("Mentor", "Add a mentor")
+    expect(page).to have_summary_list_row("Provider", "Assign a provider")
+    expect(page).to have_element(:div, text: "You can preview this placement as it appears to providers.", class: "govuk-inset-text")
+    expect(page).to have_link("Delete placement", href: "/schools/#{@school.id}/placements/#{@send_placement.id}/remove")
+  end
+
+  def and_i_see_a_key_stage_updated_success_message
+    expect(page).to have_success_banner("Key stage updated")
+  end
+end

--- a/spec/system/placements/schools/potential_placements/convert_potential_placements/school_user_manually_adds_placements_instead_of_converting_potential_placements_spec.rb
+++ b/spec/system/placements/schools/potential_placements/convert_potential_placements/school_user_manually_adds_placements_instead_of_converting_potential_placements_spec.rb
@@ -473,8 +473,8 @@ RSpec.describe "School user manually adds placements instead of converting poten
     )
     expect(page).to have_h2("Manage your placements", class: "govuk-heading-m")
     expect(page).to have_h2("Your placements offer", class: "govuk-heading-m")
-    expect(page).to have_h2("Primary placements", class: "govuk-heading-m")
-    expect(page).to have_h2("Secondary placements", class: "govuk-heading-m")
+    expect(page).to have_h3("Primary placements", class: "govuk-heading-s")
+    expect(page).to have_h3("Secondary placements", class: "govuk-heading-s")
   end
 
   def and_i_see_2_year_1_primary_placements_have_been_created

--- a/spec/wizards/placements/convert_potential_placement_wizard/select_placement_step_spec.rb
+++ b/spec/wizards/placements/convert_potential_placement_wizard/select_placement_step_spec.rb
@@ -12,10 +12,13 @@ RSpec.describe Placements::ConvertPotentialPlacementWizard::SelectPlacementStep,
   let(:english) { create(:subject, :secondary, name: "English") }
   let(:mathematics) { create(:subject, :secondary, name: "Mathematics") }
   let(:primary) { create(:subject, :primary, name: "Primary", code: "00") }
+  let(:key_stage_2) { create(:key_stage, name: "Key stage 2") }
+  let(:key_stage_5) { create(:key_stage, name: "Key stage 5") }
+
   let(:potential_placement_details) { {} }
 
   describe "attributes" do
-    it { is_expected.to have_attributes(year_groups: [], subject_ids: []) }
+    it { is_expected.to have_attributes(year_groups: [], subject_ids: [], key_stage_ids: []) }
   end
 
   describe "validations" do
@@ -26,6 +29,8 @@ RSpec.describe Placements::ConvertPotentialPlacementWizard::SelectPlacementStep,
         "year_group_placement_quantity" => { "reception" => 1, "year_2" => 2, "mixed_year_groups" => 3 },
         "secondary_subject_selection" => { "subject_ids" => [mathematics.id, english.id] },
         "secondary_placement_quantity" => { "mathematics" => 2, "english" => 1 },
+        "key_stage_selection" => { "key_stage_ids" => [key_stage_2.id, key_stage_5.id] },
+        "key_stage_placement_quantity" => { "key_stage_2" => 2, "key_stage_5" => 1 },
       }
     end
 
@@ -44,6 +49,14 @@ RSpec.describe Placements::ConvertPotentialPlacementWizard::SelectPlacementStep,
           expect(step.valid?).to be(true)
         end
       end
+
+      context "when a key stage is selected" do
+        let(:attributes) { { key_stage_ids: [key_stage_2.id] } }
+
+        it "returns valid" do
+          expect(step.valid?).to be(true)
+        end
+      end
     end
 
     context "when no subjects are selected" do
@@ -56,6 +69,39 @@ RSpec.describe Placements::ConvertPotentialPlacementWizard::SelectPlacementStep,
 
       context "when a year group is selected" do
         let(:attributes) { { year_groups: %w[year_2] } }
+
+        it "returns valid" do
+          expect(step.valid?).to be(true)
+        end
+      end
+
+      context "when a key stage is selected" do
+        let(:attributes) { { key_stage_ids: [key_stage_2.id] } }
+
+        it "returns valid" do
+          expect(step.valid?).to be(true)
+        end
+      end
+    end
+
+    context "when no key stages are selected" do
+      let(:attributes) { {} }
+
+      it "raises a validation error for not selecting a key stage" do
+        expect(step.valid?).to be(false)
+        expect(step.errors.messages[:key_stage_ids]).to include("SEND placements can't be blank")
+      end
+
+      context "when a year group is selected" do
+        let(:attributes) { { year_groups: %w[year_2] } }
+
+        it "returns valid" do
+          expect(step.valid?).to be(true)
+        end
+      end
+
+      context "when a secondary subject is selected" do
+        let(:attributes) { { subject_ids: [mathematics.id] } }
 
         it "returns valid" do
           expect(step.valid?).to be(true)
@@ -114,6 +160,32 @@ RSpec.describe Placements::ConvertPotentialPlacementWizard::SelectPlacementStep,
 
       it "returns the selected secondary subjects" do
         expect(secondary_subjects).to contain_exactly(mathematics)
+      end
+    end
+  end
+
+  describe "key_stages" do
+    subject(:key_stages) { step.key_stages }
+
+    context "when the potential placement details contain no key stages selected" do
+      it "returns an empty array" do
+        expect(key_stages).to eq([])
+      end
+    end
+
+    context "when the potential placement details contains secondary subjects selected" do
+      let(:potential_placement_details) do
+        {
+          "phase" => { "phases" => %w[secondary] },
+          "key_stage_selection" => { "key_stage_ids" => [key_stage_2.id] },
+          "key_stage_placement_quantity" => { "key_stage_2" => 2 },
+        }
+      end
+
+      before { key_stage_5 }
+
+      it "returns the selected key stages" do
+        expect(key_stages).to contain_exactly(key_stage_2)
       end
     end
   end
@@ -179,6 +251,41 @@ RSpec.describe Placements::ConvertPotentialPlacementWizard::SelectPlacementStep,
       it "returns the subject_ids attribute unchanged" do
         expect(subject_ids).to contain_exactly(
           mathematics.id, english.id
+        )
+      end
+    end
+  end
+
+  describe "key_stage_ids" do
+    subject(:key_stage_ids) { step.key_stage_ids }
+
+    before do
+      key_stage_2
+      key_stage_5
+    end
+
+    context "when key_stage_ids is blank" do
+      let(:attributes) { { key_stage_ids: [] } }
+
+      it "returns an empty array" do
+        expect(key_stage_ids).to eq([])
+      end
+    end
+
+    context "when the key_stage_ids attribute contains a blank element" do
+      let(:attributes) { { key_stage_ids: [key_stage_2.id, nil] } }
+
+      it "removes the nil element from the key_stage_ids attribute" do
+        expect(key_stage_ids).to contain_exactly(key_stage_2.id)
+      end
+    end
+
+    context "when the key_stage_ids attribute contains no blank elements" do
+      let(:attributes) { { key_stage_ids: [key_stage_2.id, key_stage_5.id] } }
+
+      it "returns the key_stage_ids attribute unchanged" do
+        expect(key_stage_ids).to contain_exactly(
+          key_stage_2.id, key_stage_5.id
         )
       end
     end

--- a/spec/wizards/placements/convert_potential_placement_wizard_spec.rb
+++ b/spec/wizards/placements/convert_potential_placement_wizard_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe Placements::ConvertPotentialPlacementWizard do
   let(:english) { create(:subject, :secondary, name: "English") }
   let(:mathematics) { create(:subject, :secondary, name: "Mathematics") }
   let(:primary) { create(:subject, :primary, name: "Primary", code: "00") }
+  let(:key_stage_2) { create(:key_stage, name: "Key stage 2") }
+  let(:key_stage_5) { create(:key_stage, name: "Key stage 5") }
 
   describe "#steps" do
     subject(:steps) { wizard.steps.keys }
@@ -37,13 +39,15 @@ RSpec.describe Placements::ConvertPotentialPlacementWizard do
       it { is_expected.to eq %i[phase check_your_answers] }
     end
 
-    context "when the primary subject selection is unknown" do
+    context "when the primary year group selection is unknown" do
       let(:potential_placement_details) do
         {
           "phase" => { "phases" => %w[primary secondary] },
           "year_group_selection" => { "year_groups" => %w[unknown] },
           "secondary_subject_selection" => { "subject_ids" => [mathematics.id] },
           "secondary_placement_quantity" => { "mathematics" => 2 },
+          "key_stage_selection" => { "key_stage_ids" => [key_stage_2.id] },
+          "key_stage_placement_quantity" => { "key_stage_2" => 2 },
         }
       end
 
@@ -57,6 +61,23 @@ RSpec.describe Placements::ConvertPotentialPlacementWizard do
           "year_group_selection" => { "year_groups" => %w[year_2] },
           "year_group_placement_quantity" => { "year_2" => 2 },
           "secondary_subject_selection" => { "subject_ids" => %w[unknown] },
+          "key_stage_selection" => { "key_stage_ids" => [key_stage_2.id] },
+          "key_stage_placement_quantity" => { "key_stage_2" => 2 },
+        }
+      end
+
+      it { is_expected.to eq %i[phase check_your_answers] }
+    end
+
+    context "when the key stage selection is unknown" do
+      let(:potential_placement_details) do
+        {
+          "phase" => { "phases" => %w[SEND] },
+          "year_group_selection" => { "year_groups" => %w[year_2] },
+          "year_group_placement_quantity" => { "year_2" => 2 },
+          "secondary_subject_selection" => { "subject_ids" => [mathematics.id] },
+          "secondary_placement_quantity" => { "mathematics" => 2 },
+          "key_stage_selection" => { "key_stage_ids" => %w[unknown] },
         }
       end
 
@@ -70,6 +91,8 @@ RSpec.describe Placements::ConvertPotentialPlacementWizard do
           "year_group_selection" => { "year_groups" => %w[year_2] },
           "secondary_subject_selection" => { "subject_ids" => [mathematics.id] },
           "secondary_placement_quantity" => { "mathematics" => 2 },
+          "key_stage_selection" => { "key_stage_ids" => [key_stage_2.id] },
+          "key_stage_placement_quantity" => { "key_stage_2" => 2 },
         }
       end
 
@@ -83,6 +106,23 @@ RSpec.describe Placements::ConvertPotentialPlacementWizard do
           "year_group_selection" => { "year_groups" => %w[year_2] },
           "year_group_placement_quantity" => { "year_2" => 2 },
           "secondary_subject_selection" => { "subject_ids" => [mathematics.id] },
+          "key_stage_selection" => { "key_stage_ids" => [key_stage_2.id] },
+          "key_stage_placement_quantity" => { "key_stage_2" => 2 },
+        }
+      end
+
+      it { is_expected.to eq %i[phase check_your_answers] }
+    end
+
+    context "when the key stage placement quantity is blank" do
+      let(:potential_placement_details) do
+        {
+          "phase" => { "phases" => %w[primary secondary] },
+          "year_group_selection" => { "year_groups" => %w[year_2] },
+          "year_group_placement_quantity" => { "year_2" => 2 },
+          "secondary_subject_selection" => { "subject_ids" => [mathematics.id] },
+          "secondary_placement_quantity" => { "mathematics" => 2 },
+          "key_stage_selection" => { "key_stage_ids" => [key_stage_2.id] },
         }
       end
 
@@ -101,6 +141,18 @@ RSpec.describe Placements::ConvertPotentialPlacementWizard do
       it { is_expected.to eq %i[convert_placement phase check_your_answers] }
     end
 
+    context "when the key stage selection and quantity are present" do
+      let(:potential_placement_details) do
+        {
+          "phase" => { "phases" => %w[primary] },
+          "key_stage_selection" => { "key_stage_ids" => [key_stage_2.id] },
+          "key_stage_placement_quantity" => { "key_stage_2" => 2 },
+        }
+      end
+
+      it { is_expected.to eq %i[convert_placement phase check_your_answers] }
+    end
+
     context "when the secondary selection and quantity are present" do
       let(:potential_placement_details) do
         {
@@ -111,23 +163,25 @@ RSpec.describe Placements::ConvertPotentialPlacementWizard do
       end
 
       it { is_expected.to eq %i[convert_placement phase check_your_answers] }
+    end
 
-      context "when the convert placement step is true" do
-        let(:state) do
-          { "convert_placement" => { "convert" => "Yes" } }
-        end
-        let(:potential_placement_details) do
-          {
-            "phase" => { "phases" => %w[primary secondary] },
-            "year_group_selection" => { "year_groups" => %w[year_2] },
-            "year_group_placement_quantity" => { "year_2" => 2 },
-            "secondary_subject_selection" => { "subject_ids" => [mathematics.id] },
-            "secondary_placement_quantity" => { "mathematics" => 2 },
-          }
-        end
-
-        it { is_expected.to eq %i[convert_placement select_placement] }
+    context "when the convert placement step is true" do
+      let(:state) do
+        { "convert_placement" => { "convert" => "Yes" } }
       end
+      let(:potential_placement_details) do
+        {
+          "phase" => { "phases" => %w[primary secondary] },
+          "year_group_selection" => { "year_groups" => %w[year_2] },
+          "year_group_placement_quantity" => { "year_2" => 2 },
+          "secondary_subject_selection" => { "subject_ids" => [mathematics.id] },
+          "secondary_placement_quantity" => { "mathematics" => 2 },
+          "key_stage_selection" => { "key_stage_ids" => [key_stage_2.id] },
+          "key_stage_placement_quantity" => { "key_stage_2" => 2 },
+        }
+      end
+
+      it { is_expected.to eq %i[convert_placement select_placement] }
     end
   end
 

--- a/spec/wizards/placements/convert_potential_placement_wizard_spec.rb
+++ b/spec/wizards/placements/convert_potential_placement_wizard_spec.rb
@@ -195,6 +195,7 @@ RSpec.describe Placements::ConvertPotentialPlacementWizard do
           "select_placement" => {
             "year_groups" => %w[year_2 mixed_year_groups],
             "subject_ids" => [mathematics.id],
+            "key_stage_ids" => [key_stage_2.id],
           },
         }
       end
@@ -205,6 +206,8 @@ RSpec.describe Placements::ConvertPotentialPlacementWizard do
           "year_group_placement_quantity" => { "reception" => 1, "year_2" => 2, "mixed_year_groups" => 3 },
           "secondary_subject_selection" => { "subject_ids" => [mathematics.id, english.id] },
           "secondary_placement_quantity" => { "mathematics" => 2, "english" => 1 },
+          "key_stage_selection" => { "key_stage_ids" => [key_stage_2.id, key_stage_5.id] },
+          "key_stage_placement_quantity" => { "key_stage_2" => 2, "key_stage_5" => 1 },
         }
       end
 
@@ -214,7 +217,8 @@ RSpec.describe Placements::ConvertPotentialPlacementWizard do
         expect { convert_placements }.to change { school.placements.where(subject: primary, year_group: "year_2").count }.to(2)
           .and change { school.placements.where(subject: primary, year_group: "mixed_year_groups").count }.to(3)
           .and change { school.placements.where(subject: mathematics).count }.to(2)
-          .and change { school.placements.count }.to(7)
+          .and change { school.placements.where(key_stage: key_stage_2).count }.to(2)
+          .and change { school.placements.count }.to(9)
 
         expect(hosting_interest.reload.appetite).to eq("actively_looking")
         expect(school.reload.potential_placement_details).to be_nil

--- a/spec/wizards/placements/edit_placement_wizard/key_stage_step_spec.rb
+++ b/spec/wizards/placements/edit_placement_wizard/key_stage_step_spec.rb
@@ -1,0 +1,111 @@
+require "rails_helper"
+
+RSpec.describe Placements::EditPlacementWizard::KeyStageStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Placements::EditPlacementWizard).tap do |mock_wizard|
+      allow(mock_wizard).to receive(:school).and_return(school)
+    end
+  end
+
+  let(:attributes) { nil }
+
+  let!(:school) { create(:placements_school, name: "School 1") }
+
+  describe "attributes" do
+    it { is_expected.to have_attributes(key_stage_id: nil) }
+  end
+
+  describe "validations" do
+    let(:early_years) { create(:key_stage, name: "Early years") }
+    let(:key_stage_1) { create(:key_stage, name: "Key stage 1") }
+    let(:key_stage_2) { create(:key_stage, name: "Key stage 2") }
+    let(:key_stage_3) { create(:key_stage, name: "Key stage 3") }
+    let(:key_stage_4) { create(:key_stage, name: "Key stage 4") }
+    let(:key_stage_5) { create(:key_stage, name: "Key stage 5") }
+    let(:mixed_key_stages) { create(:key_stage, name: "Mixed key stages") }
+
+    it { is_expected.to validate_presence_of(:key_stage_id) }
+    it { is_expected.to validate_inclusion_of(:key_stage_id).in_array(Placements::KeyStage.ids) }
+  end
+
+  describe "#key_stages_for_selection" do
+    subject(:key_stages_for_selection) { step.key_stages_for_selection }
+
+    let!(:early_years) { create(:key_stage, name: "Early years") }
+    let!(:key_stage_1) { create(:key_stage, name: "Key stage 1") }
+    let!(:key_stage_2) { create(:key_stage, name: "Key stage 2") }
+    let!(:key_stage_3) { create(:key_stage, name: "Key stage 3") }
+    let!(:key_stage_4) { create(:key_stage, name: "Key stage 4") }
+    let!(:key_stage_5) { create(:key_stage, name: "Key stage 5") }
+    let(:mixed_key_stages) { create(:key_stage, name: "Mixed key stages") }
+
+    before { mixed_key_stages }
+
+    it "returns all key stages, expect for mixed key stages" do
+      expect(key_stages_for_selection).to contain_exactly(
+        early_years,
+        key_stage_1,
+        key_stage_2,
+        key_stage_3,
+        key_stage_4,
+        key_stage_5,
+      )
+    end
+  end
+
+  describe "mixed_key_stage_option" do
+    subject(:mixed_key_stage_option) { step.mixed_key_stage_option }
+
+    let(:early_years) { create(:key_stage, name: "Early years") }
+    let(:key_stage_1) { create(:key_stage, name: "Key stage 1") }
+    let(:key_stage_2) { create(:key_stage, name: "Key stage 2") }
+    let(:key_stage_3) { create(:key_stage, name: "Key stage 3") }
+    let(:key_stage_4) { create(:key_stage, name: "Key stage 4") }
+    let(:key_stage_5) { create(:key_stage, name: "Key stage 5") }
+    let!(:mixed_key_stages) { create(:key_stage, name: "Mixed key stages") }
+
+    before do
+      early_years
+      key_stage_1
+      key_stage_2
+      key_stage_3
+      key_stage_4
+      key_stage_5
+    end
+
+    it "returns the mixed key stage" do
+      expect(mixed_key_stage_option).to eq(
+        mixed_key_stages,
+      )
+    end
+  end
+
+  describe "#key_stage" do
+    subject(:key_stage) { step.key_stage }
+
+    let(:early_years) { create(:key_stage, name: "Early years") }
+    let(:key_stage_1) { create(:key_stage, name: "Key stage 1") }
+    let(:key_stage_2) { create(:key_stage, name: "Key stage 2") }
+    let(:key_stage_3) { create(:key_stage, name: "Key stage 3") }
+    let(:key_stage_4) { create(:key_stage, name: "Key stage 4") }
+    let(:key_stage_5) { create(:key_stage, name: "Key stage 5") }
+    let!(:mixed_key_stages) { create(:key_stage, name: "Mixed key stages") }
+
+    let(:attributes) { { key_stage_id: key_stage_1.id } }
+
+    before do
+      early_years
+      key_stage_2
+      key_stage_3
+      key_stage_4
+      key_stage_5
+      mixed_key_stages
+    end
+
+    it "returns the key stage record associated with the set key stage ID" do
+      expect(key_stage).to eq(key_stage_1)
+    end
+  end
+end

--- a/spec/wizards/placements/edit_placement_wizard_spec.rb
+++ b/spec/wizards/placements/edit_placement_wizard_spec.rb
@@ -59,6 +59,12 @@ RSpec.describe Placements::EditPlacementWizard do
 
       it { is_expected.to eq %i[terms] }
     end
+
+    context "with the key stage step" do
+      let(:current_step) { :key_stage }
+
+      it { is_expected.to eq %i[key_stage] }
+    end
   end
 
   describe "#update_placement" do
@@ -69,10 +75,12 @@ RSpec.describe Placements::EditPlacementWizard do
     let(:mentor_not_known) { Placements::AddPlacementWizard::MentorsStep::NOT_KNOWN }
     let(:selected_year_group) { :year_1 }
     let(:selected_term) { create(:placements_term, :summer) }
+    let(:key_stage_1) { create(:key_stage, name: "Key stage 1") }
 
     context "when the step is valid" do
       before do
         selected_term
+        key_stage_1
         _spring_term = create(:placements_term, :spring)
         _autumn_term = create(:placements_term, :autumn)
         edit_wizard
@@ -163,6 +171,20 @@ RSpec.describe Placements::EditPlacementWizard do
 
         it "updates the placement" do
           expect(placement.terms).to contain_exactly(selected_term)
+        end
+      end
+
+      context "when the step is key stage" do
+        let(:current_step) { :key_stage }
+
+        let(:state) do
+          {
+            "key_stage" => { "key_stage_id" => key_stage_1.id },
+          }
+        end
+
+        it "updates the placement" do
+          expect(placement.key_stage).to eq(key_stage_1)
         end
       end
     end

--- a/spec/wizards/placements/edit_potential_placements_wizard_spec.rb
+++ b/spec/wizards/placements/edit_potential_placements_wizard_spec.rb
@@ -157,17 +157,21 @@ RSpec.describe Placements::EditPotentialPlacementsWizard do
 
     let(:english) { create(:subject, :secondary, name: "English") }
     let(:science) { create(:subject, :secondary, name: "Science") }
+    let(:key_stage_1) { create(:key_stage, name: "Key stage 1") }
+    let(:mixed_key_stages) { create(:key_stage, name: "Mixed key stages") }
     let(:school) { create(:placements_school, potential_placement_details:) }
 
     context "when the potential placement details includes quantities known" do
       let(:potential_placement_details) do
         {
-          "phase" => { "phases" => %w[Primary Secondary] },
+          "phase" => { "phases" => %w[Primary Secondary SEND] },
           "note_to_providers" => { "note" => "Interested in offering placements at the provider's request" },
           "year_group_selection" => { "year_groups" => %w[year_2 year_3] },
           "year_group_placement_quantity" => { "year_2" => 1, "year_3" => 2 },
           "secondary_subject_selection" => { "subject_ids" => [english.id, science.id] },
           "secondary_placement_quantity" => { "english" => 1, "science" => 2 },
+          "key_stage_selection" => { "key_stage_ids" => [key_stage_1.id, mixed_key_stages.id] },
+          "key_stage_placement_quantity" => { "key_stage_1" => 1, "mixed_key_stages" => 2 },
         }
       end
 
@@ -175,7 +179,7 @@ RSpec.describe Placements::EditPotentialPlacementsWizard do
         setup_state
         expect(state).to eq(
           {
-            "phase" => { "phases" => %w[Primary Secondary] },
+            "phase" => { "phases" => %w[Primary Secondary SEND] },
             "note_to_providers" => { "note" => "Interested in offering placements at the provider's request" },
             "year_group_selection" => { "year_groups" => %w[year_2 year_3] },
             "year_group_placement_quantity_known" => { "quantity_known" => "Yes" },
@@ -183,6 +187,9 @@ RSpec.describe Placements::EditPotentialPlacementsWizard do
             "secondary_subject_selection" => { "subject_ids" => [english.id, science.id] },
             "secondary_placement_quantity_known" => { "quantity_known" => "Yes" },
             "secondary_placement_quantity" => { "english" => 1, "science" => 2 },
+            "key_stage_selection" => { "key_stage_ids" => [key_stage_1.id, mixed_key_stages.id] },
+            "key_stage_placement_quantity_known" => { "quantity_known" => "Yes" },
+            "key_stage_placement_quantity" => { "key_stage_1" => 1, "mixed_key_stages" => 2 },
           },
         )
       end
@@ -191,10 +198,11 @@ RSpec.describe Placements::EditPotentialPlacementsWizard do
     context "when the potential placement details do not include quantities known" do
       let(:potential_placement_details) do
         {
-          "phase" => { "phases" => %w[Primary Secondary] },
+          "phase" => { "phases" => %w[Primary Secondary SEND] },
           "note_to_providers" => { "note" => "Interested in offering placements at the provider's request" },
           "year_group_selection" => { "year_groups" => %w[year_2 year_3] },
           "secondary_subject_selection" => { "subject_ids" => [english.id, science.id] },
+          "key_stage_selection" => { "key_stage_ids" => [key_stage_1.id, mixed_key_stages.id] },
         }
       end
 
@@ -202,12 +210,14 @@ RSpec.describe Placements::EditPotentialPlacementsWizard do
         setup_state
         expect(state).to eq(
           {
-            "phase" => { "phases" => %w[Primary Secondary] },
+            "phase" => { "phases" => %w[Primary Secondary SEND] },
             "note_to_providers" => { "note" => "Interested in offering placements at the provider's request" },
             "year_group_selection" => { "year_groups" => %w[year_2 year_3] },
             "year_group_placement_quantity_known" => { "quantity_known" => "No" },
             "secondary_subject_selection" => { "subject_ids" => [english.id, science.id] },
             "secondary_placement_quantity_known" => { "quantity_known" => "No" },
+            "key_stage_selection" => { "key_stage_ids" => [key_stage_1.id, mixed_key_stages.id] },
+            "key_stage_placement_quantity_known" => { "quantity_known" => "No" },
           },
         )
       end

--- a/spec/wizards/placements/multi_placement_wizard/key_stage_placement_quantity_step_spec.rb
+++ b/spec/wizards/placements/multi_placement_wizard/key_stage_placement_quantity_step_spec.rb
@@ -1,0 +1,147 @@
+require "rails_helper"
+
+RSpec.describe Placements::MultiPlacementWizard::KeyStagePlacementQuantityStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Placements::MultiPlacementWizard).tap do |mock_wizard|
+      allow(mock_wizard).to receive_messages(
+        school:,
+        selected_key_stages:,
+        state:,
+      )
+    end
+  end
+
+  let(:attributes) { nil }
+  let(:selected_key_stages) { Placements::KeyStage.none }
+  let!(:school) { create(:placements_school) }
+  let(:state) { {} }
+
+  let!(:early_years) { create(:key_stage, name: "Early years") }
+  let(:key_stage_1) { create(:key_stage, name: "Key stage 1") }
+  let!(:key_stage_2) { create(:key_stage, name: "Key stage 2") }
+  let(:key_stage_3) { create(:key_stage, name: "Key stage 3") }
+  let(:key_stage_4) { create(:key_stage, name: "Key stage 4") }
+  let(:key_stage_5) { create(:key_stage, name: "Key stage 5") }
+  let(:mixed_key_stages) { create(:key_stage, name: "Mixed key stages") }
+
+  before do
+    key_stage_1
+    key_stage_3
+    key_stage_4
+    key_stage_5
+    mixed_key_stages
+  end
+
+  describe "attributes" do
+    it "has no attributes" do
+      expect(step.attributes).to eq({})
+    end
+  end
+
+  describe "delegations" do
+    it { is_expected.to delegate_method(:selected_key_stages).to(:wizard) }
+  end
+
+  describe "variables" do
+    context "when there are no selected key stages" do
+      it "returns no variables related to any key stages" do
+        expect { step.early_years }.to raise_error(NoMethodError)
+        expect { step.key_stage_1 }.to raise_error(NoMethodError)
+        expect { step.key_stage_2 }.to raise_error(NoMethodError)
+        expect { step.key_stage_3 }.to raise_error(NoMethodError)
+        expect { step.key_stage_4 }.to raise_error(NoMethodError)
+        expect { step.key_stage_5 }.to raise_error(NoMethodError)
+        expect { step.mixed_key_stages }.to raise_error(NoMethodError)
+      end
+    end
+
+    context "when there are key stages" do
+      let(:selected_key_stages) { Placements::KeyStage.where(id: [early_years.id, key_stage_2.id]) }
+
+      it "creates a variable method per selected key stage" do
+        expect(step.early_years).to be_nil
+        expect { step.key_stage_1 }.to raise_error(NoMethodError)
+        expect(step.key_stage_2).to be_nil
+        expect { step.key_stage_3 }.to raise_error(NoMethodError)
+        expect { step.key_stage_4 }.to raise_error(NoMethodError)
+        expect { step.key_stage_5 }.to raise_error(NoMethodError)
+        expect { step.mixed_key_stages }.to raise_error(NoMethodError)
+      end
+    end
+  end
+
+  describe "validations" do
+    context "when there are no selected key stages" do
+      it "adds no errors to the step" do
+        expect(step.valid?).to be(true)
+      end
+    end
+
+    context "when there are selected key stages" do
+      let(:selected_key_stages) { Placements::KeyStage.where(id: [early_years.id, key_stage_2.id]) }
+      let(:attributes) { { early_years: nil, key_stage_2: "5" } }
+
+      context "when an input is blank" do
+        it "returns invalid" do
+          expect(step.valid?).to be(false)
+          expect(step.errors[:early_years]).to include("Early years can't be blank")
+        end
+      end
+
+      context "when an input is not an integer" do
+        let(:attributes) { { early_years: "1.2", key_stage_2: "5" } }
+
+        it "returns invalid" do
+          expect(step.valid?).to be(false)
+          expect(step.errors[:early_years]).to include("Early years must be a whole number")
+        end
+      end
+
+      context "when an input is zero" do
+        let(:attributes) { { early_years: "0", key_stage_2: "5" } }
+
+        it "returns invalid" do
+          expect(step.valid?).to be(false)
+          expect(step.errors[:early_years]).to include("Early years must be greater than 0")
+        end
+      end
+
+      context "when all inputs are integers greater than zero" do
+        let(:attributes) { { early_years: "1", key_stage_2: "5" } }
+
+        it "returns valid" do
+          expect(step.valid?).to be(true)
+        end
+      end
+    end
+  end
+
+  describe "#key_stages" do
+    let(:selected_key_stages) { Placements::KeyStage.where(id: [early_years.id, key_stage_2.id]) }
+
+    it "returns the selected key stages" do
+      expect(step.key_stages).to contain_exactly(early_years, key_stage_2)
+    end
+  end
+
+  describe "#assigned_variables" do
+    subject(:assigned_variables) { step.assigned_variables }
+
+    context "when there are no selected key stages" do
+      it "returns an empty hash" do
+        expect(assigned_variables).to eq({})
+      end
+    end
+
+    context "when there are selected key stages" do
+      let(:selected_key_stages) { Placements::KeyStage.where(id: [early_years.id, key_stage_2.id]) }
+      let(:attributes) { { early_years: "1", key_stage_2: "5" } }
+
+      it "returns a hash of assigned attributes, associated to the selected key stages" do
+        expect(assigned_variables).to eq({ "early_years" => "1", "key_stage_2" => "5" })
+      end
+    end
+  end
+end

--- a/spec/wizards/placements/multi_placement_wizard/key_stage_selection_step_spec.rb
+++ b/spec/wizards/placements/multi_placement_wizard/key_stage_selection_step_spec.rb
@@ -1,0 +1,106 @@
+require "rails_helper"
+
+RSpec.describe Placements::MultiPlacementWizard::KeyStageSelectionStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Placements::MultiPlacementWizard).tap do |mock_wizard|
+      allow(mock_wizard).to receive_messages(
+        school:,
+      )
+    end
+  end
+
+  let(:attributes) { nil }
+  let!(:school) { create(:placements_school) }
+  let(:state) { {} }
+
+  describe "attributes" do
+    it { is_expected.to have_attributes(key_stage_ids: []) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:key_stage_ids) }
+  end
+
+  describe "#key_stages_for_selection" do
+    subject(:key_stages_for_selection) { step.key_stages_for_selection }
+
+    let!(:early_years) { create(:key_stage, name: "Early years") }
+    let!(:key_stage_1) { create(:key_stage, name: "Key stage 1") }
+    let!(:key_stage_2) { create(:key_stage, name: "Key stage 2") }
+    let!(:key_stage_3) { create(:key_stage, name: "Key stage 3") }
+    let!(:key_stage_4) { create(:key_stage, name: "Key stage 4") }
+    let!(:key_stage_5) { create(:key_stage, name: "Key stage 5") }
+    let(:mixed_key_stages) { create(:key_stage, name: "Mixed key stages") }
+
+    before { mixed_key_stages }
+
+    it "returns all key stages, expect for mixed key stages" do
+      expect(key_stages_for_selection).to contain_exactly(
+        early_years,
+        key_stage_1,
+        key_stage_2,
+        key_stage_3,
+        key_stage_4,
+        key_stage_5,
+      )
+    end
+  end
+
+  describe "mixed_key_stage_option" do
+    subject(:mixed_key_stage_option) { step.mixed_key_stage_option }
+
+    let(:early_years) { create(:key_stage, name: "Early years") }
+    let(:key_stage_1) { create(:key_stage, name: "Key stage 1") }
+    let(:key_stage_2) { create(:key_stage, name: "Key stage 2") }
+    let(:key_stage_3) { create(:key_stage, name: "Key stage 3") }
+    let(:key_stage_4) { create(:key_stage, name: "Key stage 4") }
+    let(:key_stage_5) { create(:key_stage, name: "Key stage 5") }
+    let!(:mixed_key_stages) { create(:key_stage, name: "Mixed key stages") }
+
+    before do
+      early_years
+      key_stage_1
+      key_stage_2
+      key_stage_3
+      key_stage_4
+      key_stage_5
+    end
+
+    it "returns the mixed key stage" do
+      expect(mixed_key_stage_option).to eq(
+        mixed_key_stages,
+      )
+    end
+  end
+
+  describe "#key_stage_ids" do
+    subject(:key_stage_ids) { step.key_stage_ids }
+
+    context "when key_stage_ids is blank" do
+      it "returns an empty array" do
+        expect(key_stage_ids).to eq([])
+      end
+    end
+
+    context "when the key_stage_ids attribute contains a blank element" do
+      let(:attributes) { { key_stage_ids: ["123", nil] } }
+
+      it "removes the nil element from the key_stage_ids attribute" do
+        expect(key_stage_ids).to contain_exactly("123")
+      end
+    end
+
+    context "when the key_stage_ids attribute contains no blank elements" do
+      let(:attributes) { { key_stage_ids: %w[123 456] } }
+
+      it "returns the key_stage_ids attribute unchanged" do
+        expect(key_stage_ids).to contain_exactly(
+          "123",
+          "456",
+        )
+      end
+    end
+  end
+end

--- a/spec/wizards/placements/multi_placement_wizard/phase_step_spec.rb
+++ b/spec/wizards/placements/multi_placement_wizard/phase_step_spec.rb
@@ -26,8 +26,13 @@ RSpec.describe Placements::MultiPlacementWizard::PhaseStep, type: :model do
     it "returns open struct objects for the primary and secondary phase" do
       expect(phases_for_selection).to eq(
         [
-          OpenStruct.new(name: "Primary", description: "3 to 11 years"),
-          OpenStruct.new(name: "Secondary", description: "11 to 19 years"),
+          OpenStruct.new(name: "Primary", value: "Primary", description: "3 to 11 years"),
+          OpenStruct.new(name: "Secondary", value: "Secondary", description: "11 to 19 years"),
+          OpenStruct.new(
+            name: "Special educational needs and disabilities (SEND) specific",
+            value: "SEND",
+            description: "You will be able to select key stages",
+          ),
         ],
       )
     end

--- a/spec/wizards/placements/multi_placement_wizard/secondary_placement_quantity_step_spec.rb
+++ b/spec/wizards/placements/multi_placement_wizard/secondary_placement_quantity_step_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Placements::MultiPlacementWizard::SecondaryPlacementQuantityStep,
       end
     end
 
-    context "when there are primary subejects" do
+    context "when there are secondary subejects" do
       let(:selected_secondary_subjects) { Subject.where(id: [english.id, mathematics.id]) }
 
       it "creates a variable method per selected secondary subject" do

--- a/spec/wizards/placements/multi_placement_wizard/secondary_subject_selection_step_spec.rb
+++ b/spec/wizards/placements/multi_placement_wizard/secondary_subject_selection_step_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Placements::MultiPlacementWizard::SecondarySubjectSelectionStep, 
 
     before { primary_subject }
 
-    it "raises an error" do
+    it "returns only secondary subjects" do
       expect(subjects_for_selection).to contain_exactly(
         english,
         mathematics,


### PR DESCRIPTION
## Context

- Add SEND options and steps to HostingInterest and MultiPlacement wizards.

## Changes proposed in this pull request

- Add SEND options and steps to HostingInterest and MultiPlacement wizards.

## Guidance to review

- Sign in as Anne (School user)
- Go through the EOI, Edit EOI and Add Multiple Placement journeys, selecting SEND options.

## Link to Trello card

https://trello.com/c/kW75j85f/615-add-ability-for-users-to-share-a-send-placement-green-and-amber-eoi-flows

## Screenshots

https://github.com/user-attachments/assets/293895e3-ed0b-4422-8675-370cfdc8264a

https://github.com/user-attachments/assets/b70bff44-7944-4892-9b04-0a11451c6a7c

