### PR TITLE
Wayfinding improvements to the provider find interface

### DIFF
--- a/app/controllers/placements/providers/find_controller.rb
+++ b/app/controllers/placements/providers/find_controller.rb
@@ -1,7 +1,7 @@
 class Placements::Providers::FindController < Placements::ApplicationController
   before_action :set_provider
   before_action :selected_academic_year
-  before_action :load_placements_and_subjects, only: %i[placements placement_information school_details]
+  before_action :load_placements_and_subjects, only: %i[placements placement_contact school_details]
   before_action :store_filter_params, only: %i[index]
   helper_method :filter_form, :location_coordinates
 
@@ -18,11 +18,11 @@ class Placements::Providers::FindController < Placements::ApplicationController
     @interested_in_hosting = school.current_hosting_interest(academic_year: selected_academic_year).interested?
   end
 
-  def placement_information
+  def placement_contact; end
+
+  def school_details
     @placements_last_offered = placements_last_offered
   end
-
-  def school_details; end
 
   private
 

--- a/app/views/placements/providers/find/_details_navigation.html.erb
+++ b/app/views/placements/providers/find/_details_navigation.html.erb
@@ -9,16 +9,20 @@
 
 <%= render Placements::Schools::InterestTagComponent.new(school:, academic_year:) %>
 
+<% unless request.path == school_details_placements_provider_find_path %>
+  <p class="govuk-body govuk-!-margin-top-6"><%= t(".email_this_school") %></p>
+<% end %>
+
 <div class="govuk-!-margin-bottom-2"></div>
 
 <%= render SecondaryNavigationComponent.new do |component| %>
   <% if (unfilled_placements.any? || filled_placements.any?) && school.current_hosting_interest(academic_year:).actively_looking? %>
     <% component.with_navigation_item t(".placements"), placements_placements_provider_find_path %>
-    <% component.with_navigation_item t(".placement_information"), placement_information_placements_provider_find_path %>
+    <% component.with_navigation_item t(".placement_contact"), placement_contact_placements_provider_find_path %>
     <% component.with_navigation_item t(".school_details"), school_details_placements_provider_find_path %>
   <% elsif school.current_hosting_interest(academic_year:)&.interested? %>
     <% component.with_navigation_item t(".placements"), placements_placements_provider_find_path %>
-    <% component.with_navigation_item t(".placement_information"), placement_information_placements_provider_find_path %>
+    <% component.with_navigation_item t(".placement_contact"), placement_contact_placements_provider_find_path %>
     <% component.with_navigation_item t(".school_details"), school_details_placements_provider_find_path %>
   <% else %>
     <% component.with_navigation_item t(".school_details"), school_details_placements_provider_find_path %>

--- a/app/views/placements/providers/find/placement_contact.html.erb
+++ b/app/views/placements/providers/find/placement_contact.html.erb
@@ -20,30 +20,6 @@
           <% row.with_value(text: @school.school_contact_email_address) %>
         <% end %>
       <% end %>
-
-      <h2 class="govuk-heading-m">
-        <%= t(".placements_hosted_in_previous_years") %>
-      </h2>
-
-      <% if @placements_last_offered.any? %>
-        <%= govuk_summary_list(actions: false) do |summary_list| %>
-          <% @placements_last_offered.each do |academic_year, placements| %>
-            <% summary_list.with_row do |row| %>
-              <% row.with_key(text: academic_year.name) %>
-              <% row.with_value do %>
-                  <p class="govuk-body"><%= t(".offered_placements_in") %></p>
-                  <ul class="govuk-list">
-                    <% placements.each do |placement| %>
-                      <li><%= placement.title %></li>
-                    <% end %>
-                  </ul>
-              <% end %>
-            <% end %>
-          <% end %>
-        <% end %>
-      <% else %>
-        <p class="govuk-body"><%= t(".unknown") %></p>
-      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/placements/providers/find/school_details.html.erb
+++ b/app/views/placements/providers/find/school_details.html.erb
@@ -33,6 +33,29 @@
       <% end %>
 
       <h2 class="govuk-heading-m">
