### PR TITLE
Add new reminder emails for schools to support dashboard

### DIFF
--- a/app/controllers/claims/support/claims_reminders_controller.rb
+++ b/app/controllers/claims/support/claims_reminders_controller.rb
@@ -3,8 +3,8 @@ class Claims::Support::ClaimsRemindersController < Claims::Support::ApplicationC
   before_action :set_claim_window
   before_action :set_schools, only: %i[schools_not_submitted_claims send_schools_not_submitted_claims]
   before_action :set_providers, only: %i[providers_not_submitted_claims send_providers_not_submitted_claims]
-  before_action :set_schools_without_sign_in, only: %i[schools_not_signed_in send_schools_not_signed_in]
-  before_action :set_schools_with_sign_ins_without_claims, only: %i[school_has_signed_in_but_not_claimed send_your_school_has_signed_in_but_not_claimed]
+  before_action :schools_without_sign_in, only: %i[schools_not_signed_in send_schools_not_signed_in]
+  before_action :schools_with_sign_ins_without_claims, only: %i[school_has_signed_in_but_not_claimed send_your_school_has_signed_in_but_not_claimed]
 
   def schools_not_submitted_claims; end
 
@@ -104,14 +104,14 @@ class Claims::Support::ClaimsRemindersController < Claims::Support::ApplicationC
                                  .distinct
   end
 
-  def set_schools_without_sign_in
+  def schools_without_sign_in
     @schools_without_sign_in ||= Claims::School
                                 .includes(:users)
                                 .where(users: { last_signed_in_at: nil })
                                 .where.not(id: Claims::School.joins(:users).where.not(users: { last_signed_in_at: nil }))
   end
 
-  def set_schools_with_sign_ins_without_claims
+  def schools_with_sign_ins_without_claims
     @schools_with_sign_ins_without_claims ||= Claims::School
                                             .joins(:users)
                                             .where.not(users: { last_signed_in_at: nil })

--- a/app/controllers/claims/support/claims_reminders_controller.rb
+++ b/app/controllers/claims/support/claims_reminders_controller.rb
@@ -3,6 +3,8 @@ class Claims::Support::ClaimsRemindersController < Claims::Support::ApplicationC
   before_action :set_claim_window
   before_action :set_schools, only: %i[schools_not_submitted_claims send_schools_not_submitted_claims]
   before_action :set_providers, only: %i[providers_not_submitted_claims send_providers_not_submitted_claims]
+  before_action :set_schools_without_sign_in, only: %i[schools_not_signed_in send_schools_not_signed_in]
+  before_action :set_schools_with_sign_ins_without_claims, only: %i[school_has_signed_in_but_not_claimed send_your_school_has_signed_in_but_not_claimed]
 
   def schools_not_submitted_claims; end
 
@@ -38,15 +40,57 @@ class Claims::Support::ClaimsRemindersController < Claims::Support::ApplicationC
     }
   end
 
+  def schools_not_signed_in; end
+
+  def send_schools_not_signed_in
+    email_addresses_to_notify = Claims::User.joins(:schools).where(schools: { id: @schools_without_sign_in.ids }).distinct
+
+    return unless email_addresses_to_notify.exists?
+
+    NotifyRateLimiter.call(
+      collection: email_addresses_to_notify,
+      mailer: "Claims::UserMailer",
+      mailer_method: :your_school_has_not_signed_in,
+    )
+
+    redirect_to schools_not_signed_in_claims_support_claims_reminders_path, flash: {
+      heading: t(".success"),
+      body: t(".success_body"),
+    }
+  end
+
+  def school_has_signed_in_but_not_claimed; end
+
+  def send_your_school_has_signed_in_but_not_claimed
+    email_addresses_to_notify = Claims::User.joins(:schools).where(schools: { id: @schools_with_sign_ins_without_claims.ids }).distinct
+
+    return unless email_addresses_to_notify.exists?
+
+    NotifyRateLimiter.call(
+      collection: email_addresses_to_notify,
+      mailer: "Claims::UserMailer",
+      mailer_method: :your_school_has_signed_in_but_not_claimed,
+    )
+
+    redirect_to schools_not_signed_in_claims_support_claims_reminders_path, flash: {
+      heading: t(".success"),
+      body: t(".success_body"),
+    }
+  end
+
   private
 
   def set_claim_window
-    @claim_window = Claims::ClaimWindow.current.decorate
+    @claim_window = Claims::ClaimWindow.current&.decorate
+  end
+
+  def eligible_claim_windows
+    @eligible_claim_windows ||= Claims::ClaimWindow.where(academic_year_id: @claim_window.academic_year_id)
   end
 
   def set_schools
     @schools = Claims::School.includes(:eligible_claim_windows)
-                             .where(eligible_claim_windows: { id: @claim_window.id })
+                             .where(eligible_claim_windows: { id: eligible_claim_windows.ids })
                              .where.missing(:claims)
   end
 
@@ -58,5 +102,21 @@ class Claims::Support::ClaimsRemindersController < Claims::Support::ApplicationC
                                                    .where.not(claims: { claim_window_id: Claims::ClaimWindow.current.id }),
                                  )
                                  .distinct
+  end
+
+  def set_schools_without_sign_in
+    @schools_without_sign_in ||= Claims::School
+                                .includes(:users)
+                                .where(users: { last_signed_in_at: nil })
+                                .where.not(id: Claims::School.joins(:users).where.not(users: { last_signed_in_at: nil }))
+  end
+
+  def set_schools_with_sign_ins_without_claims
+    @schools_with_sign_ins_without_claims ||= Claims::School
+                                            .joins(:users)
+                                            .where.not(users: { last_signed_in_at: nil })
+                                            .includes(:eligible_claim_windows)
+                                            .where(eligible_claim_windows: { id: eligible_claim_windows.ids })
+                                            .where.missing(:claims)
   end
 end

