### PR TITLE
Add send placement details to provider find page

### DIFF
--- a/app/components/placements/schools/summary_component.html.erb
+++ b/app/components/placements/schools/summary_component.html.erb
@@ -65,6 +65,20 @@
           </dd>
         </div>
       <% end %>
+      <% if open_to_hosting? || interested_in_hosting? %>
+        <div class="app-result-detail__row">
+          <dt class="app-result-detail__key">
+            <%= t(".send_placements") %>
+          </dt>
+          <dd class="app-result-detail__value">
+            <% if offering_send? %>
+              <%= t(".yes") %>
+            <% else %>
+              <%= t(".no") %>
+            <% end %>
+          </dd>
+        </div>
+      <% end %>
       <div class="app-result-detail__row">
         <dt class="app-result-detail__key">
           <%= t(".last_offered") %>

--- a/app/components/placements/schools/summary_component.rb
+++ b/app/components/placements/schools/summary_component.rb
@@ -4,7 +4,8 @@ class Placements::Schools::SummaryComponent < ApplicationComponent
 
   delegate :school_contact, to: :school, allow_nil: true
   delegate :full_name, :email_address, to: :school_contact, prefix: true, allow_nil: true
-  delegate :available_placements, :unavailable_placements, to: :school, prefix: true, allow_nil: true
+  delegate :available_placements, :unavailable_placements, :send_placements,
+           :potential_send_placements?, to: :school, prefix: true, allow_nil: true
 
   def initialize(school:, provider:, academic_year:, location_coordinates: nil, classes: [], html_attributes: {})
     super(classes:, html_attributes:)
@@ -16,7 +17,7 @@ class Placements::Schools::SummaryComponent < ApplicationComponent
   end
 
   def link_to_school
-    if (open_to_hosting? && (unfilled_subjects.exists? || filled_subjects.exists?)) || interested_in_hosting?
+    if (open_to_hosting? && academic_year_placements.exists?) || interested_in_hosting?
       placements_placements_provider_find_path(provider, school)
     else
       school_details_placements_provider_find_path(provider, school)
@@ -36,6 +37,10 @@ class Placements::Schools::SummaryComponent < ApplicationComponent
     school_unavailable_placements(academic_year:).exists?
   end
 
+  def academic_year_placements
+    @academic_year_placements ||= school.placements.where(academic_year:)
+  end
+
   def available_placements_count
     @available_placements_count ||= school_available_placements(academic_year:).count
   end
@@ -44,12 +49,8 @@ class Placements::Schools::SummaryComponent < ApplicationComponent
     @unavailable_placements_count ||= school_unavailable_placements(academic_year:).count
   end
 
-  def unfilled_subjects
-    @unfilled_subjects ||= Subject.where(id: unfilled_subject_ids)
-  end
-
-  def filled_subjects
-    @filled_subjects ||= Subject.where(id: filled_subject_ids)
+  def send_placements_count
+    @send_placements_count ||= school_send_placements(academic_year:).count
   end
 
   def open_to_hosting?
@@ -66,6 +67,11 @@ class Placements::Schools::SummaryComponent < ApplicationComponent
 
   def not_open_to_hosting?
     current_hosting_interest_appetite == "not_open"
+  end
+
+  def offering_send?
+    send_placements_count.positive? ||
+      school_potential_send_placements?
   end
 
   private

--- a/app/controllers/placements/providers/find_controller.rb
+++ b/app/controllers/placements/providers/find_controller.rb
@@ -33,8 +33,6 @@ class Placements::Providers::FindController < Placements::ApplicationController
   def load_placements_and_subjects
     @filled_placements = filled_placements(school).decorate
     @unfilled_placements = unfilled_placements(school).decorate
-    @filled_subjects = subjects_for_placements(@filled_placements)
-    @unfilled_subjects = subjects_for_placements(@unfilled_placements)
   end
 
   def calculate_travel_time
@@ -59,6 +57,7 @@ class Placements::Providers::FindController < Placements::ApplicationController
   def unfilled_placements(school)
     school.placements
           .where(academic_year_id: selected_academic_year.id, provider_id: nil)
+          .order_by_subject_school_name
           .distinct
   end
 
@@ -66,6 +65,7 @@ class Placements::Providers::FindController < Placements::ApplicationController
     school.placements
           .where(academic_year_id: selected_academic_year.id)
           .where.not(provider_id: nil)
+          .order_by_subject_school_name
           .distinct
   end
 

--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -64,6 +64,7 @@ class Placement < ApplicationRecord
   scope :order_by_subject_school_name, -> { includes(:subject, :school).order("subjects.name", "schools.name") }
   scope :available_placements_for_academic_year, ->(academic_year) { where(provider: nil, academic_year:) }
   scope :unavailable_placements_for_academic_year, ->(academic_year) { where(academic_year:).where.not(provider: nil) }
+  scope :send_placements_for_academic_year, ->(academic_year) { where(academic_year:, send_specific: true) }
 
   # This method is used to order placement, after the schools have been ordered by distance.
   # As distance is not an attribute of school, and is given to us by the Geocoder gem.

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -170,4 +170,14 @@ class School < ApplicationRecord
   def unavailable_placements(academic_year:)
     placements.unavailable_placements_for_academic_year(academic_year)
   end
+
+  def send_placements(academic_year:)
+    placements.send_placements_for_academic_year(academic_year)
+  end
+
+  def potential_send_placements?
+    return false if potential_placement_details.blank?
+
+    potential_placement_details.dig("phase", "phases").include?("SEND")
+  end
 end

--- a/app/views/placements/providers/find/_details_navigation.html.erb
+++ b/app/views/placements/providers/find/_details_navigation.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (school:, academic_year:, provider:, unfilled_subjects:, filled_subjects: -%>
+<%# locals: (school:, academic_year:, provider:, unfilled_placements:, filled_placements: -%>
 <%= content_for(:before_content) do %>
   <%= govuk_back_link(href: placements_provider_find_index_path(provider, session["find_filter_params"])) %>
 <% end %>
@@ -12,7 +12,7 @@
 <div class="govuk-!-margin-bottom-2"></div>
 
 <%= render SecondaryNavigationComponent.new do |component| %>
-  <% if (unfilled_subjects.any? || filled_subjects.any?) && school.current_hosting_interest(academic_year:).actively_looking? %>
+  <% if (unfilled_placements.any? || filled_placements.any?) && school.current_hosting_interest(academic_year:).actively_looking? %>
     <% component.with_navigation_item t(".placements"), placements_placements_provider_find_path %>
     <% component.with_navigation_item t(".placement_information"), placement_information_placements_provider_find_path %>
     <% component.with_navigation_item t(".school_details"), school_details_placements_provider_find_path %>

--- a/app/views/placements/providers/find/placement_information.html.erb
+++ b/app/views/placements/providers/find/placement_information.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "placements/providers/find/details_navigation", school: @school, academic_year: @selected_academic_year, provider: @provider, unfilled_subjects: @unfilled_subjects, filled_subjects: @filled_subjects %>
+      <%= render "placements/providers/find/details_navigation", school: @school, academic_year: @selected_academic_year, provider: @provider, unfilled_placements: @unfilled_placements, filled_placements: @filled_placements %>
 
       <h2 class="govuk-heading-m">
         <%= t(".placement_contact") %>

--- a/app/views/placements/providers/find/placements.html.erb
+++ b/app/views/placements/providers/find/placements.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "placements/providers/find/details_navigation", school: @school, academic_year: @selected_academic_year, provider: @provider, unfilled_subjects: @unfilled_subjects, filled_subjects: @filled_subjects %>
+      <%= render "placements/providers/find/details_navigation", school: @school, academic_year: @selected_academic_year, provider: @provider, unfilled_placements: @unfilled_placements, filled_placements: @filled_placements %>
 
       <% if @interested_in_hosting && @school.potential_placement_details.present? %>
         <%= govuk_summary_list(html_attributes: { id: "education_phase" }, actions: false) do |summary_list| %>
@@ -51,7 +51,6 @@
               <% end %>
             <% end %>
           <% end %>
-
         <% end %>
 
         <% if @school.potential_placement_details["secondary_placement_quantity"].present? %>
@@ -81,13 +80,43 @@
               <% end %>
             <% end %>
           <% end %>
-          <h2 class="govuk-heading-m"><%= t(".additional_information") %></h2>
+        <% end %>
 
-          <%= govuk_summary_list(html_attributes: { id: "message_to_providers" }, actions: false) do |summary_list| %>
+        <% if @school.potential_placement_details["key_stage_placement_quantity"].present? %>
+          <h2 class="govuk-heading-m">
+            <%= t(".potential_send_placements") %>
+          </h2>
+
+          <%= govuk_summary_list(html_attributes: { id: "send_placements" }, actions: false) do |summary_list| %>
             <% summary_list.with_row do |row| %>
-              <% row.with_key(text: t(".message_to_providers")) %>
-              <% row.with_value(text: @school.potential_placement_details.dig("note_to_providers", "note")) %>
+              <% row.with_key(text: t(".key_stage")) %>
+              <% row.with_value do %>
+                <strong><%= t(".number_of_placements") %></strong>
+              <% end %>
             <% end %>
+
+            <% @school.potential_placement_details["key_stage_placement_quantity"].each do |key_stage, quantity| %>
+              <% if key_stage == "unknown" %>
+                <% summary_list.with_row do |row| %>
+                  <% row.with_key(text: t(".unknown")) %>
+                  <% row.with_value(text: t(".not_entered")) %>
+                <% end %>
+              <% else %>
+                <% summary_list.with_row do |row| %>
+                  <% row.with_key(text: key_stage.titleize) %>
+                  <% row.with_value(text: quantity.zero? ? t(".not_entered") : quantity) %>
+                <% end %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+
+        <h2 class="govuk-heading-m"><%= t(".additional_information") %></h2>
+
+        <%= govuk_summary_list(html_attributes: { id: "message_to_providers" }, actions: false) do |summary_list| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".message_to_providers")) %>
+            <% row.with_value(text: @school.potential_placement_details.dig("note_to_providers", "note")) %>
           <% end %>
         <% end %>
       <% else %>

--- a/app/views/placements/providers/find/school_details.html.erb
+++ b/app/views/placements/providers/find/school_details.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "placements/providers/find/details_navigation", school: @school, academic_year: @selected_academic_year, provider: @provider, unfilled_subjects: @unfilled_subjects, filled_subjects: @filled_subjects %>
+      <%= render "placements/providers/find/details_navigation", school: @school, academic_year: @selected_academic_year, provider: @provider, unfilled_placements: @unfilled_placements, filled_placements: @filled_placements %>
 
       <h2 class="govuk-heading-m">
         <%= t(".school_details") %>

--- a/config/locales/en/components/placements/schools/summary_component.yml
+++ b/config/locales/en/components/placements/schools/summary_component.yml
@@ -46,3 +46,6 @@ en:
           not_open_to_hosting: Not open to hosting placements
           placement_status: Previous placements
           offered_placements: Offered placements in %{academic_year_name} (%{subjects})
+          send_placements: SEND placements
+          "yes": "Yes"
+          "no": "No"

--- a/config/locales/en/placements/providers/find.yml
+++ b/config/locales/en/placements/providers/find.yml
@@ -66,6 +66,8 @@ en:
           not_entered: Not entered
           potential_secondary_placements: Potential secondary school placements
           subject: Subject
+          potential_send_placements: Potential SEND placements
+          key_stage: Key stage
           additional_information: Additional information
           message_to_providers: Message to providers
           page_title: "%{school_name} - Find"

--- a/spec/components/placements/schools/summary_component_spec.rb
+++ b/spec/components/placements/schools/summary_component_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe Placements::Schools::SummaryComponent, type: :component do
       it "displays placement information", :aggregate_failures do
         expect(page).to have_content("Placement information")
         expect(page).to have_content("Unfilled placements")
+        expect(page).to have_content("SEND placements")
         expect(page).to have_link("Approximate information available", href: "/providers/#{provider.id}/find/#{school.id}/placements")
         expect(page).to have_content("Last offered")
         expect(page).to have_content("This school has not previously hosted placements")
@@ -113,6 +114,7 @@ RSpec.describe Placements::Schools::SummaryComponent, type: :component do
       it "displays placement information", :aggregate_failures do
         expect(page).to have_content("Placement information")
         expect(page).to have_content("Unfilled placements")
+        expect(page).to have_content("SEND placements")
         expect(page).to have_link("1 unfilled placement", href: "/providers/#{provider.id}/find/#{school.id}/placements")
         expect(page).to have_content("Last offered")
         expect(page).to have_content("This school has not previously hosted placements")
@@ -174,6 +176,7 @@ RSpec.describe Placements::Schools::SummaryComponent, type: :component do
       it "displays placement information", :aggregate_failures do
         expect(page).to have_content("Placement information")
         expect(page).to have_content("Unfilled placements")
+        expect(page).to have_content("SEND placements")
         expect(page).to have_link("1 unfilled placement", href: "/providers/#{provider.id}/find/#{school.id}/placements")
         expect(page).to have_content("Hosting subjects")
         expect(page).to have_content("1 filled placement")
@@ -236,6 +239,7 @@ RSpec.describe Placements::Schools::SummaryComponent, type: :component do
 
       it "displays placement information", :aggregate_failures do
         expect(page).to have_content("Placement information")
+        expect(page).to have_content("SEND placements")
         expect(page).to have_content("Hosting subjects")
         expect(page).to have_content("1 filled placement")
         expect(page).to have_content("Last offered")

