### PR TITLE
Include submitted and payment in progress claims in payments page

### DIFF
--- a/app/models/claims/claim.rb
+++ b/app/models/claims/claim.rb
@@ -67,7 +67,7 @@ class Claims::Claim < ApplicationRecord
 
   ACTIVE_STATUSES = %i[draft submitted].freeze
   DRAFT_STATUSES = %i[internal_draft draft].freeze
-  PAYMENT_ACTIONABLE_STATUSES = %w[payment_information_requested payment_information_sent].freeze
+  PAYMENT_ACTIONABLE_STATUSES = %w[submitted payment_in_progress payment_information_requested payment_information_sent].freeze
   SAMPLING_STATUSES = %w[sampling_in_progress sampling_provider_not_approved].freeze
   CLAWBACK_STATUSES = %w[clawback_requested clawback_in_progress sampling_not_approved].freeze
   INCIDENT_STATUSES = %w[invalid_provider].freeze

--- a/spec/models/claims/claim_spec.rb
+++ b/spec/models/claims/claim_spec.rb
@@ -479,7 +479,7 @@ RSpec.describe Claims::Claim, type: :model do
       let(:claim) { create(:claim, :submitted) }
 
       it "returns false" do
-        expect(payment_actionable).to be(false)
+        expect(payment_actionable).to be(true)
       end
     end
 
@@ -487,7 +487,7 @@ RSpec.describe Claims::Claim, type: :model do
       let(:claim) { create(:claim, :payment_in_progress) }
 
       it "returns false" do
-        expect(payment_actionable).to be(false)
+        expect(payment_actionable).to be(true)
       end
     end
 

--- a/spec/system/claims/support/claims/payments/upload_payer_response/support_user_does_not_upload_a_file_spec.rb
+++ b/spec/system/claims/support/claims/payments/upload_payer_response/support_user_does_not_upload_a_file_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Support user does not upload a file",
 
     when_i_navigate_to_the_payments_claims_index_page
     then_i_see_the_payments_claims_index_page
-    and_i_see_no_payment_claims_have_been_uploaded
+    and_i_see_a_claim_with_the_status_payment_in_progress
 
     when_i_click_on_upload_payer_response
     then_i_see_the_upload_csv_page
@@ -43,6 +43,7 @@ RSpec.describe "Support user does not upload a file",
   def then_i_see_the_payments_claims_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
+    expect(page).to have_h2("Payments")
     expect(primary_navigation).to have_current_item("Claims")
     expect(secondary_navigation).to have_current_item("Payments")
     expect(page).to have_current_path(claims_support_claims_payments_path, ignore_query: true)
@@ -54,9 +55,16 @@ RSpec.describe "Support user does not upload a file",
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
 
