### PR TITLE
Add Provider Name to claims CSV's

### DIFF
--- a/app/services/claims/clawback/generate_csv_file.rb
+++ b/app/services/claims/clawback/generate_csv_file.rb
@@ -6,6 +6,7 @@ class Claims::Clawback::GenerateCSVFile < ApplicationService
     school_urn
     school_name
     school_local_authority
+    provider_name
     claim_amount
     clawback_amount
     school_type_of_establishment
@@ -28,6 +29,7 @@ class Claims::Clawback::GenerateCSVFile < ApplicationService
           claim.school.urn,
           claim.school_name,
           claim.school.local_authority_name,
+          claim.provider_name,
           claim.amount,
           claim.total_clawback_amount,
           claim.school.type_of_establishment,

--- a/app/services/claims/clawback_response/generate_csv_file.rb
+++ b/app/services/claims/clawback_response/generate_csv_file.rb
@@ -6,6 +6,7 @@ class Claims::ClawbackResponse::GenerateCSVFile < ApplicationService
     school_urn
     school_name
     school_local_authority
+    provider_name
     claim_amount
     clawback_amount
     school_type_of_establishment
@@ -28,6 +29,7 @@ class Claims::ClawbackResponse::GenerateCSVFile < ApplicationService
           row["school_urn"],
           row["school_name"],
           row["school_local_authority"],
+          row["provider_name"],
           row["claim_amount"],
           row["clawback_amount"],
           row["school_type_of_establishment"],

--- a/app/services/claims/payment_response/generate_csv_file.rb
+++ b/app/services/claims/payment_response/generate_csv_file.rb
@@ -6,6 +6,7 @@ class Claims::PaymentResponse::GenerateCSVFile < ApplicationService
     school_urn
     school_name
     school_local_authority
+    provider_name
     claim_amount
     school_type_of_establishment
     school_group
@@ -28,6 +29,7 @@ class Claims::PaymentResponse::GenerateCSVFile < ApplicationService
           row["school_urn"],
           row["school_name"],
           row["school_local_authority"],
+          row["provider_name"],
           row["claim_amount"],
           row["school_type_of_establishment"],
           row["school_group"],

--- a/app/services/claims/payments/claim/generate_csv_file.rb
+++ b/app/services/claims/payments/claim/generate_csv_file.rb
@@ -6,6 +6,7 @@ class Claims::Payments::Claim::GenerateCSVFile < ApplicationService
     school_urn
     school_name
     school_local_authority
+    provider_name
     claim_amount
     school_type_of_establishment
     school_group
@@ -28,6 +29,7 @@ class Claims::Payments::Claim::GenerateCSVFile < ApplicationService
           claim.school.urn,
           claim.school_name,
           claim.school.local_authority_name,
+          claim.provider_name,
           claim.amount.format(symbol: false, decimal_mark: ".", no_cents: false),
           claim.school.type_of_establishment,
           claim.school.group,

--- a/app/services/claims/sampling/generate_csv_file.rb
+++ b/app/services/claims/sampling/generate_csv_file.rb
@@ -8,6 +8,7 @@ class Claims::Sampling::GenerateCSVFile < ApplicationService
     school_local_authority
     school_type_of_establishment
     school_group
+    provider_name
     claim_submission_date
     mentor_full_name
     mentor_hours_of_training
@@ -33,6 +34,7 @@ class Claims::Sampling::GenerateCSVFile < ApplicationService
             claim.school.local_authority_name,
             claim.school.type_of_establishment,
             claim.school.group,
+            claim.provider_name,
             claim.submitted_at.iso8601,
             mentor_training.mentor_full_name,
             mentor_training.hours_completed,

--- a/app/services/claims/sampling_response/generate_csv_file.rb
+++ b/app/services/claims/sampling_response/generate_csv_file.rb
@@ -8,6 +8,7 @@ class Claims::SamplingResponse::GenerateCSVFile < ApplicationService
     school_local_authority
     school_type_of_establishment
     school_group
+    provider_name
     claim_submission_date
     mentor_full_name
     mentor_hours_of_training
@@ -32,6 +33,7 @@ class Claims::SamplingResponse::GenerateCSVFile < ApplicationService
           row["school_local_authority"],
           row["school_type_of_establishment"],
           row["school_group"],
+          row["provider_name"],
           row["claim_submission_date"],
           row["mentor_full_name"],
           row["mentor_hours_of_training"],

