### PR TITLE
Remove email address from schools

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -72,7 +72,6 @@
 #  fk_rails_...  (trust_id => trusts.id)
 #
 class School < ApplicationRecord
-  self.ignored_columns += %w[email_address]
   include PgSearch::Model
   extend Geocoder::Model::ActiveRecord
 

--- a/db/migrate/20250815112517_remove_email_address_from_schools.rb
+++ b/db/migrate/20250815112517_remove_email_address_from_schools.rb
@@ -1,0 +1,5 @@
+class RemoveEmailAddressFromSchools < ActiveRecord::Migration[8.0]
+  def change
+    safety_assured { remove_column :schools, :email_address, :string }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_15_093722) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_15_112517) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -557,7 +557,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_15_093722) do
     t.string "send_provision"
     t.string "rating"
     t.date "last_inspection_date"
-    t.string "email_address"
     t.string "district_admin_name"
     t.string "district_admin_code"
     t.uuid "region_id"


### PR DESCRIPTION
## Context

Now that the codebase no longer uses email_address on schools anywhere; we can remove the column from the DB/ remove the ignore_column from the schools model.

## Changes proposed in this pull request

Remove email_address from the schools table and remove the ignore column from the model. 
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/kElByRGT/60-remove-school-email-address

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