-  def and_i_see_no_payment_claims_have_been_uploaded
-    expect(page).to have_h2("Payments")
-    expect(page).to have_element(:p, text: "There are no claims waiting to be processed.")
+  def and_i_see_a_claim_with_the_status_payment_in_progress
+    expect(page).to have_claim_card({
+      "title" => "#{@claim.reference} - #{@claim.school.name}",
+      "url" => "/support/claims/payments/claims/#{@claim.id}",
+      "status" => "Payer payment review",
+      "academic_year" => @claim.academic_year.name,
+      "provider_name" => @claim.provider_name,
+      "submitted_at" => I18n.l(@claim.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
   end
 
   def when_i_click_on_upload_payer_response

--- a/spec/system/claims/support/claims/payments/upload_payer_response/support_user_uploads_a_csv_containing_an_invalid_claim_status_spec.rb
+++ b/spec/system/claims/support/claims/payments/upload_payer_response/support_user_uploads_a_csv_containing_an_invalid_claim_status_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Support user uploads a CSV containing an invalid claim status",
 
     when_i_navigate_to_the_payments_claims_index_page
     then_i_see_the_payments_claims_index_page
-    and_i_see_no_payment_claims_have_been_uploaded
+    and_i_see_claims_with_the_status_payment_in_progress
 
     when_i_click_on_upload_payer_response
     then_i_see_the_upload_csv_page
@@ -48,6 +48,7 @@ RSpec.describe "Support user uploads a CSV containing an invalid claim status",
   def then_i_see_the_payments_claims_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
+    expect(page).to have_h2("Payments")
     expect(primary_navigation).to have_current_item("Claims")
     expect(secondary_navigation).to have_current_item("Payments")
     expect(page).to have_current_path(claims_support_claims_payments_path, ignore_query: true)
@@ -59,9 +60,26 @@ RSpec.describe "Support user uploads a CSV containing an invalid claim status",
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
 
-  def and_i_see_no_payment_claims_have_been_uploaded
-    expect(page).to have_h2("Payments")
-    expect(page).to have_element(:p, text: "There are no claims waiting to be processed.")
+  def and_i_see_claims_with_the_status_payment_in_progress
+    expect(page).to have_claim_card({
+      "title" => "#{@payment_in_progress_claim_1.reference} - #{@payment_in_progress_claim_1.school.name}",
+      "url" => "/support/claims/payments/claims/#{@payment_in_progress_claim_1.id}",
+      "status" => "Payer payment review",
+      "academic_year" => @payment_in_progress_claim_1.academic_year.name,
+      "provider_name" => @payment_in_progress_claim_1.provider_name,
+      "submitted_at" => I18n.l(@payment_in_progress_claim_1.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+
+    expect(page).to have_claim_card({
+      "title" => "#{@payment_in_progress_claim_2.reference} - #{@payment_in_progress_claim_2.school.name}",
+      "url" => "/support/claims/payments/claims/#{@payment_in_progress_claim_2.id}",
+      "status" => "Payer payment review",
+      "academic_year" => @payment_in_progress_claim_2.academic_year.name,
+      "provider_name" => @payment_in_progress_claim_2.provider_name,
+      "submitted_at" => I18n.l(@payment_in_progress_claim_2.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
   end
 
   def when_i_click_on_upload_payer_response

--- a/spec/system/claims/support/claims/payments/upload_payer_response/support_user_uploads_a_csv_containing_an_invalid_unpaid_reason_spec.rb
+++ b/spec/system/claims/support/claims/payments/upload_payer_response/support_user_uploads_a_csv_containing_an_invalid_unpaid_reason_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Support user uploads a CSV containing invalid an unpaid reason",
 
     when_i_navigate_to_the_payments_claims_index_page
     then_i_see_the_payments_claims_index_page
-    and_i_see_no_payment_claims_have_been_uploaded
+    and_i_see_claims_with_the_status_payment_in_progress
 
     when_i_click_on_upload_payer_response
     then_i_see_the_upload_csv_page
@@ -49,6 +49,7 @@ RSpec.describe "Support user uploads a CSV containing invalid an unpaid reason",
   def then_i_see_the_payments_claims_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
+    expect(page).to have_h2("Payments")
     expect(primary_navigation).to have_current_item("Claims")
     expect(secondary_navigation).to have_current_item("Payments")
     expect(page).to have_current_path(claims_support_claims_payments_path, ignore_query: true)
@@ -60,9 +61,26 @@ RSpec.describe "Support user uploads a CSV containing invalid an unpaid reason",
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
 
-  def and_i_see_no_payment_claims_have_been_uploaded
-    expect(page).to have_h2("Payments")
-    expect(page).to have_element(:p, text: "There are no claims waiting to be processed.")
+  def and_i_see_claims_with_the_status_payment_in_progress
+    expect(page).to have_claim_card({
+      "title" => "#{@payment_in_progress_claim_1.reference} - #{@payment_in_progress_claim_1.school.name}",
+      "url" => "/support/claims/payments/claims/#{@payment_in_progress_claim_1.id}",
+      "status" => "Payer payment review",
+      "academic_year" => @payment_in_progress_claim_1.academic_year.name,
+      "provider_name" => @payment_in_progress_claim_1.provider_name,
+      "submitted_at" => I18n.l(@payment_in_progress_claim_1.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+
+    expect(page).to have_claim_card({
+      "title" => "#{@payment_in_progress_claim_2.reference} - #{@payment_in_progress_claim_2.school.name}",
+      "url" => "/support/claims/payments/claims/#{@payment_in_progress_claim_2.id}",
+      "status" => "Payer payment review",
+      "academic_year" => @payment_in_progress_claim_2.academic_year.name,
+      "provider_name" => @payment_in_progress_claim_2.provider_name,
+      "submitted_at" => I18n.l(@payment_in_progress_claim_2.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
   end
 
   def when_i_click_on_upload_payer_response

--- a/spec/system/claims/support/claims/payments/upload_payer_response/support_user_uploads_a_csv_containing_claims_not_with_the_status_payment_in_progress_spec.rb
+++ b/spec/system/claims/support/claims/payments/upload_payer_response/support_user_uploads_a_csv_containing_claims_not_with_the_status_payment_in_progress_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe "Support user uploads a CSV containing claims not with the status
 
     when_i_navigate_to_the_payments_claims_index_page
     then_i_see_the_payments_claims_index_page
-    and_i_see_no_payment_claims_have_been_uploaded
+    and_i_see_a_claim_with_the_status_payment_in_progress
+    and_i_do_not_see_a_claim_with_the_status_clawback_in_progress
 
     when_i_click_on_upload_payer_response
     then_i_see_the_upload_csv_page
@@ -49,6 +50,7 @@ RSpec.describe "Support user uploads a CSV containing claims not with the status
   def then_i_see_the_payments_claims_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
+    expect(page).to have_h2("Payments")
     expect(primary_navigation).to have_current_item("Claims")
     expect(secondary_navigation).to have_current_item("Payments")
     expect(page).to have_current_path(claims_support_claims_payments_path, ignore_query: true)
@@ -60,9 +62,28 @@ RSpec.describe "Support user uploads a CSV containing claims not with the status
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
 
-  def and_i_see_no_payment_claims_have_been_uploaded
-    expect(page).to have_h2("Payments")
-    expect(page).to have_element(:p, text: "There are no claims waiting to be processed.")
+  def and_i_see_a_claim_with_the_status_payment_in_progress
+    expect(page).to have_claim_card({
+      "title" => "#{@payment_in_progress_claim_2.reference} - #{@payment_in_progress_claim_2.school.name}",
+      "url" => "/support/claims/payments/claims/#{@payment_in_progress_claim_2.id}",
+      "status" => "Payer payment review",
+      "academic_year" => @payment_in_progress_claim_2.academic_year.name,
+      "provider_name" => @payment_in_progress_claim_2.provider_name,
+      "submitted_at" => I18n.l(@payment_in_progress_claim_2.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+  end
+
+  def and_i_do_not_see_a_claim_with_the_status_clawback_in_progress
+    expect(page).not_to have_claim_card({
+      "title" => "#{@payment_in_progress_claim_1.reference} - #{@payment_in_progress_claim_1.school.name}",
+      "url" => "/support/claims/payments/claims/#{@payment_in_progress_claim_1.id}",
+      "status" => "Submitted",
+      "academic_year" => @payment_in_progress_claim_1.academic_year.name,
+      "provider_name" => @payment_in_progress_claim_1.provider_name,
+      "submitted_at" => I18n.l(@payment_in_progress_claim_1.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
   end
 
   def when_i_click_on_upload_payer_response

--- a/spec/system/claims/support/claims/payments/upload_payer_response/support_user_uploads_a_csv_containing_invalid_headers_spec.rb
+++ b/spec/system/claims/support/claims/payments/upload_payer_response/support_user_uploads_a_csv_containing_invalid_headers_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe "Support user uploads a CSV containing invalid headers",
 
     when_i_navigate_to_the_payments_claims_index_page
     then_i_see_the_payments_claims_index_page
-    and_i_see_no_payment_claims_have_been_uploaded
+    and_i_see_a_claim_with_the_status_payment_in_progress
+    and_i_do_not_see_a_claim_with_the_status_clawback_in_progress
 
     when_i_click_on_upload_payer_response
     then_i_see_the_upload_csv_page
@@ -48,6 +49,7 @@ RSpec.describe "Support user uploads a CSV containing invalid headers",
   def then_i_see_the_payments_claims_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
+    expect(page).to have_h2("Payments")
     expect(primary_navigation).to have_current_item("Claims")
     expect(secondary_navigation).to have_current_item("Payments")
     expect(page).to have_current_path(claims_support_claims_payments_path, ignore_query: true)
@@ -59,9 +61,28 @@ RSpec.describe "Support user uploads a CSV containing invalid headers",
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
 
-  def and_i_see_no_payment_claims_have_been_uploaded
-    expect(page).to have_h2("Payments")
-    expect(page).to have_element(:p, text: "There are no claims waiting to be processed.")
+  def and_i_see_a_claim_with_the_status_payment_in_progress
+    expect(page).to have_claim_card({
+      "title" => "#{@payment_in_progress_claim_2.reference} - #{@payment_in_progress_claim_2.school.name}",
+      "url" => "/support/claims/payments/claims/#{@payment_in_progress_claim_2.id}",
+      "status" => "Payer payment review",
+      "academic_year" => @payment_in_progress_claim_2.academic_year.name,
+      "provider_name" => @payment_in_progress_claim_2.provider_name,
+      "submitted_at" => I18n.l(@payment_in_progress_claim_2.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+  end
+
+  def and_i_do_not_see_a_claim_with_the_status_clawback_in_progress
+    expect(page).not_to have_claim_card({
+      "title" => "#{@payment_in_progress_claim_1.reference} - #{@payment_in_progress_claim_1.school.name}",
+      "url" => "/support/claims/payments/claims/#{@payment_in_progress_claim_1.id}",
+      "status" => "Submitted",
+      "academic_year" => @payment_in_progress_claim_1.academic_year.name,
+      "provider_name" => @payment_in_progress_claim_1.provider_name,
+      "submitted_at" => I18n.l(@payment_in_progress_claim_1.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
   end
 
   def when_i_click_on_upload_payer_response

--- a/spec/system/claims/support/claims/payments/upload_payer_response/support_user_uploads_a_csv_containing_invalid_references_spec.rb
+++ b/spec/system/claims/support/claims/payments/upload_payer_response/support_user_uploads_a_csv_containing_invalid_references_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Support user uploads a CSV containing invalid references",
 
     when_i_navigate_to_the_payments_claims_index_page
     then_i_see_the_payments_claims_index_page
-    and_i_see_no_payment_claims_have_been_uploaded
+    and_i_see_claims_with_the_status_payment_in_progress
 
     when_i_click_on_upload_payer_response
     then_i_see_the_upload_csv_page
@@ -49,6 +49,7 @@ RSpec.describe "Support user uploads a CSV containing invalid references",
   def then_i_see_the_payments_claims_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
+    expect(page).to have_h2("Payments")
     expect(primary_navigation).to have_current_item("Claims")
     expect(secondary_navigation).to have_current_item("Payments")
     expect(page).to have_current_path(claims_support_claims_payments_path, ignore_query: true)
@@ -63,6 +64,28 @@ RSpec.describe "Support user uploads a CSV containing invalid references",
   def and_i_see_no_payment_claims_have_been_uploaded
     expect(page).to have_h2("Payments")
     expect(page).to have_element(:p, text: "There are no claims waiting to be processed.")
+  end
+
+  def and_i_see_claims_with_the_status_payment_in_progress
+    expect(page).to have_claim_card({
+      "title" => "#{@payment_in_progress_claim_1.reference} - #{@payment_in_progress_claim_1.school.name}",
+      "url" => "/support/claims/payments/claims/#{@payment_in_progress_claim_1.id}",
+      "status" => "Payer payment review",
+      "academic_year" => @payment_in_progress_claim_1.academic_year.name,
+      "provider_name" => @payment_in_progress_claim_1.provider_name,
+      "submitted_at" => I18n.l(@payment_in_progress_claim_1.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+
+    expect(page).to have_claim_card({
+      "title" => "#{@payment_in_progress_claim_2.reference} - #{@payment_in_progress_claim_2.school.name}",
+      "url" => "/support/claims/payments/claims/#{@payment_in_progress_claim_2.id}",
+      "status" => "Payer payment review",
+      "academic_year" => @payment_in_progress_claim_2.academic_year.name,
+      "provider_name" => @payment_in_progress_claim_2.provider_name,
+      "submitted_at" => I18n.l(@payment_in_progress_claim_2.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
   end
 
   def when_i_click_on_upload_payer_response

--- a/spec/system/claims/support/claims/payments/upload_payer_response/support_user_uploads_payer_responses_for_claims_with_the_status_payment_in_progress_spec.rb
+++ b/spec/system/claims/support/claims/payments/upload_payer_response/support_user_uploads_payer_responses_for_claims_with_the_status_payment_in_progress_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Support user uploads a CSV containing invalid references",
 
     when_i_navigate_to_the_payments_claims_index_page
     then_i_see_the_payments_claims_index_page
-    and_i_see_no_payment_claims_have_been_uploaded
+    and_i_see_claims_with_the_status_payment_in_progress
 
     when_i_click_on_upload_payer_response
     then_i_see_the_upload_csv_page
@@ -67,6 +67,7 @@ RSpec.describe "Support user uploads a CSV containing invalid references",
   def then_i_see_the_payments_claims_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
+    expect(page).to have_h2("Payments")
     expect(primary_navigation).to have_current_item("Claims")
     expect(secondary_navigation).to have_current_item("Payments")
     expect(page).to have_current_path(claims_support_claims_payments_path, ignore_query: true)
@@ -78,9 +79,26 @@ RSpec.describe "Support user uploads a CSV containing invalid references",
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
 
-  def and_i_see_no_payment_claims_have_been_uploaded
-    expect(page).to have_h2("Payments")
-    expect(page).to have_element(:p, text: "There are no claims waiting to be processed.")
+  def and_i_see_claims_with_the_status_payment_in_progress
+    expect(page).to have_claim_card({
+      "title" => "#{@payment_in_progress_claim_1.reference} - #{@payment_in_progress_claim_1.school.name}",
+      "url" => "/support/claims/payments/claims/#{@payment_in_progress_claim_1.id}",
+      "status" => "Payer payment review",
+      "academic_year" => @payment_in_progress_claim_1.academic_year.name,
+      "provider_name" => @payment_in_progress_claim_1.provider_name,
+      "submitted_at" => I18n.l(@payment_in_progress_claim_1.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+
+    expect(page).to have_claim_card({
+      "title" => "#{@payment_in_progress_claim_2.reference} - #{@payment_in_progress_claim_2.school.name}",
+      "url" => "/support/claims/payments/claims/#{@payment_in_progress_claim_2.id}",
+      "status" => "Payer payment review",
+      "academic_year" => @payment_in_progress_claim_2.academic_year.name,
+      "provider_name" => @payment_in_progress_claim_2.provider_name,
+      "submitted_at" => I18n.l(@payment_in_progress_claim_2.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
   end
 
   def when_i_click_on_upload_payer_response

--- a/spec/system/claims/support/claims/payments/upload_payer_response/support_user_uploads_the_wrong_file_type_spec.rb
+++ b/spec/system/claims/support/claims/payments/upload_payer_response/support_user_uploads_the_wrong_file_type_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Support user uploads a CSV containing invalid references",
 
     when_i_navigate_to_the_payments_claims_index_page
     then_i_see_the_payments_claims_index_page
-    and_i_see_no_payment_claims_have_been_uploaded
+    and_i_see_a_claim_with_the_status_payment_in_progress
 
     when_i_click_on_upload_payer_response
     then_i_see_the_upload_csv_page
@@ -44,6 +44,7 @@ RSpec.describe "Support user uploads a CSV containing invalid references",
   def then_i_see_the_payments_claims_index_page
     expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
     expect(page).to have_h1("Claims")
+    expect(page).to have_h2("Payments")
     expect(primary_navigation).to have_current_item("Claims")
     expect(secondary_navigation).to have_current_item("Payments")
     expect(page).to have_current_path(claims_support_claims_payments_path, ignore_query: true)
@@ -55,9 +56,16 @@ RSpec.describe "Support user uploads a CSV containing invalid references",
     expect(page).to have_element(:label, text: "Upload CSV file")
   end
 
-  def and_i_see_no_payment_claims_have_been_uploaded
-    expect(page).to have_h2("Payments")
-    expect(page).to have_element(:p, text: "There are no claims waiting to be processed.")
+  def and_i_see_a_claim_with_the_status_payment_in_progress
+    expect(page).to have_claim_card({
+      "title" => "#{@claim.reference} - #{@claim.school.name}",
+      "url" => "/support/claims/payments/claims/#{@claim.id}",
+      "status" => "Payer payment review",
+      "academic_year" => @claim.academic_year.name,
+      "provider_name" => @claim.provider_name,
+      "submitted_at" => I18n.l(@claim.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
   end
 
   def when_i_click_on_upload_payer_response

--- a/spec/system/claims/support/claims/payments/view_payments_claims_spec.rb
+++ b/spec/system/claims/support/claims/payments/view_payments_claims_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe "View payments claims", service: :claims, type: :system do
     within("#action_calculator") do
       expect(page).to have_element(
         :p,
-        text: "2 claims require more information",
+        text: "10 claims require more information",
         class: "govuk-body",
       )
     end


### PR DESCRIPTION
## Context

- Show `submitted` and `payment in progress` claims in the "Payments" tab

## Changes proposed in this pull request

- Add `:submitted` and `:payment_in_progress` to the `PAYMENT_ACTIONABLE_STATUSES` constant.

## Guidance to review

- Sign in as Colin (Support user)
⚠️ Assuming you have claims with the statuses `:submitted` and `:payment_in_progress` ⚠️ 
- Navigate to Claims -> Payments
- The claims with the `:submitted` and `:payment_in_progress` statuses will appear on this page.

## Link to Trello card

https://trello.com/c/TyELqI3A/29-show-claims-awaiting-payment-in-the-payments-tab-in-line-with-other-tabs-even-without-a-relevant-action

## Screenshots
<img width="745" height="768" alt="Screenshot 2025-07-21 at 16 18 27" src="https://github.com/user-attachments/assets/8dcda2ba-1a4c-46c1-bcaf-ca0c16acb376" />
<img width="697" height="765" alt="Screenshot 2025-07-21 at 16 18 04" src="https://github.com/user-attachments/assets/454150b4-9c74-4b15-9e5b-4179e06dbbc2" />
<img width="752" height="767" alt="Screenshot 2025-07-21 at 16 16 29" src="https://github.com/user-attachments/assets/54d85927-b6dc-461b-badd-3e8d7a52dbce" />
<img width="683" height="768" alt="Screenshot 2025-07-21 at 16 16 13" src="https://github.com/user-attachments/assets/7443983d-41bd-495e-a17a-8f82dd077fce" />


