### PR TITLE
Add ECT warnings and provider information

### DIFF
--- a/app/views/wizards/claims/add_mentor_wizard/_check_your_answers_step.html.erb
+++ b/app/views/wizards/claims/add_mentor_wizard/_check_your_answers_step.html.erb
@@ -47,7 +47,7 @@
                 )),
             ) %>
         </p>
-
+        <%= govuk_warning_text text: t(".ecf_warning") %>
         <%= f.govuk_submit t(".save_mentor") %>
       <% end %>
     </div>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -159,7 +159,7 @@ en:
         claims/add_claim_wizard/confirmation_step:
           attributes:
             confirmed:
-              blank: You must confirm training hours before submitting your claim
+              blank: You must confirm the number of training hours with your provider
         claims/add_claim_wizard/check_your_answers_step:
           attributes:
             base:

--- a/config/locales/en/claims/schools/claims.yml
+++ b/config/locales/en/claims/schools/claims.yml
@@ -15,6 +15,7 @@ en:
           further_information: If we need further information to process your claim we will email you.
           we_may_check_your_claim: We may check your claim
           after_payment: After payment we may check your claim to ensure it is accurate.
+          maintained_schools_payment: Maintained schools and maintained alternative provision settings will receive payment via their local authority. All other settings will receive payment directly. We will make this payment alongside your regular funding and it will appear as a separate line on that remittance.
           provider_contact: "%{provider_name} will contact you if your claim undergoes a check."
         rejected:
           page_title: You cannot submit the claim

--- a/config/locales/en/wizards/claims/add_claim_wizard.yml
+++ b/config/locales/en/wizards/claims/add_claim_wizard.yml
@@ -8,6 +8,7 @@ en:
           title: Enter the accredited provider for this claim
           hint_html:
             You must make a separate claim for each accredited provider you work with.<br><br>
+            Contact your training provider before submitting your claim if you are unsure of which accredited provider to select.<br><br>
             Enter a provider name, United Kingdom provider number (UKPRN), unique reference number (URN) or postcode
         provider_options_step:
           title: "%{provider_count} results found for ‘%{search_param}’ - %{contextual_text}"
@@ -30,13 +31,13 @@ en:
           other_amount: Another amount
           custom_hours_completed_hint: Enter a whole number up to %{count}
           number_of_hours: Number of hours
-          warning: You can only claim for the time spent becoming an initial teacher training (ITT) mentor. This funding is not available for training early career framework (ECF) mentors.
+          warning: This funding is not available for training early career teacher (ECT) mentors.
           initial_hours_of_training_hint: "%{mentor_full_name} (TRN %{mentor_trn}) is eligible for %{remaining_hours} hours of training."
           refresher_hours_of_training_hint: "%{mentor_full_name} (TRN %{mentor_trn}) is eligible for %{remaining_hours} hours of refresher training as they have previously claimed up to %{num_initial_hours} hours of mentor training."
         confirmation_step:
           page_title: Confirmation - %{contextual_text}
-          title: Confirm training hours have been verified with %{provider_name}
-          label: "%{provider_name} has verified the number of hours recorded in this claim"
+          title: Confirm training hours with %{provider_name}
+          label: "I have confirmed the number of training hours recorded in this claim with %{provider_name}"
           continue: Continue
         check_your_answers_step:
           page_title: Check your answers before submitting your claim - %{contextual_text}

--- a/config/locales/en/wizards/claims/add_mentor_wizard.yml
+++ b/config/locales/en/wizards/claims/add_mentor_wizard.yml
@@ -19,6 +19,7 @@ en:
           change: Change
           heading: Confirm mentor details
           details: Details
+          ecf_warning: This funding is not available for training early career teacher (ECT) mentors.
           trn: Teacher reference number (TRN)
           date_of_birth: Date of birth
           privacy_link: privacy notice

--- a/spec/system/claims/schools/claims/claim_user_changes_a_claim_details_via_check_your_answers_page_links_spec.rb
+++ b/spec/system/claims/schools/claims/claim_user_changes_a_claim_details_via_check_your_answers_page_links_spec.rb
@@ -260,16 +260,16 @@ RSpec.describe "Claims user changes a claim details via check your answers page 
   def then_i_see_the_niot_confirmation_page
     expect(page).to have_title("Confirmation - Claim details - Claim funding for mentor training - GOV.UK")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(page).to have_h1("I have confirmed the number of training hours recorded in this claim with  NIoT: National Institute of Teaching, founded by the School-Led Development Trust")
