### PR TITLE
Add eligibility mailer

### DIFF
--- a/app/jobs/claims/school/onboard_schools_job.rb
+++ b/app/jobs/claims/school/onboard_schools_job.rb
@@ -1,8 +1,12 @@
 class Claims::School::OnboardSchoolsJob < ApplicationJob
   queue_as :default
+  MAX_EMAILS_PER_MINUTE = 100
+  RATE_LIMIT_INTERVAL = 1.minute
 
   def perform(school_ids:, claim_window_id: nil)
     @claim_window_id = claim_window_id
+    wait_time = 0.minutes
+    remaining_capacity = MAX_EMAILS_PER_MINUTE
 
     school_ids.each do |school_id|
       school = School.find(school_id)
@@ -12,12 +16,71 @@ class Claims::School::OnboardSchoolsJob < ApplicationJob
         school:,
         academic_year:,
       )
+
+      user_count = school.users.count
+      next if user_count.zero?
+
+      wait_time, remaining_capacity = schedule_eligibility_email(
+        school:,
+        user_count:,
+        wait_time:,
+        remaining_capacity:,
+      )
     end
   end
 
   private
 
   attr_reader :claim_window_id
+
+  def schedule_eligibility_email(school:, user_count:, wait_time:, remaining_capacity:)
+    if user_count > MAX_EMAILS_PER_MINUTE
+      if remaining_capacity < MAX_EMAILS_PER_MINUTE
+        wait_time += RATE_LIMIT_INTERVAL
+      end
+
+      NotifyRateLimiter.call(
+        collection: school.users,
+        mailer: "Claims::UserMailer",
+        mailer_method: :your_school_is_eligible_to_claim,
+        mailer_args: [school],
+        batch_size: MAX_EMAILS_PER_MINUTE,
+        interval: RATE_LIMIT_INTERVAL,
+        initial_wait_time: wait_time,
+      )
+
+      wait_time += emails_batches_required(user_count) * RATE_LIMIT_INTERVAL
+
+      return [wait_time, MAX_EMAILS_PER_MINUTE]
+    end
+
+    if user_count > remaining_capacity
+      wait_time += RATE_LIMIT_INTERVAL
+      remaining_capacity = MAX_EMAILS_PER_MINUTE
+    end
+
+    NotifyRateLimiter.call(
+      collection: school.users,
+      mailer: "Claims::UserMailer",
+      mailer_method: :your_school_is_eligible_to_claim,
+      mailer_args: [school],
+      batch_size: MAX_EMAILS_PER_MINUTE,
+      interval: RATE_LIMIT_INTERVAL,
+      initial_wait_time: wait_time,
+    )
+
+    remaining_capacity -= user_count
+
+    if remaining_capacity.zero?
+      [wait_time + RATE_LIMIT_INTERVAL, MAX_EMAILS_PER_MINUTE]
+    else
+      [wait_time, remaining_capacity]
+    end
+  end
+
+  def emails_batches_required(total_emails)
+    (total_emails.to_f / MAX_EMAILS_PER_MINUTE).ceil
+  end
 
   def academic_year
     if claim_window_id

--- a/app/mailers/claims/user_mailer.rb
+++ b/app/mailers/claims/user_mailer.rb
@@ -171,6 +171,15 @@ class Claims::UserMailer < Claims::ApplicationMailer
                          service_url: claims_root_url(utm_source: "email", utm_medium: "notification", utm_campaign: "school"))
   end
 
+  def your_school_is_eligible_to_claim(user, school)
+    notify_email to: user.email,
+                 subject: t(".subject"),
+                 body: t(".body",
+                         user_name: user.first_name,
+                         school_name: school.name,
+                         sign_in_url: sign_in_url(utm_source: "email", utm_medium: "notification", utm_campaign: "school"))
+  end
+
   private
 
   def claim_window

--- a/app/services/notify_rate_limiter.rb
+++ b/app/services/notify_rate_limiter.rb
@@ -1,7 +1,7 @@
 class NotifyRateLimiter < ApplicationService
-  attr_accessor :collection, :mailer, :mailer_method, :batch_size, :interval, :mailer_args, :mailer_kwargs
+  attr_accessor :collection, :mailer, :mailer_method, :batch_size, :interval, :mailer_args, :mailer_kwargs, :initial_wait_time
 
-  def initialize(collection:, mailer:, mailer_method:, batch_size: 100, interval: 1.minute, mailer_args: [], mailer_kwargs: {})
+  def initialize(collection:, mailer:, mailer_method:, batch_size: 100, interval: 1.minute, mailer_args: [], mailer_kwargs: {}, initial_wait_time: 0.minutes)
     @collection = collection
     @mailer = mailer
     @mailer_method = mailer_method
