### PR TITLE
Add invalid provider status

### DIFF
--- a/app/components/claim/status_tag_component.rb
+++ b/app/components/claim/status_tag_component.rb
@@ -37,6 +37,7 @@ class Claim::StatusTagComponent < ApplicationComponent
       clawback_requested: "turquoise",
       clawback_in_progress: "yellow",
       clawback_complete: "blue",
+      invalid_provider: "red",
     }.with_indifferent_access
   end
 end

--- a/app/controllers/claims/schools/claims/invalid_provider_controller.rb
+++ b/app/controllers/claims/schools/claims/invalid_provider_controller.rb
@@ -1,0 +1,54 @@
+class Claims::Schools::Claims::InvalidProviderController < Claims::ApplicationController
+  include WizardController
+  include Claims::BelongsToSchool
+
+  before_action :set_wizard
+  before_action :authorize_claim
+
+  helper_method :index_path
+
+  def new
+    @wizard.setup_state
+    redirect_to step_path(params.require(:step).to_sym)
+  end
+
+  def update
+    if !@wizard.save_step
+      render "edit"
+    elsif @wizard.next_step.present?
+      redirect_to step_path(@wizard.next_step)
+    elsif @wizard.valid?
+      @wizard.update_claim
+      @wizard.reset_state
+      redirect_to confirmation_claims_school_claim_path(@school, @wizard.claim)
+    else
+      redirect_to rejected_claims_school_claims_path(@school)
+    end
+  end
+
+  private
+
+  def claim
+    @claim = @school.claims.find(params.require(:id))
+  end
+
+  def set_wizard
+    state = session[state_key] ||= {}
+    current_step = params.require(:step).to_sym
+    @wizard = Claims::InvalidProviderWizard.new(
+      school: @school, claim:, created_by: current_user, params:, state:, current_step:,
+    )
+  end
+
+  def authorize_claim
+    authorize claim, :invalid_provider?
+  end
+
+  def step_path(step)
+    invalid_provider_claims_school_claim_path(@school, claim, state_key:, step:)
+  end
+
+  def index_path
+    claims_school_claim_path(@school, claim)
+  end
+end

--- a/app/controllers/claims/schools/claims/invalid_provider_controller.rb
+++ b/app/controllers/claims/schools/claims/invalid_provider_controller.rb
@@ -7,16 +7,13 @@ class Claims::Schools::Claims::InvalidProviderController < Claims::ApplicationCo
 
   helper_method :index_path
 
-  def new
-    @wizard.setup_state
-    redirect_to step_path(params.require(:step).to_sym)
-  end
-
   def update
     if @wizard.valid?
       @wizard.update_claim
       @wizard.reset_state
       redirect_to confirmation_claims_school_claim_path(@school, @wizard.claim)
+    else
+      render "edit"
     end
   end
 

--- a/app/controllers/claims/schools/claims/invalid_provider_controller.rb
+++ b/app/controllers/claims/schools/claims/invalid_provider_controller.rb
@@ -13,9 +13,7 @@ class Claims::Schools::Claims::InvalidProviderController < Claims::ApplicationCo
   end
 
   def update
-    if @wizard.next_step.present?
-      redirect_to step_path(@wizard.next_step)
-    elsif @wizard.valid?
+    if @wizard.valid?
       @wizard.update_claim
       @wizard.reset_state
       redirect_to confirmation_claims_school_claim_path(@school, @wizard.claim)

--- a/app/controllers/claims/schools/claims/invalid_provider_controller.rb
+++ b/app/controllers/claims/schools/claims/invalid_provider_controller.rb
@@ -13,16 +13,12 @@ class Claims::Schools::Claims::InvalidProviderController < Claims::ApplicationCo
   end
 
   def update
-    if !@wizard.save_step
-      render "edit"
-    elsif @wizard.next_step.present?
+    if @wizard.next_step.present?
       redirect_to step_path(@wizard.next_step)
     elsif @wizard.valid?
       @wizard.update_claim
       @wizard.reset_state
       redirect_to confirmation_claims_school_claim_path(@school, @wizard.claim)
-    else
-      redirect_to rejected_claims_school_claims_path(@school)
     end
   end
 

--- a/app/mailers/claims/user_mailer.rb
+++ b/app/mailers/claims/user_mailer.rb
@@ -95,7 +95,9 @@ class Claims::UserMailer < Claims::ApplicationMailer
                  )
   end
 
-  def claims_assigned_to_invalid_provider(user, claims)
+  def claims_assigned_to_invalid_provider(user_id, claim_ids)
+    user = Claims::User.find(user_id)
+    claims = Claims::Claim.where(id: claim_ids, status: :invalid_provider)
     claims_string = claims.pluck(:reference).to_sentence
 
     notify_email to: user.email,

--- a/app/mailers/claims/user_mailer.rb
+++ b/app/mailers/claims/user_mailer.rb
@@ -94,4 +94,18 @@ class Claims::UserMailer < Claims::ApplicationMailer
                    sign_in_url: sign_in_url(utm_source: "email", utm_medium: "notification", utm_campaign: "school"),
                  )
   end
+
+  def claims_assigned_to_invalid_provider(user, claims)
+    claims_string = claims.pluck(:reference).to_sentence
+
+    notify_email to: user.email,
+                 subject: t(".subject"),
+                 body: t(
+                   ".body",
+                   user_name: user.first_name,
+                   support_email:,
+                   service_name:,
+                   claims: claims_string,
+                 )
+  end
 end

--- a/app/models/claims/claim.rb
+++ b/app/models/claims/claim.rb
@@ -70,8 +70,9 @@ class Claims::Claim < ApplicationRecord
   PAYMENT_ACTIONABLE_STATUSES = %w[payment_information_requested payment_information_sent].freeze
   SAMPLING_STATUSES = %w[sampling_in_progress sampling_provider_not_approved].freeze
   CLAWBACK_STATUSES = %w[clawback_requested clawback_in_progress sampling_not_approved].freeze
+  INCIDENT_STATUSES = %w[invalid_provider].freeze
 
