### PR TITLE
Add additional confirmation step

### DIFF
--- a/app/views/wizards/claims/add_claim_wizard/_confirmation_step.html.erb
+++ b/app/views/wizards/claims/add_claim_wizard/_confirmation_step.html.erb
@@ -1,0 +1,15 @@
+<% content_for :page_title, title_with_error_prefix(
+  t(".page_title", contextual_text:),
+  error: current_step.errors.any?,
+) %>
+<%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
+  <%= f.govuk_error_summary %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= contextual_text %></span>
+      <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+      <%= f.govuk_check_box :confirmed, true, false, label: { text: t(".label", provider_name: @wizard.provider_name) }, link_errors: true %>
+      <%= f.govuk_submit t(".continue") %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/wizards/claims/add_claim_wizard/_confirmation_step.html.erb
+++ b/app/views/wizards/claims/add_claim_wizard/_confirmation_step.html.erb
@@ -7,9 +7,11 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l"><%= contextual_text %></span>
-      <h1 class="govuk-heading-l"><%= t(".title") %></h1>
-      <%= f.govuk_check_box :confirmed, true, false, label: { text: t(".label", provider_name: @wizard.provider_name) }, link_errors: true %>
-      <%= f.govuk_submit t(".continue") %>
+      <h1 class="govuk-heading-l"><%= t(".title", provider_name: @wizard.provider_name) %></h1>
+      <div class="govuk-!-margin-bottom-4">
+        <%= f.govuk_check_box :confirmed, true, false, label: { text: t(".label", provider_name: @wizard.provider_name) }, link_errors: true %>
+      </div>
+      <%= f.govuk_submit t(".continue"), class: "govuk-margin-top" %>
     </div>
   </div>
 <% end %>

--- a/app/wizards/claims/add_claim_wizard.rb
+++ b/app/wizards/claims/add_claim_wizard.rb
@@ -22,6 +22,7 @@ module Claims
         steps.fetch(:mentor).selected_mentors.each do |mentor|
           add_step(MentorTrainingStep, { mentor_id: mentor.id }, :mentor_id)
         end
+        add_step(ConfirmationStep)
         add_step(CheckYourAnswersStep)
       else
         add_step(NoMentorsStep)

--- a/app/wizards/claims/add_claim_wizard/confirmation_step.rb
+++ b/app/wizards/claims/add_claim_wizard/confirmation_step.rb
@@ -1,0 +1,5 @@
+class Claims::AddClaimWizard::ConfirmationStep < BaseStep
+  attribute :confirmed, :boolean
+
+  validates :confirmed, presence: true, acceptance: { accept: [true] }
+end

--- a/app/wizards/claims/edit_claim_wizard.rb
+++ b/app/wizards/claims/edit_claim_wizard.rb
@@ -26,6 +26,7 @@ module Claims
           selected_mentors.each do |mentor|
             add_step(AddClaimWizard::MentorTrainingStep, { mentor_id: mentor.id }, :mentor_id)
           end
+          add_step(AddClaimWizard::ConfirmationStep)
           add_step(AddClaimWizard::CheckYourAnswersStep)
         else
           add_step(AddClaimWizard::NoMentorsStep)

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -156,6 +156,10 @@ en:
               between: Enter the number of hours between %{min} and %{max}
             hours_to_claim:
               blank: Select the number of hours
+        claims/add_claim_wizard/confirmation_step:
+          attributes:
+            confirmed:
+              blank: You must confirm before submitting your claim
         claims/add_claim_wizard/check_your_answers_step:
           attributes:
             base:

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -159,7 +159,7 @@ en:
         claims/add_claim_wizard/confirmation_step:
           attributes:
             confirmed:
-              blank: You must confirm before submitting your claim
+              blank: You must confirm training hours before submitting your claim
         claims/add_claim_wizard/check_your_answers_step:
           attributes:
             base:

--- a/config/locales/en/wizards/claims/add_claim_wizard.yml
+++ b/config/locales/en/wizards/claims/add_claim_wizard.yml
@@ -33,6 +33,11 @@ en:
           warning: You can only claim for the time spent becoming an initial teacher training (ITT) mentor. This funding is not available for training early career framework (ECF) mentors.
           initial_hours_of_training_hint: "%{mentor_full_name} (TRN %{mentor_trn}) is eligible for %{remaining_hours} hours of training."
           refresher_hours_of_training_hint: "%{mentor_full_name} (TRN %{mentor_trn}) is eligible for %{remaining_hours} hours of refresher training as they have previously claimed up to %{num_initial_hours} hours of mentor training."