--- a/spec/services/claims/clawback/generate_csv_file_spec.rb
+++ b/spec/services/claims/clawback/generate_csv_file_spec.rb
@@ -21,9 +21,10 @@ describe Claims::Clawback::GenerateCSVFile do
            group: "Independent schools",
            type_of_establishment: "Other independent school")
   end
-  let(:claim_1) { create(:claim, :submitted, status: :clawback_in_progress, school: school_a, reference: "11111111") }
-  let(:claim_2) { create(:claim, :submitted, status: :clawback_in_progress, school: school_b, reference: "22222222") }
-  let(:claim_3) { create(:claim, :submitted, status: :clawback_in_progress, school: school_b, reference: "33333333") }
+  let(:provider) { create(:claims_provider, name: "Springfield Trust") }
+  let(:claim_1) { create(:claim, :submitted, status: :clawback_in_progress, school: school_a, reference: "11111111", provider:) }
+  let(:claim_2) { create(:claim, :submitted, status: :clawback_in_progress, school: school_b, reference: "22222222", provider:) }
+  let(:claim_3) { create(:claim, :submitted, status: :clawback_in_progress, school: school_b, reference: "33333333", provider:) }
   let(:mentor_jane_doe) do
     create(:claims_mentor, schools: [school_a, school_b], first_name: "Jane", last_name: "Doe")
   end
@@ -105,6 +106,7 @@ describe Claims::Clawback::GenerateCSVFile do
         school_urn
         school_name
         school_local_authority
+        provider_name
         claim_amount
         clawback_amount
         school_type_of_establishment
@@ -118,6 +120,7 @@ describe Claims::Clawback::GenerateCSVFile do
           "aaaaaaaa",
           "School A",
           "Local Auth A",
+          "Springfield Trust",
           "876.00",
           "876.00",
           "Academy converter",
@@ -132,6 +135,7 @@ describe Claims::Clawback::GenerateCSVFile do
           "bbbbbbbb",
           "School B",
           "Local Auth B",
+          "Springfield Trust",
           "2316.00",
           "1544.00",
           "Other independent school",

--- a/spec/services/claims/clawback_response/generate_csv_file_spec.rb
+++ b/spec/services/claims/clawback_response/generate_csv_file_spec.rb
@@ -27,7 +27,7 @@ describe Claims::ClawbackResponse::GenerateCSVFile do
            reason_clawed_back: "Invalid claim")
   end
 
-  let(:csv_content) { "claim_reference,school_urn,school_name,school_local_authority,claim_amount,clawback_amount,school_type_of_establishment,school_group,claim_submission_date,claim_status\n11111111,aaaaaaaa,School A,Local Auth A,876.00,876.00,Academy converter,Academy,#{claim_1.submitted_at&.iso8601},clawback_in_progress" }
+  let(:csv_content) { "claim_reference,school_urn,school_name,school_local_authority,claim_amount,clawback_amount,school_type_of_establishment,school_group,claim_submission_date,claim_status,provider_name\n11111111,aaaaaaaa,School A,Local Auth A,876.00,876.00,Academy converter,Academy,#{claim_1.submitted_at&.iso8601},clawback_in_progress,Springfield Trust" }
 
   before { claim_1_jane_doe_mentor_training }
 
@@ -43,6 +43,7 @@ describe Claims::ClawbackResponse::GenerateCSVFile do
         school_urn
         school_name
         school_local_authority
+        provider_name
         claim_amount
         clawback_amount
         school_type_of_establishment
@@ -56,6 +57,7 @@ describe Claims::ClawbackResponse::GenerateCSVFile do
           "aaaaaaaa",
           "School A",
           "Local Auth A",
+          "Springfield Trust",
           "876.00",
           "876.00",
           "Academy converter",

--- a/spec/services/claims/payment_response/generate_csv_file_spec.rb
+++ b/spec/services/claims/payment_response/generate_csv_file_spec.rb
@@ -4,9 +4,9 @@ describe Claims::PaymentResponse::GenerateCSVFile do
   subject(:generate_csv_file) { described_class.call(csv_content:) }
 
   let(:csv_content) do
