### PR TITLE
Claims can only be assigned to accredited providers

### DIFF
--- a/app/controllers/api/provider_suggestions_controller.rb
+++ b/app/controllers/api/provider_suggestions_controller.rb
@@ -16,7 +16,7 @@ class Api::ProviderSuggestionsController < ApplicationController
   end
 
   def claims_providers_scope
-    @claims_providers_scope ||= Provider.excluding_niot_providers
+    @claims_providers_scope ||= Provider.excluding_niot_providers.accredited
   end
 
   def placements_providers_scope

--- a/app/wizards/claims/add_claim_wizard/provider_options_step.rb
+++ b/app/wizards/claims/add_claim_wizard/provider_options_step.rb
@@ -2,9 +2,12 @@ class Claims::AddClaimWizard::ProviderOptionsStep < Claims::AddClaimWizard::Prov
   attribute :search_param
 
   def providers
-    @providers ||= Claims::Provider.search_name_urn_ukprn_postcode(
-      search_param.downcase,
-    ).decorate
+    @providers ||= Claims::Provider
+      .excluding_niot_providers
+      .accredited
+      .search_name_urn_ukprn_postcode(
+        search_param.downcase,
+      ).decorate
   end
 
   def search_param

--- a/app/wizards/claims/add_claim_wizard/provider_selection_step.rb
+++ b/app/wizards/claims/add_claim_wizard/provider_selection_step.rb
@@ -4,7 +4,10 @@ class Claims::AddClaimWizard::ProviderSelectionStep < BaseStep
   validates :id, presence: true
 
   def provider
-    @provider ||= Claims::Provider.find_by(id:)
+    @provider ||= Claims::Provider
+      .excluding_niot_providers
+      .accredited
+      .find_by(id:)
   end
 
   def scope

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -69,6 +69,10 @@ FactoryBot.define do
       name { "NIoT: National Institute of Teaching, founded by the School-Led Development Trust" }
     end
 
+    trait :accredited do
+      accredited { true }
+    end
+
     transient do
       email_addresses { [] }
     end
@@ -90,6 +94,6 @@ FactoryBot.define do
     end
   end
 
-  factory :claims_provider, class: "Claims::Provider", parent: :provider
+  factory :claims_provider, class: "Claims::Provider", parent: :provider, traits: %i[accredited]
   factory :placements_provider, class: "Placements::Provider", parent: :provider, traits: %i[placements]
 end

--- a/spec/requests/api/provider_suggestions_spec.rb
+++ b/spec/requests/api/provider_suggestions_spec.rb
@@ -1,79 +1,115 @@
 require "rails_helper"
 
 RSpec.describe "Provider suggestions", type: :request do
