### PR TITLE
Edit placement with key stage

### DIFF
--- a/app/decorators/placement_decorator.rb
+++ b/app/decorators/placement_decorator.rb
@@ -4,6 +4,7 @@ class PlacementDecorator < Draper::Decorator
   decorates_association :academic_year
 
   delegate :name, to: :subject, prefix: true, allow_nil: true
+  delegate :name, to: :key_stage, prefix: true, allow_nil: true
 
   def mentor_names
     if mentors.any?

--- a/app/views/placements/schools/placements/_details.html.erb
+++ b/app/views/placements/schools/placements/_details.html.erb
@@ -10,10 +10,12 @@
       <% row.with_value(text: placement.school_level) %>
     <% end %>
   <% end %>
-  <% summary_list.with_row do |row| %>
-    <% row.with_key(text: t(".attributes.placements.subject")) %>
-    <% row.with_value do %>
-      <% placement.subject_name %>
+  <% if placement.subject.present? %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key(text: t(".attributes.placements.subject")) %>
+      <% row.with_value do %>
+        <% placement.subject_name %>
+      <% end %>
     <% end %>
   <% end %>
   <% if placement.subject_has_child_subjects? %>
@@ -22,6 +24,19 @@
       <% row.with_value do %>
         <% placement.additional_subject_names %>
       <% end %>
+    <% end %>
+  <% end %>
+   <% if placement.key_stage.present? %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key(text: t(".attributes.placements.key_stage")) %>
+      <% row.with_value do %>
+        <% placement.key_stage_name %>
+      <% end %>
+      <% row.with_action(
+        text: t(".change"),
+        href: edit_attribute_path(:key_stage),
+        visually_hidden_text: t(".attributes.placements.key_stage"),
+      ) %>
     <% end %>
   <% end %>
   <% if placement.year_group.present? %>

--- a/app/views/wizards/placements/edit_placement_wizard/_key_stage_step.html.erb
+++ b/app/views/wizards/placements/edit_placement_wizard/_key_stage_step.html.erb
@@ -1,0 +1,29 @@
+<% content_for :page_title, title_with_error_prefix(
+  t(".title", contextual_text:),
+  error: current_step.errors.any?,
+) %>
+
+<%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= contextual_text %></span>
+     <%= f.govuk_radio_buttons_fieldset(
+        :key_stage_id,
+        legend: { size: "l", text: t(".select_a_key_stage"), tag: "h1" },
+      ) do %>
+        <% current_step.key_stages_for_selection.each_with_index do |key_stage, i| %>
+          <%= f.govuk_radio_button :key_stage_id, key_stage.id,
+            label: { text: key_stage.name },
+            link_errors: i.zero? %>
+        <% end %>
+        <%= f.govuk_radio_divider %>
+        <%= f.govuk_radio_button :key_stage_id, current_step.mixed_key_stage_option.id,
+            label: { text: current_step.mixed_key_stage_option.name } %>
+      <% end %>
+
+      <%= f.govuk_submit t(".continue") %>
+    </div>
+  </div>
+<% end %>

--- a/app/wizards/placements/add_hosting_interest_wizard/interested/placement_quantity_known_step.rb
+++ b/app/wizards/placements/add_hosting_interest_wizard/interested/placement_quantity_known_step.rb
@@ -5,7 +5,7 @@ class Placements::AddHostingInterestWizard::Interested::PlacementQuantityKnownSt
   NO = "No".freeze
   QUANTITY_KNOWN_OPTIONS = [YES, NO].freeze
 
-  validates :quantity_known, presence: true, inclusion: QUANTITY_KNOWN_OPTIONS
+  validates :quantity_known, presence: true, inclusion: { in: QUANTITY_KNOWN_OPTIONS }
 
   def options_for_selection
     QUANTITY_KNOWN_OPTIONS.map do |option|

--- a/app/wizards/placements/add_hosting_interest_wizard/list_placements_step.rb
+++ b/app/wizards/placements/add_hosting_interest_wizard/list_placements_step.rb
@@ -5,7 +5,7 @@ class Placements::AddHostingInterestWizard::ListPlacementsStep < BaseStep
   NO = "No".freeze
   LIST_PLACEMENTS = [YES, NO].freeze
 
