### PR TITLE
Add claim reminder emails

### DIFF
--- a/app/controllers/claims/support/claims_reminders_controller.rb
+++ b/app/controllers/claims/support/claims_reminders_controller.rb
@@ -1,0 +1,34 @@
+class Claims::Support::ClaimsRemindersController < Claims::Support::ApplicationController
+  before_action :skip_authorization
+  before_action :set_claim_window
+  before_action :set_schools, only: %i[schools_not_submitted_claims send_schools_not_submitted_claims]
+
+  def schools_not_submitted_claims; end
+
+  def send_schools_not_submitted_claims
+    @schools.flat_map(&:users).each do |user|
+      Claims::UserMailer.claims_have_not_been_submitted(user).deliver_later
+    end
+
+    redirect_to schools_not_submitted_claims_claims_support_claims_reminders_path, flash: {
+      heading: t(".success"),
+      body: t(".success_body"),
+    }
+  end
+
+  def providers_no_claims_submitted
+    @providers = Claims::Provider.where.missing(:claims)
+  end
+
+  private
+
+  def set_claim_window
+    @claim_window = Claims::ClaimWindow.current.decorate
+  end
+
+  def set_schools
+    @schools = Claims::School.includes(:users, :eligible_claim_windows)
+                             .where(eligible_claim_windows: { id: @claim_window.id })
+                             .where.missing(:claims)
+  end
+end

--- a/app/controllers/claims/support/claims_reminders_controller.rb
+++ b/app/controllers/claims/support/claims_reminders_controller.rb
@@ -16,10 +16,6 @@ class Claims::Support::ClaimsRemindersController < Claims::Support::ApplicationC
     }
   end
 
-  def providers_no_claims_submitted
-    @providers = Claims::Provider.where.missing(:claims)
-  end
-
   private
 
   def set_claim_window

--- a/app/controllers/claims/support/claims_reminders_controller.rb
+++ b/app/controllers/claims/support/claims_reminders_controller.rb
@@ -6,7 +6,7 @@ class Claims::Support::ClaimsRemindersController < Claims::Support::ApplicationC
   def schools_not_submitted_claims; end
 
   def send_schools_not_submitted_claims
-    @schools.flat_map(&:users).each do |user|
+    Claims::User.joins(:schools).where(schools: { id: @schools.ids }).find_each do |user|
       Claims::UserMailer.claims_have_not_been_submitted(user).deliver_later
     end
 
@@ -23,7 +23,7 @@ class Claims::Support::ClaimsRemindersController < Claims::Support::ApplicationC
   end
 
   def set_schools
-    @schools = Claims::School.includes(:users, :eligible_claim_windows)
+    @schools = Claims::School.includes(:eligible_claim_windows)
                              .where(eligible_claim_windows: { id: @claim_window.id })
                              .where.missing(:claims)
   end

--- a/app/mailers/claims/user_mailer.rb
+++ b/app/mailers/claims/user_mailer.rb
@@ -74,4 +74,24 @@ class Claims::UserMailer < Claims::ApplicationMailer
                          service_name:,
                          service_url: claims_root_url(utm_source: "email", utm_medium: "notification", utm_campaign: "school"))
   end
+
+  def claims_have_not_been_submitted(user)
+    claim_window = Claims::ClaimWindow.current
+    academic_year_name = claim_window.academic_year_name
+    deadline = l(claim_window.ends_on, format: :long)
+
+    notify_email to: user.email,
+                 subject: t(".subject", deadline:),
+                 body: t(
+                   ".body",
+                   claim_window: Claims::ClaimWindow.current,
+                   next_claim_window_opens: l(Claims::ClaimWindow.next&.starts_on, format: :long),
+                   user_name: user.first_name,
+                   deadline:,
+                   academic_year_name:,
+                   service_name:,
+                   support_email:,
+                   sign_in_url: sign_in_url(utm_source: "email", utm_medium: "notification", utm_campaign: "school"),
+                 )
+  end
 end

