### PR TITLE
Add job to email users with invalid claims

### DIFF
--- a/app/jobs/claims/user/notify_users_of_invalid_provider_claims_job.rb
+++ b/app/jobs/claims/user/notify_users_of_invalid_provider_claims_job.rb
@@ -1,0 +1,9 @@
+class Claims::User::NotifyUsersOfInvalidProviderClaimsJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    if Claims::ClaimWindow.current.present?
+      Claims::Claim::InvalidProviderNotification.call
+    end
+  end
+end

--- a/app/services/claims/claim/invalid_provider_notification.rb
+++ b/app/services/claims/claim/invalid_provider_notification.rb
@@ -1,6 +1,7 @@
 class Claims::Claim::InvalidProviderNotification < ApplicationService
   def call
-    created_by_ids = Claims::Claim.where(status: :invalid_provider).select(:created_by_id)
+    claim_window_ids_for_academic_year = AcademicYear.current.claim_windows.pluck(:id)
+    created_by_ids = Claims::Claim.where(claim_window_id: claim_window_ids_for_academic_year, status: :invalid_provider).select(:created_by_id)
     users_to_notify = Claims::User.where(id: created_by_ids).distinct
 
     return if users_to_notify.empty?

--- a/config/scheduled_jobs.yml
+++ b/config/scheduled_jobs.yml
@@ -48,6 +48,11 @@ trim_expired_sessions:
   description: "Trim old sessions from the database"
 
 send_claims_slack_daily_roundup:
-    cron: "0 16 * * *" # Every day at 16:00
-    class: "Claims::Slack::DailyRoundupJob"
-    description: "Sends a daily roundup Slack message"
+  cron: "0 16 * * *" # Every day at 16:00
+  class: "Claims::Slack::DailyRoundupJob"
+  description: "Sends a daily roundup Slack message"
+
+notify_claims_users_they_have_invalid_provider_claims:
+  cron: "0 9 * * MON" # Every monday at 9:00
+  class: "Claims::User::NotifyUsersOfInvalidProviderClaimsJob"
+  description: "Reminds users to address claims with invalid providers"

--- a/spec/factories/academic_years.rb
+++ b/spec/factories/academic_years.rb
@@ -16,6 +16,12 @@ FactoryBot.define do
       ends_on { Date.parse("31 August #{Date.current.year}") }
       name { "#{starts_on.year} to #{ends_on.year}" }
     end
+
+    trait :historic do
+      starts_on { Date.parse("1 September #{Date.current.year - 2}") }
+      ends_on { Date.parse("31 August #{Date.current.year - 1}") }
+      name { "#{starts_on.year} to #{ends_on.year}" }
+    end
   end
 
   factory :placements_academic_year, class: "Placements::AcademicYear", parent: :academic_year do

--- a/spec/jobs/claims/user/notify_users_of_invalid_provider_claims_job_spec.rb
+++ b/spec/jobs/claims/user/notify_users_of_invalid_provider_claims_job_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe Claims::User::NotifyUsersOfInvalidProviderClaimsJob, type: :job do
+  describe "#perform" do
+    before do
+      allow(Claims::Claim::InvalidProviderNotification).to receive(:call).and_return(true)
+    end
+
+    it "does not call the Claims::Claim::InvalidProviderNotification service if there is no current claim window" do
+      described_class.perform_now
+      expect(Claims::Claim::InvalidProviderNotification).not_to have_received(:call)
+    end
+
+    it "calls the Claims::Claim::InvalidProviderNotification service when there is a current claim window" do
+      create(:claim_window, :current)
+      described_class.perform_now
+      expect(Claims::Claim::InvalidProviderNotification).to have_received(:call)
+    end
+
+    it "enqueues the job in the default queue" do
+      expect {
+        described_class.perform_later
+      }.to have_enqueued_job(described_class).on_queue("default")
+    end
+  end
+end


### PR DESCRIPTION
## Context

Due to claims being created with invalid providers we have a number of claims which are invalid. We need our users to update those claims with hte correct provider details before they can be submitted for payment.

## Changes proposed in this pull request

There is an existing mailer to send a notification to users about their invalid claims, we want to create a scheduled job that will email users every week on Monday at 09:00 to remind them that there are outstanding issues to resolve.

Make sure that we utilise the rate limiter service when sending these emails to prevent overloading Notify.

## Guidance to review

No Ui needed.

## Link to Trello card

https://trello.com/c/gS3Mm6zd/131-create-service-to-email-users-with-invalid-claims

## Screenshots

<!-- Sceenshots to aid with reviewing if needed-->
