### PR TITLE
Fix issue with CSV generator

### DIFF
--- a/app/services/claims/clawback/create_and_deliver.rb
+++ b/app/services/claims/clawback/create_and_deliver.rb
@@ -12,7 +12,7 @@ class Claims::Clawback::CreateAndDeliver < ApplicationService
         claim.update!(status: :clawback_in_progress)
       end
 
-      csv_file = Claims::Clawback::GenerateCSVFile.call(claims: clawback_requested_claims)
+      csv_file = Claims::Clawback::GenerateCSVFile.call(claim_ids: clawback_requested_claims.ids)
 
       clawback = Claims::Clawback.create!(claims: clawback_requested_claims, csv_file: File.open(csv_file.to_io))
 

--- a/app/services/claims/clawback/generate_csv_file.rb
+++ b/app/services/claims/clawback/generate_csv_file.rb
@@ -15,25 +15,27 @@ class Claims::Clawback::GenerateCSVFile < ApplicationService
     claim_status
   ].freeze
 
-  def initialize(claims:)
-    @claims = claims
+  def initialize(claim_ids:)
+    @claim_ids = claim_ids
   end
 
   def call
     CSV.open(file_name, "w", headers: true) do |csv|
       csv << HEADERS
 
-      claims.includes(:provider, :mentor_trainings, school: :region).order(:reference).each do |claim|
+      ordered_claims.each do |claim|
+        school = claim.school
+
         csv << [
           claim.reference,
-          claim.school.urn,
-          claim.school_name,
-          claim.school.local_authority_name,
+          school.urn,
+          school.name,
+          school.local_authority_name,
           claim.provider_name,
           claim.amount,
           claim.total_clawback_amount,
-          claim.school.type_of_establishment,
-          claim.school.group,
+          school.type_of_establishment,
+          school.group,
           claim.submitted_at.iso8601,
           claim.status,
         ]
@@ -45,7 +47,13 @@ class Claims::Clawback::GenerateCSVFile < ApplicationService
 
   private
 
-  attr_reader :claims
+  attr_reader :claim_ids
+
+  def ordered_claims
+    Claims::Claim.where(id: claim_ids)
+                 .includes(:provider, :mentor_trainings, school: :region)
+                 .order(:reference)
+  end
 
   def file_name
     Rails.root.join("tmp/clawbacks_for_payer.csv")

--- a/app/services/claims/clawback/resend_email.rb
+++ b/app/services/claims/clawback/resend_email.rb
@@ -5,7 +5,7 @@ class Claims::Clawback::ResendEmail < ApplicationService
 
   def call
     ActiveRecord::Base.transaction do |transaction|
-      csv_file = Claims::Clawback::GenerateCSVFile.call(claims: clawback.claims)
+      csv_file = Claims::Clawback::GenerateCSVFile.call(claim_ids: clawback.claims.ids)
       clawback.update!(csv_file: File.open(csv_file.to_io))
 
       transaction.after_commit do

--- a/spec/services/claims/clawback/generate_csv_file_spec.rb
+++ b/spec/services/claims/clawback/generate_csv_file_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe Claims::Clawback::GenerateCSVFile do
-  subject(:generate_csv_file) { described_class.call(claims:) }
+  subject(:generate_csv_file) { described_class.call(claim_ids:) }
 
   let(:school_a) do
     create(:claims_school,
@@ -84,7 +84,7 @@ describe Claims::Clawback::GenerateCSVFile do
            hours_clawed_back: 5,
            reason_clawed_back: "Invalid claim")
   end
-  let(:claims) { Claims::Claim.where(id: [claim_1.id, claim_2.id]).order(:reference) }
+  let(:claim_ids) { Claims::Claim.where(id: [claim_1.id, claim_2.id]).order(:reference).ids }
 
   before do
     claim_1_jane_doe_mentor_training


### PR DESCRIPTION
## Context

Due to a subquery being re-evaluated the claims were returning as an empty array when the CSV was generated. This is a bug and needs to be fixed.

## Changes proposed in this pull request

- Passes through the claim IDs directly to avoid this issue.

## Link to Trello card

https://trello.com/c/iTMSjIaO/403-fix-claims-csv-generation

