### PR TITLE
Add a training type filter to claims pages

### DIFF
--- a/app/components/claims/claim/filter_form_component.html.erb
+++ b/app/components/claims/claim/filter_form_component.html.erb
@@ -38,6 +38,22 @@
                     </div>
                   </div>
 
+                  <% if filter_form.training_types.present? %>
+                    <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t("claims.support.claims.index.training_type") %></h3>
+                    <ul class="app-filter-tags">
+                      <% filter_form.training_types.each do |training_type| %>
+                        <li>
+                        <%= govuk_link_to(
+                          training_type.titleize,
+                          filter_form.index_path_without_filter(filter: "training_types", value: training_type),
+                          class: "app-filter__tag",
+                          no_visited_state: true,
+                        ) %>
+                        </li>
+                      <% end %>
+                    </ul>
+                  <% end %>
+
                   <% if filter_form.statuses.present? %>
                     <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= t("claims.support.claims.index.status") %></h3>
                     <ul class="app-filter-tags">
@@ -173,6 +189,22 @@
                     <% end %>
                   </div>
                 <% end %>
+
+                <div class="app-filter__option">
+                    <%= form.govuk_check_boxes_fieldset(
+                      :training_types,
+                      legend: {
+                        text: t("claims.support.claims.index.training_type"),
+                        size: "s",
+                      },
+                      small: true,
+                      multiple: false,
+                    ) do %>
+                      <% training_types.each do |training_type| %>
+                        <%= form.govuk_check_box :training_types, training_type, label: { text: training_type.titleize } %>
+                      <% end %>
+                    <% end %>
+                  </div>
 
                 <div class="app-filter__option" data-controller="filter-search">
                   <%= form.govuk_check_boxes_fieldset(

--- a/app/components/claims/claim/filter_form_component.rb
+++ b/app/components/claims/claim/filter_form_component.rb
@@ -30,6 +30,10 @@ class Claims::Claim::FilterFormComponent < ApplicationComponent
     Claims::SupportUser.all.order_by_full_name
   end
 
+  def training_types
+    Claims::MentorTraining.training_types.keys.sort
+  end
+
   private
 
   attr_reader :claims, :filter_form

--- a/app/controllers/claims/support/claims/clawbacks_controller.rb
+++ b/app/controllers/claims/support/claims/clawbacks_controller.rb
@@ -62,6 +62,7 @@ class Claims::Support::Claims::ClawbacksController < Claims::Support::Applicatio
       statuses: [],
       mentor_ids: [],
       support_user_ids: [],
+      training_types: [],
     ).with_defaults(index_path:)
   end
 

--- a/app/controllers/claims/support/claims/payments_controller.rb
+++ b/app/controllers/claims/support/claims/payments_controller.rb
@@ -58,6 +58,7 @@ class Claims::Support::Claims::PaymentsController < Claims::Support::Application
       statuses: [],
       mentor_ids: [],
       support_user_ids: [],
+      training_types: [],
     )
   end
 

--- a/app/controllers/claims/support/claims/samplings_controller.rb
+++ b/app/controllers/claims/support/claims/samplings_controller.rb
@@ -58,6 +58,7 @@ class Claims::Support::Claims::SamplingsController < Claims::Support::Applicatio
       statuses: [],
       mentor_ids: [],
       support_user_ids: [],
+      training_types: [],
     ).with_defaults(index_path:)
   end
 

--- a/app/controllers/claims/support/claims_controller.rb
+++ b/app/controllers/claims/support/claims_controller.rb
@@ -48,6 +48,7 @@ class Claims::Support::ClaimsController < Claims::Support::ApplicationController
       statuses: [],
       mentor_ids: [],
       support_user_ids: [],
+      training_types: [],
     ).with_defaults(index_path:)
   end
 

--- a/app/forms/claims/support/claims/filter_form.rb
+++ b/app/forms/claims/support/claims/filter_form.rb
@@ -16,6 +16,7 @@ class Claims::Support::Claims::FilterForm < ApplicationForm
   attribute :academic_year_id, default: AcademicYear.for_date(Date.current).id
   attribute :mentor_ids, default: []
   attribute :support_user_ids, default: []
+  attribute :training_types, default: []
 
   attribute :index_path
 
@@ -33,7 +34,8 @@ class Claims::Support::Claims::FilterForm < ApplicationForm
       submitted_before.present? ||
       statuses.present? ||
       mentor_ids.present? ||
-      support_user_ids.present?
+      support_user_ids.present? ||
+      training_types.present?
   end
 
   def index_path_without_filter(filter:, value: nil)
@@ -99,6 +101,7 @@ class Claims::Support::Claims::FilterForm < ApplicationForm
       academic_year_id:,
       mentor_ids:,
       support_user_ids:,
+      training_types:,
     }
   end
 

--- a/app/queries/claims/claims_query.rb
+++ b/app/queries/claims/claims_query.rb
@@ -10,6 +10,7 @@ class Claims::ClaimsQuery < ApplicationQuery
     scope = academic_year_condition(scope)
     scope = mentor_condition(scope)
     scope = support_user_condition(scope)
+    scope = training_type_condition(scope)
 
     scope.order_created_at_desc
   end
@@ -73,5 +74,11 @@ class Claims::ClaimsQuery < ApplicationQuery
     end
 
     scope.where(support_user_id: support_user_search)
+  end
+
+  def training_type_condition(scope)
+    return scope if params[:training_types].blank?
+
+    scope.where(mentor_trainings: { training_type: params[:training_types] })
   end
 end

--- a/config/locales/en/claims/support/claims.yml
+++ b/config/locales/en/claims/support/claims.yml
@@ -30,6 +30,7 @@ en:
           status: Status
           mentor: Mentor
           support_user: Support user
+          training_type: Training type
         show:
           page_caption: Claim %{reference}
           page_title: "%{school_name} - Claim %{reference}"

--- a/spec/components/claims/claim/filter_form_component_spec.rb
+++ b/spec/components/claims/claim/filter_form_component_spec.rb
@@ -136,4 +136,12 @@ RSpec.describe Claims::Claim::FilterFormComponent, type: :component do
       expect(support_users).to contain_exactly(claims_support_user)
     end
   end
+
+  describe "#training_types" do
+    subject(:training_types) { component.training_types }
+
+    it "returns the training types" do
+      expect(training_types).to contain_exactly("initial", "refresher")
+    end
+  end
 end

--- a/spec/forms/claims/support/claims/filter_form_spec.rb
+++ b/spec/forms/claims/support/claims/filter_form_spec.rb
@@ -25,6 +25,7 @@ describe Claims::Support::Claims::FilterForm, type: :model do
         academic_year_id: current_academic_year.id,
         index_path: nil,
         support_user_ids: [],
+        training_types: [],
       )
     end
   end
@@ -63,6 +64,13 @@ describe Claims::Support::Claims::FilterForm, type: :model do
       form = described_class.new(params)
 
       expect(form.filters_selected?).to be(false)
+    end
+
+    it "returns true if training_types present" do
+      params = { training_types: %w[initial] }
+      form = described_class.new(params)
+
+      expect(form.filters_selected?).to be(true)
     end
 
     it "returns true if submitted_after is present" do
@@ -316,6 +324,7 @@ describe Claims::Support::Claims::FilterForm, type: :model do
         provider_ids: %w[provider_id],
         support_user_ids: %w[support_user_id],
         mentor_ids: %w[mentor_id],
+        training_types: %w[initial],
         statuses: %w[submitted],
         academic_year_id: current_academic_year.id,
       }
@@ -333,6 +342,7 @@ describe Claims::Support::Claims::FilterForm, type: :model do
         submitted_after: Date.new(2024, 1, 2),
         submitted_before: Date.new(2023, 1, 2),
         statuses: %w[submitted],
+        training_types: %w[initial],
         academic_year_id: current_academic_year.id,
       )
     end

--- a/spec/queries/claims/claims_query_spec.rb
+++ b/spec/queries/claims/claims_query_spec.rb
@@ -160,9 +160,31 @@ describe Claims::ClaimsQuery do
       context "when given support user ids and 'unassigned'" do
         let(:params) { { support_user_ids: ["unassigned", support_user_1.id, support_user_2.id] } }
 
-        it "filters the results" do
+        it "filters the results by support user and not assigned" do
           expect(claims_query).to contain_exactly(non_assigned_claim, claim_1, claim_2)
         end
+      end
+    end
+
+    context "when given training types" do
+      let(:params) { { training_types: %w[initial] } }
+
+      let(:claim_1) { build(:claim, :submitted) }
+      let(:claim_2) { build(:claim, :draft) }
+      let(:claim_3) { build(:claim, :submitted) }
+
+      let(:initial_mentor_training) { create(:mentor_training, claim: claim_1, training_type: :initial) }
+      let(:draft_mentor_training) { create(:mentor_training, claim: claim_2, training_type: :initial) }
+      let(:refresher_mentor_training) { create(:mentor_training, claim: claim_3, training_type: :refresher) }
+
+      before do
+        initial_mentor_training
+        draft_mentor_training
+        refresher_mentor_training
+      end
+
+      it "filters the results by mentor training 'training type'" do
+        expect(claims_query).to contain_exactly(claim_1)
       end
     end
   end

