### PR TITLE
Remove unaccredited and additional NIoT providers from claims filters

### DIFF
--- a/app/components/claims/claim/filter_form_component.rb
+++ b/app/components/claims/claim/filter_form_component.rb
@@ -13,7 +13,7 @@ class Claims::Claim::FilterFormComponent < ApplicationComponent
     @filter_form = filter_form
     @statuses = statuses
     @academic_years = academic_years
-    @providers = providers || limit_records(Claims::Provider)
+    @providers = providers || limit_records(Claims::Provider.accredited.excluding_niot_providers)
     @schools = schools || limit_records(Claims::School)
   end
 

--- a/app/controllers/claims/support/providers_controller.rb
+++ b/app/controllers/claims/support/providers_controller.rb
@@ -2,8 +2,8 @@ class Claims::Support::ProvidersController < Claims::Support::ApplicationControl
   before_action :authorize_provider
   def search
     limit = params[:limit].to_i.clamp(25, 100)
-    providers = Claims::Provider.where("name ILIKE ?", "%#{params[:q]}%") if params[:q].presence
-    providers ||= Claims::Provider
+    providers = default_claims.where("name ILIKE ?", "%#{params[:q]}%") if params[:q].presence
+    providers ||= default_claims
 
     render json: providers.limit(limit).as_json(only: %i[id name])
   end
@@ -12,5 +12,9 @@ class Claims::Support::ProvidersController < Claims::Support::ApplicationControl
 
   def authorize_provider
     authorize Claims::Provider
+  end
+
+  def default_claims
+    @default_claims ||= Claims::Provider.accredited.excluding_niot_providers
   end
 end

--- a/spec/requests/claims/support/providers_spec.rb
+++ b/spec/requests/claims/support/providers_spec.rb
@@ -98,6 +98,39 @@ RSpec.describe "Providers", type: :request do
           { "id" => provider2.id, "name" => provider2.name },
         )
       end
+
+      it "returns only accredited providers" do
+        claims_user = create(:claims_support_user)
+        sign_in_as claims_user
+
+        provider1 = create(:claims_provider, name: "Test Provider 1")
+        _provider2 = create(:claims_provider, name: "Test Provider 2", accredited: false)
+
+        get search_path
+
+        expect(response).to have_http_status(:ok)
+        json_response = JSON.parse(response.body)
+        expect(json_response).to contain_exactly(
+          { "id" => provider1.id, "name" => provider1.name },
+        )
+      end
+
+      it "returns only NIoT headquarters" do
+        claims_user = create(:claims_support_user)
+        sign_in_as claims_user
+
+        niot_headquarters = create(:claims_provider, code: "2N2", name: "NIoT")
+        _niot_site_1 = create(:claims_provider, code: "1YF", name: "NIoT")
+        _niot_site_2 = create(:claims_provider, code: "21J", name: "NIoT")
+
+        get search_path
+
+        expect(response).to have_http_status(:ok)
+        json_response = JSON.parse(response.body)
+        expect(json_response).to contain_exactly(
+          { "id" => niot_headquarters.id, "name" => niot_headquarters.name },
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

- Add scopes to remove `unaccredited` and `additional NIoT` providers from the Support Claims filters.

## Changes proposed in this pull request

- Add scopes to remove `unaccredited` and `additional NIoT` providers from the Support Claims filters.

## Guidance to review

- Sign in as Colin (Support User)
- Navigate to Claims
- Search for NIoT in the provider filter
- Only "NIoT: National Institute of Teaching, founded by the School-Led Development Trust" should appear

## Link to Trello card

https://trello.com/c/rIKPSbUj/39-remove-additional-niot-orgs-from-claims-support-filters

## Screenshots

<img width="304" height="210" alt="Screenshot 2025-07-22 at 10 55 33" src="https://github.com/user-attachments/assets/e5afc8b8-58f2-4123-a2e1-fc474e39b621" />

