### PR TITLE
Adds job to remind providers to respond to audit requests

### DIFF
--- a/app/jobs/claims/sampling/send_provider_reminders_job.rb
+++ b/app/jobs/claims/sampling/send_provider_reminders_job.rb
@@ -1,0 +1,35 @@
+class Claims::Sampling::SendProviderRemindersJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    wait_time = 0.minutes
+
+    provider_samplings.find_in_batches(batch_size: 100) do |batch|
+      batch.each do |provider_sampling|
+        provider = provider_sampling.provider
+        next unless provider&.email_addresses&.any?
+
+        provider.email_addresses.each do |email_address|
+          Claims::ProviderMailer.sampling_checks_required(provider_sampling, email_address).deliver_later(wait: wait_time)
+        end
+      end
+
+      wait_time += 1.minute
+    end
+  end
+
+  private
+
+  def outstanding_claims
+    @outstanding_claims ||= Claims::Claim.sampling_in_progress
+  end
+
+  def provider_samplings
+    @provider_samplings ||= Claims::ProviderSampling
+                              .where(
+                                id: Claims::ProviderSamplingClaim.where(claim: outstanding_claims)
+                                                                 .select("DISTINCT ON (claim_id) provider_sampling_id"),
+                              )
+                              .order("provider_id, created_at DESC")
+  end
+end

--- a/config/scheduled_jobs.yml
+++ b/config/scheduled_jobs.yml
@@ -56,3 +56,8 @@ notify_claims_users_they_have_invalid_provider_claims:
   cron: "0 9 * * MON" # Every monday at 9:00
   class: "Claims::User::NotifyUsersOfInvalidProviderClaimsJob"
   description: "Reminds users to address claims with invalid providers"
+
+remind_providers_to_respond_to_sampling:
+    cron: "0 9 * * MON" # Every monday at 10:00
+    class: "Claims::Sampling::RemindProvidersToRespondJob"
+    description: "Reminds providers to respond to audit requests"

--- a/spec/jobs/claims/sampling/send_provider_reminders_job_spec.rb
+++ b/spec/jobs/claims/sampling/send_provider_reminders_job_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe Claims::Sampling::SendProviderRemindersJob, type: :job do
+  subject(:send_reminders_job) { described_class.new }
+
+  let(:provider) { create(:provider, email_addresses: %w[example@example.com example2@example.com]) }
+  let(:provider_sampling) { create(:provider_sampling, provider:) }
+  let(:wait_time) { 5.minutes }
+  let(:mail) { instance_double(ActionMailer::MessageDelivery, deliver_later: nil) }
+
+  before do
+    allow(Claims::ProviderMailer).to receive(:sampling_checks_required).and_return(mail)
+  end
+
+  describe "#perform" do
+    it "sends emails to all provider email addresses with the correct wait time" do
+      send_reminders_job.perform
+      expect(Claims::ProviderMailer).to have_received(:sampling_checks_required).once.with(provider_sampling, "example@example.com")
+      expect(Claims::ProviderMailer).to have_received(:sampling_checks_required).once.with(provider_sampling, "example2@example.com")
+      expect(mail).to have_received(:deliver_later).twice.with(wait: wait_time)
+    end
+
+    context "when provider has no email addresses" do
+      before do
+        # Creating a provider via the factory always creates email addresses so we need to remove them
+        provider.provider_email_addresses.destroy_all
+      end
+
+      it "does not send any emails" do
+        send_reminders_job.perform
+        expect(Claims::ProviderMailer).not_to have_received(:sampling_checks_required)
+        expect(mail).not_to have_received(:deliver_later)
+      end
+    end
+  end
+end

--- a/spec/mailers/previews/claims/provider_mailer_preview.rb
+++ b/spec/mailers/previews/claims/provider_mailer_preview.rb
@@ -2,11 +2,11 @@ class Claims::ProviderMailerPreview < ActionMailer::Preview
   include ActionDispatch::TestProcess::FixtureFile
 
   def sampling_checks_required
-    Claims::ProviderMailer.sampling_checks_required("example@example.com", provider_sampling)
+    Claims::ProviderMailer.sampling_checks_required(provider_sampling, email_address: "example@example.com")
   end
 
   def resend_sampling_checks_required
-    Claims::ProviderMailer.resend_sampling_checks_required("example@example.com", provider_sampling)
+    Claims::ProviderMailer.resend_sampling_checks_required(provider_sampling, email_address: "example@example.com")
   end
 
   def claims_have_not_been_submitted


### PR DESCRIPTION
## Context

Adds a scheduled job to automatically resend the audit email for providers if they haven't responded within 7 days.

## Changes proposed in this pull request

- Adds a new job
- Adds the job to the schedule

## Guidance to review

Review the job logic, this re-uses an existing mailer.

## Link to Trello card

https://trello.com/c/U8OiMOB3/146-automate-provider-audit-request-chase-emails
