### PR TITLE
Update claim hours

### DIFF
--- a/app/components/claims/add_claim_wizard/mentor_step/disclaimer_component.rb
+++ b/app/components/claims/add_claim_wizard/mentor_step/disclaimer_component.rb
@@ -15,7 +15,7 @@ class Claims::AddClaimWizard::MentorStep::DisclaimerComponent < ApplicationCompo
                          claims_school_mentors_path(mentor_step.claim.school),
                          no_visited_state: true,
                        )))) +
-        tag.p(sanitize(t(".disclaimer", provider_name:))) +
+        tag.p(sanitize(t(".disclaimer", provider_name:, num_initial_hours: Claims::TrainingHours.for(training_type: :initial, academic_year: AcademicYear.current)))) +
         tag.p(sanitize(t(".disclaimer_contact", email_link:)))
     end
   end

--- a/app/components/claims/add_claim_wizard/mentor_step/disclaimer_component.rb
+++ b/app/components/claims/add_claim_wizard/mentor_step/disclaimer_component.rb
@@ -15,7 +15,7 @@ class Claims::AddClaimWizard::MentorStep::DisclaimerComponent < ApplicationCompo
                          claims_school_mentors_path(mentor_step.claim.school),
                          no_visited_state: true,
                        )))) +
-        tag.p(sanitize(t(".disclaimer", provider_name:, num_initial_hours: Claims::TrainingHours.for(training_type: :initial, academic_year: AcademicYear.current)))) +
+        tag.p(sanitize(t(".disclaimer", provider_name:, num_initial_hours: Claims::TrainingHours.for(training_type: :initial, academic_year: mentor_step.claim.claim_window.academic_year)))) +
         tag.p(sanitize(t(".disclaimer_contact", email_link:)))
     end
   end

--- a/app/models/claims/training_allowance.rb
+++ b/app/models/claims/training_allowance.rb
@@ -11,7 +11,7 @@ class Claims::TrainingAllowance
   end
 
   def total_hours
-    training_type == INITIAL_TRAINING_TYPE ? INITIAL_TRAINING_HOURS : REFRESHER_TRAINING_HOURS
+    training_type == INITIAL_TRAINING_TYPE ? initial_training_hours : refresher_training_hours
   end
 
   def remaining_hours
@@ -27,12 +27,9 @@ class Claims::TrainingAllowance
   attr_reader :mentor, :provider, :academic_year, :claim_to_exclude
 
   INITIAL_TRAINING_TYPE = :initial
-  INITIAL_TRAINING_HOURS = 20
   REFRESHER_TRAINING_TYPE = :refresher
-  REFRESHER_TRAINING_HOURS = 6
 
-  private_constant :INITIAL_TRAINING_TYPE, :INITIAL_TRAINING_HOURS, :REFRESHER_TRAINING_TYPE,
-                   :REFRESHER_TRAINING_HOURS
+  private_constant :INITIAL_TRAINING_TYPE, :REFRESHER_TRAINING_TYPE
 
   def mentor_training_scope
     @mentor_training_scope ||= provider.mentor_trainings
@@ -53,5 +50,13 @@ class Claims::TrainingAllowance
       .where.not(claim_id: claim_to_exclude&.id)
       .merge(Claims::Claim.not_internal_draft.not_payment_not_approved)
       .sum(:hours_completed)
+  end
+
+  def initial_training_hours
+    Claims::TrainingHours.new(academic_year:).initial
+  end
+
+  def refresher_training_hours
+    Claims::TrainingHours.new(academic_year:).refresher
   end
 end

--- a/app/models/claims/training_allowance.rb
+++ b/app/models/claims/training_allowance.rb
@@ -7,11 +7,11 @@ class Claims::TrainingAllowance
   end
 
   def training_type
-    @training_type ||= has_trained_in_a_previous_year? ? REFRESHER_TRAINING_TYPE : INITIAL_TRAINING_TYPE
+    @training_type ||= has_trained_in_a_previous_year? ? Claims::TrainingHours::REFRESHER_TRAINING_TYPE : Claims::TrainingHours::INITIAL_TRAINING_TYPE
   end
 
   def total_hours
-    training_type == INITIAL_TRAINING_TYPE ? initial_training_hours : refresher_training_hours
+    training_type == Claims::TrainingHours::INITIAL_TRAINING_TYPE ? initial_training_hours : refresher_training_hours
   end
 
   def remaining_hours
@@ -25,11 +25,6 @@ class Claims::TrainingAllowance
   private
 
   attr_reader :mentor, :provider, :academic_year, :claim_to_exclude
-
-  INITIAL_TRAINING_TYPE = :initial
-  REFRESHER_TRAINING_TYPE = :refresher
-
-  private_constant :INITIAL_TRAINING_TYPE, :REFRESHER_TRAINING_TYPE
 
   def mentor_training_scope
     @mentor_training_scope ||= provider.mentor_trainings

--- a/app/models/claims/training_hours.rb
+++ b/app/models/claims/training_hours.rb
@@ -1,0 +1,45 @@
+class Claims::TrainingHours
+  INITIAL_TRAINING_TYPE = :initial
+  REFRESHER_TRAINING_TYPE = :refresher
+
+  HOURS_BY_PERIOD = {
+    initial: {
+      pre_2026: 20,
+      post_2026: 16,
+    },
+    refresher: {
+      pre_2026: 6,
+      post_2026: 6,
+    },
+  }.freeze
+
+  private_constant :HOURS_BY_PERIOD
+
+  def self.for(academic_year:, training_type:)
+    new(academic_year:).hours_for(training_type:)
+  end
+
+  def initialize(academic_year:)
+    @academic_year = academic_year
+  end
+
+  def initial
+    hours_for(training_type: INITIAL_TRAINING_TYPE)
+  end
+
+  def refresher
+    hours_for(training_type: REFRESHER_TRAINING_TYPE)
+  end
+
+  def hours_for(training_type:)
+    HOURS_BY_PERIOD.fetch(training_type.to_sym).fetch(period)
+  end
+
+  private
+
+  attr_reader :academic_year
+
+  def period
+    academic_year.starts_on < Date.new(2026, 1, 1) ? :pre_2026 : :post_2026
+  end
+end

--- a/app/models/claims/training_hours.rb
+++ b/app/models/claims/training_hours.rb
@@ -4,12 +4,12 @@ class Claims::TrainingHours
 
   HOURS_BY_PERIOD = {
     initial: {
-      pre_2026: 20,
-      post_2026: 16,
+      pre_2025: 20,
+      post_2025: 16,
     },
     refresher: {
-      pre_2026: 6,
-      post_2026: 6,
+      pre_2025: 6,
+      post_2025: 6,
     },
   }.freeze
 
@@ -40,6 +40,6 @@ class Claims::TrainingHours
   attr_reader :academic_year
 
   def period
-    academic_year.starts_on < Date.new(2026, 1, 1) ? :pre_2026 : :post_2026
+    academic_year.starts_on < Date.new(2025, 1, 1) ? :pre_2025 : :post_2025
   end
 end

--- a/app/views/claims/schools/_grant_conditions.html.erb
+++ b/app/views/claims/schools/_grant_conditions.html.erb
@@ -23,13 +23,11 @@
 
       <h2 class="govuk-heading-m" id="introduction">1. Introduction</h2>
       <p class="govuk-body">
-        As detailed in the <%= govuk_link_to("initial teacher training reform guidance", "https://www.gov.uk/government/publications/initial-teacher-training-reform-funding-guidance") %> in the 2025/26 academic year (between 1 September 2025 and 31 August 2026), mentors working in schools that offer initial teacher training (ITT) placements will need to complete up to 16 hours of initial mentor training with an accredited training provider.
+        As detailed in the  <%= govuk_link_to("initial teacher training reform guidance", "https://assets.publishing.service.gov.uk/media/68caba76c6df905ce77084dc/Initial_teacher_training_ITT_delivery_funding_guidance_2025_to_2026.pdf") %> in the 2025/26 academic year (between 1 September 2025 and 31 August 2026), mentors working in schools that offer initial teacher training (ITT) placements will need to complete sufficient training with an accredited training provider to ensure that they can effectively support a trainee teacher to obtain the knowledge and skills they need to complete their initial teacher training (ITT) school placement.
       </p>
+
       <p class="govuk-body">
