### PR TITLE
Update hint text on edit placement provider step

### DIFF
--- a/app/views/wizards/placements/edit_placement_wizard/_provider_step.html.erb
+++ b/app/views/wizards/placements/edit_placement_wizard/_provider_step.html.erb
@@ -17,6 +17,7 @@
     value: current_step.provider_name,
     label: t(".select_a_provider"),
     caption: contextual_text,
+    hint: t(".hint_html"),
     previous_search: current_step.provider_id,
     field_name: :provider_id,
   },

--- a/config/locales/en/wizards/placements/edit_placement_wizard.yml
+++ b/config/locales/en/wizards/placements/edit_placement_wizard.yml
@@ -8,6 +8,7 @@ en:
           not_known: Not yet known
           continue: Continue
           help_with_providers: My provider is not listed
+          hint_html: Ensure you have agreed with the provider that their trainee will undertake this placement at your school
           you_need_to_add_a_provider: You must %{link} before they can be assigned to a specific placement.
           add_a_provider: add providers to your school's profile
           not_contractual_agreement: Assigning a provider is not a contractual agreement for the provider to place a trainee at your school. You must liaise with this provider to arrange the placement.

--- a/spec/system/placements/schools/placements/primary_school_user_edits_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/primary_school_user_edits_a_placement_spec.rb
@@ -407,6 +407,7 @@ RSpec.describe "Primary school user edits a placement", :js, service: :placement
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
     expect(page).to have_element(:label, text: "Select a provider", class: "govuk-label--l")
+    expect(page).to have_hint("Ensure you have agreed with the provider that their trainee will undertake this placement at your school")
     expect(page).to have_button("Continue")
     expect(page).to have_link("Cancel", href: "/schools/#{@springfield_elementary_school.id}/placements/#{@placement.id}")
   end

--- a/spec/system/placements/schools/placements/secondary_school_user_edits_a_placement_spec.rb
+++ b/spec/system/placements/schools/placements/secondary_school_user_edits_a_placement_spec.rb
@@ -325,6 +325,7 @@ RSpec.describe "Secondary school user edits a placement", :js, service: :placeme
     expect(primary_navigation).to have_current_item("Placements")
     expect(page).to have_element(:span, text: "Placement details", class: "govuk-caption-l")
     expect(page).to have_element(:label, text: "Select a provider", class: "govuk-label--l")
+    expect(page).to have_hint("Ensure you have agreed with the provider that their trainee will undertake this placement at your school")
     expect(page).to have_button("Continue")
     expect(page).to have_link("Cancel", href: "/schools/#{@hogwarts_school.id}/placements/#{@placement.id}")
   end


### PR DESCRIPTION
## Context

Users aren’t quite understanding what happens next in the journey, we’re improving our wayfinding to help address this.

## Changes proposed in this pull request

Add hint to the provider search step of the edit placements wizard. 

## Guidance to review

Check the hint text appears as expected, compare vs the figma file.

## Link to Trello card
(https://trello.com/c/aUf88OXD/737-wayfinding-assign-provider-path)
## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