-  scope :active, -> { where(status: ACTIVE_STATUSES) }
+  scope :active, -> { where(status: ACTIVE_STATUSES + INCIDENT_STATUSES) }
   scope :order_created_at_desc, -> { order(created_at: :desc) }
   scope :not_draft_status, -> { where.not(status: DRAFT_STATUSES) }
   scope :paid_for_current_academic_year, lambda {
@@ -95,6 +96,7 @@ class Claims::Claim < ApplicationRecord
          clawback_requested: "clawback_requested",
          clawback_in_progress: "clawback_in_progress",
          clawback_complete: "clawback_complete",
+         invalid_provider: "invalid_provider",
        },
        validate: true
 

--- a/app/policies/claims/claim_policy.rb
+++ b/app/policies/claims/claim_policy.rb
@@ -15,6 +15,10 @@ class Claims::ClaimPolicy < Claims::ApplicationPolicy
     edit?
   end
 
+  def invalid_provider?
+    record.invalid_provider? && (record.created_by == user || user.support_user?)
+  end
+
   def submit?
     current_claim_window? && record.in_draft? && school_eligible_to_claim?
   end

--- a/app/services/claims/claim/invalid_provider_notification.rb
+++ b/app/services/claims/claim/invalid_provider_notification.rb
@@ -7,7 +7,7 @@ class Claims::Claim::InvalidProviderNotification < ApplicationService
 
     users_to_notify.find_each do |user|
       claims = Claims::Claim.where(created_by: user, status: :invalid_provider)
-      Claims::UserMailer.claims_assigned_to_invalid_provider(user.id, claims.ids).deliver_later
+      Claims::UserMailer.claims_assigned_to_invalid_provider(user, claims).deliver_later
     end
   end
 end

--- a/app/services/claims/claim/invalid_provider_notification.rb
+++ b/app/services/claims/claim/invalid_provider_notification.rb
@@ -1,0 +1,13 @@
+class Claims::Claim::InvalidProviderNotification < ApplicationService
+  def call
+    created_by_ids = Claims::Claim.where(status: :invalid_provider).select(:created_by_id)
+    users_to_notify = Claims::User.where(id: created_by_ids).distinct
+
+    return if users_to_notify.empty?
+
+    users_to_notify.find_each do |user|
+      claims = Claims::Claim.where(created_by: user, status: :invalid_provider)
+      Claims::UserMailer.claims_assigned_to_invalid_provider(user.id, claims.ids).deliver_later
+    end
+  end
+end

--- a/app/views/claims/schools/claims/invalid_provider/edit.html.erb
+++ b/app/views/claims/schools/claims/invalid_provider/edit.html.erb
@@ -1,0 +1,13 @@
+<% render "claims/schools/primary_navigation", school: @school, current: :claims %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: back_link_path) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= render_wizard(@wizard, contextual_text: t(".caption"), contextual_save: t(".save")) %>
+
+  <p class="govuk-body">
+    <%= govuk_link_to(t(".cancel"), claims_school_claims_path(@school, @claim), no_visited_state: true) %>
+  </p>
+</div>

--- a/app/views/claims/schools/claims/show.html.erb
+++ b/app/views/claims/schools/claims/show.html.erb
@@ -22,8 +22,12 @@
         <p class="govuk-body"><%= t(".submitted_by", name: @claim.submitted_by.full_name, date: l(@claim.submitted_on, format: :long)) %></p>
       <% end %>
 
+      <% if @claim.invalid_provider? %>
+        <%= govuk_warning_text text: t(".invalid_provider") %>
+      <% end %>
+
       <h2 class="govuk-heading-m"><%= t(".details") %></h2>
-      <%= govuk_summary_list(actions: policy(@claim).edit?) do |summary_list| %>
+      <%= govuk_summary_list(actions: policy(@claim).edit? || @claim.invalid_provider?) do |summary_list| %>
         <% summary_list.with_row do |row| %>
           <% row.with_key(text: Claims::Claim.human_attribute_name(:school)) %>
           <% row.with_value(text: @school.name) %>
@@ -38,10 +42,10 @@
           <% summary_list.with_row do |row| %>
             <% row.with_key(text: Claims::Claim.human_attribute_name(:accredited_provider)) %>
             <% row.with_value(text: @claim.provider.name) %>
-            <% if policy(@claim).edit? %>
+            <% if policy(@claim).edit? || @claim.invalid_provider? %>
               <% row.with_action(
                 text: t("change"),
-                href: edit_attribute_path(:provider),
+                href: @claim.invalid_provider? ? new_invalid_provider_claims_school_claim_path(@school, @claim, step: :provider) : edit_attribute_path(:provider),
                 visually_hidden_text: Claims::Claim.human_attribute_name(:accredited_provider),
                 html_attributes: { class: "govuk-link--no-visited-state" },
               ) %>

