### PR TITLE
Add validation to prevent overlapping claim windows

### DIFF
--- a/app/models/claims/claim_window.rb
+++ b/app/models/claims/claim_window.rb
@@ -34,6 +34,7 @@ class Claims::ClaimWindow < ApplicationRecord
 
   validate :does_not_start_within_another_claim_window
   validate :does_not_end_within_another_claim_window
+  validate :does_not_overlap_another_claim_window
 
   delegate :name, :starts_on, :ends_on, to: :academic_year, prefix: true
   delegate :past?, to: :ends_on
@@ -71,5 +72,14 @@ class Claims::ClaimWindow < ApplicationRecord
     return unless Claims::ClaimWindow.where.not(id:).where("starts_on <= :ends_on AND ends_on >= :ends_on", ends_on:).exists?
 
     errors.add(:ends_on, :overlap)
+  end
+
+  def does_not_overlap_another_claim_window
+    return unless Claims::ClaimWindow.where.not(id:).where(
+      "starts_on >= :starts_on AND ends_on <= :ends_on", starts_on:, ends_on:
+    ).exists?
+
+    errors.add(:starts_on, :existing_window)
+    errors.add(:ends_on, :existing_window)
   end
 end

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -185,6 +185,7 @@ en:
             starts_on:
               blank: Enter a window opening date
               overlap: Select a date that is not within an existing claim window
+              existing_window: A claim window already exists within the selected dates
             ends_on:
               blank: Enter a window closing date
               overlap: Select a date that is not within an existing claim window

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -89,6 +89,7 @@ en:
             starts_on:
               blank: Enter a window opening date
               overlap: Select a date that is not within an existing claim window
+              existing_window: A claim window already exists within the selected dates
             ends_on:
               blank: Enter a window closing date
               overlap: Select a date that is not within an existing claim window

--- a/spec/forms/claims/claim_window_form_spec.rb
+++ b/spec/forms/claims/claim_window_form_spec.rb
@@ -21,6 +21,36 @@ describe Claims::ClaimWindowForm, type: :model do
       expect(claim_window_form).to be_invalid
       expect(claim_window_form.errors[:ends_on]).to include("Enter a window closing date that is after the opening date")
     end
+
+    context "with validating against existing claim windows" do
+      before do
+        create(:claim_window, starts_on: Date.parse("1 July 2024"), ends_on: Date.parse("31 July 2024"), academic_year:)
+      end
+
+      it "validates that the start date does not fall within an existing claim window" do
+        claim_window_form.starts_on = Date.parse("17 July 2024")
+        claim_window_form.ends_on = Date.parse("27 August 2024")
+
+        expect(claim_window_form).to be_invalid
+        expect(claim_window_form.errors[:starts_on]).to include("Select a date that is not within an existing claim window")
+      end
+
+      it "validates that the end date does not fall within an existing claim window" do
+        claim_window_form.starts_on = Date.parse("1 June 2024")
+        claim_window_form.ends_on = Date.parse("17 July 2024")
+
+        expect(claim_window_form).to be_invalid
+        expect(claim_window_form.errors[:ends_on]).to include("Select a date that is not within an existing claim window")
+      end
+
+      it "validates that no claim windows existing within the given start and end dates" do
+        claim_window_form.starts_on = Date.parse("1 June 2024")
+        claim_window_form.ends_on = Date.parse("31 August 2024")
+
+        expect(claim_window_form).to be_invalid
+        expect(claim_window_form.errors[:starts_on]).to include("A claim window already exists within the selected dates")
+      end
+    end
   end
 
   describe "#academic_year_name" do

--- a/spec/models/claims/claim_window_spec.rb
+++ b/spec/models/claims/claim_window_spec.rb
@@ -69,6 +69,14 @@ RSpec.describe Claims::ClaimWindow, type: :model do
         expect(claim_window).to be_invalid
         expect(claim_window.errors[:ends_on]).to include("Select a date that is not within an existing claim window")
       end
+
+      it "validates that no claim windows existing within the given start and end dates" do
+        claim_window.starts_on = Date.parse("1 June 2024")
+        claim_window.ends_on = Date.parse("31 August 2024")
+
+        expect(claim_window).to be_invalid
+        expect(claim_window.errors[:starts_on]).to include("A claim window already exists within the selected dates")
+      end
     end
   end
 

