### PR TITLE
Add provider model and login

### DIFF
--- a/app/controllers/personas_controller.rb
+++ b/app/controllers/personas_controller.rb
@@ -3,8 +3,17 @@ class PersonasController < ApplicationController
 
   def index
     @personas = User.where(email: PERSONA_EMAILS)
-      .where(type: ["#{current_service.to_s.titleize}::User",
-                    "#{current_service.to_s.titleize}::SupportUser"])
+      .where(type: persona_types)
       .order(:created_at)
+  end
+
+  private
+
+  def persona_types
+    if current_service == :claims
+      %w[Claims::User Claims::ProviderUser Claims::SupportUser]
+    else
+      ["#{current_service.to_s.titleize}::User", "#{current_service.to_s.titleize}::SupportUser"]
+    end
   end
 end

--- a/app/models/claims/provider_user.rb
+++ b/app/models/claims/provider_user.rb
@@ -1,0 +1,32 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                        :uuid             not null, primary key
+#  dfe_sign_in_uid           :string
+#  discarded_at              :datetime
+#  email                     :string           not null
+#  first_name                :string           not null
+#  last_name                 :string           not null
+#  last_signed_in_at         :datetime
+#  type                      :string
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  selected_academic_year_id :uuid
+#
+# Indexes
+#
+#  index_users_on_selected_academic_year_id        (selected_academic_year_id)
+#  index_users_on_type_and_discarded_at_and_email  (type,discarded_at,email)
+#  index_users_on_type_and_email                   (type,email) UNIQUE
+#
+class Claims::ProviderUser < User
+  has_many :providers,
+           through: :user_memberships,
+           source: :organisation,
+           source_type: "Provider"
+
+  def organisation_count
+    providers.count
+  end
+end

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -58,12 +58,12 @@ class DfESignInUser
   end
 
   def user
-    @user ||= User.where(type: [support_user_klass, user_klass].map(&:to_s))
+    @user ||= User.where(type: user_klasses.map(&:to_s))
       .and(
         User.where(dfe_sign_in_uid:).where.not(dfe_sign_in_uid: nil)
           .or(User.where(email:)),
       )
-      .order(type: :asc) # so support users take precedence
+      .order(Arel.sql(user_type_priority_sql))
       .first
   end
 
@@ -82,13 +82,19 @@ class DfESignInUser
     end
   end
 
-  def user_klass
+  def user_klasses
     case service
     when :placements
-      Placements::User
+      [support_user_klass, Placements::User]
     when :claims
-      Claims::User
+      [support_user_klass, Claims::User, Claims::ProviderUser]
     end
+  end
+
+  def user_type_priority_sql
+    # Ensure support users take precedence if duplicate records exist for an email/uid.
+    parts = user_klasses.each_with_index.map { |klass, index| "WHEN '#{klass}' THEN #{index}" }
+    "CASE type #{parts.join(" ")} ELSE 999 END"
   end
 
   def signed_in_from_dfe?

