### PR TITLE
Remove mention of adding schools before being assigned

### DIFF
--- a/app/controllers/placements/partnerships/add_partnership_controller.rb
+++ b/app/controllers/placements/partnerships/add_partnership_controller.rb
@@ -18,10 +18,12 @@ class Placements::Partnerships::AddPartnershipController < Placements::Applicati
         )
       end
       @wizard.reset_state
-      redirect_to index_path, flash: {
-        heading: t(".success_heading"),
-        body: t(".success_body", partner_name: @wizard.partner_organisation.name),
-      }
+
+      flash[:heading] = t(".success_heading")
+      if @wizard.organisation.is_a?(Placements::School)
+        flash[:body] = t(".success_body", partner_name: @wizard.partner_organisation.name)
+      end
+      redirect_to index_path
     end
   end
 

--- a/app/views/placements/providers/partner_schools/index.html.erb
+++ b/app/views/placements/providers/partner_schools/index.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-width-container">
   <h1 class="govuk-heading-l"><%= t(".schools_you_work_with") %></h1>
   <p class="govuk-body"><%= t(".view_all_placements") %></p>
-  <p class="govuk-body"><%= t(".only_schools_you_work_with") %></p>
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= govuk_button_link_to(t(".add_school"), new_add_partner_school_placements_provider_partner_schools_path) %>

--- a/app/views/wizards/placements/add_partnership_wizard/_check_your_answers_step.html.erb
+++ b/app/views/wizards/placements/add_partnership_wizard/_check_your_answers_step.html.erb
@@ -6,9 +6,13 @@
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l"><%= t(".title_#{wizard.partner_organisation_type}") %></h1>
-      <p class="govuk-body"><%= t(".intro_text_#{wizard.partner_organisation_type}_html") %></p>
+
+      <% if wizard.partner_organisation_type == "provider" %>
+        <p class="govuk-body"><%= t(".intro_text_provider") %></p>
+      <% end %>
 
       <h2 class="govuk-heading-m"><%= t(".header_#{wizard.partner_organisation_type}") %></h2>
+
       <%= render "placements/organisations/organisation_details", organisation: wizard.partner_organisation, change_link: step_path(:partnership) %>
       <%= f.govuk_submit t(".add_partner_#{wizard.partner_organisation_type}") %>
     <% end %>

--- a/config/locales/en/placements/providers/partner_schools.yml
+++ b/config/locales/en/placements/providers/partner_schools.yml
@@ -58,5 +58,3 @@ en:
             mentors: Mentors
             other_placements: Other placements
             status: Status
-
-          show:

--- a/config/locales/en/placements/providers/partner_schools/add_partner_school.yml
+++ b/config/locales/en/placements/providers/partner_schools/add_partner_school.yml
@@ -7,4 +7,3 @@ en:
             cancel: Cancel
           update:
             success_heading: School added
-            success_body: "%{partner_name} can now assign you to their placements."

--- a/config/locales/en/wizards/placements/add_partnership_wizard.yml
+++ b/config/locales/en/wizards/placements/add_partnership_wizard.yml
@@ -20,13 +20,9 @@ en:
           page_title_school: Confirm school details - School details
           title_provider: Confirm provider details
           title_school: Confirm school details
-          intro_text_provider_html: | 
+          intro_text_provider: | 
             Adding them means you will be able to assign them to your placements. 
             We will send them an email to let them know you have added them.
-          intro_text_school_html: | 
-            <br>Once added, they will be able to assign you to their placements. 
-            <br>
-            <br>We will send them an email to let them know you have added them.
           header_provider: Provider
           header_school: School
           add_partner_provider: Confirm and add provider

--- a/spec/system/placements/providers/partner_schools/placements/provider_user_views_a_placement_for_a_partner_school_spec.rb
+++ b/spec/system/placements/providers/partner_schools/placements/provider_user_views_a_placement_for_a_partner_school_spec.rb
@@ -73,7 +73,6 @@ RSpec.describe "Provider user views a placement for a partner school",
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Schools you work with")
     expect(page).to have_element(:p, text: "View all placements your schools have published.")
-    expect(page).to have_element(:p, text: "Only schools you work with are able to assign you their placements.")
     expect(page).to have_link("Add school")
     expect(page).to have_table_row({ "Name": "Shelbyville Elementary",
                                      "Unique reference number (URN)": "54321" })

