### PR TITLE
Add support user filter to claims index pages

### DIFF
--- a/app/components/claim/card_component.html.erb
+++ b/app/components/claim/card_component.html.erb
@@ -11,7 +11,8 @@
       <div class="govuk-body-s"><%= claim.academic_year_name %></div>
       <div class="govuk-body-s"><%= claim.provider_name %></div>
       <% if current_user.support_user? %>
-        <div>
+        <div class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-2"></div>
+        <div class="govuk-!-margin-top-2">
           <p class="govuk-body-s"><strong><%= t(".support_user") %>: </strong><%= claim.support_user_assigned %></p>
         </div>
       <% end %>

--- a/app/components/claim/card_component.html.erb
+++ b/app/components/claim/card_component.html.erb
@@ -10,14 +10,19 @@
     <div class="claim-card__body__details">
       <div class="govuk-body-s"><%= claim.academic_year_name %></div>
       <div class="govuk-body-s"><%= claim.provider_name %></div>
+      <% if current_user.support_user? %>
+        <div>
+          <p class="govuk-body-s"><strong><%= t(".support_user") %>: </strong><%= claim.support_user_assigned %></p>
+        </div>
+      <% end %>
     </div>
 
     <div class="claim-card__body__right">
       <div class="govuk-body-s"><%= l(claim.submitted_at.to_date, format: :long) %></div>
       <div class="govuk-body-s"><%= humanized_money_with_symbol(claim.amount) %></div>
       <% if claim.status == "clawback_requested" %>
-      <div class="govuk-body-s govuk-!-font-weight-bold"><%= t(".clawback_amount") %></div>
-      <div class="govuk-body-s"><%= humanized_money_with_symbol(claim.total_clawback_amount) %></div>
+        <div class="govuk-body-s govuk-!-font-weight-bold"><%= t(".clawback_amount") %></div>
+        <div class="govuk-body-s"><%= humanized_money_with_symbol(claim.total_clawback_amount) %></div>
       <% end %>
     </div>
   </div>

--- a/app/components/claim/card_component.rb
+++ b/app/components/claim/card_component.rb
@@ -1,12 +1,13 @@
 class Claim::CardComponent < ApplicationComponent
-  def initialize(claim:, href:, classes: [], html_attributes: {})
+  def initialize(claim:, href:, current_user:, classes: [], html_attributes: {})
     super(classes:, html_attributes:)
 
-    @claim = claim
+    @claim = claim.decorate
     @href = href
+    @current_user = current_user
   end
 
   private
 
-  attr_reader :claim, :href
+  attr_reader :claim, :href, :current_user
 end

--- a/app/components/claims/claim/filter_form_component.html.erb
+++ b/app/components/claims/claim/filter_form_component.html.erb
@@ -91,12 +91,22 @@
                     <ul class="app-filter-tags">
                       <% filter_form.support_users.each do |support_user| %>
                         <li>
-                        <%= govuk_link_to(
-                          support_user.full_name,
-                          filter_form.index_path_without_filter(filter: "support_user_ids", value: support_user.id),
-                          class: "app-filter__tag",
-                          no_visited_state: true,
-                        ) %>
+                          <%= govuk_link_to(
+                            support_user.full_name,
+                            filter_form.index_path_without_filter(filter: "support_user_ids", value: support_user.id),
+                            class: "app-filter__tag",
+                            no_visited_state: true,
+                          ) %>
+                        </li>
+                      <% end %>
+                      <% if filter_form.support_user_ids.include?(UNASSIGNED) %>
+                        <li>
+                          <%= govuk_link_to(
+                            UNASSIGNED.titleize,
+                            filter_form.index_path_without_filter(filter: "support_user_ids", value: UNASSIGNED),
+                            class: "app-filter__tag",
+                            no_visited_state: true,
+                          ) %>
                         </li>
                       <% end %>
                     </ul>

--- a/app/components/claims/claim/filter_form_component.html.erb
+++ b/app/components/claims/claim/filter_form_component.html.erb
@@ -86,8 +86,24 @@
                     </ul>
                   <% end %>
 
+                  <% if filter_form.support_user_ids.present? %>
+                    <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t("claims.support.claims.index.support_user") %></h3>
+                    <ul class="app-filter-tags">
+                      <% filter_form.support_users.each do |support_user| %>
+                        <li>
+                        <%= govuk_link_to(
+                          support_user.full_name,
+                          filter_form.index_path_without_filter(filter: "support_user_ids", value: support_user.id),
+                          class: "app-filter__tag",
+                          no_visited_state: true,
+                        ) %>
+                        </li>
+                      <% end %>
+                    </ul>
+                  <% end %>
+
                   <% if filter_form.mentor_ids.present? %>
-                    <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t("claims.support.claims.index.mentors") %></h3>
+                    <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t("claims.support.claims.index.mentor") %></h3>
                     <ul class="app-filter-tags">
                       <% filter_form.mentors.each do |mentor| %>
                         <li>
