### PR TITLE
Update claim window warning banner to show hours remaining

### DIFF
--- a/app/components/claims/claim_window_warning_banner_component.html.erb
+++ b/app/components/claims/claim_window_warning_banner_component.html.erb
@@ -1,5 +1,9 @@
 <% if render? %>
   <%= render(GovukComponent::NotificationBannerComponent.new(title_text: t(".important"))) do |nb|
-        nb.with_heading(text: t(".claim_window_closing_soon", count: days_until_claim_window_closes))
+        if claim_window_today?
+          nb.with_heading(text: t(".claim_window_closing_soon.hours", count: hours_until_claim_window_closes, minutes: minutes_until_claim_window_closes))
+        else
+          nb.with_heading(text: t(".claim_window_closing_soon.days", count: days_until_claim_window_closes))
+        end
       end %>
 <% end %>

--- a/app/components/claims/claim_window_warning_banner_component.rb
+++ b/app/components/claims/claim_window_warning_banner_component.rb
@@ -2,10 +2,22 @@ class Claims::ClaimWindowWarningBannerComponent < ApplicationComponent
   private
 
   def render?
-    days_until_claim_window_closes <= 30 && days_until_claim_window_closes >= 0
+    hours_until_claim_window_closes >= 0 && days_until_claim_window_closes <= 30
   end
 
   def days_until_claim_window_closes
     (Claims::ClaimWindow.current.ends_on - Date.current).to_i
+  end
+
+  def hours_until_claim_window_closes
+    (Time.current.seconds_until_end_of_day / 1.hour).to_i
+  end
+
+  def minutes_until_claim_window_closes
+    ((Time.current.seconds_until_end_of_day % 1.hour) / 1.minute).to_i
+  end
+
+  def claim_window_today?
+    Claims::ClaimWindow.current.ends_on == Date.current
   end
 end

--- a/config/locales/en/components/claims/claim_window_warning_banner_component.yml
+++ b/config/locales/en/components/claims/claim_window_warning_banner_component.yml
@@ -3,6 +3,11 @@ en:
     claims:
       claim_window_warning_banner_component:
         claim_window_closing_soon:
-          one: There is %{count} day remaining to claim for ITT general mentor training before the claim window closes.
-          other: There are %{count} days remaining to claim for ITT general mentor training before the claim window closes.
+          days:
+            one: There is %{count} day remaining to claim for ITT general mentor training before the claim window closes.
+            other: There are %{count} days remaining to claim for ITT general mentor training before the claim window closes.
+          hours:
+            zero: There are %{minutes} minutes remaining to claim for ITT general mentor training before the claim window closes.
+            one: There is %{count} hour and %{minutes} minutes remaining to claim for ITT general mentor training before the claim window closes.
+            other: There are %{count} hours and %{minutes} minutes remaining to claim for ITT general mentor training before the claim window closes.
         important: Important

--- a/spec/components/claims/claim_window_warning_banner_component_spec.rb
+++ b/spec/components/claims/claim_window_warning_banner_component_spec.rb
@@ -7,13 +7,14 @@ RSpec.describe Claims::ClaimWindowWarningBannerComponent, type: :component do
 
   before do
     claim_window
-    render_inline(component)
   end
 
   context "when there are > 30 days left in the claim window" do
     let(:ends_on) { 2.months.from_now }
 
     it "does not render the banner" do
+      render_inline(component)
+
       expect(page).not_to have_css(".govuk-notification-banner")
       expect(page).not_to have_content("Important")
     end
@@ -24,6 +25,8 @@ RSpec.describe Claims::ClaimWindowWarningBannerComponent, type: :component do
       let(:ends_on) { 1.week.from_now }
 
       it "renders the banner" do
+        render_inline(component)
+
         expect(page).to have_css(".govuk-notification-banner")
         expect(page).to have_content("Important")
         expect(page).to have_content("There are 7 days remaining to claim for ITT general mentor training before the claim window closes.")
@@ -34,9 +37,50 @@ RSpec.describe Claims::ClaimWindowWarningBannerComponent, type: :component do
       let(:ends_on) { 1.day.from_now }
 
       it "renders the banner" do
+        render_inline(component)
+
         expect(page).to have_css(".govuk-notification-banner")
         expect(page).to have_content("Important")
         expect(page).to have_content("There is 1 day remaining to claim for ITT general mentor training before the claim window closes.")
+      end
+    end
+  end
+
+  context "when there are < 1 day left in the claim window" do
+    let(:ends_on) { Date.new(2025, 7, 3) }
+
+    context "when there is 23 hours left" do
+      it "renders the banner" do
+        Timecop.travel(Time.zone.local(2025, 7, 3, 0, 54, 50)) do
+          render_inline(component)
+          expect(page).to have_css(".govuk-notification-banner")
+          expect(page).to have_content("Important")
+          expect(page).to have_content("There are 23 hours and 5 minutes remaining to claim for ITT general mentor training before the claim window closes.")
+        end
+      end
+    end
+
+    context "when there is 1 hour left" do
+      it "renders the banner" do
+        Timecop.travel(Time.zone.local(2025, 7, 3, 22, 54, 50)) do
+          render_inline(component)
+
+          expect(page).to have_css(".govuk-notification-banner")
+          expect(page).to have_content("Important")
+          expect(page).to have_content("There is 1 hour and 5 minutes remaining to claim for ITT general mentor training before the claim window closes.")
+        end
+      end
+    end
+
+    context "when there is less than 1 hour left" do
+      it "renders the banner" do
+        Timecop.travel(Time.zone.local(2025, 7, 3, 23, 44, 50)) do
+          render_inline(component)
+
+          expect(page).to have_css(".govuk-notification-banner")
+          expect(page).to have_content("Important")
+          expect(page).to have_content("There are 15 minutes remaining to claim for ITT general mentor training before the claim window closes.")
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

Ensure that on the final day of a claim window the hours and minutes are displayed; rather than 0 days.

## Changes proposed in this pull request

Update the notification banner to show hours and days on the last day of a claim window.

## Link to Trello card

https://trello.com/c/p89C1NYn/756-when-claim-window-has-0-1-day-remaining-show-hours-left-instead-of-0-days

## Screenshots

<img width="869" alt="Screenshot 2025-07-03 at 16 05 36" src="https://github.com/user-attachments/assets/21f390d2-8ecd-4a47-b371-0e84d3c3e19d" />