--- a/app/views/wizards/claims/add_claim_wizard/_provider_step.html.erb
+++ b/app/views/wizards/claims/add_claim_wizard/_provider_step.html.erb
@@ -13,7 +13,7 @@
     autocomplete_return_attributes_value: current_step.autocomplete_return_attributes_value,
   },
   input: {
-    value: current_step.provider&.name,
+    value: current_step.provider_name,
     label: t(".title"),
     caption: contextual_text,
     hint: t(".hint_html"),

--- a/app/wizards/claims/add_claim_wizard.rb
+++ b/app/wizards/claims/add_claim_wizard.rb
@@ -10,7 +10,7 @@ module Claims
 
     delegate :amount, to: :claim
     delegate :name, :region_funding_available_per_hour, to: :school, prefix: true
-    delegate :name, to: :provider, prefix: true
+    delegate :name, to: :provider, prefix: true, allow_nil: true
     delegate :name, to: :academic_year, prefix: true
 
     def define_steps

--- a/app/wizards/claims/add_claim_wizard/provider_step.rb
+++ b/app/wizards/claims/add_claim_wizard/provider_step.rb
@@ -1,6 +1,8 @@
 class Claims::AddClaimWizard::ProviderStep < Claims::AddClaimWizard::ProviderSelectionStep
   attribute :name
 
+  delegate :provider_name, to: :wizard
+
   def autocomplete_path_value
     "/api/provider_suggestions"
   end

--- a/app/wizards/claims/invalid_provider_wizard.rb
+++ b/app/wizards/claims/invalid_provider_wizard.rb
@@ -25,7 +25,7 @@ module Claims
     end
 
     def provider
-      steps[:provider_options]&.provider || steps[:provider]&.provider
+      steps[:provider]&.provider
     end
 
     private

--- a/app/wizards/claims/invalid_provider_wizard.rb
+++ b/app/wizards/claims/invalid_provider_wizard.rb
@@ -13,7 +13,6 @@ module Claims
 
     def define_steps
       add_step(AddClaimWizard::ProviderStep)
-      add_step(AddClaimWizard::ProviderOptionsStep) if steps.fetch(:provider).provider.blank?
     end
 
     def update_claim

--- a/app/wizards/claims/invalid_provider_wizard.rb
+++ b/app/wizards/claims/invalid_provider_wizard.rb
@@ -19,12 +19,8 @@ module Claims
       Claims::Claim::Submit.call(claim: updated_claim, user: created_by)
     end
 
-    def setup_state
-      state["provider"] = { "id" => nil }
-    end
-
     def provider
-      steps[:provider]&.provider
+      steps.fetch(:provider).provider
     end
 
     private

--- a/app/wizards/claims/invalid_provider_wizard.rb
+++ b/app/wizards/claims/invalid_provider_wizard.rb
@@ -1,0 +1,43 @@
+module Claims
+  class InvalidProviderWizard < ClaimBaseWizard
+    attr_reader :school, :created_by, :claim
+
+    def initialize(school:, claim:, created_by:, params:, state:, current_step: nil)
+      @school = school
+      @claim = claim
+      @created_by = created_by
+      super(state:, params:, current_step:)
+    end
+
+    delegate :name, to: :provider, prefix: true, allow_nil: true
+
+    def define_steps
+      add_step(AddClaimWizard::ProviderStep)
+      add_step(AddClaimWizard::ProviderOptionsStep) if steps.fetch(:provider).provider.blank?
+    end
+
+    def update_claim
+      Claims::Claim::Submit.call(claim: updated_claim, user: created_by)
+    end
+
+    def setup_state
+      state["provider"] = { "id" => nil }
+    end
+
+    def provider
+      steps[:provider_options]&.provider || steps[:provider]&.provider
+    end
+
+    private
+
+    def updated_claim
+      claim.provider = steps.fetch(:provider).provider
+
+      claim.mentor_trainings.each do |mentor_training|
+        mentor_training.update!(provider: claim.provider)
+      end
+
+      claim
+    end
+  end
+end

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -25,6 +25,7 @@ en:
         clawback_requested: Ready for clawback
         clawback_in_progress: Sent to payer for clawback
         clawback_complete: Clawback complete
+        invalid_provider: Invalid provider
       claims/claim_activity/action:
         approved_by_school: School %{school_name} approved audit for claim %{claim_reference}
         clawback_requested: Clawback requested for claim %{claim_reference}

--- a/config/locales/en/claims/schools/claims.yml
+++ b/config/locales/en/claims/schools/claims.yml
@@ -59,3 +59,4 @@ en:
           hour: hour
           submit: Accept and submit
           submitted_by: Submitted by %{name} on %{date}.
+          invalid_provider: The accredited provider for this claim is invalid. Use the change link below to record an accredited provider so this claim can be paid.

--- a/config/locales/en/claims/schools/claims/invalid_provider.yml
+++ b/config/locales/en/claims/schools/claims/invalid_provider.yml
@@ -1,0 +1,9 @@
+en:
+  claims:
+    schools:
+      claims:
+        invalid_provider:
+          edit:
+            caption: Claim details
+            save: Accept and submit
+            cancel: Cancel

--- a/config/locales/en/claims/user_mailer.yml
+++ b/config/locales/en/claims/user_mailer.yml
@@ -175,3 +175,39 @@ en:
           Kind regards,
           
           %{service_name} team
+
+      claims_assigned_to_invalid_provider:
+        subject: "Action by 25 July: Change your ITT mentor funding claim to ensure it gets paid"
+        body: |
+          Dear %{user_name}
+  
+          Thank you for submitting a claim through the %{service_name} service.
+        
+          The following claims, submitted by your school, cannot be processed because the ITT provider recorded is not an accredited provider:
+          
+          %{claims}
+          
+          To ensure your claim can be processed and paid, please log-in to the service and record the accredited provider.
+          
+          ## What You Need to Do
+        
+          To update your accredited provider:
+          
+          1. Log in to the %{service_name} service
+          2. Go to the ‘Claims’ tab
+          3. Click on a claim with the "Invalid provider" status
+          4. Click ‘Change’ next to your current provider selection
+          5. Enter your accredited provider's name in the search box
+          6. Click ‘Continue’
+        
+          ## Deadline: Friday 25 July 2025
+          
+          Please update your provider information by this date to avoid delays in payment.
+        
+          If you are unsure who the accredited provider is, contact your ITT provider to confirm or review this list: [https://www.gov.uk/government/publications/accredited-initial-teacher-training-itt-providers/list-of-providers-accredited-to-deliver-itt-from-september-2024]([https://www.gov.uk/government/publications/accredited-initial-teacher-training-itt-providers/list-of-providers-accredited-to-deliver-itt-from-september-2024).
+        
+          If you have any questions, contact us at:
+          [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk)
+          
+          Kind regards,
+          %{service_name} team

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -60,6 +60,10 @@ scope module: :claims, as: :claims, constraints: {
           get "edit", to: "claims/edit_claim#new", as: :new_edit_claim
           get "edit/:state_key/:step", to: "claims/edit_claim#edit", as: :edit_claim
           put "edit/:state_key/:step", to: "claims/edit_claim#update"
+
+          get "invalid_provider", to: "claims/invalid_provider#new", as: :new_invalid_provider
+          get "invalid_provider/:state_key/:step", to: "claims/invalid_provider#edit", as: :invalid_provider
+          put "invalid_provider/:state_key/:step", to: "claims/invalid_provider#update"
         end
 
         collection do

--- a/db/migrate/20250715092710_add_invalid_provider_status_to_claim.rb
+++ b/db/migrate/20250715092710_add_invalid_provider_status_to_claim.rb
@@ -1,0 +1,5 @@
+class AddInvalidProviderStatusToClaim < ActiveRecord::Migration[8.0]
+  def change
+    add_enum_value :claim_status, "invalid_provider"
+  end
+end

--- a/db/migrate/20250715093722_change_invalid_claims_status.rb
+++ b/db/migrate/20250715093722_change_invalid_claims_status.rb
@@ -5,8 +5,6 @@ class ChangeInvalidClaimsStatus < ActiveRecord::Migration[8.0]
 
     # We want this to be reflected in Big Query, so we're using callbacks despite the performance hit
     invalid_claims.find_each { |claim| claim.update!(status: :invalid_provider) }
-
-    Claims::Claim::InvalidProviderNotification.call
   end
 
   def down

--- a/db/migrate/20250715093722_change_invalid_claims_status.rb
+++ b/db/migrate/20250715093722_change_invalid_claims_status.rb
@@ -1,0 +1,15 @@
+class ChangeInvalidClaimsStatus < ActiveRecord::Migration[8.0]
+  def up
+    accredited_providers = Claims::Provider.accredited
+    invalid_claims = Claims::Claim.where.not(provider: accredited_providers)
+
+    # We want this to be reflected in Big Query, so we're using callbacks despite the performance hit
+    invalid_claims.find_each { |claim| claim.update!(status: :invalid_provider) }
+
+    Claims::Claim::InvalidProviderNotification.call
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_17_154722) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_15_093722) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -18,7 +18,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_17_154722) do
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
   create_enum "appetite", ["actively_looking", "interested", "not_open", "already_organised"]