@@ -9,6 +9,7 @@ class NotifyRateLimiter < ApplicationService
     @mailer_kwargs = mailer_kwargs
     @batch_size = batch_size
     @interval = interval
+    @initial_wait_time = initial_wait_time
   end
 
   def call
@@ -21,6 +22,6 @@ class NotifyRateLimiter < ApplicationService
   private
 
   def wait_time
-    @wait_time ||= 0.minutes
+    @wait_time ||= initial_wait_time
   end
 end

--- a/app/views/claims/pages/start.en.html.erb
+++ b/app/views/claims/pages/start.en.html.erb
@@ -29,10 +29,10 @@
 
       <h2 class="govuk-heading-m">When to submit a claim</h2>
 
-      <p class="govuk-body">For the school year starting September 2024:</p>
+      <p class="govuk-body">For the school year starting September 2025:</p>
 
       <%= govuk_list type: :bullet do %>
-        <li>you can add your ITT mentor training hours and submit a claim from May 2025</li>
+        <li>you can add your ITT mentor training hours and submit a claim from April 2026</li>
         <li>when you are registered in the service, we will email you reminders of claim opening dates and deadlines</li>
       <% end %>
 

--- a/config/locales/en/claims/user_mailer.yml
+++ b/config/locales/en/claims/user_mailer.yml
@@ -322,3 +322,27 @@ en:
           Kind regards,
 
           %{service_name} team
+      your_school_is_eligible_to_claim:
+        subject: Onboarding update to Claim funding for mentor training
+        body: |
+          Dear %{user_name},
+  
+          You have been onboarded to the Claim funding for mentor training service to submit claims for initial teacher training (ITT) general mentor funding for the academic year 2025/26.
+  
+          If you are not the right person in your organisation to submit funding claims for ITT general mentor training, please:
+          - access the service using DfE sign-in and add an appropriate colleague in the Users section
+          - forward this email to the appropriate colleague after adding them as a user
+  
+          %{school_name} has been added to the service because an accredited ITT provider has informed DfE that one or more trainee teachers have undertaken a school placement there during academic year 2025/26.
+    
+          The claim window to submit claims for ITT general mentor training for academic year 2025/26 will open on Monday 27 April 2026.
+  
+          Sign in using DfE sign-in:
+  
+          If your colleague needs to create a DfE sign-in account, they can do this after clicking "Sign in using DfE sign-in". After creating a DfE sign-in, they can return to this email to access the service.
+          
+          [%{sign_in_url}](%{sign_in_url})
+    
+          Prior to submitting claims, schools must confirm the correct number of training hours you are claiming with the relevant provider, as they may be asked to provide evidence to support this claim.
+    
+          If you have any questions or feedback, please contact the team at (support email - itt general mentor funding).

--- a/spec/jobs/claims/school/onboard_schools_job_spec.rb
+++ b/spec/jobs/claims/school/onboard_schools_job_spec.rb
@@ -113,6 +113,30 @@ RSpec.describe Claims::School::OnboardSchoolsJob, type: :job do
         expect(NotifyRateLimiter).to have_received(:call).with(hash_including(mailer_args: [london_school], initial_wait_time: 0.minutes))
         expect(NotifyRateLimiter).to have_received(:call).with(hash_including(mailer_args: [york_school], initial_wait_time: 2.minutes))
       end
+
+      it "shifts a large school to the next minute when prior schools used part of the current minute" do
+        stub_const("Claims::School::OnboardSchoolsJob::MAX_EMAILS_PER_MINUTE", 3)
+
+        create_list(:user_membership, 1, organisation: london_school)
+        create_list(:user_membership, 4, organisation: york_school)
+
+        described_class.perform_now(school_ids: [london_school.id, york_school.id])
+
+        expect(NotifyRateLimiter).to have_received(:call).with(hash_including(mailer_args: [london_school], initial_wait_time: 0.minutes))
+        expect(NotifyRateLimiter).to have_received(:call).with(hash_including(mailer_args: [york_school], initial_wait_time: 1.minute))
+      end
+
+      it "rolls over to the next minute when a smaller school exceeds remaining capacity" do
+        stub_const("Claims::School::OnboardSchoolsJob::MAX_EMAILS_PER_MINUTE", 3)
+
+        create_list(:user_membership, 2, organisation: london_school)
+        create_list(:user_membership, 2, organisation: york_school)
+
+        described_class.perform_now(school_ids: [london_school.id, york_school.id])
+
+        expect(NotifyRateLimiter).to have_received(:call).with(hash_including(mailer_args: [london_school], initial_wait_time: 0.minutes))
+        expect(NotifyRateLimiter).to have_received(:call).with(hash_including(mailer_args: [york_school], initial_wait_time: 1.minute))
+      end
     end
   end
 end