--- a/spec/system/placements/providers/find/provider_user_views_a_school_with_send_placements_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_views_a_school_with_send_placements_spec.rb
@@ -1,0 +1,201 @@
+require "rails_helper"
+
+RSpec.describe "Provider user views a school with previous, filled and unfilled placements", service: :placements, type: :system do
+  scenario do
+    given_that_schools_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_find_schools_page
+    then_i_see_the_find_schools_page
+    and_i_see_shelbyville_high_school_is_offering_send_placements
+    and_i_see_springfield_elementary_school_is_not_offering_send_placements
+    and_i_see_hogwarts_is_offering_send_placements
+    and_i_see_ogdenville_elementary_school_is_not_offering_send_placements
+
+    when_i_click_on_shelbyville_high_school
+    then_i_see_the_shelbyville_high_school_show_page
+    and_i_see_an_unfilled_placement_for_send_key_stage_1
+    and_i_see_an_filled_placement_for_send_key_stage_5
+
+    when_i_click_on_back
+    and_i_click_on_hogwarts
+    then_i_see_the_hogwarts_show_page
+    and_i_see_hogwarts_will_potentially_offer_send_placements
+  end
+
+  private
+
+  def given_that_schools_exist
+    academic_year = Placements::AcademicYear.current.next
+    @provider = build(:placements_provider, name: "Aes Sedai Trust")
+
+    @key_stage_1 = build(:key_stage, name: "Key stage 1")
+    @key_stage_5 = build(:key_stage, name: "Key stage 5")
+
+    @english = build(:subject, :secondary, name: "English")
+    @science = build(:subject, :secondary, name: "Science")
+
+    send_placements_school_hosting_interest = build(:hosting_interest, academic_year:)
+    @send_placements_school = create(
+      :placements_school,
+      :secondary,
+      name: "Shelbyville High School",
+      hosting_interests: [send_placements_school_hosting_interest],
+    )
+    create(
+      :placement,
+      :send,
+      academic_year:,
+      key_stage: @key_stage_1,
+      school: @send_placements_school,
+    )
+    create(
+      :placement,
+      :send,
+      academic_year:,
+      key_stage: @key_stage_5,
+      school: @send_placements_school,
+      provider: @provider,
+    )
+
+    non_send_placements_school_hosting_interest = build(:hosting_interest, academic_year:)
+    @non_send_placements_school = create(
+      :placements_school,
+      :secondary,
+      name: "Springfield Elementary School",
+      hosting_interests: [non_send_placements_school_hosting_interest],
+    )
+    create(:placement, academic_year:, subject: @english, school: @non_send_placements_school)
+    create(:placement, academic_year:, subject: @science, school: @non_send_placements_school)
+
+    potential_send_placement_school_hosting_interest = build(
+      :hosting_interest,
+      academic_year:,
+      appetite: "interested",
+    )
+    @potential_send_placement_school = create(
+      :placements_school,
+      :secondary,
+      name: "Hogwarts",
+      hosting_interests: [potential_send_placement_school_hosting_interest],
+      potential_placement_details: { "phase" => { "phases" => %w[SEND] },
+                                     "key_stage_selection" => { "key_stage_ids" => [@key_stage_1.id, @key_stage_5.id] },
+                                     "key_stage_placement_quantity" => { "key_stage_1" => 2, "key_stage_5" => 1 } },
+    )
+
+    potential_non_send_placement_school_hosting_interest = build(
+      :hosting_interest,
+      academic_year:,
+      appetite: "interested",
+    )
+    @potential_non_send_placement_school = create(
+      :placements_school,
+      :secondary,
+      name: "Ogdenville Elementary School",
+      hosting_interests: [potential_non_send_placement_school_hosting_interest],
+      potential_placement_details: { "phase" => { "phases" => %w[Primary Secondary] },
+                                     "year_group_selection" => { "year_groups" => ["Year 1, Year 2"] },
+                                     "secondary_placement_quantity" => { "biology" => 1, "chemistry" => 2 },
+                                     "year_group_placement_quantity" => { "year_1" => 2, "year_2" => 1 } },
+    )
+  end
+
+  def and_i_am_signed_in
+    sign_in_placements_user(organisations: [@provider])
+  end
+
+  def when_i_navigate_to_the_find_schools_page
+    within ".app-primary-navigation__nav" do
+      click_on "Find"
+    end
+  end
+
+  def then_i_see_the_find_schools_page
+    expect(page).to have_title("Find schools hosting placements - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Find schools hosting placements")
+    expect(page).to have_h2("Filter")
+  end
+
+  def and_i_see_shelbyville_high_school_is_offering_send_placements
+    shelbyville_result = page.find(".app-search-results__item", text: "Shelbyville High School")
+    within(shelbyville_result) do
+      expect(page).to have_tag("Placements available", "green")
+      expect(page).to have_result_detail_row("SEND placements", "Yes")
+    end
+  end
+
+  def and_i_see_springfield_elementary_school_is_not_offering_send_placements
+    springfield_result = page.find(".app-search-results__item", text: "Springfield Elementary School")
+    within(springfield_result) do
+      expect(page).to have_tag("Placements available", "green")
+      expect(page).to have_result_detail_row("SEND placements", "No")
+    end
+  end
+
+  def and_i_see_hogwarts_is_offering_send_placements
+    hogwarts_result = page.find(".app-search-results__item", text: "Hogwarts")
+    within(hogwarts_result) do
+      expect(page).to have_tag("May offer placements", "yellow")
+      expect(page).to have_result_detail_row("SEND placements", "Yes")
+    end
+  end
+
+  def and_i_see_ogdenville_elementary_school_is_not_offering_send_placements
+    ogdenville_result = page.find(".app-search-results__item", text: "Ogdenville Elementary School")
+    within(ogdenville_result) do
+      expect(page).to have_tag("May offer placements", "yellow")
+      expect(page).to have_result_detail_row("SEND placements", "No")
+    end
+  end
+
+  def when_i_click_on_shelbyville_high_school
+    click_on "Shelbyville High School"
+  end
+
+  def then_i_see_the_shelbyville_high_school_show_page
+    expect(page).to have_title("Shelbyville High School - Find - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Shelbyville High School")
+    expect(page).to have_tag("Placements available", "green")
+  end
+
+  def and_i_see_an_unfilled_placement_for_send_key_stage_1
+    expect(page).to have_h2("1 unfilled placement")
+    expect(page).to have_table_row({
+      "Subject" => "SEND (Key stage 1)",
+      "Expected date" => "Any time in the academic year",
+    })
+  end
+
+  def and_i_see_an_filled_placement_for_send_key_stage_5
+    expect(page).to have_h2("1 filled placement")
+    expect(page).to have_table_row({
+      "Subject" => "SEND (Key stage 5)",
+      "Expected date" => "Any time in the academic year",
+    })
+  end
+
+  def when_i_click_on_back
+    click_on "Back"
+  end
+
+  def and_i_click_on_hogwarts
+    click_on "Hogwarts"
+  end
+
+  def then_i_see_the_hogwarts_show_page
+    expect(page).to have_title("Hogwarts - Find - Manage school placements - GOV.UK")
+    expect(primary_navigation).to have_current_item("Find")
+    expect(page).to have_h1("Hogwarts")
+    expect(page).to have_tag("May offer placements", "yellow")
+  end
+
+  def and_i_see_hogwarts_will_potentially_offer_send_placements
+    expect(page).to have_summary_list_row("Phase", "SEND")
+    expect(page).to have_h2("Potential SEND placements")
+    expect(page).to have_summary_list_row("Key stage", "Number of placements")
+    expect(page).to have_summary_list_row("Key Stage 1", "2")
+    expect(page).to have_summary_list_row("Key Stage 5", "1")
+  end
+end


