### PR TITLE
Add remind providers tool to support console

### DIFF
--- a/app/controllers/claims/support/claims_reminders_controller.rb
+++ b/app/controllers/claims/support/claims_reminders_controller.rb
@@ -2,6 +2,7 @@ class Claims::Support::ClaimsRemindersController < Claims::Support::ApplicationC
   before_action :skip_authorization
   before_action :set_claim_window
   before_action :set_schools, only: %i[schools_not_submitted_claims send_schools_not_submitted_claims]
+  before_action :set_providers, only: %i[providers_not_submitted_claims send_providers_not_submitted_claims]
 
   def schools_not_submitted_claims; end
 
@@ -11,6 +12,21 @@ class Claims::Support::ClaimsRemindersController < Claims::Support::ApplicationC
     end
 
     redirect_to schools_not_submitted_claims_claims_support_claims_reminders_path, flash: {
+      heading: t(".success"),
+      body: t(".success_body"),
+    }
+  end
+
+  def providers_not_submitted_claims; end
+
+  def send_providers_not_submitted_claims
+    @providers.find_each do |provider|
+      provider.email_addresses.each do |email_address|
+        Claims::ProviderMailer.claims_have_not_been_submitted(provider_name: provider.name, email_address:).deliver_later
+      end
+    end
+
+    redirect_to providers_not_submitted_claims_claims_support_claims_reminders_path, flash: {
       heading: t(".success"),
       body: t(".success_body"),
     }
@@ -26,5 +42,15 @@ class Claims::Support::ClaimsRemindersController < Claims::Support::ApplicationC
     @schools = Claims::School.includes(:eligible_claim_windows)
                              .where(eligible_claim_windows: { id: @claim_window.id })
                              .where.missing(:claims)
+  end
+
+  def set_providers
+    @providers = Claims::Provider.left_outer_joins(:claims)
+                                 .where(claims: { id: nil })
+                                 .or(
+                                   Claims::Provider.left_outer_joins(:claims)
+                                                   .where.not(claims: { claim_window_id: Claims::ClaimWindow.current.id }),
+                                 )
+                                 .distinct
   end
 end

--- a/app/controllers/claims/support/claims_reminders_controller.rb
+++ b/app/controllers/claims/support/claims_reminders_controller.rb
@@ -45,7 +45,7 @@ class Claims::Support::ClaimsRemindersController < Claims::Support::ApplicationC
   end
 
   def set_providers
-    @providers = Claims::Provider.left_outer_joins(:claims)
+    @providers = Claims::Provider.accredited.left_outer_joins(:claims)
                                  .where(claims: { id: nil })
                                  .or(
                                    Claims::Provider.left_outer_joins(:claims)

--- a/app/mailers/claims/provider_mailer.rb
+++ b/app/mailers/claims/provider_mailer.rb
@@ -27,6 +27,26 @@ class Claims::ProviderMailer < Claims::ApplicationMailer
                  )
   end
 
+  def claims_have_not_been_submitted(provider_name:, email_address:)
+    claim_window = Claims::ClaimWindow.current
+    academic_year_name = claim_window.academic_year_name
+    deadline = l(claim_window.ends_on, format: :long)
+
+    notify_email to: email_address,
+                 subject: t(".subject", deadline:),
+                 body: t(
+                   ".body",
+                   claim_window: Claims::ClaimWindow.current,
+                   next_claim_window_opens: l(Claims::ClaimWindow.next.starts_on, format: :long),
+                   provider_name:,
+                   deadline:,
+                   academic_year_name:,
+                   service_name:,
+                   support_email:,
+                   sign_in_url: sign_in_url(utm_source: "email", utm_medium: "notification", utm_campaign: "school"),
+                 )
+  end
+
   private
 
   attr_reader :provider_sampling, :email_address

--- a/app/views/claims/support/claims_reminders/providers_not_submitted_claims.html.erb
+++ b/app/views/claims/support/claims_reminders/providers_not_submitted_claims.html.erb
@@ -6,7 +6,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 
-      <% if @providers.count.positive? %>
+      <% if @providers.exists? %>
         <p class="govuk-body"><%= t(".number_of_providers", count: @providers.count) %></p>
 
         <p class="govuk-body"><%= t(".deadline", deadline: l(@claim_window.ends_on, format: :long)) %></p>