@@ -198,12 +214,29 @@
                   <% end %>
                 </div>
 
+                <div class="app-filter__option" data-controller="filter-search">
+                  <%= form.govuk_check_boxes_fieldset(
+                    :support_user_ids,
+                    legend: {
+                      text: t("claims.support.claims.index.support_user"),
+                      size: "s",
+                    },
+                    small: true,
+                    multiple: false,
+                  ) do %>
+                    <% support_users.each do |support_user| %>
+                      <%= form.govuk_check_box :support_user_ids, support_user.id, label: { text: support_user.full_name } %>
+                    <% end %>
+                    <%= form.govuk_check_box :support_user_ids, UNASSIGNED, label: { text: t(".unassigned") } %>
+                  <% end %>
+                </div>
+
                 <div class="app-filter__option" data-controller="async-filter-search" data-async-filter-search-endpoint-value="/support/mentors/search/<%= filter_form.academic_year.id %>"
                      data-async-filter-search-fieldname-value="claims_support_claims_filter_form[mentor_ids][]" data-async-filter-search-labelname-value="claims-support-claims-filter-form-mentor-ids">
                   <%= form.govuk_check_boxes_fieldset(
                     :mentor_ids,
                     legend: {
-                      text: t("claims.support.claims.index.mentors"),
+                      text: t("claims.support.claims.index.mentor"),
                       size: "s",
                     },
                     small: true,

--- a/app/components/claims/claim/filter_form_component.rb
+++ b/app/components/claims/claim/filter_form_component.rb
@@ -1,4 +1,6 @@
 class Claims::Claim::FilterFormComponent < ApplicationComponent
+  UNASSIGNED = "unassigned".freeze
+
   def initialize(
     filter_form:,
     statuses: Claims::Claim.statuses.values.without(*Claims::Claim::DRAFT_STATUSES.map(&:to_s)),
@@ -22,6 +24,10 @@ class Claims::Claim::FilterFormComponent < ApplicationComponent
       Mentor.trained_in_academic_year(filter_form.academic_year),
       order: %i[first_name last_name],
     )
+  end
+
+  def support_users
+    Claims::SupportUser.all.order_by_full_name
   end
 
   private

--- a/app/controllers/claims/support/claims/clawbacks_controller.rb
+++ b/app/controllers/claims/support/claims/clawbacks_controller.rb
@@ -61,6 +61,7 @@ class Claims::Support::Claims::ClawbacksController < Claims::Support::Applicatio
       school_ids: [],
       statuses: [],
       mentor_ids: [],
+      support_user_ids: [],
     ).with_defaults(index_path:)
   end
 

--- a/app/controllers/claims/support/claims/payments_controller.rb
+++ b/app/controllers/claims/support/claims/payments_controller.rb
@@ -57,6 +57,7 @@ class Claims::Support::Claims::PaymentsController < Claims::Support::Application
       school_ids: [],
       statuses: [],
       mentor_ids: [],
+      support_user_ids: [],
     )
   end
 

--- a/app/controllers/claims/support/claims/samplings_controller.rb
+++ b/app/controllers/claims/support/claims/samplings_controller.rb
@@ -57,6 +57,7 @@ class Claims::Support::Claims::SamplingsController < Claims::Support::Applicatio
       school_ids: [],
       statuses: [],
       mentor_ids: [],
+      support_user_ids: [],
     ).with_defaults(index_path:)
   end
 

--- a/app/controllers/claims/support/claims_controller.rb
+++ b/app/controllers/claims/support/claims_controller.rb
@@ -47,6 +47,7 @@ class Claims::Support::ClaimsController < Claims::Support::ApplicationController
       school_ids: [],
       statuses: [],
       mentor_ids: [],
+      support_user_ids: [],
     ).with_defaults(index_path:)
   end
 

--- a/app/decorators/claims/claim_decorator.rb
+++ b/app/decorators/claims/claim_decorator.rb
@@ -1,0 +1,17 @@
+class Claims::ClaimDecorator < Draper::Decorator
+  delegate_all
+
+  def support_user_assigned
+    if support_user.present?
+      support_user.full_name
+    else
+      I18n.t(".#{translation_path}.support_user.unassigned")
+    end
+  end
+
+  private
+
+  def translation_path
+    "activerecord.attributes.claims/claim"
+  end
+end

--- a/app/forms/claims/support/claims/filter_form.rb
+++ b/app/forms/claims/support/claims/filter_form.rb
@@ -81,7 +81,9 @@ class Claims::Support::Claims::FilterForm < ApplicationForm
   end
 
   def support_users
-    @support_users ||= Claims::SupportUser.find(support_user_ids)
+    @support_users ||= Claims::SupportUser.find(support_user_ids.reject do |id|
+      id == Claims::Claim::FilterFormComponent::UNASSIGNED
+    end)
   end
 
   def query_params

