### PR TITLE
Claims filter persist when moving between pages

### DIFF
--- a/app/controllers/claims/support/claims_controller.rb
+++ b/app/controllers/claims/support/claims_controller.rb
@@ -2,6 +2,7 @@ class Claims::Support::ClaimsController < Claims::Support::ApplicationController
   before_action :set_claim, only: %i[show]
   before_action :authorize_claim
   helper_method :filter_form
+  before_action :store_filter_params, only: %i[index]
   before_action :set_filtered_claims, only: %i[index download_csv]
 
   def index
@@ -62,5 +63,9 @@ class Claims::Support::ClaimsController < Claims::Support::ApplicationController
 
   def index_path
     claims_support_claims_path
+  end
+
+  def store_filter_params
+    session["claims_filter_params"] = { claims_support_claims_filter_form: filter_params.to_h }
   end
 end

--- a/app/views/claims/support/claims/show.html.erb
+++ b/app/views/claims/support/claims/show.html.erb
@@ -2,7 +2,7 @@
 <% content_for(:page_title) { sanitize t(".page_title", school_name: @claim.school_name, reference: @claim.reference) } %>
 
 <% content_for(:before_content) do %>
-  <%= govuk_back_link href: claims_support_claims_path %>
+  <%= govuk_back_link href: claims_support_claims_path(session["claims_filter_params"]) %>
 <% end %>
 
 <div class="govuk-width-container">

--- a/spec/system/claims/support/claims/view_claims_spec.rb
+++ b/spec/system/claims/support/claims/view_claims_spec.rb
@@ -49,6 +49,25 @@ RSpec.describe "View claims", service: :claims, type: :system do
     then_i_see_a_list_of_claims([claim_4, claim_5, claim_6, claim_7])
   end
 
+  scenario "Filters persist across claim navigation" do
+    when_i_visit_claim_index_page
+    then_i_see_a_list_of_claims([claim_4, claim_5, claim_6, claim_7])
+    when_i_check_school_filter(school_1)
+    then_i_see_a_list_of_claims([claim_4, claim_5, claim_6])
+
+    # Navigate to a claim
+    within(".claim-card:nth-child(1)") do
+      click_link(claim_4.reference)
+    end
+    expect(page).to have_content(claim_4.reference)
+
+    # Use the back link (which should include session filter)
+    click_link("Back")
+
+    # Confirm that the filter is still applied after returning
+    then_i_see_a_list_of_claims([claim_4, claim_5, claim_6])
+  end
+
   context "when filtering by a status" do
     scenario "Support user filters claims in a submitted status" do
       when_i_visit_claim_index_page


### PR DESCRIPTION
## Context

When we use the backlinks; filter options should be persisted. They currently aren't and we should address this.

## Changes proposed in this pull request

Make sure that when a user navigates between claims, that the selected page and filters still persist until a fresh page load or the filters have been reset.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Us7WyhPQ/27-check-that-claims-filters-persist-when-moving-between-pages-similar-to-placements

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
