### PR TITLE
Invert clawback logic

### DIFF
--- a/app/models/claims/mentor_training.rb
+++ b/app/models/claims/mentor_training.rb
@@ -59,9 +59,20 @@ class Claims::MentorTraining < ApplicationRecord
 
   delegate :full_name, to: :mentor, prefix: true, allow_nil: true
   delegate :name, to: :provider, prefix: true, allow_nil: true
+  delegate :school, to: :claim
+  delegate :region, to: :school
+  delegate :region_funding_available_per_hour, to: :school
 
   def set_training_type
     self.training_type = training_allowance.training_type
+  end
+
+  def corrected_hours_completed
+    hours_completed - hours_clawed_back.to_i
+  end
+
+  def clawback_amount
+    corrected_hours_completed * region_funding_available_per_hour
   end
 
   private

--- a/app/models/claims/mentor_training.rb
+++ b/app/models/claims/mentor_training.rb
@@ -60,8 +60,7 @@ class Claims::MentorTraining < ApplicationRecord
   delegate :full_name, to: :mentor, prefix: true, allow_nil: true
   delegate :name, to: :provider, prefix: true, allow_nil: true
   delegate :school, to: :claim
-  delegate :region, to: :school
-  delegate :region_funding_available_per_hour, to: :school
+  delegate :region, :region_funding_available_per_hour, to: :school
 
   def set_training_type
     self.training_type = training_allowance.training_type
@@ -72,7 +71,7 @@ class Claims::MentorTraining < ApplicationRecord
   end
 
   def clawback_amount
-    corrected_hours_completed * region_funding_available_per_hour
+    hours_clawed_back * region_funding_available_per_hour
   end
 
   private

--- a/app/services/claims/claim/clawback/clawback_requested.rb
+++ b/app/services/claims/claim/clawback/clawback_requested.rb
@@ -11,7 +11,7 @@ class Claims::Claim::Clawback::ClawbackRequested < ApplicationService
         next if esfa_mentor_training_response.blank?
 
         mentor_training.update!(
-          hours_clawed_back: esfa_mentor_training_response[:number_of_hours],
+          hours_clawed_back: esfa_mentor_training_response[:hours_clawed_back],
           reason_clawed_back: esfa_mentor_training_response[:reason_for_clawback],
         )
       end

--- a/app/views/claims/support/claims/_details.html.erb
+++ b/app/views/claims/support/claims/_details.html.erb
@@ -83,59 +83,57 @@
 
 <h2 class="govuk-heading-m"><%= t(".hours_of_training") %></h2>
   <% if claim.in_clawback? %>
-      <% claim.mentor_trainings.not_assured.order_by_mentor_full_name.each do |mentor_training| %>
-       <%= govuk_summary_list do |summary_list| %>
+    <% claim.mentor_trainings.not_assured.order_by_mentor_full_name.each do |mentor_training| %>
+      <%= govuk_summary_card(title: mentor_training.mentor.full_name) do |card| %>
+        <% card.with_summary_list do |summary_list| %>
           <% summary_list.with_row do |row| %>
-            <% row.with_key(text: mentor_training.mentor.full_name) %>
+            <% row.with_key(text: t(".original")) %>
+            <% row.with_value(text: pluralize(mentor_training.hours_completed, t(".hour"))) %>
           <% end %>
 
-        <% summary_list.with_row do |row| %>
-          <% row.with_key(text: t(".original")) %>
-          <% row.with_value(text: pluralize(mentor_training.hours_completed, t(".hour"))) %>
-        <% end %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".mentor_worked_hours")) %>
+            <% row.with_value(text: pluralize(mentor_training.corrected_hours_completed, t(".hour"))) %>
+            <% if policy(claim).edit? || claim.clawback_requested? %>
+              <% row.with_action(text: t("change"),
+                                 href: new_edit_request_clawback_claims_support_claims_clawback_path(
+                                  claim_id: claim.id,
+                                  mentor_training_id: mentor_training.id,
+                                ),
+                                 html_attributes: {
+                                   class: "govuk-link--no-visited-state",
+                                 }) %>
+              <% end %>
+          <% end %>
 
-        <% summary_list.with_row do |row| %>
-          <% row.with_key(text: t(".mentor_worked_hours")) %>
-          <% row.with_value(text: pluralize(mentor_training.corrected_hours_completed, t(".hour"))) %>
-          <% if policy(claim).edit? || claim.clawback_requested? %>
-            <% row.with_action(text: t("change"),
-                               href: new_edit_request_clawback_claims_support_claims_clawback_path(
-                                claim_id: claim.id,
-                                mentor_training_id: mentor_training.id,
-                              ),
-                               html_attributes: {
-                              class: "govuk-link--no-visited-state",
-                              }) %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".hours_clawed_back")) %>
+            <% row.with_value(text: pluralize(mentor_training.hours_clawed_back, t(".hour"))) %>
+          <% end %>
+
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".rate")) %>
+            <% row.with_value(text: humanized_money_with_symbol(mentor_training.region_funding_available_per_hour)) %>
+          <% end %>
+
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".clawback_amount")) %>
+            <% row.with_value(text: humanized_money_with_symbol(mentor_training.clawback_amount)) %>
+          <% end %>
+
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".reason_clawed_back")) %>
+            <% row.with_value(text: mentor_training.reason_clawed_back) %>
+            <% if policy(claim).edit? || claim.clawback_requested? %>
+              <% row.with_action(text: t("change"),
+                                 href: new_edit_request_clawback_claims_support_claims_clawback_path(
+                                  claim_id: claim.id,
+                                  mentor_training_id: mentor_training.id,
+                                ),
+                                 html_attributes: {
+                                  class: "govuk-link--no-visited-state",
+                                 }) %>
             <% end %>
-        <% end %>
-
-        <% summary_list.with_row do |row| %>
-          <% row.with_key(text: t(".hours_clawed_back")) %>
-          <% row.with_value(text: pluralize(mentor_training.hours_clawed_back, t(".hour"))) %>
-        <% end %>
-
-        <% summary_list.with_row do |row| %>
-          <% row.with_key(text: t(".rate")) %>
-          <% row.with_value(text: humanized_money_with_symbol(mentor_training.region_funding_available_per_hour)) %>
-        <% end %>
-
-        <% summary_list.with_row do |row| %>
-          <% row.with_key(text: t(".clawback_amount")) %>
-          <% row.with_value(text: humanized_money_with_symbol(mentor_training.clawback_amount)) %>
-        <% end %>
-
-        <% summary_list.with_row do |row| %>
-          <% row.with_key(text: t(".reason_clawed_back")) %>
-          <% row.with_value(text: mentor_training.reason_clawed_back) %>
-          <% if policy(claim).edit? || claim.clawback_requested? %>
-            <% row.with_action(text: t("change"),
-                               href: new_edit_request_clawback_claims_support_claims_clawback_path(
-                                claim_id: claim.id,
-                                mentor_training_id: mentor_training.id,
-                              ),
-                               html_attributes: {
-                               class: "govuk-link--no-visited-state",
-                              }) %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/claims/support/claims/_details.html.erb
+++ b/app/views/claims/support/claims/_details.html.erb
@@ -84,59 +84,63 @@
 <h2 class="govuk-heading-m"><%= t(".hours_of_training") %></h2>
   <% if claim.in_clawback? %>
     <% claim.mentor_trainings.not_assured.order_by_mentor_full_name.each do |mentor_training| %>