+    expect(page).to have_h1("Confirm training hours with NIoT: National Institute of Teaching, founded by the School-Led Development Trust")
     expect(page).to have_button("Continue")
   end
 
   def when_i_check_the_niot_confirmation_box
-    check "NIoT: National Institute of Teaching, founded by the School-Led Development Trust has verified the number of hours recorded in this claim"
+    check "I have confirmed the number of training hours recorded in this claim with NIoT: National Institute of Teaching, founded by the School-Led Development Trust"
   end
 
   def when_i_check_the_confirmation_box
-    check "Best Practice Network has verified the number of hours recorded in this claim"
+    check "I have confirmed the number of training hours recorded in this claim with Best Practice Network"
   end
 
   def then_i_see_the_check_your_answers_page

--- a/spec/system/claims/schools/claims/claim_user_changes_a_claim_details_via_check_your_answers_page_links_spec.rb
+++ b/spec/system/claims/schools/claims/claim_user_changes_a_claim_details_via_check_your_answers_page_links_spec.rb
@@ -253,14 +253,14 @@ RSpec.describe "Claims user changes a claim details via check your answers page 
   def then_i_see_the_confirmation_page
     expect(page).to have_title("Confirmation - Claim details - Claim funding for mentor training - GOV.UK")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(page).to have_h1("Confirm training hours have been verified with Best Practice Network")
+    expect(page).to have_h1("Confirm training hours with Best Practice Network")
     expect(page).to have_button("Continue")
   end
 
   def then_i_see_the_niot_confirmation_page
     expect(page).to have_title("Confirmation - Claim details - Claim funding for mentor training - GOV.UK")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(page).to have_h1("Confirm training hours have been verified with NIoT: National Institute of Teaching, founded by the School-Led Development Trust")
+    expect(page).to have_h1("I have confirmed the number of training hours recorded in this claim with  NIoT: National Institute of Teaching, founded by the School-Led Development Trust")
     expect(page).to have_button("Continue")
   end
 

--- a/spec/system/claims/schools/claims/claim_user_creates_a_claim_spec.rb
+++ b/spec/system/claims/schools/claims/claim_user_creates_a_claim_spec.rb
@@ -221,12 +221,12 @@ RSpec.describe "Claims user creates a claim", :js, service: :claims, type: :syst
   def then_i_see_the_confirmation_page
     expect(page).to have_title("Confirmation - Claim details - Claim funding for mentor training - GOV.UK")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(page).to have_h1("Confirm training hours have been verified with Best Practice Network")
+    expect(page).to have_h1("Confirm training hours with Best Practice Network")
     expect(page).to have_button("Continue")
   end
 
   def when_i_check_the_confirmation_box
-    check "Best Practice Network has verified the number of hours recorded in this claim"
+    check "I have confirmed the number of training hours recorded in this claim with Best Practice Network"
   end
 
   def then_i_see_the_check_your_answers_page

--- a/spec/system/claims/schools/claims/claims_user_creates_a_claim_for_a_mentor_with_a_previous_year_claim_spec.rb
+++ b/spec/system/claims/schools/claims/claims_user_creates_a_claim_for_a_mentor_with_a_previous_year_claim_spec.rb
@@ -185,12 +185,12 @@ RSpec.describe "Claims user creates a claim for a mentor with a previous year cl
   def then_i_see_the_confirmation_page
     expect(page).to have_title("Confirmation - Claim details - Claim funding for mentor training - GOV.UK")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(page).to have_h1("Confirm training hours have been verified with Best Practice Network")
+    expect(page).to have_h1("Confirm training hours with Best Practice Network")
     expect(page).to have_button("Continue")
   end
 
   def when_i_check_the_confirmation_box
-    check "Best Practice Network has verified the number of hours recorded in this claim"
+    check "I have confirmed the number of training hours recorded in this claim with Best Practice Network"
   end
 
   def then_i_see_the_check_your_answers_page