-  let!(:niot_headquarters) { create(:provider, code: "2N2", name: "NIoT") }
-  let!(:niot_site_1) { create(:provider, code: "1YF", name: "NIoT") }
-  let!(:niot_site_2) { create(:provider, code: "21J", name: "NIoT") }
-  let!(:niot_site_3) { create(:provider, code: "1GV", name: "NIoT") }
-  let!(:niot_site_4) { create(:provider, code: "2HE", name: "NIoT") }
-  let!(:niot_site_5) { create(:provider, code: "24P", name: "NIoT") }
-  let!(:niot_site_6) { create(:provider, code: "1MN", name: "NIoT") }
-  let!(:niot_site_7) { create(:provider, code: "1TZ", name: "NIoT") }
-  let!(:niot_site_8) { create(:provider, code: "5J5", name: "NIoT") }
-  let!(:niot_site_9) { create(:provider, code: "7K9", name: "NIoT") }
-  let!(:niot_site_10) { create(:provider, code: "L06", name: "NIoT") }
-  let!(:niot_site_11) { create(:provider, code: "2P4", name: "NIoT") }
-  let!(:niot_site_12) { create(:provider, code: "21P", name: "NIoT") }
-  let!(:niot_site_13) { create(:provider, code: "1FE", name: "NIoT") }
-  let!(:niot_site_14) { create(:provider, code: "3P4", name: "NIoT") }
-  let!(:niot_site_15) { create(:provider, code: "3L4", name: "NIoT") }
-  let!(:niot_site_16) { create(:provider, code: "2H7", name: "NIoT") }
-  let!(:niot_site_17) { create(:provider, code: "2A6", name: "NIoT") }
-  let!(:niot_site_18) { create(:provider, code: "4W2", name: "NIoT") }
-  let!(:niot_site_19) { create(:provider, code: "4L1", name: "NIoT") }
-  let!(:niot_site_20) { create(:provider, code: "4L3", name: "NIoT") }
-  let!(:niot_site_21) { create(:provider, code: "4C2", name: "NIoT") }
-  let!(:niot_site_22) { create(:provider, code: "5A6", name: "NIoT") }
-  let!(:niot_site_23) { create(:provider, code: "2U6", name: "NIoT") }
+  describe "filtering NIoT providers" do
+    let!(:niot_headquarters) { create(:provider, :accredited, code: "2N2", name: "NIoT") }
+    let!(:niot_site_1) { create(:provider, :accredited, code: "1YF", name: "NIoT") }
+    let!(:niot_site_2) { create(:provider, :accredited, code: "21J", name: "NIoT") }
+    let!(:niot_site_3) { create(:provider, :accredited, code: "1GV", name: "NIoT") }
+    let!(:niot_site_4) { create(:provider, :accredited, code: "2HE", name: "NIoT") }
+    let!(:niot_site_5) { create(:provider, :accredited, code: "24P", name: "NIoT") }
+    let!(:niot_site_6) { create(:provider, :accredited, code: "1MN", name: "NIoT") }
+    let!(:niot_site_7) { create(:provider, :accredited, code: "1TZ", name: "NIoT") }
+    let!(:niot_site_8) { create(:provider, :accredited, code: "5J5", name: "NIoT") }
+    let!(:niot_site_9) { create(:provider, :accredited, code: "7K9", name: "NIoT") }
+    let!(:niot_site_10) { create(:provider, :accredited, code: "L06", name: "NIoT") }
+    let!(:niot_site_11) { create(:provider, :accredited, code: "2P4", name: "NIoT") }
+    let!(:niot_site_12) { create(:provider, :accredited, code: "21P", name: "NIoT") }
+    let!(:niot_site_13) { create(:provider, :accredited, code: "1FE", name: "NIoT") }
+    let!(:niot_site_14) { create(:provider, :accredited, code: "3P4", name: "NIoT") }
+    let!(:niot_site_15) { create(:provider, :accredited, code: "3L4", name: "NIoT") }
+    let!(:niot_site_16) { create(:provider, :accredited, code: "2H7", name: "NIoT") }
+    let!(:niot_site_17) { create(:provider, :accredited, code: "2A6", name: "NIoT") }
+    let!(:niot_site_18) { create(:provider, :accredited, code: "4W2", name: "NIoT") }
+    let!(:niot_site_19) { create(:provider, :accredited, code: "4L1", name: "NIoT") }
+    let!(:niot_site_20) { create(:provider, :accredited, code: "4L3", name: "NIoT") }
+    let!(:niot_site_21) { create(:provider, :accredited, code: "4C2", name: "NIoT") }
+    let!(:niot_site_22) { create(:provider, :accredited, code: "5A6", name: "NIoT") }
+    let!(:niot_site_23) { create(:provider, :accredited, code: "2U6", name: "NIoT") }
 
-  describe "when requested from the claims service", service: :claims do
-    let(:claims_user) { create(:claims_user) }
+    describe "when requested from the claims service", service: :claims do
+      let(:claims_user) { create(:claims_user) }
 
-    it "does not return additional NIoT providers" do
-      sign_in_as claims_user
+      it "does not return additional NIoT providers" do
+        sign_in_as claims_user
 
-      get "/api/provider_suggestions?query=niot"
+        get "/api/provider_suggestions?query=niot"
 
