### PR TITLE
Combine the support claim views

### DIFF
--- a/app/views/claims/support/claims/_claim_show.html.erb
+++ b/app/views/claims/support/claims/_claim_show.html.erb
@@ -1,0 +1,44 @@
+<%= render "claims/support/primary_navigation", current: :claims %>
+<% content_for(:page_title) { sanitize t("#{translation_scope}.page_title", school_name: claim.school_name, reference: claim.reference) } %>
+
+<% content_for(:before_content) do %>
+  <%= govuk_back_link href: back_path %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= govuk_tabs do |tabs| %>
+        <% tabs.with_tab(label: t("#{translation_scope}.claim_details")) do %>
+          <span class="govuk-caption-l"><%= t("#{translation_scope}.page_caption", reference: claim.reference) %></span>
+          <h1 class="govuk-heading-l"><%= claim.school_name %> <%= render Claim::StatusTagComponent.new(claim:) %></h1>
+
+          <%= render Claims::Support::Claim::ResponsesComponent.new(claim:) %>
+
+          <%= render Claims::Support::Claim::ActionsComponent.new(claim:) %>
+
+          <% if claim.submitted_by_id? %>
+            <p class="govuk-body"><%= t("#{translation_scope}.submitted_by", name: claim.submitted_by.full_name, date: l(claim.submitted_on, format: :long)) %></p>
+          <% end %>
+
+          <%= render "claims/support/claims/details", claim: %>
+        <% end %>
+
+        <% tabs.with_tab(label: t("#{translation_scope}.school_details")) do %>
+          <p class="govuk-caption-l"><%= t("#{translation_scope}.page_caption", reference: claim.reference) %></p>
+          <%= render "claims/support/claims/school_details", organisation: claim.school %>
+        <% end %>
+
+        <% tabs.with_tab(label: t("#{translation_scope}.school_users")) do %>
+          <p class="govuk-caption-l"><%= t("#{translation_scope}.page_caption", reference: claim.reference) %></p>
+          <%= render "claims/support/claims/school_users", organisation: claim.school %>
+        <% end %>
+
+        <% tabs.with_tab(label: t("#{translation_scope}.history")) do %>
+          <p class="govuk-caption-l"><%= t("#{translation_scope}.page_caption", reference: claim.reference) %></p>
+          <%= render "claims/support/claims/history", claim: %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/claims/support/claims/clawbacks/show.html.erb
+++ b/app/views/claims/support/claims/clawbacks/show.html.erb
@@ -1,44 +1,4 @@
-<%= render "claims/support/primary_navigation", current: :claims %>
-<% content_for(:page_title) { sanitize t(".page_title", school_name: @claim.school.name, reference: @claim.reference) } %>
-
-<% content_for(:before_content) do %>
-  <%= govuk_back_link href: claims_support_claims_path %>
-<% end %>
-
-<div class="govuk-width-container">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= govuk_tabs do |tabs| %>
-        <% tabs.with_tab(label: t(".claim_details")) do %>
-          <span class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></span>
-          <h1 class="govuk-heading-l"><%= @claim.school_name %> <%= render Claim::StatusTagComponent.new(claim: @claim) %></h1>
-
-          <%= render Claims::Support::Claim::ResponsesComponent.new(claim: @claim) %>
-
-          <%= render Claims::Support::Claim::ActionsComponent.new(claim: @claim) %>
-
-          <% if @claim.submitted_by_id? %>
-            <p class="govuk-body"><%= t(".submitted_by", name: @claim.submitted_by.full_name, date: l(@claim.submitted_on, format: :long)) %></p>
-          <% end %>
-
-          <%= render "claims/support/claims/details", claim: @claim %>
-        <% end %>
-
-        <% tabs.with_tab(label: t(".school_details")) do %>
-          <p class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></p>
-          <%= render "claims/support/claims/school_details", organisation: @claim.school %>
-        <% end %>
-
-        <% tabs.with_tab(label: t(".school_users")) do %>
-          <p class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></p>
-          <%= render "claims/support/claims/school_users", organisation: @claim.school %>
-        <% end %>
-
-        <% tabs.with_tab(label: t(".history")) do %>
-          <p class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></p>
-          <%= render "claims/support/claims/history", claim: @claim %>
-        <% end %>
-      <% end %>
-    </div>
-  </div>
-</div>
+<%= render "claims/support/claims/claim_show",
+           claim: @claim,
+           back_path: claims_support_claims_path,
+           translation_scope: "claims.support.claims.clawbacks.show" %>