--- a/spec/system/claims/schools/claims/claims_user_edits_a_draft_claim_spec.rb
+++ b/spec/system/claims/schools/claims/claims_user_edits_a_draft_claim_spec.rb
@@ -264,12 +264,12 @@ RSpec.describe "Claims user edits a draft claim", service: :claims, type: :syste
   def then_i_see_the_confirmation_page
     expect(page).to have_title("Confirmation - Claim details - Claim funding for mentor training - GOV.UK")
     expect(primary_navigation).to have_current_item("Claims")
-    expect(page).to have_h1("Confirm training hours have been verified with Best Practice Network")
+    expect(page).to have_h1("Confirm training hours with Best Practice Network")
     expect(page).to have_button("Continue")
   end
 
   def when_i_check_the_confirmation_box
-    check "Best Practice Network has verified the number of hours recorded in this claim"
+    check "I have confirmed the number of training hours recorded in this claim with Best Practice Network"
   end
 
   def then_i_see_the_check_your_answers_page_with_barry_garlow_as_a_mentor_and_fifteen_hours_of_training

--- a/spec/system/claims/schools/claims/school_user_creates_a_claim_with_javascript_disabled_spec.rb
+++ b/spec/system/claims/schools/claims/school_user_creates_a_claim_with_javascript_disabled_spec.rb
@@ -173,12 +173,12 @@ RSpec.describe "School user creates a claim with javascript disabled", service: 
 
   def then_i_see_the_confirmation_page
     expect(page).to have_title("Confirmation - Claim details - Claim funding for mentor training - GOV.UK")
-    expect(page).to have_h1("Confirm training hours have been verified with Best Practice Network")
+    expect(page).to have_h1("Confirm training hours with Best Practice Network")
     expect(page).to have_button("Continue")
   end
 
   def when_i_check_the_confirmation_box
-    check "Best Practice Network has verified the number of hours recorded in this claim"
+    check "I have confirmed the number of training hours recorded in this claim with Best Practice Network"
   end
 
   def then_i_see_the_check_your_answers_page

--- a/spec/system/claims/support/schools/claims/edit_draft_claim_spec.rb
+++ b/spec/system/claims/support/schools/claims/edit_draft_claim_spec.rb
@@ -261,12 +261,12 @@ RSpec.describe "Edit a draft claim", service: :claims, type: :system do
   end
 
   def then_i_see_the_confirmation_page
-    expect(page).to have_h1("Confirm training hours have been verified with NIoT: National Institute of Teaching, founded by the School-Led Development Trust")
+    expect(page).to have_h1("Confirm training hours with NIoT: National Institute of Teaching, founded by the School-Led Development Trust")
     expect(page).to have_button("Continue")
   end
 
   def when_i_check_the_confirmation_box
-    check "NIoT: National Institute of Teaching, founded by the School-Led Development Trust has verified the number of hours recorded in this claim"
+    check "I have confirmed the number of training hours recorded in this claim with NIoT: National Institute of Teaching, founded by the School-Led Development Trust"
   end
 
   def then_i_see_the_check_your_answers_page(provider:, hours_completed:)

--- a/spec/system/claims/support/schools/claims/support_user_creates_a_claim_with_javascript_disabled_spec.rb
+++ b/spec/system/claims/support/schools/claims/support_user_creates_a_claim_with_javascript_disabled_spec.rb
@@ -190,12 +190,12 @@ RSpec.describe "School user creates a claim with javascript disabled", service: 
   end
 
   def then_i_see_the_confirmation_page
-    expect(page).to have_h1("Confirm training hours have been verified with Best Practice Network")
+    expect(page).to have_h1("Confirm training hours with Best Practice Network")
     expect(page).to have_button("Continue")
   end
 
   def when_i_check_the_confirmation_box
-    check "Best Practice Network has verified the number of hours recorded in this claim"
+    check "I have confirmed the number of training hours recorded in this claim with Best Practice Network"
   end
 
   def then_i_see_the_check_your_answers_page