+        <%= t(".placements_hosted_in_previous_years") %>
+      </h2>
+
+      <% if @placements_last_offered.any? %>
+        <%= govuk_summary_list(actions: false) do |summary_list| %>
+          <% @placements_last_offered.each do |academic_year, placements| %>
+            <% summary_list.with_row do |row| %>
+              <% row.with_key(text: academic_year.name) %>
+              <% row.with_value do %>
+                <ul class="govuk-list">
+                  <% placements.each do |placement| %>
+                    <li><%= placement.title %></li>
+                  <% end %>
+                </ul>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% else %>
+        <p class="govuk-body"><%= t(".unknown_previous_placements") %></p>
+      <% end %>
+
+      <h2 class="govuk-heading-m">
         <%= t(".general_contact_details") %>
       </h2>
 

--- a/config/locales/en/placements/providers/find.yml
+++ b/config/locales/en/placements/providers/find.yml
@@ -75,7 +75,7 @@ en:
           additional_information: Additional information
           message_to_providers: Message to providers
           page_title: "%{school_name} - Find"
-          description: This school has specified which placements they would like to host in the %{academic_year_name} academic year.
+          description: This school has specified which placements they can offer in the %{academic_year_name} academic year.
           unfilled_placements:
             one: "%{count} unfilled placement"
             other: "%{count} unfilled placements"
@@ -88,27 +88,26 @@ en:
               expected_date: Expected date
         details_navigation:
           page_title: "%{school_name} - Find"
+          email_this_school: Email this school if you have suitable trainees.
           placements: Placements
-          placement_information: Placement information
+          placement_contact: Contact
           school_details: School details
-        placement_information:
+        placement_contact:
           page_title: "%{school_name} - Find"
           placements: Placements
-          placement_information: Placement information
           school_details: School details
           placement_contact: Placement contact
           name: Name
           email: Email
           mentors: Mentors
           trained_mentors: Trained mentors
-          placements_hosted_in_previous_years: Placements hosted in previous years
-          offered_placements_in: "Offered placements in:"
-          unknown: This school has not previously offered placements
         school_details:
           page_title: "%{school_name} - Find"
           placements: Placements
           placement_information: Placement information
           school_details: School details
+          placements_hosted_in_previous_years: Previously offered placements
+          unknown_previous_placements: This school has not previously offered placements
           phase: Phase
           age_range: Age range
           ukprn: UK provider reference number (UKPRN)

--- a/config/routes/placements.rb
+++ b/config/routes/placements.rb
@@ -182,7 +182,7 @@ scope module: :placements,
       resources :find, only: %i[index] do
         member do
           get "placements", to: "find#placements"
-          get "placement_information", to: "find#placement_information"
+          get "placement_contact", to: "find#placement_contact"
           get "school_details", to: "find#school_details"
         end
       end

--- a/spec/system/placements/providers/find/provider_user_views_a_not_hosting_school_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_views_a_not_hosting_school_spec.rb
@@ -50,6 +50,6 @@ RSpec.describe "Provider user views a not hosting school", service: :placements,
 
   def and_i_cannot_see_a_link_to_view_the_not_hosting_school_details
     expect(page).not_to have_link("Shelbyville High School", href: placements_placements_provider_find_path(@provider, @not_hosting_school))
-    expect(page).not_to have_link("Shelbyville High School", href: placement_information_placements_provider_find_path(@provider, @not_hosting_school))
+    expect(page).not_to have_link("Shelbyville High School", href: placement_contact_placements_provider_find_path(@provider, @not_hosting_school))
   end
 end

--- a/spec/system/placements/providers/find/provider_user_views_a_placements_already_organised_school_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_views_a_placements_already_organised_school_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe "Provider user views a placements already organised school", serv
     then_i_can_see_the_placements_school_detail_page
     and_i_do_not_see_available_placements
 
