### PR TITLE
Reinstate onboard schools/users validations

### DIFF
--- a/app/wizards/claims/onboard_multiple_schools_wizard/upload_step.rb
+++ b/app/wizards/claims/onboard_multiple_schools_wizard/upload_step.rb
@@ -37,13 +37,11 @@ class Claims::OnboardMultipleSchoolsWizard::UploadStep < BaseStep
     return true if csv_content.blank?
 
     reset_input_attributes
-    csv.each_with_index do |row, _i|
-      next if row["name"].blank? &&
-        row["urn"].blank?
+    csv.each_with_index do |row, i|
+      next if row["name"].blank? && row["urn"].blank?
 
-      # Temp removed to make the CSV upload work
-      # validate_name(row, i)
-      # validate_urn(row, i)
+      validate_name(row, i)
+      validate_urn(row, i)
     end
 
     invalid_school_name_rows.blank? &&

--- a/app/wizards/claims/onboard_users_wizard/upload_step.rb
+++ b/app/wizards/claims/onboard_users_wizard/upload_step.rb
@@ -49,8 +49,8 @@ class Claims::OnboardUsersWizard::UploadStep < BaseStep
       next if row.all? { |_k, v| v.blank? }
 
       validate_name_fields(row, i)
-      # validate_email(row, i)
-      # validate_school_urn(row, i)
+      validate_email(row, i)
+      validate_school_urn(row, i)
     end
 
     invalid_email_rows.blank? &&

--- a/spec/system/claims/support/settings/onboard_multiple_schools/support_user_uploads_a_file_with_invalid_inputs_spec.rb
+++ b/spec/system/claims/support/settings/onboard_multiple_schools/support_user_uploads_a_file_with_invalid_inputs_spec.rb
@@ -2,8 +2,6 @@ require "rails_helper"
 
 RSpec.describe "Support user uploads a file with invalid inputs", service: :claims, type: :system do
   scenario do
-    pending "Validation temp removed"
-
     given_claim_windows_exist
     and_schools_exist
     and_i_am_signed_in
@@ -44,7 +42,7 @@ RSpec.describe "Support user uploads a file with invalid inputs", service: :clai
   end
 
   def and_i_navigate_to_onboard_multiple_schools
-    click_on "Onboard schools"
+    click_on "Make schools eligible to submit claims"
   end
 
   def then_i_see_the_upload_page

--- a/spec/system/claims/support/settings/onboard_multiple_users/support_user_onboards_users_for_an_invalid_school_urn_spec.rb
+++ b/spec/system/claims/support/settings/onboard_multiple_users/support_user_onboards_users_for_an_invalid_school_urn_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe "Support user onboards users for an invalid school urn", service: :claims, type: :system do
   scenario do
-    pending "Validation temp removed"
     given_schools_exist
     and_i_am_signed_in
     when_i_navigate_to_the_settings_index_page
@@ -32,7 +31,7 @@ RSpec.describe "Support user onboards users for an invalid school urn", service:
   end
 
   def and_i_navigate_to_onboard_multiple_users
-    click_on "Onboard users"
+    click_on "Invite users to the service"
   end
 
   def then_i_see_the_upload_page

--- a/spec/system/claims/support/settings/onboard_multiple_users/support_user_uploads_a_file_with_invalid_inputs_spec.rb
+++ b/spec/system/claims/support/settings/onboard_multiple_users/support_user_uploads_a_file_with_invalid_inputs_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe "Support user uploads a file with invalid inputs", service: :claims, type: :system do
   scenario do
-    pending "Validation temp removed"
     given_schools_exist
     and_i_am_signed_in
     when_i_navigate_to_the_settings_index_page
@@ -32,7 +31,7 @@ RSpec.describe "Support user uploads a file with invalid inputs", service: :clai
   end
 
   def and_i_navigate_to_onboard_multiple_users
-    click_on "Onboard users"
+    click_on "Invite users to the service"
   end
 
   def then_i_see_the_upload_page

--- a/spec/wizards/claims/onboard_multiple_schools_wizard/upload_step_spec.rb
+++ b/spec/wizards/claims/onboard_multiple_schools_wizard/upload_step_spec.rb
@@ -116,8 +116,6 @@ RSpec.describe Claims::OnboardMultipleSchoolsWizard::UploadStep, type: :model do
       let(:attributes) { { csv_content: } }
 
       it "returns false and assigns the csv row to the 'invalid_school_name_rows' attribute" do
-        pending "Validation temp removed"
-
         expect(csv_inputs_valid).to be(false)
         expect(step.invalid_school_name_rows).to contain_exactly(0)
       end
