### PR TITLE
Paginate activity log page

### DIFF
--- a/app/controllers/claims/support/claims/claim_activities_controller.rb
+++ b/app/controllers/claims/support/claims/claim_activities_controller.rb
@@ -9,9 +9,14 @@ class Claims::Support::Claims::ClaimActivitiesController < Claims::Support::Appl
 
   def show
     authorize [:claims, claim_activity]
-
-    if claim_activity.sampling_uploaded?
-      @pagy, @provider_samplings = pagy(claim_activity.record.provider_samplings.order_by_provider_name)
+    case @claim_activity.action
+    when *Claims::ClaimActivity::SAMPLING_ACTIONS
+      @pagy, @provider_samplings = pagy(@claim_activity.record.provider_samplings.order_by_provider_name)
+    when *Claims::ClaimActivity::PAYMENT_AND_CLAWBACK_ACTIONS
+      @pagy, @claims = pagy(@claim_activity.record.claims.order(:reference))
+      @claims_by_provider = @claims.group_by(&:provider)
+    when *Claims::ClaimActivity::MANUAL_ACTIONS
+      @claim = @claim_activity.record
     end
 
     @claim_activity = claim_activity.decorate

--- a/app/views/claims/support/claims/claim_activities/_manual_activities.html.erb
+++ b/app/views/claims/support/claims/claim_activities/_manual_activities.html.erb
@@ -1,8 +1,8 @@
-<%# locals: (claim_activity:) -%>
+<%# locals: (claim:) -%>
 
 <h2 class="govuk-heading-m"><%= t(".providers") %></h2>
 
-<h3 class="govuk-heading-s"><%= claim_activity.record.provider_name %></h3>
+<h3 class="govuk-heading-s"><%= claim.provider_name %></h3>
 
 <%= govuk_table do |table| %>
   <% table.with_head do |head| %>
@@ -15,9 +15,9 @@
 
   <% table.with_body do |body| %>
     <% body.with_row do |row| %>
-      <% row.with_cell text: govuk_link_to(claim_activity.record.reference, claims_support_claim_path(claim_activity.record)) %>
-      <% row.with_cell text: claim_activity.record.mentors.count %>
-      <% row.with_cell text: humanized_money_with_symbol(claim_activity.record.amount) %>
+      <% row.with_cell text: govuk_link_to(claim.reference, claims_support_claim_path(claim)) %>
+      <% row.with_cell text: claim.mentors.count %>
+      <% row.with_cell text: humanized_money_with_symbol(claim.amount) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/claims/support/claims/claim_activities/_payment_and_clawback_activities.html.erb
+++ b/app/views/claims/support/claims/claim_activities/_payment_and_clawback_activities.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (claim_activity:) -%>
+<%# locals: (claim_activity:, claims:) -%>
 
 <div class="govuk-button-group">
   <%= govuk_button_link_to t(".download_csv"), claim_activity.record.csv_file, secondary: true %>
@@ -9,7 +9,7 @@
 
 <h2 class="govuk-heading-m"><%= t(".providers") %></h2>
 
-<% claim_activity.claims_by_provider.each do |provider, provider_claims| %>
+<% claims.each do |provider, provider_claims| %>
   <h3 class="govuk-heading-s"><%= provider.name %></h3>
 
   <%= govuk_table do |table| %>

--- a/app/views/claims/support/claims/claim_activities/_sampling_activities.html.erb
+++ b/app/views/claims/support/claims/claim_activities/_sampling_activities.html.erb
@@ -1,9 +1,9 @@
-<%# locals: (claim_activity:) -%>
+<%# locals: (claim_activity:, provider_samplings:) -%>
 
 <h2 class="govuk-heading-m"><%= t(".providers") %></h2>
 
-<% claim_activity.record.provider_samplings.each do |provider_sampling| %>
-  <h3 class="govuk-heading-s"><%= provider_sampling.provider.name %></h3>
+<% provider_samplings.each do |provider_sampling| %>
+  <h3 class="govuk-heading-s"><%= provider_sampling.provider_name %></h3>
 
   <div class="govuk-button-group">
     <%= govuk_button_link_to t(".download_csv"), provider_sampling.csv_file, secondary: true %>

--- a/app/views/claims/support/claims/claim_activities/show.html.erb
+++ b/app/views/claims/support/claims/claim_activities/show.html.erb
@@ -13,14 +13,14 @@
 
   <% case @claim_activity.action %>
   <% when *Claims::ClaimActivity::SAMPLING_ACTIONS %>
-    <%= render "sampling_activities", claim_activity: @claim_activity %>
+    <%= render "sampling_activities", claim_activity: @claim_activity, provider_samplings: @provider_samplings %>
   <% when *Claims::ClaimActivity::PAYMENT_AND_CLAWBACK_ACTIONS %>
-    <%= render "payment_and_clawback_activities", claim_activity: @claim_activity %>
+    <%= render "payment_and_clawback_activities", claim_activity: @claim_activity, claims: @claims_by_provider %>
   <% when *Claims::ClaimActivity::MANUAL_ACTIONS %>
-    <%= render "manual_activities", claim_activity: @claim_activity %>
+    <%= render "manual_activities", claim: @claim %>
   <% else %>
     <%= render "base_response_activity", claim_activity: @claim_activity %>
   <% end %>
 
-  <%= render PaginationComponent.new(pagy: @pagy) if @pagy %>
+  <%= render PaginationComponent.new(pagy: @pagy) if @pagy.present? %>
 </div>


### PR DESCRIPTION
## Context

Currently we show all the claims on a single page, creating a massive list of claims is fairly slow to load. We should paginate this list as we do elsewhere in the application.

## Changes proposed in this pull request

Paginate the claims that are shown on the activity log page

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/UeC0Xhxh/762-paginate-activity-log-show-page

## Screenshots

<img width="3584" height="4688" alt="image" src="https://github.com/user-attachments/assets/a643f09c-a261-4381-8efd-e9e837dad092" />

<img width="3584" height="3158" alt="image" src="https://github.com/user-attachments/assets/abfb04d8-9e28-45dd-a19d-538eb64c49ca" />