-        Schools can claim for the actual hours of training undertaken by the mentor to a maximum of 16 hours, per accredited provider. <%= govuk_link_to "Guidance explaining the general mentor training", "https://www.gov.uk/government/publications/initial-teacher-training-reform-funding-guidance" %>, in addition to the lead mentor and intensive training and practice element of the ITT curriculum was updated in March 2024.
-      </p>
-      <p class="govuk-body">
-        <%= govuk_link_to("Guidance explaining what schools need to do to offer ITT placements", "https://www.gov.uk/guidance/offer-a-trainee-teacher-placement") %> from September 2024, was published in November 2023.
+        Schools can claim for the actual hours of training undertaken by the mentor to a maximum of 16 hours, per accredited provider. Additional <%= govuk_link_to("guidance", "https://www.gov.uk/government/publications/initial-teacher-training-reform-funding-guidance-2025-to-2026") %> on the general mentor training grant, as well as the lead mentor and intensive training and practice (ITAP) grants was updated in September 2025.
       </p>
 
       <h2 class="govuk-heading-m" id="details-of-the-grant">2. Details of the grant</h2>

--- a/app/views/claims/schools/_grant_conditions.html.erb
+++ b/app/views/claims/schools/_grant_conditions.html.erb
@@ -23,10 +23,10 @@
 
       <h2 class="govuk-heading-m" id="introduction">1. Introduction</h2>
       <p class="govuk-body">
-        As detailed in the <%= govuk_link_to("initial teacher training reform guidance", "https://www.gov.uk/government/publications/initial-teacher-training-reform-funding-guidance") %> in the 2024/25 academic year (between 1 September 2024 and 31 August 2025), mentors working in schools that offer initial teacher training (ITT) placements will need to complete up to 20 hours of initial mentor training with an accredited training provider.
+        As detailed in the <%= govuk_link_to("initial teacher training reform guidance", "https://www.gov.uk/government/publications/initial-teacher-training-reform-funding-guidance") %> in the 2025/26 academic year (between 1 September 2025 and 31 August 2026), mentors working in schools that offer initial teacher training (ITT) placements will need to complete up to 16 hours of initial mentor training with an accredited training provider.
       </p>
       <p class="govuk-body">
-        Schools can claim for the actual hours of training undertaken by the mentor to a maximum of 20 hours, per accredited provider. <%= govuk_link_to "Guidance explaining the general mentor training", "https://www.gov.uk/government/publications/initial-teacher-training-reform-funding-guidance" %>, in addition to the lead mentor and intensive training and practice element of the ITT curriculum was updated in March 2024.
+        Schools can claim for the actual hours of training undertaken by the mentor to a maximum of 16 hours, per accredited provider. <%= govuk_link_to "Guidance explaining the general mentor training", "https://www.gov.uk/government/publications/initial-teacher-training-reform-funding-guidance" %>, in addition to the lead mentor and intensive training and practice element of the ITT curriculum was updated in March 2024.
       </p>
       <p class="govuk-body">
         <%= govuk_link_to("Guidance explaining what schools need to do to offer ITT placements", "https://www.gov.uk/guidance/offer-a-trainee-teacher-placement") %> from September 2024, was published in November 2023.
@@ -43,8 +43,8 @@
       <p class="govuk-body">This funding applies to schools that:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>offer placements to ITT trainees, including special schools, pupil referral units, independent schools, early years settings and further education organisations</li>
-        <li>have mentors working with ITT trainees who started or returned to their training at any time between 1 September 2024 and 31 May 2025 (1 June 2024 for apprenticeship trainees)</li>
-        <li>have mentors that intended to work with ITT trainees who would have started their training any time between 1 September 2024 and 31 May 2025 (1 June for apprenticeship trainees), but the provider was unable to place the trainee/ the trainee withdrew after the mentor training took place.</li>
+        <li>have mentors working with ITT trainees who started or returned to their training at any time between 1 September 2025 and 31 May 2026 (1 June 2025 for apprenticeship trainees)</li>
+        <li>have mentors that intended to work with ITT trainees who would have started their training any time between 1 September 2025 and 31 May 2026 (1 June for apprenticeship trainees), but the provider was unable to place the trainee/ the trainee withdrew after the mentor training took place.</li>
       </ul>
 
       <h2 class="govuk-heading-m" id="eligibility">3. Eligibility</h2>
@@ -56,15 +56,15 @@
       <h3 class="govuk-heading-s">School location</h3>
       <p class="govuk-body">Only educational organisations located in England are eligible to apply for this grant funding.</p>
       <h3 class="govuk-heading-s">Mentors who cannot continue with mentoring</h3>
-      <p class="govuk-body">A school can claim funding when a mentor starts their initial training between 6 April 2024 and 31 May 2025, begins mentoring a trainee but then cannot continue mentoring for any reason. The school should arrange a new mentor for the trainee. The school can claim funding for both mentors if they both started their training between 6 April 2024 and 31 May 2025.</p>
+      <p class="govuk-body">A school can claim funding when a mentor starts their initial training between 6 April 2025 and 31 May 2026, begins mentoring a trainee but then cannot continue mentoring for any reason. The school should arrange a new mentor for the trainee. The school can claim funding for both mentors if they both started their training between 6 April 2025 and 31 May 2026.</p>
       <h3 class="govuk-heading-s">Mentors training with different providers</h3>
       <p class="govuk-body">Each accredited ITT provider can develop their own mentor training, which can result in different training for mentors working with different providers. If a school hosts trainees from different providers, a mentor might have to undertake their initial mentor training with each provider, but accredited ITT providers should consider prior training when deciding what aspects of their mentor training a mentor should complete.</p>
       <p class="govuk-body">Schools can claim funding for the time a mentor spends training at each provider.</p>
-      <p class="govuk-body">For schools to claim this funding, a mentor must have worked with a trainee who started or intended to start their ITT in the 2024/25 academic year (between 1 September 2024 and 31 May 2025, 1 June 2024 for apprenticeship trainees). Schools must ensure a trainee has one dedicated mentor during their placement (unless the mentor works in a job-share). Other teachers may support elements of the trainee’s placement, but schools can only claim funding for the training time of the trainee’s dedicated mentor.</p>
+      <p class="govuk-body">For schools to claim this funding, a mentor must have worked with a trainee who started or intended to start their ITT in the 2025/26 academic year (between 1 September 2025 and 31 May 2026, 1 June 2025 for apprenticeship trainees). Schools must ensure a trainee has one dedicated mentor during their placement (unless the mentor works in a job-share). Other teachers may support elements of the trainee’s placement, but schools can only claim funding for the training time of the trainee’s dedicated mentor.</p>
       <p class="govuk-body">This funding is not available to schools if a mentor only works with high potential initial teacher training (HPITT) trainees, as funding is provided separately for such mentors.</p>
       <h3 class="govuk-heading-s">Mentors working with multiple schools</h3>
-      <p class="govuk-body">Mentors can work with multiple schools while undertaking their training. For example, if a mentor is working across multiple schools in a trust then those schools can only claim for a total of 20 hours of funding per mentor with a single accredited ITT provider.</p>
-      <p class="govuk-body">For instance, if school A claimed 10 hours of funding for mentor A, with provider A, then school B could only claim 10 hours for mentor A, with provider A. If school A claimed 20 hours of funding for mentor A, with provider A, then school B could not claim any funding for mentor A with provider A.</p>
+      <p class="govuk-body">Mentors can work with multiple schools while undertaking their training. For example, if a mentor is working across multiple schools in a trust then those schools can only claim for a total of 16 hours of funding per mentor with a single accredited ITT provider.</p>
+      <p class="govuk-body">For instance, if school A claimed 10 hours of funding for mentor A, with provider A, then school B could only claim 6 hours for mentor A, with provider A. If school A claimed 16 hours of funding for mentor A, with provider A, then school B could not claim any funding for mentor A with provider A.</p>
       <h3 class="govuk-heading-s">Trainees that defer or withdraw from their training</h3>
       <p class="govuk-body">Schools can claim mentor funding if a mentor works with a trainee who:</p>
       <ul class="govuk-list govuk-list--bullet">
@@ -76,9 +76,9 @@
       <p class="govuk-body">If a trainee withdraws mid-year, the school, accredited provider and the mentor can decide whether the mentor completes the training. The school can claim funding for the total amount of training undertaken.</p>
 
       <h2 class="govuk-heading-m" id="conditions-of-this-funding">4. Conditions of this funding</h2>
