### PR TITLE
Move create and deliver service into a background job

### DIFF
--- a/app/jobs/claims/payment/create_and_deliver_job.rb
+++ b/app/jobs/claims/payment/create_and_deliver_job.rb
@@ -1,0 +1,22 @@
+class Claims::Payment::CreateAndDeliverJob < ApplicationJob
+  queue_as :default
+
+  def perform(current_user_id:, claim_window_id:)
+    @current_user_id = current_user_id
+    @claim_window_id = claim_window_id
+
+    Claims::Payment::CreateAndDeliver.call(current_user:, claim_window:)
+  end
+
+  private
+
+  attr_reader :current_user_id, :claim_window_id
+
+  def claim_window
+    @claim_window ||= Claims::ClaimWindow.find(claim_window_id)
+  end
+
+  def current_user
+    @current_user ||= User.find(current_user_id)
+  end
+end

--- a/app/wizards/claims/submit_claims_to_be_paid_wizard.rb
+++ b/app/wizards/claims/submit_claims_to_be_paid_wizard.rb
@@ -19,7 +19,10 @@ module Claims
     def pay_claims
       raise "Invalid wizard state" unless valid?
 
-      Claims::Payment::CreateAndDeliver.call(current_user:, claim_window:)
+      Claims::Payment::CreateAndDeliverJob.perform_later(
+        current_user_id: current_user.id,
+        claim_window_id: claim_window.id,
+      )
     end
 
     private

--- a/spec/jobs/claims/payment/create_and_deliver_job_spec.rb
+++ b/spec/jobs/claims/payment/create_and_deliver_job_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Claims::Payment::CreateAndDeliverJob, type: :job do
+  let(:current_user) { create(:claims_user) }
+  let(:claim_window) { create(:claim_window, :historic) }
+
+  describe "#perform" do
+    before do
+      allow(Claims::Payment::CreateAndDeliver).to receive(:call).and_return(true)
+    end
+
+    it "calls the Claims::Payment::CreateAndDeliver service" do
+      described_class.perform_now(current_user_id: current_user.id, claim_window_id: claim_window.id)
+      expect(Claims::Payment::CreateAndDeliver).to have_received(:call).with(current_user:, claim_window:).once
+    end
+
+    it "enqueues the job in the default queue" do
+      expect {
+        described_class.perform_later(current_user_id: current_user.id, claim_window_id: claim_window.id)
+      }.to have_enqueued_job(described_class).on_queue("default")
+    end
+  end
+end

--- a/spec/wizards/claims/submit_claims_to_be_paid_wizard_spec.rb
+++ b/spec/wizards/claims/submit_claims_to_be_paid_wizard_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe Claims::SubmitClaimsToBePaidWizard do
 
     context "when the steps are valid" do
       it "the payments create and deliver service" do
-        expect(Claims::Payment::CreateAndDeliver).to receive(:call).with(
-          current_user:,
-          claim_window:,
+        expect(Claims::Payment::CreateAndDeliverJob).to receive(:perform_later).with(
+          current_user_id: current_user.id,
+          claim_window_id:,
         )
 
         pay_claims


### PR DESCRIPTION
## Context

The amount of claims are too large to send to the ESFA without the service timing out. Create a job to move this to a background process.

## Changes proposed in this pull request

- Create create and deliver job
- Utilise new job

## Guidance to review

- Review logic