### PR DESCRIPTION
## Context

- Add SEND information to Provider Find page.

## Changes proposed in this pull request

- Add SEND information to School details in Provider index and show pages

## Guidance to review

- Sign in as Patricia (Provider user)
Assuming you have either SEND placements or Potential SEND Placement details
- On the "Find" page, you should see a new "SEND placements" row in the school details
- Click a school offering SEND
- You should see the SEND placements/potential placement details displayed.

## Link to Trello card

https://trello.com/c/jnIXRpNU/750-add-send-placement-details-to-provider-find-page

## Screenshots

![screencapture-placements-localhost-3000-providers-000a36aa-1d68-470b-9da4-dc0c1ee1bd62-find-2025-06-27-09_29_07](https://github.com/user-attachments/assets/aa3f774e-4650-412d-9a2e-1058db1c3982)

![screencapture-placements-localhost-3000-providers-000a36aa-1d68-470b-9da4-dc0c1ee1bd62-find-0000a28f-a328-4fab-8b50-a6c847693f00-placements-2025-06-27-09_29_49](https://github.com/user-attachments/assets/520b3053-eef8-4463-82ef-6fbe118ad398)

![screencapture-placements-localhost-3000-providers-000a36aa-1d68-470b-9da4-dc0c1ee1bd62-find-fff95bf3-5d88-4331-a4f0-795ccff12ec9-placements-2025-06-27-09_30_25](https://github.com/user-attachments/assets/5ba59896-31ad-49b1-bb2b-8a2186f0d18e)