-      <p class="govuk-body">Schools will be able to claim this funding at the end of the 2024/25 academic year and will be paid in arrears between September 2025 and January 2026. When schools make a claim, DfE will not ask for evidence where the information provided can be validated through its services including, but not limited to, Publish teacher training courses, Register trainee teachers and Get information about schools. Where this information cannot be validated, as part of the claim process, DfE may ask for evidence of:</p>
+      <p class="govuk-body">Schools will be able to claim this funding at the end of the 2025/26 academic year and will be paid in arrears between September 2026 and January 2027. When schools make a claim, DfE will not ask for evidence where the information provided can be validated through its services including, but not limited to, Publish teacher training courses, Register trainee teachers and Get information about schools. Where this information cannot be validated, as part of the claim process, DfE may ask for evidence of:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>a mentor’s employment at the school, such as a copy of their employment contract or payslips from the 2024/25 academic year</li>
+        <li>a mentor’s employment at the school, such as a copy of their employment contract or payslips from the 2025/26 academic year</li>
         <li>arranging placements at their school for ITT trainees, such as communication with providers</li>
         <li>the number of hours of initial mentor training completed</li>
         <li>the accredited provider and lead mentor who delivered the training</li>
@@ -94,10 +94,10 @@
       <p class="govuk-body">For a school to claim this funding, the mentor must:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>be employed by the school making the claim</li>
-        <li>undertake up to 20 hours of initial mentor training, per accredited ITT provider</li>
+        <li>undertake up to 16 hours of initial mentor training, per accredited ITT provider</li>
         <li>mentor at least one trainee, or intended to mentor a trainee (as evidenced by schools arranging placements for ITT trainees at their schools)</li>
       </ul>
-      <p class="govuk-body">Mentor training typically takes place at the start of the academic year or during the preceding summer term. In some instances, training can take place later than the start of the autumn term due to some courses starting later. Mentors can start their initial mentor training between 6 April 2024 and 31 May 2025 for courses starting in the 2024/25 academic year.</p>
+      <p class="govuk-body">Mentor training typically takes place at the start of the academic year or during the preceding summer term. In some instances, training can take place later than the start of the autumn term due to some courses starting later. Mentors can start their initial mentor training between 6 April 2025 and 31 May 2026 for courses starting in the 2025/26 academic year.</p>
       <p class="govuk-body">To claim funding for training that began in advance of the 24/25 academic year, schools may need to provide evidence of agreeing to host placements at their school for ITT trainees, such as communication with providers to organise this. This evidence may be requested where a mentor did not mentor a trainee during the academic year.</p>
       <p class="govuk-body">Schools can only claim funding for one mentor per trainee, unless the mentor withdraws. If the mentor role is undertaken by staff on a job-share basis then the school can claim full funding for both staff members.</p>
       <p class="govuk-body">The funding can be used to cover costs incurred by the school in implementing the general mentor role, including backfill of the mentor whilst they were training.</p>
@@ -107,11 +107,11 @@
       <p class="govuk-body">The amount of funding schools will receive depends on:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>the location of the school (recognising the different costs in different areas of the country)</li>
-        <li>how many hours a mentor has spent training (which can be up to a maximum of 20 hours, per accredited ITT provider)</li>
+        <li>how many hours a mentor has spent training (which can be up to a maximum of 16 hours, per accredited ITT provider)</li>
       </ul>
       <p class="govuk-body">Check the location of your school in <a href="#annex-a--definition-of-areas">Annex A</a>.</p>
-      <p class="govuk-body">For each mentor that completes the full 20 hours of training, the table below sets out how much a school can claim.</p>
-      <p class="govuk-body">If a mentor undertakes fewer than 20 hours of training, the funding is calculated per hour. For example, if a mentor in a school outside London completed 10 hours of training, the school can claim £438. This is calculated at £43.80 (per hour) x 10 (hours of training).</p>
+      <p class="govuk-body">For each mentor that completes the full 16 hours of training, the table below sets out how much a school can claim.</p>
+      <p class="govuk-body">If a mentor undertakes fewer than 16 hours of training, the funding is calculated per hour. For example, if a mentor in a school outside London completed 10 hours of training, the school can claim £438. This is calculated at £43.80 (per hour) x 10 (hours of training).</p>
 
       <%= app_table do |table| %>
         <% table.with_head do |head| %>
@@ -129,22 +129,22 @@
               Up to £876 (£43.80 per hour) — for schools outside London (the rest of England)<br><br>Up to £902 (£45.10 per hour) — for schools in the fringe region (the area between Outer London and the rest of England)<br><br>Up to £965 (£48.25 per hour) — for schools in Outer London<br><br>Up to £1,072 (£53.60 per hour) — for schools in Inner London
             <% end %>
             <% row.with_cell do %>
-              Academic year 2024/25
+              Academic year 2025/26
             <% end %>
             <% row.with_cell do %>
               Schools who host ITT trainees
             <% end %>
             <% row.with_cell do %>
-              Payments will be made in arrears based on the number of hours of training<br><br>Schools will be able to claim this funding at the end of the 2024/25 academic year
+              Payments will be made in arrears based on the number of hours of training<br><br>Schools will be able to claim this funding at the end of the 2025/26 academic year
             <% end %>
           <% end %>
         <% end %>
       <% end %>
 
       <h2 class="govuk-heading-m" id="payments">6. Payments</h2>
-      <p class="govuk-body">Payments will be made in arrears from September 2025. Schools will be able to submit a claim via a new GOV.UK service. The service will open in May 2025 and schools will be able to submit their claims once their mentors have completed their training.</p>
-      <p class="govuk-body">Schools must complete their claims by the end of July to receive payment from the payer in late September/early October. If schools miss the payment window, they will be able to submit a claim in September, with payment being made in December 2025.</p>
-      <p class="govuk-body">DfE will begin communicating details of this new service to schools and providers from September 2024.</p>
+      <p class="govuk-body">Payments will be made in arrears from September 2026. Schools will be able to submit a claim via a new GOV.UK service. The service will open in May 2026 and schools will be able to submit their claims once their mentors have completed their training.</p>
+      <p class="govuk-body">Schools must complete their claims by the end of July to receive payment from the payer in late September/early October. If schools miss the payment window, they will be able to submit a claim in September, with payment being made in December 2026.</p>
+      <p class="govuk-body">DfE will begin communicating details of this new service to schools and providers from September 2025.</p>
       <p class="govuk-body">If you would like additional information about the payments email <%= govuk_mail_to(t("claims.support_email")) %>.</p>
 
       <h2 class="govuk-heading-m" id="variation">7. Variation</h2>

--- a/app/views/wizards/claims/add_claim_wizard/_no_mentors_step.html.erb
+++ b/app/views/wizards/claims/add_claim_wizard/_no_mentors_step.html.erb
@@ -8,7 +8,8 @@
     <h1 class="govuk-heading-l"><%= t(".heading_empty", provider_name: @wizard.provider_name) %></h1>
 
     <p class="govuk-body">
-      <%= t(".no_mentors_with_claimable_hours", provider_name: @wizard.provider_name) %>
+      <%= t(".no_mentors_with_claimable_hours", provider_name: @wizard.provider_name,
+                                                num_initial_hours: Claims::TrainingHours.for(training_type: :initial, academic_year: AcademicYear.current)) %>
     </p>
 
     <p class="govuk-body">

--- a/app/views/wizards/claims/add_claim_wizard/_no_mentors_step.html.erb
+++ b/app/views/wizards/claims/add_claim_wizard/_no_mentors_step.html.erb
@@ -9,7 +9,7 @@
 
     <p class="govuk-body">
       <%= t(".no_mentors_with_claimable_hours", provider_name: @wizard.provider_name,
-                                                num_initial_hours: Claims::TrainingHours.for(training_type: :initial, academic_year: AcademicYear.current)) %>
+                                                num_initial_hours: Claims::TrainingHours.for(training_type: :initial, academic_year: @wizard.academic_year)) %>
     </p>
 
     <p class="govuk-body">

--- a/app/views/wizards/claims/invalid_provider_wizard/_unable_to_assign_provider_step.html.erb
+++ b/app/views/wizards/claims/invalid_provider_wizard/_unable_to_assign_provider_step.html.erb
@@ -10,8 +10,7 @@
     </p>
 
     <p class="govuk-body">