--- a/config/initializers/persona.rb
+++ b/config/initializers/persona.rb
@@ -6,6 +6,12 @@ CLAIMS_PERSONAS = [
     type: "Claims::User",
   },
   {
+    first_name: "Patricia",
+    last_name: "Adebayo",
+    email: "patricia@example.com",
+    type: "Claims::ProviderUser",
+  },
+  {
     first_name: "Mary",
     last_name: "Lawson",
     email: "mary@example.com",

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -122,6 +122,12 @@ schools.each do |school|
   claims_mary.user_memberships.find_or_create_by!(organisation: school)
 end
 
+# Provider Patricia
+claims_patricia = Claims::ProviderUser.find_by!(email: "patricia@example.com")
+Claims::Provider.order_by_name.first(2).each do |provider|
+  claims_patricia.user_memberships.find_or_create_by!(organisation: provider)
+end
+
 # Create dummy mentors
 mentors_data = [{ first_name: "Sarah", last_name: "Doe", trn: "1234567" },
                 { first_name: "John", last_name: "Doe", trn: "1212121" },

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -67,6 +67,7 @@ FactoryBot.define do
   end
 
   factory :claims_user, class: "Claims::User", parent: :user
+  factory :claims_provider_user, class: "Claims::ProviderUser", parent: :user
   factory :support_user, traits: [:support], parent: :user
 
   factory :placements_user,

--- a/spec/models/claims/provider_user_spec.rb
+++ b/spec/models/claims/provider_user_spec.rb
@@ -1,0 +1,53 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                        :uuid             not null, primary key
+#  first_name                :string           not null
+#  last_name                 :string           not null
+#  email                     :string           not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  type                      :string
+#  dfe_sign_in_uid           :string
+#  last_signed_in_at         :datetime
+#  discarded_at              :datetime
+#  selected_academic_year_id :uuid
+#
+# Indexes
+#
+#  index_users_on_selected_academic_year_id        (selected_academic_year_id)
+#  index_users_on_type_and_discarded_at_and_email  (type,discarded_at,email)
+#  index_users_on_type_and_email                   (type,email) UNIQUE
+#
+
+require "rails_helper"
+
+RSpec.describe Claims::ProviderUser do
+  describe "associations" do
+    describe "#providers" do
+      it { is_expected.to have_many(:providers).through(:user_memberships).source(:organisation) }
+
+      it "returns providers linked through memberships" do
+        provider_user = create(:claims_provider_user)
+        provider_1 = create(:claims_provider)
+        provider_2 = create(:claims_provider)
+
+        provider_user.providers << provider_1
+        provider_user.providers << provider_2
+
+        expect(provider_user.providers).to contain_exactly(provider_1, provider_2)
+      end
+    end
+  end
+
+  describe "#organisation_count" do
+    it "returns the number of providers linked to the user" do
+      provider_user = create(:claims_provider_user)
+      provider_user.providers << create(:claims_provider)
+      provider_user.providers << create(:claims_provider)
+
+      expect(provider_user.organisation_count).to eq(2)
+    end
+  end
+end

--- a/spec/requests/personas_spec.rb
+++ b/spec/requests/personas_spec.rb
@@ -19,5 +19,12 @@ RSpec.describe "Personas", type: :request do
       get "/personas"
       expect(response).to have_http_status(:success)
     end
+
+    context "when placements service", service: :placements do
+      it "returns http success" do
+        get "/personas"
+        expect(response).to have_http_status(:success)
+      end
+    end
   end
 end

--- a/spec/system/claims/sign_in_as_a_claims_user_spec.rb
+++ b/spec/system/claims/sign_in_as_a_claims_user_spec.rb
@@ -25,6 +25,32 @@ RSpec.describe "Sign In as a Claims User", service: :claims, type: :system do
     end
   end
 
+  context "when the user is assigned to a provider" do
+    let!(:provider_organisation) { create(:claims_provider, name: "Claims Provider") }
+
+    scenario "I sign in as a provider user and can access the service" do
+      given_there_is_an_existing_provider_user_for("Patricia")
+      and_the_provider_user_is_part_of_an_organisation(provider_organisation)
+      when_i_visit_the_sign_in_path
+      when_i_click_sign_in
+      then_i_am_redirected_to_the_schools_page
+    end
+  end
+
+  context "when the provider user is assigned to multiple providers" do
+    let!(:provider_organisation) { create(:claims_provider, name: "Claims Provider 1") }
+    let!(:another_provider_organisation) { create(:claims_provider, name: "Claims Provider 2") }
+
+    scenario "I sign in as a provider user and can access the service" do
+      given_there_is_an_existing_provider_user_for("Patricia")
+      and_the_provider_user_is_part_of_an_organisation(provider_organisation)
+      and_the_provider_user_is_part_of_an_organisation(another_provider_organisation)
+      when_i_visit_the_sign_in_path
+      when_i_click_sign_in
+      then_i_am_redirected_to_the_schools_page
+    end
+  end
+
   scenario "I sign in as a support user" do
     given_a_school_has_been_onboarded_onto_the_claims_service(name: "Claims School")
     given_there_is_an_existing_support_user_for("Colin")
@@ -160,8 +186,18 @@ RSpec.describe "Sign In as a Claims User", service: :claims, type: :system do
     user_exists_in_dfe_sign_in(user:)
   end
 
+  def given_there_is_an_existing_provider_user_for(user_name, with_dfe_sign_id: true)
+    user = create(:claims_provider_user, user_name.downcase.to_sym)
+    user.update!(dfe_sign_in_uid: nil) unless with_dfe_sign_id
+    user_exists_in_dfe_sign_in(user:)
+  end
+
   def and_the_user_is_part_of_an_organisation(organisation)
     organisation.users << User.find_by(email: "anne_wilson@example.org")
+  end
+
+  def and_the_provider_user_is_part_of_an_organisation(organisation)
+    organisation.users << User.find_by(email: "patricia@example.com")
   end
 
   def given_a_school_has_been_onboarded_onto_the_claims_service(name:)


### PR DESCRIPTION
## Context

Add a new Provider user type to facilitate the addition of a provider facing side of the service.

## Changes proposed in this pull request

- [x] Adds a new Claims::ProviderUser model
- [x] Adds the Patricia provider persona to the Claims side of the service
- [x] Updates user logic to accomodate the new type of user

## Guidance to review

Ensure that there are no gaps in the logic that could allow bad faith actors access to the service.

## Link to Trello card

https://trello.com/c/kbfEQVki/449-create-provideruser-model

## Screenshots

<img width="606" height="372" alt="image" src="https://github.com/user-attachments/assets/5e199dd8-5608-4d8c-9742-bcaa11223457" />