--- a/app/mailers/claims/user_mailer.rb
+++ b/app/mailers/claims/user_mailer.rb
@@ -85,7 +85,7 @@ class Claims::UserMailer < Claims::ApplicationMailer
                  body: t(
                    ".body",
                    claim_window: Claims::ClaimWindow.current,
-                   next_claim_window_opens: l(Claims::ClaimWindow.next&.starts_on, format: :long),
+                   next_claim_window_opens: l(Claims::ClaimWindow.next.starts_on, format: :long),
                    user_name: user.first_name,
                    deadline:,
                    academic_year_name:,

--- a/app/views/claims/support/claims_reminders/schools_not_submitted_claims.html.erb
+++ b/app/views/claims/support/claims_reminders/schools_not_submitted_claims.html.erb
@@ -1,0 +1,22 @@
+<%# content_for :page_title, t(".heading") %>
+<% render "claims/support/primary_navigation", current: :settings %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+
+      <% if @schools.count.positive? %>
+        <p class="govuk-body"><%= t(".number_of_schools", count: @schools.count) %></p>
+
+        <p class="govuk-body"><%= t(".deadline", deadline: l(@claim_window.ends_on, format: :long)) %></p>
+
+        <%= govuk_warning_text(text: t(".warning")) %>
+
+        <%= govuk_button_to(t(".send_reminders"), send_schools_not_submitted_claims_claims_support_claims_reminders_path) %>
+      <% else %>
+        <p class="govuk-body"><%= t(".no_schools") %></p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/claims/support/claims_reminders/schools_not_submitted_claims.html.erb
+++ b/app/views/claims/support/claims_reminders/schools_not_submitted_claims.html.erb
@@ -6,7 +6,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 
-      <% if @schools.count.positive? %>
+      <% if @schools.exists? %>
         <p class="govuk-body"><%= t(".number_of_schools", count: @schools.count) %></p>
 
         <p class="govuk-body"><%= t(".deadline", deadline: l(@claim_window.ends_on, format: :long)) %></p>

--- a/app/views/claims/support/claims_reminders/schools_not_submitted_claims.html.erb
+++ b/app/views/claims/support/claims_reminders/schools_not_submitted_claims.html.erb
@@ -11,6 +11,10 @@
 
         <p class="govuk-body"><%= t(".deadline", deadline: l(@claim_window.ends_on, format: :long)) %></p>
 
+        <p class="govuk-body">
+          <%= govuk_link_to(t(".preview"), url_for(controller: "/rails/mailers", action: :preview, path: "claims/user_mailer/claims_have_not_been_submitted"), no_visited_state: true, new_tab: true) %>
+        </p>
+
         <%= govuk_warning_text(text: t(".warning")) %>
 
         <%= govuk_button_to(t(".send_reminders"), send_schools_not_submitted_claims_claims_support_claims_reminders_path) %>

--- a/app/views/claims/support/settings/index.html.erb
+++ b/app/views/claims/support/settings/index.html.erb
@@ -6,15 +6,25 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 
+      <h2 class="govuk-heading-m"><%= t(".service_management") %></h2>
+      <%= govuk_list [
+        govuk_link_to(t(".onboard_users"), new_onboard_users_claims_support_schools_path, no_visited_state: true),
+        govuk_link_to(t(".onboard_schools"), new_onboard_schools_claims_support_schools_path, no_visited_state: true),
+        govuk_link_to(t(".claim_windows"), claims_support_claim_windows_path, no_visited_state: true),
+        govuk_link_to(t(".schools_not_submitted_claims"), schools_not_submitted_claims_claims_support_claims_reminders_path, no_visited_state: true),
+      ], spaced: true %>
+
+      <h2 class="govuk-heading-m"><%= t(".service_information") %></h2>
+      <%= govuk_list [
+        govuk_link_to(t(".emails"), claims_support_mailers_path, no_visited_state: true),
+        govuk_link_to(t(".manually_onboarded_schools"), claims_support_manually_onboarded_schools_path, no_visited_state: true),
+      ], spaced: true %>
+
+      <h2 class="govuk-heading-m"><%= t(".developer_tools") %></h2>
       <%= govuk_list [
         govuk_link_to(t(".background_jobs"), "/good_job", no_visited_state: true, new_tab: true),
         # Uncomment the following line and add a translation to add a link to the feature flags page
         # govuk_link_to(t(".feature_flags"), "/flipper", no_visited_state: true, new_tab: true),
-        govuk_link_to(t(".claim_windows"), claims_support_claim_windows_path, no_visited_state: true),
-        govuk_link_to(t(".onboard_users"), new_onboard_users_claims_support_schools_path, no_visited_state: true),
-        govuk_link_to(t(".onboard_schools"), new_onboard_schools_claims_support_schools_path, no_visited_state: true),
-        govuk_link_to(t(".manually_onboarded_schools"), claims_support_manually_onboarded_schools_path, no_visited_state: true),
-        govuk_link_to(t(".emails"), claims_support_mailers_path, no_visited_state: true),
         (govuk_link_to(t(".reset_database"), reset_claims_support_database_path, no_visited_state: true) unless HostingEnvironment.env.production?),
         (govuk_link_to(t(".revert_claims_to_submitted"), revert_to_submitted_claims_support_database_databases_claims_path, no_visited_state: true) unless HostingEnvironment.env.production?),
       ], spaced: true %>

--- a/app/views/claims/support/settings/index.html.erb
+++ b/app/views/claims/support/settings/index.html.erb
@@ -23,8 +23,6 @@
       <h2 class="govuk-heading-m"><%= t(".developer_tools") %></h2>
       <%= govuk_list [
         govuk_link_to(t(".background_jobs"), "/good_job", no_visited_state: true, new_tab: true),
-        # Uncomment the following line and add a translation to add a link to the feature flags page
-        # govuk_link_to(t(".feature_flags"), "/flipper", no_visited_state: true, new_tab: true),
         (govuk_link_to(t(".reset_database"), reset_claims_support_database_path, no_visited_state: true) unless HostingEnvironment.env.production?),
         (govuk_link_to(t(".revert_claims_to_submitted"), revert_to_submitted_claims_support_database_databases_claims_path, no_visited_state: true) unless HostingEnvironment.env.production?),
       ], spaced: true %>

--- a/config/locales/en/claims/support/claims_reminders.yml
+++ b/config/locales/en/claims/support/claims_reminders.yml
@@ -14,3 +14,4 @@ en:
           warning: An email will be sent to all of the users for schools that have not submitted claims for the current claim window. This action cannot be undone.
           send_reminders: Send reminders
           no_schools: All eligible schools have submitted claims for the current claim window, therefore no reminders can be sent.
+          preview: Preview email

--- a/config/locales/en/claims/support/claims_reminders.yml
+++ b/config/locales/en/claims/support/claims_reminders.yml
@@ -1,0 +1,16 @@
+en:
+  claims:
+    support:
+      claims_reminders:
+        send_schools_not_submitted_claims:
+          success: Emails dispatched successfully
+          success_body: An email has been sent to all of the users for schools that have not submitted claims for the current claim window.
+        schools_not_submitted_claims:
+          heading: Remind schools to submit claims
+          number_of_schools:
+            one: There is currently %{count} school that has not submitted claims for the current claim window.
+            other: There are currently %{count} schools that have not submitted claims for the current claim window.
+          deadline: The deadline for submitting claims is %{deadline}, the email that is sent will use this date.
+          warning: An email will be sent to all of the users for schools that have not submitted claims for the current claim window. This action cannot be undone.
+          send_reminders: Send reminders
+          no_schools: All eligible schools have submitted claims for the current claim window, therefore no reminders can be sent.

--- a/config/locales/en/claims/support/settings.yml
+++ b/config/locales/en/claims/support/settings.yml
@@ -5,10 +5,14 @@ en:
         index:
           heading: Settings
           background_jobs: Background jobs
-          claim_windows: Claim windows
-          emails: Emails
+          claim_windows: Manage claim windows
+          schools_not_submitted_claims: Remind schools to submit claims
+          emails: View email templates
           reset_database: Reset database
           revert_claims_to_submitted: Revert all claims to 'Submitted'
-          onboard_users: Onboard users
-          onboard_schools: Onboard schools
-          manually_onboarded_schools: Manually onboarded schools
+          onboard_users: Invite users to the service
+          onboard_schools: Make schools eligible to submit claims
+          manually_onboarded_schools: View manually onboarded schools
+          service_management: Service management
+          service_information: Service information
+          developer_tools: Developer tools

--- a/config/locales/en/claims/user_mailer.yml
+++ b/config/locales/en/claims/user_mailer.yml
@@ -126,3 +126,52 @@ en:
           Regards
           
           %{service_name} team
+
+      claims_have_not_been_submitted:
+        subject: "Deadline %{deadline}: Claim Your ITT Mentor Training Funding"
+        body: |
+          Dear %{user_name},
+  
+          The Claim Funding for ITT Mentoring Training digital service launched in April 2025.
+  
+          We believe your school is eligible to claim funding for the time your Initial Teacher Training (ITT) mentors spent in training this academic year.
+  
+          If your school has been added to the Register trainee teacher service by your accredited provider, you should have been onboarded and are eligible to claim. However, we’ve not yet received a claim from you.
+  
+          ## Eligibility Criteria
+
+          To claim funding, an ITT mentor must have:
+          
+          - Completed up to 20 hours of initial mentor training
+          - Mentored at least one trainee during the %{academic_year_name} academic year
+  
+          ## How to access the service
+          
+          Check if you’ve received an onboarding email from DfE.
+          
+          If not, ask your school’s DfE Sign-in approver if they’ve received it and can add users.
+          
+          If no one has received it, confirm with your accredited provider that your school is on the Register trainee teacher service.
+          
+          For further help see [additional guidance](https://assets.publishing.service.gov.uk/media/67448404e26d6f8ca3cb358d/General_mentor_training_-_additional_guidance.pdf) or contact: [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk).
+          
+          ## How to make a claim
+        
+          To make a claim, you will need to:
+          
+          - Sign in using your DfE Sign-in account*
+          - Claim for ITT general mentors only (if you’re claiming for ECT mentors, [follow this guidance](https://www.gov.uk/guidance/funding-and-eligibility-for-ecf-based-training))
+          - Ensure the mentor’s name matches the Teacher Register (update names via Access Teaching Qualifications if needed)**
+  
+          \*DfE Sign-in now uses multi-factor authentication. You may need to create a new account with a secure password.
+          \*\*To update a mentor’s name, submit a change via [Access Teaching Qualifications](https://www.gov.uk/guidance/access-your-teaching-qualifications).
+  
+          ## Important
+          
+          The deadline to submit claims is %{deadline}. After this date, you will have to wait until the next claim window to opens on %{next_claim_window_opens}.
+          
+          For more information, see [additional guidance](https://assets.publishing.service.gov.uk/media/67448404e26d6f8ca3cb358d/General_mentor_training_-_additional_guidance.pdf) or email [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk).
+          
+          Kind regards,
+          
+          %{service_name} team

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -295,6 +295,14 @@ scope module: :claims, as: :claims, constraints: {
 
     resources :manually_onboarded_schools, only: :index
 
+    resources :claims_reminders do
+      collection do
+        get "schools_not_submitted_claims", to: "claims_reminders#schools_not_submitted_claims", as: :schools_not_submitted_claims
+        get "providers_no_claims_submitted", to: "claims_reminders#providers_no_claims_submitted", as: :remind_providers
+        post "schools_not_submitted_claims", to: "claims_reminders#send_schools_not_submitted_claims", as: :send_schools_not_submitted_claims
+      end
+    end
+
     resources :claim_windows do
       get :new_check, path: :check, on: :collection
       get :edit_check, path: :check, on: :member

--- a/spec/mailers/claims/user_mailer_spec.rb
+++ b/spec/mailers/claims/user_mailer_spec.rb
@@ -281,4 +281,64 @@ RSpec.describe Claims::UserMailer, type: :mailer do
       EMAIL
     end
   end
+
+  describe "#claims_have_not_been_submitted" do
+    subject(:claims_not_submitted_email) { described_class.claims_have_not_been_submitted(user) }
+
+    let(:user) { create(:claims_user, first_name: "Joe") }
+    let!(:claim_window) { create(:claim_window, :current) }
+    let!(:next_claim_window) { create(:claim_window, :upcoming) }
+
+    it "sends the claims not submitted email" do
+      expect(claims_not_submitted_email.to).to contain_exactly(user.email)
+      expect(claims_not_submitted_email.subject).to eq("Deadline #{I18n.l(claim_window.ends_on, format: :long)}: Claim Your ITT Mentor Training Funding")
+      expect(claims_not_submitted_email.body.to_s.squish).to eq(<<~EMAIL.squish)
+        Dear Joe,
+
+        The Claim Funding for ITT Mentoring Training digital service launched in April 2025.
+
+        We believe your school is eligible to claim funding for the time your Initial Teacher Training (ITT) mentors spent in training this academic year.
+
+        If your school has been added to the Register trainee teacher service by your accredited provider, you should have been onboarded and are eligible to claim. However, we’ve not yet received a claim from you.
+
+        ## Eligibility Criteria
+
+        To claim funding, an ITT mentor must have:
+
+        - Completed up to 20 hours of initial mentor training
+        - Mentored at least one trainee during the #{claim_window.academic_year_name} academic year
+
+        ## How to access the service
+
+        Check if you’ve received an onboarding email from DfE.
+
+        If not, ask your school’s DfE Sign-in approver if they’ve received it and can add users.
+
+        If no one has received it, confirm with your accredited provider that your school is on the Register trainee teacher service.
+
+        For further help see [additional guidance](https://assets.publishing.service.gov.uk/media/67448404e26d6f8ca3cb358d/General_mentor_training_-_additional_guidance.pdf) or contact: [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk).
+
+        ## How to make a claim
+
+        To make a claim, you will need to:
+
+        - Sign in using your DfE Sign-in account*
+        - Claim for ITT general mentors only (if you’re claiming for ECT mentors, [follow this guidance](https://www.gov.uk/guidance/funding-and-eligibility-for-ecf-based-training))
+        - Ensure the mentor’s name matches the Teacher Register (update names via Access Teaching Qualifications if needed)**
+
+        \\*DfE Sign-in now uses multi-factor authentication. You may need to create a new account with a secure password.
+        \\*\\*To update a mentor’s name, submit a change via [Access Teaching Qualifications](https://www.gov.uk/guidance/access-your-teaching-qualifications).
+
+        ## Important
+
+        The deadline to submit claims is #{I18n.l(claim_window.ends_on, format: :long)}. After this date, you will have to wait until the next claim window to opens on #{I18n.l(next_claim_window.starts_on, format: :long)}.
+
+        For more information, see [additional guidance](https://assets.publishing.service.gov.uk/media/67448404e26d6f8ca3cb358d/General_mentor_training_-_additional_guidance.pdf) or email [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk).
+
+        Kind regards,
+
+        Claim funding for mentor training team
+      EMAIL
+    end
+  end
 end

--- a/spec/mailers/previews/claims/user_mailer_preview.rb
+++ b/spec/mailers/previews/claims/user_mailer_preview.rb
@@ -19,6 +19,10 @@ class Claims::UserMailerPreview < ActionMailer::Preview
     Claims::UserMailer.claim_requires_clawback(claim, user)
   end
 
+  def claims_have_not_been_submitted
+    Claims::UserMailer.claims_have_not_been_submitted(user)
+  end
+
   private
 
   def user

--- a/spec/requests/claims/support/claims_reminders_spec.rb
+++ b/spec/requests/claims/support/claims_reminders_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe "Claims Reminders", type: :request do
+  describe "POST /claims/support/claims_reminders/send_schools_not_submitted_claims" do
+    let(:claim_window) { create(:claim_window, :current) }
+    let(:next_claim_window) { create(:claim_window, :upcoming) }
+    let(:claims_school) { build(:claims_school, eligible_claim_windows: [claim_window]) }
+    let!(:claims_user) { create(:claims_user, schools: [claims_school]) }
+    let(:support_user) { create(:claims_support_user) }
+
+    before do
+      claim_window
+      next_claim_window
+      sign_in_as support_user
+      mailer_double = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+      allow(Claims::UserMailer).to receive(:claims_have_not_been_submitted).and_return(mailer_double)
+    end
+
+    it "sends reminders to users and redirects with a flash message" do
+      post send_schools_not_submitted_claims_claims_support_claims_reminders_path
+
+      expect(Claims::UserMailer).to have_received(:claims_have_not_been_submitted).at_least(:once).with(claims_user)
+    end
+  end
+end

--- a/spec/system/claims/support/create_a_claim_window_spec.rb
+++ b/spec/system/claims/support/create_a_claim_window_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Create a claim window", freeze: "20 July 2024", service: :claims
 
   def when_i_visit_the_claim_windows_page
     click_on "Settings"
-    click_on "Claim windows"
+    click_on "Manage claim windows"
   end
 
   def and_i_click_on_the_add_claim_window_button

--- a/spec/system/claims/support/remove_a_claim_window_spec.rb
+++ b/spec/system/claims/support/remove_a_claim_window_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Remove a claim window", freeze: "17 July 2024", service: :claims
 
   def when_i_visit_the_claim_windows_page
     click_on "Settings"
-    click_on "Claim windows"
+    click_on "Manage claim windows"
   end
 
   alias_method :and_i_click_on, :click_on

--- a/spec/system/claims/support/settings/onboard_multiple_schools/support_user_can_not_onboard_schools_when_there_are_no_claim_windows_spec.rb
+++ b/spec/system/claims/support/settings/onboard_multiple_schools/support_user_can_not_onboard_schools_when_there_are_no_claim_windows_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Support user can not onboard schools when there are no claim win
   end
 
   def and_i_navigate_to_onboard_multiple_schools
-    click_on "Onboard schools"
+    click_on "Make schools eligible to submit claims"
   end
 
   def then_i_see_the_no_claim_window_page

--- a/spec/system/claims/support/settings/onboard_multiple_schools/support_user_does_not_select_a_claim_window_spec.rb
+++ b/spec/system/claims/support/settings/onboard_multiple_schools/support_user_does_not_select_a_claim_window_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Support user does not select a claim window", service: :claims, 
   end
 
   def and_i_navigate_to_onboard_multiple_schools
-    click_on "Onboard schools"
+    click_on "Make schools eligible to submit claims"
   end
 
   def then_i_see_the_claim_window_page

--- a/spec/system/claims/support/settings/onboard_multiple_schools/support_user_does_not_upload_a_file_spec.rb
+++ b/spec/system/claims/support/settings/onboard_multiple_schools/support_user_does_not_upload_a_file_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Support user does not upload a file", service: :claims, type: :s
   end
 
   def and_i_navigate_to_onboard_multiple_schools
-    click_on "Onboard schools"
+    click_on "Make schools eligible to submit claims"
   end
 
   def then_i_see_the_upload_page

--- a/spec/system/claims/support/settings/onboard_multiple_schools/support_user_onboards_multiple_schools_for_the_current_claim_window_spec.rb
+++ b/spec/system/claims/support/settings/onboard_multiple_schools/support_user_onboards_multiple_schools_for_the_current_claim_window_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Support user onboards multiple schools for the current claim win
   end
 
   def and_i_navigate_to_onboard_multiple_schools
-    click_on "Onboard schools"
+    click_on "Make schools eligible to submit claims"
   end
 
   def then_i_see_the_upload_page

--- a/spec/system/claims/support/settings/onboard_multiple_schools/support_user_onboards_multiple_schools_when_only_a_current_claim_window_exists_spec.rb
+++ b/spec/system/claims/support/settings/onboard_multiple_schools/support_user_onboards_multiple_schools_when_only_a_current_claim_window_exists_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "Support user onboards multiple schools when only a current claim
   end
 
   def and_i_navigate_to_onboard_multiple_schools
-    click_on "Onboard schools"
+    click_on "Make schools eligible to submit claims"
   end
 
   def then_i_see_the_upload_page

--- a/spec/system/claims/support/settings/onboard_multiple_schools/support_user_onboards_multiple_schools_when_only_a_future_claim_window_exists_spec.rb
+++ b/spec/system/claims/support/settings/onboard_multiple_schools/support_user_onboards_multiple_schools_when_only_a_future_claim_window_exists_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "Support user onboards multiple schools when only a upcoming clai
   end
 
   def and_i_navigate_to_onboard_multiple_schools
-    click_on "Onboard schools"
+    click_on "Make schools eligible to submit claims"
   end
 
   def then_i_see_the_upload_page

--- a/spec/system/claims/support/settings/onboard_multiple_schools/support_user_uploads_a_file_with_the_wrong_headers_spec.rb
+++ b/spec/system/claims/support/settings/onboard_multiple_schools/support_user_uploads_a_file_with_the_wrong_headers_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Support user does upload a file with wrong headers", service: :c
   end
 
   def and_i_navigate_to_onboard_multiple_schools
-    click_on "Onboard schools"
+    click_on "Make schools eligible to submit claims"
   end
 
   def then_i_see_the_upload_page

--- a/spec/system/claims/support/settings/onboard_multiple_users/support_user_does_not_upload_a_file_spec.rb
+++ b/spec/system/claims/support/settings/onboard_multiple_users/support_user_does_not_upload_a_file_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Support user does not upload a file", service: :claims, type: :s
   end
 
   def and_i_navigate_to_onboard_multiple_users
-    click_on "Onboard users"
+    click_on "Invite users to the service"
   end
 
   def then_i_see_the_upload_page

--- a/spec/system/claims/support/settings/onboard_multiple_users/support_user_onboards_users_spec.rb
+++ b/spec/system/claims/support/settings/onboard_multiple_users/support_user_onboards_users_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Support user onboards users", service: :claims, type: :system do
   end
 
   def and_i_navigate_to_onboard_multiple_users
-    click_on "Onboard users"
+    click_on "Invite users to the service"
   end
 
   def then_i_see_the_upload_page

--- a/spec/system/claims/support/settings/onboard_multiple_users/support_user_uploads_a_file_with_invalid_headers_spec.rb
+++ b/spec/system/claims/support/settings/onboard_multiple_users/support_user_uploads_a_file_with_invalid_headers_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Support user uploads a file with invalid headers", service: :cla
   end
 
   def and_i_navigate_to_onboard_multiple_users
-    click_on "Onboard users"
+    click_on "Invite users to the service"
   end
 
   def then_i_see_the_upload_page

--- a/spec/system/claims/support/settings/support_user_views_manually_onboarded_schools_spec.rb
+++ b/spec/system/claims/support/settings/support_user_views_manually_onboarded_schools_spec.rb
@@ -38,11 +38,11 @@ RSpec.describe "Support user views manually onboarded schools", service: :claims
   end
 
   def then_i_see_the_manually_onboarded_schools_link
-    expect(page).to have_link("Manually onboarded schools", href: "/support/manually_onboarded_schools")
+    expect(page).to have_link("View manually onboarded schools", href: "/support/manually_onboarded_schools")
   end
 
   def when_i_click_on_the_manually_onboarded_schools_link
-    click_on "Manually onboarded schools"
+    click_on "View manually onboarded schools"
   end
 
   def then_i_see_the_manually_onboarded_schools_page

--- a/spec/system/claims/support/settings/support_user_views_manually_onboarded_schools_when_none_are_present_spec.rb
+++ b/spec/system/claims/support/settings/support_user_views_manually_onboarded_schools_when_none_are_present_spec.rb
@@ -23,11 +23,11 @@ RSpec.describe "Support user views manually onboarded schools when none are pres
   end
 
   def then_i_see_the_manually_onboarded_schools_link
-    expect(page).to have_link("Manually onboarded schools", href: "/support/manually_onboarded_schools")
+    expect(page).to have_link("View manually onboarded schools", href: "/support/manually_onboarded_schools")
   end
 
   def when_i_click_on_the_manually_onboarded_schools_link
-    click_on "Manually onboarded schools"
+    click_on "View manually onboarded schools"
   end
 
   def then_i_do_not_see_any_schools

--- a/spec/system/claims/support/settings/support_user_views_remind_schools_to_submit_claims_when_all_schools_claimed_spec.rb
+++ b/spec/system/claims/support/settings/support_user_views_remind_schools_to_submit_claims_when_all_schools_claimed_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe "Support user views remind schools to submit claims when all schools claimed", service: :claims, type: :system do
+  scenario do
+    given_i_am_signed_in_and_a_claim_window_is_open
+    when_i_navigate_to_the_settings_index_page
+    then_i_see_the_remind_schools_to_submit_claims_link
+
+    when_i_click_on_the_remind_schools_to_submit_claims_link
+    then_i_do_not_see_any_schools
+  end
+
+  private
+
+  def given_i_am_signed_in_and_a_claim_window_is_open
+    @claim_window = create(:claim_window, :current)
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_settings_index_page
+    within(primary_navigation) do
+      click_on "Settings"
+    end
+  end
+
+  def then_i_see_the_remind_schools_to_submit_claims_link
+    expect(page).to have_link("Remind schools to submit claims", href: "/support/claims_reminders/schools_not_submitted_claims")
+  end
+
+  def when_i_click_on_the_remind_schools_to_submit_claims_link
+    click_on "Remind schools to submit claims"
+  end
+
+  def then_i_do_not_see_any_schools
+    expect(page).to have_paragraph("All eligible schools have submitted claims for the current claim window, therefore no reminders can be sent.")
+  end
+end

--- a/spec/system/claims/support/settings/support_user_views_remind_schools_to_submit_claims_when_schools_have_not_claimed_spec.rb
+++ b/spec/system/claims/support/settings/support_user_views_remind_schools_to_submit_claims_when_schools_have_not_claimed_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe "Support user views remind schools to submit claims when schools have not claimed", service: :claims, type: :system do
+  scenario do
+    given_i_am_signed_in
+    and_schools_have_not_claimed
+    when_i_navigate_to_the_settings_index_page
+    then_i_see_the_remind_schools_to_submit_claims_link
+
+    when_i_click_on_the_remind_schools_to_submit_claims_link
+    then_i_see_information_about_schools_that_have_not_claimed
+  end
+
+  private
+
+  def given_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def and_schools_have_not_claimed
+    @claim_window = create(:claim_window, :current)
+    @school = create(:claims_school, eligible_claim_windows: [@claim_window])
+  end
+
+  def when_i_navigate_to_the_settings_index_page
+    within(primary_navigation) do
+      click_on "Settings"
+    end
+  end
+
+  def then_i_see_the_remind_schools_to_submit_claims_link
+    expect(page).to have_link("Remind schools to submit claims", href: "/support/claims_reminders/schools_not_submitted_claims")
+  end
+
+  def when_i_click_on_the_remind_schools_to_submit_claims_link
+    click_on "Remind schools to submit claims"
+  end
+
+  def then_i_see_information_about_schools_that_have_not_claimed
+    expect(page).to have_title("Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Settings")
+    expect(page).to have_h1("Remind schools to submit claims")
+    expect(page).to have_paragraph("There is currently 1 school that has not submitted claims for the current claim window.")
+    expect(page).to have_paragraph("The deadline for submitting claims is #{I18n.l(@claim_window.ends_on, format: :long)}, the email that is sent will use this date.")
+    expect(page).to have_warning_text("An email will be sent to all of the users for schools that have not submitted claims for the current claim window. This action cannot be undone.")
+    expect(page).to have_button("Send reminders")
+  end
+
+  def when_i_click_on_send_reminders
+    click_on "Send reminders"
+  end
+
+  def then_i_see_the_reminders_sent_success_banner
+    expect(page).to have_success_banner("An email has been sent to all of the users for schools that have not submitted claims for the current claim window.")
+  end
+end

--- a/spec/system/claims/support/settings/support_user_views_remind_schools_to_submit_claims_when_schools_have_not_claimed_spec.rb
+++ b/spec/system/claims/support/settings/support_user_views_remind_schools_to_submit_claims_when_schools_have_not_claimed_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe "Support user views remind schools to submit claims when schools 
     expect(page).to have_h1("Remind schools to submit claims")
     expect(page).to have_paragraph("There is currently 1 school that has not submitted claims for the current claim window.")
     expect(page).to have_paragraph("The deadline for submitting claims is #{I18n.l(@claim_window.ends_on, format: :long)}, the email that is sent will use this date.")
+    expect(page).to have_link("Preview email (opens in new tab)", href: "/rails/mailers/claims/user_mailer/claims_have_not_been_submitted")
     expect(page).to have_warning_text("An email will be sent to all of the users for schools that have not submitted claims for the current claim window. This action cannot be undone.")
     expect(page).to have_button("Send reminders")
   end

--- a/spec/system/claims/support/support_users_adds_a_claim_window_which_includes_dates_within_an_existing_claim_window_spec.rb
+++ b/spec/system/claims/support/support_users_adds_a_claim_window_which_includes_dates_within_an_existing_claim_window_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Support user adds a claim window which includes dates within an 
   end
 
   def and_click_on_claims_windows
-    click_on "Claim windows"
+    click_on "Manage claim windows"
   end
 
   def then_i_see_the_claims_windows_index_page

--- a/spec/system/claims/support/update_a_claim_window_spec.rb
+++ b/spec/system/claims/support/update_a_claim_window_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Update a claim window", freeze: "17 July 2024", service: :claims
 
   def when_i_visit_the_claim_windows_page
     click_on "Settings"
-    click_on "Claim windows"
+    click_on "Manage claim windows"
   end
 
   def then_i_see(content)

--- a/spec/system/claims/support/view_emails_spec.rb
+++ b/spec/system/claims/support/view_emails_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "View Emails", service: :claims, type: :system do
 
   def when_i_visit_the_emails_page
     click_on "Settings"
-    click_on "Emails"
+    click_on "View email templates"
   end
 
   def then_i_can_see_the_list_of_claims_email_templates


### PR DESCRIPTION
## Context

We need to remind schools that have not claimed that the claim window is closing soon, instead of doing this manually we've opted to add the functionality to the service.

## Changes proposed in this pull request

- Updates the structure of the settings page as it was becoming cluttered
- Adds a new mailer
- Adds a support page to send an email to users from schools who have not made claims for the current academic year

## Guidance to review

- Log in as colin
- Navigate to settings
- Review new format
- Click on "Remind schools to submit claims"
- Review content

## Link to Trello card

https://trello.com/c/8hs4wPht/34-add-some-headers-descriptions-to-the-support-settings-page-to-improve-clarity
https://trello.com/c/C8srvib5/40-add-remind-schools-to-make-claims-support-service


## Screenshots

<img width="2560" height="1328" alt="image" src="https://github.com/user-attachments/assets/79cedc74-58ca-4c10-91b8-cfd6a88ee1ea" />
<img width="2560" height="1328" alt="image" src="https://github.com/user-attachments/assets/07c6a281-f6d4-4ebe-9f54-1e49d438b3c6" />
<img width="2560" height="1497" alt="image" src="https://github.com/user-attachments/assets/18a8882e-c5a6-4e79-8c66-deff8926f46d" />

