### PR TITLE
736 wayfinding amber path

### DIFF
--- a/app/controllers/placements/schools/placements/add_multiple_placements_controller.rb
+++ b/app/controllers/placements/schools/placements/add_multiple_placements_controller.rb
@@ -48,6 +48,7 @@ class Placements::Schools::Placements::AddMultiplePlacementsController < Placeme
       user: current_user,
       school: @school,
       placements: placements,
+      academic_year: current_user.selected_academic_year,
     )
   end
 end

--- a/app/controllers/placements/schools/placements/add_placement_controller.rb
+++ b/app/controllers/placements/schools/placements/add_placement_controller.rb
@@ -64,6 +64,7 @@ class Placements::Schools::Placements::AddPlacementController < Placements::Appl
       user: current_user,
       school: @school,
       placements: [placement],
+      academic_year: current_user.selected_academic_year,
     )
   end
 end

--- a/app/mailers/placements/school_user_mailer.rb
+++ b/app/mailers/placements/school_user_mailer.rb
@@ -11,13 +11,14 @@ class Placements::SchoolUserMailer < Placements::UserMailer
     super
   end
 
-  def placement_information_added_notification(user, organisation, placements)
+  def placement_information_added_notification(user, organisation, placements, academic_year)
     @user_name = user.first_name
     @placements = placements.map do |placement|
       { title: placement.decorate.title, url: placements_school_placement_url(organisation, placement, utm_source: "email", utm_medium: "notification", utm_campaign: "school") }
     end
     @contact_email = organisation.school_contact_email_address
     @service_name = service_name
+    @hosting_interest = organisation.current_hosting_interest(academic_year:)
     @sign_in_url = sign_in_url(utm_source: "email", utm_medium: "notification", utm_campaign: "school")
 
     notify_email to: user.email, subject: t(".subject")

--- a/app/services/placements/placements/notify_school/create_placements.rb
+++ b/app/services/placements/placements/notify_school/create_placements.rb
@@ -2,10 +2,11 @@ module Placements
   module Placements
     module NotifySchool
       class CreatePlacements < ApplicationService
-        def initialize(user:, school:, placements:)
+        def initialize(user:, school:, placements:, academic_year:)
           @user = user
           @school = school
           @placements = placements
+          @academic_year = academic_year
         end
 
         def call
@@ -17,7 +18,7 @@ module Placements
         def notify_user
           ::Placements::SchoolUserMailer
             .placement_information_added_notification(
-              @user, @school, @placements
+              @user, @school, @placements, @academic_year
             ).deliver_later
         end
       end

--- a/app/views/placements/school_user_mailer/placement_information_added_notification.text.erb
+++ b/app/views/placements/school_user_mailer/placement_information_added_notification.text.erb
@@ -1,6 +1,21 @@
 <%= @user_name %>,
 
-You added placements on the Manage school placements service
+<% if @hosting_interest.interested? %>
+You added placements on the <%= @service_name %> service. Providers can see that your school may offer placements.
+
+<% @placements.each do |placement| %>
+- [<%= placement[:title] %>](<%= placement[:url] %>)
+<% end %>
+
+## What happens next?
+
+Providers will be able to email [<%= @contact_email %>](mailto:<%= @contact_email %>) about your placements your school may be able to offer.
+
+You do not need to take any further action until providers contact you.
+
+Once you are sure which placements your school can offer you can add individual placements with more detail. You can then assign providers to your placements.
+<% else %>
+You added placements on the <%= @service_name %> service.
 
 <% @placements.each do |placement| %>
 - [<%= placement[:title] %>](<%= placement[:url] %>)
@@ -11,8 +26,9 @@ You added placements on the Manage school placements service
 Providers will be able to email [<%= @contact_email %>](mailto:<%= @contact_email %>) about your placement offers.
 
 You do not need to take any further action until providers contact you. After discussions with one or more providers you can then assign providers to your placements.
+<% end %>
 
 ## Your account
-[Sign in to Manage school placements](<%= @sign_in_url %>)
+[Sign in to <%= @service_name %>](<%= @sign_in_url %>)
 
 <%= @service_name %> service

--- a/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_interested.html.erb
+++ b/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_interested.html.erb
@@ -15,6 +15,8 @@
   ) %>
 </p>
 