--- a/app/views/claims/support/claims/payments/claims/show.html.erb
+++ b/app/views/claims/support/claims/payments/claims/show.html.erb
@@ -1,44 +1,4 @@
-<%= render "claims/support/primary_navigation", current: :claims %>
-<% content_for(:page_title) { sanitize t(".page_title", school_name: @claim.school_name, reference: @claim.reference) } %>
-
-<% content_for(:before_content) do %>
-  <%= govuk_back_link href: claims_support_claims_payments_path %>
-<% end %>
-
-<div class="govuk-width-container">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= govuk_tabs do |tabs| %>
-        <% tabs.with_tab(label: t(".claim_details")) do %>
-          <span class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></span>
-          <h1 class="govuk-heading-l"><%= @claim.school_name %> <%= render Claim::StatusTagComponent.new(claim: @claim) %></h1>
-
-          <%= render Claims::Support::Claim::ResponsesComponent.new(claim: @claim) %>
-
-          <%= render Claims::Support::Claim::ActionsComponent.new(claim: @claim) %>
-
-          <% if @claim.submitted_by_id? %>
-            <p class="govuk-body"><%= t(".submitted_by", name: @claim.submitted_by.full_name, date: l(@claim.submitted_on, format: :long)) %></p>
-          <% end %>
-
-          <%= render "claims/support/claims/details", claim: @claim %>
-        <% end %>
-
-        <% tabs.with_tab(label: t(".school_details")) do %>
-          <p class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></p>
-          <%= render "claims/support/claims/school_details", organisation: @claim.school %>
-        <% end %>
-
-        <% tabs.with_tab(label: t(".school_users")) do %>
-          <p class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></p>
-          <%= render "claims/support/claims/school_users", organisation: @claim.school %>
-        <% end %>
-
-        <% tabs.with_tab(label: t(".history")) do %>
-          <p class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></p>
-          <%= render "claims/support/claims/history", claim: @claim %>
-        <% end %>
-      <% end %>
-    </div>
-  </div>
-</div>
+<%= render "claims/support/claims/claim_show",
+           claim: @claim,
+           back_path: claims_support_claims_payments_path,
+           translation_scope: "claims.support.claims.payments.claims.show" %>