--- a/app/forms/claims/support/claims/filter_form.rb
+++ b/app/forms/claims/support/claims/filter_form.rb
@@ -15,6 +15,7 @@ class Claims::Support::Claims::FilterForm < ApplicationForm
   attribute :statuses, default: []
   attribute :academic_year_id, default: AcademicYear.for_date(Date.current).id
   attribute :mentor_ids, default: []
+  attribute :support_user_ids, default: []
 
   attribute :index_path
 
@@ -31,7 +32,8 @@ class Claims::Support::Claims::FilterForm < ApplicationForm
       submitted_after.present? ||
       submitted_before.present? ||
       statuses.present? ||
-      mentor_ids.present?
+      mentor_ids.present? ||
+      support_user_ids.present?
   end
 
   def index_path_without_filter(filter:, value: nil)
@@ -78,6 +80,10 @@ class Claims::Support::Claims::FilterForm < ApplicationForm
     @mentors ||= Mentor.find(mentor_ids)
   end
 
+  def support_users
+    @support_users ||= Claims::SupportUser.find(support_user_ids)
+  end
+
   def query_params
     {
       search:,
@@ -90,6 +96,7 @@ class Claims::Support::Claims::FilterForm < ApplicationForm
       statuses:,
       academic_year_id:,
       mentor_ids:,
+      support_user_ids:,
     }
   end
 

--- a/app/queries/claims/claims_query.rb
+++ b/app/queries/claims/claims_query.rb
@@ -9,6 +9,7 @@ class Claims::ClaimsQuery < ApplicationQuery
     scope = status_condition(scope)
     scope = academic_year_condition(scope)
     scope = mentor_condition(scope)
+    scope = support_user_condition(scope)
 
     scope.order_created_at_desc
   end
@@ -61,5 +62,16 @@ class Claims::ClaimsQuery < ApplicationQuery
     return scope if params[:mentor_ids].blank?
 
     scope.where(mentor_trainings: { mentor_id: params[:mentor_ids] })
+  end
+
+  def support_user_condition(scope)
+    return scope if params[:support_user_ids].blank?
+
+    # replace unassigned with nil
+    support_user_search = params[:support_user_ids].map do |support_user_id|
+      support_user_id == Claims::Claim::FilterFormComponent::UNASSIGNED ? nil : support_user_id
+    end
+
+    scope.where(support_user_id: support_user_search)
   end
 end

--- a/app/views/claims/support/claims/clawbacks/index.html.erb
+++ b/app/views/claims/support/claims/clawbacks/index.html.erb
@@ -19,7 +19,7 @@
     <div class="govuk-!-margin-bottom-2">
       <% if @claims.any? %>
         <% @claims.each do |claim| %>
-          <%= render Claim::CardComponent.new(claim:, href: claims_support_claims_clawback_path(claim)) %>
+          <%= render Claim::CardComponent.new(claim:, href: claims_support_claims_clawback_path(claim), current_user:) %>
         <% end %>
       <% else %>
         <p class="govuk-body">

--- a/app/views/claims/support/claims/index.html.erb
+++ b/app/views/claims/support/claims/index.html.erb
@@ -18,7 +18,7 @@
     <% if @claims.any? %>
       <div class="govuk-!-margin-bottom-2">
         <% @claims.each do |claim| %>
-          <%= render Claim::CardComponent.new(claim:, href: claims_support_claim_path(claim)) %>
+          <%= render Claim::CardComponent.new(claim:, href: claims_support_claim_path(claim), current_user:) %>
         <% end %>
       </div>
 

--- a/app/views/claims/support/claims/payments/index.html.erb
+++ b/app/views/claims/support/claims/payments/index.html.erb
@@ -22,7 +22,7 @@
     <div class="govuk-!-margin-bottom-2">
       <% if @claims.any? %>
         <% @claims.each do |claim| %>
-          <%= render Claim::CardComponent.new(claim:, href: claims_support_claims_payments_claim_path(claim)) %>
+          <%= render Claim::CardComponent.new(claim:, href: claims_support_claims_payments_claim_path(claim), current_user:) %>
         <% end %>
       <% else %>
         <p class="govuk-body"><%= t(".no_claims") %></p>

--- a/app/views/claims/support/claims/samplings/index.html.erb
+++ b/app/views/claims/support/claims/samplings/index.html.erb
@@ -20,7 +20,7 @@
     <div class="govuk-!-margin-bottom-2">
       <% if @claims.any? %>
         <% @claims.each do |claim| %>
-          <%= render Claim::CardComponent.new(claim:, href: claims_support_claims_sampling_path(claim)) %>
+          <%= render Claim::CardComponent.new(claim:, href: claims_support_claims_sampling_path(claim), current_user:) %>
         <% end %>
       <% else %>
         <p class="govuk-body">

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -10,6 +10,8 @@ en:
         id: ID
         reference: Claim reference
         submitted_at: Date submitted
+        support_user:
+          unassigned: Unassigned
       claims/claim/status:
         internal_draft: Internal draft
         draft: Draft