--- a/spec/system/placements/providers/partner_schools/placements/provider_user_views_placment_list_for_partner_school_spec.rb
+++ b/spec/system/placements/providers/partner_schools/placements/provider_user_views_placment_list_for_partner_school_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe "Provider user views placement list for partner school",
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Schools you work with")
     expect(page).to have_element(:p, text: "View all placements your schools have published.")
-    expect(page).to have_element(:p, text: "Only schools you work with are able to assign you their placements.")
     expect(page).to have_link("Add school")
     expect(page).to have_table_row({ "Name": "Shelbyville Elementary",
                                      "Unique reference number (URN)": "54321" })

--- a/spec/system/placements/providers/partner_schools/provider_user_adds_a_school_spec.rb
+++ b/spec/system/placements/providers/partner_schools/provider_user_adds_a_school_spec.rb
@@ -92,7 +92,6 @@ RSpec.describe "Provider user adds a school", :js,
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Schools you work with")
     expect(page).to have_element(:p, text: "View all placements your schools have published.")
-    expect(page).to have_element(:p, text: "Only schools you work with are able to assign you their placements.")
     expect(page).to have_link("Add school", href: new_add_partner_school_placements_provider_partner_schools_path(@provider))
     expect(page).to have_element(:p, text: "There are no partner schools for Westbrook Provider")
   end
@@ -140,8 +139,6 @@ RSpec.describe "Provider user adds a school", :js,
     expect(page).to have_title("Confirm school details - School details - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Confirm school details")
-    expect(page).to have_element(:p, text: "Once added, they will be able to assign you to their placements.")
-    expect(page).to have_element(:p, text: "We will send them an email to let them know you have added them.")
     expect(page).to have_summary_list_row("Name", "Shelbyville Elementary")
     expect(page).to have_summary_list_row("UK provider reference number (UKPRN)", "54321")
     expect(page).to have_summary_list_row("Unique reference number (URN)", "12345")
@@ -172,11 +169,10 @@ RSpec.describe "Provider user adds a school", :js,
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Schools you work with")
     expect(page).to have_element(:p, text: "View all placements your schools have published.")
-    expect(page).to have_element(:p, text: "Only schools you work with are able to assign you their placements.")
     expect(page).to have_link("Add school")
     expect(page).to have_table_row({ "Name": "Shelbyville Elementary",
                                      "Unique reference number (URN)": "12345" })
-    expect(page).to have_success_banner("School added", "Shelbyville Elementary can now assign you to their placements.")
+    expect(page).to have_success_banner("School added")
   end
 
   def then_i_see_an_error_that_shelbyville_elementary_has_already_been_added

--- a/spec/system/placements/providers/partner_schools/provider_user_adds_a_school_without_javascript_spec.rb
+++ b/spec/system/placements/providers/partner_schools/provider_user_adds_a_school_without_javascript_spec.rb
@@ -102,7 +102,6 @@ RSpec.describe "Provider user adds a school without JavaScript",
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Schools you work with")
     expect(page).to have_element(:p, text: "View all placements your schools have published.")
-    expect(page).to have_element(:p, text: "Only schools you work with are able to assign you their placements.")
     expect(page).to have_link("Add school", href: new_add_partner_school_placements_provider_partner_schools_path(@provider))
     expect(page).to have_element(:p, text: "There are no partner schools for Westbrook Provider")
   end
@@ -181,8 +180,6 @@ RSpec.describe "Provider user adds a school without JavaScript",
     expect(page).to have_title("Confirm school details - School details - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Confirm school details")
-    expect(page).to have_element(:p, text: "Once added, they will be able to assign you to their placements.")
-    expect(page).to have_element(:p, text: "We will send them an email to let them know you have added them.")
     expect(page).to have_summary_list_row("Name", "Shelbyville Elementary")
     expect(page).to have_summary_list_row("UK provider reference number (UKPRN)", "54321")
     expect(page).to have_summary_list_row("Unique reference number (URN)", "12345")
@@ -211,11 +208,10 @@ RSpec.describe "Provider user adds a school without JavaScript",
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Schools you work with")
     expect(page).to have_element(:p, text: "View all placements your schools have published.")
-    expect(page).to have_element(:p, text: "Only schools you work with are able to assign you their placements.")
     expect(page).to have_link("Add school", href: new_add_partner_school_placements_provider_partner_schools_path(@provider))
     expect(page).to have_table_row({ "Name": "Shelbyville Elementary",
                                      "Unique reference number (URN)": "12345" })
-    expect(page).to have_success_banner("School added", "Shelbyville Elementary can now assign you to their placements.")
+    expect(page).to have_success_banner("School added")
   end
 
   def then_i_see_an_error_that_shelbyville_elementary_has_already_been_added

