### PR TITLE
Add missing support email address

### DIFF
--- a/app/mailers/claims/user_mailer.rb
+++ b/app/mailers/claims/user_mailer.rb
@@ -177,6 +177,7 @@ class Claims::UserMailer < Claims::ApplicationMailer
                  body: t(".body",
                          user_name: user.first_name,
                          school_name: school.name,
+                         support_email:,
                          sign_in_url: sign_in_url(utm_source: "email", utm_medium: "notification", utm_campaign: "school"))
   end
 

--- a/config/locales/en/claims/user_mailer.yml
+++ b/config/locales/en/claims/user_mailer.yml
@@ -345,4 +345,4 @@ en:
     
           Prior to submitting claims, schools must confirm the correct number of training hours you are claiming with the relevant provider, as they may be asked to provide evidence to support this claim.
     
-          If you have any questions or feedback, please contact the team at (support email - itt general mentor funding).
+          If you have any questions or feedback, please contact the team at [%{support_email}](mailto:%{support_email}).

--- a/spec/mailers/claims/user_mailer_spec.rb
+++ b/spec/mailers/claims/user_mailer_spec.rb
@@ -601,7 +601,7 @@ RSpec.describe Claims::UserMailer, type: :mailer do
 
         Prior to submitting claims, schools must confirm the correct number of training hours you are claiming with the relevant provider, as they may be asked to provide evidence to support this claim.
 
-        If you have any questions or feedback, please contact the team at (support email - itt general mentor funding).
+        If you have any questions or feedback, please contact the team at [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk).
       EMAIL
     end
 


### PR DESCRIPTION
## Context

When adding the copy for a new email, the support email address was not added.

## Changes proposed in this pull request

- Adds the missed support email address

## Guidance to review

- Check the yml files to ensure the changes look correct

## Link to Trello card

https://trello.com/c/cz6bshEj/431-add-missing-support-email-address-in-comms

