### PR TITLE
Add average claim amount to slack notification

### DIFF
--- a/app/jobs/claims/slack/daily_roundup_job.rb
+++ b/app/jobs/claims/slack/daily_roundup_job.rb
@@ -9,7 +9,8 @@ class Claims::Slack::DailyRoundupJob < ApplicationJob
     new_schools = new_organisations(todays_claims, :school_id)
     new_providers = new_organisations(todays_claims, :provider_id)
     total_claims = Claims::Claim.joins(:claim_window).where(claim_window: { academic_year_id: current_academic_year.id })
-    average_amount = total_claims.map(&:amount).sum / total_claims.count.to_f
+    total_amount = total_claims.map(&:amount).sum
+    average_amount = total_amount / total_claims.count.to_f
 
     Claims::ClaimSlackNotifier.claim_submitted_notification(
       claim_count: todays_claims.count,
@@ -17,9 +18,9 @@ class Claims::Slack::DailyRoundupJob < ApplicationJob
       provider_count: new_providers.count,
       claim_amount: humanized_money_with_symbol(todays_claims.map(&:amount).sum),
       total_claims_count: total_claims.count,
-      total_claims_amount: humanized_money_with_symbol(total_claims.map(&:amount).sum),
+      total_claims_amount: humanized_money_with_symbol(total_amount),
       invalid_claim_count: total_claims.where(status: :invalid_provider).count,
-      average_claim_amount: average_amount,
+      average_claim_amount: humanized_money_with_symbol(average_amount),
     ).deliver_now
   end
 

--- a/app/slack_notifiers/claims/claim_slack_notifier.rb
+++ b/app/slack_notifiers/claims/claim_slack_notifier.rb
@@ -1,5 +1,5 @@
 class Claims::ClaimSlackNotifier < Claims::ApplicationSlackNotifier
-  def claim_submitted_notification(academic_year: AcademicYear.for_date(Date.current), claim_count: 0, school_count: 0, provider_count: 0, claim_amount: "£0", total_claims_count: 0, total_claims_amount: "£0", invalid_claim_count: 0)
+  def claim_submitted_notification(academic_year: AcademicYear.for_date(Date.current), claim_count: 0, school_count: 0, provider_count: 0, claim_amount: "£0", total_claims_count: 0, total_claims_amount: "£0", invalid_claim_count: 0, average_claim_amount: "£0")
     message(
       blocks: [
         {
@@ -74,6 +74,13 @@ class Claims::ClaimSlackNotifier < Claims::ApplicationSlackNotifier
           text: {
             type: "mrkdwn",
             text: ":bank: *#{total_claims_amount}* has been claimed",
+          },
+        },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: ":abacus: *#{average_claim_amount}* is the average amount claimed",
           },
         },
       ],

--- a/spec/jobs/claims/slack/daily_roundup_job_spec.rb
+++ b/spec/jobs/claims/slack/daily_roundup_job_spec.rb
@@ -27,6 +27,9 @@ RSpec.describe Claims::Slack::DailyRoundupJob, type: :job do
     it "sends the daily claims notification" do
       described_class.perform_now
 
+      total_claims_amount = Claims::Claim.all.map(&:amount).sum
+      average_claim_amount = total_claims_amount / Claims::Claim.count.to_f
+
       expect(slack_notifier).to have_received(:claim_submitted_notification).with(
         claim_count: 1,
         school_count: 1,
@@ -34,7 +37,8 @@ RSpec.describe Claims::Slack::DailyRoundupJob, type: :job do
         invalid_claim_count: 1,
         claim_amount: humanized_money_with_symbol(yesterdays_claim.amount),
         total_claims_count: 3,
-        total_claims_amount: humanized_money_with_symbol(previous_claim.amount + yesterdays_claim.amount),
+        total_claims_amount: humanized_money_with_symbol(total_claims_amount),
+        average_claim_amount: humanized_money_with_symbol(average_claim_amount),
       )
 
       expect(slack_message).to have_received(:deliver_now)

--- a/spec/slack_notifiers/claims/claim_slack_notifier_spec.rb
+++ b/spec/slack_notifiers/claims/claim_slack_notifier_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Claims::ClaimSlackNotifier do
         claim_amount:,
         total_claims_count:,
         total_claims_amount:,
+        average_claim_amount:,
       )
     end
 
@@ -25,6 +26,7 @@ RSpec.describe Claims::ClaimSlackNotifier do
       let(:invalid_claim_count) { 3 }
       let(:total_claims_count) { 100 }
       let(:total_claims_amount) { "£50000" }
+      let(:average_claim_amount) { "£500" }
 
       it "returns a message with the correct blocks" do
         expect(notification.blocks).to include(
@@ -102,6 +104,13 @@ RSpec.describe Claims::ClaimSlackNotifier do
               text: ":bank: *#{total_claims_amount}* has been claimed",
             },
           },
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: ":abacus: *#{average_claim_amount}* is the average amount claimed",
+            },
+          },
         )
       end
     end
@@ -114,6 +123,7 @@ RSpec.describe Claims::ClaimSlackNotifier do
       let(:invalid_claim_count) { 1 }
       let(:total_claims_count) { 1 }
       let(:total_claims_amount) { "£1000" }
+      let(:average_claim_amount) { "£1000" }
 
       it "returns a message with the correct blocks" do
         expect(notification.blocks).to include(
@@ -189,6 +199,13 @@ RSpec.describe Claims::ClaimSlackNotifier do
             text: {
               type: "mrkdwn",
               text: ":bank: *#{total_claims_amount}* has been claimed",
+            },
+          },
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: ":abacus: *#{average_claim_amount}* is the average amount claimed",
             },
           },
         )


### PR DESCRIPTION
## Context

- Correct academic year query on claims for Slack notification
- Add Average total amount to Slack notification

## Changes proposed in this pull request

- Correct academic year query on claims for Slack notification
- Add Average total amount to Slack notification

## Link to Trello card

https://trello.com/c/eG66dK64/26-add-average-claim-value-to-slack-bot