--- a/spec/system/placements/providers/partner_schools/provider_user_removes_partner_schools_spec.rb
+++ b/spec/system/placements/providers/partner_schools/provider_user_removes_partner_schools_spec.rb
@@ -95,7 +95,6 @@ RSpec.describe "Provider user removes partner schools",
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Schools you work with")
     expect(page).to have_element(:p, text: "View all placements your schools have published.")
-    expect(page).to have_element(:p, text: "Only schools you work with are able to assign you their placements.")
     expect(page).to have_link("Add school")
     expect(page).to have_table_row({ "Name": "Shelbyville Elementary",
                                      "Unique reference number (URN)": "54321" })
@@ -150,7 +149,6 @@ RSpec.describe "Provider user removes partner schools",
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Schools you work with")
     expect(page).to have_element(:p, text: "View all placements your schools have published.")
-    expect(page).to have_element(:p, text: "Only schools you work with are able to assign you their placements.")
     expect(page).to have_link("Add school")
     expect(page).to have_table_row({ "Name": "Shelbyville Elementary",
                                      "Unique reference number (URN)": "54321" })
@@ -211,7 +209,6 @@ RSpec.describe "Provider user removes partner schools",
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Schools you work with")
     expect(page).to have_element(:p, text: "View all placements your schools have published.")
-    expect(page).to have_element(:p, text: "Only schools you work with are able to assign you their placements.")
     expect(page).to have_link("Add school")
     expect(page).to have_element(:p, text: "There are no partner schools for Westbrook Provider")
   end
@@ -227,7 +224,6 @@ RSpec.describe "Provider user removes partner schools",
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Schools you work with")
     expect(page).to have_element(:p, text: "View all placements your schools have published.")
-    expect(page).to have_element(:p, text: "Only schools you work with are able to assign you their placements.")
     expect(page).to have_link("Add school")
     expect(page).to have_element(:p, text: "There are no partner schools for Westbrook Provider")
   end

--- a/spec/system/placements/providers/partner_schools/provider_user_views_a_populated_schools_list_spec.rb
+++ b/spec/system/placements/providers/partner_schools/provider_user_views_a_populated_schools_list_spec.rb
@@ -54,7 +54,6 @@ RSpec.describe "Provider user views a populated schools list",
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Schools you work with")
     expect(page).to have_element(:p, text: "View all placements your schools have published.")
-    expect(page).to have_element(:p, text: "Only schools you work with are able to assign you their placements.")
     expect(page).to have_link("Add school")
     expect(page).to have_table_row({ "Name": "Shelbyville School",
                                      "Unique reference number (URN)": "12345" })

--- a/spec/system/placements/providers/partner_schools/provider_user_views_a_provider_partner_school_spec.rb
+++ b/spec/system/placements/providers/partner_schools/provider_user_views_a_provider_partner_school_spec.rb
@@ -63,7 +63,6 @@ RSpec.describe "Provider user views a provider partner school",
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Schools you work with")
     expect(page).to have_element(:p, text: "View all placements your schools have published.")
-    expect(page).to have_element(:p, text: "Only schools you work with are able to assign you their placements.")
     expect(page).to have_link("Add school")
     expect(page).to have_table_row({ "Name": "Shelbyville Elementary",
                                      "Unique reference number (URN)": "54321" })

--- a/spec/system/placements/providers/partner_schools/provider_user_views_an_empty_schools_list_spec.rb
+++ b/spec/system/placements/providers/partner_schools/provider_user_views_an_empty_schools_list_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe "Provider user views an empty schools list",
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Schools you work with")
     expect(page).to have_element(:p, text: "View all placements your schools have published.")
-    expect(page).to have_element(:p, text: "Only schools you work with are able to assign you their placements.")
     expect(page).to have_link("Add school")
     expect(page).to have_element(:p, text: "There are no partner schools for Westbrook Provider")
   end

--- a/spec/system/placements/support/providers/partner_schools/support_user_adds_a_partner_school_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/support_user_adds_a_partner_school_spec.rb
@@ -105,7 +105,6 @@ RSpec.describe "Support user adds a partner school", :js,
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Schools you work with")
     expect(page).to have_paragraph("View all placements your schools have published.")
-    expect(page).to have_paragraph("Only schools you work with are able to assign you their placements.")
     expect(page).to have_link("Add school", href: new_add_partner_school_placements_provider_partner_schools_path(@provider))
     expect(page).to have_paragraph("There are no partner schools for Westbrook Provider")
   end