-      <%= govuk_summary_card(title: mentor_training.mentor.full_name) do |card| %>
-        <% card.with_summary_list do |summary_list| %>
-          <% summary_list.with_row do |row| %>
-            <% row.with_key(text: t(".original")) %>
-            <% row.with_value(text: pluralize(mentor_training.hours_completed, t(".hour"))) %>
-          <% end %>
+      <div id="mentor-training-<%= mentor_training.id %>">
+        <%= govuk_summary_card(title: mentor_training.mentor.full_name) do |card| %>
+          <% card.with_summary_list do |summary_list| %>
+            <% summary_list.with_row do |row| %>
+              <% row.with_key(text: t(".original")) %>
+              <% row.with_value(text: pluralize(mentor_training.hours_completed, t(".hour"))) %>
+            <% end %>
 
-          <% summary_list.with_row do |row| %>
-            <% row.with_key(text: t(".mentor_worked_hours")) %>
-            <% row.with_value(text: pluralize(mentor_training.corrected_hours_completed, t(".hour"))) %>
-            <% if policy(claim).edit? || claim.clawback_requested? %>
-              <% row.with_action(text: t("change"),
-                                 href: new_edit_request_clawback_claims_support_claims_clawback_path(
-                                  claim_id: claim.id,
-                                  mentor_training_id: mentor_training.id,
-                                ),
-                                 html_attributes: {
-                                   class: "govuk-link--no-visited-state",
-                                 }) %>
+            <% summary_list.with_row do |row| %>
+              <% row.with_key(text: t(".mentor_worked_hours")) %>
+              <% row.with_value(text: pluralize(mentor_training.corrected_hours_completed, t(".hour"))) %>
+              <% if policy(claim).edit? || claim.clawback_requested? %>
+                <% row.with_action(text: t("change"),
+                                   visually_hidden_text: "#{mentor_training.mentor.full_name} #{t(".mentor_worked_hours")}",
+                                   href: new_edit_request_clawback_claims_support_claims_clawback_path(
+                                     claim_id: claim.id,
+                                     mentor_training_id: mentor_training.id,
+                                   ),
+                                   html_attributes: {
+                                     class: "govuk-link--no-visited-state",
+                                   }) %>
+                <% end %>
+            <% end %>
+
+            <% summary_list.with_row do |row| %>
+              <% row.with_key(text: t(".hours_clawed_back")) %>
+              <% row.with_value(text: pluralize(mentor_training.hours_clawed_back, t(".hour"))) %>
+            <% end %>
+
+            <% summary_list.with_row do |row| %>
+              <% row.with_key(text: t(".rate")) %>
+              <% row.with_value(text: humanized_money_with_symbol(mentor_training.region_funding_available_per_hour)) %>
+            <% end %>
+
+            <% summary_list.with_row do |row| %>
+              <% row.with_key(text: t(".clawback_amount")) %>
+              <% row.with_value(text: humanized_money_with_symbol(mentor_training.clawback_amount)) %>
+            <% end %>
+
+            <% summary_list.with_row do |row| %>
+              <% row.with_key(text: t(".reason_clawed_back")) %>
+              <% row.with_value(text: mentor_training.reason_clawed_back) %>
+              <% if policy(claim).edit? || claim.clawback_requested? %>
+                <% row.with_action(text: t("change"),
+                                   visually_hidden_text: "#{mentor_training.mentor.full_name} #{t(".reason_clawed_back")}",
+                                   href: new_edit_request_clawback_claims_support_claims_clawback_path(
+                                     claim_id: claim.id,
+                                     mentor_training_id: mentor_training.id,
+                                   ),
+                                   html_attributes: {
+                                     class: "govuk-link--no-visited-state",
+                                   }) %>
               <% end %>
-          <% end %>
-
-          <% summary_list.with_row do |row| %>
-            <% row.with_key(text: t(".hours_clawed_back")) %>
-            <% row.with_value(text: pluralize(mentor_training.hours_clawed_back, t(".hour"))) %>
-          <% end %>
-
-          <% summary_list.with_row do |row| %>
-            <% row.with_key(text: t(".rate")) %>
-            <% row.with_value(text: humanized_money_with_symbol(mentor_training.region_funding_available_per_hour)) %>
-          <% end %>
-
-          <% summary_list.with_row do |row| %>
-            <% row.with_key(text: t(".clawback_amount")) %>
-            <% row.with_value(text: humanized_money_with_symbol(mentor_training.clawback_amount)) %>
-          <% end %>
-
-          <% summary_list.with_row do |row| %>
-            <% row.with_key(text: t(".reason_clawed_back")) %>
-            <% row.with_value(text: mentor_training.reason_clawed_back) %>
-            <% if policy(claim).edit? || claim.clawback_requested? %>
-              <% row.with_action(text: t("change"),
-                                 href: new_edit_request_clawback_claims_support_claims_clawback_path(
-                                  claim_id: claim.id,
-                                  mentor_training_id: mentor_training.id,
-                                ),
-                                 html_attributes: {
-                                  class: "govuk-link--no-visited-state",
-                                 }) %>
             <% end %>
           <% end %>
         <% end %>
-      <% end %>
+      </div>
     <% end %>
   <% else %>
     <%= govuk_summary_list(actions: policy(claim).edit?) do |summary_list| %>
@@ -157,9 +161,10 @@
   <% end %>
 <% end %>
 
-<h2 class="govuk-heading-m"><%= t(".grant_funding") %></h2>
+<div id="grant_funding">
+  <h2 class="govuk-heading-m"><%= t(".grant_funding") %></h2>
   <% if claim.in_clawback? %>
-      <%= govuk_summary_list(actions: false) do |summary_list| %>
+    <%= govuk_summary_list(actions: false) do |summary_list| %>
       <% summary_list.with_row do |row| %>
         <% row.with_key(text: t(".original_amount")) %>
         <% row.with_value(text: humanized_money_with_symbol(claim.amount)) %>
@@ -198,3 +203,4 @@
       <% end %>
     <% end %>
   <% end %>
+</div>

--- a/app/views/claims/support/claims/_details.html.erb
+++ b/app/views/claims/support/claims/_details.html.erb
@@ -95,8 +95,8 @@
         <% end %>
 
         <% summary_list.with_row do |row| %>
-          <% row.with_key(text: t(".clawed_back")) %>
-          <% row.with_value(text: pluralize(mentor_training.hours_clawed_back, t(".hour"))) %>
+          <% row.with_key(text: t(".mentor_worked_hours")) %>
+          <% row.with_value(text: pluralize(mentor_training.corrected_hours_completed, t(".hour"))) %>
           <% if policy(claim).edit? || claim.clawback_requested? %>
             <% row.with_action(text: t("change"),
                                href: new_edit_request_clawback_claims_support_claims_clawback_path(
@@ -107,6 +107,21 @@
                               class: "govuk-link--no-visited-state",
                               }) %>
             <% end %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".hours_clawed_back")) %>
