### PR TITLE
Remove claim window from eligibility

### DIFF
--- a/app/jobs/claims/school/onboard_schools_job.rb
+++ b/app/jobs/claims/school/onboard_schools_job.rb
@@ -10,7 +10,7 @@ class Claims::School::OnboardSchoolsJob < ApplicationJob
 
       Claims::Eligibility.find_or_create_by!(
         school:,
-        claim_window:,
+        academic_year:,
       )
     end
   end
@@ -19,11 +19,11 @@ class Claims::School::OnboardSchoolsJob < ApplicationJob
 
   attr_reader :claim_window_id
 
-  def claim_window
+  def academic_year
     if claim_window_id
-      Claims::ClaimWindow.find(claim_window_id)
+      Claims::ClaimWindow.find(claim_window_id).academic_year
     else
-      Claims::ClaimWindow.current
+      Claims::ClaimWindow.current.academic_year
     end
   end
 end

--- a/app/models/academic_year.rb
+++ b/app/models/academic_year.rb
@@ -11,6 +11,8 @@
 #
 class AcademicYear < ApplicationRecord
   has_many :claim_windows, class_name: "Claims::ClaimWindow"
+  has_many :eligibilities, class_name: "Claims::Eligibility"
+  has_many :eligible_schools, through: :eligibilities, source: :school
 
   validates :name, presence: true
   validates :starts_on, presence: true

--- a/app/models/claims/claim_window.rb
+++ b/app/models/claims/claim_window.rb
@@ -26,9 +26,6 @@ class Claims::ClaimWindow < ApplicationRecord
 
   belongs_to :academic_year
 
-  has_many :eligibilities, dependent: :destroy
-  has_many :eligible_schools, through: :eligibilities, source: :school
-
   validates :starts_on, presence: true
   validates :ends_on, presence: true, comparison: { greater_than_or_equal_to: :starts_on }
 
@@ -60,6 +57,11 @@ class Claims::ClaimWindow < ApplicationRecord
 
   def self.next
     upcoming.first
+  end
+
+  def eligible_schools
+    eligible_school_ids = Claims::Eligibility.where(academic_year:).select(:school_id)
+    Claims::School.where(id: eligible_school_ids)
   end
 
   private

--- a/app/models/claims/claim_window.rb
+++ b/app/models/claims/claim_window.rb
@@ -34,6 +34,7 @@ class Claims::ClaimWindow < ApplicationRecord
   validate :does_not_overlap_another_claim_window
 
   delegate :name, :starts_on, :ends_on, to: :academic_year, prefix: true
+  delegate :eligible_schools, to: :academic_year, allow_nil: true
   delegate :past?, to: :ends_on
   delegate :future?, to: :starts_on
 
@@ -57,11 +58,6 @@ class Claims::ClaimWindow < ApplicationRecord
 
   def self.next
     upcoming.first
-  end
-
-  def eligible_schools
-    eligible_school_ids = Claims::Eligibility.where(academic_year:).select(:school_id)
-    Claims::School.where(id: eligible_school_ids)
   end
 
   private

--- a/app/models/claims/eligibility.rb
+++ b/app/models/claims/eligibility.rb
@@ -3,7 +3,6 @@
 # Table name: eligibilities
 #
 #  id               :uuid             not null, primary key
-#  claim_window_id  :uuid             not null
 #  school_id        :uuid             not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
@@ -12,12 +11,11 @@
 # Indexes
 #
 #  index_eligibilities_on_academic_year_id  (academic_year_id)
-#  index_eligibilities_on_claim_window_id   (claim_window_id)
 #  index_eligibilities_on_school_id         (school_id)
 #
 
 class Claims::Eligibility < ApplicationRecord
   belongs_to :school
-  belongs_to :claim_window
-  belongs_to :academic_year, optional: true
+  belongs_to :academic_year
+  has_many :claim_windows, through: :academic_year
 end