--- a/spec/jobs/claims/school/onboard_schools_job_spec.rb
+++ b/spec/jobs/claims/school/onboard_schools_job_spec.rb
@@ -62,5 +62,57 @@ RSpec.describe Claims::School::OnboardSchoolsJob, type: :job do
         described_class.perform_later(school_ids:)
       }.to have_enqueued_job(described_class).on_queue("default")
     end
+
+    describe "eligibility email rate limiting" do
+      let(:school_ids) { [london_school.id, york_school.id, guildford_school.id] }
+
+      before do
+        create(:claim_window, :current)
+        allow(NotifyRateLimiter).to receive(:call)
+      end
+
+      it "sends eligibility emails via NotifyRateLimiter with school context" do
+        create_list(:user_membership, 1, organisation: london_school)
+
+        described_class.perform_now(school_ids: [london_school.id])
+
+        expect(NotifyRateLimiter).to have_received(:call).with(
+          hash_including(
+            mailer: "Claims::UserMailer",
+            mailer_method: :your_school_is_eligible_to_claim,
+            mailer_args: [london_school],
+            batch_size: described_class::MAX_EMAILS_PER_MINUTE,
+            interval: 1.minute,
+            initial_wait_time: 0.minutes,
+          ),
+        )
+      end
+
+      it "batches smaller schools into the same minute up to the configured cap" do
+        stub_const("Claims::School::OnboardSchoolsJob::MAX_EMAILS_PER_MINUTE", 3)
+
+        create_list(:user_membership, 2, organisation: london_school)
+        create_list(:user_membership, 1, organisation: york_school)
+        create_list(:user_membership, 1, organisation: guildford_school)
+
+        described_class.perform_now(school_ids:)
+
+        expect(NotifyRateLimiter).to have_received(:call).with(hash_including(mailer_args: [london_school], initial_wait_time: 0.minutes))
+        expect(NotifyRateLimiter).to have_received(:call).with(hash_including(mailer_args: [york_school], initial_wait_time: 0.minutes))
+        expect(NotifyRateLimiter).to have_received(:call).with(hash_including(mailer_args: [guildford_school], initial_wait_time: 1.minute))
+      end
+
+      it "reserves enough minutes for a school that needs multiple batches" do
+        stub_const("Claims::School::OnboardSchoolsJob::MAX_EMAILS_PER_MINUTE", 3)
+
+        create_list(:user_membership, 4, organisation: london_school)
+        create_list(:user_membership, 1, organisation: york_school)
+
+        described_class.perform_now(school_ids: [london_school.id, york_school.id])
+
+        expect(NotifyRateLimiter).to have_received(:call).with(hash_including(mailer_args: [london_school], initial_wait_time: 0.minutes))
+        expect(NotifyRateLimiter).to have_received(:call).with(hash_including(mailer_args: [york_school], initial_wait_time: 2.minutes))
+      end
+    end
   end
 end

--- a/spec/mailers/claims/user_mailer_spec.rb
+++ b/spec/mailers/claims/user_mailer_spec.rb
@@ -571,6 +571,61 @@ RSpec.describe Claims::UserMailer, type: :mailer do
     end
   end
 