+        confirmation_step:
+          page_title: Confirmation - %{contextual_text}
+          title: Confirmation
+          label: I confirm that the school has verified the number of hours of training with %{provider_name}
+          continue: Continue
         check_your_answers_step:
           page_title: Check your answers before submitting your claim - %{contextual_text}
           title: Check your answers before submitting your claim

--- a/config/locales/en/wizards/claims/add_claim_wizard.yml
+++ b/config/locales/en/wizards/claims/add_claim_wizard.yml
@@ -35,8 +35,8 @@ en:
           refresher_hours_of_training_hint: "%{mentor_full_name} (TRN %{mentor_trn}) is eligible for %{remaining_hours} hours of refresher training as they have previously claimed up to %{num_initial_hours} hours of mentor training."
         confirmation_step:
           page_title: Confirmation - %{contextual_text}
-          title: Confirmation
-          label: I confirm that the school has verified the number of hours of training with %{provider_name}
+          title: Confirm training hours have been verified with %{provider_name}
+          label: "%{provider_name} has verified the number of hours recorded in this claim"
           continue: Continue
         check_your_answers_step:
           page_title: Check your answers before submitting your claim - %{contextual_text}

--- a/spec/system/claims/schools/claims/claim_user_changes_a_claim_details_via_check_your_answers_page_links_spec.rb
+++ b/spec/system/claims/schools/claims/claim_user_changes_a_claim_details_via_check_your_answers_page_links_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe "Claims user changes a claim details via check your answers page 
 
     when_i_enter_fifteen_for_training_hours_for_james_jameson
     and_i_click_on_continue
+    then_i_see_the_confirmation_page
+
+    when_i_check_the_confirmation_box
+    and_i_click_on_continue
     then_i_see_the_check_your_answers_page
 
     when_i_click_change_provider
@@ -46,6 +50,10 @@ RSpec.describe "Claims user changes a claim details via check your answers page 
     then_i_see_the_select_training_hours_step_for_james_jameson_with_persisted_details
 
     when_i_click_on_continue
+    then_i_see_the_confirmation_page
+
+    when_i_check_the_niot_confirmation_box
+    and_i_click_on_continue
     then_i_see_the_check_the_check_answers_page_with_updated_details
 
     when_i_click_on_accept_and_submit