--- a/config/locales/en/claims/support/claims.yml
+++ b/config/locales/en/claims/support/claims.yml
@@ -28,7 +28,8 @@ en:
           submit: Search
           clear: Clear search
           status: Status
-          mentors: Mentors
+          mentor: Mentor
+          support_user: Support user
         show:
           page_caption: Claim %{reference}
           page_title: "%{school_name} - Claim %{reference}"

--- a/config/locales/en/components/claim/card_component.yml
+++ b/config/locales/en/components/claim/card_component.yml
@@ -3,4 +3,5 @@ en:
     claim:
       card_component:
         claim_title: "%{reference} - %{school_name}"
-        clawback_amount: Clawback amount
+        clawback_amount: Clawback 
+        support_user: Support user

--- a/config/locales/en/components/claims/claim/filter_form_component.yml
+++ b/config/locales/en/components/claims/claim/filter_form_component.yml
@@ -6,3 +6,4 @@ en:
           submit: Search
           search_label: Search by claim reference
           search_clear: Clear search
+          unassigned: Unassigned

--- a/spec/components/claim/card_component_spec.rb
+++ b/spec/components/claim/card_component_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Claim::CardComponent, type: :component do
   include Rails.application.routes.url_helpers
 
-  subject(:component) { described_class.new(claim:, href:) }
+  subject(:component) { described_class.new(claim:, href:, current_user:) }
 
   let(:claim) do
     create(:claim, :submitted, submitted_at: "2024/04/08", school:) do |claim|
@@ -12,8 +12,8 @@ RSpec.describe Claim::CardComponent, type: :component do
   end
 
   let(:href) { claims_support_claim_path(claim) }
-
   let(:school) { create(:claims_school, region: regions(:inner_london)) }
+  let(:current_user) { create(:claims_user, schools: [school]) }
 
   it "renders a card with claim details" do
     render_inline(component)

--- a/spec/components/claim/card_component_spec.rb
+++ b/spec/components/claim/card_component_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Claim::CardComponent, type: :component do
   subject(:component) { described_class.new(claim:, href:, current_user:) }
 
   let(:claim) do
-    create(:claim, :submitted, submitted_at: "2024/04/08", school:) do |claim|
+    create(:claim, :submitted, submitted_at: "2024/04/08", school:, support_user:) do |claim|
       claim.mentor_trainings << create(:mentor_training, hours_completed: 20)
     end
   end
@@ -14,17 +14,39 @@ RSpec.describe Claim::CardComponent, type: :component do
   let(:href) { claims_support_claim_path(claim) }
   let(:school) { create(:claims_school, region: regions(:inner_london)) }
   let(:current_user) { create(:claims_user, schools: [school]) }
+  let(:support_user) { create(:claims_support_user, first_name: "John", last_name: "Smith") }
 
-  it "renders a card with claim details" do
-    render_inline(component)
+  context "when current user is not a support user" do
+    it "renders a card with claim details without support user details" do
+      render_inline(component)
 
-    expect(page).to have_link(claim.school_name, href: claims_support_claim_path(claim))
-    expect(page).to have_content(claim.reference)
-    expect(page).to have_content("Submitted")
+      expect(page).to have_link(claim.school_name, href: claims_support_claim_path(claim))
+      expect(page).to have_content(claim.reference)
+      expect(page).to have_content("Submitted")
 
-    expect(page).to have_content(claim.academic_year_name)
-    expect(page).to have_content(claim.provider_name)
-    expect(page).to have_content("8 April 2024")
-    expect(page).to have_content("£1,072.00")
+      expect(page).to have_content(claim.academic_year_name)
+      expect(page).to have_content(claim.provider_name)
+      expect(page).to have_content("8 April 2024")
+      expect(page).to have_content("£1,072.00")
+      expect(page).not_to have_content("Support user: John Smith")
+    end
+  end
+
+  context "when current user is a support user" do
+    let(:current_user) { support_user }
+
+    it "renders a card with claim details with support user details" do
+      render_inline(component)
+
+      expect(page).to have_link(claim.school_name, href: claims_support_claim_path(claim))
+      expect(page).to have_content(claim.reference)
+      expect(page).to have_content("Submitted")
+
+      expect(page).to have_content(claim.academic_year_name)
+      expect(page).to have_content(claim.provider_name)
+      expect(page).to have_content("8 April 2024")
+      expect(page).to have_content("£1,072.00")
+      expect(page).to have_content("Support user: John Smith")
+    end
   end
 end

--- a/spec/components/claims/claim/filter_form_component_spec.rb
+++ b/spec/components/claims/claim/filter_form_component_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Claims::Claim::FilterFormComponent, type: :component do
     current_mentor_training
   end
 
-  it "renders search bar with the statuses, provider_ids, school_ids, mentor_ids, submitted_after, and submitted_before filters" do
+  it "renders search bar with the statuses, provider_ids, school_ids, mentor_ids, support_user_ids, submitted_after, and submitted_before filters" do
     render_inline(component)
 
     expect(page).to have_field("claims_support_claims_filter_form[search]")