-      json = JSON.parse(response.body)
-      expect(json).to eq([{ "code" => "2N2", "id" => niot_headquarters.id, "name" => "NIoT", "postcode" => nil }])
+        json = JSON.parse(response.body)
+        expect(json).to eq([{ "code" => "2N2", "id" => niot_headquarters.id, "name" => "NIoT", "postcode" => nil }])
+      end
+    end
+
+    describe "when requested from the placements service", service: :placements do
+      let(:placements_user) { create(:placements_user) }
+
+      it "returns all NIoT providers" do
+        sign_in_as placements_user
+
+        get "/api/provider_suggestions?query=niot"
+
+        json = JSON.parse(response.body)
+        expect(json).to contain_exactly(
+          { "code" => "2N2", "id" => niot_headquarters.id, "name" => "NIoT", "postcode" => nil },
+          { "code" => "1YF", "id" => niot_site_1.id, "name" => "NIoT", "postcode" => nil },
+          { "code" => "21J", "id" => niot_site_2.id, "name" => "NIoT", "postcode" => nil },
+          { "code" => "1GV", "id" => niot_site_3.id, "name" => "NIoT", "postcode" => nil },
+          { "code" => "2HE", "id" => niot_site_4.id, "name" => "NIoT", "postcode" => nil },
+          { "code" => "24P", "id" => niot_site_5.id, "name" => "NIoT", "postcode" => nil },
+          { "code" => "1MN", "id" => niot_site_6.id, "name" => "NIoT", "postcode" => nil },
+          { "code" => "1TZ", "id" => niot_site_7.id, "name" => "NIoT", "postcode" => nil },
+          { "code" => "5J5", "id" => niot_site_8.id, "name" => "NIoT", "postcode" => nil },
+          { "code" => "7K9", "id" => niot_site_9.id, "name" => "NIoT", "postcode" => nil },
+          { "code" => "L06", "id" => niot_site_10.id, "name" => "NIoT", "postcode" => nil },
+          { "code" => "2P4", "id" => niot_site_11.id, "name" => "NIoT", "postcode" => nil },
+          { "code" => "21P", "id" => niot_site_12.id, "name" => "NIoT", "postcode" => nil },
+          { "code" => "1FE", "id" => niot_site_13.id, "name" => "NIoT", "postcode" => nil },
+          { "code" => "3P4", "id" => niot_site_14.id, "name" => "NIoT", "postcode" => nil },
+          { "code" => "3L4", "id" => niot_site_15.id, "name" => "NIoT", "postcode" => nil },
+          { "code" => "2H7", "id" => niot_site_16.id, "name" => "NIoT", "postcode" => nil },
+          { "code" => "2A6", "id" => niot_site_17.id, "name" => "NIoT", "postcode" => nil },
+          { "code" => "4W2", "id" => niot_site_18.id, "name" => "NIoT", "postcode" => nil },
+          { "code" => "4L1", "id" => niot_site_19.id, "name" => "NIoT", "postcode" => nil },
+          { "code" => "4L3", "id" => niot_site_20.id, "name" => "NIoT", "postcode" => nil },
+          { "code" => "4C2", "id" => niot_site_21.id, "name" => "NIoT", "postcode" => nil },
+          { "code" => "5A6", "id" => niot_site_22.id, "name" => "NIoT", "postcode" => nil },
+          { "code" => "2U6", "id" => niot_site_23.id, "name" => "NIoT", "postcode" => nil },
+        )
+      end
     end
   end
 
-  describe "when requested from the placements service", service: :placements do
-    let(:placements_user) { create(:placements_user) }
+  describe "filtering accredited providers" do
+    let!(:accredited_provider) { create(:provider, :accredited, name: "Accredited provider", code: "AC1") }
+    let!(:unaccredited_provider) { create(:provider, name: "Unaccredited provider", code: "UA2") }
 
-    it "returns all NIoT providers" do
-      sign_in_as placements_user
+    describe "when requested from the claims service", service: :claims do
+      let(:claims_user) { create(:claims_user) }
 
-      get "/api/provider_suggestions?query=niot"
+      it "does not return only accredited providers" do
+        sign_in_as claims_user
 