@@ -240,6 +248,22 @@ RSpec.describe "Claims user changes a claim details via check your answers page 
 
     expect(page).to have_button("Continue")
     expect(page).to have_link("Cancel")
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_title("Confirmation - Claim details - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(page).to have_h1("Confirmation")
+    expect(page).to have_button("Continue")
+  end
+
+  def when_i_check_the_niot_confirmation_box
+    check "I confirm that the school has verified the number of hours of training with NIoT: National Institute of Teaching, founded by the School-Led Development Trust"
+
+  end
+
+  def when_i_check_the_confirmation_box
+    check "I confirm that the school has verified the number of hours of training with Best Practice Network"
   end
 
   def then_i_see_the_check_your_answers_page

--- a/spec/system/claims/schools/claims/claim_user_changes_a_claim_details_via_check_your_answers_page_links_spec.rb
+++ b/spec/system/claims/schools/claims/claim_user_changes_a_claim_details_via_check_your_answers_page_links_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Claims user changes a claim details via check your answers page 
     then_i_see_the_select_training_hours_step_for_james_jameson_with_persisted_details
 
     when_i_click_on_continue
-    then_i_see_the_confirmation_page
+    then_i_see_the_niot_confirmation_page
 
     when_i_check_the_niot_confirmation_box
     and_i_click_on_continue
@@ -253,17 +253,23 @@ RSpec.describe "Claims user changes a claim details via check your answers page 
   def then_i_see_the_confirmation_page
     expect(page).to have_title("Confirmation - Claim details - Claim funding for mentor training - GOV.UK")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(page).to have_h1("Confirmation")
+    expect(page).to have_h1("Confirm training hours have been verified with Best Practice Network")
+    expect(page).to have_button("Continue")
+  end
+
+  def then_i_see_the_niot_confirmation_page
+    expect(page).to have_title("Confirmation - Claim details - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(page).to have_h1("Confirm training hours have been verified with NIoT: National Institute of Teaching, founded by the School-Led Development Trust")
     expect(page).to have_button("Continue")
   end
 
   def when_i_check_the_niot_confirmation_box
-    check "I confirm that the school has verified the number of hours of training with NIoT: National Institute of Teaching, founded by the School-Led Development Trust"
-
+    check "NIoT: National Institute of Teaching, founded by the School-Led Development Trust has verified the number of hours recorded in this claim"
   end
 
   def when_i_check_the_confirmation_box
-    check "I confirm that the school has verified the number of hours of training with Best Practice Network"
+    check "Best Practice Network has verified the number of hours recorded in this claim"
   end
 
   def then_i_see_the_check_your_answers_page

--- a/spec/system/claims/schools/claims/claim_user_creates_a_claim_spec.rb
+++ b/spec/system/claims/schools/claims/claim_user_creates_a_claim_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe "Claims user creates a claim", :js, service: :claims, type: :syst
 
     when_i_enter_fifteen_for_training_hours_for_james_jameson
     and_i_click_on_continue
+    then_i_see_the_confirmation_page
+
+    when_i_check_the_confirmation_box
+    and_i_click_on_continue
     then_i_see_the_check_your_answers_page
 
     when_i_click_on_accept_and_submit
@@ -212,6 +216,17 @@ RSpec.describe "Claims user creates a claim", :js, service: :claims, type: :syst
 
     expect(page).to have_button("Continue")
     expect(page).to have_link("Cancel")
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_title("Confirmation - Claim details - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(page).to have_h1("Confirmation")
+    expect(page).to have_button("Continue")
+  end
+
+  def when_i_check_the_confirmation_box
+    check "I confirm that the school has verified the number of hours of training with Best Practice Network"
   end
 
   def then_i_see_the_check_your_answers_page

--- a/spec/system/claims/schools/claims/claim_user_creates_a_claim_spec.rb
+++ b/spec/system/claims/schools/claims/claim_user_creates_a_claim_spec.rb
@@ -221,12 +221,12 @@ RSpec.describe "Claims user creates a claim", :js, service: :claims, type: :syst
   def then_i_see_the_confirmation_page
     expect(page).to have_title("Confirmation - Claim details - Claim funding for mentor training - GOV.UK")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(page).to have_h1("Confirmation")
+    expect(page).to have_h1("Confirm training hours have been verified with Best Practice Network")
     expect(page).to have_button("Continue")
   end
 
   def when_i_check_the_confirmation_box
-    check "I confirm that the school has verified the number of hours of training with Best Practice Network"
+    check "Best Practice Network has verified the number of hours recorded in this claim"
   end
 
   def then_i_see_the_check_your_answers_page

--- a/spec/system/claims/schools/claims/claims_user_creates_a_claim_for_a_mentor_with_a_previous_year_claim_spec.rb
+++ b/spec/system/claims/schools/claims/claims_user_creates_a_claim_for_a_mentor_with_a_previous_year_claim_spec.rb
@@ -185,12 +185,12 @@ RSpec.describe "Claims user creates a claim for a mentor with a previous year cl
   def then_i_see_the_confirmation_page
     expect(page).to have_title("Confirmation - Claim details - Claim funding for mentor training - GOV.UK")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(page).to have_h1("Confirmation")
+    expect(page).to have_h1("Confirm training hours have been verified with Best Practice Network")
     expect(page).to have_button("Continue")
   end
 
   def when_i_check_the_confirmation_box
-    check "I confirm that the school has verified the number of hours of training with Best Practice Network"
+    check "Best Practice Network has verified the number of hours recorded in this claim"
   end
 
   def then_i_see_the_check_your_answers_page

--- a/spec/system/claims/schools/claims/claims_user_creates_a_claim_for_a_mentor_with_a_previous_year_claim_spec.rb
+++ b/spec/system/claims/schools/claims/claims_user_creates_a_claim_for_a_mentor_with_a_previous_year_claim_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe "Claims user creates a claim for a mentor with a previous year cl
 
       when_i_select_the_maximum_hours_for_barry_garlow
       and_i_click_on_continue
+      then_i_see_the_confirmation_page
+
+      when_i_check_the_confirmation_box
+      and_i_click_on_continue
       then_i_see_the_check_your_answers_page
 
       when_i_click_on_accept_and_submit
@@ -176,6 +180,17 @@ RSpec.describe "Claims user creates a claim for a mentor with a previous year cl
 
   def when_i_select_the_maximum_hours_for_barry_garlow
     choose "6 hours"
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_title("Confirmation - Claim details - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(page).to have_h1("Confirmation")
+    expect(page).to have_button("Continue")
+  end
+
+  def when_i_check_the_confirmation_box
+    check "I confirm that the school has verified the number of hours of training with Best Practice Network"
   end
 
   def then_i_see_the_check_your_answers_page

--- a/spec/system/claims/schools/claims/claims_user_edits_a_draft_claim_spec.rb
+++ b/spec/system/claims/schools/claims/claims_user_edits_a_draft_claim_spec.rb
@@ -264,12 +264,12 @@ RSpec.describe "Claims user edits a draft claim", service: :claims, type: :syste
   def then_i_see_the_confirmation_page
     expect(page).to have_title("Confirmation - Claim details - Claim funding for mentor training - GOV.UK")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(page).to have_h1("Confirmation")
+    expect(page).to have_h1("Confirm training hours have been verified with Best Practice Network")
     expect(page).to have_button("Continue")
   end
 
   def when_i_check_the_confirmation_box
-    check "I confirm that the school has verified the number of hours of training with Best Practice Network"
+    check "Best Practice Network has verified the number of hours recorded in this claim"
   end
 
   def then_i_see_the_check_your_answers_page_with_barry_garlow_as_a_mentor_and_fifteen_hours_of_training

--- a/spec/system/claims/schools/claims/claims_user_edits_a_draft_claim_spec.rb
+++ b/spec/system/claims/schools/claims/claims_user_edits_a_draft_claim_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe "Claims user edits a draft claim", service: :claims, type: :syste
 
     when_i_choose_fifteen_hours
     and_i_click_on_continue
+    then_i_see_the_confirmation_page
+
+    when_i_check_the_confirmation_box
+    and_i_click_on_continue
     then_i_see_the_check_your_answers_page_with_barry_garlow_as_a_mentor_and_fifteen_hours_of_training
 
     when_i_click_on_accept_and_submit
@@ -255,6 +259,17 @@ RSpec.describe "Claims user edits a draft claim", service: :claims, type: :syste
   def when_i_choose_fifteen_hours
     page.choose("Another amount")
     fill_in "Number of hours", with: "15"
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_title("Confirmation - Claim details - Claim funding for mentor training - GOV.UK")
+    expect(primary_navigation).to have_current_item("Claims")
+    expect(page).to have_h1("Confirmation")
+    expect(page).to have_button("Continue")
+  end
+
+  def when_i_check_the_confirmation_box
+    check "I confirm that the school has verified the number of hours of training with Best Practice Network"
   end
 
   def then_i_see_the_check_your_answers_page_with_barry_garlow_as_a_mentor_and_fifteen_hours_of_training

--- a/spec/system/claims/schools/claims/school_user_creates_a_claim_with_javascript_disabled_spec.rb
+++ b/spec/system/claims/schools/claims/school_user_creates_a_claim_with_javascript_disabled_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe "School user creates a claim with javascript disabled", service: 
     when_i_choose_another_amount
     and_enter_6_hours
     and_i_click_on_continue
+    then_i_see_the_confirmation_page
+
+    when_i_check_the_confirmation_box
+    and_i_click_on_continue
     then_i_see_the_check_your_answers_page
 
     when_i_click_on_submit_claim
@@ -165,6 +169,16 @@ RSpec.describe "School user creates a claim with javascript disabled", service: 
 
   def and_enter_6_hours
     fill_in "Number of hours", with: 6
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_title("Confirmation - Claim details - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_h1("Confirmation")
+    expect(page).to have_button("Continue")
+  end
+
+  def when_i_check_the_confirmation_box
+    check "I confirm that the school has verified the number of hours of training with Best Practice Network"
   end
 
   def then_i_see_the_check_your_answers_page

--- a/spec/system/claims/schools/claims/school_user_creates_a_claim_with_javascript_disabled_spec.rb
+++ b/spec/system/claims/schools/claims/school_user_creates_a_claim_with_javascript_disabled_spec.rb
@@ -173,12 +173,12 @@ RSpec.describe "School user creates a claim with javascript disabled", service: 
 
   def then_i_see_the_confirmation_page
     expect(page).to have_title("Confirmation - Claim details - Claim funding for mentor training - GOV.UK")
-    expect(page).to have_h1("Confirmation")
+    expect(page).to have_h1("Confirm training hours have been verified with Best Practice Network")
     expect(page).to have_button("Continue")
   end
 
   def when_i_check_the_confirmation_box
-    check "I confirm that the school has verified the number of hours of training with Best Practice Network"
+    check "Best Practice Network has verified the number of hours recorded in this claim"
   end
 
   def then_i_see_the_check_your_answers_page

--- a/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
+++ b/spec/system/claims/support/schools/claims/change_claim_on_check_page_spec.rb
@@ -49,6 +49,9 @@ RSpec.describe "Change claim on check page", :js, service: :claims, skip: "flaky
     then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor2)
     when_i_choose_other_amount_and_input_hours(12)
     when_i_click("Continue")
+    then_i_see_the_confirmation_page
+    when_i_check_the_confirmation_box
+    when_i_click("Continue")
     then_i_check_my_answers(bpn, [mentor1, mentor2], [20, 12])
   end
 
@@ -76,6 +79,9 @@ RSpec.describe "Change claim on check page", :js, service: :claims, skip: "flaky
     then_i_expect_the_training_hours_for(12, mentor2)
 
     when_i_click("Continue") # Mentors 2 step
+    then_i_see_the_confirmation_page
+    when_i_check_the_confirmation_box
+    when_i_click("Continue")
     then_i_check_my_answers(niot, [mentor1, mentor2], [20, 12])
     when_i_click("Accept and submit")
     then_i_am_redirected_to_index_page
@@ -95,6 +101,9 @@ RSpec.describe "Change claim on check page", :js, service: :claims, skip: "flaky
     then_i_expect_the_training_hours_for(12, mentor2)
 
     when_i_click("Continue") # Mentors 2 step
+    then_i_see_the_confirmation_page
+    when_i_check_the_confirmation_box
+    when_i_click("Continue")
     then_i_check_my_answers(
       bpn,
       [mentor2],
@@ -124,6 +133,9 @@ RSpec.describe "Change claim on check page", :js, service: :claims, skip: "flaky
 
     when_i_add_training_hours("20 hours")
     and_i_click("Continue")
+    then_i_see_the_confirmation_page
+    when_i_check_the_confirmation_box
+    when_i_click("Continue")
     then_i_check_my_answers(bpn, [mentor1, mentor2, mentor3], [20, 12, 20])
   end
 
@@ -139,6 +151,9 @@ RSpec.describe "Change claim on check page", :js, service: :claims, skip: "flaky
     and_i_click("Continue")
     then_i_expect_the_training_hours_for(12, mentor2)
 
+    when_i_click("Continue")
+    then_i_see_the_confirmation_page
+    when_i_check_the_confirmation_box
     when_i_click("Continue")
     then_i_check_my_answers(bpn, [mentor1, mentor2], [6, 12])
   end
@@ -238,6 +253,15 @@ RSpec.describe "Change claim on check page", :js, service: :claims, skip: "flaky
   def then_i_expect_the_training_hours_for(hours, mentor)
     expect(page).to have_content("How many hours of training did #{mentor.full_name} complete?")
     then_i_expect_the_training_hours_to_be_selected(hours)
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_h1("Confirmation")
+    expect(page).to have_button("Continue")
+  end
+
+  def when_i_check_the_confirmation_box
+    check "I confirm that the school has verified the number of hours of training with Best Practice Network"
   end
 
   def then_i_check_my_answers(provider, mentors, mentor_hours)

--- a/spec/system/claims/support/schools/claims/create_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/create_claim_spec.rb
@@ -61,6 +61,9 @@ RSpec.describe "Create claim", :js, service: :claims, skip: "flaky", type: :syst
     then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor2)
     when_i_choose_other_amount_and_input_hours(12)
     when_i_click("Continue")
+    then_i_see_the_confirmation_page
+    when_i_check_the_confirmation_box
+    when_i_click("Continue")
     then_i_check_my_answers
     when_i_click("Accept and submit")
     then_i_see_the_new_claim
@@ -107,6 +110,9 @@ RSpec.describe "Create claim", :js, service: :claims, skip: "flaky", type: :syst
     when_i_click("Continue")
     then_i_expect_to_be_able_to_add_training_hours_to_mentor(mentor2)
     when_i_choose_other_amount_and_input_hours(12)
+    when_i_click("Continue")
+    then_i_see_the_confirmation_page
+    when_i_check_the_confirmation_box
     when_i_click("Continue")
     then_i_check_my_answers
     when_another_claim_with_same_mentors_has_been_created([mentor1, mentor2])
@@ -263,6 +269,15 @@ RSpec.describe "Create claim", :js, service: :claims, skip: "flaky", type: :syst
   def when_i_choose_other_amount_and_input_hours(hours)
     page.choose("Another amount")
     fill_in("Number of hours", with: hours)
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_h1("Confirmation")
+    expect(page).to have_button("Continue")
+  end
+
+  def when_i_check_the_confirmation_box
+    check "I confirm that the school has verified the number of hours of training with Best Practice Network"
   end
 
   def then_i_check_my_answers

--- a/spec/system/claims/support/schools/claims/edit_draft_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/edit_draft_claim_spec.rb
@@ -261,12 +261,12 @@ RSpec.describe "Edit a draft claim", service: :claims, type: :system do
   end
 
   def then_i_see_the_confirmation_page
-    expect(page).to have_h1("Confirmation")
+    expect(page).to have_h1("Confirm training hours have been verified with NIoT: National Institute of Teaching, founded by the School-Led Development Trust")
     expect(page).to have_button("Continue")
   end
 
   def when_i_check_the_confirmation_box
-    check "I confirm that the school has verified the number of hours of training with NIoT: National Institute of Teaching, founded by the School-Led Development Trust"
+    check "NIoT: National Institute of Teaching, founded by the School-Led Development Trust has verified the number of hours recorded in this claim"
   end
 
   def then_i_see_the_check_your_answers_page(provider:, hours_completed:)

--- a/spec/system/claims/support/schools/claims/edit_draft_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/edit_draft_claim_spec.rb
@@ -68,6 +68,10 @@ RSpec.describe "Edit a draft claim", service: :claims, type: :system do
     when_i_select_another_amount
     and_i_enter_another_amount_of_hours(15)
     and_i_click("Continue")
+    then_i_see_the_confirmation_page
+
+    when_i_check_the_confirmation_box
+    and_i_click("Continue")
     then_i_expect_the_current_draft_claims_to_not_have_my_changes
 
     when_i_click("Update claim")
@@ -101,6 +105,10 @@ RSpec.describe "Edit a draft claim", service: :claims, type: :system do
     when_i_click("Continue")
     then_i_expect_the_training_hours_for(claims_mentor, niot_provider)
 
+    when_i_click("Continue")
+    then_i_see_the_confirmation_page
+
+    when_i_check_the_confirmation_box
     when_i_click("Continue")
     then_i_see_the_check_your_answers_page(
       provider: niot_provider,
@@ -250,6 +258,15 @@ RSpec.describe "Edit a draft claim", service: :claims, type: :system do
   def then_i_see_i_can_not_submit_the_claim
     expect(page).to have_h1("You cannot submit the claim")
     expect(page).to have_content("You cannot submit the claim because your mentors’ information has recently changed.")
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_h1("Confirmation")
+    expect(page).to have_button("Continue")
+  end
+
+  def when_i_check_the_confirmation_box
+    check "I confirm that the school has verified the number of hours of training with NIoT: National Institute of Teaching, founded by the School-Led Development Trust"
   end
 
   def then_i_see_the_check_your_answers_page(provider:, hours_completed:)

--- a/spec/system/claims/support/schools/claims/support_user_creates_a_claim_with_javascript_disabled_spec.rb
+++ b/spec/system/claims/support/schools/claims/support_user_creates_a_claim_with_javascript_disabled_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe "School user creates a claim with javascript disabled", service: 
     when_i_choose_another_amount
     and_enter_6_hours
     and_i_click_on_continue
+    then_i_see_the_confirmation_page
+
+    when_i_check_the_confirmation_box
+    and_i_click_on_continue
     then_i_see_the_check_your_answers_page
 
     when_i_click_on_save_claim
@@ -183,6 +187,15 @@ RSpec.describe "School user creates a claim with javascript disabled", service: 
 
   def and_enter_6_hours
     fill_in "Number of hours", with: 6
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_h1("Confirmation")
+    expect(page).to have_button("Continue")
+  end
+
+  def when_i_check_the_confirmation_box
+    check "I confirm that the school has verified the number of hours of training with Best Practice Network"
   end
 
   def then_i_see_the_check_your_answers_page

--- a/spec/system/claims/support/schools/claims/support_user_creates_a_claim_with_javascript_disabled_spec.rb
+++ b/spec/system/claims/support/schools/claims/support_user_creates_a_claim_with_javascript_disabled_spec.rb
@@ -190,12 +190,12 @@ RSpec.describe "School user creates a claim with javascript disabled", service: 
   end
 
   def then_i_see_the_confirmation_page
-    expect(page).to have_h1("Confirmation")
+    expect(page).to have_h1("Confirm training hours have been verified with Best Practice Network")
     expect(page).to have_button("Continue")
   end
 
   def when_i_check_the_confirmation_box
-    check "I confirm that the school has verified the number of hours of training with Best Practice Network"
+    check "Best Practice Network has verified the number of hours recorded in this claim"
   end
 
   def then_i_see_the_check_your_answers_page

--- a/spec/wizards/claims/add_claim_wizard_spec.rb
+++ b/spec/wizards/claims/add_claim_wizard_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Claims::AddClaimWizard do
       let!(:mentor_1) { create(:claims_mentor, schools: [school], first_name: "Alan", last_name: "Anderson") }
 
       context "with claimable hours" do
-        it { is_expected.to eq %i[provider mentor check_your_answers] }
+        it { is_expected.to eq %i[provider mentor confirmation check_your_answers] }
 
         context "when the provider is set in the provider options step" do
           let(:state) do
@@ -50,7 +50,7 @@ RSpec.describe Claims::AddClaimWizard do
             }
           end
 
-          it { is_expected.to eq %i[provider provider_options mentor check_your_answers] }
+          it { is_expected.to eq %i[provider provider_options mentor confirmation check_your_answers] }
         end
       end
 
@@ -64,7 +64,7 @@ RSpec.describe Claims::AddClaimWizard do
           }
         end
 
-        it { is_expected.to eq [:provider, :mentor, "mentor_training_#{mentor_1.id}".to_sym, "mentor_training_#{mentor_2.id}".to_sym, :check_your_answers] }
+        it { is_expected.to eq [:provider, :mentor, "mentor_training_#{mentor_1.id}".to_sym, "mentor_training_#{mentor_2.id}".to_sym, :confirmation, :check_your_answers] }
       end
 
       context "with no claimable hours" do

--- a/spec/wizards/claims/edit_claim_wizard_spec.rb
+++ b/spec/wizards/claims/edit_claim_wizard_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Claims::EditClaimWizard do
       }
     end
 
-    it { is_expected.to eq [:provider, :mentor, "mentor_training_#{mentor_1.id}".to_sym, :check_your_answers] }
+    it { is_expected.to eq [:provider, :mentor, "mentor_training_#{mentor_1.id}".to_sym, :confirmation, :check_your_answers] }
 
     context "when current step is declaration" do
       let(:current_step) { :declaration }
@@ -66,7 +66,7 @@ RSpec.describe Claims::EditClaimWizard do
         }
       end
 
-      it { is_expected.to eq [:provider, :provider_options, :mentor, "mentor_training_#{mentor_1.id}".to_sym, :check_your_answers] }
+      it { is_expected.to eq [:provider, :provider_options, :mentor, "mentor_training_#{mentor_1.id}".to_sym, :confirmation, :check_your_answers] }
     end
 
     context "when there are no mentors with claimable hours for the given provider" do


### PR DESCRIPTION
## Context

We've added an additional step to encourage schools to check that the training hours are correct before submitting a claim.

## Changes proposed in this pull request

- Adds the new confirmation step.

## Guidance to review

- Run through the Add Claim wizard and ensure the step is visible.

## Link to Trello card

https://trello.com/c/lhpJ6nVL/397-add-confirmation-step-before-check-your-answers-when-creating-claims

## Screenshots

<img width="797" height="575" alt="image" src="https://github.com/user-attachments/assets/cc179bd3-f5d7-4691-af3a-04aba0657c5d" />