@@ -27,6 +27,7 @@ RSpec.describe Claims::Claim::FilterFormComponent, type: :component do
     expect(page).to have_field("claims_support_claims_filter_form[provider_ids][]")
     expect(page).to have_field("claims_support_claims_filter_form[school_ids][]")
     expect(page).to have_field("claims_support_claims_filter_form[mentor_ids][]")
+    expect(page).to have_field("claims_support_claims_filter_form[support_user_ids][]")
     expect(page).to have_field("claims_support_claims_filter_form[submitted_after(1i)]")
     expect(page).to have_field("claims_support_claims_filter_form[submitted_after(2i)]")
     expect(page).to have_field("claims_support_claims_filter_form[submitted_after(3i)]")
@@ -122,6 +123,17 @@ RSpec.describe Claims::Claim::FilterFormComponent, type: :component do
 
     it "returns only mentors who trained during the selected academic year" do
       expect(mentors).to contain_exactly(current_trained_mentor)
+    end
+  end
+
+  describe "#support_users" do
+    subject(:support_users) { component.support_users }
+
+    let!(:claims_support_user) { create(:claims_support_user) }
+    let(:placements_support_user) { create(:placements_support_user) }
+
+    it "returns only claims support users" do
+      expect(support_users).to contain_exactly(claims_support_user)
     end
   end
 end

--- a/spec/components/previews/claim/card_component_preview.rb
+++ b/spec/components/previews/claim/card_component_preview.rb
@@ -1,7 +1,8 @@
 class Claim::CardComponentPreview < ApplicationComponentPreview
   def default
     claim = FactoryBot.build_stubbed(:claim, :submitted)
+    current_user = FactoryBot.build_stubbed(:claims_support_user)
 
-    render Claim::CardComponent.new(claim:)
+    render Claim::CardComponent.new(claim:, href: "", current_user:)
   end
 end

--- a/spec/decorators/claims/claim_decorator_spec.rb
+++ b/spec/decorators/claims/claim_decorator_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe Claims::ClaimDecorator do
+  describe "#support_user_assigned" do
+    subject(:support_user_assigned) { claim.decorate.support_user_assigned }
+
+    let(:claim) { create(:claim, support_user:) }
+
+    context "when the claim is assigned to a support user" do
+      let(:support_user) { create(:claims_support_user, first_name: "John", last_name: "Smith") }
+
+      it "returns the full name of the support user" do
+        expect(support_user_assigned).to eq("John Smith")
+      end
+    end
+
+    context "when the claim is not assigned to a support user" do
+      let(:support_user) { nil }
+
+      it "returns the full name of the support user" do
+        expect(support_user_assigned).to eq("Unassigned")
+      end
+    end
+  end
+end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -40,7 +40,7 @@ FactoryBot.define do
   factory :provider do
     # Provider codes are 3 character alphanumeric strings – e.g. "T92"
     # Since they're derived from a sequence, they're guaranteed to be unique.
-    sequence(:code) { |n| n.to_s(36).rjust(3, "0").upcase }
+    sequence(:code, "AA1")
 
     name { Faker::University.name }
     provider_type { Provider.provider_types.keys.sample }

--- a/spec/forms/claims/support/claims/filter_form_spec.rb
+++ b/spec/forms/claims/support/claims/filter_form_spec.rb
@@ -24,6 +24,7 @@ describe Claims::Support::Claims::FilterForm, type: :model do
         statuses: [],
         academic_year_id: current_academic_year.id,
         index_path: nil,
+        support_user_ids: [],
       )
     end
   end
@@ -45,6 +46,13 @@ describe Claims::Support::Claims::FilterForm, type: :model do
 
     it "returns true if mentor_ids present" do
       params = { mentor_ids: %w[mentor_id] }
+      form = described_class.new(params)
+
+      expect(form.filters_selected?).to be(true)
+    end
+
+    it "returns true if support_user_ids present" do
+      params = { support_user_ids: %w[support_user_id] }
       form = described_class.new(params)
 
       expect(form.filters_selected?).to be(true)
@@ -225,6 +233,25 @@ describe Claims::Support::Claims::FilterForm, type: :model do
     end
   end
 
+  describe "#support_users" do
+    it "returns a collection of claims support users based on support_user_ids param" do
+      support_user = create(:claims_support_user)
+      params = { support_user_ids: [support_user.id] }
+      call = described_class.new(params).support_users
+
+      expect(call).to eq([support_user])
+    end
+
+    context "when support_user_ids is empty" do
+      it "returns empty array" do
+        params = { support_user_ids: [] }
+        call = described_class.new(params).support_users
+
+        expect(call).to eq([])
+      end
+    end
+  end
+
   describe "#mentors" do
     it "returns a collection of mentors based on mentor_ids param" do
       mentor = create(:mentor)