+          <% row.with_value(text: pluralize(mentor_training.hours_clawed_back, t(".hour"))) %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".rate")) %>
+          <% row.with_value(text: humanized_money_with_symbol(mentor_training.region_funding_available_per_hour)) %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".clawback_amount")) %>
+          <% row.with_value(text: humanized_money_with_symbol(mentor_training.clawback_amount)) %>
         <% end %>
 
         <% summary_list.with_row do |row| %>

--- a/app/views/wizards/claims/request_clawback_wizard/_check_your_answers_step.html.erb
+++ b/app/views/wizards/claims/request_clawback_wizard/_check_your_answers_step.html.erb
@@ -54,9 +54,9 @@
                 <% row.with_key(text: t(".number_of_hours")) %>
                 <% row.with_value(text: pluralize(current_step.mentor_training_correct_hours(mentor_training), t(".hour"))) %>
                 <% row.with_action(text: t(".change"),
-                                  href: step_path(@wizard.step_name_for_mentor_training_clawback(mentor_training)),
-                                  visually_hidden_text: t(".number_of_hours"),
-                                  classes: ["govuk-link--no-visited-state"]) %>
+                                   href: step_path(@wizard.step_name_for_mentor_training_clawback(mentor_training)),
+                                   visually_hidden_text: t(".number_of_hours"),
+                                   classes: ["govuk-link--no-visited-state"]) %>
               <% end %>
               <% summary_list.with_row do |row| %>
                 <% row.with_key(text: t(".hours_clawed_back")) %>
@@ -74,9 +74,9 @@
                 <% row.with_key(text: t(".reason")) %>
                 <% row.with_value(text: current_step.mentor_training_clawback_reason(mentor_training)) %>
                 <% row.with_action(text: t(".change"),
-                                  href: step_path(@wizard.step_name_for_mentor_training_clawback(mentor_training)),
-                                  visually_hidden_text: t(".reason"),
-                                  classes: ["govuk-link--no-visited-state"]) %>
+                                   href: step_path(@wizard.step_name_for_mentor_training_clawback(mentor_training)),
+                                   visually_hidden_text: t(".reason"),
+                                   classes: ["govuk-link--no-visited-state"]) %>
               <% end %>
             <% end %>
           <% end %>

--- a/app/views/wizards/claims/request_clawback_wizard/_check_your_answers_step.html.erb
+++ b/app/views/wizards/claims/request_clawback_wizard/_check_your_answers_step.html.erb
@@ -41,36 +41,42 @@
         <% end %>
       <% end %>
 
+      <h2 class="govuk-heading-m"><%= t(".clawback_details") %></h2>
       <% @wizard.mentor_trainings.each do |mentor_training| %>
-        <h2 class="govuk-heading-m"><%= t(".mentor_training_title", mentor_name: mentor_training.mentor_full_name) %></h2>
-        <%= govuk_summary_list(html_attributes: { id: "mentor-training-#{mentor_training.id}" }) do |summary_list| %>
-          <% summary_list.with_row do |row| %>
-            <% row.with_key(text: t(".number_of_hours")) %>
-            <% row.with_value(text: current_step.mentor_training_correct_hours(mentor_training)) %>
-            <% row.with_action(text: t(".change"),
-                               href: step_path(@wizard.step_name_for_mentor_training_clawback(mentor_training)),
-                               visually_hidden_text: t(".number_of_hours"),
-                               classes: ["govuk-link--no-visited-state"]) %>
-          <% end %>
-          <% summary_list.with_row do |row| %>
-            <% row.with_key(text: t(".hours_clawed_back")) %>
-            <% row.with_value(text: current_step.mentor_training_clawback_hours(mentor_training)) %>
-          <% end %>
-          <% summary_list.with_row do |row| %>
-            <% row.with_key(text: t(".rate")) %>
-            <% row.with_value(text: humanized_money_with_symbol(current_step.region_funding_available_per_hour)) %>
-          <% end %>
-          <% summary_list.with_row do |row| %>
-            <% row.with_key(text: t(".clawback_amount")) %>
-            <% row.with_value(text: humanized_money_with_symbol(current_step.mentor_training_clawback_amount(mentor_training))) %>
-          <% end %>
-          <% summary_list.with_row do |row| %>
-            <% row.with_key(text: t(".reason")) %>
-            <% row.with_value(text: current_step.mentor_training_clawback_reason(mentor_training)) %>
-            <% row.with_action(text: t(".change"),
-                               href: step_path(@wizard.step_name_for_mentor_training_clawback(mentor_training)),
-                               visually_hidden_text: t(".reason"),
-                               classes: ["govuk-link--no-visited-state"]) %>
+        <%= govuk_summary_card(title: mentor_training.mentor_full_name) do |card| %>
+          <% card.with_summary_list do |summary_list| %>
+            <% summary_list.with_row do |row| %>
+              <% row.with_key(text: t(".original")) %>
+              <% row.with_value(text: pluralize(mentor_training.hours_completed, t(".hour"))) %>
+            <% end %>
+            <% summary_list.with_row do |row| %>
+              <% row.with_key(text: t(".number_of_hours")) %>
+              <% row.with_value(text: pluralize(current_step.mentor_training_correct_hours(mentor_training), t(".hour"))) %>
+              <% row.with_action(text: t(".change"),
+                                 href: step_path(@wizard.step_name_for_mentor_training_clawback(mentor_training)),
+                                 visually_hidden_text: t(".number_of_hours"),
+                                 classes: ["govuk-link--no-visited-state"]) %>
+            <% end %>
+            <% summary_list.with_row do |row| %>
+              <% row.with_key(text: t(".hours_clawed_back")) %>
+              <% row.with_value(text: pluralize(current_step.mentor_training_clawback_hours(mentor_training), t(".hour"))) %>
+            <% end %>
+            <% summary_list.with_row do |row| %>
+              <% row.with_key(text: t(".rate")) %>
+              <% row.with_value(text: humanized_money_with_symbol(current_step.region_funding_available_per_hour)) %>
+            <% end %>
+            <% summary_list.with_row do |row| %>
+              <% row.with_key(text: t(".clawback_amount")) %>
+              <% row.with_value(text: humanized_money_with_symbol(current_step.mentor_training_clawback_amount(mentor_training))) %>
+            <% end %>
+            <% summary_list.with_row do |row| %>
+              <% row.with_key(text: t(".reason")) %>
+              <% row.with_value(text: current_step.mentor_training_clawback_reason(mentor_training)) %>
+              <% row.with_action(text: t(".change"),
+                                 href: step_path(@wizard.step_name_for_mentor_training_clawback(mentor_training)),
+                                 visually_hidden_text: t(".reason"),
+                                 classes: ["govuk-link--no-visited-state"]) %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/wizards/claims/request_clawback_wizard/_check_your_answers_step.html.erb
+++ b/app/views/wizards/claims/request_clawback_wizard/_check_your_answers_step.html.erb
@@ -46,11 +46,15 @@
         <%= govuk_summary_list(html_attributes: { id: "mentor-training-#{mentor_training.id}" }) do |summary_list| %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".number_of_hours")) %>
