### PR TITLE
Add 1 minute wait time per 100 user invites

### DIFF
--- a/app/jobs/claims/user/create_collection_job.rb
+++ b/app/jobs/claims/user/create_collection_job.rb
@@ -2,6 +2,7 @@ class Claims::User::CreateCollectionJob < ApplicationJob
   queue_as :default
 
   MAX_COUNT = 500
+  MAX_CREATE_AND_DELIVER_PER_MINUTE = 100
 
   def perform(user_details:)
     if user_details.count > MAX_COUNT
@@ -9,12 +10,17 @@ class Claims::User::CreateCollectionJob < ApplicationJob
         Claims::User::CreateCollectionJob.perform_later(user_details: batch)
       end
     else
-      user_details.each do |user_detail|
+      user_details.each_with_index do |user_detail, index|
         school = Claims::School.find(user_detail[:school_id])
         existing_user = school.users.find_by(email: user_detail[:email])
         next if existing_user.present?
 
-        Claims::User::CreateAndDeliverJob.perform_later(school_id: school.id, user_details: user_detail)
+        wait_time = (index / MAX_CREATE_AND_DELIVER_PER_MINUTE).minutes
+
+        Claims::User::CreateAndDeliverJob.set(wait: wait_time).perform_later(
+          school_id: school.id,
+          user_details: user_detail,
+        )
       end
     end
   end

--- a/spec/jobs/claims/user/create_collection_job_spec.rb
+++ b/spec/jobs/claims/user/create_collection_job_spec.rb
@@ -43,6 +43,16 @@ RSpec.describe Claims::User::CreateCollectionJob, type: :job do
         }.to have_enqueued_job(Claims::User::CreateAndDeliverJob).twice
       end
 
+      it "rate limits Claims::User::CreateAndDeliverJob scheduling" do
+        stub_const("Claims::User::CreateCollectionJob::MAX_CREATE_AND_DELIVER_PER_MINUTE", 1)
+        allow(Claims::User::CreateAndDeliverJob).to receive(:set).and_call_original
+
+        described_class.perform_now(user_details:)
+
+        expect(Claims::User::CreateAndDeliverJob).to have_received(:set).with(wait: 0.minutes)
+        expect(Claims::User::CreateAndDeliverJob).to have_received(:set).with(wait: 1.minute)
+      end
+
       context "when a user already exists" do
         before do
           create(:claims_user, schools: [school], email: "joe_bloggs@example.com")


### PR DESCRIPTION
## Context

Our user invites were sending in real time which would overload the Notify rate limit for our service.

## Changes proposed in this pull request

- Limit the amount of jobs that are spawned to 100 per minute utilising the schedule.