-      <%= t(".mentors_on_this_claim_have_already_claimed", provider_name: current_step.provider.name, num_initial_hours: Claims::TrainingHours.for(training_type: :initial, academic_year: AcademicYear.current)) %>
-    </p>
+      <%= t(".mentors_on_this_claim_have_already_claimed", provider_name: current_step.provider.name, num_initial_hours: Claims::TrainingHours.for(training_type: :initial, academic_year: current_step.claim.claim_window.academic_year)) %>    </p>
 
     <p class="govuk-body">
       <%= embedded_link_text(

--- a/app/views/wizards/claims/invalid_provider_wizard/_unable_to_assign_provider_step.html.erb
+++ b/app/views/wizards/claims/invalid_provider_wizard/_unable_to_assign_provider_step.html.erb
@@ -10,7 +10,7 @@
     </p>
 
     <p class="govuk-body">
-      <%= t(".mentors_on_this_claim_have_already_claimed", provider_name: current_step.provider.name) %>
+      <%= t(".mentors_on_this_claim_have_already_claimed", provider_name: current_step.provider.name, num_initial_hours: Claims::TrainingHours.for(training_type: :initial, academic_year: AcademicYear.current)) %>
     </p>
 
     <p class="govuk-body">

--- a/app/wizards/claims/add_claim_wizard/mentor_training_step.rb
+++ b/app/wizards/claims/add_claim_wizard/mentor_training_step.rb
@@ -57,7 +57,10 @@ class Claims::AddClaimWizard::MentorTrainingStep < BaseStep
     if training_allowance.training_type == :initial
       I18n.t("wizards.claims.add_claim_wizard.mentor_training_step.initial_hours_of_training_hint", mentor_full_name:, mentor_trn:, remaining_hours:)
     else
-      I18n.t("wizards.claims.add_claim_wizard.mentor_training_step.refresher_hours_of_training_hint", mentor_full_name:, mentor_trn:, remaining_hours:)
+      I18n.t("wizards.claims.add_claim_wizard.mentor_training_step.refresher_hours_of_training_hint",
+             mentor_full_name:,
+             mentor_trn:, remaining_hours:,
+             num_initial_hours: Claims::TrainingHours.for(training_type: :initial, academic_year: AcademicYear.current))
     end
   end
 

--- a/app/wizards/claims/add_claim_wizard/mentor_training_step.rb
+++ b/app/wizards/claims/add_claim_wizard/mentor_training_step.rb
@@ -60,7 +60,7 @@ class Claims::AddClaimWizard::MentorTrainingStep < BaseStep
       I18n.t("wizards.claims.add_claim_wizard.mentor_training_step.refresher_hours_of_training_hint",
              mentor_full_name:,
              mentor_trn:, remaining_hours:,
-             num_initial_hours: Claims::TrainingHours.for(training_type: :initial, academic_year: AcademicYear.current))
+             num_initial_hours: Claims::TrainingHours.for(training_type: :initial, academic_year: @wizard.academic_year))
     end
   end
 

--- a/config/locales/en/components/claims/add_claim_wizard/mentor_step/disclaimer_component.yml
+++ b/config/locales/en/components/claims/add_claim_wizard/mentor_step/disclaimer_component.yml
@@ -6,6 +6,6 @@ en:
           disclaimer_component:
             disclaimer_foreword: You must %{mentors_link} before they can be associated with a claim.
             add_mentors: add mentors
-            disclaimer: If a mentor you have added is not showing in the list, they have already claimed 20 hours with %{provider_name}.
+            disclaimer: If a mentor you have added is not showing in the list, they have already claimed %{num_initial_hours} hours with %{provider_name}.
             disclaimer_contact: If you think this is a mistake, contact %{email_link}.
             mentor_not_listed: My mentor is not listed

--- a/config/locales/en/wizards/claims/add_claim_wizard.yml
+++ b/config/locales/en/wizards/claims/add_claim_wizard.yml
@@ -32,7 +32,7 @@ en:
           number_of_hours: Number of hours
           warning: You can only claim for the time spent becoming an initial teacher training (ITT) mentor. This funding is not available for training early career framework (ECF) mentors.
           initial_hours_of_training_hint: "%{mentor_full_name} (TRN %{mentor_trn}) is eligible for %{remaining_hours} hours of training."
-          refresher_hours_of_training_hint: "%{mentor_full_name} (TRN %{mentor_trn}) is eligible for %{remaining_hours} hours of refresher training as they have previously claimed up 20 hours of mentor training."
+          refresher_hours_of_training_hint: "%{mentor_full_name} (TRN %{mentor_trn}) is eligible for %{remaining_hours} hours of refresher training as they have previously claimed up to %{num_initial_hours} hours of mentor training."
         check_your_answers_step:
           page_title: Check your answers before submitting your claim - %{contextual_text}
           title: Check your answers before submitting your claim
@@ -57,5 +57,5 @@ en:
         no_mentors_step:
           page_title: No mentors for %{provider_name} - %{contextual_text}
           heading_empty: No mentors for %{provider_name}
-          no_mentors_with_claimable_hours: There are no mentors you can include in a claim because they have already had 20 hours of training claimed for with %{provider_name}.
+          no_mentors_with_claimable_hours: There are no mentors you can include in a claim because they have already had %{num_initial_hours} hours of training claimed for with %{provider_name}.
           change_provider: Change the accredited provider

--- a/config/locales/en/wizards/claims/invalid_provider_wizard.yml
+++ b/config/locales/en/wizards/claims/invalid_provider_wizard.yml
@@ -9,8 +9,8 @@ en:
           can_not_assign_provider:
             You can not assign this claim to %{provider_name}.
           mentors_on_this_claim_have_already_claimed:
-            There are mentors included in this claim who have already had 20 hours of training,
-            or will exceed 20 hours of training, claimed for with Best Practice Network.
+            There are mentors included in this claim who have already had %{num_initial_hours} hours of training,
+            or will exceed %{num_initial_hours} hours of training, claimed for with %{provider_name}.
           you_may_need_to_delete_this_claim:
             You may need to %{link} and submit another claim for %{provider_name}, or another provider.
           delete_this_claim: delete this claim

--- a/spec/factories/academic_years.rb
+++ b/spec/factories/academic_years.rb
@@ -12,14 +12,14 @@
 FactoryBot.define do
   factory :academic_year do
     trait :current do
-      starts_on { Date.parse("1 September #{Date.current.year - 1}") }
-      ends_on { Date.parse("31 August #{Date.current.year}") }
+      starts_on { Date.parse("1 September 2024") }
+      ends_on { Date.parse("31 August 2025") }
       name { "#{starts_on.year} to #{ends_on.year}" }
     end
 
     trait :historic do
-      starts_on { Date.parse("1 September #{Date.current.year - 2}") }
-      ends_on { Date.parse("31 August #{Date.current.year - 1}") }
+      starts_on { Date.parse("1 September 2023") }
+      ends_on { Date.parse("31 August 2024") }
       name { "#{starts_on.year} to #{ends_on.year}" }
     end
   end

--- a/spec/factories/claims/claim_windows.rb
+++ b/spec/factories/claims/claim_windows.rb
@@ -21,7 +21,7 @@
 #
 FactoryBot.define do
   factory :claim_window, class: "Claims::ClaimWindow" do
-    academic_year { AcademicYear.for_date(Date.current) }
+    academic_year { AcademicYear.for_date(Date.new(2024, 1, 1)) }
 
     trait :current do
       starts_on { 2.days.ago }
@@ -31,7 +31,7 @@ FactoryBot.define do
     trait :historic do
       starts_on { 2.years.ago }
       ends_on { starts_on + 2.months }
-      academic_year { AcademicYear.for_date(starts_on) }
+      academic_year { AcademicYear.for_date(Date.new(2023, 1, 1)) }
     end
 
     trait :upcoming do

--- a/spec/models/claims/training_allowance_spec.rb
+++ b/spec/models/claims/training_allowance_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe Claims::TrainingAllowance, type: :model do
           end
         end
 
-        context "when the mentor has completed 20 hours of training in the current academic year" do
+        context "when the mentor has completed 16 hours of training in the current academic year" do
           let(:hours_completed) { 16 }
 
           it "returns the expected results" do

--- a/spec/models/claims/training_allowance_spec.rb
+++ b/spec/models/claims/training_allowance_spec.rb
@@ -6,113 +6,231 @@ RSpec.describe Claims::TrainingAllowance, type: :model do
   let(:claim_to_exclude) { nil }
   let!(:mentor) { create(:claims_mentor) }
   let!(:provider) { create(:claims_provider) }
-  let!(:academic_year) do
-    create(:academic_year,
-           starts_on: Date.parse("1 September 2019"),
-           ends_on: Date.parse("31 August 2020"),
-           name: "2019 to 2020")
-  end
-  let!(:previous_academic_year) do
-    create(:academic_year,
-           starts_on: Date.parse("1 September 2018"),
-           ends_on: Date.parse("31 August 2019"),
-           name: "2018 to 2019")
-  end
 
   describe "initial training" do