--- a/spec/system/placements/schools/partner_providers/add_a_provider_spec.rb
+++ b/spec/system/placements/schools/partner_providers/add_a_provider_spec.rb
@@ -148,11 +148,11 @@ RSpec.describe "School user adds a provider to their list of providers",
   end
 
   def then_i_see_a_dropdown_item_for_springfield_university
-    expect(page).to have_css(".autocomplete__option", text: "Springfield University", wait: 10)
+    then_i_see_a_dropdown_item_for("Springfield University")
   end
 
   def when_i_click_on_the_springfield_university_dropdown_item
-    page.find(".autocomplete__option", text: "Springfield University").click
+    when_i_click_on_the_dropdown_item_for("Springfield University")
   end
 
   def and_i_click_on_continue
@@ -225,11 +225,11 @@ RSpec.describe "School user adds a provider to their list of providers",
   end
 
   def then_i_see_a_dropdown_item_for_shelbyville_university
-    expect(page).to have_css(".autocomplete__option", text: "Shelbyville University", wait: 10)
+    then_i_see_a_dropdown_item_for("Shelbyville University")
   end
 
   def when_i_click_on_the_shelbyville_university_dropdown_item
-    page.find(".autocomplete__option", text: "Shelbyville University").click
+    when_i_click_on_the_dropdown_item_for("Shelbyville University")
   end
 
   def then_i_see_a_validation_error_for_shelbyville_university_is_already_in_my_list_of_providers
@@ -241,11 +241,34 @@ RSpec.describe "School user adds a provider to their list of providers",
   end
 
   def then_i_see_a_dropdown_item_for_ogdenville_university
-    expect(page).to have_css(".autocomplete__option", text: "Ogdenville University", wait: 10)
+    then_i_see_a_dropdown_item_for("Ogdenville University")
   end
 
   def when_i_click_on_the_ogdenville_university_dropdown_item
-    page.find(".autocomplete__option", text: "Ogdenville University").click
+    when_i_click_on_the_dropdown_item_for("Ogdenville University")
+  end
+
+  def then_i_see_a_dropdown_item_for(provider_name)
+    within(".autocomplete__wrapper") do
+      expect(page).to have_css(".autocomplete__option", text: provider_name, wait: 10)
+    end
+  end
+
+  def when_i_click_on_the_dropdown_item_for(provider_name)
+    attempts = 0
+
+    begin
+      attempts += 1
+      within(".autocomplete__wrapper") do
+        expect(page).to have_css(".autocomplete__option", text: provider_name, wait: 10)
+        all(".autocomplete__option", text: provider_name, minimum: 1).first.click
+      end
+    rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::StaleElementReferenceError => e
+      stale_node_error = e.message.include?("Node with given id does not belong to the document")
+      raise unless attempts < 3 && stale_node_error
+
+      retry
+    end
   end
 
   def then_i_see_the_confirm_provider_details_page_for_ogdenville_university


### PR DESCRIPTION
## Context

Enhance service content to raise awareness that this service is not for ECT claims and add additional information for

## Changes proposed in this pull request

- Adds warning when adding a mentor
- Adds warning when selecting number of hours mentor trained
- Adds information about provider
- Updates confirmation step content

## Guidance to review

- Add a new mentor
- Create a claim
- Confirm changes are visible

## Link to Trello card

https://trello.com/c/TysoV4C9/417-review-and-update-ecf-ecte-wording
https://trello.com/c/jK6kIBfB/400-add-new-content-to-how-many-hours-of-training-claim-step
https://trello.com/c/scJjtb16/399-add-warning-component-when-adding-a-new-mentor
https://trello.com/c/nC5zKroY/398-add-subtext-to-provider-selection-step

## Screenshots

<img width="735" height="633" alt="image" src="https://github.com/user-attachments/assets/1da6a0fc-4047-4c14-bf4d-83f1af3d8104" />
<img width="738" height="557" alt="image" src="https://github.com/user-attachments/assets/5c93a967-e05c-4576-999c-4353aaccd09f" />
<img width="735" height="867" alt="image" src="https://github.com/user-attachments/assets/2114a253-72f5-4890-9948-dbcf0cd6c519" />
<img width="1039" height="784" alt="image" src="https://github.com/user-attachments/assets/0edecf42-5367-4eb5-8edc-8aacd4db4fc2" />