-            <% row.with_value(text: current_step.mentor_training_clawback_hours(mentor_training)) %>
+            <% row.with_value(text: current_step.mentor_training_correct_hours(mentor_training)) %>
             <% row.with_action(text: t(".change"),
                                href: step_path(@wizard.step_name_for_mentor_training_clawback(mentor_training)),
                                visually_hidden_text: t(".number_of_hours"),
                                classes: ["govuk-link--no-visited-state"]) %>
+          <% end %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key(text: t(".hours_clawed_back")) %>
+            <% row.with_value(text: current_step.mentor_training_clawback_hours(mentor_training)) %>
           <% end %>
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: t(".rate")) %>

--- a/app/views/wizards/claims/request_clawback_wizard/_check_your_answers_step.html.erb
+++ b/app/views/wizards/claims/request_clawback_wizard/_check_your_answers_step.html.erb
@@ -43,42 +43,44 @@
 
       <h2 class="govuk-heading-m"><%= t(".clawback_details") %></h2>
       <% @wizard.mentor_trainings.each do |mentor_training| %>
-        <%= govuk_summary_card(title: mentor_training.mentor_full_name) do |card| %>
-          <% card.with_summary_list do |summary_list| %>
-            <% summary_list.with_row do |row| %>
-              <% row.with_key(text: t(".original")) %>
-              <% row.with_value(text: pluralize(mentor_training.hours_completed, t(".hour"))) %>
-            <% end %>
-            <% summary_list.with_row do |row| %>
-              <% row.with_key(text: t(".number_of_hours")) %>
-              <% row.with_value(text: pluralize(current_step.mentor_training_correct_hours(mentor_training), t(".hour"))) %>
-              <% row.with_action(text: t(".change"),
-                                 href: step_path(@wizard.step_name_for_mentor_training_clawback(mentor_training)),
-                                 visually_hidden_text: t(".number_of_hours"),
-                                 classes: ["govuk-link--no-visited-state"]) %>
-            <% end %>
-            <% summary_list.with_row do |row| %>
-              <% row.with_key(text: t(".hours_clawed_back")) %>
-              <% row.with_value(text: pluralize(current_step.mentor_training_clawback_hours(mentor_training), t(".hour"))) %>
-            <% end %>
-            <% summary_list.with_row do |row| %>
-              <% row.with_key(text: t(".rate")) %>
-              <% row.with_value(text: humanized_money_with_symbol(current_step.region_funding_available_per_hour)) %>
-            <% end %>
-            <% summary_list.with_row do |row| %>
-              <% row.with_key(text: t(".clawback_amount")) %>
-              <% row.with_value(text: humanized_money_with_symbol(current_step.mentor_training_clawback_amount(mentor_training))) %>
-            <% end %>
-            <% summary_list.with_row do |row| %>
-              <% row.with_key(text: t(".reason")) %>
-              <% row.with_value(text: current_step.mentor_training_clawback_reason(mentor_training)) %>
-              <% row.with_action(text: t(".change"),
-                                 href: step_path(@wizard.step_name_for_mentor_training_clawback(mentor_training)),
-                                 visually_hidden_text: t(".reason"),
-                                 classes: ["govuk-link--no-visited-state"]) %>
+        <div id="mentor-training-<%= mentor_training.id %>">
+          <%= govuk_summary_card(title: mentor_training.mentor_full_name) do |card| %>
+            <% card.with_summary_list do |summary_list| %>
+              <% summary_list.with_row do |row| %>
+                <% row.with_key(text: t(".original")) %>
+                <% row.with_value(text: pluralize(mentor_training.hours_completed, t(".hour"))) %>
+              <% end %>
+              <% summary_list.with_row do |row| %>
+                <% row.with_key(text: t(".number_of_hours")) %>
+                <% row.with_value(text: pluralize(current_step.mentor_training_correct_hours(mentor_training), t(".hour"))) %>
+                <% row.with_action(text: t(".change"),
+                                  href: step_path(@wizard.step_name_for_mentor_training_clawback(mentor_training)),
+                                  visually_hidden_text: t(".number_of_hours"),
+                                  classes: ["govuk-link--no-visited-state"]) %>
+              <% end %>
+              <% summary_list.with_row do |row| %>
+                <% row.with_key(text: t(".hours_clawed_back")) %>
+                <% row.with_value(text: pluralize(current_step.mentor_training_clawback_hours(mentor_training), t(".hour"))) %>
+              <% end %>
+              <% summary_list.with_row do |row| %>
+                <% row.with_key(text: t(".rate")) %>
+                <% row.with_value(text: humanized_money_with_symbol(current_step.region_funding_available_per_hour)) %>
+              <% end %>
+              <% summary_list.with_row do |row| %>
+                <% row.with_key(text: t(".clawback_amount")) %>
+                <% row.with_value(text: humanized_money_with_symbol(current_step.mentor_training_clawback_amount(mentor_training))) %>
+              <% end %>
+              <% summary_list.with_row do |row| %>
+                <% row.with_key(text: t(".reason")) %>
+                <% row.with_value(text: current_step.mentor_training_clawback_reason(mentor_training)) %>
+                <% row.with_action(text: t(".change"),
+                                  href: step_path(@wizard.step_name_for_mentor_training_clawback(mentor_training)),
+                                  visually_hidden_text: t(".reason"),
+                                  classes: ["govuk-link--no-visited-state"]) %>
+              <% end %>
             <% end %>
           <% end %>
-        <% end %>
+        </div>
       <% end %>
 
       <%= f.govuk_submit t(".submit") %>

--- a/app/wizards/claims/edit_request_clawback_wizard.rb
+++ b/app/wizards/claims/edit_request_clawback_wizard.rb
@@ -39,19 +39,21 @@ module Claims
     end
 
     def esfa_responses_for_mentor_trainings
-      mentor_trainings.map do |mentor_training|
+      mentor_trainings.map { |mentor_training|
         mentor_training_clawback_step = steps[step_name_for_mentor_training_clawback(mentor_training)]
+        next if mentor_training_clawback_step.blank?
+
         {
           id: mentor_training.id,
-          number_of_hours: mentor_training_clawback_step.number_of_hours,
+          hours_clawed_back: mentor_training_clawback_step.hours_clawed_back,
           reason_for_clawback: mentor_training_clawback_step.reason_for_clawback,
         }
-      end
+      }.compact.flatten
     end
 
     def setup_state
       state[step_name_for_mentor_training_clawback(mentor_training).to_s] = {
-        "number_of_hours" => mentor_training.hours_clawed_back,
+        "number_of_hours" => mentor_training.hours_completed - mentor_training.hours_clawed_back,
         "reason_for_clawback" => mentor_training.reason_clawed_back,
       }
     end

