### PR TITLE
[Draft] Add rate limiting to notify 

### DIFF
--- a/app/jobs/notify_email_batch_job.rb
+++ b/app/jobs/notify_email_batch_job.rb
@@ -1,0 +1,21 @@
+class NotifyEmailBatchJob < ApplicationJob
+  queue_as :default
+
+  def perform(email_ids)
+    NotifyEmailQueue.where(id: email_ids).find_each do |email|
+      notify_client.send_email(
+        email_address: email.recipient,
+        subject: email.subject,
+        body: email.body,
+      )
+      email.update!(status: :sent, sent_at: Time.current)
+    rescue StandardError => e
+      email.update!(status: :failed, error: e.message)
+      Rails.logger.error("[NotifyEmail] Failed for #{email.recipient}: #{e.message}")
+    end
+  end
+
+  def notify_client
+    #unsure as of yet what should go here
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -10,6 +10,20 @@ class ApplicationMailer < Mail::Notify::Mailer
 
   private
 
+  def view_mail(_template_id, subject:, to:, **_headers)
+    # Compose the email body from the view
+    body = render_to_string(template: "#{mailer_name}/#{action_name}")
+
+    NotifyEmailQueue.create!(
+      recipient: to,
+      subject: subject,
+      body: body,
+    )
+
+    # Return a dummy Mail::Message object so Rails mailer logic doesn't break
+    Mail::Message.new(to: to, subject: subject, body: body)
+  end
+
   def environment_prefix
     return "" if HostingEnvironment.env.in? %w[production test]
 

--- a/app/models/notify_email_queue.rb
+++ b/app/models/notify_email_queue.rb
@@ -1,0 +1,5 @@
+class NotifyEmailQueue < ApplicationRecord
+  enum status: { pending: 0, sent: 1, failed: 2 }
+
+  validates :recipient, :subject, :body, presence: true
+end

--- a/app/services/notify_email_rate_limiter.rb
+++ b/app/services/notify_email_rate_limiter.rb
@@ -1,0 +1,11 @@
+class NotifyEmailRateLimiter
+  BATCH_SIZE = 100
+
+  def self.schedule!
+    pending_ids = NotifyEmailQueue.pending.order(:created_at).limit(1000).pluck(:id)
+
+    pending_ids.each_slice(BATCH_SIZE).with_index do |batch_ids, index|
+      NotifyEmailBatchJob.set(wait: index.minutes).perform_later(batch_ids)
+    end
+  end
+end

--- a/config/scheduled_jobs.yml
+++ b/config/scheduled_jobs.yml
@@ -51,3 +51,8 @@ send_claims_slack_daily_roundup:
     cron: "0 16 * * *" # Every day at 16:00
     class: "Claims::Slack::DailyRoundupJob"
     description: "Sends a daily roundup Slack message"
+
+send_notify_email_batches:
+  cron: "*/1 * * * *" # Every minute
+  class: "NotifyEmailDispatchJob"
+  description: "Dispatches queued Notify emails in batches of 100"

--- a/db/migrate/20250716143424_create_notify_email_queues.rb
+++ b/db/migrate/20250716143424_create_notify_email_queues.rb
@@ -1,0 +1,18 @@
+class CreateNotifyEmailQueues < ActiveRecord::Migration[8.0]
+  def change
+    create_table :notify_email_queues do |t|
+      t.string :recipient, null: false
+      t.string :subject, null: false
+      t.text :body, null: false
+      t.integer :status, null: false, default: 0
+      t.datetime :sent_at
+      t.text :error
+
+      t.timestamps
+    end
+
+    add_index :notify_email_queues, :status
+    add_index :notify_email_queues, :recipient
+    add_index :notify_email_queues, :sent_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_15_093722) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_16_143424) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -332,6 +332,20 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_15_093722) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["trn"], name: "index_mentors_on_trn", unique: true
+  end
+
+  create_table "notify_email_queues", force: :cascade do |t|
+    t.string "recipient", null: false
+    t.string "subject", null: false
+    t.text "body", null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "sent_at"
+    t.text "error"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["recipient"], name: "index_notify_email_queues_on_recipient"
+    t.index ["sent_at"], name: "index_notify_email_queues_on_sent_at"
+    t.index ["status"], name: "index_notify_email_queues_on_status"
   end
 
   create_table "partnerships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/jobs/notify_email_dispatch_job_spec.rb
+++ b/spec/jobs/notify_email_dispatch_job_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe NotifyEmailDispatchJob, type: :job do
+  describe "#perform" do
+    it "schedules the email batches via NotifyEmailRateLimiter" do
+      expect(NotifyEmailRateLimiter).to receive(:schedule!)
+
+      described_class.perform_now
+    end
+  end
+end


### PR DESCRIPTION
## Context

Wrote some quick code to draft an idea for the fix - could use some input on the implementation - Do we want to store the emails in the db? 

We sent over 3000 emails in a minute and found that hitting a rate limit in Notify takes down other services in the BAT sevice line. We need to add internal rate limiting to prevent this happening again.

## Changes proposed in this pull request

Create a service that rate limits the emails we send to Notify, we should probably batch 100 emails together and then send those, adding another 100 every minute. We likely also want to combine this logic with a background job that will spawn whatever it needs to complete sending all of the emails

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/uL10HPQX/46-add-rate-limiting-to-mailers-across-the-service

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