+  describe "#your_school_is_eligible_to_claim" do
+    subject(:eligibility_email) { described_class.your_school_is_eligible_to_claim(user, school) }
+
+    let(:user) { create(:claims_user, first_name: "Joe") }
+    let(:school) { create(:claims_school, name: "Shelbyville Elementary") }
+
+    it "sends the eligibility email" do
+      expect(eligibility_email.to).to contain_exactly(user.email)
+      expect(eligibility_email.subject).to eq("Onboarding update to Claim funding for mentor training")
+      expect(eligibility_email.body).to have_content <<~EMAIL
+        Dear Joe,
+
+        You have been onboarded to the Claim funding for mentor training service to submit claims for initial teacher training (ITT) general mentor funding for the academic year 2025/26.
+
+        If you are not the right person in your organisation to submit funding claims for ITT general mentor training, please:
+        - access the service using DfE sign-in and add an appropriate colleague in the Users section
+        - forward this email to the appropriate colleague after adding them as a user
+
+        Shelbyville Elementary has been added to the service because an accredited ITT provider has informed DfE that one or more trainee teachers have undertaken a school placement there during academic year 2025/26.
+
+        The claim window to submit claims for ITT general mentor training for academic year 2025/26 will open on Monday 27 April 2026.
+
+        Sign in using DfE sign-in:
+
+        If your colleague needs to create a DfE sign-in account, they can do this after clicking "Sign in using DfE sign-in". After creating a DfE sign-in, they can return to this email to access the service.
+
+        [http://claims.localhost/sign-in?utm_campaign=school&utm_medium=notification&utm_source=email](http://claims.localhost/sign-in?utm_campaign=school&utm_medium=notification&utm_source=email)
+
+        Prior to submitting claims, schools must confirm the correct number of training hours you are claiming with the relevant provider, as they may be asked to provide evidence to support this claim.
+
+        If you have any questions or feedback, please contact the team at (support email - itt general mentor funding).
+      EMAIL
+    end
+
+    context "when HostingEnvironment.env is 'production'" do
+      before do
+        allow(HostingEnvironment).to receive(:env).and_return("production")
+      end
+
+      it "does not prepend the hosting environment to the subject" do
+        expect(eligibility_email.subject).to eq("Onboarding update to Claim funding for mentor training")
+      end
+    end
+
+    context "when HostingEnvironment.env is 'staging'" do
+      before do
+        allow(HostingEnvironment).to receive(:env).and_return("staging")
+      end
+
+      it "prepends the hosting environment to the subject" do
+        expect(eligibility_email.subject).to eq("[STAGING] Onboarding update to Claim funding for mentor training")
+      end
+    end
+  end
+
   describe "delivery scheduling" do
     include ActiveJob::TestHelper
 

--- a/spec/mailers/previews/claims/user_mailer_preview.rb
+++ b/spec/mailers/previews/claims/user_mailer_preview.rb
@@ -39,6 +39,10 @@ class Claims::UserMailerPreview < ActionMailer::Preview
     Claims::UserMailer.claim_rejected_by_provider(user, claim)
   end
 
+  def your_school_is_eligible_to_claim
+    Claims::UserMailer.your_school_is_eligible_to_claim(user, school)
+  end
+
   private
 
   def user

--- a/spec/services/notify_rate_limiter_spec.rb
+++ b/spec/services/notify_rate_limiter_spec.rb
@@ -37,5 +37,17 @@ describe NotifyRateLimiter do
         expect(NotifyRateLimiterJob).to have_received(:perform_later).with(1.minute, anything, mailer, mailer_method, %w[arg1 arg2], { name: "Bob" })
       end
     end
+
+    context "when an initial wait time is provided" do
+      it "offsets the first batch by the provided wait time" do
+        allow(NotifyRateLimiterJob).to receive(:perform_later).with(2.minutes, anything, mailer, mailer_method, mailer_args, mailer_kwargs)
+        allow(NotifyRateLimiterJob).to receive(:perform_later).with(3.minutes, anything, mailer, mailer_method, mailer_args, mailer_kwargs)
+
+        described_class.call(collection:, mailer:, mailer_method:, initial_wait_time: 2.minutes)
+
+        expect(NotifyRateLimiterJob).to have_received(:perform_later).with(2.minutes, anything, mailer, mailer_method, mailer_args, mailer_kwargs)
+        expect(NotifyRateLimiterJob).to have_received(:perform_later).with(3.minutes, anything, mailer, mailer_method, mailer_args, mailer_kwargs)
+      end
+    end
   end
 end

--- a/spec/system/claims/start_page_spec.rb
+++ b/spec/system/claims/start_page_spec.rb
@@ -90,8 +90,8 @@ RSpec.describe "Start Page", freeze: "17 July 2024", service: :claims, type: :sy
 
     expect(page).to have_content(
       "When to submit a claim\n"\
-      "For the school year starting September 2024:\n"\
-      "you can add your ITT mentor training hours and submit a claim from May 2025 "\
+      "For the school year starting September 2025:\n"\
+      "you can add your ITT mentor training hours and submit a claim from April 2026 "\
       "when you are registered in the service, we will email you reminders of claim opening dates and deadlines",\
     )
 


### PR DESCRIPTION
## Context

Sends an email when onboarding schools for a new claim window when they have existing users in the service,

## Changes proposed in this pull request

- Sends an email (shown below) to users which are already associated to a school when onboarding for a new claim window
- Updates start page text to match current date

## Guidance to review

- Onboard an existing school with at least one user for the new claim window and ensure an email is captured.
- Open the service and check the start page

## Link to Trello card

https://trello.com/c/2ok1aFie/414-new-claims-task

## Screenshots

<img width="3024" height="1972" alt="image" src="https://github.com/user-attachments/assets/3e6caa88-0cd5-4150-b75e-d9f65c4fa9ea" />