--- a/app/wizards/claims/request_clawback_wizard.rb
+++ b/app/wizards/claims/request_clawback_wizard.rb
@@ -30,7 +30,7 @@ module Claims
         mentor_training_clawback_step = steps[step_name_for_mentor_training_clawback(mentor_training)]
         {
           id: mentor_training.id,
-          number_of_hours: mentor_training_clawback_step.number_of_hours,
+          hours_clawed_back: mentor_training_clawback_step.hours_clawed_back,
           reason_for_clawback: mentor_training_clawback_step.reason_for_clawback,
         }
       end

--- a/app/wizards/claims/request_clawback_wizard/check_your_answers_step.rb
+++ b/app/wizards/claims/request_clawback_wizard/check_your_answers_step.rb
@@ -7,8 +7,12 @@ class Claims::RequestClawbackWizard::CheckYourAnswersStep < BaseStep
     steps.fetch(step_name_for_mentor_training_clawback(mentor_training))
   end
 
-  def mentor_training_clawback_hours(mentor_training)
+  def mentor_training_correct_hours(mentor_training)
     mentor_training_clawback_data(mentor_training).number_of_hours.to_i
+  end
+
+  def mentor_training_clawback_hours(mentor_training)
+    mentor_training_clawback_data(mentor_training).hours_clawed_back
   end
 
   def mentor_training_clawback_amount(mentor_training)

--- a/app/wizards/claims/request_clawback_wizard/mentor_training_clawback_step.rb
+++ b/app/wizards/claims/request_clawback_wizard/mentor_training_clawback_step.rb
@@ -4,14 +4,19 @@ class Claims::RequestClawbackWizard::MentorTrainingClawbackStep < BaseStep
   attribute :reason_for_clawback
 
   validates :mentor_training_id, presence: true
-  validates :number_of_hours, presence: true, numericality: { only_integer: true, less_than_or_equal_to: proc { |step| step.mentor_training.hours_completed }, greater_than: 0 }
+  validates :number_of_hours, presence: true, numericality: { only_integer: true, less_than: proc { |step| step.mentor_training.hours_completed }, greater_than_or_equal_to: 0 }
   validates :reason_for_clawback, presence: true
 
   delegate :mentor_trainings, :claim, to: :wizard
+  delegate :hours_completed, to: :claim
   delegate :mentor, :reason_rejected, :reason_not_assured, to: :mentor_training
   delegate :full_name, :full_name_possessive, to: :mentor, prefix: true
 
   def mentor_training
     mentor_trainings.find(mentor_training_id)
+  end
+
+  def hours_clawed_back
+    mentor_training.hours_completed - number_of_hours.to_i
   end
 end

--- a/config/locales/en/claims/support/claims.yml
+++ b/config/locales/en/claims/support/claims.yml
@@ -61,3 +61,5 @@ en:
           hours_clawed_back: Hours clawed back
           clawback_amount: Clawback amount
           adjusted_total: Adjusted grant funding total
+          mentor_worked_hours: Mentor worked hours
+          rate: Hourly rate

--- a/config/locales/en/wizards/claims/request_clawback_wizard.yml
+++ b/config/locales/en/wizards/claims/request_clawback_wizard.yml
@@ -20,7 +20,7 @@ en:
           page_title: Check your answers - %{school_name} - Claim %{reference}
           title: Check your answers
           total_title: Total clawback
-          mentor_training_title: Clawback request for %{mentor_name}
+          clawback_details: Clawback details
           rate: Hourly rate
           number_of_hours: Hours the mentor worked
           hours_clawed_back: Hours clawed back
@@ -31,3 +31,5 @@ en:
           original_claim: Original claim
           amount: Amount
           information_shared_with_school: This information will be shared with %{school_name}.
+          original: Original hours claimed
+          hour: hour

--- a/config/locales/en/wizards/claims/request_clawback_wizard.yml
+++ b/config/locales/en/wizards/claims/request_clawback_wizard.yml
@@ -5,7 +5,7 @@ en:
         mentor_training_clawback_step:
           page_title: Clawback details for %{mentor_name} - %{school_name} - Claim %{reference}
           title: Clawback details for %{mentor_name}
-          hours: Number of hours to clawback
+          hours: Number of hours the mentor worked
           hours_hint: 
             one: "%{mentor_name} original claim was for %{count} hour"
             other: "%{mentor_name} original claim was for %{count} hours"
@@ -22,7 +22,8 @@ en:
           total_title: Total clawback
           mentor_training_title: Clawback request for %{mentor_name}
           rate: Hourly rate
-          number_of_hours: Hours
+          number_of_hours: Hours the mentor worked
+          hours_clawed_back: Hours clawed back
           clawback_amount: Clawback amount
           reason: Notes on your decision
           submit: Request clawback

--- a/spec/models/claims/mentor_training_spec.rb
+++ b/spec/models/claims/mentor_training_spec.rb
@@ -99,6 +99,9 @@ RSpec.describe Claims::MentorTraining, type: :model do
   describe "delegations" do
     it { is_expected.to delegate_method(:full_name).to(:mentor).with_prefix.allow_nil }
     it { is_expected.to delegate_method(:name).to(:provider).with_prefix.allow_nil }
+    it { is_expected.to delegate_method(:school).to(:claim) }
+    it { is_expected.to delegate_method(:region).to(:school) }
+    it { is_expected.to delegate_method(:region_funding_available_per_hour).to(:school) }
   end
 
   describe "#hours_completed" do
@@ -198,6 +201,26 @@ RSpec.describe Claims::MentorTraining, type: :model do
       mentor_training.set_training_type
 
       expect(mentor_training.training_type).to eq("pineapple")
+    end
+  end
+
+  describe "#corrected_hours_completed" do
+    subject(:corrected_hours_completed) { mentor_training.corrected_hours_completed }
+
+    let(:mentor_training) { build(:mentor_training, hours_completed: 20, hours_clawed_back: 5) }
+
+    it "returns the hours_completed minus the hours_clawed_back" do
+      expect(corrected_hours_completed).to eq(15)
+    end
+  end
+
+  describe "#clawback_amount" do
+    subject(:clawback_amount) { mentor_training.clawback_amount }
+
+    let(:mentor_training) { create(:mentor_training, hours_completed: 20, hours_clawed_back: 5) }
+
+    it "returns the amount claimed back for the mentor training" do
+      expect(clawback_amount.to_f).to eq(225.5)
     end
   end
 end

--- a/spec/models/claims/mentor_training_spec.rb
+++ b/spec/models/claims/mentor_training_spec.rb
@@ -217,10 +217,21 @@ RSpec.describe Claims::MentorTraining, type: :model do
   describe "#clawback_amount" do
     subject(:clawback_amount) { mentor_training.clawback_amount }
 
-    let(:mentor_training) { create(:mentor_training, hours_completed: 20, hours_clawed_back: 5) }
+    let(:region) { regions(:inner_london) }
+    let(:school) { build(:claims_school, region:) }
+    let(:claim) { build(:claim, school:) }
+
+    let(:mentor_training) do
+      create(
+        :mentor_training,
+        claim:,
+        hours_completed: 20,
+        hours_clawed_back: 5,
+      )
+    end
 
     it "returns the amount claimed back for the mentor training" do
-      expect(clawback_amount.to_f).to eq(225.5)
+      expect(clawback_amount.to_f).to eq(268.0)
     end
   end
 end