+<p class ="govuk-body"><%=t(".you_do_not_need_to_take_any_further_action")%></p>
+
 <p class="govuk-body">
   <%= embedded_link_text(
     t(".once_you_know_which_placements",

--- a/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_interested.html.erb
+++ b/app/views/placements/schools/hosting_interests/add_hosting_interest/whats_next/_interested.html.erb
@@ -15,7 +15,7 @@
   ) %>
 </p>
 
-<p class ="govuk-body"><%=t(".you_do_not_need_to_take_any_further_action")%></p>
+<p class="govuk-body"><%= t(".you_do_not_need_to_take_any_further_action") %></p>
 
 <p class="govuk-body">
   <%= embedded_link_text(

--- a/config/locales/en/placements/schools/hosting_interests.yml
+++ b/config/locales/en/placements/schools/hosting_interests.yml
@@ -28,6 +28,7 @@ en:
               what_happens_next: What happens next
               providers_can_contact_you:
                 Providers who are looking for schools to work with can contact you on %{mailto}.
+              you_do_not_need_to_take_any_further_action: You do not need to take any further action until providers contact you.
               once_you_know_which_placements:
                 Once you are sure which placements your school can offer, %{link}. Doing so will mean you will be able to assign providers to them.
               add_placements: add your placements

--- a/spec/mailers/previews/placements/school_user_mailer_preview.rb
+++ b/spec/mailers/previews/placements/school_user_mailer_preview.rb
@@ -11,8 +11,22 @@ class Placements::SchoolUserMailerPreview < ActionMailer::Preview
     Placements::SchoolUserMailer.partnership_created_notification(user, provider, school)
   end
 
-  def placement_information_added_notification
-    Placements::SchoolUserMailer.placement_information_added_notification(user, school, [placement])
+  def placement_information_added_notification_green_path
+    Placements::SchoolUserMailer.placement_information_added_notification(
+      user,
+      school_with_appetite("actively_looking"),
+      [placement],
+      academic_year,
+    )
+  end
+
+  def placement_information_added_notification_amber_path
+    Placements::SchoolUserMailer.placement_information_added_notification(
+      user,
+      school_with_appetite("interested"),
+      [placement],
+      academic_year,
+    )
   end
 
   def partnership_destroyed_notification
@@ -34,6 +48,33 @@ class Placements::SchoolUserMailerPreview < ActionMailer::Preview
     )
   end
 
+  def school_with_appetite(appetite)
+    school = Placements::School.new(
+      id: stubbed_id,
+      name: "Test School",
+    )
+
+    hosting_interest = hosting_interest(appetite)
+
+    school.define_singleton_method(:current_hosting_interest) do |*_args|
+      hosting_interest
+    end
+
+    school.define_singleton_method(:school_contact_email_address) do |*_args|
+      "test@sample.com"
+    end
+
+    school
+  end
+
+  def hosting_interest(appetite)
+    Placements::HostingInterest.new(
+      id: stubbed_id,
+      academic_year:,
+      appetite:,
+    )
+  end
+
   def school
     Placements::School.new(id: stubbed_id, name: "Test School")
   end
@@ -48,6 +89,10 @@ class Placements::SchoolUserMailerPreview < ActionMailer::Preview
 
   def subject
     Subject.new(id: stubbed_id, name: "English")
+  end
+
+  def academic_year
+    Placements::AcademicYear.current.next
   end
 
   def stubbed_id

--- a/spec/services/placements/placements/notify_school/create_placements_spec.rb
+++ b/spec/services/placements/placements/notify_school/create_placements_spec.rb
@@ -1,14 +1,15 @@
 require "rails_helper"
 
 RSpec.describe Placements::Placements::NotifySchool::CreatePlacements do
-  subject(:notify_school_service) { described_class.call(user:, school:, placements:) }
+  subject(:notify_school_service) { described_class.call(user:, school:, placements:, academic_year:) }
 
   it_behaves_like "a service object" do
-    let(:params) { { user: create(:placements_user), school: create(:school), placements: [create(:placement)] } }
+    let(:params) { { user: create(:placements_user), school: create(:school), placements: [create(:placement)], academic_year: create(:placements_academic_year) } }
   end
 
   describe "#call" do
     let(:placements) { [create(:placement)] }
+    let(:academic_year) { create(:placements_academic_year, :next) }
     let(:school) { create(:placements_school) }
     let!(:user) { create(:placements_user, schools: [school]) }
 
@@ -17,7 +18,7 @@ RSpec.describe Placements::Placements::NotifySchool::CreatePlacements do
         Placements::SchoolUserMailer,
         :placement_information_added_notification,
       ).with(
-        user, school, placements
+        user, school, placements, academic_year
       )
     end
   end

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
@@ -124,16 +124,8 @@ RSpec.describe "School user completes the interested journey and declares primar
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_h1("Confirm and share what you may be able to offer", class: "govuk-heading-l")
     expect(page).to have_element(:span, text: "Potential placement details", class: "govuk-caption-l")
-    expect(page).to have_element(
-      :p,
-      text: "Providers will be able to see that you may be able to offer placements for trainee teachers.",
-      class: "govuk-body",
-    )
-    expect(page).to have_element(
-      :p,
-      text: "They will be able to see your potential placement details and will be able to use your email to contact you.",
-      class: "govuk-body",
-    )
+    expect(page).to have_paragraph("Providers will be able to see that you may be able to offer placements for trainee teachers.")
+    expect(page).to have_paragraph("They will be able to see your potential placement details and will be able to use your email to contact you.")
   end
 
   def then_i_see_the_school_contact_form
