### PR TITLE
Pin 3rd party github actions

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Post comment to Pull Request ${{ github.event.number }}
         if: ${{ github.event_name == 'pull_request' }}
-        uses: marocchino/sticky-pull-request-comment@v3
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # Pinned at v3.0.4
         with:
           header: aks
           message: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Post comment to Pull Request ${{ inputs.pr-number }}
         if: ${{ inputs.environment != 'review' && inputs.environment != 'dv_review' }}
-        uses: marocchino/sticky-pull-request-comment@v3
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # Pinned at v3.0.4
         with:
           header: aks
           message: |


### PR DESCRIPTION
### Trello card

https://trello.com/c/8RwMeaL4/2682-pin-third-party-github-actions-mobilise

### Changes proposed in this pull request

- pin all 3rd party github actions at specific versions (for security)

### Guidance to review

see successful workflows run by this PR