--- a/spec/services/claims/claim/clawback/clawback_requested_spec.rb
+++ b/spec/services/claims/claim/clawback/clawback_requested_spec.rb
@@ -21,8 +21,8 @@ describe Claims::Claim::Clawback::ClawbackRequested do
       let(:mentor_training_2) { create(:mentor_training, claim:, not_assured: true, reason_not_assured: "reason") }
       let(:esfa_responses) do
         [
-          { id: mentor_training_1.id, number_of_hours: 20, reason_for_clawback: "Some reason" },
-          { id: mentor_training_2.id, number_of_hours: 10, reason_for_clawback: "Another reason" },
+          { id: mentor_training_1.id, hours_clawed_back: 20, reason_for_clawback: "Some reason" },
+          { id: mentor_training_2.id, hours_clawed_back: 10, reason_for_clawback: "Another reason" },
         ]
       end
 
@@ -43,7 +43,7 @@ describe Claims::Claim::Clawback::ClawbackRequested do
       context "when an esfa response is not given for a mentor training associated with this claim" do
         let(:esfa_responses) do
           [
-            { id: mentor_training_1.id, number_of_hours: 20, reason_for_clawback: "Some reason" },
+            { id: mentor_training_1.id, hours_clawed_back: 20, reason_for_clawback: "Some reason" },
           ]
         end
 

--- a/spec/system/claims/support/claims/clawbacks/support_user_edits_a_mentor_training_for_a_clawback_request_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/support_user_edits_a_mentor_training_for_a_clawback_request_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Support user edits a clawback request on a claim", service: :claims, type: :system do
+RSpec.describe "Support user edits a mentor training for a clawback request", service: :claims, type: :system do
   include ActionView::Helpers::TextHelper
 
   scenario do
@@ -39,12 +39,18 @@ RSpec.describe "Support user edits a clawback request on a claim", service: :cla
                         reference: 11_111_111)
 
     @john_doe = create(:claims_mentor, first_name: "John", last_name: "Doe")
+    @sarah_jane = create(:claims_mentor, first_name: "Sarah", last_name: "Jane")
 
     @john_doe_training = create(:mentor_training, claim: @claim_one, mentor: @john_doe,
                                                   hours_completed: 20, not_assured: true,
                                                   hours_clawed_back: 7,
                                                   reason_not_assured: "Mismatch in hours recorded compared with hours claimed.",
                                                   reason_clawed_back: "Mismatch in hours recorded compared with hours claimed.")
+    @sarah_jane_training = create(:mentor_training, claim: @claim_one, mentor: @sarah_jane,
+                                                    hours_completed: 15, not_assured: true,
+                                                    hours_clawed_back: 5,
+                                                    reason_not_assured: "Mismatch in hours recorded compared with hours claimed.",
+                                                    reason_clawed_back: "Mismatch in hours recorded compared with hours claimed.")
   end
 
   def and_i_am_signed_in
@@ -77,13 +83,15 @@ RSpec.describe "Support user edits a clawback request on a claim", service: :cla
     expect(page).to have_summary_list_row("Accredited provider", @claim_one.provider.name)
     expect(page).to have_h2("Hours of training")
     @claim_one.mentor_trainings.not_assured.order_by_mentor_full_name.each do |mentor_training|
-      within(".govuk-summary-card") do
-        expect(page).to have_element(:div, text: mentor_training.mentor.full_name, class: "govuk-summary-card__title-wrapper")
-        within(".govuk-summary-card__content") do
-          expect(page).to have_summary_list_row("Mentor worked hours", pluralize(mentor_training.corrected_hours_completed, "hour"))
-          expect(page).to have_summary_list_row("Original hours claimed", pluralize(mentor_training.hours_completed, "hour"))
-          expect(page).to have_summary_list_row("Hours clawed back", pluralize(mentor_training.hours_clawed_back, "hour"))
-          expect(page).to have_summary_list_row("Reason for clawback", mentor_training.reason_clawed_back)
+      within("#mentor-training-#{mentor_training.id}") do
+        within(".govuk-summary-card") do
+          expect(page).to have_element(:div, text: mentor_training.mentor.full_name, class: "govuk-summary-card__title-wrapper")
+          within(".govuk-summary-card__content") do
+            expect(page).to have_summary_list_row("Mentor worked hours", pluralize(mentor_training.corrected_hours_completed, "hour"))
+            expect(page).to have_summary_list_row("Original hours claimed", pluralize(mentor_training.hours_completed, "hour"))
+            expect(page).to have_summary_list_row("Hours clawed back", pluralize(mentor_training.hours_clawed_back, "hour"))
+            expect(page).to have_summary_list_row("Reason for clawback", mentor_training.reason_clawed_back)
+          end
         end
       end
     end
@@ -97,7 +105,7 @@ RSpec.describe "Support user edits a clawback request on a claim", service: :cla
   alias_method :and_i_see_the_show_page_for_claim_one, :then_i_see_the_show_page_for_claim_one
 
   def when_i_click_on_the_change_link_for_clawback_reason
-    all("a", text: "Change").last.click
+    click_on "Change John Doe Mentor worked hours"
   end
 
   def then_i_see_the_clawback_step_for_claim_one
@@ -146,13 +154,15 @@ RSpec.describe "Support user edits a clawback request on a claim", service: :cla
   def and_i_see_the_updated_show_page_for_claim_one
     expect(page).to have_h2("Hours of training")
     @claim_one.mentor_trainings.not_assured.order_by_mentor_full_name.each do |mentor_training|
-      within(".govuk-summary-card") do
-        expect(page).to have_element(:div, text: mentor_training.mentor.full_name, class: "govuk-summary-card__title-wrapper")
-        within(".govuk-summary-card__content") do
-          expect(page).to have_summary_list_row("Mentor worked hours", pluralize(mentor_training.corrected_hours_completed, "hour"))
-          expect(page).to have_summary_list_row("Original hours claimed", pluralize(mentor_training.hours_completed, "hour"))
-          expect(page).to have_summary_list_row("Hours clawed back", pluralize(mentor_training.hours_clawed_back, "hour"))
-          expect(page).to have_summary_list_row("Reason for clawback", mentor_training.reason_clawed_back)
+      within("#mentor-training-#{mentor_training.id}") do
+        within(".govuk-summary-card") do
+          expect(page).to have_element(:div, text: mentor_training.mentor.full_name, class: "govuk-summary-card__title-wrapper")
+          within(".govuk-summary-card__content") do
+            expect(page).to have_summary_list_row("Mentor worked hours", pluralize(mentor_training.corrected_hours_completed, "hour"))
+            expect(page).to have_summary_list_row("Original hours claimed", pluralize(mentor_training.hours_completed, "hour"))
+            expect(page).to have_summary_list_row("Hours clawed back", pluralize(mentor_training.hours_clawed_back, "hour"))
+            expect(page).to have_summary_list_row("Reason for clawback", mentor_training.reason_clawed_back)
+          end
         end
       end
     end