--- a/app/views/claims/support/claims_reminders/providers_not_submitted_claims.html.erb
+++ b/app/views/claims/support/claims_reminders/providers_not_submitted_claims.html.erb
@@ -11,6 +11,10 @@
 
         <p class="govuk-body"><%= t(".deadline", deadline: l(@claim_window.ends_on, format: :long)) %></p>
 
+        <p class="govuk-body">
+          <%= govuk_link_to(t(".preview"), url_for(controller: "/rails/mailers", action: :preview, path: "claims/provider_mailer/claims_have_not_been_submitted"), no_visited_state: true, new_tab: true) %>
+        </p>
+
         <%= govuk_warning_text(text: t(".warning")) %>
 
         <%= govuk_button_to(t(".send_reminders"), send_providers_not_submitted_claims_claims_support_claims_reminders_path) %>

--- a/app/views/claims/support/claims_reminders/providers_not_submitted_claims.html.erb
+++ b/app/views/claims/support/claims_reminders/providers_not_submitted_claims.html.erb
@@ -1,0 +1,22 @@
+<%# content_for :page_title, t(".heading") %>
+<% render "claims/support/primary_navigation", current: :settings %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+
+      <% if @providers.count.positive? %>
+        <p class="govuk-body"><%= t(".number_of_providers", count: @providers.count) %></p>
+
+        <p class="govuk-body"><%= t(".deadline", deadline: l(@claim_window.ends_on, format: :long)) %></p>
+
+        <%= govuk_warning_text(text: t(".warning")) %>
+
+        <%= govuk_button_to(t(".send_reminders"), send_providers_not_submitted_claims_claims_support_claims_reminders_path) %>
+      <% else %>
+        <p class="govuk-body"><%= t(".no_providers") %></p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/claims/support/settings/index.html.erb
+++ b/app/views/claims/support/settings/index.html.erb
@@ -11,8 +11,9 @@
         govuk_link_to(t(".onboard_users"), new_onboard_users_claims_support_schools_path, no_visited_state: true),
         govuk_link_to(t(".onboard_schools"), new_onboard_schools_claims_support_schools_path, no_visited_state: true),
         govuk_link_to(t(".claim_windows"), claims_support_claim_windows_path, no_visited_state: true),
+        govuk_link_to(t(".providers_not_submitted_claims"), providers_not_submitted_claims_claims_support_claims_reminders_path, no_visited_state: true),
         govuk_link_to(t(".schools_not_submitted_claims"), schools_not_submitted_claims_claims_support_claims_reminders_path, no_visited_state: true),