--- a/app/views/claims/support/claims_reminders/school_has_signed_in_but_not_claimed.erb
+++ b/app/views/claims/support/claims_reminders/school_has_signed_in_but_not_claimed.erb
@@ -1,0 +1,26 @@
+<%# content_for :page_title, t(".heading") %>
+<% render "claims/support/primary_navigation", current: :settings %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+
+      <% if @schools_with_sign_ins_without_claims.exists? %>
+        <p class="govuk-body"><%= t(".number_of_schools", count: @schools_with_sign_ins_without_claims.count) %></p>
+
+        <p class="govuk-body"><%= t(".deadline", deadline: l(@claim_window.ends_on, format: :long)) %></p>
+
+        <p class="govuk-body">
+          <%= govuk_link_to(t(".preview"), url_for(controller: "/rails/mailers", action: :preview, path: "claims/user_mailer/your_school_has_signed_in_but_not_claimed"), no_visited_state: true, new_tab: true) %>
+        </p>
+
+        <%= govuk_warning_text(text: t(".warning")) %>
+
+        <%= govuk_button_to(t(".send_reminders"), send_schools_not_submitted_claims_claims_support_claims_reminders_path) %>
+      <% else %>
+        <p class="govuk-body"><%= t(".no_schools") %></p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/claims/support/claims_reminders/school_has_signed_in_but_not_claimed.erb
+++ b/app/views/claims/support/claims_reminders/school_has_signed_in_but_not_claimed.erb
@@ -1,4 +1,4 @@
-<%# content_for :page_title, t(".heading") %>
+<% content_for :page_title, t(".heading") %>
 <% render "claims/support/primary_navigation", current: :settings %>
 
 <div class="govuk-width-container">

--- a/app/views/claims/support/claims_reminders/schools_not_signed_in.html.erb
+++ b/app/views/claims/support/claims_reminders/schools_not_signed_in.html.erb
@@ -1,0 +1,26 @@
+<%# content_for :page_title, t(".heading") %>
+<% render "claims/support/primary_navigation", current: :settings %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+
+      <% if @schools_without_sign_in.exists? %>
+        <p class="govuk-body"><%= t(".number_of_schools", count: @schools_without_sign_in.count) %></p>
+
+        <p class="govuk-body"><%= t(".deadline", deadline: l(@claim_window.ends_on, format: :long)) %></p>
+
+        <p class="govuk-body">
+          <%= govuk_link_to(t(".preview"), url_for(controller: "/rails/mailers", action: :preview, path: "claims/user_mailer/your_school_has_not_signed_in"), no_visited_state: true, new_tab: true) %>
+        </p>
+
+        <%= govuk_warning_text(text: t(".warning")) %>
+
+        <%= govuk_button_to(t(".send_reminders"), send_schools_not_submitted_claims_claims_support_claims_reminders_path) %>
+      <% else %>
+        <p class="govuk-body"><%= t(".no_schools") %></p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/claims/support/claims_reminders/schools_not_signed_in.html.erb
+++ b/app/views/claims/support/claims_reminders/schools_not_signed_in.html.erb
@@ -1,4 +1,4 @@
-<%# content_for :page_title, t(".heading") %>
+<% content_for :page_title, t(".heading") %>
 <% render "claims/support/primary_navigation", current: :settings %>
 
 <div class="govuk-width-container">

--- a/app/views/claims/support/claims_reminders/schools_not_submitted_claims.html.erb
+++ b/app/views/claims/support/claims_reminders/schools_not_submitted_claims.html.erb
@@ -1,4 +1,4 @@
-<%# content_for :page_title, t(".heading") %>
+<% content_for :page_title, t(".heading") %>
 <% render "claims/support/primary_navigation", current: :settings %>
 
 <div class="govuk-width-container">

--- a/app/views/claims/support/settings/index.html.erb
+++ b/app/views/claims/support/settings/index.html.erb
@@ -13,6 +13,8 @@
         govuk_link_to(t(".claim_windows"), claims_support_claim_windows_path, no_visited_state: true),
         govuk_link_to(t(".providers_not_submitted_claims"), providers_not_submitted_claims_claims_support_claims_reminders_path, no_visited_state: true),
         govuk_link_to(t(".schools_not_submitted_claims"), schools_not_submitted_claims_claims_support_claims_reminders_path, no_visited_state: true),
+        govuk_link_to(t(".schools_not_signed_in"), schools_not_signed_in_claims_support_claims_reminders_path, no_visited_state: true),
+        govuk_link_to(t(".school_has_signed_in_but_not_claimed"), school_has_signed_in_but_not_claimed_claims_support_claims_reminders_path, no_visited_state: true),
                      ], spaced: true %>
 
       <h2 class="govuk-heading-m"><%= t(".service_information") %></h2>

--- a/config/locales/en/claims/support/claims_reminders.yml
+++ b/config/locales/en/claims/support/claims_reminders.yml
@@ -4,7 +4,7 @@ en:
       claims_reminders:
         send_schools_not_submitted_claims:
           success: Emails dispatched successfully
-          success_body: An email has been sent to all of the users for schools that have not submitted claims for the current claim window.
+          success_body: An email has been sent to all of the users for schools that have not submitted claims for the current academic year.
         schools_not_submitted_claims:
           heading: Remind schools to submit claims
           number_of_schools:
@@ -28,3 +28,29 @@ en:
             send_reminders: Send reminders
             no_providers: All providers have had claims assigned to them for the current claim window, therefore no reminders can be sent.
             preview: Preview email