--- a/spec/system/claims/support/claims/clawbacks/support_user_requests_a_clawback_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/support_user_requests_a_clawback_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe "Support user requests a clawback on a claim", service: :claims, 
 
     expect(page).to have_element(:span, text: "Clawbacks - Claim 11111111", class: "govuk-caption-l")
     expect(page).to have_h1("Clawback details")
-    expect(page).to have_element(:label, text: "Number of hours to clawback", class: "govuk-label")
+    expect(page).to have_element(:label, text: "Number of hours the mentor worked", class: "govuk-label")
     expect(page).to have_element(:div, text: "Jane Smith's original claim was for 20 hours", class: "govuk-hint")
     expect(page).to have_element(:label, text: "Notes on your decision", class: "govuk-label")
     expect(page).to have_element(:div, text: "Only include details related to Jane Smith", class: "govuk-hint")
@@ -132,7 +132,7 @@ RSpec.describe "Support user requests a clawback on a claim", service: :claims, 
 
     expect(page).to have_element(:span, text: "Clawbacks - Claim 11111111", class: "govuk-caption-l")
     expect(page).to have_h1("Clawback details")
-    expect(page).to have_element(:label, text: "Number of hours to clawback", class: "govuk-label")
+    expect(page).to have_element(:label, text: "Number of hours the mentor worked", class: "govuk-label")
     expect(page).to have_element(:div, text: "John Doe's original claim was for 20 hours", class: "govuk-hint")
     expect(page).to have_element(:label, text: "Notes on your decision", class: "govuk-label")
     expect(page).to have_element(:div, text: "Only include details related to John Doe", class: "govuk-hint")
@@ -158,7 +158,7 @@ RSpec.describe "Support user requests a clawback on a claim", service: :claims, 
   end
 
   def then_i_see_a_validation_error_when_entering_too_many_hours_for_jane_smith
-    expect(page).to have_validation_error("must be less than or equal to 20")
+    expect(page).to have_validation_error("must be less than 20")
   end
 
   def when_i_enter_valid_data
@@ -174,27 +174,31 @@ RSpec.describe "Support user requests a clawback on a claim", service: :claims, 
     expect(page).to have_element(:p, text: "This information will be shared with #{@claim_one.school_name}.", class: "govuk-body")
 
     within "#claim-totals" do
-      expect(page).to have_summary_list_row("Hours", "40")
+      expect(page).to have_summary_list_row("Hours the mentor worked", "40")
       expect(page).to have_summary_list_row("Hourly rate", @claim_one.school_region_funding_available_per_hour)
       expect(page).to have_summary_list_row("Amount", "£#{ActiveSupport::NumberHelper.number_to_delimited(@claim_one.school_region_funding_available_per_hour * 40)}")
     end
 
     within "#clawback-totals" do
-      expect(page).to have_summary_list_row("Hours", "16")
+      expect(page).to have_summary_list_row("Hours the mentor worked", "24")
       expect(page).to have_summary_list_row("Hourly rate", @claim_one.school_region_funding_available_per_hour)
-      expect(page).to have_summary_list_row("Clawback amount", "£#{@claim_one.school_region_funding_available_per_hour * 16}")
+      expect(page).to have_summary_list_row("Clawback amount", "£#{ActiveSupport::NumberHelper.number_to_delimited(@claim_one.school_region_funding_available_per_hour * 24)}")
     end
 
     within "#mentor-training-#{@john_doe_training.id}" do
-      expect(page).to have_summary_list_row("Hours", "8")
+      expect(page).to have_summary_list_row("Original hours claimed", "20")
+      expect(page).to have_summary_list_row("Hours the mentor worked", "8")
+      expect(page).to have_summary_list_row("Hours clawed back", "12")
       expect(page).to have_summary_list_row("Hourly rate", @claim_one.school_region_funding_available_per_hour)
-      expect(page).to have_summary_list_row("Clawback amount", "£#{@claim_one.school_region_funding_available_per_hour * 8}")
+      expect(page).to have_summary_list_row("Clawback amount", "£#{@claim_one.school_region_funding_available_per_hour * 12}")
     end
 
     within "#mentor-training-#{@john_doe_training.id}" do
-      expect(page).to have_summary_list_row("Hours", "8")
+      expect(page).to have_summary_list_row("Original hours claimed", "20")
+      expect(page).to have_summary_list_row("Hours the mentor worked", "8")
+      expect(page).to have_summary_list_row("Hours clawed back", "12")
       expect(page).to have_summary_list_row("Hourly rate", @claim_one.school_region_funding_available_per_hour)
-      expect(page).to have_summary_list_row("Clawback amount", "£#{@claim_one.school_region_funding_available_per_hour * 8}")
+      expect(page).to have_summary_list_row("Clawback amount", "£#{@claim_one.school_region_funding_available_per_hour * 12}")
     end
 
     expect(page).to have_button("Request clawback")

--- a/spec/system/claims/support/claims/clawbacks/support_user_views_clawbacks_show_page_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/support_user_views_clawbacks_show_page_spec.rb
@@ -118,14 +118,22 @@ RSpec.describe "Support user requests a clawback on a claim", service: :claims, 
     expect(page).to have_summary_list_row("Accredited provider", @clawback_requested_claim.provider.name)
     expect(page).to have_h2("Hours of training")
     @clawback_requested_claim.mentor_trainings.not_assured.order_by_mentor_full_name.each do |mentor_training|
-      expect(page).to have_element(:dt, text: mentor_training.mentor.full_name, class: "govuk-summary-list__key")
-      expect(page).to have_summary_list_row("Original hours claimed", pluralize(mentor_training.hours_completed, "hour"))
-      expect(page).to have_summary_list_row("Amount clawed back", pluralize(mentor_training.hours_clawed_back, "hour"))
-      expect(page).to have_summary_list_row("Reason for clawback", mentor_training.reason_clawed_back)
+      within(".govuk-summary-card") do
+        expect(page).to have_element(:div, text: mentor_training.mentor.full_name, class: "govuk-summary-card__title-wrapper")
+        within(".govuk-summary-card__content") do
+          expect(page).to have_summary_list_row("Mentor worked hours", pluralize(mentor_training.corrected_hours_completed, "hour"))
+          expect(page).to have_summary_list_row("Original hours claimed", pluralize(mentor_training.hours_completed, "hour"))
+          expect(page).to have_summary_list_row("Hours clawed back", pluralize(mentor_training.hours_clawed_back, "hour"))
+          expect(page).to have_summary_list_row("Reason for clawback", mentor_training.reason_clawed_back)
+        end
+      end
     end
-    expect(page).to have_h2("Grant funding")
-    expect(page).to have_summary_list_row("Original claim amount", @clawback_requested_claim.amount)
-    expect(page).to have_summary_list_row("Hours clawed back", pluralize(@clawback_requested_claim.mentor_trainings.sum(:hours_clawed_back), "hour"))
+
+    within("#grant_funding") do
+      expect(page).to have_h2("Grant funding")
+      expect(page).to have_summary_list_row("Original claim amount", @clawback_requested_claim.amount)
+      expect(page).to have_summary_list_row("Hours clawed back", pluralize(@clawback_requested_claim.mentor_trainings.sum(:hours_clawed_back), "hour"))
+    end
   end
 
   def when_i_click_on_change