@@ -152,8 +151,6 @@ RSpec.describe "Support user adds a partner school", :js,
     expect(page).to have_title("Confirm school details - School details - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Confirm school details")
-    expect(page).to have_paragraph("Once added, they will be able to assign you to their placements.")
-    expect(page).to have_paragraph("We will send them an email to let them know you have added them.")
     expect(page).to have_summary_list_row("Name", "Shelbyville Elementary")
     expect(page).to have_summary_list_row("UK provider reference number (UKPRN)", "54321")
     expect(page).to have_summary_list_row("Unique reference number (URN)", "12345")
@@ -184,11 +181,10 @@ RSpec.describe "Support user adds a partner school", :js,
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Schools you work with")
     expect(page).to have_paragraph("View all placements your schools have published.")
-    expect(page).to have_paragraph("Only schools you work with are able to assign you their placements.")
     expect(page).to have_link("Add school", href: new_add_partner_school_placements_provider_partner_schools_path(@provider))
     expect(page).to have_table_row({ "Name": "Shelbyville Elementary",
                                      "Unique reference number (URN)": "12345" })
-    expect(page).to have_success_banner("School added", "Shelbyville Elementary can now assign you to their placements.")
+    expect(page).to have_success_banner("School added")
   end
 
   def then_i_see_an_error_that_shelbyville_elementary_has_already_been_added

--- a/spec/system/placements/support/providers/partner_schools/support_user_adds_a_partner_school_without_javascript_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/support_user_adds_a_partner_school_without_javascript_spec.rb
@@ -119,7 +119,6 @@ RSpec.describe "Support user adds a partner school without JavaScript",
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Schools you work with")
     expect(page).to have_paragraph("View all placements your schools have published.")
-    expect(page).to have_paragraph("Only schools you work with are able to assign you their placements.")
     expect(page).to have_link("Add school", href: new_add_partner_school_placements_provider_partner_schools_path(@provider))
     expect(page).to have_paragraph("There are no partner schools for Westbrook Provider")
   end
@@ -201,8 +200,6 @@ RSpec.describe "Support user adds a partner school without JavaScript",
     expect(page).to have_title("Confirm school details - School details - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Confirm school details")
-    expect(page).to have_paragraph("Once added, they will be able to assign you to their placements.")
-    expect(page).to have_paragraph("We will send them an email to let them know you have added them.")
     expect(page).to have_summary_list_row("Name", "Shelbyville Elementary")
     expect(page).to have_summary_list_row("UK provider reference number (UKPRN)", "54321")
     expect(page).to have_summary_list_row("Unique reference number (URN)", "12345")
@@ -231,11 +228,10 @@ RSpec.describe "Support user adds a partner school without JavaScript",
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Schools you work with")
     expect(page).to have_paragraph("View all placements your schools have published.")
-    expect(page).to have_paragraph("Only schools you work with are able to assign you their placements.")
     expect(page).to have_link("Add school", href: new_add_partner_school_placements_provider_partner_schools_path(@provider))
     expect(page).to have_table_row({ "Name": "Shelbyville Elementary",
                                      "Unique reference number (URN)": "12345" })
-    expect(page).to have_success_banner("School added", "Shelbyville Elementary can now assign you to their placements.")
+    expect(page).to have_success_banner("School added")
   end
 
   def then_i_see_an_error_that_shelbyville_elementary_has_already_been_added

--- a/spec/system/placements/support/providers/partner_schools/support_user_removes_partner_schools_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/support_user_removes_partner_schools_spec.rb
@@ -105,7 +105,6 @@ RSpec.describe "Support user removes partner schools",
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Schools you work with")
     expect(page).to have_paragraph("View all placements your schools have published.")
-    expect(page).to have_paragraph("Only schools you work with are able to assign you their placements.")
     expect(page).to have_link("Add school", href: new_add_partner_school_placements_provider_partner_schools_path(@provider))
     expect(page).to have_table_row({ "Name": "Shelbyville Elementary",
                                      "Unique reference number (URN)": "54321" })
@@ -160,7 +159,6 @@ RSpec.describe "Support user removes partner schools",
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Schools you work with")
     expect(page).to have_paragraph("View all placements your schools have published.")
-    expect(page).to have_paragraph("Only schools you work with are able to assign you their placements.")
     expect(page).to have_link("Add school", href: new_add_partner_school_placements_provider_partner_schools_path(@provider))
     expect(page).to have_table_row({ "Name": "Shelbyville Elementary",
                                      "Unique reference number (URN)": "54321" })
