### PR TITLE
Fix claim window banner spec

### DIFF
--- a/spec/components/claims/claim_window_warning_banner_component_spec.rb
+++ b/spec/components/claims/claim_window_warning_banner_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Claims::ClaimWindowWarningBannerComponent, type: :component do
+RSpec.describe Claims::ClaimWindowWarningBannerComponent, freeze: "1 July 2025", type: :component do
   subject(:component) { described_class.new }
 
   let(:claim_window) { create(:claim_window, :current, ends_on:) }
@@ -10,7 +10,7 @@ RSpec.describe Claims::ClaimWindowWarningBannerComponent, type: :component do
   end
 
   context "when there are > 30 days left in the claim window" do
-    let(:ends_on) { 2.months.from_now }
+    let(:ends_on) { Date.new(2025, 9, 1) }
 
     it "does not render the banner" do
       render_inline(component)
@@ -22,7 +22,7 @@ RSpec.describe Claims::ClaimWindowWarningBannerComponent, type: :component do
 
   context "when there are <= 30 days left in the claim window" do
     context "when there is more than 1 day left" do
-      let(:ends_on) { 1.week.from_now }
+      let(:ends_on) { Date.new(2025, 7, 8) }
 
       it "renders the banner" do
         render_inline(component)
@@ -34,7 +34,7 @@ RSpec.describe Claims::ClaimWindowWarningBannerComponent, type: :component do
     end
 
     context "when there is 1 day left" do
-      let(:ends_on) { 1.day.from_now }
+      let(:ends_on) { Date.new(2025, 7, 2) }
 
       it "renders the banner" do
         render_inline(component)


### PR DESCRIPTION
## Context

Claim window banner spec needs a start date as well as an end date; otherwise validation error is created when instantiating the claim_window object.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