--- a/app/views/claims/support/claims/samplings/show.html.erb
+++ b/app/views/claims/support/claims/samplings/show.html.erb
@@ -1,44 +1,4 @@
-<%= render "claims/support/primary_navigation", current: :claims %>
-<% content_for(:page_title) { sanitize t(".page_title", school_name: @claim.school_name, reference: @claim.reference) } %>
-
-<% content_for(:before_content) do %>
-  <%= govuk_back_link href: claims_support_claims_samplings_path %>
-<% end %>
-
-<div class="govuk-width-container">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= govuk_tabs do |tabs| %>
-        <% tabs.with_tab(label: t(".claim_details")) do %>
-          <span class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></span>
-          <h1 class="govuk-heading-l"><%= @claim.school_name %> <%= render Claim::StatusTagComponent.new(claim: @claim) %></h1>
-
-          <%= render Claims::Support::Claim::ResponsesComponent.new(claim: @claim) %>
-
-          <%= render Claims::Support::Claim::ActionsComponent.new(claim: @claim) %>
-
-          <% if @claim.submitted_by_id? %>
-            <p class="govuk-body"><%= t(".submitted_by", name: @claim.submitted_by.full_name, date: l(@claim.submitted_on, format: :long)) %></p>
-          <% end %>
-
-          <%= render "claims/support/claims/details", claim: @claim %>
-        <% end %>
-
-        <% tabs.with_tab(label: t(".school_details")) do %>
-          <p class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></p>
-          <%= render "claims/support/claims/school_details", organisation: @claim.school %>
-        <% end %>
-
-        <% tabs.with_tab(label: t(".school_users")) do %>
-          <p class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></p>
-          <%= render "claims/support/claims/school_users", organisation: @claim.school %>
-        <% end %>
-
-        <% tabs.with_tab(label: t(".history")) do %>
-          <p class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></p>
-          <%= render "claims/support/claims/history", claim: @claim %>
-        <% end %>
-      <% end %>
-    </div>
-  </div>
-</div>
+<%= render "claims/support/claims/claim_show",
+           claim: @claim,
+           back_path: claims_support_claims_samplings_path,
+           translation_scope: "claims.support.claims.samplings.show" %>

--- a/app/views/claims/support/claims/show.html.erb
+++ b/app/views/claims/support/claims/show.html.erb
@@ -1,44 +1,4 @@
-<%= render "claims/support/primary_navigation", current: :claims %>
-<% content_for(:page_title) { sanitize t(".page_title", school_name: @claim.school_name, reference: @claim.reference) } %>
-
-<% content_for(:before_content) do %>
-  <%= govuk_back_link href: claims_support_claims_path(session["claims_filter_params"]) %>
-<% end %>
-
-<div class="govuk-width-container">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= govuk_tabs do |tabs| %>
-        <% tabs.with_tab(label: t(".claim_details")) do %>
-          <span class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></span>
-          <h1 class="govuk-heading-l"><%= @claim.school_name %> <%= render Claim::StatusTagComponent.new(claim: @claim) %></h1>
-
-          <%= render Claims::Support::Claim::ResponsesComponent.new(claim: @claim) %>
-
-          <%= render Claims::Support::Claim::ActionsComponent.new(claim: @claim) %>
-
-          <% if @claim.submitted_by_id? %>
-            <p class="govuk-body"><%= t(".submitted_by", name: @claim.submitted_by.full_name, date: l(@claim.submitted_on, format: :long)) %></p>
-          <% end %>
-
-          <%= render "claims/support/claims/details", claim: @claim %>
-        <% end %>
-
-        <% tabs.with_tab(label: t(".school_details")) do %>
-          <p class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></p>
-          <%= render "claims/support/claims/school_details", organisation: @claim.school %>
-        <% end %>
-
-        <% tabs.with_tab(label: t(".school_users")) do %>
-          <p class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></p>
-          <%= render "claims/support/claims/school_users", organisation: @claim.school %>
-        <% end %>
-
-        <% tabs.with_tab(label: t(".history")) do %>
-          <p class="govuk-caption-l"><%= t(".page_caption", reference: @claim.reference) %></p>
-          <%= render "claims/support/claims/history", claim: @claim %>
-        <% end %>
-      <% end %>
-    </div>
-  </div>
-</div>
+<%= render "claims/support/claims/claim_show",
+           claim: @claim,
+           back_path: claims_support_claims_path(session["claims_filter_params"]),
+           translation_scope: "claims.support.claims.show" %>


### PR DESCRIPTION
## Context

The claim views for the support console are all very similar, updates across all four can be a painful process. This brings all of the claim views in line under a single file.

## Changes proposed in this pull request

- Combines the four claim views into one

## Guidance to review

Log in as Colin and ensure the support console still works as expected

## Link to Trello card

https://trello.com/c/13CpJuum/371-combine-claim-views-into-a-single-partial-to-reduce-duplication