-  validates :list_placements, presence: true, inclusion: LIST_PLACEMENTS
+  validates :list_placements, presence: true, inclusion: { in: LIST_PLACEMENTS }
 
   def responses_for_selection
     [

--- a/app/wizards/placements/add_hosting_interest_wizard/subjects_known_step.rb
+++ b/app/wizards/placements/add_hosting_interest_wizard/subjects_known_step.rb
@@ -5,7 +5,7 @@ class Placements::AddHostingInterestWizard::SubjectsKnownStep < BaseStep
   NO = "No".freeze
   VALID_SUBJECTS_KNOWN = [YES, NO].freeze
 
-  validates :subjects_known, presence: true, inclusion: VALID_SUBJECTS_KNOWN
+  validates :subjects_known, presence: true, inclusion: { in: VALID_SUBJECTS_KNOWN }
 
   def responses_for_selection
     [

--- a/app/wizards/placements/edit_placement_wizard.rb
+++ b/app/wizards/placements/edit_placement_wizard.rb
@@ -22,6 +22,7 @@ module Placements
       add_step(AddPlacementWizard::YearGroupStep) if current_step == :year_group
       add_step(AddPlacementWizard::MentorsStep) if current_step == :mentors
       add_step(AddPlacementWizard::TermsStep) if current_step == :terms
+      add_step(KeyStageStep) if current_step == :key_stage
     end
 
     def update_placement
@@ -44,6 +45,10 @@ module Placements
         placement.terms = steps[:terms].terms
       end
 
+      if steps[:key_stage].present?
+        placement.key_stage = steps[:key_stage].key_stage
+      end
+
       placement.save!
     end
 
@@ -52,6 +57,7 @@ module Placements
       state["year_group"] = { "year_group" => placement.year_group }
       state["mentors"] = { "mentor_ids" => placement.mentors.ids }
       state["terms"] = { "term_ids" => placement.terms.ids }
+      state["key_stage"] = { "key_stage_id" => placement.key_stage_id }
     end
   end
 end

--- a/app/wizards/placements/edit_placement_wizard/key_stage_step.rb
+++ b/app/wizards/placements/edit_placement_wizard/key_stage_step.rb
@@ -1,0 +1,23 @@
+class Placements::EditPlacementWizard::KeyStageStep < BaseStep
+  attribute :key_stage_id
+
+  validates :key_stage_id, presence: true, inclusion: { in: ->(step) { step.key_stage_ids } }
+
+  MIXED_KEY_STAGES = "Mixed key stages".freeze
+
+  def key_stages_for_selection
+    Placements::KeyStage.where.not(name: MIXED_KEY_STAGES).order_by_name
+  end
+
+  def mixed_key_stage_option
+    Placements::KeyStage.find_by(name: MIXED_KEY_STAGES)
+  end
+
+  def key_stage
+    @key_stage ||= Placements::KeyStage.find(key_stage_id)
+  end
+
+  def key_stage_ids
+    Placements::KeyStage.ids
+  end
+end

--- a/config/locales/en/placements/schools/placements.yml
+++ b/config/locales/en/placements/schools/placements.yml
@@ -61,6 +61,7 @@ en:
               assign_last_placement: Provider updated
               year_group: Year group updated
               terms: Expected date updated
+              key_stage: Key stage updated
           edit:
             edit_placement: Placement details
             cancel: Cancel
@@ -150,6 +151,7 @@ en:
               mentor: Mentor
               status: Status
               provider: Provider
+              key_stage: Key stage
         confirm_remove:
           page_title: "Are you sure you want to delete this placement? - %{subject_names}"
           are_you_sure: Are you sure you want to delete this placement?

--- a/config/locales/en/wizards/placements/edit_placement_wizard.yml
+++ b/config/locales/en/wizards/placements/edit_placement_wizard.yml
@@ -22,3 +22,7 @@ en:
             Your status will be set to ‘no placements available’. Providers will no longer contact you about available placements.
           you_can_add_more_placements:
             You can add more placements at anytime.
+        key_stage_step:
+          title: Select a key stage - %{contextual_text}
+          select_a_key_stage: Select a key stage
+          continue: Continue

--- a/spec/system/placements/schools/placements/school_user_edits_a_send_placement_spec.rb
+++ b/spec/system/placements/schools/placements/school_user_edits_a_send_placement_spec.rb
@@ -1,0 +1,137 @@
+require "rails_helper"
+
+RSpec.describe "Primary school user edits a placement", service: :placements, type: :system do
+  scenario do
+    given_key_stages_exists
+    and_a_placement_exist
+    and_i_am_signed_in
+
+    when_i_am_on_the_placements_index_page
+    then_i_see_my_placement
+
+    when_i_click_on_my_placement
+    then_i_see_the_placement_details_page
+
+    when_i_click_on_change_key_stage
+    then_i_see_the_select_a_key_stage_page
+    and_i_see_the_key_stage_options
+
+    when_i_select_key_stage_5
+    and_i_click_on_continue
+    then_i_see_the_placement_details_page_with_my_updated_key_stage
+    and_i_see_a_key_stage_updated_success_message
+  end
+
+  private
+
+  def given_key_stages_exists
+    @early_years = create(:key_stage, name: "Early years")
+    @key_stage_1 = create(:key_stage, name: "Key stage 1")
+    @key_stage_2 = create(:key_stage, name: "Key stage 2")
+    @key_stage_3 = create(:key_stage, name: "Key stage 3")
+    @key_stage_4 = create(:key_stage, name: "Key stage 4")
+    @key_stage_5 = create(:key_stage, name: "Key stage 5")
+    @mixed_key_stages = create(:key_stage, name: "Mixed key stages")
+  end
+
+  def and_a_placement_exist
+    @school = create(:placements_school, :primary)
+
+    @next_academic_year = Placements::AcademicYear.current.next
+    @next_academic_year_name = @next_academic_year.name
+
+    @send_placement = create(
+      :placement,
+      :send,
+      key_stage: @key_stage_1,
+      school: @school,
+      academic_year: @next_academic_year,
+    )
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@school])
+  end
+
+  def when_i_am_on_the_placements_index_page
+    expect(page).to have_title("Placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_h1("Placements")
+    expect(page).to have_element(:a, text: "Add placement", class: "govuk-button")
+  end
+
+  def then_i_see_my_placement
+    expect(page).to have_table_row({
+      "Placement" => "SEND (Key stage 1)",
+      "Mentor" => "Mentor not assigned",
+      "Expected date" => "Any time in the academic year",
+      "Provider" => "Provider not assigned",
+    })
+  end
+
+  def when_i_click_on_my_placement
+    click_on "SEND (Key stage 1)"
+  end
+
+  def then_i_see_the_placement_details_page
+    expect(page).to have_title("SEND (Key stage 1) - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_tag("Available", "green")
+    expect(page).to have_summary_list_row("Key stage", "Key stage 1")
+    expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
+    expect(page).to have_summary_list_row("Expected date", "Any time in the academic year")
+    expect(page).to have_summary_list_row("Mentor", "Add a mentor")
+    expect(page).to have_summary_list_row("Provider", "Assign a provider")
+    expect(page).to have_element(:div, text: "You can preview this placement as it appears to providers.", class: "govuk-inset-text")
+    expect(page).to have_link("Delete placement", href: "/schools/#{@school.id}/placements/#{@send_placement.id}/remove")
+  end
+
+  def when_i_click_on_change_key_stage
+    click_on "Change Key stage"
+  end
+
+  def then_i_see_the_select_a_key_stage_page
+    expect(page).to have_title("Select a key stage - Placement details - Manage school placements - GOV.UK")
+    expect(page).to have_element(
+      :legend,
+      text: "Select a key stage",
+      class: "govuk-fieldset__legend",
+    )
+    expect(page).to have_link("Cancel", href: "/schools/#{@school.id}/placements/#{@send_placement.id}")
+  end
+
+  def and_i_see_the_key_stage_options
+    expect(page).to have_field("Early years", type: :radio)
+    expect(page).to have_field("Key stage 1", type: :radio, checked: true)
+    expect(page).to have_field("Key stage 2", type: :radio)
+    expect(page).to have_field("Key stage 3", type: :radio)
+    expect(page).to have_field("Key stage 4", type: :radio)
+    expect(page).to have_field("Key stage 5", type: :radio)
+    expect(page).to have_field("Mixed key stages", type: :radio)
+  end
+
+  def when_i_select_key_stage_5
+    choose "Key stage 5"
+  end
+
+  def and_i_click_on_continue
+    click_on "Continue"
+  end
+
+  def then_i_see_the_placement_details_page_with_my_updated_key_stage
+    expect(page).to have_title("SEND (Key stage 5) - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Placements")
+    expect(page).to have_tag("Available", "green")
+    expect(page).to have_summary_list_row("Key stage", "Key stage 5")
+    expect(page).to have_summary_list_row("Academic year", "Next year (#{@next_academic_year_name})")
+    expect(page).to have_summary_list_row("Expected date", "Any time in the academic year")
+    expect(page).to have_summary_list_row("Mentor", "Add a mentor")
+    expect(page).to have_summary_list_row("Provider", "Assign a provider")
+    expect(page).to have_element(:div, text: "You can preview this placement as it appears to providers.", class: "govuk-inset-text")
+    expect(page).to have_link("Delete placement", href: "/schools/#{@school.id}/placements/#{@send_placement.id}/remove")
+  end
+
+  def and_i_see_a_key_stage_updated_success_message
+    expect(page).to have_success_banner("Key stage updated")
+  end
+end

--- a/spec/wizards/placements/edit_placement_wizard/key_stage_step_spec.rb
+++ b/spec/wizards/placements/edit_placement_wizard/key_stage_step_spec.rb
@@ -1,0 +1,111 @@
+require "rails_helper"
+
+RSpec.describe Placements::EditPlacementWizard::KeyStageStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Placements::EditPlacementWizard).tap do |mock_wizard|
+      allow(mock_wizard).to receive(:school).and_return(school)
+    end
+  end
+
+  let(:attributes) { nil }
+
+  let!(:school) { create(:placements_school, name: "School 1") }
+
+  describe "attributes" do
+    it { is_expected.to have_attributes(key_stage_id: nil) }
+  end
+
+  describe "validations" do
+    let(:early_years) { create(:key_stage, name: "Early years") }
+    let(:key_stage_1) { create(:key_stage, name: "Key stage 1") }
+    let(:key_stage_2) { create(:key_stage, name: "Key stage 2") }
+    let(:key_stage_3) { create(:key_stage, name: "Key stage 3") }
+    let(:key_stage_4) { create(:key_stage, name: "Key stage 4") }
+    let(:key_stage_5) { create(:key_stage, name: "Key stage 5") }
+    let(:mixed_key_stages) { create(:key_stage, name: "Mixed key stages") }
+
+    it { is_expected.to validate_presence_of(:key_stage_id) }
+    it { is_expected.to validate_inclusion_of(:key_stage_id).in_array(Placements::KeyStage.ids) }
+  end
+
+  describe "#key_stages_for_selection" do
+    subject(:key_stages_for_selection) { step.key_stages_for_selection }
+
+    let!(:early_years) { create(:key_stage, name: "Early years") }
+    let!(:key_stage_1) { create(:key_stage, name: "Key stage 1") }
+    let!(:key_stage_2) { create(:key_stage, name: "Key stage 2") }
+    let!(:key_stage_3) { create(:key_stage, name: "Key stage 3") }
+    let!(:key_stage_4) { create(:key_stage, name: "Key stage 4") }
+    let!(:key_stage_5) { create(:key_stage, name: "Key stage 5") }
+    let(:mixed_key_stages) { create(:key_stage, name: "Mixed key stages") }
+
+    before { mixed_key_stages }
+
+    it "returns all key stages, expect for mixed key stages" do
+      expect(key_stages_for_selection).to contain_exactly(
+        early_years,
+        key_stage_1,
+        key_stage_2,
+        key_stage_3,
+        key_stage_4,
+        key_stage_5,
+      )
+    end
+  end
+
+  describe "mixed_key_stage_option" do
+    subject(:mixed_key_stage_option) { step.mixed_key_stage_option }
+
+    let(:early_years) { create(:key_stage, name: "Early years") }
+    let(:key_stage_1) { create(:key_stage, name: "Key stage 1") }
+    let(:key_stage_2) { create(:key_stage, name: "Key stage 2") }
+    let(:key_stage_3) { create(:key_stage, name: "Key stage 3") }
+    let(:key_stage_4) { create(:key_stage, name: "Key stage 4") }
+    let(:key_stage_5) { create(:key_stage, name: "Key stage 5") }
+    let!(:mixed_key_stages) { create(:key_stage, name: "Mixed key stages") }
+
+    before do
+      early_years
+      key_stage_1
+      key_stage_2
+      key_stage_3
+      key_stage_4
+      key_stage_5
+    end
+
+    it "returns the mixed key stage" do
+      expect(mixed_key_stage_option).to eq(
+        mixed_key_stages,
+      )
+    end
+  end
+
+  describe "#key_stage" do
+    subject(:key_stage) { step.key_stage }
+
+    let(:early_years) { create(:key_stage, name: "Early years") }
+    let(:key_stage_1) { create(:key_stage, name: "Key stage 1") }
+    let(:key_stage_2) { create(:key_stage, name: "Key stage 2") }
+    let(:key_stage_3) { create(:key_stage, name: "Key stage 3") }
+    let(:key_stage_4) { create(:key_stage, name: "Key stage 4") }
+    let(:key_stage_5) { create(:key_stage, name: "Key stage 5") }
+    let!(:mixed_key_stages) { create(:key_stage, name: "Mixed key stages") }
+
+    let(:attributes) { { key_stage_id: key_stage_1.id } }
+
+    before do
+      early_years
+      key_stage_2
+      key_stage_3
+      key_stage_4
+      key_stage_5
+      mixed_key_stages
+    end
+
+    it "returns the key stage record associated with the set key stage ID" do
+      expect(key_stage).to eq(key_stage_1)
+    end
+  end
+end

--- a/spec/wizards/placements/edit_placement_wizard_spec.rb
+++ b/spec/wizards/placements/edit_placement_wizard_spec.rb
@@ -59,6 +59,12 @@ RSpec.describe Placements::EditPlacementWizard do
 
       it { is_expected.to eq %i[terms] }
     end
+
+    context "with the key stage step" do
+      let(:current_step) { :key_stage }
+
+      it { is_expected.to eq %i[key_stage] }
+    end
   end
 
   describe "#update_placement" do
@@ -69,10 +75,12 @@ RSpec.describe Placements::EditPlacementWizard do
     let(:mentor_not_known) { Placements::AddPlacementWizard::MentorsStep::NOT_KNOWN }
     let(:selected_year_group) { :year_1 }
     let(:selected_term) { create(:placements_term, :summer) }
+    let(:key_stage_1) { create(:key_stage, name: "Key stage 1") }
 
     context "when the step is valid" do
       before do
         selected_term
+        key_stage_1
         _spring_term = create(:placements_term, :spring)
         _autumn_term = create(:placements_term, :autumn)
         edit_wizard
@@ -163,6 +171,20 @@ RSpec.describe Placements::EditPlacementWizard do
 
         it "updates the placement" do
           expect(placement.terms).to contain_exactly(selected_term)
+        end
+      end
+
+      context "when the step is key stage" do
+        let(:current_step) { :key_stage }
+
+        let(:state) do
+          {
+            "key_stage" => { "key_stage_id" => key_stage_1.id },
+          }
+        end
+
+        it "updates the placement" do
+          expect(placement.key_stage).to eq(key_stage_1)
         end
       end
     end


### PR DESCRIPTION
## Context

- Allow school users to change the key stage of a SEND placement.

## Changes proposed in this pull request

- Add a step to the EditPlacementWizard to allow users to change the Key Stage of SEND placements.

## Guidance to review

- Sign in as Anne (School user)
Assuming you already have a SEND placement created
- Click on the SEND placement
- Click to "Change" the Key stage
- Select another key stage
- Click "Continue"
- The key stage should be updated

## Link to Trello card

https://trello.com/c/GVk0Tzvp/740-add-the-ability-to-change-the-key-stage-of-send-placements

## Screenshots


https://github.com/user-attachments/assets/d83d3ca2-cdd3-4d57-b289-e1772af9aa81