-    let(:claim_window) { build(:claim_window, :current, academic_year:) }
-    let(:claim) { build(:claim, :submitted, claim_window:) }
-    let(:mentor_training) { create(:mentor_training, mentor:, provider:, claim:, hours_completed:) }
-
-    context "when the mentor has not completed any training for the academic year" do
-      it "returns the expected results" do
-        expect(training_allowance.training_type).to eq(:initial)
-        expect(training_allowance.total_hours).to eq(20)
-        expect(training_allowance.remaining_hours).to eq(20)
-        expect(training_allowance).to be_available
+    context "when the claim is made before 2026" do
+      let!(:academic_year) do
+        create(:academic_year,
+               starts_on: Date.parse("1 September 2019"),
+               ends_on: Date.parse("31 August 2020"),
+               name: "2019 to 2020")
       end
-    end
-
-    context "when an internal draft claim exists and the mentor has not completed any training for the academic year" do
-      let(:internal_draft_claim) { build(:claim, status: :internal_draft, claim_window:) }
-
-      before do
-        create(:mentor_training, mentor:, provider:, claim: internal_draft_claim, hours_completed: 1)
+      let(:previous_academic_year) do
+        create(:academic_year,
+               starts_on: Date.parse("1 September 2018"),
+               ends_on: Date.parse("31 August 2019"),
+               name: "2018 to 2019")
       end
+      let(:claim_window) { build(:claim_window, :current, academic_year:) }
+      let(:claim) { build(:claim, :submitted, claim_window:) }
+      let(:mentor_training) { create(:mentor_training, mentor:, provider:, claim:, hours_completed:) }
 
-      it "does not include the internal draft claim" do
-        expect(training_allowance.training_type).to eq(:initial)
-        expect(training_allowance.total_hours).to eq(20)
-        expect(training_allowance.remaining_hours).to eq(20)
-        expect(training_allowance).to be_available
-      end
-    end
+      before { previous_academic_year }
 
-    context "when the mentor has completed training for the academic year" do
-      before { mentor_training }
-
-      context "when the mentor has completed 5 hours of training in the current academic year" do
-        let(:hours_completed) { 5 }
-
-        it "returns the expected results" do
-          expect(training_allowance.training_type).to eq(:initial)
-          expect(training_allowance.total_hours).to eq(20)
-          expect(training_allowance.remaining_hours).to eq(15)
-          expect(training_allowance).to be_available
-        end
-      end
-
-      context "when the mentor has completed 20 hours of training in the current academic year" do
-        let(:hours_completed) { 20 }
-
-        it "returns the expected results" do
-          expect(training_allowance.training_type).to eq(:initial)
-          expect(training_allowance.total_hours).to eq(20)
-          expect(training_allowance.remaining_hours).to eq(0)
-          expect(training_allowance).not_to be_available
-        end
-      end
-
-      context "when the mentor has completed 10 hours of training in the current academic year for a claim they want to exclude" do
-        let(:hours_completed) { 10 }
-        let(:claim_to_exclude) { claim }
-
+      context "when the mentor has not completed any training for the academic year" do
         it "returns the expected results" do
           expect(training_allowance.training_type).to eq(:initial)
           expect(training_allowance.total_hours).to eq(20)
           expect(training_allowance.remaining_hours).to eq(20)
           expect(training_allowance).to be_available
         end
+      end
 
-        context "when a second claim has been made whilst excluding a previous claim" do
-          let(:second_claim) { build(:claim, :submitted, claim_window:, provider:) }
-          let(:second_mentor_training) { create(:mentor_training, mentor:, provider:, claim: second_claim, hours_completed: 3) }
+      context "when an internal draft claim exists and the mentor has not completed any training for the academic year" do
+        let(:internal_draft_claim) { build(:claim, status: :internal_draft, claim_window:) }
 
-          before do
-            second_mentor_training
-          end
+        before do
+          create(:mentor_training, mentor:, provider:, claim: internal_draft_claim, hours_completed: 1)
+        end
 
-          it "does not exclude other claims" do
+        it "does not include the internal draft claim" do
+          expect(training_allowance.training_type).to eq(:initial)
+          expect(training_allowance.total_hours).to eq(20)
+          expect(training_allowance.remaining_hours).to eq(20)
+          expect(training_allowance).to be_available
+        end
+      end
+
+      context "when the mentor has completed training for the academic year" do
+        before { mentor_training }
+
+        context "when the mentor has completed 5 hours of training in the current academic year" do
+          let(:hours_completed) { 5 }
+
+          it "returns the expected results" do
             expect(training_allowance.training_type).to eq(:initial)
             expect(training_allowance.total_hours).to eq(20)
-            expect(training_allowance.remaining_hours).to eq(17)
+            expect(training_allowance.remaining_hours).to eq(15)
             expect(training_allowance).to be_available
           end
         end
 
-        context "when a second claim has been paid whilst excluding a previous claim" do
-          let(:second_claim) { build(:claim, :paid, claim_window:, provider:) }
-          let(:second_mentor_training) { create(:mentor_training, mentor:, provider:, claim: second_claim, hours_completed: 3) }
+        context "when the mentor has completed 20 hours of training in the current academic year" do
+          let(:hours_completed) { 20 }
 
-          before do
-            second_mentor_training
-          end
-
-          it "does not exclude other claims" do
+          it "returns the expected results" do
             expect(training_allowance.training_type).to eq(:initial)
             expect(training_allowance.total_hours).to eq(20)
-            expect(training_allowance.remaining_hours).to eq(17)
+            expect(training_allowance.remaining_hours).to eq(0)
+            expect(training_allowance).not_to be_available
+          end
+        end
+
+        context "when the mentor has completed 10 hours of training in the current academic year for a claim they want to exclude" do
+          let(:hours_completed) { 10 }
+          let(:claim_to_exclude) { claim }
+
+          it "returns the expected results" do
+            expect(training_allowance.training_type).to eq(:initial)
+            expect(training_allowance.total_hours).to eq(20)
+            expect(training_allowance.remaining_hours).to eq(20)
             expect(training_allowance).to be_available
