### PR TITLE
2683 - New GitHub action validate infra workflow

### DIFF
--- a/.github/workflows/validate-infrastructure.yml
+++ b/.github/workflows/validate-infrastructure.yml
@@ -1,0 +1,43 @@
+name: Validate Infra
+
+on:
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+jobs:
+  validate:
+    name: ${{ matrix.display }}
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - display: AKS infrastructure
+            validation_plan: aks-infra
+            terraform_base: terraform/application
+          - display: Domains infrastructure
+            validation_plan: domains-infra
+            terraform_base: terraform/domains/infrastructure
+          - display: Domains environment
+            validation_plan: domains-env
+            terraform_base: terraform/domains/environment_domains
+
+    steps:
+      - name: Validate ${{ matrix.display }}
+        uses: DFE-Digital/github-actions/validate-infra@master
+        with:
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          environment: production
+          terraform-base: ${{ matrix.terraform_base }}
+          validation-plan: ${{ matrix.validation_plan }}
+          service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
+          teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL_INFRA }}
+          gcp-wip: ${{ vars.GCP_WIP }}
+          gcp-project-id: ${{ vars.GCP_PROJECT_ID }}

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ terraform-init: composed-variables set-azure-account
 	$(eval export TF_VAR_environment=${ENVIRONMENT})
 
 terraform-plan: terraform-init
-	terraform -chdir=terraform/application plan -var-file "config/${CONFIG}.tfvars.json"
+	terraform -chdir=terraform/application plan ${DETAILED_EXITCODE} -var-file "config/${CONFIG}.tfvars.json"
 
 terraform-apply: terraform-init
 	terraform -chdir=terraform/application apply -var-file "config/${CONFIG}.tfvars.json" ${AUTO_APPROVE}
@@ -125,7 +125,7 @@ domains-infra-init: ittms_domain set-azure-account ## make domains-infra-init - 
 	terraform -chdir=terraform/domains/infrastructure init -reconfigure -upgrade
 
 domains-infra-plan: domains-infra-init ## terraform plan for dns core resources
-	terraform -chdir=terraform/domains/infrastructure plan -var-file config/zones.tfvars.json
+	terraform -chdir=terraform/domains/infrastructure plan ${DETAILED_EXITCODE} -var-file config/zones.tfvars.json
 
 domains-infra-apply: domains-infra-init ## terraform apply for dns core resources
 	terraform -chdir=terraform/domains/infrastructure apply -var-file config/zones.tfvars.json ${AUTO_APPROVE}
@@ -137,7 +137,7 @@ domains-init: ittms_domain composed-variables set-azure-account
 	terraform -chdir=terraform/domains/environment_domains init -upgrade -reconfigure -backend-config=key=$(or $(DOMAINS_TERRAFORM_BACKEND_KEY), ittmsdomains_${ENVIRONMENT}.tfstate)
 
 domains-plan: domains-init  ## Terraform plan for DNS environment domains. Usage: make development domains-plan
-	terraform -chdir=terraform/domains/environment_domains plan -var-file config/${ENVIRONMENT}.tfvars.json
+	terraform -chdir=terraform/domains/environment_domains plan ${DETAILED_EXITCODE} -var-file config/${ENVIRONMENT}.tfvars.json
 
 domains-apply: domains-init ## Terraform apply for DNS environment domains. Usage: make development domains-apply
 	terraform -chdir=terraform/domains/environment_domains apply -var-file config/${ENVIRONMENT}.tfvars.json ${AUTO_APPROVE}


### PR DESCRIPTION
### Context

Adding a validate infra workflow to detect any changes in SD Infra Terraform 

### Changes proposed in this pull request

Add a new GitHub action workflow validate-infrastructure.yml.
${DETAILED_EXITCODE} added to Terraform plan in Makefile.
TEAMS_WEBHOOK_URL_INFRA added as an Action repository secret.

### Guidance to review

Manually test changes by altering terraform/domains/environment_domains/config/production.tfvars.json **cached_paths** and running locally the following command.
`make production domains-plan`
This will produce a Terraform update in place.

To validate the workflow once available. Make a test branch with a change to terraform/domains/environment_domains/config/production.tfvars.json **cached_paths**.

Run the workflow against that branch. It must produce a post in the SD Infra Alerts Teams channel with description **Domains environment infrastructure drift detected in production**

### Link to Trello card

https://trello.com/c/p76gfyrn/2683-schedule-validate-infra-workflow

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