--- a/app/wizards/claims/add_organisation_wizard.rb
+++ b/app/wizards/claims/add_organisation_wizard.rb
@@ -34,16 +34,12 @@ module Claims
     end
 
     def create_organisation
-      organisation.eligibilities.build(claim_window:, academic_year:)
+      organisation.eligibilities.build(academic_year:)
       organisation.save!
     end
 
-    def claim_window
-      @claim_window ||= Claims::ClaimWindow.current
-    end
-
     def academic_year
-      @academic_year ||= @claim_window.academic_year
+      @academic_year ||= Claims::ClaimWindow.current.academic_year
     end
 
     private

--- a/app/wizards/claims/add_school_wizard.rb
+++ b/app/wizards/claims/add_school_wizard.rb
@@ -24,7 +24,7 @@ module Claims
       school.update!(claims_service: true, manually_onboarded_by: current_user)
       school.becomes(Claims::School)
         .eligibilities
-        .create!(claim_window:)
+        .create!(academic_year: claim_window.academic_year)
     end
 
     def claim_window

--- a/db/migrate/20250821125922_remove_claim_window_from_eligibility.rb
+++ b/db/migrate/20250821125922_remove_claim_window_from_eligibility.rb
@@ -1,0 +1,8 @@
+class RemoveClaimWindowFromEligibility < ActiveRecord::Migration[8.0]
+  def change
+    remove_foreign_key :eligibilities, :claim_windows
+
+    # The logic has already been implemented to support the removal of the claim_window_id column.
+    safety_assured { remove_column :eligibilities, :claim_window_id, type: :uuid }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_20_132738) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_21_125922) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -164,13 +164,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_20_132738) do
   end
 
   create_table "eligibilities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "claim_window_id", null: false
     t.uuid "school_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "academic_year_id"
     t.index ["academic_year_id"], name: "index_eligibilities_on_academic_year_id"
-    t.index ["claim_window_id"], name: "index_eligibilities_on_claim_window_id"
     t.index ["school_id"], name: "index_eligibilities_on_school_id"
   end
 
@@ -670,7 +668,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_20_132738) do
   add_foreign_key "clawback_claims", "claims"
   add_foreign_key "clawback_claims", "clawbacks"
   add_foreign_key "eligibilities", "academic_years", validate: false
-  add_foreign_key "eligibilities", "claim_windows"
   add_foreign_key "eligibilities", "schools"
   add_foreign_key "hosting_interests", "academic_years"
   add_foreign_key "hosting_interests", "schools"

--- a/spec/factories/eligibilities.rb
+++ b/spec/factories/eligibilities.rb
@@ -3,7 +3,6 @@
 # Table name: eligibilities
 #
 #  id               :uuid             not null, primary key
-#  claim_window_id  :uuid             not null
 #  school_id        :uuid             not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
@@ -12,13 +11,15 @@
 # Indexes
 #
 #  index_eligibilities_on_academic_year_id  (academic_year_id)
-#  index_eligibilities_on_claim_window_id   (claim_window_id)
 #  index_eligibilities_on_school_id         (school_id)
 #
 
 FactoryBot.define do
   factory :eligibility, class: Claims::Eligibility do
-    claim_window { Claims::ClaimWindow.current || create(:claim_window, :current) }
+    transient do
+      claim_window { Claims::ClaimWindow.current || create(:claim_window, :current) }
+    end
+
     academic_year { claim_window.academic_year }
     association :school, factory: :claims_school
   end

--- a/spec/models/academic_year_spec.rb
+++ b/spec/models/academic_year_spec.rb
@@ -12,6 +12,12 @@
 require "rails_helper"
 
 RSpec.describe AcademicYear, type: :model do