@@ -131,8 +129,6 @@ RSpec.describe Claims::OnboardMultipleSchoolsWizard::UploadStep, type: :model do
       let(:attributes) { { csv_content: } }
 
       it "returns false and assigns the csv row to the 'invalid_school_urn_rows' attribute" do
-        pending "Validation temp removed"
-
         expect(csv_inputs_valid).to be(false)
         expect(step.invalid_school_urn_rows).to contain_exactly(0)
       end

--- a/spec/wizards/claims/onboard_multiple_schools_wizard_spec.rb
+++ b/spec/wizards/claims/onboard_multiple_schools_wizard_spec.rb
@@ -37,9 +37,7 @@ RSpec.describe Claims::OnboardMultipleSchoolsWizard, type: :model do
           }
         end
 
-        # Temp removed to make the CSV upload work
-        # it { is_expected.to eq(%i[claim_window upload upload_errors]) }
-        it { is_expected.to eq(%i[claim_window upload confirmation]) }
+        it { is_expected.to eq(%i[claim_window upload upload_errors]) }
       end
     end
   end
@@ -93,7 +91,6 @@ RSpec.describe Claims::OnboardMultipleSchoolsWizard, type: :model do
         end
 
         it "returns an invalid wizard error" do
-          pending "Validation temp removed"
           expect { onboard_schools }.to raise_error("Invalid wizard state")
         end
       end

--- a/spec/wizards/claims/onboard_users_wizard/upload_step_spec.rb
+++ b/spec/wizards/claims/onboard_users_wizard/upload_step_spec.rb
@@ -120,7 +120,6 @@ RSpec.describe Claims::OnboardUsersWizard::UploadStep, type: :model do
       let(:attributes) { { csv_content: } }
 
       it "returns false and assigns the csv row to the 'invalid_school_urn_rows' attribute" do
-        pending "Validation temp removed"
         expect(csv_inputs_valid).to be(false)
         expect(step.invalid_school_urn_rows).to contain_exactly(0)
       end
@@ -134,7 +133,6 @@ RSpec.describe Claims::OnboardUsersWizard::UploadStep, type: :model do
       let(:attributes) { { csv_content: } }
 
       it "returns false and assigns the csv row to the 'invalid_email_rows' attribute" do
-        pending "Validation temp removed"
         expect(csv_inputs_valid).to be(false)
         expect(step.invalid_email_rows).to contain_exactly(0)
       end

--- a/spec/wizards/claims/onboard_users_wizard_spec.rb
+++ b/spec/wizards/claims/onboard_users_wizard_spec.rb
@@ -31,9 +31,7 @@ RSpec.describe Claims::OnboardUsersWizard do
         }
       end
 
-      # Temp removed to make the CSV upload work
-      # it { is_expected.to eq(%i[upload upload_errors]) }
-      it { is_expected.to eq(%i[upload confirmation]) }
+      it { is_expected.to eq(%i[upload upload_errors]) }
     end
   end
 
@@ -69,11 +67,7 @@ RSpec.describe Claims::OnboardUsersWizard do
       end
 
       it "returns an invalid wizard error" do
-        # expect { upload_users }.to raise_error("Invalid wizard state")
-
-        expect { upload_users }.not_to have_enqueued_job(
-          Claims::User::CreateCollectionJob,
-        )
+        expect { upload_users }.to raise_error("Invalid wizard state")
       end
     end
 
@@ -84,11 +78,7 @@ RSpec.describe Claims::OnboardUsersWizard do
       end
 
       it "returns an invalid wizard error" do
-        # expect { upload_users }.to raise_error("Invalid wizard state")
-
-        expect { upload_users }.not_to have_enqueued_job(
-          Claims::User::CreateCollectionJob,
-        )
+        expect { upload_users }.to raise_error("Invalid wizard state")
       end
     end
   end


### PR DESCRIPTION
## Context

When we onboarded schools for the public beta the data we held wasn’t as good as we’d have liked and we had to relax the rules to allow us to onboard users in a timely manner. Now that data quality should be improved and the rate of user onboarding can be lower; we should reinstate these validations.

## Changes proposed in this pull request

Remove pending flags on tests for validations and reimplement them.

## Guidance to review

Navigate to the settings page and test the flows. (invite users and onboard multiple schools)

## Link to Trello card

https://trello.com/c/CgeJSiHh/32-fix-onboard-schools-onboard-users-validation-and-reinstate-tests

## Screenshots
See below upload_user.csv uploaded with invalid URN:
<img width="679" height="877" alt="Screenshot 2025-07-28 at 14 49 13" src="https://github.com/user-attachments/assets/b43bee06-edd9-40ea-bf7c-452a6887410c" />
