### PR TITLE
Add SEND only filter

### DIFF
--- a/app/controllers/placements/providers/find_controller.rb
+++ b/app/controllers/placements/providers/find_controller.rb
@@ -89,6 +89,7 @@ class Placements::Providers::FindController < Placements::ApplicationController
       itt_statuses: [],
       last_offered_placements_academic_year_ids: [],
       trained_mentors: [],
+      send_only: [],
     )
   end
 

--- a/app/forms/placements/schools/filter_form.rb
+++ b/app/forms/placements/schools/filter_form.rb
@@ -10,6 +10,7 @@ class Placements::Schools::FilterForm < ApplicationForm
   attribute :itt_statuses, default: []
   attribute :last_offered_placements_academic_year_ids, default: []
   attribute :schools_to_show, default: "active"
+  attribute :send_only, default: []
 
   def initialize(provider, params = {})
     @provider = provider
@@ -56,6 +57,7 @@ class Placements::Schools::FilterForm < ApplicationForm
       itt_statuses:,
       last_offered_placements_academic_year_ids:,
       schools_to_show:,
+      send_only:,
     }
   end
 

--- a/app/queries/placements/schools_query.rb
+++ b/app/queries/placements/schools_query.rb
@@ -1,5 +1,6 @@
 class Placements::SchoolsQuery < ApplicationQuery
   MAX_LOCATION_DISTANCE = 50
+  SEND_ONLY = "SEND only".freeze
 
   def initialize(academic_year:, params: {})
     @academic_year = academic_year
@@ -17,6 +18,7 @@ class Placements::SchoolsQuery < ApplicationQuery
     scope = last_offered_placements_condition(scope)
     scope = year_group_condition(scope)
     scope = itt_statuses_condition(scope)
+    scope = send_condition(scope)
     order_condition(scope)
   end
 
@@ -133,5 +135,12 @@ class Placements::SchoolsQuery < ApplicationQuery
     return scope if filter_params[:schools_to_show] == "all"
 
     scope.where(expression_of_interest_completed: true).or(scope.where.associated(:hosting_interests))
+  end
+
+  def send_condition(scope)
+    return scope if filter_params[:send_only].blank? ||
+      !filter_params[:send_only].include?(SEND_ONLY)
+
+    scope.where(placements: { send_specific: true })
   end
 end

--- a/app/views/placements/providers/find/_filter.html.erb
+++ b/app/views/placements/providers/find/_filter.html.erb
@@ -117,6 +117,25 @@
             </ul>
           <% end %>
 
+          <% if filter_form.send_only.present? %>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".send_placements") %></h3>
+            <ul class="app-filter-tags">
+              <% filter_form.send_only.each do |send_only| %>
+                <li>
+                  <%= govuk_link_to(
+                        t(".show_only_send_placements"),
+                        filter_form.index_path_without_filter(
+                          filter: "send_only",
+                          value: send_only,
+                        ),
+                        class: "app-filter__tag",
+                        no_visited_state: true,
+                      ) %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+
           <% if filter_form.last_offered_placements_academic_year_ids.present? %>
             <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t(".last_offered_placements") %></h3>
             <ul class="app-filter-tags">
@@ -286,6 +305,17 @@
               <% %w[open not_open filled_placements unfilled_placements].each do |appetite| %>
                 <%= form.govuk_check_box :itt_statuses, appetite, label: { text: t("components.placements.schools.interest_tag_component.#{appetite}") } %>
               <% end %>
+            <% end %>
+          </div>
+
+          <div class="app-filter__option">
+            <%= form.govuk_check_boxes_fieldset(
+              :send_only,
+              legend: { text: t(".send_placements"), size: "s" },
+              small: true,
+              multiple: true,
+            ) do %>
+              <%= form.govuk_check_box :send_only, Placements::SchoolsQuery::SEND_ONLY, label: { text: t(".show_only_send_placements") } %>
             <% end %>
           </div>
 

--- a/config/locales/en/placements/providers/find.yml
+++ b/config/locales/en/placements/providers/find.yml
@@ -57,6 +57,10 @@ en:
           schools_to_show:
             active: Only schools using the service
             all: All schools
+          send_placements: SEND placements
+          send_only: SEND only
+          show_only_send_placements:
+            Show only schools with SEND specific placements
         placements:
           phase: Phase
           unknown: Unknown

--- a/spec/forms/placements/schools/filter_form_spec.rb
+++ b/spec/forms/placements/schools/filter_form_spec.rb
@@ -93,6 +93,14 @@ describe Placements::Schools::FilterForm, type: :model do
       end
     end
 
+    context "when given send only params" do
+      let(:params) { { send_only: %w[SEND only] } }
+
+      it "returns true" do
+        expect(filters_selected).to be(true)
+      end
+    end
+
     context "when given no params" do
       let(:params) { {} }
 
@@ -271,6 +279,28 @@ describe Placements::Schools::FilterForm, type: :model do
         )
       end
     end
+
+    context "when removing send only params" do
+      let(:params) do
+        { send_only: ["SEND only"] }
+      end
+
+      it "returns the find index page path without the given send only param" do
+        expect(
+          filter_form.index_path_without_filter(
+            filter: "send_only",
+            value: "SEND only",
+          ),
+        ).to eq(
+          placements_provider_find_index_path(
+            provider,
+            filters: {
+              schools_to_show: "active",
+            },
+          ),
+        )
+      end
+    end
   end
 
   describe "#query_params" do