--- a/spec/system/claims/support/support_users_adds_a_claim_window_which_includes_dates_within_an_existing_claim_window_spec.rb
+++ b/spec/system/claims/support/support_users_adds_a_claim_window_which_includes_dates_within_an_existing_claim_window_spec.rb
@@ -1,0 +1,130 @@
+require "rails_helper"
+
+RSpec.describe "Support user adds a claim window which includes dates within an existing claim window",
+               freeze: "04 July 2025",
+               service: :claims,
+               type: :system do
+  scenario do
+    given_a_claims_window_exists
+    and_i_am_signed_in
+
+    when_i_navigate_to_settings
+    and_click_on_claims_windows
+    then_i_see_the_claims_windows_index_page
+    and_i_see_an_existing_claim_window
+
+    when_i_click_on_add_claim_window
+    then_i_see_the_claim_window_form
+
+    when_i_enter_a_window_opens_date_before_the_existing_claim_window
+    and_i_enter_a_window_closes_date_after_the_existing_claim_window
+    and_i_select_the_academic_year_of_the_existing_claims_window
+    and_i_click_on_continue
+    then_i_see_a_validation_error_for_entering_dates_containing_existing_claims_windows
+  end
+
+  private
+
+  def given_a_claims_window_exists
+    @academic_year = AcademicYear.for_date("01/07/2025")
+    @existing_claim_window = create(
+      :claim_window,
+      starts_on: Date.parse("01/07/2025"),
+      ends_on: Date.parse("31/07/2025"),
+      academic_year: @academic_year,
+    )
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_settings
+    within(primary_navigation) do
+      click_on "Settings"
+    end
+  end
+
+  def and_click_on_claims_windows
+    click_on "Claim windows"
+  end
+
+  def then_i_see_the_claims_windows_index_page
+    expect(page).to have_title("Claim windows - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Claim windows")
+    expect(page).to have_current_path(claims_support_claim_windows_path)
+    expect(page).to have_link(
+      "Add claim window",
+      href: new_claims_support_claim_window_path,
+      class: "govuk-button",
+    )
+  end
+
+  def and_i_see_an_existing_claim_window
+    expect(page).to have_table_row(
+      "Claim window" => "1 July 2025 to 31 July 2025",
+      "Academic year" => "2024 to 2025",
+      "Status" => "Current",
+    )
+  end
+
+  def when_i_click_on_add_claim_window
+    click_on "Add claim window"
+  end
+
+  def then_i_see_the_claim_window_form
+    expect(page).to have_title("Window details - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_span_caption("Add claim window")
+    expect(page).to have_h1("Window details")
+
+    expect(page).to have_element(
+      :legend,
+      text: "Window opens",
+      class: "govuk-fieldset__legend govuk-fieldset__legend--s",
+    )
+    within_fieldset "Window opens" do
+      expect(page).to have_field("Day", type: :text)
+      expect(page).to have_field("Month", type: :text)
+      expect(page).to have_field("Year", type: :text)
+    end
+
+    expect(page).to have_element(
+      :legend,
+      text: "Window closes",
+      class: "govuk-fieldset__legend govuk-fieldset__legend--s",
+    )
+    within_fieldset "Window closes" do
+      expect(page).to have_field("Day", type: :text)
+      expect(page).to have_field("Month", type: :text)
+      expect(page).to have_field("Year", type: :text)
+    end
+  end
+
+  def when_i_enter_a_window_opens_date_before_the_existing_claim_window
+    within_fieldset "Window opens" do
+      fill_in "Day", with: "1"
+      fill_in "Month", with: "6"
+      fill_in "Year", with: "2025"
+    end
+  end
+
+  def and_i_enter_a_window_closes_date_after_the_existing_claim_window
+    within_fieldset "Window closes" do
+      fill_in "Day", with: "1"
+      fill_in "Month", with: "8"
+      fill_in "Year", with: "2025"
+    end
+  end
+
+  def and_i_select_the_academic_year_of_the_existing_claims_window
+    choose "2024 to 2025"
+  end
+
+  def and_i_click_on_continue
+    click_on "Continue"
+  end
+
+  def then_i_see_a_validation_error_for_entering_dates_containing_existing_claims_windows
+    expect(page).to have_validation_error("A claim window already exists within the selected dates")
+  end
+end


### PR DESCRIPTION
## Context

- Add validation to claim windows to prevent overlapping claim windows.

## Changes proposed in this pull request

- Add validation to claim windows to prevent overlapping claim windows.

## Guidance to review

- Sign in as Colin (Support user)
- Navigate to "Settings"
- Click on "Claim windows"
- Make note of an existing start and end date of a claim window
- Click on "Add claim window"
- Fill in the form to create a claim window starting before and ending after an existing claim window
- You will see a validation error

## Link to Trello card

https://trello.com/c/6aQ0TtoE/765-add-validation-to-prevent-2-current-claim-windows-existing

## Screenshots

![screencapture-claims-localhost-3000-support-claim-windows-2025-07-04-14_17_52](https://github.com/user-attachments/assets/48fe89b9-4843-4c7a-97df-3d126ccbbdb6)

![screencapture-claims-localhost-3000-support-claim-windows-check-2025-07-04-14_11_03](https://github.com/user-attachments/assets/8199e7ff-653e-45ab-a82a-a3f6f023f83e)