@@ -142,11 +134,7 @@ RSpec.describe "School user completes the interested journey and declares primar
     )
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_h1("Who should providers contact?")
-    expect(page).to have_element(
-      :p,
-      text: "Choose the person best placed to organise placements for trainee teachers at your school",
-      class: "govuk-body",
-    )
+    expect(page).to have_paragraph("Choose the person best placed to organise placements for trainee teachers at your school")
 
     expect(page).to have_field("First name")
     expect(page).to have_field("Last name")
@@ -172,21 +160,15 @@ RSpec.describe "School user completes the interested journey and declares primar
   end
 
   def then_i_see_the_whats_next_page
+    save_and_open_page
     expect(page).to have_panel(
       "Information added",
       "Providers can see that you may offer placements",
     )
     expect(page).to have_h1("What happens next", class: "govuk-heading-l")
-    expect(page).to have_element(
-      :p,
-      text: "Providers who are looking for schools to work with can contact you on joe_bloggs@example.com.",
-      class: "govuk-body",
-    )
-    expect(page).to have_element(
-      :p,
-      text: "Once you are sure which placements your school can offer, add your placements. Doing so will mean you will be able to assign providers to them.",
-      class: "govuk-body",
-    )
+    expect(page).to have_paragraph("Providers who are looking for schools to work with can contact you on joe_bloggs@example.com.")
+    expect(page).to have_paragraph("You do not need to take any further action until providers contact you.")
+    expect(page).to have_paragraph("Once you are sure which placements your school can offer, add your placements. Doing so will mean you will be able to assign providers to them.")
     expect(page).to have_link("add your placements", href: placements_school_placements_path(@school))
   end
 

--- a/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
+++ b/spec/system/placements/schools/hosting_interest/add_hosting_interest/appetite_interested/school_user_completes_the_interested_journey_and_declares_primary_and_secondary_potential_placement_details_spec.rb
@@ -160,7 +160,6 @@ RSpec.describe "School user completes the interested journey and declares primar
   end
 
   def then_i_see_the_whats_next_page
-    save_and_open_page
     expect(page).to have_panel(
       "Information added",
       "Providers can see that you may offer placements",

--- a/spec/system/placements/schools/placements/all_through_school_user_adds_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/all_through_school_user_adds_a_placement_spec.rb
@@ -146,7 +146,8 @@ RSpec.describe "All-through school user adds a placement", service: :placements,
   end
 
   def given_that_placements_exist
-    @user_anne = create(:placements_user, first_name: "Anne", last_name: "Wilson", email: "anne_wilson@education.gov.uk")
+    @next_academic_year = build(:placements_academic_year, :next)
+    @user_anne = build(:placements_user, first_name: "Anne", last_name: "Wilson", email: "anne_wilson@education.gov.uk")
     @school = create(
       :placements_school,
       with_school_contact: true,

--- a/spec/system/placements/schools/placements/bulk_add_placements/school_user_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
+++ b/spec/system/placements/schools/placements/bulk_add_placements/school_user_bulk_adds_placements_for_primary_and_secondary_phases_spec.rb
@@ -109,8 +109,13 @@ RSpec.describe "School user bulk adds placements for primary and secondary phase
   end
 
   def and_i_am_signed_in
-    @user_anne = create(:placements_user, first_name: "Anne", last_name: "Wilson", email: "anne_wilson@education.gov.uk")
-    @school = create(:placements_school, users: [@user_anne])
+    @user_anne = build(:placements_user, first_name: "Anne", last_name: "Wilson", email: "anne_wilson@education.gov.uk")
+    @hosting_interest = build(
+      :hosting_interest,
+      academic_year: @next_academic_year,
+    )
+    @school = create(:placements_school, users: [@user_anne], hosting_interests: [@hosting_interest])
+
     sign_in_as(@user_anne)
   end
 


### PR DESCRIPTION
## Context

Users aren’t quite understanding what happens next in the journey, we’re improving our wayfinding to help address this.

## Changes proposed in this pull request

Update content on the whats next page.

Biforcate the placements created email so different content is shown for actively looking and interested schools.

## Guidance to review

Check the email and the content page against the figma designs

## Link to Trello card

(https://trello.com/c/uaPrNF6B/736-wayfinding-amber-path)

## Screenshots
Amber path email: 
<img width="588" alt="Screenshot 2025-07-04 at 09 43 31" src="https://github.com/user-attachments/assets/e4b38d98-20a4-4429-8a4b-e84e2dda0f34" />

Green path email: 

<img width="589" alt="Screenshot 2025-07-04 at 09 43 43" src="https://github.com/user-attachments/assets/825aa8bd-160b-4a8a-a009-8dd985ec1d45" />