-  create_enum "claim_status", ["internal_draft", "draft", "submitted", "payment_in_progress", "payment_information_requested", "payment_information_sent", "paid", "payment_not_approved", "sampling_in_progress", "sampling_provider_not_approved", "sampling_not_approved", "clawback_requested", "clawback_in_progress", "clawback_complete"]
+  create_enum "claim_status", ["internal_draft", "draft", "submitted", "payment_in_progress", "payment_information_requested", "payment_information_sent", "paid", "payment_not_approved", "sampling_in_progress", "sampling_provider_not_approved", "sampling_not_approved", "clawback_requested", "clawback_in_progress", "clawback_complete", "invalid_provider"]
   create_enum "mentor_training_type", ["refresher", "initial"]
   create_enum "placement_status", ["draft", "published"]
   create_enum "placement_year_group", ["nursery", "reception", "year_1", "year_2", "year_3", "year_4", "year_5", "year_6", "mixed_year_groups"]

--- a/spec/components/claim/status_tag_component_spec.rb
+++ b/spec/components/claim/status_tag_component_spec.rb
@@ -119,6 +119,14 @@ RSpec.describe Claim::StatusTagComponent, type: :component do
     end
   end
 
+  context "when the claim's status is 'invalid_provider'" do
+    let(:claim) { build(:claim, status: :invalid_provider) }
+
+    it "renders a red tag" do
+      expect(page).to have_css(".govuk-tag--red", text: "Invalid provider")
+    end
+  end
+
   Claims::Claim.statuses.each_key do |status|
     context "with a claim of status '#{status}'" do
       let(:claim) { build(:claim, status:) }

--- a/spec/helpers/claims/claim_helper_spec.rb
+++ b/spec/helpers/claims/claim_helper_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Claims::ClaimHelper do
         "clawback_requested",
         "clawback_in_progress",
         "clawback_complete",
+        "invalid_provider",
       )
     end
   end

--- a/spec/mailers/claims/user_mailer_spec.rb
+++ b/spec/mailers/claims/user_mailer_spec.rb
@@ -343,14 +343,14 @@ RSpec.describe Claims::UserMailer, type: :mailer do
   end
 
   describe "claims_assigned_to_invalid_provider" do
-    subject(:claims_assigned_to_invalid_provider_email) { described_class.claims_assigned_to_invalid_provider(user, claims) }
+    subject(:claims_assigned_to_invalid_provider_email) { described_class.claims_assigned_to_invalid_provider(user.id, claims.map(&:id)) }
 
     let(:user) { create(:claims_user, first_name: "Joe") }
     let(:claims) do
       [
-        create(:claim, reference: "123", school: school),
-        create(:claim, reference: "456", school: school),
-        create(:claim, reference: "789", school: school),
+        create(:claim, reference: "123", school: school, status: :invalid_provider),
+        create(:claim, reference: "456", school: school, status: :invalid_provider),
+        create(:claim, reference: "789", school: school, status: :invalid_provider),
       ]
     end
     let(:school) { create(:claims_school, name: "Shelbyville Elementary") }

--- a/spec/mailers/claims/user_mailer_spec.rb
+++ b/spec/mailers/claims/user_mailer_spec.rb
@@ -341,4 +341,57 @@ RSpec.describe Claims::UserMailer, type: :mailer do
       EMAIL
     end
   end
+
+  describe "claims_assigned_to_invalid_provider" do
+    subject(:claims_assigned_to_invalid_provider_email) { described_class.claims_assigned_to_invalid_provider(user, claims) }
+
+    let(:user) { create(:claims_user, first_name: "Joe") }
+    let(:claims) do
+      [
+        create(:claim, reference: "123", school: school),
+        create(:claim, reference: "456", school: school),
+        create(:claim, reference: "789", school: school),
+      ]
+    end
+    let(:school) { create(:claims_school, name: "Shelbyville Elementary") }
+
+    it "sends the invalid provider email" do
+      expect(claims_assigned_to_invalid_provider_email.to).to contain_exactly(user.email)
+      expect(claims_assigned_to_invalid_provider_email.subject).to eq("Action by 25 July: Change your ITT mentor funding claim to ensure it gets paid")
+      expect(claims_assigned_to_invalid_provider_email.body.to_s.squish).to eq(<<~EMAIL.squish)
+        Dear Joe
+
+        Thank you for submitting a claim through the Claim funding for mentor training service.
+
+        The following claims, submitted by your school, cannot be processed because the ITT provider recorded is not an accredited provider:
+
+        #{claims.pluck(:reference).to_sentence}
+
+        To ensure your claim can be processed and paid, please log-in to the service and record the accredited provider.
+
+        ## What You Need to Do
+
+        To update your accredited provider:
+
+        1. Log in to the Claim funding for mentor training service
+        2. Go to the ‘Claims’ tab
+        3. Click on a claim with the "Invalid provider" status
+        4. Click ‘Change’ next to your current provider selection
+        5. Enter your accredited provider's name in the search box
+        6. Click ‘Continue’
+
+        ## Deadline: Friday 25 July 2025
+
+        Please update your provider information by this date to avoid delays in payment.
+
+        If you are unsure who the accredited provider is, contact your ITT provider to confirm or review this list: [https://www.gov.uk/government/publications/accredited-initial-teacher-training-itt-providers/list-of-providers-accredited-to-deliver-itt-from-september-2024]([https://www.gov.uk/government/publications/accredited-initial-teacher-training-itt-providers/list-of-providers-accredited-to-deliver-itt-from-september-2024).
+
+        If you have any questions, contact us at:
+        [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk)
+
+        Kind regards,
+        Claim funding for mentor training team
+      EMAIL
+    end
+  end
 end

--- a/spec/mailers/previews/claims/user_mailer_preview.rb
+++ b/spec/mailers/previews/claims/user_mailer_preview.rb
@@ -23,6 +23,10 @@ class Claims::UserMailerPreview < ActionMailer::Preview
     Claims::UserMailer.claims_have_not_been_submitted(user)
   end
 
+  def claims_assigned_to_invalid_provider
+    Claims::UserMailer.claims_assigned_to_invalid_provider(user, [claim, claim, claim])
+  end
+
   private
 
   def user

--- a/spec/models/claims/claim_spec.rb
+++ b/spec/models/claims/claim_spec.rb
@@ -118,6 +118,7 @@ RSpec.describe Claims::Claim, type: :model do
           clawback_requested: "clawback_requested",
           clawback_in_progress: "clawback_in_progress",
           clawback_complete: "clawback_complete",
+          invalid_provider: "invalid_provider",
         )
         .backed_by_column_of_type(:enum)
     end