+  describe "associations" do
+    it { is_expected.to have_many(:claim_windows).class_name("Claims::ClaimWindow") }
+    it { is_expected.to have_many(:eligibilities).class_name("Claims::Eligibility") }
+    it { is_expected.to have_many(:eligible_schools).through(:eligibilities).source(:school) }
+  end
+
   describe "with validations" do
     subject(:academic_year) do
       build(:academic_year,

--- a/spec/models/claims/claim_window_spec.rb
+++ b/spec/models/claims/claim_window_spec.rb
@@ -28,9 +28,6 @@ RSpec.describe Claims::ClaimWindow, type: :model do
 
   describe "associations" do
     it { is_expected.to belong_to(:academic_year) }
-
-    it { is_expected.to have_many(:eligibilities).dependent(:destroy) }
-    it { is_expected.to have_many(:eligible_schools).through(:eligibilities) }
   end
 
   describe "validations" do
@@ -150,6 +147,25 @@ RSpec.describe Claims::ClaimWindow, type: :model do
       _another_next_window = create(:claim_window, starts_on: Date.parse("8 August 2024"), ends_on: Date.parse("31 October 2024"), academic_year:)
 
       expect(described_class.next).to eq(next_window)
+    end
+  end
+
+  describe "#eligible_schools" do
+    it "returns schools that are eligible for the claim window" do
+      school1 = create(:claims_school)
+      school2 = create(:claims_school)
+      create(:eligibility, school: school1, academic_year:)
+      create(:eligibility, school: school2, academic_year:)
+
+      expect(claim_window.eligible_schools).to contain_exactly(school1, school2)
+    end
+
+    it "does not return schools that are not eligible for the claim window" do
+      school1 = create(:claims_school)
+      _school2 = create(:claims_school)
+      create(:eligibility, school: school1, academic_year:)
+
+      expect(claim_window.eligible_schools).to contain_exactly(school1)
     end
   end
 end

--- a/spec/models/claims/claim_window_spec.rb
+++ b/spec/models/claims/claim_window_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe Claims::ClaimWindow, type: :model do
     it { is_expected.to delegate_method(:name).to(:academic_year).with_prefix }
     it { is_expected.to delegate_method(:starts_on).to(:academic_year).with_prefix }
     it { is_expected.to delegate_method(:ends_on).to(:academic_year).with_prefix }
+    it { is_expected.to delegate_method(:eligible_schools).to(:academic_year).allow_nil }
     it { is_expected.to delegate_method(:past?).to(:ends_on) }
     it { is_expected.to delegate_method(:future?).to(:starts_on) }
   end
@@ -147,25 +148,6 @@ RSpec.describe Claims::ClaimWindow, type: :model do
       _another_next_window = create(:claim_window, starts_on: Date.parse("8 August 2024"), ends_on: Date.parse("31 October 2024"), academic_year:)
 
       expect(described_class.next).to eq(next_window)
-    end
-  end
-
-  describe "#eligible_schools" do
-    it "returns schools that are eligible for the claim window" do
-      school1 = create(:claims_school)
-      school2 = create(:claims_school)
-      create(:eligibility, school: school1, academic_year:)
-      create(:eligibility, school: school2, academic_year:)
-
-      expect(claim_window.eligible_schools).to contain_exactly(school1, school2)
-    end
-
-    it "does not return schools that are not eligible for the claim window" do
-      school1 = create(:claims_school)
-      _school2 = create(:claims_school)
-      create(:eligibility, school: school1, academic_year:)
-
-      expect(claim_window.eligible_schools).to contain_exactly(school1)
     end
   end
 end

--- a/spec/models/claims/eligibility_spec.rb
+++ b/spec/models/claims/eligibility_spec.rb
@@ -3,7 +3,6 @@
 # Table name: eligibilities
 #
 #  id               :uuid             not null, primary key
-#  claim_window_id  :uuid             not null
 #  school_id        :uuid             not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
@@ -12,7 +11,6 @@
 # Indexes
 #
 #  index_eligibilities_on_academic_year_id  (academic_year_id)
-#  index_eligibilities_on_claim_window_id   (claim_window_id)
 #  index_eligibilities_on_school_id         (school_id)
 #
 
@@ -21,7 +19,6 @@ require "rails_helper"
 RSpec.describe Claims::Eligibility, type: :model do
   context "with associations" do
     it { is_expected.to belong_to(:school).class_name("Claims::School") }
-    it { is_expected.to belong_to(:claim_window) }
-    it { is_expected.to belong_to(:academic_year).optional }
+    it { is_expected.to belong_to(:academic_year) }
   end
 end

--- a/spec/requests/claims/support/claims_reminders_spec.rb
+++ b/spec/requests/claims/support/claims_reminders_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe "Claims Reminders", type: :request do
   end
 
   describe "POST /claims/support/claims_reminders/send_schools_not_submitted_claims" do
-    let(:claim_window) { build(:claim_window, :current) }
+    let(:claim_window) { create(:claim_window, :current) }
     let(:next_claim_window) { create(:claim_window, :upcoming) }
-    let(:eligibility) { build(:eligibility, claim_window: claim_window) }
+    let(:eligibility) { build(:eligibility, academic_year: claim_window.academic_year) }
     let(:claims_school) { build(:claims_school, eligibilities: [eligibility]) }
     let(:claims_user) { create(:claims_user, schools: [claims_school]) }
     let(:support_user) { create(:claims_support_user) }

--- a/spec/system/claims/schools/claims/claim_user_changes_a_claim_details_via_check_your_answers_page_links_spec.rb
+++ b/spec/system/claims/schools/claims/claim_user_changes_a_claim_details_via_check_your_answers_page_links_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe "Claims user changes a claim details via check your answers page 
     @user_anne = build(:claims_user, first_name: "Anne", last_name: "Wilson", email: "anne_wilson@education.gov.uk")
     @mentor_james = build(:claims_mentor, first_name: "James", last_name: "Jameson", trn: "1111111")
     @mentor_barry = build(:claims_mentor, first_name: "Barry", last_name: "Garlow", trn: "8888888")
-    @claim_window = build(:claim_window, :current)
-    @eligibility = build(:eligibility, claim_window: @claim_window)
+    @claim_window = create(:claim_window, :current)
+    @eligibility = build(:eligibility, academic_year: @claim_window.academic_year)
     @provider = create(:claims_provider, :best_practice_network)
     @ineligible_provider = create(:claims_provider, :niot)
     @date_completed = @claim_window.starts_on + 1.day

--- a/spec/system/claims/schools/claims/claim_user_creates_a_claim_spec.rb
+++ b/spec/system/claims/schools/claims/claim_user_creates_a_claim_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe "Claims user creates a claim", :js, service: :claims, type: :syst
     @mentor_barry = build(:claims_mentor, first_name: "Barry", last_name: "Garlow", trn: "8888888")
     @provider = create(:claims_provider, :best_practice_network, postcode: "BR20RL")
     @ineligible_provider = create(:claims_provider, :niot)
-    @claim_window = build(:claim_window, :current)
-    @eligibility = build(:eligibility, claim_window: @claim_window)
+    @claim_window = create(:claim_window, :current)
+    @eligibility = build(:eligibility, academic_year: @claim_window.academic_year)
     @date_completed = @claim_window.starts_on + 1.day
     @shelbyville_school = create(
       :claims_school,

--- a/spec/system/claims/schools/claims/claim_user_views_the_claims_index_page_when_claim_window_has_closed_but_another_window_is_upcoming_spec.rb
+++ b/spec/system/claims/schools/claims/claim_user_views_the_claims_index_page_when_claim_window_has_closed_but_another_window_is_upcoming_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Claims user views the claims index page when claim window has cl
   def given_an_eligible_school_exists_and_the_claim_window_is_closing
     @user_anne = build(:claims_user, first_name: "Anne", last_name: "Wilson", email: "anne_wilson@education.gov.uk")
     @mentor =  build(:claims_mentor)
-    @claim_window = build(:claim_window, :current, ends_on: 1.day.ago)
+    @claim_window = create(:claim_window, :current, ends_on: 1.day.ago)
     @academic_year = @claim_window.academic_year
     @upcoming_claim_window = create(
       :claim_window,
@@ -21,7 +21,7 @@ RSpec.describe "Claims user views the claims index page when claim window has cl
       ends_on: @claim_window.ends_on + 2.weeks,
       academic_year: @academic_year,
     )
-    @eligibility = build(:eligibility, claim_window: @claim_window, academic_year: @academic_year)
+    @eligibility = build(:eligibility, academic_year: @academic_year)
     @shelbyville_school = create(
       :claims_school,
       name: "Shelbyville Elementary",

--- a/spec/system/claims/schools/claims/claim_user_views_the_claims_index_page_when_claim_window_has_closed_spec.rb
+++ b/spec/system/claims/schools/claims/claim_user_views_the_claims_index_page_when_claim_window_has_closed_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe "Claims user views the claims index page when claim window has cl
   def given_an_eligible_school_exists_and_the_claim_window_is_closing
     @user_anne = build(:claims_user, first_name: "Anne", last_name: "Wilson", email: "anne_wilson@education.gov.uk")
     @mentor =  build(:claims_mentor)
-    @claim_window = build(:claim_window, :current, ends_on: 1.day.ago)
+    @claim_window = create(:claim_window, :current, ends_on: 1.day.ago)
     @academic_year = @claim_window.academic_year
-    @eligibility = build(:eligibility, claim_window: @claim_window, academic_year: @academic_year)
+    @eligibility = build(:eligibility, academic_year: @academic_year)
     @shelbyville_school = create(
       :claims_school,
       name: "Shelbyville Elementary",

--- a/spec/system/claims/schools/claims/claims_user_creates_a_claim_for_a_mentor_with_a_previous_year_claim_spec.rb
+++ b/spec/system/claims/schools/claims/claims_user_creates_a_claim_for_a_mentor_with_a_previous_year_claim_spec.rb
@@ -41,10 +41,10 @@ RSpec.describe "Claims user creates a claim for a mentor with a previous year cl
     @provider = build(:claims_provider, :best_practice_network) do |provider|
       provider.provider_email_addresses.build(email_address: "best_practice_network@example.com", primary: true)
     end
-    @current_claim_window = build(:claim_window, :current)
+    @current_claim_window = create(:claim_window, :current)
     @historic_claim_window = build(:claim_window, :historic)
     @date_submitted = @historic_claim_window.starts_on + 1.day
-    @eligibility = build(:eligibility, claim_window: @current_claim_window)
+    @eligibility = build(:eligibility, academic_year: @current_claim_window.academic_year)
     @shelbyville_school = build(
       :claims_school,
       name: "Shelbyville Elementary",

--- a/spec/system/claims/schools/claims/claims_user_views_the_claims_index_page_when_claim_window_is_closing_spec.rb
+++ b/spec/system/claims/schools/claims/claims_user_views_the_claims_index_page_when_claim_window_is_closing_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe "Claims user views the claims index page when claim window is clo
   def given_an_eligible_school_exists_and_the_claim_window_is_closing
     @user_anne = build(:claims_user, first_name: "Anne", last_name: "Wilson", email: "anne_wilson@education.gov.uk")
     @mentor =  build(:claims_mentor)
-    @claim_window = build(:claim_window, :current, ends_on: 1.day.from_now)
-    @eligibility = build(:eligibility, claim_window: @claim_window)
+    @claim_window = create(:claim_window, :current, ends_on: 1.day.from_now)
+    @eligibility = build(:eligibility, academic_year: @claim_window.academic_year)
     @shelbyville_school = create(
       :claims_school,
       name: "Shelbyville Elementary",

--- a/spec/system/claims/schools/claims/claims_user_views_the_claims_index_page_when_mentors_are_present_spec.rb
+++ b/spec/system/claims/schools/claims/claims_user_views_the_claims_index_page_when_mentors_are_present_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe "Claims user views the claims index page when mentors are present
   def given_an_eligible_school_exists_with_a_mentor_and_no_claims
     @user_anne = build(:claims_user, first_name: "Anne", last_name: "Wilson", email: "anne_wilson@education.gov.uk")
     @mentor =  build(:claims_mentor)
-    @claim_window = build(:claim_window, :current)
-    @eligibility = build(:eligibility, claim_window: @claim_window)
+    @claim_window = create(:claim_window, :current)
+    @eligibility = build(:eligibility, academic_year: @claim_window.academic_year)
     @shelbyville_school = create(
       :claims_school,
       name: "Shelbyville Elementary",

--- a/spec/system/claims/schools/claims/claims_user_views_the_claims_index_page_when_no_mentors_are_present_spec.rb
+++ b/spec/system/claims/schools/claims/claims_user_views_the_claims_index_page_when_no_mentors_are_present_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe "Claims user views the claims index page when no mentors are pres
 
   def given_an_eligible_school_exists_with_no_mentors_or_internal_draft_claims
     @user_anne = build(:claims_user, first_name: "Anne", last_name: "Wilson", email: "anne_wilson@education.gov.uk")
-    @claim_window = build(:claim_window, :current)
-    @eligibility = build(:eligibility, claim_window: @claim_window)
+    @claim_window = create(:claim_window, :current)
+    @eligibility = build(:eligibility, academic_year: @claim_window.academic_year)
     @shelbyville_school = create(
       :claims_school,
       name: "Shelbyville Elementary",

--- a/spec/system/claims/support/settings/support_user_views_remind_schools_to_submit_claims_when_schools_have_not_claimed_spec.rb
+++ b/spec/system/claims/support/settings/support_user_views_remind_schools_to_submit_claims_when_schools_have_not_claimed_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe "Support user views remind schools to submit claims when schools 
   end
 
   def and_schools_have_not_claimed
-    @claim_window = build(:claim_window, :current)
-    @eligibility = build(:eligibility, claim_window: @claim_window)
+    @claim_window = create(:claim_window, :current)
+    @eligibility = build(:eligibility, academic_year: @claim_window.academic_year)
     @school = create(:claims_school, eligibilities: [@eligibility])
   end
 

--- a/spec/wizards/claims/add_organisation_wizard_spec.rb
+++ b/spec/wizards/claims/add_organisation_wizard_spec.rb
@@ -141,8 +141,8 @@ RSpec.describe Claims::AddOrganisationWizard do
     end
   end
 
-  describe "#claim_window" do
-    subject(:claim_window) { wizard.claim_window }
+  describe "#academic_year" do
+    subject(:academic_year) { wizard.academic_year }
 
     let(:current_claim_window) { create(:claim_window, :current) }
     let(:state) do
@@ -151,8 +151,8 @@ RSpec.describe Claims::AddOrganisationWizard do
       }
     end
 
-    it "returns the current claim window" do
-      expect(claim_window).to eq(current_claim_window)
+    it "returns the academic year for the specified claim window" do
+      expect(academic_year).to eq(current_claim_window.academic_year)
     end
   end
 end


### PR DESCRIPTION
## Context

Removes all references to the `claim_window_id` from the `eligibilities` table as we're now utilising the `academic_year_id` column to calculate eligibility.

## Changes proposed in this pull request

- Removes the `claim_windows` foreign key from `eligibilities`
- Removed the `claim_window_id` column from `eligibilities`
- Updates specs to reflect these changes

## Guidance to review

- Ensure test suite passes, review migration for accuracy

## Link to Trello card

https://trello.com/c/VAI8NRJp/126-remove-claimwindowid-from-eligibilites-table