@@ -287,6 +314,7 @@ describe Claims::Support::Claims::FilterForm, type: :model do
         "submitted_before(3i)" => "2",
         school_ids: %w[school_id],
         provider_ids: %w[provider_id],
+        support_user_ids: %w[support_user_id],
         mentor_ids: %w[mentor_id],
         statuses: %w[submitted],
         academic_year_id: current_academic_year.id,
@@ -298,6 +326,7 @@ describe Claims::Support::Claims::FilterForm, type: :model do
         provider_ids: %w[provider_id],
         school_ids: %w[school_id],
         mentor_ids: %w[mentor_id],
+        support_user_ids: %w[support_user_id],
         search: "claim_reference",
         search_provider: "provider",
         search_school: "school_name",

--- a/spec/queries/claims/claims_query_spec.rb
+++ b/spec/queries/claims/claims_query_spec.rb
@@ -123,5 +123,47 @@ describe Claims::ClaimsQuery do
         expect(claims_query).to contain_exactly(mentor_1_claim)
       end
     end
+
+    context "when given support user ids" do
+      let(:support_user_1) { build(:claims_support_user, first_name: "John", last_name: "Smith") }
+      let(:support_user_2) { build(:claims_support_user, first_name: "Anne", last_name: "Doe") }
+      let(:support_user_3) { build(:claims_support_user, first_name: "Sarah", last_name: "James") }
+
+      let(:claim_1) { create(:claim, :submitted, support_user: support_user_1) }
+      let(:claim_2) { create(:claim, :submitted, support_user: support_user_2) }
+      let(:claim_3) { create(:claim, :submitted, support_user: support_user_3) }
+      let(:non_assigned_claim) { create(:claim, :submitted) }
+
+      before do
+        claim_1
+        claim_2
+        claim_3
+        non_assigned_claim
+      end
+
+      context "when only support user ids are given" do
+        let(:params) { { support_user_ids: [support_user_1.id, support_user_2.id] } }
+
+        it "filters the results by supoort user" do
+          expect(claims_query).to contain_exactly(claim_1, claim_2)
+        end
+      end
+
+      context "when the only support user id given is 'unassigned'" do
+        let(:params) { { support_user_ids: %w[unassigned] } }
+
+        it "filters the results not assigned to support users" do
+          expect(claims_query).to contain_exactly(non_assigned_claim)
+        end
+      end
+
+      context "when given support user ids and 'unassigned'" do
+        let(:params) { { support_user_ids: ["unassigned", support_user_1.id, support_user_2.id] } }
+
+        it "filters the results" do
+          expect(claims_query).to contain_exactly(non_assigned_claim, claim_1, claim_2)
+        end
+      end
+    end
   end
 end