+        send_schools_not_signed_in:
+          success: Emails dispatched successfully
+          success_body: An email has been sent to all of the users for schools that have not signed in to the service during the current academic year.
+        send_your_school_has_signed_in_but_not_claimed:
+          success: Emails dispatched successfully
+          success_body: An email has been sent to all of the users for schools that have signed in to the service during the current academic year but haven't made a claim.
+        schools_not_signed_in:
+          heading: Remind schools to sign in
+          number_of_schools:
+            one: There is currently %{count} school that has not signed in for the current academic year.
+            other: There are currently %{count} schools that have not signed in for the current academic year.
+          deadline: The deadline for submitting claims is %{deadline}, the email that is sent will use this date.
+          warning: An email will be sent to all of the users for schools that have not signed in for the current academic year. This action cannot be undone.
+          send_reminders: Send reminders
+          no_schools: All eligible schools have signed in for the current academic year, therefore no reminders can be sent.
+          preview: Preview email
+        school_has_signed_in_but_not_claimed:
+          heading: Remind schools that have signed in to make claims
+          number_of_schools:
+              one: There is currently %{count} school that has signed in but not made a claim for the current academic year.
+              other: There are currently %{count} schools that have signed in but not made a claim for the current academic year.
+          deadline: The deadline for submitting claims is %{deadline}, the email that is sent will use this date.
+          warning: An email will be sent to all of the users for schools that have signed in but not made a claim for the current academic year. This action cannot be undone.
+          send_reminders: Send reminders
+          no_schools: All eligible schools have made a claim for the current academic year, therefore no reminders can be sent.
+          preview: Preview email

--- a/config/locales/en/claims/support/settings.yml
+++ b/config/locales/en/claims/support/settings.yml
@@ -8,6 +8,8 @@ en:
           claim_windows: Manage claim windows
           schools_not_submitted_claims: Remind schools to submit claims
           providers_not_submitted_claims: Remind providers to submit claims
+          schools_not_signed_in: Remind schools to sign in
+          school_has_signed_in_but_not_claimed: Remind schools that have signed in to make claims
           export: Export
           export_users: Export users (CSV)
           emails: View email templates

--- a/config/locales/en/claims/user_mailer.yml
+++ b/config/locales/en/claims/user_mailer.yml
@@ -5,7 +5,7 @@ en:
         subject: Invitation to join %{service_name}
         body: |
           Dear %{user_name},
-  
+          
           You have been invited to join the %{service_name} service for %{organisation_name} because you are a [DfE-sign approver](%{sign_in_approver_url}) for your organisation.
 
           If you are not the right person in your organisation to submit funding claims for initial teacher training (ITT) general mentor training, please:
@@ -14,45 +14,45 @@ en:
           - forward this email to the appropriate colleague after adding them as a user
           
           # Claim funding for mentor training service
-  
+          
           This new DfE service enables schools and education organisations to claim funding for the time spent becoming an ITT general mentor.
-  
+          
           Your organisation has been added to the service because an accredited ITT provider has informed DfE that one or more trainee teachers have undertaken a school placement there during academic year %{academic_year_name}.
 
           # Sign in to submit claims
-  
+          
           Sign in using DfE sign-in:
-  
+          
           [%{sign_in_url}](%{sign_in_url})
-  
+          
           If your colleague needs to create a DfE Sign-in account, they can do this after clicking "Sign in using DfE Sign-in"
-  
+          
           After creating a DfE Sign-in account, they will need to return to this email and [sign in to access the service](%{sign_in_url})
 
           # Prior to submitting claims
 
           We recommend confirming with your accredited ITT provider the number of hours you are claiming, as they may be asked to provide evidence to support this claim.
-  
+          
           # Give feedback or report a problem
-  
+          
           If you have any questions or feedback, please contact the team at [%{support_email}](mailto:%{support_email}).
-  
+          
           Regards
-  
+          
           %{service_name} team
       user_membership_destroyed_notification:
         subject: You have been removed from %{service_name}
         body: |
           Dear %{user_name},
-  
+          
           You have been removed from the %{service_name} service for %{organisation_name}.
-  
+          
           # Give feedback or report a problem
-  
+          
           If you have any questions or feedback, please contact the team at [%{support_email}](mailto:%{support_email}).
-  
+          
           Regards
-  
+          
           %{service_name} team
 
       claim_submitted_notification:
@@ -80,20 +80,20 @@ en:
         subject: New draft claim for mentor training
         body: |
           Dear %{user_name},
-  
+          
           We have added a draft claim for mentor training for %{organisation_name}.
             Your claim reference is %{reference}.
-  
+          
           You can view the claim, edit and submit it on Claim funding for mentor training:
-  
+          
           %{link_to_claim}
-  
+          
           # Give feedback or report a problem
-  
+          
           If you have any questions or feedback, please contact the team at [%{support_email}](mailto:%{support_email}).
-  
+          
           Regards
-  
+          
           Claim funding for mentor training team
 
       claim_requires_clawback:
@@ -131,20 +131,20 @@ en:
         subject: "Deadline %{deadline}: Claim Your ITT Mentor Training Funding"
         body: |
           Dear %{user_name},
-  
+          
           The Claim Funding for ITT Mentoring Training digital service launched in April 2025.
-  
+          
           We believe your school is eligible to claim funding for the time your Initial Teacher Training (ITT) mentors spent in training this academic year.
-  
+          
           If your school has been added to the Register trainee teacher service by your accredited provider, you should have been onboarded and are eligible to claim. However, we’ve not yet received a claim from you.
-  
+          
           ## Eligibility Criteria
 
           To claim funding, an ITT mentor must have:
           
           - Completed up to 20 hours of initial mentor training
           - Mentored at least one trainee during the %{academic_year_name} academic year