-      json = JSON.parse(response.body)
-      expect(json).to contain_exactly(
-        { "code" => "2N2", "id" => niot_headquarters.id, "name" => "NIoT", "postcode" => nil },
-        { "code" => "1YF", "id" => niot_site_1.id, "name" => "NIoT", "postcode" => nil },
-        { "code" => "21J", "id" => niot_site_2.id, "name" => "NIoT", "postcode" => nil },
-        { "code" => "1GV", "id" => niot_site_3.id, "name" => "NIoT", "postcode" => nil },
-        { "code" => "2HE", "id" => niot_site_4.id, "name" => "NIoT", "postcode" => nil },
-        { "code" => "24P", "id" => niot_site_5.id, "name" => "NIoT", "postcode" => nil },
-        { "code" => "1MN", "id" => niot_site_6.id, "name" => "NIoT", "postcode" => nil },
-        { "code" => "1TZ", "id" => niot_site_7.id, "name" => "NIoT", "postcode" => nil },
-        { "code" => "5J5", "id" => niot_site_8.id, "name" => "NIoT", "postcode" => nil },
-        { "code" => "7K9", "id" => niot_site_9.id, "name" => "NIoT", "postcode" => nil },
-        { "code" => "L06", "id" => niot_site_10.id, "name" => "NIoT", "postcode" => nil },
-        { "code" => "2P4", "id" => niot_site_11.id, "name" => "NIoT", "postcode" => nil },
-        { "code" => "21P", "id" => niot_site_12.id, "name" => "NIoT", "postcode" => nil },
-        { "code" => "1FE", "id" => niot_site_13.id, "name" => "NIoT", "postcode" => nil },
-        { "code" => "3P4", "id" => niot_site_14.id, "name" => "NIoT", "postcode" => nil },
-        { "code" => "3L4", "id" => niot_site_15.id, "name" => "NIoT", "postcode" => nil },
-        { "code" => "2H7", "id" => niot_site_16.id, "name" => "NIoT", "postcode" => nil },
-        { "code" => "2A6", "id" => niot_site_17.id, "name" => "NIoT", "postcode" => nil },
-        { "code" => "4W2", "id" => niot_site_18.id, "name" => "NIoT", "postcode" => nil },
-        { "code" => "4L1", "id" => niot_site_19.id, "name" => "NIoT", "postcode" => nil },
-        { "code" => "4L3", "id" => niot_site_20.id, "name" => "NIoT", "postcode" => nil },
-        { "code" => "4C2", "id" => niot_site_21.id, "name" => "NIoT", "postcode" => nil },
-        { "code" => "5A6", "id" => niot_site_22.id, "name" => "NIoT", "postcode" => nil },
-        { "code" => "2U6", "id" => niot_site_23.id, "name" => "NIoT", "postcode" => nil },
-      )
+        get "/api/provider_suggestions?query=provider"
+
+        json = JSON.parse(response.body)
+        expect(json).to contain_exactly({ "code" => "AC1", "id" => accredited_provider.id, "name" => "Accredited provider", "postcode" => nil })
+      end
+    end
+
+    describe "when requested from the placements service", service: :placements do
+      let(:placements_user) { create(:placements_user) }
+
+      it "does not return only accredited providers" do
+        sign_in_as placements_user
+
+        get "/api/provider_suggestions?query=provider"
+
+        json = JSON.parse(response.body)
+        expect(json).to contain_exactly(
+          { "code" => "AC1", "id" => accredited_provider.id, "name" => "Accredited provider", "postcode" => nil },
+          { "code" => "UA2", "id" => unaccredited_provider.id, "name" => "Unaccredited provider", "postcode" => nil },
+        )
+      end
     end
   end
 end

--- a/spec/system/claims/schools/claims/school_user_creates_a_claim_with_javascript_disabled_spec.rb
+++ b/spec/system/claims/schools/claims/school_user_creates_a_claim_with_javascript_disabled_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe "School user creates a claim with javascript disabled", service: 
   end
 
   def and_providers_exist
-    @niot_provider = create(:provider, :niot)
-    @bpn_provider = create(:provider, :best_practice_network, postcode: "BR20RL", code: "111")
+    @niot_provider = create(:provider, :niot, :accredited)
+    @bpn_provider = create(:provider, :best_practice_network, :accredited, postcode: "BR20RL", code: "111")
   end
 
   def and_i_am_signed_in

--- a/spec/system/claims/support/schools/claims/support_user_creates_a_claim_with_javascript_spec.rb
+++ b/spec/system/claims/support/schools/claims/support_user_creates_a_claim_with_javascript_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe "School user creates a claim with javascript disabled", service: 
   end
 
   def and_providers_exist
-    @niot_provider = create(:provider, :niot)
-    @bpn_provider = create(:provider, :best_practice_network)
+    @niot_provider = create(:provider, :niot, :accredited)
+    @bpn_provider = create(:provider, :best_practice_network, :accredited)
   end
 
   def and_i_am_signed_in


### PR DESCRIPTION
## Context

- When creating a claim, only accredited providers will appear in the autocomplete dropdown.

## Changes proposed in this pull request

- Add `accredited` scope to claims controllers when searching for providers.
