### PR TITLE
Fix claim window banner spec

### DIFF
--- a/spec/components/claims/claim_window_warning_banner_component_spec.rb
+++ b/spec/components/claims/claim_window_warning_banner_component_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 RSpec.describe Claims::ClaimWindowWarningBannerComponent, type: :component do
   subject(:component) { described_class.new }
 
-  let(:claim_window) { create(:claim_window, :current, ends_on:) }
+  let(:claim_window) { create(:claim_window, :current, ends_on:, starts_on:) }
+  let(:starts_on) { 8.months.ago }
 
   before do
     claim_window


### PR DESCRIPTION
## Context

Claim window banner spec needs a start date as well as an end date; otherwise validation error is created when instantiating the claim_window object.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