--- a/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_by_training_type_spec.rb
+++ b/spec/system/claims/support/claims/sampling/support_user_filters_sampled_claims_by_training_type_spec.rb
@@ -1,0 +1,212 @@
+require "rails_helper"
+
+RSpec.describe "Support user filters sampled claims by training type", service: :claims, type: :system do
+  scenario do
+    given_claims_exist
+    and_i_am_signed_in
+
+    when_i_navigate_to_the_sampling_claims_index_page
+    then_i_see_the_sampling_claims_index_page
+    and_i_see_2_claims_have_been_found
+    and_i_see_the_sampled_claim_with_reference_111111
+    and_i_see_the_sampled_claim_with_reference_222222
+
+    when_i_select_initial_from_the_training_type_filter
+    and_i_click_on_apply_filters
+    then_i_see_the_sampling_claims_index_page
+    and_i_see_1_claim_has_been_found
+    and_i_see_the_sampled_claim_with_reference_111111
+    and_i_do_not_see_the_sampled_claim_with_reference_222222
+    and_i_see_initial_selected_from_the_training_type_filter
+    and_i_do_not_see_refresher_selected_from_the_training_type_filter
+
+    when_i_select_refresher_from_the_training_type_filter
+    and_i_click_on_apply_filters
+    then_i_see_the_sampling_claims_index_page
+    and_i_see_2_claims_have_been_found
+    and_i_see_the_sampled_claim_with_reference_111111
+    and_i_see_the_sampled_claim_with_reference_222222
+    and_i_see_initial_selected_from_the_training_type_filter
+    and_i_see_refresher_selected_from_the_training_type_filter
+
+    when_i_unselect_initial_from_the_training_type_filter
+    and_i_click_on_apply_filters
+    then_i_see_the_sampling_claims_index_page
+    and_i_see_1_claim_has_been_found
+    and_i_do_not_see_the_sampled_claim_with_reference_111111
+    and_i_see_the_sampled_claim_with_reference_222222
+    and_i_do_not_see_initial_selected_from_the_training_type_filter
+    and_i_see_refresher_selected_from_the_training_type_filter
+
+    when_i_click_on_the_refresher_filter_tag
+    then_i_see_the_sampling_claims_index_page
+    and_i_see_2_claims_have_been_found
+    and_i_see_the_sampled_claim_with_reference_111111
+    and_i_see_the_sampled_claim_with_reference_222222
+    and_i_do_not_see_initial_selected_from_the_training_type_filter
+    and_i_do_not_see_refresher_selected_from_the_training_type_filter
+
+    when_i_select_initial_from_the_training_type_filter
+    and_i_select_refresher_from_the_training_type_filter
+    and_i_click_on_apply_filters
+    then_i_see_the_sampling_claims_index_page
+    and_i_see_2_claims_have_been_found
+    and_i_see_the_sampled_claim_with_reference_111111
+    and_i_see_the_sampled_claim_with_reference_222222
+    and_i_see_initial_selected_from_the_training_type_filter
+    and_i_see_refresher_selected_from_the_training_type_filter
+
+    when_i_click_clear_filters
+    then_i_see_the_sampling_claims_index_page
+    and_i_see_2_claims_have_been_found
+    and_i_see_the_sampled_claim_with_reference_111111
+    and_i_see_the_sampled_claim_with_reference_222222
+    and_i_do_not_see_initial_selected_from_the_training_type_filter
+    and_i_do_not_see_refresher_selected_from_the_training_type_filter
+  end
+
+  private
+
+  def given_claims_exist
+    @claim_window = build(:claim_window, :current)
+    @historic_claim_window = build(:claim_window, :historic)
+
+    @claim_1 = build(:claim, :audit_requested, reference: 111_111)
+    @claim_2 = build(:claim, :audit_requested, reference: 222_222)
+
+    @initial_mentor_training = create(:mentor_training, claim: @claim_1, training_type: :initial)
+    @refresher_mentor_training = create(:mentor_training, claim: @claim_2, training_type: :refresher)
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_sampling_claims_index_page
+    within primary_navigation do
+      click_on "Claims"
+    end
+
+    within secondary_navigation do
+      click_on "Auditing"
+    end
+  end
+
+  def then_i_see_the_sampling_claims_index_page
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Claims")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(secondary_navigation).to have_current_item("Auditing")
+    expect(page).to have_current_path(claims_support_claims_samplings_path, ignore_query: true)
+  end
+
+  def and_i_see_2_claims_have_been_found
+    expect(page).to have_h2("Auditing (2)")
+  end
+
+  def and_i_see_1_claim_has_been_found
+    expect(page).to have_h2("Auditing (1)")
+  end
+
+  def and_i_see_the_sampled_claim_with_reference_111111
+    expect(page).to have_claim_card({
+      "title" => "111111 - #{@claim_1.school.name}",
+      "url" => "/support/claims/sampling/claims/#{@claim_1.id}",
+      "status" => "Sampling in progress",
+      "academic_year" => @claim_1.academic_year.name,
+      "provider_name" => @claim_1.provider_name,
+      "submitted_at" => I18n.l(@claim_1.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+  end
+
+  def and_i_see_the_sampled_claim_with_reference_222222
+    expect(page).to have_claim_card({
+      "title" => "222222 - #{@claim_2.school.name}",
+      "url" => "/support/claims/sampling/claims/#{@claim_2.id}",
+      "status" => "Sampling in progress",
+      "academic_year" => @claim_2.academic_year.name,
+      "provider_name" => @claim_2.provider_name,
+      "submitted_at" => I18n.l(@claim_2.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+  end
+
+  def when_i_select_initial_from_the_training_type_filter
+    check "Initial"
+  end
+
+  def when_i_select_refresher_from_the_training_type_filter
+    check "Refresher"
+  end
+  alias_method :and_i_select_refresher_from_the_training_type_filter,
+               :when_i_select_refresher_from_the_training_type_filter
+
+  def and_i_click_on_apply_filters
+    click_on "Apply filters"
+  end
+
+  def and_i_do_not_see_the_sampled_claim_with_reference_111111
+    expect(page).not_to have_claim_card({
+      "title" => "111111 - #{@claim_1.school.name}",
+      "url" => "/support/claims/sampling/claims/#{@claim_1.id}",
+      "status" => "Sampling in progress",
+      "academic_year" => @claim_1.academic_year.name,
+      "provider_name" => @claim_1.provider_name,
+      "submitted_at" => I18n.l(@claim_1.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+  end
+
+  def and_i_do_not_see_the_sampled_claim_with_reference_222222
+    expect(page).not_to have_claim_card({
+      "title" => "222222 - #{@claim_2.school.name}",
+      "url" => "/support/claims/sampling/claims/#{@claim_2.id}",
+      "status" => "Sampling in progress",
+      "academic_year" => @claim_2.academic_year.name,
+      "provider_name" => @claim_2.provider_name,
+      "submitted_at" => I18n.l(@claim_2.submitted_at.to_date, format: :long),
+      "amount" => "£0.00",
+    })
+  end
+
+  def and_i_see_initial_selected_from_the_training_type_filter
+    expect(page).to have_element(:legend, text: "Training type", class: "govuk-fieldset__legend")
+    expect(page).to have_checked_field("Initial")
+    expect(page).to have_filter_tag("Initial")
+  end
+
+  def and_i_see_refresher_selected_from_the_training_type_filter
+    expect(page).to have_element(:legend, text: "Training type", class: "govuk-fieldset__legend")
+    expect(page).to have_checked_field("Refresher")
+    expect(page).to have_filter_tag("Refresher")
+  end
+
+  def and_i_do_not_see_initial_selected_from_the_training_type_filter
+    expect(page).not_to have_checked_field("Initial")
+    expect(page).not_to have_filter_tag("Initial")
+  end
+
+  def and_i_do_not_see_refresher_selected_from_the_training_type_filter
+    expect(page).not_to have_checked_field("Refresher")
+    expect(page).not_to have_filter_tag("Refresher")
+  end
+
+  def when_i_unselect_initial_from_the_training_type_filter
+    uncheck "Initial"
+  end
+
+  def when_i_unselect_refresher_from_the_training_type_filter
+    uncheck "Refresher"
+  end
+
+  def when_i_click_on_the_refresher_filter_tag
+    within ".app-filter-tags" do
+      click_on "Refresher"
+    end
+  end
+
+  def when_i_click_clear_filters
+    click_on "Clear filters"
+  end
+end


### PR DESCRIPTION
## Context

- Add a Training Type filter to claims index pages.

## Changes proposed in this pull request

- Add a Training Type filter to claims index pages.

## Guidance to review

- Sign in as Colin (Support user)
⚠️ Assuming you have a claim with at least one mentor training with the training type `refresher` ⚠️ 
- Navigate to "Claims"
- Use the "Training type" filter to filter results between `initial` and `refresher` training types.

## Link to Trello card

https://trello.com/c/aB0yfPQb/23-add-filter-to-show-initial-and-refresher-claims

## Screenshots

https://github.com/user-attachments/assets/51b20645-378c-4afb-ab2d-b50fe07848c9