-    "claim_reference,school_urn,school_name,school_local_authority,claim_amount,school_type_of_establishment,school_group,claim_submission_date,claim_status,claim_unpaid_reason\n" \
-    "12345678,11111111,School A,London,500.00,Free schools 16 to 19,Free Schools,2025-01-27,paid\n" \
-    "87654321,22222222,School B,York,999.99,Academy sponsor led,Academies,2025-01-27,unpaid,Some reason"
+    "claim_reference,school_urn,school_name,school_local_authority,claim_amount,school_type_of_establishment,school_group,claim_submission_date,claim_status,claim_unpaid_reason,provider_name\n" \
+    "12345678,11111111,School A,London,500.00,Free schools 16 to 19,Free Schools,2025-01-27,paid,,Springfield Trust\n" \
+    "87654321,22222222,School B,York,999.99,Academy sponsor led,Academies,2025-01-27,unpaid,Some reason,Springfield Trust"
   end
 
   describe "#call" do
@@ -17,7 +17,7 @@ describe Claims::PaymentResponse::GenerateCSVFile do
       csv = CSV.read(generate_csv_file.path, headers: true)
 
       expect(csv.headers).to eq(
-        %w[claim_reference school_urn school_name school_local_authority claim_amount school_type_of_establishment school_group claim_submission_date claim_status claim_unpaid_reason],
+        %w[claim_reference school_urn school_name school_local_authority provider_name claim_amount school_type_of_establishment school_group claim_submission_date claim_status claim_unpaid_reason],
       )
 
       first_row = csv[0]
@@ -31,6 +31,7 @@ describe Claims::PaymentResponse::GenerateCSVFile do
       expect(first_row["claim_submission_date"]).to eq("2025-01-27")
       expect(first_row["claim_status"]).to eq("paid")
       expect(first_row["claim_unpaid_reason"]).to be_nil
+      expect(first_row["provider_name"]).to eq("Springfield Trust")
 
       last_row = csv[1]
       expect(last_row["claim_reference"]).to eq("87654321")
@@ -43,6 +44,7 @@ describe Claims::PaymentResponse::GenerateCSVFile do
       expect(last_row["claim_submission_date"]).to eq("2025-01-27")
       expect(last_row["claim_status"]).to eq("unpaid")
       expect(last_row["claim_unpaid_reason"]).to eq("Some reason")
+      expect(last_row["provider_name"]).to eq("Springfield Trust")
     end
   end
 end

--- a/spec/services/claims/payments/claim/generate_csv_file_spec.rb
+++ b/spec/services/claims/payments/claim/generate_csv_file_spec.rb
@@ -12,7 +12,7 @@ describe Claims::Payments::Claim::GenerateCSVFile do
 
       csv = CSV.read(generate_csv_file.path)
 