--- a/spec/policies/claims/claim_policy_spec.rb
+++ b/spec/policies/claims/claim_policy_spec.rb
@@ -402,4 +402,32 @@ describe Claims::ClaimPolicy do
       end
     end
   end
+
+  permissions :invalid_provider? do
+    context "when the claim is invalid provider and created by the user" do
+      let(:claim) { build(:claim, status: :invalid_provider, created_by: user) }
+
+      it "grants access" do
+        expect(claim_policy).to permit(user, claim)
+      end
+    end
+
+    context "when the claim is invalid provider and created by another user" do
+      let(:other_user) { build(:claims_user) }
+      let(:claim) { build(:claim, status: :invalid_provider, created_by: other_user) }
+
+      it "denies access" do
+        expect(claim_policy).not_to permit(user, claim)
+      end
+    end
+
+    context "when the user is a support user" do
+      let(:support_user) { build(:claims_support_user) }
+      let(:claim) { build(:claim, status: :invalid_provider, created_by: user) }
+
+      it "grants access" do
+        expect(claim_policy).to permit(support_user, claim)
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,6 +43,12 @@ RSpec.configure do |config|
   config.include GeocodingHelper
   config.include GovukComponentMatchers, type: :system
 
+  RSpec.configure do |rspec|
+    rspec.expect_with :rspec do |c|
+      c.max_formatted_output_length = nil
+    end
+  end
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [Rails.root.join("spec/fixtures")]
 

--- a/spec/services/claims/claim/invalid_provider_notification_spec.rb
+++ b/spec/services/claims/claim/invalid_provider_notification_spec.rb
@@ -29,20 +29,20 @@ RSpec.describe Claims::Claim::InvalidProviderNotification, type: :service do
 
       before do
         allow(Claims::UserMailer).to receive(:claims_assigned_to_invalid_provider)
-          .with(user, [claim1, claim2]).and_return(instance_double(ActionMailer::MessageDelivery, deliver_later: true))
+          .with(user.id, [claim1.id, claim2.id]).and_return(instance_double(ActionMailer::MessageDelivery, deliver_later: true))
         allow(Claims::UserMailer).to receive(:claims_assigned_to_invalid_provider)
-          .with(other_user, [other_claim]).and_return(instance_double(ActionMailer::MessageDelivery, deliver_later: true))
+          .with(other_user.id, [other_claim.id]).and_return(instance_double(ActionMailer::MessageDelivery, deliver_later: true))
 
         described_class.call
       end
 
       it "sends email notifications to users with invalid provider claims" do
-        expect(Claims::UserMailer).to have_received(:claims_assigned_to_invalid_provider).with(user, [claim1, claim2])
-        expect(Claims::UserMailer).to have_received(:claims_assigned_to_invalid_provider).with(other_user, [other_claim])
+        expect(Claims::UserMailer).to have_received(:claims_assigned_to_invalid_provider).with(user.id, [claim1.id, claim2.id])
+        expect(Claims::UserMailer).to have_received(:claims_assigned_to_invalid_provider).with(other_user.id, [other_claim.id])
       end
 
       it "does not send duplicate notifications for the same user" do
-        expect(Claims::UserMailer).to have_received(:claims_assigned_to_invalid_provider).with(user, [claim1, claim2]).once
+        expect(Claims::UserMailer).to have_received(:claims_assigned_to_invalid_provider).with(user.id, [claim1.id, claim2.id]).once
       end
 
       context "when there are over 100 emails to send" do

--- a/spec/services/claims/claim/invalid_provider_notification_spec.rb
+++ b/spec/services/claims/claim/invalid_provider_notification_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe Claims::Claim::InvalidProviderNotification, type: :service do
+  describe "#call" do
+    let(:user) { build(:claims_user) }
+    let(:other_user) { build(:claims_user) }
+
+    context "when there are no claims with invalid provider status" do
+      let(:user) { build(:claims_user) }
+      let(:claim_1) { create(:claim, created_by: user, status: :submitted) }
+
+      before do
+        claim_1
+        allow(Claims::UserMailer).to receive(:claims_assigned_to_invalid_provider)
+
+        described_class.call
+      end
+
+      it "does not send notification" do
+        expect(Claims::UserMailer).not_to have_received(:claims_assigned_to_invalid_provider)
+      end
+    end
+
+    context "when there are claims with invalid provider status" do
+      let!(:claim1) { create(:claim, created_by: user, status: :invalid_provider) }
+      let!(:claim2) { create(:claim, created_by: user, status: :invalid_provider) }
+
+      let!(:other_claim) { create(:claim, created_by: other_user, status: :invalid_provider) }
+
+      before do
+        allow(Claims::UserMailer).to receive(:claims_assigned_to_invalid_provider)
+          .with(user, [claim1, claim2]).and_return(instance_double(ActionMailer::MessageDelivery, deliver_later: true))
+        allow(Claims::UserMailer).to receive(:claims_assigned_to_invalid_provider)
+          .with(other_user, [other_claim]).and_return(instance_double(ActionMailer::MessageDelivery, deliver_later: true))
+
+        described_class.call
+      end
+
+      it "sends email notifications to users with invalid provider claims" do
+        expect(Claims::UserMailer).to have_received(:claims_assigned_to_invalid_provider).with(user, [claim1, claim2])
+        expect(Claims::UserMailer).to have_received(:claims_assigned_to_invalid_provider).with(other_user, [other_claim])
+      end
+
+      it "does not send duplicate notifications for the same user" do
+        expect(Claims::UserMailer).to have_received(:claims_assigned_to_invalid_provider).with(user, [claim1, claim2]).once
+      end
+    end
+  end
+end

