### PR TITLE
Allow clawback to be cancelled

### DIFF
--- a/app/controllers/claims/support/claims/request_clawback_controller.rb
+++ b/app/controllers/claims/support/claims/request_clawback_controller.rb
@@ -17,10 +17,10 @@ class Claims::Support::Claims::RequestClawbackController < Claims::ApplicationCo
     elsif @wizard.next_step.present?
       redirect_to step_path(@wizard.next_step)
     else
-      @wizard.submit_esfa_responses
+      @wizard.update_claim
       @wizard.reset_state
       redirect_to index_path, flash: {
-        heading: t(".success_heading"),
+        heading: @wizard.success_message,
       }
     end
   end

--- a/app/services/claims/claim/clawback/clawback_not_required.rb
+++ b/app/services/claims/claim/clawback/clawback_not_required.rb
@@ -1,0 +1,33 @@
+class Claims::Claim::Clawback::ClawbackNotRequired < ApplicationService
+  def initialize(claim:, esfa_responses: [])
+    @claim = claim
+    @esfa_responses = esfa_responses
+  end
+
+  def call
+    claim.transaction do
+      claim.mentor_trainings.each do |mentor_training|
+        esfa_mentor_training_response = esfa_responses.find { |response| response[:id] == mentor_training.id }
+        next if esfa_mentor_training_response.blank?
+
+        mentor_training.update!(
+          hours_clawed_back: nil,
+          reason_clawed_back: nil,
+          rejected: false,
+          reason_rejected: nil,
+          not_assured: false,
+          reason_not_assured: nil,
+        )
+      end
+
+      claim.update!(
+        status: :paid,
+        clawback_requested_by: nil,
+      )
+    end
+  end
+
+  private
+
+  attr_reader :claim, :esfa_responses
+end

--- a/app/views/claims/support/claims/_details.html.erb
+++ b/app/views/claims/support/claims/_details.html.erb
@@ -85,7 +85,7 @@
   <% if claim.in_clawback? %>
     <% claim.mentor_trainings.not_assured.order_by_mentor_full_name.each do |mentor_training| %>
       <div id="mentor-training-<%= mentor_training.id %>">
-        <%= govuk_summary_card(title: mentor_training.mentor.full_name) do |card| %>
+        <%= govuk_summary_card(title: t(".mentor_training_title", mentor_name: mentor_training.mentor.full_name, count: mentor_training.hours_clawed_back)) do |card| %>
           <% card.with_summary_list do |summary_list| %>
             <% summary_list.with_row do |row| %>
               <% row.with_key(text: t(".original")) %>
@@ -95,7 +95,7 @@
             <% summary_list.with_row do |row| %>
               <% row.with_key(text: t(".mentor_worked_hours")) %>
               <% row.with_value(text: pluralize(mentor_training.corrected_hours_completed, t(".hour"))) %>
