### PR TITLE
Upgrade Postgre sku

### DIFF
--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -4,7 +4,7 @@
   "enable_monitoring": true,
   "app_replicas": 2,
   "worker_replicas": 2,
-  "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
+  "postgres_flexible_server_sku": "GP_Standard_D2ds_v5",
   "postgres_enable_high_availability": true,
   "enable_postgres_backup_storage": true,
   "postgres_version": 17,


### PR DESCRIPTION
## Context
Production Postgres flexible server SKU needs upgrading from GP_Standard_D2ds_v4 to GP_Standard_D2ds_v5, per ticket. This is an in-place resize that briefly restarts the server, so apply is held until the outage window is confirmed with the service owner.

What might surprise a reviewer: the local plan shows 5 changes, not 1. 2 are related to the SKU upgrade. 3 are not caused by this change at all, they come from the vendored terraform-modules postgres module being recloned at the stable tag, which has moved on since this environment's last apply. Details below.

## Changes proposed in this pull request
Single line change in terraform/application/config/production.tfvars.json, updating postgres_flexible_server_sku from GP_Standard_D2ds_v4 to GP_Standard_D2ds_v5.

Local plan breakdown:

1. azurerm_postgresql_flexible_server.main[0], the intended SKU upgrade.
2. azurerm_monitor_diagnostic_setting.main[0], recompute of enabled_log categories. Expected and tied to the SKU change. The diagnostic categories data source depends on the postgres resource, so it cannot resolve the categories until after the SKU change applies, and shows as a placeholder removal until then.

Not related to this PR:

3. azurerm_monitor_metric_alert.cpu[0]
4. azurerm_monitor_metric_alert.memory[0]
5. azurerm_monitor_metric_alert.storage[0]

These update the action block's webhook_properties. There is no action group, webhook, or alert config anywhere in this repo's terraform files. Production state here was last applied against an older terraform-modules stable commit, and stable has since moved forward with a change to how the module sets webhook_properties on these alerts. Pulling stable for this run picks up that module update alongside the SKU change.

## Guidance to review
Check that production.tfvars.json only changes the sku value. The other 3 alert changes can be verified as pre-existing module drift by running a plan with TERRAFORM_MODULES_TAG pinned to the commit the environment was last applied against (before the webhook_properties change in terraform-modules), they should disappear from that plan, confirming they are unrelated to this PR. Happy to pin the ref here instead and let the module version bump go through its own separate PR if preferred.

## Link to Trello card
https://trello.com/c/nuxdGW4R/2815-upgrade-ittms-postgres-sku

## Screenshots
Plan output attached. Summary: 0 to add, 5 to change, 0 to destroy. 2 changes relate to the SKU upgrade, 3 are unrelated module-version drift described above.
<img width="1345" height="297" alt="image" src="https://github.com/user-attachments/assets/66f4c123-e1f5-4dc6-b8ac-f70188cb1908" />