-      expect(csv.first).to eq(%w[claim_reference school_urn school_name school_local_authority claim_amount school_type_of_establishment school_group claim_submission_date claim_status claim_unpaid_reason])
+      expect(csv.first).to eq(%w[claim_reference school_urn school_name school_local_authority provider_name claim_amount school_type_of_establishment school_group claim_submission_date claim_status claim_unpaid_reason])
 
       claims.each_with_index do |claim, index|
         expect(csv[index + 1]).to eq([
@@ -20,6 +20,7 @@ describe Claims::Payments::Claim::GenerateCSVFile do
           claim.school.urn,
           claim.school_name,
           claim.school.local_authority_name,
+          claim.provider_name,
           claim.amount.format(symbol: false, decimal_mark: ".", no_cents: false),
           claim.school.type_of_establishment,
           claim.school.group,

--- a/spec/services/claims/sampling/generate_csv_file_spec.rb
+++ b/spec/services/claims/sampling/generate_csv_file_spec.rb
@@ -21,6 +21,7 @@ describe Claims::Sampling::GenerateCSVFile do
         school_local_authority
         school_type_of_establishment
         school_group
+        provider_name
         claim_submission_date
         mentor_full_name
         mentor_hours_of_training
@@ -36,6 +37,7 @@ describe Claims::Sampling::GenerateCSVFile do
           school.local_authority_name,
           school.type_of_establishment,
           school.group,
+          claim.provider_name,
           claim.submitted_at.iso8601,
           claim.mentor_trainings.first.mentor_full_name,
           claim.mentor_trainings.first.hours_completed.to_s,

--- a/spec/services/claims/sampling_response/generate_csv_file_spec.rb
+++ b/spec/services/claims/sampling_response/generate_csv_file_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+describe Claims::SamplingResponse::GenerateCSVFile do
+  subject(:generate_csv_file) { described_class.call(csv_content:, provider_name: "Springfield Trust") }
+
+  let(:csv_content) do
+    "claim_reference,school_urn,school_name,school_local_authority,school_type_of_establishment,school_group,claim_submission_date,mentor_full_name,mentor_hours_of_training,claim_accepted,rejection_reason,provider_name\n" \
+    "12345678,11111111,School A,London,Free schools 16 to 19,Free Schools,2025-01-27,John Doe,15,true,,Springfield Trust\n" \
+    "87654321,22222222,School B,York,Academy sponsor led,Academies,2025-01-27,Jane Doe,10,false,Some reason,Springfield Trust"
+  end
+
+  describe "#call" do
+    it "generates a CSV file of claims" do
+      expect(generate_csv_file).to be_a(CSV)
+      expect(generate_csv_file).to be_closed
+
+      csv = CSV.read(generate_csv_file.path, headers: true)
+
+      expect(csv.headers).to eq(%w[
+        claim_reference
+        school_urn
+        school_name
+        school_local_authority
+        school_type_of_establishment
+        school_group
+        provider_name
+        claim_submission_date
+        mentor_full_name
+        mentor_hours_of_training
+        claim_accepted
+        rejection_reason
+      ])
+
+      first_row = csv[0]
+      expect(first_row["claim_reference"]).to eq("12345678")
+      expect(first_row["school_urn"]).to eq("11111111")
+      expect(first_row["school_name"]).to eq("School A")
+      expect(first_row["school_local_authority"]).to eq("London")
+      expect(first_row["school_type_of_establishment"]).to eq("Free schools 16 to 19")
+      expect(first_row["school_group"]).to eq("Free Schools")
+      expect(first_row["claim_submission_date"]).to eq("2025-01-27")
+      expect(first_row["mentor_full_name"]).to eq("John Doe")
+      expect(first_row["mentor_hours_of_training"]).to eq("15")
+      expect(first_row["claim_accepted"]).to eq("true")
+      expect(first_row["rejection_reason"]).to be_nil
+      expect(first_row["provider_name"]).to eq("Springfield Trust")
+
+      last_row = csv[1]
+      expect(last_row["claim_reference"]).to eq("87654321")
+      expect(last_row["school_urn"]).to eq("22222222")
+      expect(last_row["school_name"]).to eq("School B")
+      expect(last_row["school_local_authority"]).to eq("York")
+      expect(last_row["school_type_of_establishment"]).to eq("Academy sponsor led")
+      expect(last_row["school_group"]).to eq("Academies")
+      expect(last_row["claim_submission_date"]).to eq("2025-01-27")
+      expect(last_row["mentor_full_name"]).to eq("Jane Doe")
+      expect(last_row["mentor_hours_of_training"]).to eq("10")
+      expect(last_row["claim_accepted"]).to eq("false")
+      expect(last_row["rejection_reason"]).to eq("Some reason")
+      expect(last_row["provider_name"]).to eq("Springfield Trust")
+    end
+  end
+end

--- a/spec/system/claims/support/claims/view_claims_spec.rb
+++ b/spec/system/claims/support/claims/view_claims_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe "View claims", :js, service: :claims, type: :system do
         expect(page).to have_content(claim.school_name)
         expect(page).to have_content(claim.reference)
         expect(page).to have_content("Submitted")
-        expect(page).to have_content(claim.provider.name)
+        expect(page).to have_content(claim.provider_name)
         expect(page).to have_content(I18n.l(claim.submitted_at.to_date, format: :long))
         expect(page).to have_content(claim.amount.format(no_cents_if_whole: true))
       end


### PR DESCRIPTION
## Context

Users and support staff need more information to work with when processing claims. Adding provider names to the csvs reduces the need to leave their current workflow to look this up.

## Changes proposed in this pull request

Update all generated CSVs from the service (payments, auditing, clawbacks) to include the provider the claim is assigned to.

Most providers have URNs and/or UKPRNs but not all, so for now the provider’s name is likely good enough.

Add a provider_name header to each CSV.

## Guidance to review

Generate/upload some csvs to see if they are pulling through correctly.

## Link to Trello card

https://trello.com/c/cd1mrDQP/775-update-csvs-to-include-provider

## Screenshots

<img width="1142" alt="Screenshot 2025-07-07 at 14 17 46" src="https://github.com/user-attachments/assets/1a010b16-037b-472e-a50e-5e064876206c" />