@@ -286,6 +316,7 @@ describe Placements::Schools::FilterForm, type: :model do
           itt_statuses: [],
           last_offered_placements_academic_year_ids: [],
           schools_to_show: "active",
+          send_only: [],
         },
       )
     end

--- a/spec/queries/placements/schools_query_spec.rb
+++ b/spec/queries/placements/schools_query_spec.rb
@@ -203,6 +203,20 @@ describe Placements::SchoolsQuery do
       end
     end
 
+    context "when filtering by send only" do
+      let(:params) { { filters: { send_only: ["SEND only"] } } }
+      let(:key_stage) { build(:key_stage, name: "Key stage 1") }
+
+      before do
+        create(:placement, :send, school: query_school, academic_year:, key_stage:)
+      end
+
+      it "returns the filtered schools with SEND placements" do
+        expect(query.call).to include(query_school)
+        expect(query.call).not_to include(non_query_school)
+      end
+    end
+
     context "when filtering by location" do
       let!(:close_query_school) do
         create(

--- a/spec/system/placements/providers/find/provider_user_filters_schools_by_send_placements_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_filters_schools_by_send_placements_spec.rb
@@ -1,0 +1,101 @@
+require "rails_helper"
+
+RSpec.describe "Provider user filters schools by SEND placements", service: :placements, type: :system do
+  scenario do
+    given_that_schools_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_find_schools_page
+    then_i_see_the_find_schools_page
+    and_i_see_all_schools
+    and_i_see_the_send_placement_filter
+
+    when_i_select_show_only_schools_with_sends_specific_placements_filter
+    and_i_click_on_apply_filters
+    then_i_see_the_springfield_elementary_school
+    and_i_do_not_see_the_hogwarts_elementary_school
+    and_i_see_my_selected_show_only_schools_with_sends_specific_placements_filter
+
+    when_i_click_on_the_show_only_schools_with_sends_specific_placements_filter_tag
+    then_i_see_all_schools
+    and_i_do_not_see_the_show_only_schools_with_sends_specific_placements_filter_tag
+  end
+
+  private
+
+  def given_that_schools_exist
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+
+    @primary_school_with_send_placement = build(:placements_school, phase: "Primary", name: "Springfield Elementary", partner_providers: [@provider])
+    key_stage_1 = build(:key_stage, name: "Key stage 1")
+    _send_placement = create(:placement, :send, key_stage: key_stage_1, school: @primary_school_with_send_placement)
+
+    @primary_school_without_send_placement = build(:placements_school, phase: "Primary", name: "Hogwarts Elementary", partner_providers: [@provider])
+    @primary_subject = build(:subject, name: "Primary", subject_area: "primary")
+    _primary_placement = create(:placement, school: @primary_school_without_send_placement, subject: @primary_subject)
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_navigate_to_the_find_schools_page
+    within ".app-primary-navigation__nav" do
+      click_on "Find"
+    end
+  end
+
+  def then_i_see_the_find_schools_page
+    expect(page).to have_title("Find schools hosting placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Find schools hosting placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def and_i_see_all_schools
+    expect(page).to have_h2("Springfield Elementary")
+    expect(page).to have_h2("Hogwarts Elementary")
+  end
+  alias_method :then_i_see_all_schools, :and_i_see_all_schools
+
+  def and_i_see_the_send_placement_filter
+    expect(page).to have_element(:legend, text: "SEND placements", class: "govuk-fieldset__legend")
+    expect(page).to have_field(
+      "Show only schools with SEND specific placements",
+      type: :checkbox,
+      unchecked: true,
+    )
+  end
+
+  def when_i_select_show_only_schools_with_sends_specific_placements_filter
+    check "Show only schools with SEND specific placements"
+  end
+
+  def and_i_click_on_apply_filters
+    click_on "Apply filters"
+  end
+
+  def then_i_see_the_springfield_elementary_school
+    expect(page).to have_h2("Springfield Elementary")
+  end
+
+  def and_i_do_not_see_the_hogwarts_elementary_school
+    expect(page).not_to have_h2("Hogwarts Elementary")
+  end
+
+  def and_i_see_my_selected_show_only_schools_with_sends_specific_placements_filter
+    expect(page).to have_filter_tag("Show only schools with SEND specific placements")
+    expect(page).to have_checked_field("Show only schools with SEND specific placements")
+  end
+
+  def when_i_click_on_the_show_only_schools_with_sends_specific_placements_filter_tag
+    within ".app-filter-tags" do
+      click_on "Show only schools with SEND specific placements"
+    end
+  end
+
+  def and_i_do_not_see_the_show_only_schools_with_sends_specific_placements_filter_tag
+    expect(page).not_to have_filter_tag("Show only schools with SEND specific placements")
+    expect(page).not_to have_checked_field("Show only schools with SEND specific placements")
+  end
+end


### PR DESCRIPTION
## Context

- Add filter to Provider's Find page to filter schools with SEND placements

## Changes proposed in this pull request

- Add filter to Provider's Find page to filter schools with SEND placements

## Guidance to review

- Sign in as Patricia (Provider user)
- Assuming you have SEND placements
- Select "Show only schools with SEND specific placements"
- Click "Apply filters"
- You should then only see schools with SEND placements

## Link to Trello card

https://trello.com/c/Qrhwyva1/636-add-send-filter-to-the-provider-find-filters

## Screenshots

https://github.com/user-attachments/assets/585d475c-6708-4e6d-80f9-56b41cd37cc0