+          end
+
+          context "when a second claim has been made whilst excluding a previous claim" do
+            let(:second_claim) { build(:claim, :submitted, claim_window:, provider:) }
+            let(:second_mentor_training) { create(:mentor_training, mentor:, provider:, claim: second_claim, hours_completed: 3) }
+
+            before do
+              second_mentor_training
+            end
+
+            it "does not exclude other claims" do
+              expect(training_allowance.training_type).to eq(:initial)
+              expect(training_allowance.total_hours).to eq(20)
+              expect(training_allowance.remaining_hours).to eq(17)
+              expect(training_allowance).to be_available
+            end
+          end
+
+          context "when a second claim has been paid whilst excluding a previous claim" do
+            let(:second_claim) { build(:claim, :paid, claim_window:, provider:) }
+            let(:second_mentor_training) { create(:mentor_training, mentor:, provider:, claim: second_claim, hours_completed: 3) }
+
+            before do
+              second_mentor_training
+            end
+
+            it "does not exclude other claims" do
+              expect(training_allowance.training_type).to eq(:initial)
+              expect(training_allowance.total_hours).to eq(20)
+              expect(training_allowance.remaining_hours).to eq(17)
+              expect(training_allowance).to be_available
+            end
+          end
+        end
+      end
+    end
+
+    context "when the claim is made after 2026" do
+      let!(:academic_year) do
+        create(:academic_year,
+               starts_on: Date.parse("1 September 2026"),
+               ends_on: Date.parse("31 August 2027"),
+               name: "2026 to 2027")
+      end
+      let(:previous_academic_year) do
+        create(:academic_year,
+               starts_on: Date.parse("1 September 2025"),
+               ends_on: Date.parse("31 August 2026"),
+               name: "2025 to 2026")
+      end
+      let(:claim_window) { build(:claim_window, :current, academic_year:) }
+      let(:claim) { build(:claim, :submitted, claim_window:) }
+      let(:mentor_training) { create(:mentor_training, mentor:, provider:, claim:, hours_completed:) }
+
+      before { previous_academic_year }
+
+      context "when the mentor has not completed any training for the academic year" do
+        it "returns the expected results" do
+          expect(training_allowance.training_type).to eq(:initial)
+          expect(training_allowance.total_hours).to eq(16)
+          expect(training_allowance.remaining_hours).to eq(16)
+          expect(training_allowance).to be_available
+        end
+      end
+
+      context "when an internal draft claim exists and the mentor has not completed any training for the academic year" do
+        let(:internal_draft_claim) { build(:claim, status: :internal_draft, claim_window:) }
+
+        before do
+          create(:mentor_training, mentor:, provider:, claim: internal_draft_claim, hours_completed: 1)
+        end
+
+        it "does not include the internal draft claim" do
+          expect(training_allowance.training_type).to eq(:initial)
+          expect(training_allowance.total_hours).to eq(16)
+          expect(training_allowance.remaining_hours).to eq(16)
+          expect(training_allowance).to be_available
+        end
+      end
+
+      context "when the mentor has completed training for the academic year" do
+        before { mentor_training }
+
+        context "when the mentor has completed 5 hours of training in the current academic year" do
+          let(:hours_completed) { 5 }
+
+          it "returns the expected results" do
+            expect(training_allowance.training_type).to eq(:initial)
+            expect(training_allowance.total_hours).to eq(16)
+            expect(training_allowance.remaining_hours).to eq(11)
+            expect(training_allowance).to be_available
+          end
+        end
+
+        context "when the mentor has completed 20 hours of training in the current academic year" do
+          let(:hours_completed) { 16 }
+
+          it "returns the expected results" do
+            expect(training_allowance.training_type).to eq(:initial)
+            expect(training_allowance.total_hours).to eq(16)
+            expect(training_allowance.remaining_hours).to eq(0)
+            expect(training_allowance).not_to be_available
+          end
+        end
+
+        context "when the mentor has completed 10 hours of training in the current academic year for a claim they want to exclude" do
+          let(:hours_completed) { 10 }
+          let(:claim_to_exclude) { claim }
+
+          it "returns the expected results" do
+            expect(training_allowance.training_type).to eq(:initial)
+            expect(training_allowance.total_hours).to eq(16)
+            expect(training_allowance.remaining_hours).to eq(16)
+            expect(training_allowance).to be_available
+          end
+
+          context "when a second claim has been made whilst excluding a previous claim" do
+            let(:second_claim) { build(:claim, :submitted, claim_window:, provider:) }
+            let(:second_mentor_training) { create(:mentor_training, mentor:, provider:, claim: second_claim, hours_completed: 3) }
+
+            before do
+              second_mentor_training
+            end
+
+            it "does not exclude other claims" do
+              expect(training_allowance.training_type).to eq(:initial)
+              expect(training_allowance.total_hours).to eq(16)
+              expect(training_allowance.remaining_hours).to eq(13)
+              expect(training_allowance).to be_available
+            end
+          end
+
+          context "when a second claim has been paid whilst excluding a previous claim" do
+            let(:second_claim) { build(:claim, :paid, claim_window:, provider:) }
+            let(:second_mentor_training) { create(:mentor_training, mentor:, provider:, claim: second_claim, hours_completed: 3) }
+
+            before do
+              second_mentor_training
+            end
+
+            it "does not exclude other claims" do
+              expect(training_allowance.training_type).to eq(:initial)
+              expect(training_allowance.total_hours).to eq(16)
+              expect(training_allowance.remaining_hours).to eq(13)
+              expect(training_allowance).to be_available
+            end
           end
         end
       end
@@ -120,109 +238,249 @@ RSpec.describe Claims::TrainingAllowance, type: :model do
   end
 
   describe "refresher training" do
-    let(:claim_window) { build(:claim_window, :current, academic_year:) }
-    let(:claim) { build(:claim, :submitted, claim_window:, provider:) }
-    let(:mentor_training) { create(:mentor_training, mentor:, provider:, claim:, hours_completed:) }
-
-    let(:previous_claim_window) { build(:claim_window, starts_on: 8.days.ago, ends_on: 4.days.ago, academic_year: previous_academic_year) }
-    let(:previous_claim) { build(:claim, :submitted, claim_window: previous_claim_window, provider:) }
-    let(:previous_mentor_training) { create(:mentor_training, mentor:, provider:, claim: previous_claim, hours_completed: 20) }
-
-    context "when the mentor has not completed any training for the academic year" do
-      before { previous_mentor_training }
-
-      it "returns the expected results" do
-        expect(training_allowance.training_type).to eq(:refresher)
-        expect(training_allowance.total_hours).to eq(6)
-        expect(training_allowance.remaining_hours).to eq(6)
-        expect(training_allowance).to be_available
+    context "when the claim is made before 2026" do
+      let!(:academic_year) do
+        create(:academic_year,
+               starts_on: Date.parse("1 September 2019"),
+               ends_on: Date.parse("31 August 2020"),
+               name: "2019 to 2020")
       end
-    end
-
-    context "when an internal draft claim exists and the mentor has not completed any training for the academic year" do
-      let(:internal_draft_claim) { build(:claim, status: :internal_draft, claim_window:) }
-
-      before do
-        previous_mentor_training
-        create(:mentor_training, mentor:, provider:, claim: internal_draft_claim, hours_completed: 1)
+      let(:previous_academic_year) do
+        create(:academic_year,
+               starts_on: Date.parse("1 September 2018"),
+               ends_on: Date.parse("31 August 2019"),
+               name: "2018 to 2019")
       end
+      let(:claim_window) { build(:claim_window, :current, academic_year:) }
+      let(:claim) { build(:claim, :submitted, claim_window:, provider:) }
+      let(:mentor_training) { create(:mentor_training, mentor:, provider:, claim:, hours_completed:) }
 
-      it "does not include the internal draft claim" do
-        expect(training_allowance.training_type).to eq(:refresher)
-        expect(training_allowance.total_hours).to eq(6)
-        expect(training_allowance.remaining_hours).to eq(6)
-        expect(training_allowance).to be_available
-      end
-    end
+      let(:previous_claim_window) { build(:claim_window, starts_on: 8.days.ago, ends_on: 4.days.ago, academic_year: previous_academic_year) }
+      let(:previous_claim) { build(:claim, :submitted, claim_window: previous_claim_window, provider:) }
+      let(:previous_mentor_training) { create(:mentor_training, mentor:, provider:, claim: previous_claim, hours_completed: 20) }
 
-    context "when the mentor has completed training for the academic year" do
-      before do
-        mentor_training
-        previous_mentor_training
-      end
+      before { previous_academic_year }
 
-      context "when the mentor has completed 5 hours of training in the current academic year and 20 hours in the previous academic year" do
-        let(:hours_completed) { 5 }
+      context "when the mentor has not completed any training for the academic year" do
+        before { previous_mentor_training }
 
         it "returns the expected results" do
-          expect(training_allowance.training_type).to eq(:refresher)
-          expect(training_allowance.total_hours).to eq(6)
-          expect(training_allowance.remaining_hours).to eq(1)
-          expect(training_allowance).to be_available
-        end
-      end
-
-      context "when the mentor has completed 6 hours of training in the current academic year and 20 hours in the previous academic year" do
-        let(:hours_completed) { 6 }
-
-        it "returns the expected results" do
-          expect(training_allowance.training_type).to eq(:refresher)
-          expect(training_allowance.total_hours).to eq(6)
-          expect(training_allowance.remaining_hours).to eq(0)
-          expect(training_allowance).not_to be_available
-        end
-      end
-
-      context "when the mentor has completed 3 hours of training in the current academic year and 20 hours in the previous academic year for a claim they want to exclude" do
-        let(:hours_completed) { 3 }
-        let(:claim_to_exclude) { claim }
-
-        it "excludes the excluded claim" do
           expect(training_allowance.training_type).to eq(:refresher)
           expect(training_allowance.total_hours).to eq(6)
           expect(training_allowance.remaining_hours).to eq(6)
           expect(training_allowance).to be_available
         end
+      end
 
-        context "when a second claim has been made whilst excluding a previous claim" do
-          let(:second_claim) { build(:claim, :submitted, claim_window:, provider:) }
-          let(:second_mentor_training) { create(:mentor_training, mentor:, provider:, claim: second_claim, hours_completed: 3) }
+      context "when an internal draft claim exists and the mentor has not completed any training for the academic year" do
+        let(:internal_draft_claim) { build(:claim, status: :internal_draft, claim_window:) }
 
-          before do
-            second_mentor_training
-          end
+        before do
+          previous_mentor_training
+          create(:mentor_training, mentor:, provider:, claim: internal_draft_claim, hours_completed: 1)
+        end
 
-          it "does not exclude other claims" do
+        it "does not include the internal draft claim" do
+          expect(training_allowance.training_type).to eq(:refresher)
+          expect(training_allowance.total_hours).to eq(6)
+          expect(training_allowance.remaining_hours).to eq(6)
+          expect(training_allowance).to be_available
+        end
+      end
+
+      context "when the mentor has completed training for the academic year" do
+        before do
+          mentor_training
+          previous_mentor_training
+        end
+
+        context "when the mentor has completed 5 hours of training in the current academic year and 20 hours in the previous academic year" do
+          let(:hours_completed) { 5 }
+
+          it "returns the expected results" do
             expect(training_allowance.training_type).to eq(:refresher)
             expect(training_allowance.total_hours).to eq(6)
-            expect(training_allowance.remaining_hours).to eq(3)
+            expect(training_allowance.remaining_hours).to eq(1)
             expect(training_allowance).to be_available
           end
         end
 
-        context "when a second claim has been paid whilst excluding a previous claim" do
-          let(:second_claim) { build(:claim, :paid, claim_window:, provider:) }
-          let(:second_mentor_training) { create(:mentor_training, mentor:, provider:, claim: second_claim, hours_completed: 3) }
+        context "when the mentor has completed 6 hours of training in the current academic year and 20 hours in the previous academic year" do
+          let(:hours_completed) { 6 }
 
-          before do
-            second_mentor_training
-          end
-
-          it "does not exclude other claims" do
+          it "returns the expected results" do
             expect(training_allowance.training_type).to eq(:refresher)
             expect(training_allowance.total_hours).to eq(6)
-            expect(training_allowance.remaining_hours).to eq(3)
+            expect(training_allowance.remaining_hours).to eq(0)
+            expect(training_allowance).not_to be_available
+          end
+        end
+
+        context "when the mentor has completed 3 hours of training in the current academic year and 20 hours in the previous academic year for a claim they want to exclude" do
+          let(:hours_completed) { 3 }
+          let(:claim_to_exclude) { claim }
+
+          it "excludes the excluded claim" do
+            expect(training_allowance.training_type).to eq(:refresher)
+            expect(training_allowance.total_hours).to eq(6)
+            expect(training_allowance.remaining_hours).to eq(6)
             expect(training_allowance).to be_available
+          end
+
+          context "when a second claim has been made whilst excluding a previous claim" do
+            let(:second_claim) { build(:claim, :submitted, claim_window:, provider:) }
+            let(:second_mentor_training) { create(:mentor_training, mentor:, provider:, claim: second_claim, hours_completed: 3) }
+
+            before do
+              second_mentor_training
+            end
+
+            it "does not exclude other claims" do
+              expect(training_allowance.training_type).to eq(:refresher)
+              expect(training_allowance.total_hours).to eq(6)
+              expect(training_allowance.remaining_hours).to eq(3)
+              expect(training_allowance).to be_available
+            end
+          end
+
+          context "when a second claim has been paid whilst excluding a previous claim" do
+            let(:second_claim) { build(:claim, :paid, claim_window:, provider:) }
+            let(:second_mentor_training) { create(:mentor_training, mentor:, provider:, claim: second_claim, hours_completed: 3) }
+
+            before do
+              second_mentor_training
+            end
+
+            it "does not exclude other claims" do
+              expect(training_allowance.training_type).to eq(:refresher)
+              expect(training_allowance.total_hours).to eq(6)
+              expect(training_allowance.remaining_hours).to eq(3)
+              expect(training_allowance).to be_available
+            end
+          end
+        end
+      end
+    end
+
+    context "when the claim is made after 2026" do
+      let!(:academic_year) do
+        create(:academic_year,
+               starts_on: Date.parse("1 September 2026"),
+               ends_on: Date.parse("31 August 2027"),
+               name: "2026 to 2027")
+      end
+      let(:previous_academic_year) do
+        create(:academic_year,
+               starts_on: Date.parse("1 September 2025"),
+               ends_on: Date.parse("31 August 2026"),
+               name: "2025 to 2026")
+      end
+      let(:claim_window) { build(:claim_window, :current, academic_year:) }
+      let(:claim) { build(:claim, :submitted, claim_window:, provider:) }
+      let(:mentor_training) { create(:mentor_training, mentor:, provider:, claim:, hours_completed:) }
+
+      let(:previous_claim_window) { build(:claim_window, starts_on: 8.days.ago, ends_on: 4.days.ago, academic_year: previous_academic_year) }
+      let(:previous_claim) { build(:claim, :submitted, claim_window: previous_claim_window, provider:) }
+      let(:previous_mentor_training) { create(:mentor_training, mentor:, provider:, claim: previous_claim, hours_completed: 20) }
+
+      before { previous_academic_year }
+
+      context "when the mentor has not completed any training for the academic year" do
+        before { previous_mentor_training }
+
+        it "returns the expected results" do
+          expect(training_allowance.training_type).to eq(:refresher)
+          expect(training_allowance.total_hours).to eq(6)
+          expect(training_allowance.remaining_hours).to eq(6)
+          expect(training_allowance).to be_available
+        end
+      end
+
+      context "when an internal draft claim exists and the mentor has not completed any training for the academic year" do
+        let(:internal_draft_claim) { build(:claim, status: :internal_draft, claim_window:) }
+
+        before do
+          previous_mentor_training
+          create(:mentor_training, mentor:, provider:, claim: internal_draft_claim, hours_completed: 1)
+        end
+
+        it "does not include the internal draft claim" do
+          expect(training_allowance.training_type).to eq(:refresher)
+          expect(training_allowance.total_hours).to eq(6)
+          expect(training_allowance.remaining_hours).to eq(6)
+          expect(training_allowance).to be_available
+        end
+      end
+
+      context "when the mentor has completed training for the academic year" do
+        before do
+          mentor_training
+          previous_mentor_training
+        end
+
+        context "when the mentor has completed 5 hours of training in the current academic year and 20 hours in the previous academic year" do
+          let(:hours_completed) { 5 }
+
+          it "returns the expected results" do
+            expect(training_allowance.training_type).to eq(:refresher)
+            expect(training_allowance.total_hours).to eq(6)
+            expect(training_allowance.remaining_hours).to eq(1)
+            expect(training_allowance).to be_available
+          end
+        end
+
+        context "when the mentor has completed 6 hours of training in the current academic year and 20 hours in the previous academic year" do
+          let(:hours_completed) { 6 }
+
+          it "returns the expected results" do
+            expect(training_allowance.training_type).to eq(:refresher)
+            expect(training_allowance.total_hours).to eq(6)
+            expect(training_allowance.remaining_hours).to eq(0)
+            expect(training_allowance).not_to be_available
+          end
+        end
+
+        context "when the mentor has completed 3 hours of training in the current academic year and 20 hours in the previous academic year for a claim they want to exclude" do
+          let(:hours_completed) { 3 }
+          let(:claim_to_exclude) { claim }
+
+          it "excludes the excluded claim" do
+            expect(training_allowance.training_type).to eq(:refresher)
+            expect(training_allowance.total_hours).to eq(6)
+            expect(training_allowance.remaining_hours).to eq(6)
+            expect(training_allowance).to be_available
+          end
+
+          context "when a second claim has been made whilst excluding a previous claim" do
+            let(:second_claim) { build(:claim, :submitted, claim_window:, provider:) }
+            let(:second_mentor_training) { create(:mentor_training, mentor:, provider:, claim: second_claim, hours_completed: 3) }
+
+            before do
+              second_mentor_training
+            end
+
+            it "does not exclude other claims" do
+              expect(training_allowance.training_type).to eq(:refresher)
+              expect(training_allowance.total_hours).to eq(6)
+              expect(training_allowance.remaining_hours).to eq(3)
+              expect(training_allowance).to be_available
+            end
+          end
+
+          context "when a second claim has been paid whilst excluding a previous claim" do
+            let(:second_claim) { build(:claim, :paid, claim_window:, provider:) }
+            let(:second_mentor_training) { create(:mentor_training, mentor:, provider:, claim: second_claim, hours_completed: 3) }
+
+            before do
+              second_mentor_training
+            end
+
+            it "does not exclude other claims" do
+              expect(training_allowance.training_type).to eq(:refresher)
+              expect(training_allowance.total_hours).to eq(6)
+              expect(training_allowance.remaining_hours).to eq(3)
+              expect(training_allowance).to be_available
+            end
           end
         end
       end

