### PR TITLE
Use claims' claim window instead of current

### DIFF
--- a/app/wizards/claims/invalid_provider_wizard.rb
+++ b/app/wizards/claims/invalid_provider_wizard.rb
@@ -45,7 +45,7 @@ module Claims
         params: {
           school:,
           provider:,
-          claim: Claims::Claim.new(claim_window: Claims::ClaimWindow.current),
+          claim: Claims::Claim.new(claim_window: claim.claim_window),
         },
       )
     end


### PR DESCRIPTION
## Context

Use the claim's set claim window instead of the current claim window to resolve 500 when no claim window is active.