### PR TITLE
Fix claim window warning

### DIFF
--- a/app/models/academic_year.rb
+++ b/app/models/academic_year.rb
@@ -10,6 +10,8 @@
 #  updated_at :datetime         not null
 #
 class AcademicYear < ApplicationRecord
+  has_many :claim_windows, class_name: "Claims::ClaimWindow"
+
   validates :name, presence: true
   validates :starts_on, presence: true
   validates :ends_on, presence: true, comparison: { greater_than_or_equal_to: :starts_on }
@@ -38,5 +40,9 @@ class AcademicYear < ApplicationRecord
       ends_on:,
       name: "#{start_year} to #{start_year + 1}",
     )
+  end
+
+  def has_upcoming_claim_windows?
+    claim_windows.upcoming.exists?
   end
 end

--- a/app/models/claims/claim_window.rb
+++ b/app/models/claims/claim_window.rb
@@ -40,6 +40,8 @@ class Claims::ClaimWindow < ApplicationRecord
   delegate :past?, to: :ends_on
   delegate :future?, to: :starts_on
 
+  scope :upcoming, -> { where(starts_on: Date.current..).order(starts_on: :asc) }
+
   def current?
     (starts_on..ends_on).cover?(Date.current)
   end
@@ -57,7 +59,7 @@ class Claims::ClaimWindow < ApplicationRecord
   end
 
   def self.next
-    where(starts_on: Date.current..).order(starts_on: :asc).first
+    upcoming.first
   end
 
   private

--- a/app/views/claims/schools/claims/index.html.erb
+++ b/app/views/claims/schools/claims/index.html.erb
@@ -17,7 +17,7 @@
         <% else %>
           <%= govuk_inset_text text: t(".add_mentor_guidance_html", link_to: govuk_link_to(t(".add_a_mentor"), claims_school_mentors_path(@school))) %>
         <% end %>
-      <% elsif !@school.eligible_for_claim_window?(Claims::ClaimWindow.current) %>
+      <% elsif Claims::ClaimWindow.current.present? && !@school.eligible_for_claim_window?(Claims::ClaimWindow.current) %>
         <%= govuk_warning_text do %>
           <p class="govuk-body"><%= t(".not_eligible_html", support_email: mail_to(t("claims.support_email"), t("claims.support_email_html"), class: "govuk-link")) %>
         <% end %>
@@ -25,6 +25,10 @@
         <%= govuk_inset_text do %>
           <p class="govuk-body"><%= t(".window_closed", start_year: Claims::ClaimWindow.previous.academic_year.starts_on.year, end_year: Claims::ClaimWindow.previous.academic_year.ends_on.year) %></p>
           <p class="govuk-body"><%= sanitize t(".window_closed_guidance", link_to: govuk_link_to(t(".window_closed_guidance_link_text"), claims_school_mentors_path(@school)), time: l(Claims::ClaimWindow.previous.ends_on.end_of_day, format: :time_on_date)) %></p>
+          <% if AcademicYear.for_date(Date.current).has_upcoming_claim_windows? %>
+            <% next_window = Claims::ClaimWindow.next %>
+            <p class="govuk-body"><%= t(".upcoming_window_guidance", starts_on: l(next_window.starts_on, format: :long_with_day), ends_on: l(next_window.ends_on, format: :long_with_day), academic_year_name: next_window.academic_year_name) %></p>
+          <% end %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/claims/support/schools/claims/index.html.erb
+++ b/app/views/claims/support/schools/claims/index.html.erb
@@ -14,7 +14,7 @@
     <% else %>
       <%= govuk_inset_text text: t(".add_mentor_guidance_html", link_to: govuk_link_to(t(".add_a_mentor"), claims_support_school_mentors_path(@school))) %>
     <% end %>
-  <% elsif !@school.eligible_for_claim_window?(Claims::ClaimWindow.current) %>
+  <% elsif Claims::ClaimWindow.current.present? && !@school.eligible_for_claim_window?(Claims::ClaimWindow.current) %>
     <%= govuk_warning_text do %>
       <p class="govuk-body"><%= t(".not_eligible_html", support_email: mail_to(t("claims.support_email"), t("claims.support_email_html"), class: "govuk-link")) %>
     <% end %>

--- a/config/locales/en/claims/schools/claims.yml
+++ b/config/locales/en/claims/schools/claims.yml
@@ -39,6 +39,7 @@ en:
           window_closed_guidance: "You can still %{link_to}. Final closing date for claims: <strong>%{time}</strong>."
           window_closed_guidance_link_text: add a mentor
           window_closed_support: Email %{link_to} if you have a query about your claims.
+          upcoming_window_guidance: A second claim window will open %{starts_on} and will close %{ends_on} to enable you to submit claims for any remaining mentor training for the %{academic_year_name} academic year.
         remove:
           page_title: Are you sure you want to remove this claim?
           caption: Claim - %{reference}