-    when_i_navigate_to_the_placement_information_page
-    then_i_see_the_placement_information_page
+    when_i_navigate_to_the_placement_contact_page
+    then_i_see_the_placement_contact_page
 
     when_i_navigate_to_the_school_details_page
     then_i_see_the_school_details_page
@@ -87,7 +87,7 @@ RSpec.describe "Provider user views a placements already organised school", serv
     expect(page).to have_h1("Shelbyville High School")
     expect(page).to have_tag("No placements available", "blue")
     expect(secondary_navigation).to have_current_item("Placements")
-    expect(page).to have_element(:p, text: "This school has specified which placements they would like to host in the #{@academic_year.name} academic year.", class: "govuk-body")
+    expect(page).to have_element(:p, text: "This school has specified which placements they can offer in the #{@academic_year.name} academic year.", class: "govuk-body")
     expect(page).to have_h2("1 filled placement")
     expect(page).to have_table_row({
       "Subject" => "Primary (Year 1)",
@@ -99,21 +99,20 @@ RSpec.describe "Provider user views a placements already organised school", serv
     expect(page).not_to have_h2("Available placements")
   end
 
-  def when_i_navigate_to_the_placement_information_page
-    click_on "Placement information"
+  def when_i_navigate_to_the_placement_contact_page
+    click_on "Contact"
   end
 
-  def then_i_see_the_placement_information_page
+  def then_i_see_the_placement_contact_page
     expect(page).to have_title("Shelbyville High School - Find - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Find")
     expect(page).to have_h1("Shelbyville High School")
     expect(page).to have_tag("No placements available", "blue")
-    expect(secondary_navigation).to have_current_item("Placement information")
+    expect(page).to have_paragraph("Email this school if you have suitable trainees.")
+    expect(secondary_navigation).to have_current_item("Contact")
     expect(page).to have_h2("Placement contact")
     expect(page).to have_summary_list_row("Name", "Placement Coordinator")
     expect(page).to have_summary_list_row("Email", "placement_coordinator@example.school")
-    expect(page).to have_h2("Placements hosted in previous years")
-    expect(page).to have_element(:p, text: "This school has not previously offered placements", class: "govuk-body")
   end
 
   def when_i_navigate_to_the_school_details_page

--- a/spec/system/placements/providers/find/provider_user_views_a_school_which_is_not_onboarded_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_views_a_school_which_is_not_onboarded_spec.rb
@@ -41,6 +41,6 @@ RSpec.describe "Provider user views a school which is not onboarded", service: :
 
   def and_i_cannot_see_a_link_to_view_the_school_that_is_not_onboarded
     expect(page).not_to have_link("Shelbyville High School", href: placements_placements_provider_find_path(@provider, @not_onboarded_school))
-    expect(page).not_to have_link("Shelbyville High School", href: placement_information_placements_provider_find_path(@provider, @not_onboarded_school))
+    expect(page).not_to have_link("Shelbyville High School", href: placement_contact_placements_provider_find_path(@provider, @not_onboarded_school))
   end
 end

--- a/spec/system/placements/providers/find/provider_user_views_a_school_with_previous_filled_unfilled_placements_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_views_a_school_with_previous_filled_unfilled_placements_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe "Provider user views a school with previous, filled and unfilled 
     when_i_click_on_the_unfilled_placements_school_name
     then_i_can_see_the_placements_school_detail_page
 
-    when_i_navigate_to_the_placement_information_page
-    then_i_see_the_placement_information_page
+    when_i_navigate_to_the_placement_contact_page
+    then_i_see_the_placement_contact_page
 
     when_i_navigate_to_the_school_details_page
     then_i_see_the_school_details_page
@@ -90,7 +90,7 @@ RSpec.describe "Provider user views a school with previous, filled and unfilled 
     expect(page).to have_h1("Shelbyville High School")
     expect(page).to have_tag("Placements available", "green")
     expect(secondary_navigation).to have_current_item("Placements")
-    expect(page).to have_element(:p, text: "This school has specified which placements they would like to host in the #{@academic_year.name} academic year.", class: "govuk-body")
+    expect(page).to have_element(:p, text: "This school has specified which placements they can offer in the #{@academic_year.name} academic year.", class: "govuk-body")
     expect(page).to have_h2("1 unfilled placement")
     expect(page).to have_table_row({
       "Subject" => "Primary (Year 1)",
@@ -107,22 +107,20 @@ RSpec.describe "Provider user views a school with previous, filled and unfilled 
     expect(page).not_to have_h2("filled placements")
   end
 
-  def when_i_navigate_to_the_placement_information_page
-    click_on "Placement information"
+  def when_i_navigate_to_the_placement_contact_page
+    click_on "Contact"
   end
 
-  def then_i_see_the_placement_information_page
+  def then_i_see_the_placement_contact_page
     expect(page).to have_title("Shelbyville High School - Find - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Find")
     expect(page).to have_h1("Shelbyville High School")
     expect(page).to have_tag("Placements available", "green")
-    expect(secondary_navigation).to have_current_item("Placement information")
+    expect(page).to have_paragraph("Email this school if you have suitable trainees.")
+    expect(secondary_navigation).to have_current_item("Contact")
     expect(page).to have_h2("Placement contact")
     expect(page).to have_summary_list_row("Name", "Placement Coordinator")
     expect(page).to have_summary_list_row("Email", "placement_coordinator@example.school")
-    expect(page).to have_h2("Placements hosted in previous years")
-    expect(page).to have_summary_list_row(@previous_academic_year.name, "Offered placements in:")
-    expect(page).to have_summary_list_row(@previous_academic_year.name, "Primary (Year 3)")
   end
 
   def when_i_navigate_to_the_school_details_page
@@ -142,8 +140,10 @@ RSpec.describe "Provider user views a school with previous, filled and unfilled 
     expect(page).to have_summary_list_row("UK provider reference number (UKPRN)", "12345678")
     expect(page).to have_summary_list_row("Unique reference number (URN)", "123456")
 
+    expect(page).to have_h2("Previously offered placements")
+    expect(page).to have_summary_list_row(@previous_academic_year.name, "Primary (Year 3)")
+
     expect(page).to have_h2("General contact details")
-    expect(page).to have_summary_list_row("Telephone number", "01234567890")
     expect(page).to have_summary_list_row("Website", "www.shelbyville.sch.uk (opens in new tab)")
     expect(page).to have_link("www.shelbyville.sch.uk (opens in new tab)", href: "http://www.shelbyville.sch.uk", target: "_blank")
     expect(page).to have_summary_list_row("Address", "123 Main St Shelbyville 12345")

--- a/spec/system/placements/providers/find/provider_user_views_an_open_to_hosting_school_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_views_an_open_to_hosting_school_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Provider user views a school which is open to hosting", service:
     and_i_see_all_schools
 
     when_i_click_on_the_open_to_hosting_school_name
-    then_i_see_the_placement_information_page
+    then_i_see_the_placements_page
 
     when_i_navigate_to_the_school_details_page
     then_i_see_the_school_details_page
@@ -80,11 +80,12 @@ RSpec.describe "Provider user views a school which is open to hosting", service:
     click_on "Shelbyville High School"
   end
 
-  def then_i_see_the_placement_information_page
+  def then_i_see_the_placements_page
     expect(page).to have_title("Shelbyville High School - Find - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Find")
     expect(page).to have_h1("Shelbyville High School")
     expect(page).to have_tag("May offer placements", "yellow")
+    expect(page).to have_paragraph("Email this school if you have suitable trainees.")
     expect(secondary_navigation).to have_current_item("Placements")
     expect(page).to have_summary_list_row("Phase", "Primary Secondary")
     expect(page).to have_h2("Potential primary school placements")

--- a/spec/system/placements/providers/find/provider_user_views_an_unfilled_placements_school_spec.rb
+++ b/spec/system/placements/providers/find/provider_user_views_an_unfilled_placements_school_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe "Provider user views a school which has unfilled placements", ser
     then_i_can_see_the_placements_school_detail_page
     and_i_do_not_see_unavailable_placements
 
-    when_i_navigate_to_the_placement_information_page
-    then_i_see_the_placement_information_page
+    when_i_navigate_to_the_placement_contact_page
+    then_i_see_the_placement_contact_page
 
     when_i_navigate_to_the_school_details_page
     then_i_see_the_school_details_page
@@ -87,7 +87,7 @@ RSpec.describe "Provider user views a school which has unfilled placements", ser
     expect(page).to have_h1("Shelbyville High School")
     expect(page).to have_tag("Placements available", "green")
     expect(secondary_navigation).to have_current_item("Placements")
-    expect(page).to have_element(:p, text: "This school has specified which placements they would like to host in the #{@academic_year.name} academic year.", class: "govuk-body")
+    expect(page).to have_element(:p, text: "This school has specified which placements they can offer in the #{@academic_year.name} academic year.", class: "govuk-body")
     expect(page).to have_h2("1 unfilled placement")
     expect(page).to have_table_row({
       "Subject" => "Primary (Year 1)",
@@ -99,21 +99,19 @@ RSpec.describe "Provider user views a school which has unfilled placements", ser
     expect(page).not_to have_h2("filled placements")
   end
 
-  def when_i_navigate_to_the_placement_information_page
-    click_on "Placement information"
+  def when_i_navigate_to_the_placement_contact_page
+    click_on "Contact"
   end
 
-  def then_i_see_the_placement_information_page
+  def then_i_see_the_placement_contact_page
     expect(page).to have_title("Shelbyville High School - Find - Manage school placements - GOV.UK")
     expect(primary_navigation).to have_current_item("Find")
     expect(page).to have_h1("Shelbyville High School")
     expect(page).to have_tag("Placements available", "green")
-    expect(secondary_navigation).to have_current_item("Placement information")
+    expect(secondary_navigation).to have_current_item("Contact")
     expect(page).to have_h2("Placement contact")
     expect(page).to have_summary_list_row("Name", "Placement Coordinator")
     expect(page).to have_summary_list_row("Email", "placement_coordinator@example.school")
-    expect(page).to have_h2("Placements hosted in previous years")
-    expect(page).to have_element(:p, text: "This school has not previously offered placements", class: "govuk-body")
   end
 
   def when_i_navigate_to_the_school_details_page


### PR DESCRIPTION
## Context

Users aren’t quite understanding what happens next in the journey, we’re improving our wayfinding to help address this.

## Changes proposed in this pull request

Rename placement information secondary nav to contact. Add content to placements and contact pages. Move previously offered placements to school details. 

## Guidance to review

Go through the provider find pages and look for any discrepancies from the Figma files.

## Link to Trello card

https://trello.com/c/MSNmNuvB/738-wayfinding-provider-view

## Screenshots
Placements page: 
<img width="701" alt="Screenshot 2025-07-02 at 17 09 54" src="https://github.com/user-attachments/assets/836fc230-6d77-41d0-8a2f-46dd1937aeff" />
Contact page: 
<img width="693" alt="Screenshot 2025-07-02 at 17 10 26" src="https://github.com/user-attachments/assets/2997e8dc-9adf-4bba-9ae7-bec5fbbdfc46" />

School details page: 
<img width="686" alt="Screenshot 2025-07-02 at 17 10 40" src="https://github.com/user-attachments/assets/54d722e7-05c8-4ca5-8ccd-980ab09cfe36" />