-      ], spaced: true %>
+                     ], spaced: true %>
 
       <h2 class="govuk-heading-m"><%= t(".service_information") %></h2>
       <%= govuk_list [

--- a/config/locales/en/claims/provider_mailer.yml
+++ b/config/locales/en/claims/provider_mailer.yml
@@ -142,3 +142,49 @@ en:
 
 
           Claim funding for mentor training team
+
+      claims_have_not_been_submitted:
+        subject: "Deadline %{deadline}: your schools haven’t claimed for ITT mentor funding"
+        body: |
+          Dear %{provider_name},
+  
+          The Claim Funding for ITT Mentoring Training digital service launched in April 2025.
+  
+          Your placement schools are eligible to claim funding for the time their ITT mentors spent in training this academic year.
+  
+          However, no claims are currently associated with you as an accredited provider, which means your schools may be missing out on funding they’re entitled to.
+  
+          ## What You Need to Do
+
+          To help your schools claim their funding:
+  
+          1. Add all your placement schools for this academic year to the Register trainee teacher service.
+          2. Contact your placement schools to advise them to submit their claims via the new service.
+  
+          ## Claim Deadline
+  
+          The deadline for schools to submit claims is %{deadline}. Claims submitted after this date will need to wait until the next window opens on %{next_claim_window_opens}.
+  
+          ## Guidance for Schools
+          
+          ## How to Access the Service
+          
+          1. Check for an onboarding email from DfE.
+          2. If not received, ask the school’s DfE Sign-in approver to check and add users.
+          3. If no one has received it, confirm with the accredited provider that the school is on the Register trainee teacher service.
+          4. For help, contact: [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk)
+          
+          ### How to Make a Claim
+          
+          - Sign in using a DfE Sign-in account*
+          - Claim for ITT general mentors only (for ECT mentors, [follow this guidance](https://www.gov.uk/guidance/funding-and-eligibility-for-ecf-based-training))
+          - Ensure the mentor’s name matches the Teacher Register (update via [Access Teaching Qualifications](https://www.gov.uk/guidance/access-your-teaching-qualifications) if needed)**
+          
+          \* DfE Sign-in now uses multi-factor authentication. Users may need to create a new account with a secure password.
+          \*\* To update a mentor’s name, submit a change via Access Teaching Qualifications.
+          
+          For more information, see [additional guidance](https://assets.publishing.service.gov.uk/media/67448404e26d6f8ca3cb358d/General_mentor_training_-_additional_guidance.pdf) or contact: [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk).
+          
+          Kind regards
+          
+          %{service_name} team

--- a/config/locales/en/claims/support/claims_reminders.yml
+++ b/config/locales/en/claims/support/claims_reminders.yml
@@ -15,3 +15,15 @@ en:
           send_reminders: Send reminders
           no_schools: All eligible schools have submitted claims for the current claim window, therefore no reminders can be sent.
           preview: Preview email
+        send_providers_not_submitted_claims:
+            success: Emails dispatched successfully
+            success_body: An email has been sent to all of the providers that have not had claims assigned to them for the current claim window.
+        providers_not_submitted_claims:
+            heading: Remind providers to submit claims
+            number_of_providers:
+                one: There is currently %{count} provider that has not had claims assigned to them for the current claim window.
+                other: There are currently %{count} providers that have not had claims assigned to them for the current claim window.
+            deadline: The deadline for submitting claims is %{deadline}, the email that is sent will use this date.
+            warning: An email will be sent to all of the providers that have not had claims assigned to them for the current claim window. This action cannot be undone.
+            send_reminders: Send reminders
+            no_providers: All providers have had claims assigned to them for the current claim window, therefore no reminders can be sent.

--- a/config/locales/en/claims/support/claims_reminders.yml
+++ b/config/locales/en/claims/support/claims_reminders.yml
@@ -27,3 +27,4 @@ en:
             warning: An email will be sent to all of the providers that have not had claims assigned to them for the current claim window. This action cannot be undone.
             send_reminders: Send reminders
             no_providers: All providers have had claims assigned to them for the current claim window, therefore no reminders can be sent.
+            preview: Preview email

--- a/config/locales/en/claims/support/settings.yml
+++ b/config/locales/en/claims/support/settings.yml
@@ -7,6 +7,7 @@ en:
           background_jobs: Background jobs
           claim_windows: Manage claim windows
           schools_not_submitted_claims: Remind schools to submit claims
+          providers_not_submitted_claims: Remind providers to submit claims
           emails: View email templates
           reset_database: Reset database
           revert_claims_to_submitted: Revert all claims to 'Submitted'

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -304,8 +304,10 @@ scope module: :claims, as: :claims, constraints: {
     resources :claims_reminders do
       collection do
         get "schools_not_submitted_claims", to: "claims_reminders#schools_not_submitted_claims", as: :schools_not_submitted_claims
-        get "providers_no_claims_submitted", to: "claims_reminders#providers_no_claims_submitted", as: :remind_providers
         post "schools_not_submitted_claims", to: "claims_reminders#send_schools_not_submitted_claims", as: :send_schools_not_submitted_claims
+
+        get "providers_not_submitted_claims", to: "claims_reminders#providers_not_submitted_claims", as: :providers_not_submitted_claims
+        post "providers_not_submitted_claims", to: "claims_reminders#send_providers_not_submitted_claims", as: :send_providers_not_submitted_claims
       end
     end
 

--- a/spec/mailers/claims/provider_mailer_spec.rb
+++ b/spec/mailers/claims/provider_mailer_spec.rb
@@ -366,4 +366,67 @@ RSpec.describe Claims::ProviderMailer, type: :mailer do
       end
     end
   end
+
+  describe "#claims_have_not_been_submitted" do
+    subject(:claims_have_not_been_submitted_email) do
+      described_class.claims_have_not_been_submitted(
+        provider_name: provider_name,
+        email_address: email_address,
+      )
+    end
+
+    let(:provider_name) { "Aes Sedai Trust" }
+    let(:email_address) { "admin@aes-sedai-trust.com" }
+    let!(:claim_window) { create(:claim_window, :current) }
+    let!(:next_claim_window) { create(:claim_window, :upcoming) }
+
+    it "sends the claims have not been submitted email" do
+      expect(claims_have_not_been_submitted_email.to).to contain_exactly(email_address)
+      expect(claims_have_not_been_submitted_email.subject).to eq("Deadline #{I18n.l(claim_window.ends_on, format: :long)}: your schools haven’t claimed for ITT mentor funding")
+      expect(claims_have_not_been_submitted_email.body.to_s.squish).to eq(<<~EMAIL.squish)
+        Dear Aes Sedai Trust,
+
+        The Claim Funding for ITT Mentoring Training digital service launched in April 2025.
+
+        Your placement schools are eligible to claim funding for the time their ITT mentors spent in training this academic year.
+
+        However, no claims are currently associated with you as an accredited provider, which means your schools may be missing out on funding they’re entitled to.
+
+        ## What You Need to Do
+
+        To help your schools claim their funding:
+
+        1. Add all your placement schools for this academic year to the Register trainee teacher service.
+        2. Contact your placement schools to advise them to submit their claims via the new service.
+
+        ## Claim Deadline
+
+        The deadline for schools to submit claims is #{I18n.l(claim_window.ends_on, format: :long)}. Claims submitted after this date will need to wait until the next window opens on #{I18n.l(next_claim_window.starts_on, format: :long)}.
+
+        ## Guidance for Schools
+
+        ## How to Access the Service
+
+        1. Check for an onboarding email from DfE.
+        2. If not received, ask the school’s DfE Sign-in approver to check and add users.
+        3. If no one has received it, confirm with the accredited provider that the school is on the Register trainee teacher service.
+        4. For help, contact: [#{support_email}](mailto:#{support_email})
+
+        ### How to Make a Claim
+
+        - Sign in using a DfE Sign-in account\*
+        - Claim for ITT general mentors only (for ECT mentors, [follow this guidance](https://www.gov.uk/guidance/funding-and-eligibility-for-ecf-based-training))
+        - Ensure the mentor’s name matches the Teacher Register (update via [Access Teaching Qualifications](https://www.gov.uk/guidance/access-your-teaching-qualifications) if needed)\*\*
+
+        \\* DfE Sign-in now uses multi-factor authentication. Users may need to create a new account with a secure password.
+        \\*\\* To update a mentor’s name, submit a change via Access Teaching Qualifications.
+
+        For more information, see [additional guidance](https://assets.publishing.service.gov.uk/media/67448404e26d6f8ca3cb358d/General_mentor_training_-_additional_guidance.pdf) or contact: [#{support_email}](mailto:#{support_email}).
+
+        Kind regards
+
+        #{service_name} team
+      EMAIL
+    end
+  end
 end

--- a/spec/mailers/previews/claims/provider_mailer_preview.rb
+++ b/spec/mailers/previews/claims/provider_mailer_preview.rb
@@ -9,6 +9,10 @@ class Claims::ProviderMailerPreview < ActionMailer::Preview
     Claims::ProviderMailer.resend_sampling_checks_required(provider_sampling, email_address: "example@example.com")
   end
 
+  def claims_have_not_been_submitted
+    Claims::ProviderMailer.claims_have_not_been_submitted(provider_name: provider.name, email_address: "test.provider@example.com")
+  end
+
   private
 
   def provider_sampling

--- a/spec/requests/claims/support/claims_reminders_spec.rb
+++ b/spec/requests/claims/support/claims_reminders_spec.rb
@@ -22,4 +22,30 @@ RSpec.describe "Claims Reminders", type: :request do
       expect(Claims::UserMailer).to have_received(:claims_have_not_been_submitted).at_least(:once).with(claims_user)
     end
   end
+
+  describe "POST /claims/support/claims_reminders/send_providers_not_submitted_claims" do
+    let(:claim_window) { create(:claim_window, :current) }
+    let(:email_address) { build(:provider_email_address) }
+    let(:current_claim) { build(:claim, claim_window: claim_window) }
+    let(:previous_claim) { build(:claim, claim_window: build(:claim_window, :historic)) }
+    let!(:provider_with_no_claims) { create(:claims_provider, name: "Test Provider") }
+    let!(:provider_with_claims_in_current_window) { create(:claims_provider, name: "Provider with Claims", claims: [current_claim]) }
+    let!(:provider_with_claims_in_previous_window) { create(:claims_provider, name: "Provider with Previous Claims", claims: [previous_claim]) }
+    let(:support_user) { create(:claims_support_user) }
+
+    before do
+      claim_window
+      sign_in_as support_user
+      mailer_double = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+      allow(Claims::ProviderMailer).to receive(:claims_have_not_been_submitted).and_return(mailer_double)
+    end
+
+    it "sends reminders to providers and redirects with a flash message" do
+      post send_providers_not_submitted_claims_claims_support_claims_reminders_path
+
+      expect(Claims::ProviderMailer).to have_received(:claims_have_not_been_submitted).once.with(provider_name: provider_with_no_claims.name, email_address: provider_with_no_claims.email_addresses.first)
+      expect(Claims::ProviderMailer).not_to have_received(:claims_have_not_been_submitted).with(provider_name: provider_with_claims_in_current_window.name, email_address: provider_with_claims_in_current_window.email_addresses.first)
+      expect(Claims::ProviderMailer).to have_received(:claims_have_not_been_submitted).with(provider_name: provider_with_claims_in_previous_window.name, email_address: provider_with_claims_in_previous_window.email_addresses.first)
+    end
+  end
 end

--- a/spec/requests/claims/support/claims_reminders_spec.rb
+++ b/spec/requests/claims/support/claims_reminders_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe "Claims Reminders", type: :request do
     let(:email_address) { build(:provider_email_address) }
     let(:current_claim) { build(:claim, claim_window: claim_window) }
     let(:previous_claim) { build(:claim, claim_window: build(:claim_window, :historic)) }
-    let!(:provider_with_no_claims) { create(:claims_provider, name: "Test Provider") }
-    let!(:provider_with_claims_in_current_window) { create(:claims_provider, name: "Provider with Claims", claims: [current_claim]) }
-    let!(:provider_with_claims_in_previous_window) { create(:claims_provider, name: "Provider with Previous Claims", claims: [previous_claim]) }
+    let!(:provider_with_no_claims) { create(:claims_provider, name: "Test Provider", accredited: true) }
+    let!(:provider_with_claims_in_current_window) { create(:claims_provider, name: "Provider with Claims", claims: [current_claim], accredited: true) }
+    let!(:provider_with_claims_in_previous_window) { create(:claims_provider, name: "Provider with Previous Claims", claims: [previous_claim], accredited: true) }
     let(:support_user) { create(:claims_support_user) }
 
     before do

--- a/spec/system/claims/support/settings/support_user_views_remind_providers_to_submit_claims_when_all_schools_claimed_spec.rb
+++ b/spec/system/claims/support/settings/support_user_views_remind_providers_to_submit_claims_when_all_schools_claimed_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe "Support user views remind providers to submit claims when all schools claimed", service: :claims, type: :system do
+  scenario do
+    given_i_am_signed_in_and_a_claim_window_is_open
+    when_i_navigate_to_the_settings_index_page
+    then_i_see_the_remind_providers_to_submit_claims_link
+
+    when_i_click_on_the_remind_providers_to_submit_claims_link
+    then_i_do_not_see_any_providers
+  end
+
+  private
+
+  def given_i_am_signed_in_and_a_claim_window_is_open
+    @claim_window = create(:claim_window, :current)
+    @provider = create(:claims_provider, name: "Test Provider")
+    @claim = create(:claim, claim_window: @claim_window, provider: @provider)
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_settings_index_page
+    within(primary_navigation) do
+      click_on "Settings"
+    end
+  end
+
+  def then_i_see_the_remind_providers_to_submit_claims_link
+    expect(page).to have_link("Remind providers to submit claims", href: "/support/claims_reminders/providers_not_submitted_claims")
+  end
+
+  def when_i_click_on_the_remind_providers_to_submit_claims_link
+    click_on "Remind providers to submit claims"
+  end
+
+  def then_i_do_not_see_any_providers
+    expect(page).to have_paragraph("All providers have had claims assigned to them for the current claim window, therefore no reminders can be sent.")
+  end
+end

--- a/spec/system/claims/support/settings/support_user_views_remind_providers_to_submit_claims_when_schools_have_not_claimed_spec.rb
+++ b/spec/system/claims/support/settings/support_user_views_remind_providers_to_submit_claims_when_schools_have_not_claimed_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe "Support user views remind providers to submit claims when schools have not claimed", service: :claims, type: :system do
+  scenario do
+    given_i_am_signed_in
+    and_schools_have_not_claimed
+    when_i_navigate_to_the_settings_index_page
+    then_i_see_the_remind_providers_to_submit_claims_link
+
+    when_i_click_on_the_remind_providers_to_submit_claims_link
+    then_i_see_information_about_providers_that_have_not_claimed
+  end
+
+  private
+
+  def given_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def and_schools_have_not_claimed
+    @claim_window = create(:claim_window, :current)
+    @provider = create(:claims_provider, name: "Test Provider")
+    @claim = create(:claim, claim_window: @claim_window)
+    @school = create(:claims_school, eligible_claim_windows: [@claim_window])
+  end
+
+  def when_i_navigate_to_the_settings_index_page
+    within(primary_navigation) do
+      click_on "Settings"
+    end
+  end
+
+  def then_i_see_the_remind_providers_to_submit_claims_link
+    expect(page).to have_link("Remind providers to submit claims", href: "/support/claims_reminders/providers_not_submitted_claims")
+  end
+
+  def when_i_click_on_the_remind_providers_to_submit_claims_link
+    click_on "Remind providers to submit claims"
+  end
+
+  def then_i_see_information_about_providers_that_have_not_claimed
+    expect(page).to have_title("Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Settings")
+    expect(page).to have_h1("Remind providers to submit claims")
+    expect(page).to have_paragraph("There is currently 1 provider that has not had claims assigned to them for the current claim window.")
+    expect(page).to have_paragraph("The deadline for submitting claims is #{I18n.l(@claim_window.ends_on, format: :long)}, the email that is sent will use this date.")
+    expect(page).to have_warning_text("An email will be sent to all of the providers that have not had claims assigned to them for the current claim window. This action cannot be undone.")
+    expect(page).to have_button("Send reminders")
+  end
+
+  def when_i_click_on_send_reminders
+    click_on "Send reminders"
+  end
+
+  def then_i_see_the_reminders_sent_success_banner
+    expect(page).to have_success_banner("An email has been sent to all of the providers that have not had claims assigned to them for the current claim window.")
+  end
+end

--- a/spec/system/claims/support/settings/support_user_views_remind_providers_to_submit_claims_when_schools_have_not_claimed_spec.rb
+++ b/spec/system/claims/support/settings/support_user_views_remind_providers_to_submit_claims_when_schools_have_not_claimed_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Support user views remind providers to submit claims when school
 
   def and_schools_have_not_claimed
     @claim_window = create(:claim_window, :current)
-    @provider = create(:claims_provider, name: "Test Provider")
+    @provider = create(:claims_provider, name: "Test Provider", accredited: true)
     @claim = create(:claim, claim_window: @claim_window)
     @school = create(:claims_school, eligible_claim_windows: [@claim_window])
   end
@@ -44,6 +44,7 @@ RSpec.describe "Support user views remind providers to submit claims when school
     expect(page).to have_h1("Remind providers to submit claims")
     expect(page).to have_paragraph("There is currently 1 provider that has not had claims assigned to them for the current claim window.")
     expect(page).to have_paragraph("The deadline for submitting claims is #{I18n.l(@claim_window.ends_on, format: :long)}, the email that is sent will use this date.")
+    expect(page).to have_link("Preview email (opens in new tab)", href: "/rails/mailers/claims/provider_mailer/claims_have_not_been_submitted")
     expect(page).to have_warning_text("An email will be sent to all of the providers that have not had claims assigned to them for the current claim window. This action cannot be undone.")
     expect(page).to have_button("Send reminders")
   end


### PR DESCRIPTION
## Context

We need to remind providers that have no had claims assigned to them that the claim window is closing soon, instead of doing this manually we've opted to add the functionality to the service.

## Changes proposed in this pull request

- Adds a new mailer
- Adds a support page to send an email to providers who have not had claims assigned to them for the current academic year

## Guidance to review

- Log in as colin
- Navigate to settings
- Click on "Remind providers to submit claims"
- Review content

## Link to Trello card

https://trello.com/c/8hs4wPht/34-add-some-headers-descriptions-to-the-support-settings-page-to-improve-clarity
https://trello.com/c/TnJw6CsW/41-add-remind-providers-to-ask-schools-to-create-claims-support-service


<img width="1044" height="657" alt="image" src="https://github.com/user-attachments/assets/80b4e193-9dd4-4e4c-afdb-e2e86174c891" />