--- a/spec/system/claims/schools/claims/claim_user_views_the_claims_index_page_when_claim_window_has_closed_but_another_window_is_upcoming_spec.rb
+++ b/spec/system/claims/schools/claims/claim_user_views_the_claims_index_page_when_claim_window_has_closed_but_another_window_is_upcoming_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe "Claims user views the claims index page when claim window has closed, but another window is upcoming", service: :claims, type: :system do
+  scenario do
+    given_an_eligible_school_exists_and_the_claim_window_is_closing
+    and_i_am_signed_in
+    then_i_see_the_claims_index_page_with_add_a_claim_button_and_no_claims
+    and_i_see_an_inset_text_showing_claims_can_not_be_submitted
+  end
+
+  private
+
+  def given_an_eligible_school_exists_and_the_claim_window_is_closing
+    @user_anne = build(:claims_user, first_name: "Anne", last_name: "Wilson", email: "anne_wilson@education.gov.uk")
+    @mentor =  build(:claims_mentor)
+    @claim_window = build(:claim_window, :current, ends_on: 1.day.ago)
+    @academic_year = @claim_window.academic_year
+    @upcoming_claim_window = create(
+      :claim_window,
+      starts_on: @claim_window.ends_on + 1.week,
+      ends_on: @claim_window.ends_on + 2.weeks,
+      academic_year: @academic_year,
+    )
+    @shelbyville_school = create(
+      :claims_school,
+      name: "Shelbyville Elementary",
+      users: [@user_anne],
+      eligible_claim_windows: [@claim_window],
+      mentors: [@mentor],
+    )
+  end
+
+  def and_i_am_signed_in
+    sign_in_as(@user_anne)
+  end
+
+  def then_i_see_the_claims_index_page_with_add_a_claim_button_and_no_claims
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(page).to have_h1("Claims")
+    expect(page).not_to have_link("Add claim", href: "/schools/#{@shelbyville_school.id}/claims/new")
+    expect(page).to have_text("There are no claims for Shelbyville Elementary.")
+  end
+
+  def and_i_see_an_inset_text_showing_claims_can_not_be_submitted
+    expect(page).to have_inset_text(
+      "Claims can no longer be submitted for school year September #{@academic_year.starts_on.year} to July #{@academic_year.ends_on.year}.\n" \
+      "You can still add a mentor. Final closing date for claims: #{I18n.l(@claim_window.ends_on.end_of_day, format: :time_on_date)}.\n" \
+      "A second claim window will open #{I18n.l(@upcoming_claim_window.starts_on, format: :long_with_day)} and will close #{I18n.l(@upcoming_claim_window.ends_on, format: :long_with_day)} to enable you to submit claims for any remaining mentor training for the #{@academic_year.name} academic year.",
+    )
+  end
+end

--- a/spec/system/claims/schools/claims/claim_user_views_the_claims_index_page_when_claim_window_has_closed_spec.rb
+++ b/spec/system/claims/schools/claims/claim_user_views_the_claims_index_page_when_claim_window_has_closed_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe "Claims user views the claims index page when claim window has closed", service: :claims, type: :system do
+  scenario do
+    given_an_eligible_school_exists_and_the_claim_window_is_closing
+    and_i_am_signed_in
+    then_i_see_the_claims_index_page_with_add_a_claim_button_and_no_claims
+    and_i_see_an_inset_text_showing_claims_can_not_be_submitted
+  end
+
+  private
+
+  def given_an_eligible_school_exists_and_the_claim_window_is_closing
+    @user_anne = build(:claims_user, first_name: "Anne", last_name: "Wilson", email: "anne_wilson@education.gov.uk")
+    @mentor =  build(:claims_mentor)
+    @claim_window = build(:claim_window, :current, ends_on: 1.day.ago)
+    @academic_year = @claim_window.academic_year
+    @shelbyville_school = create(
+      :claims_school,
+      name: "Shelbyville Elementary",
+      users: [@user_anne],
+      eligible_claim_windows: [@claim_window],
+      mentors: [@mentor],
+    )
+  end
+
+  def and_i_am_signed_in
+    sign_in_as(@user_anne)
+  end
+
+  def then_i_see_the_claims_index_page_with_add_a_claim_button_and_no_claims
+    expect(page).to have_title("Claims - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(page).to have_h1("Claims")
+    expect(page).not_to have_link("Add claim", href: "/schools/#{@shelbyville_school.id}/claims/new")
+    expect(page).to have_text("There are no claims for Shelbyville Elementary.")
+  end
+
+  def and_i_see_an_inset_text_showing_claims_can_not_be_submitted
+    expect(page).to have_inset_text(
+      "Claims can no longer be submitted for school year September #{@academic_year.starts_on.year} to July #{@academic_year.ends_on.year}.\n" \
+      "You can still add a mentor. Final closing date for claims: #{I18n.l(@claim_window.ends_on.end_of_day, format: :time_on_date)}.",
+    )
+  end
+end


### PR DESCRIPTION
## Context

- Fix the logic to show when a claim window has closed.

## Changes proposed in this pull request

- Fix the logic to show when a claim window has closed.

## Guidance to review

- Sign in as Anne
⚠️ The claim window must be closed ⚠️ 
- Navigate to claims.
- You will see an inset text informing you the claim window has closed.

## Screenshots

<img width="633" height="259" alt="Screenshot 2025-07-28 at 14 11 20" src="https://github.com/user-attachments/assets/8fca1313-83dd-49f1-bde7-92a151bdf881" />