--- a/spec/models/claims/training_allowance_spec.rb
+++ b/spec/models/claims/training_allowance_spec.rb
@@ -365,14 +365,14 @@ RSpec.describe Claims::TrainingAllowance, type: :model do
     context "when the claim is made after 2026" do
       let!(:academic_year) do
         create(:academic_year,
-               starts_on: Date.parse("1 September 2026"),
-               ends_on: Date.parse("31 August 2027"),
+               starts_on: Date.parse("1 September 2025"),
+               ends_on: Date.parse("31 August 2026"),
                name: "2026 to 2027")
       end
       let(:previous_academic_year) do
         create(:academic_year,
-               starts_on: Date.parse("1 September 2025"),
-               ends_on: Date.parse("31 August 2026"),
+               starts_on: Date.parse("1 September 2024"),
+               ends_on: Date.parse("31 August 2025"),
                name: "2025 to 2026")
       end
       let(:claim_window) { build(:claim_window, :current, academic_year:) }

--- a/spec/models/claims/training_hours_spec.rb
+++ b/spec/models/claims/training_hours_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe Claims::TrainingHours, type: :model do
+  subject(:training_hours) { described_class.new(academic_year:) }
+
+  context "when the academic year starts before 2026" do
+    let(:academic_year) do
+      create(:academic_year,
+             starts_on: Date.parse("1 September 2019"),
+             ends_on: Date.parse("31 August 2020"),
+             name: "2019 to 2020")
+    end
+
+    describe "#initial" do
+      it "returns the initial training hours" do
+        expect(training_hours.initial).to eq(20)
+      end
+    end
+
+    describe "#refresher" do
+      it "returns the refresher training hours" do
+        expect(training_hours.refresher).to eq(6)
+      end
+    end
+
+    describe ".for" do
+      it "returns the hours for the requested training type" do
+        expect(described_class.for(academic_year:, training_type: :initial)).to eq(20)
+        expect(described_class.for(academic_year:, training_type: :refresher)).to eq(6)
+      end
+    end
+  end
+
+  context "when the academic year starts in 2026 or later" do
+    let(:academic_year) do
+      create(:academic_year,
+             starts_on: Date.parse("1 September 2026"),
+             ends_on: Date.parse("31 August 2027"),
+             name: "2026 to 2027")
+    end
+
+    describe "#initial" do
+      it "returns the initial training hours" do
+        expect(training_hours.initial).to eq(16)
+      end
+    end
+
+    describe "#refresher" do
+      it "returns the refresher training hours" do
+        expect(training_hours.refresher).to eq(6)
+      end
+    end
+
+    describe ".for" do
+      it "returns the hours for the requested training type" do
+        expect(described_class.for(academic_year:, training_type: :initial)).to eq(16)
+        expect(described_class.for(academic_year:, training_type: :refresher)).to eq(6)
+      end
+    end
+  end
+end

--- a/spec/services/claims/claim/invalid_provider_notification_spec.rb
+++ b/spec/services/claims/claim/invalid_provider_notification_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe Claims::Claim::InvalidProviderNotification, type: :service do
   end
 
   describe "#call" do
+    let!(:current_academic_year) { AcademicYear.for_date(Date.current) }
+    let!(:current_claim_window) { create(:claim_window, :current, academic_year: current_academic_year) }
+
     let(:user) { build(:claims_user) }
     let(:other_user) { build(:claims_user) }
 
@@ -86,10 +89,10 @@ RSpec.describe Claims::Claim::InvalidProviderNotification, type: :service do
     end
 
     context "when there are invalid claims in previous academic years" do
-      let(:current_academic_year) { create(:academic_year, :current) }
+      let(:current_academic_year) { AcademicYear.for_date(Date.current) }
       let(:previous_academic_year) { create(:academic_year, :historic) }
 
-      let(:current_claim_window) { create(:claim_window, :current) }
+      let(:current_claim_window) { create(:claim_window, :current, academic_year: current_academic_year) }
       let(:older_claim_window_in_current_academic_year) { create(:claim_window, starts_on: 4.months.ago, ends_on: 3.months.ago, academic_year: current_academic_year) }
       let(:historic_claim_window) { create(:claim_window, :historic) }
 

--- a/spec/system/claims/schools/claims/claim_user_views_the_claims_index_page_when_claim_window_has_closed_but_another_window_is_upcoming_spec.rb
+++ b/spec/system/claims/schools/claims/claim_user_views_the_claims_index_page_when_claim_window_has_closed_but_another_window_is_upcoming_spec.rb
@@ -13,13 +13,14 @@ RSpec.describe "Claims user views the claims index page when claim window has cl
   def given_an_eligible_school_exists_and_the_claim_window_is_closing
     @user_anne = build(:claims_user, first_name: "Anne", last_name: "Wilson", email: "anne_wilson@education.gov.uk")
     @mentor =  build(:claims_mentor)
-    @claim_window = create(:claim_window, :current, ends_on: 1.day.ago)
+    @current_academic_year = AcademicYear.for_date(Date.current)
+    @claim_window = create(:claim_window, :current, ends_on: 1.day.ago, academic_year: @current_academic_year)
     @academic_year = @claim_window.academic_year
     @upcoming_claim_window = create(
       :claim_window,
       starts_on: @claim_window.ends_on + 1.week,
       ends_on: @claim_window.ends_on + 2.weeks,
-      academic_year: @academic_year,
+      academic_year: @current_academic_year,
     )
     @eligibility = build(:eligibility, academic_year: @academic_year)
     @shelbyville_school = create(

--- a/spec/system/claims/schools/claims/claims_user_creates_a_claim_for_a_mentor_with_a_previous_year_claim_spec.rb
+++ b/spec/system/claims/schools/claims/claims_user_creates_a_claim_for_a_mentor_with_a_previous_year_claim_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "Claims user creates a claim for a mentor with a previous year cl
     expect(primary_navigation).to have_current_item("Claims")
     expect(page).to have_h1("Claims")
     expect(page).to have_link("Add claim", href: "/schools/#{@shelbyville_school.id}/claims/new")
-    expect(page).to have_paragraph("There are no claims for Shelbyville Elementary in the 2024 to 2025 academic year.")
+    expect(page).to have_paragraph("There are no claims for Shelbyville Elementary in the 2023 to 2024 academic year.")
   end
 
   def when_i_click_on_previous_academic_year

--- a/spec/system/claims/schools/claims/claims_user_creates_a_claim_for_a_mentor_with_a_previous_year_claim_spec.rb
+++ b/spec/system/claims/schools/claims/claims_user_creates_a_claim_for_a_mentor_with_a_previous_year_claim_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe "Claims user creates a claim for a mentor with a previous year cl
     expect(page).to have_title("How many hours of training did Barry Garlow complete? - Claim details - Best Practice Network - Claim funding for mentor training - GOV.UK")
     expect(primary_navigation).to have_current_item("Claims")
     expect(page).to have_element(:h1, class: "govuk-fieldset__heading", text: "How many hours of training did Barry Garlow complete?")
-    expect(page).to have_hint("Barry Garlow (TRN 8888888) is eligible for 6 hours of refresher training as they have previously claimed up 20 hours of mentor training.")
+    expect(page).to have_hint("Barry Garlow (TRN 8888888) is eligible for 6 hours of refresher training as they have previously claimed up to 20 hours of mentor training.")
     expect(page).to have_element(:label, class: "govuk-label govuk-radios__label", text: "6 hours")
     expect(page).to have_element(:label, class: "govuk-label govuk-radios__label", text: "Another amount")
 

--- a/spec/wizards/claims/add_claim_wizard/mentor_training_step_spec.rb
+++ b/spec/wizards/claims/add_claim_wizard/mentor_training_step_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe Claims::AddClaimWizard::MentorTrainingStep, type: :model do
       before { allow(step.training_allowance).to receive(:training_type).and_return(:refresher) }
 
       it "returns the hint message for refresher training" do
-        expect(hours_of_training_hint).to include("#{mentor.first_name} #{mentor.last_name} (TRN #{mentor.trn}) is eligible for 6 hours of refresher training as they have previously claimed up 20 hours of mentor training.")
+        expect(hours_of_training_hint).to include("#{mentor.first_name} #{mentor.last_name} (TRN #{mentor.trn}) is eligible for 6 hours of refresher training as they have previously claimed up to 20 hours of mentor training.")
       end
     end
   end


### PR DESCRIPTION
## Context

With the upcoming academic year the claim hours are changing, however we still need to be able to calculate claims for previous years, therefore we must add variable claim hours.

## Changes proposed in this pull request

- Abstracts the training hours into their own class
- Updates the training allowance class to utilise the new training hours logic
- Updates the grant funding guidance to match the upcoming academic year
- Updates user facing text to use dynamic data from the new training hours class

## Link to Trello card

https://trello.com/c/8Ntbut3o/321-updating-logic-for-hours-you-can-claim-for-initial-and-refresher-training