--- a/spec/system/claims/schools/claims/claim_user_updares_an_invalid_provider_without_entering_a_new_provider_spec.rb
+++ b/spec/system/claims/schools/claims/claim_user_updares_an_invalid_provider_without_entering_a_new_provider_spec.rb
@@ -1,0 +1,124 @@
+require "rails_helper"
+
+RSpec.describe "Claim user updates an invalid provider claim", :js, service: :claims, type: :system do
+  scenario do
+    given_an_eligible_school_exists_with_an_invalid_provider_claim
+    and_i_am_signed_in
+    then_i_see_the_claims_index_page_with_the_invalid_provider_claim
+
+    when_i_click_on_the_claim_reference
+    then_i_see_the_claim_show_page
+
+    when_i_click_on_change_provider
+    then_i_see_the_accredited_provider_page_with_an_empty_input
+
+    when_i_click_on_continue
+    then_i_see_a_validation_error_for_not_entering_a_provider_search_term
+  end
+
+  private
+
+  def given_an_eligible_school_exists_with_an_invalid_provider_claim
+    @user_anne = build(:claims_user, first_name: "Anne", last_name: "Wilson", email: "anne_wilson@education.gov.uk")
+    @mentor_james = build(:claims_mentor, first_name: "James", last_name: "Jameson")
+    @provider = create(:claims_provider, :best_practice_network, accredited: true) do |provider|
+      provider.provider_email_addresses.build(email_address: "best_practice_network@example.com", primary: true)
+    end
+    @unaccredited_provider = build(:claims_provider, name: "Unaccredited provider")
+    @claim_window = build(:claim_window, :current)
+    @date_completed = @claim_window.starts_on + 1.day
+    @shelbyville_school = build(
+      :claims_school,
+      name: "Shelbyville Elementary",
+      users: [@user_anne],
+      eligible_claim_windows: [@claim_window],
+      mentors: [@mentor_james],
+    )
+    @claim = build(:claim,
+                   :invalid_provider,
+                   school: @shelbyville_school,
+                   reference: "88888888",
+                   provider: @unaccredited_provider,
+                   claim_window: @claim_window,
+                   created_by: @user_anne)
+    @mentor_training = create(:mentor_training,
+                              claim: @claim,
+                              mentor: @mentor_james,
+                              hours_completed: 8,
+                              provider: @unaccredited_provider,
+                              date_completed: @date_completed)
+  end
+
+  def and_i_am_signed_in
+    sign_in_as(@user_anne)
+  end
+
+  def then_i_see_the_claims_index_page_with_the_invalid_provider_claim
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(page).to have_h1("Claims")
+    expect(page).to have_link("Add claim", href: "/schools/#{@shelbyville_school.id}/claims/new")
+    expect(page).to have_table_row({
+      "Reference" => "88888888",
+      "Accredited provider" => "Unaccredited provider",
+      "Mentors" => "James Jameson",
+      "Amount" => "£#{@shelbyville_school.region.funding_available_per_hour * 8}",
+      "Date submitted" => "-",
+      "Status" => "Invalid provider",
+    })
+  end
+
+  def when_i_click_on_the_claim_reference
+    click_on "88888888"
+  end
+
+  def then_i_see_the_claim_show_page
+    expect(page).to have_title("Claim - 88888888 - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(page).to have_h1("Claim - 88888888")
+    expect(page).to have_tag("Invalid provider", "red")
+    expect(page).to have_warning_text("The accredited provider for this claim is invalid. Use the change link below to record an accredited provider so this claim can be paid.")
+    expect(page).to have_h2("Details")
+    expect(page).to have_summary_list_row("School", "Shelbyville Elementary")
+    expect(page).to have_summary_list_row("Academic year", @claim_window.academic_year.name.to_s)
+    expect(page).to have_summary_list_row("Accredited provider", "Unaccredited provider")
+    expect(page).to have_summary_list_row("Mentors", "James Jameson")
+
+    expect(page).to have_h2("Hours of training")
+    expect(page).to have_summary_list_row("James Jameson", "8 hours")
+
+    expect(page).to have_h2("Grant funding")
+    expect(page).to have_summary_list_row("Total hours", "8 hours")
+    expect(page).to have_summary_list_row("Hourly rate", "£#{@shelbyville_school.region.funding_available_per_hour}")
+    expect(page).to have_summary_list_row("Claim amount", "£#{@shelbyville_school.region.funding_available_per_hour * 8}")
+  end
+
+  def when_i_click_on_change_provider
+    click_on "Change Accredited provider"
+  end
+
+  def then_i_see_the_accredited_provider_page_with_an_empty_input
+    expect(page).to have_title("Enter the accredited provider for this claim - Claim details - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(page).to have_hint("You must make a separate claim for each accredited provider you work with.")
+    expect(page).to have_element(:input, class: "autocomplete__input autocomplete__input--default", id: "claims-add-claim-wizard-provider-step-id-field", value: nil)
+    expect(page).to have_button("Continue")
+    expect(page).to have_link("Cancel")
+  end
+
+  def when_i_click_on_continue
+    click_on "Continue"
+  end
+
+  def when_i_navigate_back_to_the_claims_index_page
+    within ".app-primary-navigation" do
+      click_on "Claims"
+    end
+  end
+
+  def then_i_see_a_validation_error_for_not_entering_a_provider_search_term
+    expect(page).to have_validation_error(
+      "Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode",
+    )
+  end
+end

--- a/spec/system/claims/schools/claims/claim_user_updates_an_invalid_provider_claim_spec.rb
+++ b/spec/system/claims/schools/claims/claim_user_updates_an_invalid_provider_claim_spec.rb
@@ -1,0 +1,164 @@
+require "rails_helper"
+
+RSpec.describe "Claim user updates an invalid provider claim", :js, service: :claims, type: :system do
+  scenario do
+    given_an_eligible_school_exists_with_an_invalid_provider_claim
+    and_i_am_signed_in
+    then_i_see_the_claims_index_page_with_the_invalid_provider_claim
+
+    when_i_click_on_the_claim_reference
+    then_i_see_the_claim_show_page
+
+    when_i_click_on_change_provider
+    then_i_see_the_accredited_provider_page_with_an_empty_input
+
+    when_i_enter_a_provider_named_best_practice_network
+    and_i_click_the_dropdown_item_for_best_practice_network
+    and_i_click_on_continue
+    then_i_see_the_claim_submitted_page
+
+    when_i_navigate_back_to_the_claims_index_page
+    then_i_see_the_claims_index_page_with_a_submitted_claim
+  end
+
+  private
+
+  def given_an_eligible_school_exists_with_an_invalid_provider_claim
+    @user_anne = build(:claims_user, first_name: "Anne", last_name: "Wilson", email: "anne_wilson@education.gov.uk")
+    @mentor_james = build(:claims_mentor, first_name: "James", last_name: "Jameson")
+    @provider = create(:claims_provider, :best_practice_network, accredited: true) do |provider|
+      provider.provider_email_addresses.build(email_address: "best_practice_network@example.com", primary: true)
+    end
+    @unaccredited_provider = build(:claims_provider, name: "Unaccredited provider")
+    @claim_window = build(:claim_window, :current)
+    @date_completed = @claim_window.starts_on + 1.day
+    @shelbyville_school = build(
+      :claims_school,
+      name: "Shelbyville Elementary",
+      users: [@user_anne],
+      eligible_claim_windows: [@claim_window],
+      mentors: [@mentor_james],
+    )
+    @claim = build(:claim,
+                   :invalid_provider,
+                   school: @shelbyville_school,
+                   reference: "88888888",
+                   provider: @unaccredited_provider,
+                   claim_window: @claim_window,
+                   created_by: @user_anne)
+    @mentor_training = create(:mentor_training,
+                              claim: @claim,
+                              mentor: @mentor_james,
+                              hours_completed: 8,
+                              provider: @unaccredited_provider,
+                              date_completed: @date_completed)
+  end
+
+  def and_i_am_signed_in
+    sign_in_as(@user_anne)
+  end
+
+  def then_i_see_the_claims_index_page_with_the_invalid_provider_claim
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(page).to have_h1("Claims")
+    expect(page).to have_link("Add claim", href: "/schools/#{@shelbyville_school.id}/claims/new")
+    expect(page).to have_table_row({
+      "Reference" => "88888888",
+      "Accredited provider" => "Unaccredited provider",
+      "Mentors" => "James Jameson",
+      "Amount" => "£#{@shelbyville_school.region.funding_available_per_hour * 8}",
+      "Date submitted" => "-",
+      "Status" => "Invalid provider",
+    })
+  end
+
+  def when_i_click_on_the_claim_reference
+    click_on "88888888"
+  end
+
+  def then_i_see_the_claim_show_page
+    expect(page).to have_title("Claim - 88888888 - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(page).to have_h1("Claim - 88888888")
+    expect(page).to have_tag("Invalid provider", "red")
+    expect(page).to have_warning_text("The accredited provider for this claim is invalid. Use the change link below to record an accredited provider so this claim can be paid.")
+    expect(page).to have_h2("Details")
+    expect(page).to have_summary_list_row("School", "Shelbyville Elementary")
+    expect(page).to have_summary_list_row("Academic year", @claim_window.academic_year.name.to_s)
+    expect(page).to have_summary_list_row("Accredited provider", "Unaccredited provider")
+    expect(page).to have_summary_list_row("Mentors", "James Jameson")
+
+    expect(page).to have_h2("Hours of training")
+    expect(page).to have_summary_list_row("James Jameson", "8 hours")
+
+    expect(page).to have_h2("Grant funding")
+    expect(page).to have_summary_list_row("Total hours", "8 hours")
+    expect(page).to have_summary_list_row("Hourly rate", "£#{@shelbyville_school.region.funding_available_per_hour}")
+    expect(page).to have_summary_list_row("Claim amount", "£#{@shelbyville_school.region.funding_available_per_hour * 8}")
+  end
+
+  def when_i_click_on_change_provider
+    click_on "Change Accredited provider"
+  end
+
+  def then_i_see_the_accredited_provider_page_with_an_empty_input
+    expect(page).to have_title("Enter the accredited provider for this claim - Claim details - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(page).to have_hint("You must make a separate claim for each accredited provider you work with.")
+    expect(page).to have_element(:input, class: "autocomplete__input autocomplete__input--default", id: "claims-add-claim-wizard-provider-step-id-field", value: nil)
+    expect(page).to have_button("Continue")
+    expect(page).to have_link("Cancel")
+  end
+
+  def when_i_enter_a_provider_named_best_practice_network
+    fill_in "Enter the accredited provider", with: "Best Practice Network"
+  end
+
+  def and_i_click_the_dropdown_item_for_best_practice_network
+    page.find(".autocomplete__option", text: "Best Practice Network").click
+  end
+
+  def and_i_click_on_continue
+    click_on "Continue"
+  end
+
+  def then_i_see_the_claim_submitted_page
+    expect(page).to have_title("Claim submitted - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(page).to have_element(:h1, class: "govuk-panel__title", text: "Claim submitted")
+    expect(page).to have_text("Your reference number")
+
+    expect(page).to have_text("88888888")
+    expect(page).to have_text("We have sent a copy of your claim to best_practice_network@example.com")
+
+    expect(page).to have_h2("What happens next")
+    expect(page).to have_text("If we need further information to process your claim we will email you.")
+
+    expect(page).to have_h2("We may check your claim")
+    expect(page).to have_text("After payment we may check your claim to ensure it is accurate.")
+
+    expect(page).to have_text("Best Practice Network will contact you if your claim undergoes a check.")
+  end
+
+  def when_i_navigate_back_to_the_claims_index_page
+    within ".app-primary-navigation" do
+      click_on "Claims"
+    end
+  end
+
+  def then_i_see_the_claims_index_page_with_a_submitted_claim
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(page).to have_h1("Claims")
+    expect(page).to have_link("Add claim", href: "/schools/#{@shelbyville_school.id}/claims/new")
+    expect(page).to have_table_row({
+      "Reference" => "88888888",
+      "Accredited provider" => "Best Practice Network",
+      "Mentors" => "James Jameson",
+      "Amount" => "£#{@shelbyville_school.region.funding_available_per_hour * 8}",
+      "Date submitted" => (@date_completed + 1.day).strftime("%-d %B %Y").to_s,
+      "Status" => "Submitted",
+    })
+  end
+end

--- a/spec/wizards/claims/invalid_provider_wizard_spec.rb
+++ b/spec/wizards/claims/invalid_provider_wizard_spec.rb
@@ -99,20 +99,5 @@ RSpec.describe Claims::InvalidProviderWizard do
         expect(wizard.provider).to eq(another_provider)
       end
     end
-
-    context "when the provider is set in the provider options step" do
-      let(:another_provider) { create(:claims_provider, :niot) }
-
-      let(:state) do
-        {
-          "provider" => { "id" => another_provider.name },
-          "provider_options" => { "id" => another_provider.id, "search_param" => another_provider.name },
-        }
-      end
-
-      it "returns the provider assigned to the provider options step" do
-        expect(wizard.provider).to eq(another_provider)
-      end
-    end
   end
 end

--- a/spec/wizards/claims/invalid_provider_wizard_spec.rb
+++ b/spec/wizards/claims/invalid_provider_wizard_spec.rb
@@ -1,0 +1,118 @@
+require "rails_helper"
+
+RSpec.describe Claims::InvalidProviderWizard do
+  subject(:wizard) { described_class.new(school:, claim:, created_by:, state:, params:, current_step:) }
+
+  let(:state) { {} }
+  let(:params_data) { {} }
+  let(:current_step) { nil }
+  let(:params) { ActionController::Parameters.new(params_data) }
+  let(:school) { build(:claims_school) }
+  let(:created_by) { build(:claims_user, schools: [school]) }
+  let(:provider) { build(:claims_provider, :niot) }
+  let(:mentor_1) { build(:claims_mentor, schools: [school], first_name: "Alan", last_name: "Anderson") }
+  let(:claim_window) { Claims::ClaimWindow.current || create(:claim_window, :current) }
+  let!(:claim) do
+    create(
+      :claim,
+      :draft,
+      school:,
+      reference: "12345678",
+      provider:,
+      created_by:,
+      reviewed: true,
+      claim_window:,
+    )
+  end
+  let(:mentor_1_training) do
+    create(
+      :mentor_training,
+      claim:,
+      mentor: mentor_1,
+      provider:,
+      hours_completed: 6,
+      date_completed: claim_window.starts_on + 1.day,
+    )
+  end
+
+  before { mentor_1_training }
+
+  describe "delegations" do
+    it { is_expected.to delegate_method(:name).to(:provider).with_prefix(true) }
+  end
+
+  describe "#update_claim" do
+    subject(:update_claim) { wizard.update_claim }
+
+    let(:state) do
+      {
+        "provider" => { "id" => provider.id },
+      }
+    end
+
+    context "when the provider is changed" do
+      let(:another_provider) { create(:claims_provider, :best_practice_network) }
+      let(:state) do
+        {
+          "provider" => { "id" => another_provider.id },
+        }
+      end
+
+      it "updates the claim's provider to the one set in the provider step" do
+        expect { update_claim }.to change(claim, :provider).from(provider).to(another_provider)
+
+        claim.reload
+        mentor_1_training = claim.mentor_trainings.find_by(mentor_id: mentor_1)
+        expect(mentor_1_training.provider).to eq(another_provider)
+      end
+    end
+  end
+
+  describe "#setup_state" do
+    subject(:setup_state) { wizard.setup_state }
+
+    it "sets the state to values related to the claim" do
+      expect { setup_state }.to change(wizard, :state).to(
+        {
+          "provider" => { "id" => nil },
+        },
+      )
+    end
+  end
+
+  describe "#provider" do
+    context "when the provider isn't set in the provider step" do
+      it "returns nil as the provider is invalid" do
+        expect(wizard.provider).to be_nil
+      end
+    end
+
+    context "when the provider is set in the provider step" do
+      let(:another_provider) { create(:claims_provider, :niot) }
+      let(:state) do
+        {
+          "provider" => { "id" => another_provider.id },
+        }
+      end
+
+      it "returns the provider assigned to the provider step" do
+        expect(wizard.provider).to eq(another_provider)
+      end
+    end
+
+    context "when the provider is set in the provider options step" do
+      let(:another_provider) { create(:claims_provider, :niot) }
+
+      let(:state) do
+        {
+          "provider" => { "id" => another_provider.name },
+          "provider_options" => { "id" => another_provider.id, "search_param" => another_provider.name },
+        }
+      end
+
+      it "returns the provider assigned to the provider options step" do
+        expect(wizard.provider).to eq(another_provider)
+      end
+    end
+  end
+end

--- a/spec/wizards/claims/invalid_provider_wizard_spec.rb
+++ b/spec/wizards/claims/invalid_provider_wizard_spec.rb
@@ -68,18 +68,6 @@ RSpec.describe Claims::InvalidProviderWizard do
     end
   end
 
-  describe "#setup_state" do
-    subject(:setup_state) { wizard.setup_state }
-
-    it "sets the state to values related to the claim" do
-      expect { setup_state }.to change(wizard, :state).to(
-        {
-          "provider" => { "id" => nil },
-        },
-      )
-    end
-  end
-
   describe "#provider" do
     context "when the provider isn't set in the provider step" do
       it "returns nil as the provider is invalid" do


### PR DESCRIPTION
## Changes proposed in this pull request

Add new "Invalid provider state to claims"
Adds a invalid provider mailer 
Adds a data migration to update claims to "Invalid claim" state
Adds ability to edit claims with invalid providers


## Guidance to review

- The review environment isn't going to be much help sadly.
- Can walk you through it!

## Link to Trello card

[Add invalid providers state](https://trello.com/c/2TGURXj2/45-create-error-state-for-claims)

## Screenshots

<img width="629" height="705" alt="image" src="https://github.com/user-attachments/assets/99136e33-ccca-4a24-b94a-8973d72531ed" />
<img width="751" height="771" alt="image" src="https://github.com/user-attachments/assets/15c7414b-df59-4f31-8d7b-19dfe8c6ad65" />
<img width="1019" height="786" alt="image" src="https://github.com/user-attachments/assets/cc933d3a-6d74-4357-94b9-9a75d52e42a2" />

