### PR TITLE
Add invalid claims to slackbot

### DIFF
--- a/app/jobs/claims/slack/daily_roundup_job.rb
+++ b/app/jobs/claims/slack/daily_roundup_job.rb
@@ -16,6 +16,7 @@ class Claims::Slack::DailyRoundupJob < ApplicationJob
       claim_amount: humanized_money_with_symbol(todays_claims.map(&:amount).sum),
       total_claims_count: total_claims.count,
       total_claims_amount: humanized_money_with_symbol(total_claims.map(&:amount).sum),
+      invalid_claim_count: total_claims.where(status: :invalid_provider).count,
     ).deliver_now
   end
 

--- a/app/slack_notifiers/claims/claim_slack_notifier.rb
+++ b/app/slack_notifiers/claims/claim_slack_notifier.rb
@@ -1,5 +1,5 @@
 class Claims::ClaimSlackNotifier < Claims::ApplicationSlackNotifier
-  def claim_submitted_notification(academic_year: AcademicYear.for_date(Date.current), claim_count: 0, school_count: 0, provider_count: 0, claim_amount: "£0", total_claims_count: 0, total_claims_amount: "£0")
+  def claim_submitted_notification(academic_year: AcademicYear.for_date(Date.current), claim_count: 0, school_count: 0, provider_count: 0, claim_amount: "£0", total_claims_count: 0, total_claims_amount: "£0", invalid_claim_count: 0)
     message(
       blocks: [
         {
@@ -43,6 +43,13 @@ class Claims::ClaimSlackNotifier < Claims::ApplicationSlackNotifier
           text: {
             type: "mrkdwn",
             text: ":money_with_wings: *#{claim_amount}* has been claimed in the past 24 hours",
+          },
+        },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: ":warning: *#{invalid_claim_count} #{"claim".pluralize(invalid_claim_count)}* #{has_or_have(invalid_claim_count)} an invalid provider and cannot be paid",
           },
         },
         {

--- a/config/locales/en/claims/user_mailer.yml
+++ b/config/locales/en/claims/user_mailer.yml
@@ -181,13 +181,13 @@ en:
         body: |
           Dear %{user_name}
   
-          Thank you for submitting a claim through the %{service_name} service.
-        
+          Thank you for using the %{service_name} service.
+          
           The following claims, submitted by your school, cannot be processed because the ITT provider recorded is not an accredited provider:
           
           %{claims}
           
-          To ensure your claim can be processed and paid, please log-in to the service and record the accredited provider.
+          To ensure your claims can be processed and paid, please log-in to the service and record the accredited provider. You will need to do this for each claim with the “Invalid provider” status.
           
           ## What You Need to Do
         

--- a/spec/jobs/claims/slack/daily_roundup_job_spec.rb
+++ b/spec/jobs/claims/slack/daily_roundup_job_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Claims::Slack::DailyRoundupJob, type: :job do
     let(:claims) { create_list(:claim, 3, claim_window:, created_at: 2.weeks.ago) }
     let(:previous_claim_mentor_trainings) { build_list(:mentor_training, 3, hours_completed: 15) }
     let(:previous_claim) { create(:claim, claim_window:, created_at: 2.weeks.ago, mentor_trainings: previous_claim_mentor_trainings) }
+    let(:invalid_claim) { create(:claim, claim_window:, status: :invalid_provider, created_at: 2.weeks.ago) }
     let(:yesterdays_claim_mentor_trainings) { build_list(:mentor_training, 3, hours_completed: 15) }
     let(:yesterdays_claim) { create(:claim, claim_window:, created_at: Time.current.yesterday.change(hour: 16), mentor_trainings: yesterdays_claim_mentor_trainings) }
     let(:slack_notifier) { instance_double(Claims::ClaimSlackNotifier) }
@@ -17,6 +18,7 @@ RSpec.describe Claims::Slack::DailyRoundupJob, type: :job do
     before do
       previous_claim
       yesterdays_claim
+      invalid_claim
 
       allow(Claims::ClaimSlackNotifier).to receive(:new).and_return(slack_notifier)
       allow(slack_notifier).to receive(:claim_submitted_notification).and_return(slack_message)
@@ -29,8 +31,9 @@ RSpec.describe Claims::Slack::DailyRoundupJob, type: :job do
         claim_count: 1,
         school_count: 1,
         provider_count: 0,
+        invalid_claim_count: 1,
         claim_amount: humanized_money_with_symbol(yesterdays_claim.amount),
-        total_claims_count: 2,
+        total_claims_count: 3,
         total_claims_amount: humanized_money_with_symbol(previous_claim.amount + yesterdays_claim.amount),
       )
 

--- a/spec/mailers/claims/user_mailer_spec.rb
+++ b/spec/mailers/claims/user_mailer_spec.rb
@@ -361,13 +361,13 @@ RSpec.describe Claims::UserMailer, type: :mailer do
       expect(claims_assigned_to_invalid_provider_email.body.to_s.squish).to eq(<<~EMAIL.squish)
         Dear Joe
 
-        Thank you for submitting a claim through the Claim funding for mentor training service.
+        Thank you for using the Claim funding for mentor training service.
 
         The following claims, submitted by your school, cannot be processed because the ITT provider recorded is not an accredited provider:
 
         #{claims.pluck(:reference).to_sentence}
 
-        To ensure your claim can be processed and paid, please log-in to the service and record the accredited provider.
+        To ensure your claims can be processed and paid, please log-in to the service and record the accredited provider. You will need to do this for each claim with the “Invalid provider” status.
 
         ## What You Need to Do
 

--- a/spec/slack_notifiers/claims/claim_slack_notifier_spec.rb
+++ b/spec/slack_notifiers/claims/claim_slack_notifier_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Claims::ClaimSlackNotifier do
         claim_count:,
         school_count:,
         provider_count:,
+        invalid_claim_count:,
         claim_amount:,
         total_claims_count:,
         total_claims_amount:,
@@ -21,6 +22,7 @@ RSpec.describe Claims::ClaimSlackNotifier do
       let(:school_count) { 3 }
       let(:provider_count) { 2 }
       let(:claim_amount) { "£5000" }
+      let(:invalid_claim_count) { 3 }
       let(:total_claims_count) { 100 }
       let(:total_claims_amount) { "£50000" }
 
@@ -70,6 +72,13 @@ RSpec.describe Claims::ClaimSlackNotifier do
             },
           },
           {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: ":warning: *#{invalid_claim_count} claims* have an invalid provider and cannot be paid",
+            },
+          },
+          {
             type: "divider",
           },
           {
@@ -102,6 +111,7 @@ RSpec.describe Claims::ClaimSlackNotifier do
       let(:school_count) { 1 }
       let(:claim_amount) { "£1000" }
       let(:provider_count) { 1 }
+      let(:invalid_claim_count) { 1 }
       let(:total_claims_count) { 1 }
       let(:total_claims_amount) { "£1000" }
 
@@ -141,6 +151,13 @@ RSpec.describe Claims::ClaimSlackNotifier do
             text: {
               type: "mrkdwn",
               text: ":student: *#{provider_count} #{"provider".pluralize(provider_count)}* has been selected for the first time",
+            },
+          },
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: ":warning: *#{invalid_claim_count} claim* has an invalid provider and cannot be paid",
             },
           },
           {


### PR DESCRIPTION
## Context

We need to be able to track how many claims have invalid providers, as part of this work I have also fixed some issues with email consistency.

## Changes proposed in this pull request

- Update the invalid provider user mailer text to use "Claims" more consistently
- Adds the number of invalid provider claims to the Slackbot

## Guidance to review

This PR has nothing to physically see, review the new content and check for errors.

## Link to Trello card

N/A

## Screenshots

<img width="720" height="682" alt="image" src="https://github.com/user-attachments/assets/ef34d27f-578d-476b-95a6-e63637bfba1c" />