-              <% if policy(claim).edit? || claim.clawback_requested? %>
+              <% if policy(claim).edit? || claim.clawback_requires_approval? %>
                 <% row.with_action(text: t("change"),
                                    visually_hidden_text: "#{mentor_training.mentor.full_name} #{t(".mentor_worked_hours")}",
                                    href: new_edit_request_clawback_claims_support_claims_clawback_path(
@@ -126,7 +126,7 @@
             <% summary_list.with_row do |row| %>
               <% row.with_key(text: t(".reason_clawed_back")) %>
               <% row.with_value(text: mentor_training.reason_clawed_back) %>
-              <% if policy(claim).edit? || claim.clawback_requested? %>
+              <% if policy(claim).edit? || claim.clawback_requires_approval? %>
                 <% row.with_action(text: t("change"),
                                    visually_hidden_text: "#{mentor_training.mentor.full_name} #{t(".reason_clawed_back")}",
                                    href: new_edit_request_clawback_claims_support_claims_clawback_path(
@@ -136,6 +136,14 @@
                                    html_attributes: {
                                      class: "govuk-link--no-visited-state",
                                    }) %>
+              <% end %>
+            <% end %>
+            <% unless mentor_training.hours_clawed_back.positive? %>
+              <% summary_list.with_row do |row| %>
+                <% row.with_key(text: t(".notice")) %>
+                <% row.with_value do %>
+                  <%= govuk_warning_text text: t(".no_hours_clawed_back") %>
+                <% end %>
               <% end %>
             <% end %>
           <% end %>

--- a/app/views/wizards/claims/request_clawback_wizard/_check_your_answers_step.html.erb
+++ b/app/views/wizards/claims/request_clawback_wizard/_check_your_answers_step.html.erb
@@ -78,7 +78,7 @@
                                    visually_hidden_text: t(".reason"),
                                    classes: ["govuk-link--no-visited-state"]) %>
               <% end %>
-              <% if current_step.mentor_training_clawback_hours(mentor_training) == 0 %>
+              <% if current_step.mentor_training_clawback_hours(mentor_training).zero? %>
                 <% summary_list.with_row do |row| %>
                   <% row.with_key(text: t(".notice")) %>
                   <% row.with_value do %>

--- a/app/views/wizards/claims/request_clawback_wizard/_no_clawback_required_step.html.erb
+++ b/app/views/wizards/claims/request_clawback_wizard/_no_clawback_required_step.html.erb
@@ -76,7 +76,7 @@
                                    visually_hidden_text: t(".reason"),
                                    classes: ["govuk-link--no-visited-state"]) %>
               <% end %>
-              <% if current_step.mentor_training_clawback_hours(mentor_training) == 0 %>
+              <% if current_step.mentor_training_clawback_hours(mentor_training).zero? %>
                 <% summary_list.with_row do |row| %>
                   <% row.with_key(text: t(".notice")) %>
                   <% row.with_value do %>

--- a/app/views/wizards/claims/request_clawback_wizard/_no_clawback_required_step.html.erb
+++ b/app/views/wizards/claims/request_clawback_wizard/_no_clawback_required_step.html.erb
@@ -7,8 +7,6 @@
 
       <h1 class="govuk-heading-l"><%= t(".title") %></h1>
 
-      <p class="govuk-body"><%= t(".information_shared_with_school", school_name: @claim.school_name) %></p>
-
       <h2 class="govuk-heading-m"><%= t(".original_claim") %></h2>
       <%= govuk_summary_list(html_attributes: { id: "claim-totals" }) do |summary_list| %>
         <% summary_list.with_row do |row| %>
@@ -90,6 +88,8 @@
           <% end %>
         </div>
       <% end %>
+
+      <%= govuk_warning_text text: t(".there_are_no_hours_to_clawback") %>
 
       <%= f.govuk_submit t(".submit") %>
     <% end %>

--- a/app/wizards/claims/reject_claim_wizard.rb
+++ b/app/wizards/claims/reject_claim_wizard.rb
@@ -48,6 +48,7 @@ module Claims
           id: mentor_training.id,
           rejected: true,
           reason_rejected: school_response_step.reason_rejected,
+          clawback_requested: true,
         }
       end
     end

--- a/app/wizards/claims/request_clawback_wizard/mentor_training_clawback_step.rb
+++ b/app/wizards/claims/request_clawback_wizard/mentor_training_clawback_step.rb
@@ -4,7 +4,7 @@ class Claims::RequestClawbackWizard::MentorTrainingClawbackStep < BaseStep
   attribute :reason_for_clawback
 
   validates :mentor_training_id, presence: true
-  validates :number_of_hours, presence: true, numericality: { only_integer: true, less_than: proc { |step| step.mentor_training.hours_completed }, greater_than_or_equal_to: 0 }
+  validates :number_of_hours, presence: true, numericality: { only_integer: true, less_than_or_equal_to: proc { |step| step.mentor_training.hours_completed }, greater_than_or_equal_to: 0 }
   validates :reason_for_clawback, presence: true
 
   delegate :mentor_trainings, :claim, to: :wizard
@@ -13,7 +13,7 @@ class Claims::RequestClawbackWizard::MentorTrainingClawbackStep < BaseStep
   delegate :full_name, :full_name_possessive, to: :mentor, prefix: true
 
   def mentor_training
-    mentor_trainings.find(mentor_training_id)
+    Claims::MentorTraining.find(mentor_training_id)
   end
 
   def hours_clawed_back

--- a/app/wizards/claims/request_clawback_wizard/no_clawback_required_step.rb
+++ b/app/wizards/claims/request_clawback_wizard/no_clawback_required_step.rb
@@ -1,0 +1,33 @@
+class Claims::RequestClawbackWizard::NoClawbackRequiredStep < BaseStep
+  delegate :mentor_trainings, :steps, :step_name_for_mentor_training_clawback, :claim, to: :wizard
+  delegate :school, to: :claim
+  delegate :region_funding_available_per_hour, to: :school
+
+  def mentor_training_clawback_data(mentor_training)
+    steps.fetch(step_name_for_mentor_training_clawback(mentor_training))
+  end
+
+  def mentor_training_correct_hours(mentor_training)
+    mentor_training_clawback_data(mentor_training).number_of_hours.to_i
+  end
+
+  def mentor_training_clawback_hours(mentor_training)
+    mentor_training_clawback_data(mentor_training).hours_clawed_back
+  end
+
+  def mentor_training_clawback_amount(mentor_training)
+    mentor_training_clawback_hours(mentor_training) * region_funding_available_per_hour
+  end
+
+  def mentor_training_clawback_reason(mentor_training)
+    mentor_training_clawback_data(mentor_training).reason_for_clawback
+  end
+
+  def total_clawback_hours
+    mentor_trainings.sum { |mentor_training| mentor_training_clawback_hours(mentor_training) }
+  end
+
+  def total_clawback_amount
+    mentor_trainings.sum { |mentor_training| mentor_training_clawback_hours(mentor_training) * region_funding_available_per_hour }
+  end
+end

--- a/config/locales/en/claims/support/claims.yml
+++ b/config/locales/en/claims/support/claims.yml
@@ -50,6 +50,9 @@ en:
           view_all_files: View all files
           view_details: View details
         details:
+          mentor_training_title:
+            zero: "%{mentor_name} — no clawback required"
+            other: "%{mentor_name}"
           original: Original hours claimed
           clawed_back: Amount clawed back
           reason_clawed_back: Reason for clawback
@@ -73,3 +76,5 @@ en:
           adjusted_total: Adjusted grant funding total
           mentor_worked_hours: Mentor worked hours
           rate: Hourly rate
+          notice: No clawback required
+          no_hours_clawed_back: This mentor will not have any hours clawed back

--- a/config/locales/en/claims/support/claims/request_clawback.yml
+++ b/config/locales/en/claims/support/claims/request_clawback.yml
@@ -4,4 +4,5 @@ en:
       claims:
         request_clawback:
           update:
-            success_heading: Clawback requested
+            clawback_requested_success: Clawback requested
+            no_clawback_success: Claim has been moved to the paid status

--- a/config/locales/en/wizards/claims/request_clawback_wizard.yml
+++ b/config/locales/en/wizards/claims/request_clawback_wizard.yml
@@ -33,3 +33,24 @@ en:
           information_shared_with_school: This information will be shared with %{school_name}.
           original: Original hours claimed
           hour: hour
+          notice: No clawback required
+          no_hours_clawed_back: This mentor will not have any hours clawed back
+        no_clawback_required_step:
+          page_title: No clawback required - %{school_name} - Claim %{reference}
+          title: No clawback required
+          total_title: Total clawback
+          clawback_details: Clawback details
+          rate: Hourly rate
+          number_of_hours: Hours the mentor worked
+          submit: Move claim to paid
+          original_claim: Original claim
+          amount: Amount
+          there_are_no_hours_to_clawback: You have indicated that the original claim was correct and that all hours claimed for were worked. As there are no hours to clawback, this claim will move back to the paid status.
+          hour: hour
+          hours_clawed_back: Hours clawed back
+          clawback_amount: Clawback amount
+          reason: Notes on your decision
+          change: Change
+          notice: No clawback required
+          no_hours_clawed_back: This mentor will not have any hours clawed back
+          original: Original hours claimed

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,8 +3,9 @@ return unless Rails.env.development? || HostingEnvironment.env.review?
 
 def create_claim(school:, provider:, created_by:, reference:, status:)
   claim_window = Claims::ClaimWindow.current
+  academic_year = claim_window.academic_year
 
-  Claims::Eligibility.find_or_create_by!(school:, claim_window:)
+  Claims::Eligibility.find_or_create_by!(school:, academic_year:)
   return unless mentor_remaining_hours(school:, provider:).any?
 
   claim = Claims::Claim.create!(

--- a/spec/services/claims/claim/clawback/clawback_not_required_spec.rb
+++ b/spec/services/claims/claim/clawback/clawback_not_required_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+describe Claims::Claim::Clawback::ClawbackNotRequired do
+  let!(:claim) { create(:claim, :submitted, status: :sampling_not_approved) }
+
+  describe "#call" do
+    subject(:call) { described_class.call(claim:, esfa_responses:) }
+
+    context "when given an esfa responses" do
+      let(:mentor_training_1) { create(:mentor_training, claim:, not_assured: true, reason_not_assured: "reason") }
+      let(:mentor_training_2) { create(:mentor_training, claim:, not_assured: true, reason_not_assured: "reason") }
+      let(:esfa_responses) do
+        [
+          { id: mentor_training_1.id, hours_clawed_back: 0, reason_for_clawback: "Some reason" },
+          { id: mentor_training_2.id, hours_clawed_back: 0, reason_for_clawback: "Another reason" },
+        ]
+      end
+
+      it "updates the mentor trainings with the given response" do
+        expect { call }.to change(claim, :status)
+          .from("sampling_not_approved")
+          .to("paid")
+
+        mentor_training_1.reload
+        mentor_training_2.reload
+
+        expect(mentor_training_1.hours_clawed_back).to be_nil
+        expect(mentor_training_1.reason_clawed_back).to be_nil
+        expect(mentor_training_2.hours_clawed_back).to be_nil
+        expect(mentor_training_2.reason_clawed_back).to be_nil
+      end
+
+      context "when an esfa response is not given for a mentor training associated with this claim" do
+        let(:esfa_responses) do
+          [
+            { id: mentor_training_1.id, hours_clawed_back: 20, reason_for_clawback: "Some reason" },
+          ]
+        end
+
+        before do
+          mentor_training_1
+          mentor_training_2
+        end
+
+        it "skips the mentor training not associated with the claim" do
+          expect { call }.not_to change(mentor_training_1, :hours_clawed_back).from(nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/system/claims/support/claims/clawbacks/support_user_edits_a_clawback_request_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/support_user_edits_a_clawback_request_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Support user edits a clawback request on a claim", service: :cla
   def given_claims_exist
     @claim_one = create(:claim,
                         :submitted,
-                        status: :clawback_requested,
+                        status: :clawback_requires_approval,
                         reference: 11_111_111)
 
     @john_doe = create(:claims_mentor, first_name: "John", last_name: "Doe")
@@ -70,7 +70,7 @@ RSpec.describe "Support user edits a clawback request on a claim", service: :cla
     expect(primary_navigation).to have_current_item("Claims")
     expect(page).to have_element(:span, text: "Clawbacks - Claim 11111111", class: "govuk-caption-l")
     expect(page).to have_h1(@claim_one.school_name)
-    expect(page).to have_element(:strong, text: "Ready for clawback", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_element(:strong, text: "Clawback requires approval", class: "govuk-tag govuk-tag--orange")
     expect(page).not_to have_link("Request clawback", href: "/support/claims/clawbacks/claims/new/#{@claim_one.id}", class: "govuk-link govuk-button")
     expect(page).to have_summary_list_row("School", @claim_one.school_name)
     expect(page).to have_summary_list_row("Academic year", @claim_one.academic_year_name)
@@ -127,7 +127,7 @@ RSpec.describe "Support user edits a clawback request on a claim", service: :cla
   end
 
   def then_i_see_a_validation_error_for_entering_too_many_hours
-    expect(page).to have_validation_error("must be less than #{@john_doe_training.hours_completed}")
+    expect(page).to have_validation_error("must be less than or equal to #{@john_doe_training.hours_completed}")
   end
 
   def when_i_enter_a_valid_number_of_hours

--- a/spec/system/claims/support/claims/clawbacks/support_user_edits_a_mentor_training_for_a_clawback_request_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/support_user_edits_a_mentor_training_for_a_clawback_request_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Support user edits a mentor training for a clawback request", se
   def given_claims_exist
     @claim_one = create(:claim,
                         :submitted,
-                        status: :clawback_requested,
+                        status: :clawback_requires_approval,
                         reference: 11_111_111)
 
     @john_doe = create(:claims_mentor, first_name: "John", last_name: "Doe")
@@ -76,7 +76,7 @@ RSpec.describe "Support user edits a mentor training for a clawback request", se
     expect(primary_navigation).to have_current_item("Claims")
     expect(page).to have_element(:span, text: "Clawbacks - Claim 11111111", class: "govuk-caption-l")
     expect(page).to have_h1(@claim_one.school_name)
-    expect(page).to have_element(:strong, text: "Ready for clawback", class: "govuk-tag govuk-tag--turquoise")
+    expect(page).to have_element(:strong, text: "Clawback requires approval", class: "govuk-tag govuk-tag--orange")
     expect(page).not_to have_link("Request clawback", href: "/support/claims/clawbacks/claims/new/#{@claim_one.id}", class: "govuk-link govuk-button")
     expect(page).to have_summary_list_row("School", @claim_one.school_name)
     expect(page).to have_summary_list_row("Academic year", @claim_one.academic_year_name)
@@ -135,7 +135,7 @@ RSpec.describe "Support user edits a mentor training for a clawback request", se
   end
 
   def then_i_see_a_validation_error_for_entering_too_many_hours
-    expect(page).to have_validation_error("must be less than #{@john_doe_training.hours_completed}")
+    expect(page).to have_validation_error("must be less than or equal to #{@john_doe_training.hours_completed}")
   end
 
   def when_i_enter_a_valid_number_of_hours

--- a/spec/system/claims/support/claims/clawbacks/support_user_views_clawbacks_show_page_spec.rb
+++ b/spec/system/claims/support/claims/clawbacks/support_user_views_clawbacks_show_page_spec.rb
@@ -19,13 +19,6 @@ RSpec.describe "Support user requests a clawback on a claim", service: :claims, 
     and_i_click_on_claim_with_status_of_clawback_requested
     then_i_see_the_show_page_for_the_clawback_requested_claim
 
-    when_i_click_on_change
-    then_i_see_the_clawback_step_for_the_clawback_requested_claim
-
-    # support user clicks back on wizard step
-    when_i_click_on_back
-    then_i_see_the_show_page_for_the_clawback_requested_claim
-
     when_i_navigate_to_the_clawbacks_index_page
     and_i_click_on_claim_with_status_of_clawback_in_progress
     then_i_see_the_show_page_for_the_clawback_in_progress_claim
@@ -147,24 +140,6 @@ RSpec.describe "Support user requests a clawback on a claim", service: :claims, 
     expect(page).to have_h2("History")
     expect(page).to have_element("h3", class: "app-timeline__title", text: "Clawback requested for claim 22222222")
     expect(page).to have_link("View details", href: claims_support_claims_claim_activity_path(@clawback_requested_activity_log))
-  end
-
-  def when_i_click_on_change
-    all("a", text: "Change").last.click
-  end
-
-  def then_i_see_the_clawback_step_for_the_clawback_requested_claim
-    expect(page).to have_title("Clawback details for #{@mentor.full_name} - #{@clawback_requested_claim.school_name} - Claim 22222222 - Claim funding for mentor training - GOV.UK")
-    expect(primary_navigation).to have_current_item("Claims")
-
-    expect(page).to have_element(:span, text: "Clawbacks - Claim 22222222", class: "govuk-caption-l")
-    expect(page).to have_h1("Clawback details")
-    expect(page).to have_element(:label, text: "Number of hours the mentor worked", class: "govuk-label")
-    expect(page).to have_element(:div, text: "James Chess' original claim was for 15 hours", class: "govuk-hint")
-    expect(page).to have_element(:label, text: "Notes on your decision", class: "govuk-label")
-    expect(page).to have_element(:div, text: "Only include details related to #{@mentor.full_name}", class: "govuk-hint")
-    expect(page).to have_button("Continue")
-    expect(page).to have_link("Cancel", href: "/support/claims/clawbacks/claims/#{@clawback_requested_claim.id}")
   end
 
   def then_i_see_the_clawbacks_index_page

--- a/spec/wizards/claims/request_clawback_wizard/mentor_training_clawback_step_spec.rb
+++ b/spec/wizards/claims/request_clawback_wizard/mentor_training_clawback_step_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Claims::RequestClawbackWizard::MentorTrainingClawbackStep, type: 
     context "when the number of hours is equal to the hours completed" do
       let(:attributes) { { mentor_training_id: mentor_training.id, number_of_hours: 3, reason_for_clawback: "reason" } }
 
-      it { is_expected.not_to be_valid }
+      it { is_expected.to be_valid }
     end
 
     context "when the number of hours is less than 1" do

--- a/spec/wizards/claims/request_clawback_wizard_spec.rb
+++ b/spec/wizards/claims/request_clawback_wizard_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Claims::RequestClawbackWizard do
     end
   end
 
-  describe "#submit_esfa_responses" do
+  describe "#update_claim" do
     let(:esfa_responses) { [{ id: mentor_training.id, hours_clawed_back: 15, reason_for_clawback: "Some reason" }] }
 
     before do
@@ -78,12 +78,12 @@ RSpec.describe Claims::RequestClawbackWizard do
       end
 
       it "calls the ClawbackRequested service with the claim and payer responses" do
-        wizard.submit_esfa_responses
+        wizard.update_claim
         expect(Claims::Claim::Clawback::ClawbackRequested).to have_received(:call).with(claim:, esfa_responses:, current_user:)
       end
 
       it "creates a claim activity record" do
-        expect { wizard.submit_esfa_responses }.to change(Claims::ClaimActivity, :count).by(1)
+        expect { wizard.update_claim }.to change(Claims::ClaimActivity, :count).by(1)
         expect(Claims::UserMailer).to have_received(:claim_requires_clawback).with(user, claim).once
         expect(Claims::ClaimActivity.last.action).to eq("clawback_requested")
         expect(Claims::ClaimActivity.last.user).to eq(current_user)
@@ -93,7 +93,7 @@ RSpec.describe Claims::RequestClawbackWizard do
 
     context "when the wizard is invalid" do
       it "raises an error" do
-        expect { wizard.submit_esfa_responses }.to raise_error("Invalid wizard state")
+        expect { wizard.update_claim }.to raise_error("Invalid wizard state")
       end
     end
   end


### PR DESCRIPTION
## Context

If a claim has incorrectly been rejected by the provider and school, support users need a way to correct the hours a mentor has worked

## Changes proposed in this pull request
- Allows support to enter the same number of hours a mentor originally worked and displays a warning when there are no hours to claw back
- If a claim has no hours clawed back for any mentors it is moved back to paid

## Guidance to review

- Log in as Colin
- Audit some claims
- Mark the hours worked the same as the original hours

## Link to Trello card

https://trello.com/c/jRVwj0AK/132-allow-clawback-to-equal-the-original-number-of-hours-if-a-clawback-has-been-requested-incorrectly

## Screenshots

<img width="705" height="1249" alt="image" src="https://github.com/user-attachments/assets/9162c57a-7e6a-4cef-a8b6-4f3974c7345e" />
<img width="661" height="733" alt="image" src="https://github.com/user-attachments/assets/fee28b9b-87c2-484d-b00b-413f8c91b34b" />