-  
+          
           ## How to access the service
           
           Check if you’ve received an onboarding email from DfE.
@@ -156,16 +156,16 @@ en:
           For further help see [additional guidance](https://assets.publishing.service.gov.uk/media/67448404e26d6f8ca3cb358d/General_mentor_training_-_additional_guidance.pdf) or contact: [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk).
           
           ## How to make a claim
-        
+          
           To make a claim, you will need to:
           
           - Sign in using your DfE Sign-in account*
           - Claim for ITT general mentors only (if you’re claiming for ECT mentors, [follow this guidance](https://www.gov.uk/guidance/funding-and-eligibility-for-ecf-based-training))
           - Ensure the mentor’s name matches the Teacher Register (update names via Access Teaching Qualifications if needed)**
-  
+          
           \*DfE Sign-in now uses multi-factor authentication. You may need to create a new account with a secure password.
           \*\*To update a mentor’s name, submit a change via [Access Teaching Qualifications](https://www.gov.uk/guidance/access-your-teaching-qualifications).
-  
+          
           ## Important
           
           The deadline to submit claims is %{deadline}.
@@ -180,7 +180,7 @@ en:
         subject: "Action by 5 December: Change your ITT mentor funding claim to ensure it gets paid"
         body: |
           Dear %{user_name}
-  
+          
           Thank you for using the %{service_name} service.
           
           The following claims, submitted by your school, cannot be processed because the ITT provider recorded is not an accredited provider:
@@ -190,7 +190,7 @@ en:
           To ensure your claims can be processed and paid, please log-in to the service and record the accredited provider. You will need to do this for each claim with the “Invalid provider” status.
           
           ## What You Need to Do
-        
+          
           To update your accredited provider:
           
           1. Log in to the %{service_name} service
@@ -199,15 +199,107 @@ en:
           4. Click ‘Change’ next to your current provider selection
           5. Enter your accredited provider's name in the search box
           6. Click ‘Continue’
-        
+          
           ## Deadline: Friday 5 December 2025
           
           Please update your provider information by this date to avoid delays in payment.
-        
+          
           If you are unsure who the accredited provider is, contact your ITT provider to confirm or review this list: [https://www.gov.uk/government/publications/accredited-initial-teacher-training-itt-providers/list-of-providers-accredited-to-deliver-itt-from-september-2024]([https://www.gov.uk/government/publications/accredited-initial-teacher-training-itt-providers/list-of-providers-accredited-to-deliver-itt-from-september-2024).
-        
+          
           If you have any questions, contact us at:
           [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk)
+          
+          Kind regards,
+          %{service_name} team
+
+      your_school_has_not_signed_in:
+        subject: "Deadline %{deadline}: Claim funding for ITT Mentor training"
+        body: |
+          Dear %{user_name},
+          
+          The Claim Funding for ITT Mentoring Training digital service launched in April 2025.
+          
+          We believe your school is eligible to claim funding for the time your Initial Teacher Training (ITT) mentors spent in training this academic year, but we can see you’ve not yet accessed the service.
+          
+          Your eligible schools include %{user_school_names}.
+          
+          If your school has been added to the Register trainee teacher service by your accredited provider, you should have been onboarded and are eligible to claim. Follow the simple steps below to access the service and claim funding for your ITT Mentor training for the %{academic_year_name} academic year.
+          
+          ## Eligibility Criteria
+          
+          To claim funding, an ITT mentor must have:
+          
+          - Completed up to 20 hours of initial mentor training
+          - Mentored at least one trainee during the %{academic_year_name} academic year
+          
+          ## How to access the service
+          
+          1. Check if you’ve received an onboarding email from DfE.
+          2. If not, ask your school’s DfE Sign-in approver if they’ve received it and can add users.
+          3. If no one has received it, confirm with your accredited provider that your school is on the Register trainee teacher service.
+          4. For further help see [additional guidance](https://assets.publishing.service.gov.uk/media/67448404e26d6f8ca3cb358d/General_mentor_training_-_additional_guidance.pdf) or [%{support_email}](mailto:%{support_email})
+          
+          ## How to make a claim
+          
+          To make a claim, you will need to:
+          
+          - Sign in using yourDfE Sign-in account*
+          - Claim for ITT general mentors only (if you’re claiming for ECT mentors, [follow this guidance](https://www.gov.uk/guidance/funding-and-eligibility-for-ecf-based-training))
+          - Add your mentor(s) by inputting their teacher reference number and date of birth to look up their name in our data
+          - Ensure the mentor’s name matches the Teacher Register (update names via [Access Teaching Qualifications](https://www.gov.uk/guidance/access-your-teaching-qualifications) if needed)**
+          
+          \*DfE Sign-in now uses multi-factor authentication. You may need to create a new account with a secure password.
+          \*\*To update a mentor’s name, submit a change via [Access Teaching Qualifications](https://www.gov.uk/guidance/access-your-teaching-qualifications).
+          
+          ## Deadline
+          
+          The final claim window for the %{academic_year_name} academic year is open now and closes on %{deadline}. Submit your claim before this date to ensure you don’t lose out on funding.
+          
+          Kind regards,
+          %{service_name} team
+
+      your_school_has_signed_in_but_not_claimed:
+        subject: "Deadline %{deadline}: Claim funding for ITT Mentor training"
+        body: |
+          Dear %{user_name},
+          
+          The Claim Funding for ITT Mentoring Training digital service launched in April 2025.
+          
+          We can see you’ve logged into the service but not submitted a claim - we believe your school is eligible to claim funding for the time your Initial Teacher Training (ITT) mentors spent in training in the %{academic_year_name} academic year.
+          
+          Your eligible schools include %{user_school_names}.
+          
+          Follow the simple steps below to submit a claim.
+          
+          ## Eligibility Criteria
+          
+          To claim funding, an ITT mentor must have:
+          
+          - Completed up to 20 hours of initial mentor training
+          - Mentored at least one trainee during the %{academic_year_name} academic year
+          
+          ## How to access the service
+          
+          1. Check if you’ve received an onboarding email from DfE.
+          2. If not, ask your school’s DfE Sign-in approver if they’ve received it and can add users.
+          3. If no one has received it, confirm with your accredited provider that your school is on the Register trainee teacher service.
+          4. For further help see [additional guidance](https://assets.publishing.service.gov.uk/media/67448404e26d6f8ca3cb358d/General_mentor_training_-_additional_guidance.pdf) or [%{support_email}](mailto:%{support_email})
+          
+          ## How to make a claim
+          
+          To make a claim, you will need to:
+          
+          - Sign in using yourDfE Sign-in account*
+          - Claim for ITT general mentors only (if you’re claiming for ECT mentors, [follow this guidance](https://www.gov.uk/guidance/funding-and-eligibility-for-ecf-based-training))
+          - Add your mentor(s) by inputting their teacher reference number and date of birth to look up their name in our data
+          - Ensure the mentor’s name matches the Teacher Register (update names via [Access Teaching Qualifications](https://www.gov.uk/guidance/access-your-teaching-qualifications) if needed)**
+          
+          \*DfE Sign-in now uses multi-factor authentication. You may need to create a new account with a secure password.
+          \*\*To update a mentor’s name, submit a change via [Access Teaching Qualifications](https://www.gov.uk/guidance/access-your-teaching-qualifications).
+          
+          ## Deadline
+          
+          The final claim window for the %{academic_year_name} academic year is open now and closes on %{deadline}. Submit your claim before this date to ensure you don’t lose out on funding.
           
           Kind regards,
           %{service_name} team

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -276,6 +276,12 @@ scope module: :claims, as: :claims, constraints: {
 
         get "providers_not_submitted_claims", to: "claims_reminders#providers_not_submitted_claims", as: :providers_not_submitted_claims
         post "providers_not_submitted_claims", to: "claims_reminders#send_providers_not_submitted_claims", as: :send_providers_not_submitted_claims
+
+        get "schools_not_signed_in", to: "claims_reminders#schools_not_signed_in", as: :schools_not_signed_in
+        post "schools_not_signed_in", to: "claims_reminders#send_schools_not_signed_in", as: :send_schools_not_signed_in
+
+        get "school_has_signed_in_but_not_claimed", to: "claims_reminders#school_has_signed_in_but_not_claimed", as: :school_has_signed_in_but_not_claimed
+        post "school_has_signed_in_but_not_claimed", to: "claims_reminders#send_your_school_has_signed_in_but_not_claimed", as: :send_your_school_has_signed_in_but_not_claimed
       end
     end
 

--- a/spec/mailers/claims/user_mailer_spec.rb
+++ b/spec/mailers/claims/user_mailer_spec.rb
@@ -395,4 +395,124 @@ RSpec.describe Claims::UserMailer, type: :mailer do
       EMAIL
     end
   end
+
+  describe "#your_school_has_not_signed_in" do
+    subject(:school_not_signed_in_email) { described_class.your_school_has_not_signed_in(user) }
+
+    let!(:claim_window) { create(:claim_window, :current) }
+    let(:hogwarts_eligibility) { build(:eligibility, claim_window:) }
+    let(:hogwarts) { build(:claims_school, name: "Hogwarts", eligibilities: [hogwarts_eligibility]) }
+    let(:springfield_eligibility) { build(:eligibility, claim_window:) }
+    let(:springfield_elementary) { build(:claims_school, name: "Springfield Elementary", eligibilities: [springfield_eligibility]) }
+    let(:user) { create(:claims_user, first_name: "Joe", schools: [hogwarts, springfield_elementary]) }
+
+    it "sends the school not signed in email" do
+      expect(school_not_signed_in_email.to).to contain_exactly(user.email)
+      expect(school_not_signed_in_email.subject).to eq("Deadline #{I18n.l(claim_window.ends_on, format: :long)}: Claim funding for ITT Mentor training")
+      expect(school_not_signed_in_email.body.to_s.squish).to eq(<<~EMAIL.squish)
+        Dear Joe,
+
+        The Claim Funding for ITT Mentoring Training digital service launched in April 2025.
+
+        We believe your school is eligible to claim funding for the time your Initial Teacher Training (ITT) mentors spent in training this academic year, but we can see you’ve not yet accessed the service.
+
+        Your eligible schools include Hogwarts and Springfield Elementary.
+
+        If your school has been added to the Register trainee teacher service by your accredited provider, you should have been onboarded and are eligible to claim. Follow the simple steps below to access the service and claim funding for your ITT Mentor training for the #{claim_window.academic_year_name} academic year.
+
+        ## Eligibility Criteria
+
+        To claim funding, an ITT mentor must have:
+
+        - Completed up to 20 hours of initial mentor training
+        - Mentored at least one trainee during the #{claim_window.academic_year_name} academic year
+
+        ## How to access the service
+
+        1. Check if you’ve received an onboarding email from DfE.
+        2. If not, ask your school’s DfE Sign-in approver if they’ve received it and can add users.
+        3. If no one has received it, confirm with your accredited provider that your school is on the Register trainee teacher service.
+        4. For further help see [additional guidance](https://assets.publishing.service.gov.uk/media/67448404e26d6f8ca3cb358d/General_mentor_training_-_additional_guidance.pdf) or [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk)
+
+        ## How to make a claim
+
+        To make a claim, you will need to:
+
+        - Sign in using yourDfE Sign-in account*
+        - Claim for ITT general mentors only (if you’re claiming for ECT mentors, [follow this guidance](https://www.gov.uk/guidance/funding-and-eligibility-for-ecf-based-training))
+        - Add your mentor(s) by inputting their teacher reference number and date of birth to look up their name in our data
+        - Ensure the mentor’s name matches the Teacher Register (update names via [Access Teaching Qualifications](https://www.gov.uk/guidance/access-your-teaching-qualifications) if needed)**
+
+        \\*DfE Sign-in now uses multi-factor authentication. You may need to create a new account with a secure password.
+        \\*\\*To update a mentor’s name, submit a change via [Access Teaching Qualifications](https://www.gov.uk/guidance/access-your-teaching-qualifications).
+
+        ## Deadline
+
+        The final claim window for the #{claim_window.academic_year_name} academic year is open now and closes on #{I18n.l(claim_window.ends_on, format: :long)}. Submit your claim before this date to ensure you don’t lose out on funding.
+
+        Kind regards,
+        Claim funding for mentor training team
+      EMAIL
+    end
+  end
+
+  describe "#your_school_has_signed_in_but_not_claimed" do
+    subject(:school_not_signed_in_email) { described_class.your_school_has_signed_in_but_not_claimed(user) }
+
+    let!(:claim_window) { create(:claim_window, :current) }
+    let(:hogwarts_eligibility) { build(:eligibility, claim_window:) }
+    let(:hogwarts) { build(:claims_school, name: "Hogwarts", eligibilities: [hogwarts_eligibility]) }
+    let(:springfield_eligibility) { build(:eligibility, claim_window:) }
+    let(:springfield_elementary) { build(:claims_school, name: "Springfield Elementary", eligibilities: [springfield_eligibility]) }
+    let(:user) { create(:claims_user, first_name: "Joe", schools: [hogwarts, springfield_elementary], last_signed_in_at: 1.day.ago) }
+
+    it "sends the school not signed in email" do
+      expect(school_not_signed_in_email.to).to contain_exactly(user.email)
+      expect(school_not_signed_in_email.subject).to eq("Deadline #{I18n.l(claim_window.ends_on, format: :long)}: Claim funding for ITT Mentor training")
+      expect(school_not_signed_in_email.body.to_s.squish).to eq(<<~EMAIL.squish)
+        Dear Joe,
+
+        The Claim Funding for ITT Mentoring Training digital service launched in April 2025.
+
+        We can see you’ve logged into the service but not submitted a claim - we believe your school is eligible to claim funding for the time your Initial Teacher Training (ITT) mentors spent in training in the #{claim_window.academic_year_name} academic year.
+
+        Your eligible schools include Hogwarts and Springfield Elementary.
+
+        Follow the simple steps below to submit a claim.
+
+        ## Eligibility Criteria
+
+        To claim funding, an ITT mentor must have:
+
+        - Completed up to 20 hours of initial mentor training
+        - Mentored at least one trainee during the #{claim_window.academic_year_name} academic year
+
+        ## How to access the service
+
+        1. Check if you’ve received an onboarding email from DfE.
+        2. If not, ask your school’s DfE Sign-in approver if they’ve received it and can add users.
+        3. If no one has received it, confirm with your accredited provider that your school is on the Register trainee teacher service.
+        4. For further help see [additional guidance](https://assets.publishing.service.gov.uk/media/67448404e26d6f8ca3cb358d/General_mentor_training_-_additional_guidance.pdf) or [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk)
+
+        ## How to make a claim
+
+        To make a claim, you will need to:
+
+        - Sign in using yourDfE Sign-in account*
+        - Claim for ITT general mentors only (if you’re claiming for ECT mentors, [follow this guidance](https://www.gov.uk/guidance/funding-and-eligibility-for-ecf-based-training))
+        - Add your mentor(s) by inputting their teacher reference number and date of birth to look up their name in our data
+        - Ensure the mentor’s name matches the Teacher Register (update names via [Access Teaching Qualifications](https://www.gov.uk/guidance/access-your-teaching-qualifications) if needed)**
+
+        \\*DfE Sign-in now uses multi-factor authentication. You may need to create a new account with a secure password.
+        \\*\\*To update a mentor’s name, submit a change via [Access Teaching Qualifications](https://www.gov.uk/guidance/access-your-teaching-qualifications).
+
+        ## Deadline
+
+        The final claim window for the #{claim_window.academic_year_name} academic year is open now and closes on #{I18n.l(claim_window.ends_on, format: :long)}. Submit your claim before this date to ensure you don’t lose out on funding.
+
+        Kind regards,
+        Claim funding for mentor training team
+      EMAIL
+    end
+  end
 end

--- a/spec/mailers/previews/claims/user_mailer_preview.rb
+++ b/spec/mailers/previews/claims/user_mailer_preview.rb
@@ -27,6 +27,14 @@ class Claims::UserMailerPreview < ActionMailer::Preview
     Claims::UserMailer.claims_assigned_to_invalid_provider(user)
   end
 
+  def your_school_has_not_signed_in
+    Claims::UserMailer.your_school_has_not_signed_in(user)
+  end
+
+  def your_school_has_signed_in_but_not_claimed
+    Claims::UserMailer.your_school_has_signed_in_but_not_claimed(user)
+  end
+
   private
 
   def user

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -17,7 +17,7 @@ Capybara.register_driver :selenium_chrome_headless do |app|
     opts.add_argument("--window-size=1400,1400")
   end
 
-  options.browser_version = "128"
+  options.browser_version = "140"
 
   Capybara::Selenium::Driver.new(app, browser: :chrome, options:)
 end

--- a/spec/system/claims/support/settings/support_user_views_remind_schools_that_have_signed_in_to_make_claims_when_all_schools_have_claimed_spec.rb
+++ b/spec/system/claims/support/settings/support_user_views_remind_schools_that_have_signed_in_to_make_claims_when_all_schools_have_claimed_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe "Support user views remind schools that have signed in to make claims when all schools have claimed", service: :claims, type: :system do
+  scenario do
+    given_i_am_signed_in
+    and_schools_have_signed_in
+    when_i_navigate_to_the_settings_index_page
+    then_i_see_the_remind_schools_that_have_signed_in_link
+
+    when_i_click_on_the_remind_schools_that_have_signed_in_link
+    then_i_do_not_see_any_schools
+  end
+
+  private
+
+  def given_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def and_schools_have_signed_in
+    @claim_window = create(:claim_window, :current)
+    @eligibility = build(:eligibility, academic_year: @claim_window.academic_year)
+    @school = build(:claims_school, eligibilities: [@eligibility])
+    @user = create(:claims_user, last_signed_in_at: Time.zone.now, schools: [@school])
+  end
+
+  def when_i_navigate_to_the_settings_index_page
+    within(primary_navigation) do
+      click_on "Settings"
+    end
+  end
+
+  def then_i_see_the_remind_schools_that_have_signed_in_link
+    expect(page).to have_link("Remind schools that have signed in to make claims", href: "/support/claims_reminders/school_has_signed_in_but_not_claimed")
+  end
+
+  def when_i_click_on_the_remind_schools_that_have_signed_in_link
+    click_on "Remind schools to sign in"
+  end
+
+  def then_i_do_not_see_any_schools
+    expect(page).to have_paragraph("All eligible schools have signed in for the current academic year, therefore no reminders can be sent.")
+  end
+end

--- a/spec/system/claims/support/settings/support_user_views_remind_schools_that_have_signed_in_to_make_claims_when_no_schools_have_claimed_spec.rb
+++ b/spec/system/claims/support/settings/support_user_views_remind_schools_that_have_signed_in_to_make_claims_when_no_schools_have_claimed_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe "Support user views remind schools that have signed in to make claims when all schools have claimed", service: :claims, type: :system do
+  scenario do
+    given_i_am_signed_in
+    and_schools_have_signed_in
+    when_i_navigate_to_the_settings_index_page
+    then_i_see_the_remind_schools_that_have_signed_in_link
+
+    when_i_click_on_the_remind_schools_that_have_signed_in_link
+    then_i_see_information_about_schools_that_have_signed_in_and_not_claimed
+
+    when_i_click_on_send_reminders
+    then_i_see_the_reminders_sent_success_banner
+  end
+
+  private
+
+  def given_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def and_schools_have_signed_in
+    @claim_window = create(:claim_window, :current)
+    @eligibility = build(:eligibility, academic_year: @claim_window.academic_year)
+    @school = build(:claims_school, eligibilities: [@eligibility])
+    @user = create(:claims_user, last_signed_in_at: Time.zone.now, schools: [@school])
+  end
+
+  def when_i_navigate_to_the_settings_index_page
+    within(primary_navigation) do
+      click_on "Settings"
+    end
+  end
+
+  def then_i_see_the_remind_schools_that_have_signed_in_link
+    expect(page).to have_link("Remind schools that have signed in to make claims", href: "/support/claims_reminders/school_has_signed_in_but_not_claimed")
+  end
+
+  def when_i_click_on_the_remind_schools_that_have_signed_in_link
+    click_on "Remind schools that have signed in to make claims"
+  end
+
+  def then_i_see_information_about_schools_that_have_signed_in_and_not_claimed
+    expect(page).to have_title("Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Settings")
+    expect(page).to have_h1("Remind schools that have signed in to make claims")
+    expect(page).to have_paragraph("There is currently 1 school that has signed in but not made a claim for the current academic year.")
+    expect(page).to have_paragraph("The deadline for submitting claims is #{I18n.l(@claim_window.ends_on, format: :long)}, the email that is sent will use this date.")
+    expect(page).to have_link("Preview email (opens in new tab)", href: "/rails/mailers/claims/user_mailer/your_school_has_signed_in_but_not_claimed")
+    expect(page).to have_warning_text("An email will be sent to all of the users for schools that have signed in but not made a claim for the current academic year. This action cannot be undone.")
+    expect(page).to have_button("Send reminders")
+  end
+
+  def when_i_click_on_send_reminders
+    click_on "Send reminders"
+  end
+
+  def then_i_see_the_reminders_sent_success_banner
+    expect(page).to have_success_banner("Emails dispatched successfully", "An email has been sent to all of the users for schools that have not submitted claims for the current academic year.")
+  end
+end

--- a/spec/system/claims/support/settings/support_user_views_remind_schools_to_sign_in_when_all_schools_have_signed_in_spec.rb
+++ b/spec/system/claims/support/settings/support_user_views_remind_schools_to_sign_in_when_all_schools_have_signed_in_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe "Support user views schools not signed in when schools have not signed in", service: :claims, type: :system do
+  scenario do
+    given_i_am_signed_in
+    and_schools_have_signed_in
+    when_i_navigate_to_the_settings_index_page
+    then_i_see_the_schools_have_not_signed_in_link
+
+    when_i_click_on_the_schools_have_not_signed_in_link
+    then_i_do_not_see_any_schools
+  end
+
+  private
+
+  def given_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def and_schools_have_signed_in
+    @claim_window = create(:claim_window, :current)
+    @eligibility = build(:eligibility, academic_year: @claim_window.academic_year)
+    @school = build(:claims_school, eligibilities: [@eligibility])
+    @user = create(:claims_user, last_signed_in_at: Time.zone.now, schools: [@school])
+  end
+
+  def when_i_navigate_to_the_settings_index_page
+    within(primary_navigation) do
+      click_on "Settings"
+    end
+  end
+
+  def then_i_see_the_schools_have_not_signed_in_link
+    expect(page).to have_link("Remind schools to sign in", href: "/support/claims_reminders/schools_not_signed_in")
+  end
+
+  def when_i_click_on_the_schools_have_not_signed_in_link
+    click_on "Remind schools to sign in"
+  end
+
+  def then_i_do_not_see_any_schools
+    expect(page).to have_paragraph("All eligible schools have signed in for the current academic year, therefore no reminders can be sent.")
+  end
+end

--- a/spec/system/claims/support/settings/support_user_views_remind_schools_to_sign_in_when_schools_have_not_signed_in_spec.rb
+++ b/spec/system/claims/support/settings/support_user_views_remind_schools_to_sign_in_when_schools_have_not_signed_in_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe "Support user views schools not signed in when schools have not signed in", service: :claims, type: :system do
+  scenario do
+    given_i_am_signed_in
+    and_schools_have_not_signed_in
+    when_i_navigate_to_the_settings_index_page
+    then_i_see_the_schools_have_not_signed_in_link
+
+    when_i_click_on_the_schools_have_not_signed_in_link
+    then_i_see_information_about_schools_that_have_not_signed_in
+  end
+
+  private
+
+  def given_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def and_schools_have_not_signed_in
+    @claim_window = create(:claim_window, :current)
+    @eligibility = build(:eligibility, academic_year: @claim_window.academic_year)
+    @school = create(:claims_school, eligibilities: [@eligibility])
+  end
+
+  def when_i_navigate_to_the_settings_index_page
+    within(primary_navigation) do
+      click_on "Settings"
+    end
+  end
+
+  def then_i_see_the_schools_have_not_signed_in_link
+    expect(page).to have_link("Remind schools to sign in", href: "/support/claims_reminders/schools_not_signed_in")
+  end
+
+  def when_i_click_on_the_schools_have_not_signed_in_link
+    click_on "Remind schools to sign in"
+  end
+
+  def then_i_see_information_about_schools_that_have_not_signed_in
+    expect(page).to have_title("Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Settings")
+    expect(page).to have_h1("Remind schools to sign in")
+    expect(page).to have_paragraph("There is currently 1 school that has not signed in for the current academic year.")
+    expect(page).to have_paragraph("The deadline for submitting claims is #{I18n.l(@claim_window.ends_on, format: :long)}, the email that is sent will use this date.")
+    expect(page).to have_link("Preview email (opens in new tab)", href: "/rails/mailers/claims/user_mailer/your_school_has_not_signed_in")
+    expect(page).to have_warning_text("An email will be sent to all of the users for schools that have not signed in for the current academic year. This action cannot be undone.")
+    expect(page).to have_button("Send reminders")
+  end
+
+  def when_i_click_on_send_reminders
+    click_on "Send reminders"
+  end
+
+  def then_i_see_the_reminders_sent_success_banner
+    expect(page).to have_success_banner("An email has been sent to all of the users for schools that have not signed in to the service during the current academic year.")
+  end
+end

--- a/spec/system/claims/support/settings/support_user_views_remind_schools_to_submit_claims_when_schools_have_not_claimed_spec.rb
+++ b/spec/system/claims/support/settings/support_user_views_remind_schools_to_submit_claims_when_schools_have_not_claimed_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe "Support user views remind schools to submit claims when schools 
 
     when_i_click_on_the_remind_schools_to_submit_claims_link
     then_i_see_information_about_schools_that_have_not_claimed
+
+    when_i_click_on_send_reminders
+    then_i_see_the_reminders_sent_success_banner
   end
 
   private
@@ -53,6 +56,6 @@ RSpec.describe "Support user views remind schools to submit claims when schools 
   end
 
   def then_i_see_the_reminders_sent_success_banner
-    expect(page).to have_success_banner("An email has been sent to all of the users for schools that have not submitted claims for the current claim window.")
+    expect(page).to have_success_banner("Emails dispatched successfully", "An email has been sent to all of the users for schools that have not submitted claims for the current academic year.")
   end
 end


### PR DESCRIPTION
## Context

Adds a mailer to remind schools who have not logged in to claim and a mailer to remind schools who have logged in but not claimed to claim.

## Changes proposed in this pull request

- Adds 2 new mailers and adds access to them via the support settings page

## Guidance to review

- Log in as Colin
- Navigate to settings
- View Remind schools to sign 
- View Remind schools that have signed in to make claims

## Link to Trello card

https://trello.com/c/CtDq8olg/169-consider-any-actions-required-to-help-address-trends-on-schools-not-submitting-claims

## Screenshots

<img width="543" height="903" alt="image" src="https://github.com/user-attachments/assets/948f5c81-accb-4724-a627-eea7f6789e20" />
<img width="1005" height="663" alt="image" src="https://github.com/user-attachments/assets/0f8a9ac9-9011-4080-99b1-a731d3eca395" />
<img width="588" height="1165" alt="image" src="https://github.com/user-attachments/assets/4797dc93-b28c-4158-a850-fae247403cc6" />
<img width="1005" height="709" alt="image" src="https://github.com/user-attachments/assets/58e13d19-2058-4d66-85c6-92f371bf6c18" />
<img width="625" height="1164" alt="image" src="https://github.com/user-attachments/assets/23fd3da8-7297-46be-abe7-2558dc351388" />
