### PR TITLE
Fix small issues

### DIFF
--- a/app/jobs/claims/slack/daily_roundup_job.rb
+++ b/app/jobs/claims/slack/daily_roundup_job.rb
@@ -4,15 +4,16 @@ class Claims::Slack::DailyRoundupJob < ApplicationJob
 
   def perform
     current_claim_window = Claims::ClaimWindow.current
-    current_academic_year = current_claim_window.academic_year
+    claim_window_academic_year = current_claim_window.academic_year
     todays_claims = claims_since(Time.current.yesterday.change(hour: 16))
     new_schools = new_organisations(todays_claims, :school_id)
     new_providers = new_organisations(todays_claims, :provider_id)
-    total_claims = Claims::Claim.joins(:claim_window).where(claim_window: { academic_year_id: current_academic_year.id })
+    total_claims = Claims::Claim.joins(:claim_window).where(claim_window: { academic_year_id: claim_window_academic_year.id })
     total_amount = total_claims.map(&:amount).sum
     average_amount = total_amount / total_claims.count.to_f
 
     Claims::ClaimSlackNotifier.claim_submitted_notification(
+      academic_year: claim_window_academic_year,
       claim_count: todays_claims.count,
       school_count: new_schools.count,
       provider_count: new_providers.count,

--- a/app/services/claims/claim/submit.rb
+++ b/app/services/claims/claim/submit.rb
@@ -33,7 +33,12 @@ class Claims::Claim::Submit < ApplicationService
       claim.submitted_at = Time.current
       claim.submitted_by = user
       claim.reference = generate_reference if claim.reference.nil?
+      claim.claim_window = claim_window
       claim
     end
+  end
+
+  def claim_window
+    Claims::ClaimWindow.current || claim.claim_window
   end
 end

--- a/spec/jobs/claims/slack/daily_roundup_job_spec.rb
+++ b/spec/jobs/claims/slack/daily_roundup_job_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Claims::Slack::DailyRoundupJob, type: :job do
       average_claim_amount = total_claims_amount / Claims::Claim.count.to_f
 
       expect(slack_notifier).to have_received(:claim_submitted_notification).with(
+        academic_year: claim_window.academic_year,
         claim_count: 1,
         school_count: 1,
         provider_count: 0,

--- a/spec/services/claims/claim/submit_spec.rb
+++ b/spec/services/claims/claim/submit_spec.rb
@@ -60,5 +60,28 @@ describe Claims::Claim::Submit do
         expect(claim.submitted_at).to eq(submitted_at)
       end
     end
+
+    context "when there is a current claim window" do
+      it "assigns the claim to the current claim window" do
+        current_claim_window = Claims::ClaimWindow.current
+        past_claim_window = create(:claim_window, :historic)
+        claim.update!(claim_window: past_claim_window)
+
+        expect { submit_service }.to change(claim, :claim_window).from(past_claim_window).to(current_claim_window)
+      end
+    end
+
+    context "when there is no current claim window" do
+      before do
+        allow(Claims::ClaimWindow).to receive(:current).and_return(nil)
+      end
+
+      it "does not change the claim window" do
+        past_claim_window = create(:claim_window, :historic)
+        claim.update!(claim_window: past_claim_window)
+
+        expect { submit_service }.to not_change(claim, :claim_window)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

- Fixes the academic year text for the claims daily roundup job
- Updates claims to the current claim window when they've been edited


## Changes proposed in this pull request

- Passed the academic year for the current claim window to the slack bot
- Updated claim to the current claim window if one is present and left the same if not.

## Guidance to review

- Review logic

## Link to Trello card

<!-- http://trello.com/123-example-card -->
