### PR TITLE
Enforce non-root user

### DIFF
--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -47,6 +47,8 @@ module "web_application" {
   docker_image               = var.docker_image
   enable_logit               = true
 
+  run_as_non_root = var.run_as_non_root
+
   send_traffic_to_maintenance_page = false
 }
 
@@ -69,4 +71,6 @@ module "worker_application" {
   docker_image               = var.docker_image
   enable_logit               = true
   enable_gcp_wif             = true
+
+  run_as_non_root = var.run_as_non_root
 }

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -112,6 +112,12 @@ variable "enable_logit" {
   default     = false
 }
 
+variable "run_as_non_root" {
+  type        = bool
+  default     = true
+  description = "Whether to enforce that containers must run as non-root user"
+}
+
 locals {
   postgres_ssl_mode       = var.enable_postgres_ssl ? "require" : "disable"
   app_env_values_from_yml = yamldecode(file("${path.module}/config/${var.config}_app_env.yml"))


### PR DESCRIPTION
## Context
Enforce containers to run as non-root user

## Changes proposed in this pull request
Update the application and worker pods to run as non-root users

## Guidance to review
- Application should run without any issues.
- Application runs as non-root user

## Link to Trello card
https://trello.com/c/YekUhaCn

### Checklist
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally