### PR TITLE
Add darwin 24 to gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -708,6 +708,7 @@ PLATFORMS
   arm64-darwin
   x86_64-darwin-22
   x86_64-darwin-23
+  x86_64-darwin-24
   x86_64-linux
   x86_64-linux-musl
 


### PR DESCRIPTION
## Context

My local setup adds darwin-24 to the gemfile everytime I run rspec. It is the latest version and we should have it in our repo.

## Changes proposed in this pull request

Add darwin-24 to gemfile.lock

