### PR TITLE
Require user first + last name when onboarding users to the claims service

### DIFF
--- a/app/views/wizards/claims/onboard_users_wizard/_upload_errors_step.html.erb
+++ b/app/views/wizards/claims/onboard_users_wizard/_upload_errors_step.html.erb
@@ -26,6 +26,8 @@
       <% table.with_head do |head| %>
         <% head.with_row do |row| %>
           <% row.with_cell text: 1 %>
+          <% row.with_cell text: t(".csv_table.headers.first_name") %>
+          <% row.with_cell text: t(".csv_table.headers.last_name") %>
           <% row.with_cell text: t(".csv_table.headers.school_urn") %>
           <% row.with_cell text: t(".csv_table.headers.email") %>
         <% end %>
@@ -36,6 +38,22 @@
         <% csv_row = current_step.csv[csv_row_index] %>
         <% body.with_row do |row| %>
           <% row.with_cell(text: csv_row_index + 2) %>
+          <% row.with_cell do %>
+            <p>
+              <% if current_step.missing_first_name_rows.include?(csv_row_index) %>
+                <strong class="error-text"><%= t(".csv_table.errors.missing_first_name") %></strong><br>
+              <% end %>
+              <%= csv_row["first_name"] %>
+            </p>
+          <% end %>
+          <% row.with_cell do %>
+            <p>
+              <% if current_step.missing_last_name_rows.include?(csv_row_index) %>
+                <strong class="error-text"><%= t(".csv_table.errors.missing_last_name") %></strong><br>
+              <% end %>
+              <%= csv_row["last_name"] %>
+            </p>
+          <% end %>
           <% row.with_cell do %>
             <p>
               <% if current_step.invalid_school_urn_rows.include?(csv_row_index) %>

--- a/app/wizards/claims/onboard_users_wizard/upload_errors_step.rb
+++ b/app/wizards/claims/onboard_users_wizard/upload_errors_step.rb
@@ -1,6 +1,8 @@
 class Claims::OnboardUsersWizard::UploadErrorsStep < BaseStep
   delegate :invalid_email_rows,
            :invalid_school_urn_rows,
+           :missing_first_name_rows,
+           :missing_last_name_rows,
            :file_name,
            :csv,
            to: :upload_step
@@ -17,7 +19,9 @@ class Claims::OnboardUsersWizard::UploadErrorsStep < BaseStep
 
   def combined_errors
     invalid_email_rows +
-      invalid_school_urn_rows
+      invalid_school_urn_rows +
+      missing_first_name_rows +
+      missing_last_name_rows
   end
 
   def upload_step

--- a/config/locales/en/wizards/claims/onboard_users_wizard.yml
+++ b/config/locales/en/wizards/claims/onboard_users_wizard.yml
@@ -17,6 +17,8 @@ en:
 
               - email
               - school_urn
+              - first_name
+              - last_name
         confirmation_step:
           page_title: Are you sure you want to upload the users? - Onboard users - Claims
           caption: Onboard users
@@ -42,6 +44,8 @@ en:
               last_name: last_name
               email: email
             errors:
+              missing_first_name: Enter a first name
+              missing_last_name: Enter a last name
               invalid_email: Enter a valid email address
               invalid_school: Enter a valid onboarded school urn
           only_showing_rows_with_errors: Only showing rows with errors

--- a/spec/wizards/claims/onboard_users_wizard/upload_errors_step_spec.rb
+++ b/spec/wizards/claims/onboard_users_wizard/upload_errors_step_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe Claims::OnboardUsersWizard::UploadErrorsStep, type: :model do
         file_name:,
         invalid_email_rows:,
         invalid_school_urn_rows:,
+        missing_first_name_rows:,
+        missing_last_name_rows:,
       )
     end
   end
@@ -23,10 +25,14 @@ RSpec.describe Claims::OnboardUsersWizard::UploadErrorsStep, type: :model do
   let(:file_name) { nil }
   let(:invalid_email_rows) { [] }
   let(:invalid_school_urn_rows) { [] }
+  let(:missing_first_name_rows) { [] }
+  let(:missing_last_name_rows) { [] }
 
   describe "delegations" do
     it { is_expected.to delegate_method(:invalid_email_rows).to(:upload_step) }
     it { is_expected.to delegate_method(:invalid_school_urn_rows).to(:upload_step) }
+    it { is_expected.to delegate_method(:missing_first_name_rows).to(:upload_step) }
+    it { is_expected.to delegate_method(:missing_last_name_rows).to(:upload_step) }
     it { is_expected.to delegate_method(:file_name).to(:upload_step) }
     it { is_expected.to delegate_method(:csv).to(:upload_step) }
   end
@@ -36,9 +42,11 @@ RSpec.describe Claims::OnboardUsersWizard::UploadErrorsStep, type: :model do
 
     let(:invalid_email_rows) { [1] }
     let(:invalid_school_urn_rows) { [1, 2, 3] }
+    let(:missing_first_name_rows) { [3, 4] }
+    let(:missing_last_name_rows) { [4, 5] }
 
     it "merges all the validation attributes containing row numbers together (removing duplicates)" do
-      expect(row_indexes_with_errors).to contain_exactly(1, 2, 3)
+      expect(row_indexes_with_errors).to contain_exactly(1, 2, 3, 4, 5)
     end
   end
 
@@ -47,9 +55,11 @@ RSpec.describe Claims::OnboardUsersWizard::UploadErrorsStep, type: :model do
 
     let(:invalid_email_rows) { [1] }
     let(:invalid_school_urn_rows) { [1, 2, 3, 4] }
+    let(:missing_first_name_rows) { [3, 4] }
+    let(:missing_last_name_rows) { [3, 4] }
 
     it "adds together the number of elements in validation attribute" do
-      expect(error_count).to eq(5)
+      expect(error_count).to eq(9)
     end
   end
 end


### PR DESCRIPTION
## Context

We require the user’s name to be able to send them an email, yet it’s possible to upload a CSV without these details which means the email is never sent due to an error.

## Changes proposed in this pull request

Add validation for the first_name and last_name columns when onboarding users via the support > settings page.

## Guidance to review

Use the csv data below to try and upload a user with a missing first_name or last_name

school_name,school_urn,first_name,last_name,email
Tameside Primary Academy,146358,,Smith,test@sample.com
Tameside Primary Academy,146358,James,,test@sample.com

## Link to Trello card

https://trello.com/c/UusQxPZf/22-require-user-names-when-onboarding-users-to-the-claims-service

## Screenshots

<img width="1792" height="1120" alt="Screenshot 2025-07-16 at 14 29 33" src="https://github.com/user-attachments/assets/3fe42f2a-9a88-443c-b6e9-e118a992151d" />