--- a/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_by_support_user_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_by_support_user_spec.rb
@@ -1,0 +1,268 @@
+require "rails_helper"
+
+RSpec.describe "Support user filters sampled claims by support user", service: :claims, type: :system do
+  scenario do
+    given_claims_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_sampling_claims_index_page
+    then_i_see_the_sampling_claims_index_page
+    and_i_see_3_claims_have_been_found
+    and_i_see_the_sampled_claim_with_reference_111111
+    and_i_see_the_sampled_claim_with_reference_222222
+    and_i_see_the_sampled_claim_with_reference_333333
+
+    when_i_select_john_smith_from_the_support_user_filter
+    and_i_click_on_apply_filters
+    then_i_see_the_sampling_claims_index_page
+    and_i_see_1_claim_has_been_found
+    and_i_see_the_sampled_claim_with_reference_111111
+    and_i_do_not_see_the_sampled_claim_with_reference_222222
+    and_i_do_not_see_the_sampled_claim_with_reference_333333
+    and_i_see_john_smith_selected_from_the_support_user_filter
+    and_i_do_not_see_sarah_doe_selected_from_the_support_user_filter
+    and_i_do_not_see_unassigned_selected_from_the_support_user_filter
+
+    when_i_select_sarah_doe_from_the_support_user_filter
+    and_i_click_on_apply_filters
+    then_i_see_the_sampling_claims_index_page
+    and_i_see_2_claims_have_been_found
+    and_i_see_the_sampled_claim_with_reference_111111
+    and_i_see_the_sampled_claim_with_reference_222222
+    and_i_do_not_see_the_sampled_claim_with_reference_333333
+    and_i_see_john_smith_selected_from_the_support_user_filter
+    and_i_see_sarah_doe_selected_from_the_support_user_filter
+    and_i_do_not_see_unassigned_selected_from_the_support_user_filter
+
+    when_i_unselect_john_smith_from_the_support_user_filter
+    and_i_click_on_apply_filters
+    then_i_see_the_sampling_claims_index_page
+    and_i_see_1_claim_has_been_found
+    and_i_do_not_see_the_sampled_claim_with_reference_111111
+    and_i_see_the_sampled_claim_with_reference_222222
+    and_i_do_not_see_the_sampled_claim_with_reference_333333
+    and_i_do_not_see_john_smith_selected_from_the_support_user_filter
+    and_i_see_sarah_doe_selected_from_the_support_user_filter
+    and_i_do_not_see_unassigned_selected_from_the_support_user_filter
+
+    when_i_click_on_the_sarah_doe_filter_tag
+    then_i_see_the_sampling_claims_index_page
+    and_i_see_3_claims_have_been_found
+    and_i_see_the_sampled_claim_with_reference_111111
+    and_i_see_the_sampled_claim_with_reference_222222
+    and_i_see_the_sampled_claim_with_reference_333333
+    and_i_do_not_see_john_smith_selected_from_the_support_user_filter
+    and_i_do_not_see_sarah_doe_selected_from_the_support_user_filter
+    and_i_do_not_see_unassigned_selected_from_the_support_user_filter
+
+    when_i_select_unassigned_from_the_support_user_filter
+    and_i_click_on_apply_filters
+    then_i_see_the_sampling_claims_index_page
+    and_i_see_1_claim_has_been_found
+    and_i_do_not_see_the_sampled_claim_with_reference_111111
+    and_i_do_not_see_the_sampled_claim_with_reference_222222
+    and_i_see_the_sampled_claim_with_reference_333333
+    and_i_see_unassigned_selected_from_the_support_user_filter
+    and_i_do_not_see_john_smith_selected_from_the_support_user_filter
+    and_i_do_not_see_sarah_doe_selected_from_the_support_user_filter
+
+    when_i_click_clear_filters
+    then_i_see_the_sampling_claims_index_page
+    and_i_see_3_claims_have_been_found
+    and_i_see_the_sampled_claim_with_reference_111111
+    and_i_see_the_sampled_claim_with_reference_222222
+    and_i_see_the_sampled_claim_with_reference_333333
+    and_i_do_not_see_john_smith_selected_from_the_support_user_filter
+    and_i_do_not_see_sarah_doe_selected_from_the_support_user_filter
+    and_i_do_not_see_unassigned_selected_from_the_support_user_filter
+  end
+
+  private
+
+  def given_claims_exist
+    @claim_window = build(:claim_window, :current)
+    @historic_claim_window = build(:claim_window, :historic)
+
+    @support_user_1 = build(:claims_support_user, first_name: "John", last_name: "Smith")
+    @support_user_2 = build(:claims_support_user, first_name: "Sarah", last_name: "Doe")
+
+    @support_user_1_claim = create(:claim, :audit_requested, support_user: @support_user_1, reference: 111_111)
+    @support_user_2_claim = create(:claim, :audit_requested, support_user: @support_user_2, reference: 222_222)
+    @support_user_3_claim = create(:claim, :audit_requested, reference: 333_333)
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_sampling_claims_index_page
+    within primary_navigation do
+      click_on "Claims"
+    end
+
+    within secondary_navigation do
+      click_on "Auditing"
+    end
+  end
+
+  def then_i_see_the_sampling_claims_index_page
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Claims")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(secondary_navigation).to have_current_item("Auditing")
+    expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
+  end
+
+  def and_i_see_3_claims_have_been_found
+    expect(page).to have_h2("Auditing (3)")
+  end
+
+  def and_i_see_2_claims_have_been_found
+    expect(page).to have_h2("Auditing (2)")
+  end
+
+  def and_i_see_1_claim_has_been_found
+    expect(page).to have_h2("Auditing (1)")
+  end
+
+  def and_i_see_the_sampled_claim_with_reference_111111
+    expect(page).to have_claim_card({
+      "title" => "111111 - #{@support_user_1_claim.school.name}",
+      "url" => "/support/claims/sampling/claims/#{@support_user_1_claim.id}",
+      "status" => "Sampling in progress",
+      "academic_year" => @support_user_1_claim.academic_year.name,
+      "provider_name" => @support_user_1_claim.provider_name,
+      "submitted_at" => I18n.l(@support_user_1_claim.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+  end
+
+  def and_i_see_the_sampled_claim_with_reference_222222
+    expect(page).to have_claim_card({
+      "title" => "222222 - #{@support_user_2_claim.school.name}",
+      "url" => "/support/claims/sampling/claims/#{@support_user_2_claim.id}",
+      "status" => "Sampling in progress",
+      "academic_year" => @support_user_2_claim.academic_year.name,
+      "provider_name" => @support_user_2_claim.provider_name,
+      "submitted_at" => I18n.l(@support_user_2_claim.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+  end
+
+  def and_i_see_the_sampled_claim_with_reference_333333
+    expect(page).to have_claim_card({
+      "title" => "333333 - #{@support_user_3_claim.school.name}",
+      "url" => "/support/claims/sampling/claims/#{@support_user_3_claim.id}",
+      "status" => "Sampling in progress",
+      "academic_year" => @support_user_3_claim.academic_year.name,
+      "provider_name" => @support_user_3_claim.provider_name,
+      "submitted_at" => I18n.l(@support_user_3_claim.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+  end
+
+  def when_i_select_john_smith_from_the_support_user_filter
+    check "John Smith"
+  end
+
+  def when_i_select_sarah_doe_from_the_support_user_filter
+    check "Sarah Doe"
+  end
+  alias_method :and_i_select_sarah_doe_from_the_support_user_filter,
+               :when_i_select_sarah_doe_from_the_support_user_filter
+
+  def when_i_select_unassigned_from_the_support_user_filter
+    check "Unassigned"
+  end
+
+  def and_i_click_on_apply_filters
+    click_on "Apply filters"
+  end
+
+  def and_i_do_not_see_the_sampled_claim_with_reference_111111
+    expect(page).not_to have_claim_card({
+      "title" => "111111 - #{@support_user_1_claim.school.name}",
+      "url" => "/support/claims/sampling/claims/#{@support_user_1_claim.id}",
+      "status" => "Sampling in progress",
+      "academic_year" => @support_user_1_claim.academic_year.name,
+      "provider_name" => @support_user_1_claim.provider_name,
+      "submitted_at" => I18n.l(@support_user_1_claim.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+  end
+
+  def and_i_do_not_see_the_sampled_claim_with_reference_222222
+    expect(page).not_to have_claim_card({
+      "title" => "222222 - #{@support_user_2_claim.school.name}",
+      "url" => "/support/claims/sampling/claims/#{@support_user_2_claim.id}",
+      "status" => "Sampling in progress",
+      "academic_year" => @support_user_2_claim.academic_year.name,
+      "provider_name" => @support_user_2_claim.provider_name,
+      "submitted_at" => I18n.l(@support_user_2_claim.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+  end
+
+  def and_i_do_not_see_the_sampled_claim_with_reference_333333
+    expect(page).not_to have_claim_card({
+      "title" => "333333 - #{@support_user_3_claim.school.name}",
+      "url" => "/support/claims/sampling/claims/#{@support_user_3_claim.id}",
+      "status" => "Sampling in progress",
+      "academic_year" => @support_user_3_claim.academic_year.name,
+      "provider_name" => @support_user_3_claim.provider_name,
+      "submitted_at" => I18n.l(@support_user_3_claim.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+  end
+
+  def and_i_see_john_smith_selected_from_the_support_user_filter
+    expect(page).to have_element(:legend, text: "Support user", class: "govuk-fieldset__legend")
+    expect(page).to have_checked_field("John Smith")
+    expect(page).to have_filter_tag("John Smith")
+  end
+
+  def and_i_see_sarah_doe_selected_from_the_support_user_filter
+    expect(page).to have_element(:legend, text: "Support user", class: "govuk-fieldset__legend")
+    expect(page).to have_checked_field("Sarah Doe")
+    expect(page).to have_filter_tag("Sarah Doe")
+  end
+
+  def and_i_see_unassigned_selected_from_the_support_user_filter
+    expect(page).to have_element(:legend, text: "Support user", class: "govuk-fieldset__legend")
+    expect(page).to have_checked_field("Unassigned")
+    expect(page).to have_filter_tag("Unassigned")
+  end
+
+  def and_i_do_not_see_john_smith_selected_from_the_support_user_filter
+    expect(page).not_to have_checked_field("John Smith")
+    expect(page).not_to have_filter_tag("John Smith")
+  end
+
+  def and_i_do_not_see_sarah_doe_selected_from_the_support_user_filter
+    expect(page).not_to have_checked_field("Sarah Doe")
+    expect(page).not_to have_filter_tag("Sarah Doe")
+  end
+
+  def and_i_do_not_see_unassigned_selected_from_the_support_user_filter
+    expect(page).not_to have_checked_field("Unassigned")
+    expect(page).not_to have_filter_tag("Unassigned")
+  end
+
+  def when_i_unselect_john_smith_from_the_support_user_filter
+    uncheck "John Smith"
+  end
+
+  def when_i_unselect_sarah_doe_from_the_support_user_filter
+    uncheck "Sarah Doe"
+  end
+
+  def when_i_click_on_the_sarah_doe_filter_tag
+    within ".app-filter-tags" do
+      click_on "Sarah Doe"
+    end
+  end
+
+  def when_i_click_clear_filters
+    click_on "Clear filters"
+  end
+end


### PR DESCRIPTION
## Context

- Add support users filter to the claims page.
- Add detail to the Claims card component to show assigned support users.

## Changes proposed in this pull request

- Add support users filter to the claims page.
- Add detail to the Claims card component to show assigned support users.

## Guidance to review

- Sign in as Colin (Support user)
- Navigate to "Claims"
⚠️ If you haven't already, assign some claims to support users ⚠️ 
- Use the "Support user" filter to filter results based on selected Support users.

## Link to Trello card

https://trello.com/c/Xw2JCIrV/28-add-support-user-details-to-claim-summary-on-index-page-and-support-user-filter

## Screenshots

https://github.com/user-attachments/assets/5ddb75fb-361f-4935-b378-e821550afec8