@@ -221,7 +219,6 @@ RSpec.describe "Support user removes partner schools",
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Schools you work with")
     expect(page).to have_paragraph("View all placements your schools have published.")
-    expect(page).to have_paragraph("Only schools you work with are able to assign you their placements.")
     expect(page).to have_link("Add school", href: new_add_partner_school_placements_provider_partner_schools_path(@provider))
     expect(page).to have_paragraph("There are no partner schools for Westbrook Provider")
   end
@@ -237,7 +234,6 @@ RSpec.describe "Support user removes partner schools",
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Schools you work with")
     expect(page).to have_paragraph("View all placements your schools have published.")
-    expect(page).to have_paragraph("Only schools you work with are able to assign you their placements.")
     expect(page).to have_link("Add school", href: new_add_partner_school_placements_provider_partner_schools_path(@provider))
     expect(page).to have_paragraph("There are no partner schools for Westbrook Provider")
   end

--- a/spec/system/placements/support/providers/partner_schools/support_user_views_a_populated_schools_list_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/support_user_views_a_populated_schools_list_spec.rb
@@ -64,7 +64,6 @@ RSpec.describe "Support user views a populated schools list",
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Schools you work with")
     expect(page).to have_paragraph("View all placements your schools have published.")
-    expect(page).to have_paragraph("Only schools you work with are able to assign you their placements.")
     expect(page).to have_link("Add school", href: new_add_partner_school_placements_provider_partner_schools_path(@provider))
     expect(page).to have_table_row({ "Name": "Shelbyville School",
                                      "Unique reference number (URN)": "12345" })

--- a/spec/system/placements/support/providers/partner_schools/support_user_views_a_provider_partner_school_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/support_user_views_a_provider_partner_school_spec.rb
@@ -73,7 +73,6 @@ RSpec.describe "Support user views a provider partner school",
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Schools you work with")
     expect(page).to have_paragraph("View all placements your schools have published.")
-    expect(page).to have_paragraph("Only schools you work with are able to assign you their placements.")
     expect(page).to have_link("Add school", href: new_add_partner_school_placements_provider_partner_schools_path(@provider))
     expect(page).to have_table_row({ "Name": "Shelbyville Elementary",
                                      "Unique reference number (URN)": "54321" })

--- a/spec/system/placements/support/providers/partner_schools/support_user_views_an_empty_schools_list_spec.rb
+++ b/spec/system/placements/support/providers/partner_schools/support_user_views_an_empty_schools_list_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe "Support user views an empty schools list",
     expect(primary_navigation).to have_current_item("Schools")
     expect(page).to have_h1("Schools you work with")
     expect(page).to have_paragraph("View all placements your schools have published.")
-    expect(page).to have_paragraph("Only schools you work with are able to assign you their placements.")
     expect(page).to have_link("Add school", href: new_add_partner_school_placements_provider_partner_schools_path(@provider))
     expect(page).to have_paragraph("There are no partner schools for Westbrook Provider")
   end


### PR DESCRIPTION
## Context

- Remove content informing providers that they will need to add schools before they can be assigned to placements.

## Changes proposed in this pull request

- Remove content informing providers that they will need to add schools before they can be assigned to placements.

## Guidance to review

- Sign in as Patricia (Provider user)
- Navigate to "Schools"
- Note that the content has been removed from the index page.
- Click "Add school"
- Follow the journey
- On the Check Your Answers page, not that the contact has been remove
- Click "Confirm and add school"
- Note that the body has been removed from the success banner

## Link to Trello card

https://trello.com/c/qTwylVKA/727-remove-mention-of-providers-having-to-add-school-before-they-can-be-assigned

## Screenshots
![screencapture-placements-localhost-3000-providers-0015352e-cd75-47f4-b43c-322c345b2e3b-partner-schools-2025-06-24-15_22_22](https://github.com/user-attachments/assets/5baac520-79e7-4638-94d1-65385a325b06)
![screencapture-placements-localhost-3000-providers-0015352e-cd75-47f4-b43c-322c345b2e3b-partner-schools-new-1f428cd0-d51b-442d-9126-cb67d110864d-check-your-answers-2025-06-24-15_22_47](https://github.com/user-attachments/assets/1b38c5d8-621f-4dd2-bac7-5795489c02fb)
![screencapture-placements-localhost-3000-providers-0015352e-cd75-47f4-b43c-322c345b2e3b-partner-schools-2025-06-24-15_22_59](https://github.com/user-attachments/assets/43f75630-87e2-41aa-ac4c-3ea14e9b7337)