@@ -138,7 +146,7 @@ RSpec.describe "Support user requests a clawback on a claim", service: :claims, 
 
     expect(page).to have_element(:span, text: "Clawbacks - Claim 22222222", class: "govuk-caption-l")
     expect(page).to have_h1("Clawback details")
-    expect(page).to have_element(:label, text: "Number of hours to clawback", class: "govuk-label")
+    expect(page).to have_element(:label, text: "Number of hours the mentor worked", class: "govuk-label")
     expect(page).to have_element(:div, text: "James Chess' original claim was for 15 hours", class: "govuk-hint")
     expect(page).to have_element(:label, text: "Notes on your decision", class: "govuk-label")
     expect(page).to have_element(:div, text: "Only include details related to #{@mentor.full_name}", class: "govuk-hint")

--- a/spec/wizards/claims/edit_request_clawback_wizard_spec.rb
+++ b/spec/wizards/claims/edit_request_clawback_wizard_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Claims::EditRequestClawbackWizard, type: :model do
     it "prepopulates the state with the relevant clawback information" do
       step_name = wizard.step_name_for_mentor_training_clawback(mentor_training).to_s
       expected_state = {
-        "number_of_hours" => 6,
+        "number_of_hours" => 14,
         "reason_for_clawback" => "Insufficient evidence",
       }
 
@@ -70,7 +70,7 @@ RSpec.describe Claims::EditRequestClawbackWizard, type: :model do
         wizard.update_clawback
 
         mentor_training.reload
-        expect(mentor_training.hours_clawed_back).to eq(1)
+        expect(mentor_training.hours_clawed_back).to eq(19)
         expect(mentor_training.reason_clawed_back).to eq("New evidence")
       end
     end

--- a/spec/wizards/claims/request_clawback_wizard/check_your_answers_step_spec.rb
+++ b/spec/wizards/claims/request_clawback_wizard/check_your_answers_step_spec.rb
@@ -46,6 +46,12 @@ RSpec.describe Claims::RequestClawbackWizard::CheckYourAnswersStep, type: :model
     end
   end
 
+  describe "#mentor_training_correct_hours" do
+    it "return the number of hours the mentor actually trained for" do
+      expect(step.mentor_training_correct_hours(mentor_training)).to eq(5)
+    end
+  end
+
   describe "#mentor_training_clawback_hours" do
     it "returns the number of hours for the mentor training clawback" do
       expect(step.mentor_training_clawback_hours(mentor_training)).to eq(15)

--- a/spec/wizards/claims/request_clawback_wizard/check_your_answers_step_spec.rb
+++ b/spec/wizards/claims/request_clawback_wizard/check_your_answers_step_spec.rb
@@ -16,7 +16,11 @@ RSpec.describe Claims::RequestClawbackWizard::CheckYourAnswersStep, type: :model
 
   let(:mentor_training_clawback_step) do
     instance_double(Claims::RequestClawbackWizard::MentorTrainingClawbackStep).tap do |mentor_training_clawback_step|
-      allow(mentor_training_clawback_step).to receive_messages(number_of_hours: 15, reason_for_clawback: "reason")
+      allow(mentor_training_clawback_step).to receive_messages(
+        number_of_hours: 5,
+        hours_clawed_back: 15,
+        reason_for_clawback: "reason",
+      )
     end
   end
 

--- a/spec/wizards/claims/request_clawback_wizard/mentor_training_clawback_step_spec.rb
+++ b/spec/wizards/claims/request_clawback_wizard/mentor_training_clawback_step_spec.rb
@@ -40,13 +40,13 @@ RSpec.describe Claims::RequestClawbackWizard::MentorTrainingClawbackStep, type: 
     context "when the number of hours is equal to the hours completed" do
       let(:attributes) { { mentor_training_id: mentor_training.id, number_of_hours: 3, reason_for_clawback: "reason" } }
 
-      it { is_expected.to be_valid }
+      it { is_expected.not_to be_valid }
     end
 
     context "when the number of hours is less than 1" do
       let(:attributes) { { mentor_training_id: mentor_training.id, number_of_hours: 0, reason_for_clawback: "reason" } }
 
-      it { is_expected.not_to be_valid }
+      it { is_expected.to be_valid }
     end
   end
 

--- a/spec/wizards/claims/request_clawback_wizard/mentor_training_clawback_step_spec.rb
+++ b/spec/wizards/claims/request_clawback_wizard/mentor_training_clawback_step_spec.rb
@@ -69,4 +69,14 @@ RSpec.describe Claims::RequestClawbackWizard::MentorTrainingClawbackStep, type: 
       expect(step.mentor_training).to eq(mentor_trainings.first)
     end
   end
+
+  describe "#hours_clawed_back" do
+    let(:attributes) { { mentor_training_id: mentor_training.id, number_of_hours: 5, reason_for_clawback: "reason" } }
+
+    let(:mentor_training) { create(:mentor_training, claim:, hours_completed: 15, not_assured: true, reason_not_assured: "reason") }
+
+    it "returns the hours clawed back for a mentor training" do
+      expect(step.hours_clawed_back).to eq(10)
+    end
+  end
 end

--- a/spec/wizards/claims/request_clawback_wizard_spec.rb
+++ b/spec/wizards/claims/request_clawback_wizard_spec.rb
@@ -46,13 +46,13 @@ RSpec.describe Claims::RequestClawbackWizard do
       end
 
       it "returns an array of hashes containing the mentor training id, number of hours and reason for clawback" do
-        expect(wizard.esfa_responses_for_mentor_trainings).to eq([{ id: mentor_training.id, number_of_hours: 5, reason_for_clawback: "Some reason" }])
+        expect(wizard.esfa_responses_for_mentor_trainings).to eq([{ id: mentor_training.id, hours_clawed_back: 15, reason_for_clawback: "Some reason" }])
       end
     end
   end
 
   describe "#submit_esfa_responses" do
-    let(:esfa_responses) { [{ id: mentor_training.id, number_of_hours: 5, reason_for_clawback: "Some reason" }] }
+    let(:esfa_responses) { [{ id: mentor_training.id, hours_clawed_back: 15, reason_for_clawback: "Some reason" }] }
 
     before do
       user


### PR DESCRIPTION
## Context

- Invert the logic on the clawback request to enter "Hours the mentor worked"

## Changes proposed in this pull request

- Swap the logic and input on the clawback request wizard to allow users to enter the correct number of hours worked by the mentor, then calculate the clawback.

## Guidance to review

- Sign in as Colin (Support user)
- Navigate to "Claims" -> "Clawback"
⚠️ You will need to have a claim with the status "Rejected by school" ⚠️ 
- Click the claim
- Click "Request clawback"
- You will now see that you must enter "Number of hours the mentor worked"
- Continue the journey
- On the check your answers page, you will see that the clawback amount is calculated and shown.

## Link to Trello card

https://trello.com/c/4gMiigVt/44-invert-clawback-logic-to-calculate-clawback-amount

## Screenshots

https://github.com/user-attachments/assets/5a4edf32-bcfa-4f68-a155-452dc18c1e85


