### PR TITLE
Add link to claim for clawback email

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-rspec
 
 inherit_gem:

--- a/config/locales/en/claims/user_mailer.yml
+++ b/config/locales/en/claims/user_mailer.yml
@@ -108,6 +108,10 @@ en:
           Amount being clawed back: %{clawback_amount}
           Claim reference: %{claim_reference}
           
+          You can view the claim on Claim funding for mentor training:
+          
+          %{link_to_claim}
+          
           # What happens next
           The funds will automatically be taken from you.
           

--- a/spec/mailers/claims/user_mailer_spec.rb
+++ b/spec/mailers/claims/user_mailer_spec.rb
@@ -260,6 +260,10 @@ RSpec.describe Claims::UserMailer, type: :mailer do
 
         Amount being clawed back: £214.40
         Claim reference: 123
+          
+        You can view the claim on Claim funding for mentor training:
+        
+        http://claims.localhost/schools/#{school.id}/claims/#{claim.id}?utm_campaign=school&utm_medium=notification&utm_source=email
 
         # What happens next
         The funds will automatically be taken from you.

--- a/spec/mailers/claims/user_mailer_spec.rb
+++ b/spec/mailers/claims/user_mailer_spec.rb
@@ -260,9 +260,9 @@ RSpec.describe Claims::UserMailer, type: :mailer do
 
         Amount being clawed back: £214.40
         Claim reference: 123
-          
+
         You can view the claim on Claim funding for mentor training:
-        
+
         http://claims.localhost/schools/#{school.id}/claims/#{claim.id}?utm_campaign=school&utm_medium=notification&utm_source=email
 
         # What happens next


### PR DESCRIPTION
## Context

Users want to be able to click on a link to view their claim

## Changes proposed in this pull request

- Add link to claim in clawback email

## Guidance to review

- Review content and screenshot

## Link to Trello card

https://trello.com/c/npvq5gC7/747-add-link-to-claim-for-school-facing-clawback-email

## Screenshots

![image](https://github.com/user-attachments/assets/c4df0e97-25c0-4912-a894-e7a2c27076e8)

