### PR TITLE
Add provider onboarding

### DIFF
--- a/app/controllers/claims/support/settings/onboard_providers_controller.rb
+++ b/app/controllers/claims/support/settings/onboard_providers_controller.rb
@@ -1,0 +1,44 @@
+class Claims::Support::Settings::OnboardProvidersController < Claims::Support::ApplicationController
+  include WizardController
+
+  before_action :has_school_accepted_grant_conditions?
+  before_action :set_wizard
+  before_action :authorize_user
+
+  helper_method :index_path
+
+  def update
+    if !@wizard.save_step
+      render "edit"
+    elsif @wizard.next_step.present?
+      redirect_to step_path(@wizard.next_step)
+    else
+      @wizard.upload_providers
+      @wizard.reset_state
+      redirect_to index_path, flash: {
+        heading: t(".success"),
+        body: t(".body"),
+      }
+    end
+  end
+
+  private
+
+  def set_wizard
+    state = session[state_key] ||= {}
+    current_step = params[:step]&.to_sym
+    @wizard = Claims::OnboardProvidersWizard.new(params:, state:, current_step:)
+  end
+
+  def authorize_user
+    authorize Claims::ProviderUser, :new?
+  end
+
+  def step_path(step)
+    onboard_providers_claims_support_schools_path(state_key:, step:)
+  end
+
+  def index_path
+    claims_support_settings_path
+  end
+end

--- a/app/jobs/claims/provider_user/create_and_deliver_job.rb
+++ b/app/jobs/claims/provider_user/create_and_deliver_job.rb
@@ -1,0 +1,17 @@
+class Claims::ProviderUser::CreateAndDeliverJob < ApplicationJob
+  queue_as :default
+
+  def perform(provider_id:, user_details:)
+    provider = Claims::Provider.find(provider_id)
+    return if provider.users.find_by(email: user_details[:email])
+
+    user = Claims::ProviderUser.find_or_create_by!(email: user_details[:email]) do |u|
+      u.first_name = user_details[:first_name]
+      u.last_name = user_details[:last_name]
+    end
+
+    user.user_memberships.create!(organisation: provider)
+
+    User::Invite.call(user:, organisation: provider)
+  end
+end

--- a/app/jobs/claims/provider_user/create_collection_job.rb
+++ b/app/jobs/claims/provider_user/create_collection_job.rb
@@ -1,0 +1,27 @@
+class Claims::ProviderUser::CreateCollectionJob < ApplicationJob
+  queue_as :default
+
+  MAX_COUNT = 500
+  MAX_CREATE_AND_DELIVER_PER_MINUTE = 100
+
+  def perform(provider_user_details:)
+    if provider_user_details.count > MAX_COUNT
+      provider_user_details.each_slice(MAX_COUNT) do |batch|
+        Claims::ProviderUser::CreateCollectionJob.perform_later(provider_user_details: batch)
+      end
+    else
+      provider_user_details.each_with_index do |user_detail, index|
+        provider = Claims::Provider.find(user_detail[:provider_id])
+        existing_user = provider.users.find_by(email: user_detail[:email])
+        next if existing_user.present?
+
+        wait_time = (index / MAX_CREATE_AND_DELIVER_PER_MINUTE).minutes
+
+        Claims::ProviderUser::CreateAndDeliverJob.set(wait: wait_time).perform_later(
+          provider_id: provider.id,
+          user_details: user_detail,
+        )
+      end
+    end
+  end
+end

--- a/app/mailers/claims/provider_user_mailer.rb
+++ b/app/mailers/claims/provider_user_mailer.rb
@@ -1,0 +1,26 @@
+class Claims::ProviderUserMailer < Claims::ApplicationMailer
+  def user_membership_created_notification(user, organisation)
+    notify_email to: user.email,
+                 subject: t(".subject", service_name:),
+                 body: t(
+                   ".body",
+                   user_name: user.first_name,
+                   organisation_name: organisation.name,
+                   service_name:,
+                   support_email:,
+                   sign_in_url: sign_in_url(utm_source: "email", utm_medium: "notification", utm_campaign: "provider"),
+                 )
+  end
+
+  def user_membership_destroyed_notification(user, organisation)
+    notify_email to: user.email,
+                 subject: t(".subject", service_name:),
+                 body: t(
+                   ".body",
+                   user_name: user.first_name,
+                   organisation_name: organisation.name,
+                   service_name:,
+                   support_email:,
+                 )
+  end
+end

--- a/app/models/claims/provider.rb
+++ b/app/models/claims/provider.rb
@@ -42,6 +42,10 @@ class Claims::Provider < Provider
     "NIoT: National Institute of Teaching, founded by the School-Led Development Trust",
   ].freeze
 
+  has_many :users,
+           through: :user_memberships,
+           source: :user,
+           class_name: "Claims::ProviderUser"
   has_many :mentor_trainings
   has_many :claims
 

--- a/app/policies/claims/support/provider_user_policy.rb
+++ b/app/policies/claims/support/provider_user_policy.rb
@@ -1,0 +1,13 @@
+class Claims::Support::ProviderUserPolicy < Claims::ApplicationPolicy
+  def update?
+    true
+  end
+
+  def download?
+    true
+  end
+
+  def destroy?
+    user != record
+  end
+end

--- a/app/services/user/invite.rb
+++ b/app/services/user/invite.rb
@@ -4,19 +4,25 @@ class User::Invite < ApplicationService
     @organisation = organisation
   end
 
-  attr_reader :user, :organisation, :service
+  attr_reader :user, :organisation
 
   def call
-    user_mailer_class(user.service).user_membership_created_notification(user, organisation).deliver_later
+    user_mailer_class.user_membership_created_notification(user, organisation).deliver_later
   end
 
   private
 
-  def user_mailer_class(service)
-    service == :placements ? placements_mailer_class : Claims::UserMailer
+  def user_mailer_class
+    return placements_mailer_class if user.service == :placements
+
+    claims_mailer_class
   end
 
   def placements_mailer_class
     organisation.is_a?(School) ? ::Placements::SchoolUserMailer : ::Placements::ProviderUserMailer
+  end
+
+  def claims_mailer_class
+    user.is_a?(Claims::ProviderUser) ? Claims::ProviderUserMailer : Claims::UserMailer
   end
 end

--- a/app/views/claims/support/settings/index.html.erb
+++ b/app/views/claims/support/settings/index.html.erb
@@ -9,6 +9,7 @@
       <h2 class="govuk-heading-m"><%= t(".service_management") %></h2>
       <%= govuk_list [
         govuk_link_to(t(".onboard_users"), new_onboard_users_claims_support_schools_path, no_visited_state: true),
+        govuk_link_to(t(".onboard_providers"), new_onboard_providers_claims_support_schools_path, no_visited_state: true),
         govuk_link_to(t(".onboard_schools"), new_onboard_schools_claims_support_schools_path, no_visited_state: true),
         govuk_link_to(t(".claim_windows"), claims_support_claim_windows_path, no_visited_state: true),
         govuk_link_to(t(".providers_not_submitted_claims"), providers_not_submitted_claims_claims_support_claims_reminders_path, no_visited_state: true),

--- a/app/views/claims/support/settings/onboard_providers/edit.html.erb
+++ b/app/views/claims/support/settings/onboard_providers/edit.html.erb
@@ -1,0 +1,13 @@
+<% render "claims/support/primary_navigation", current: :settings %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: back_link_path) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= render_wizard(@wizard) %>
+
+  <p class="govuk-body">
+    <%= govuk_link_to(t(".cancel"), index_path, no_visited_state: true) %>
+  </p>
+</div>

--- a/app/views/wizards/claims/onboard_providers_wizard/_confirmation_step.html.erb
+++ b/app/views/wizards/claims/onboard_providers_wizard/_confirmation_step.html.erb
@@ -1,0 +1,50 @@
+<% content_for(:page_title) { sanitize t(".page_title") } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= t(".caption") %></span>
+      <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+
+      <%= form_for(current_step, url: current_step_path, method: :put) do |f| %>
+        <%= f.govuk_error_summary %>
+
+        <h2 class="govuk-heading-m"><%= t(".preview_file_name", file_name: current_step.file_name) %></h2>
+
+        <div class="horizontal-scrollable">
+          <%= govuk_table do |table| %>
+            <% table.with_head do |head| %>
+              <% head.with_row do |row| %>
+                <% row.with_cell text: 1 %>
+                <% current_step.csv_headers.each do |header| %>
+                  <% row.with_cell text: header %>
+                <% end %>
+              <% end %>
+            <% end %>
+
+            <% table.with_body do |body| %>
+              <% current_step.csv.first(5).each_with_index do |csv_row, index| %>
+                <% if csv_row["email"].present? %>
+                  <% body.with_row do |row| %>
+                    <% row.with_cell text: index + 2 %>
+                    <% current_step.csv_headers.each do |header| %>
+                      <%= row.with_cell text: csv_row[header] %>
+                    <% end %>
+                  <% end %>
+                <% end %>
+              <% end %>
+            <% end %>
+          <% end %>
+        </div>
+
+        <p class="govuk_body govuk-!-text-align-centre secondary-text">
+          <% if current_step.csv.count > 5 %>
+            <%= t(".only_showing_first_five_rows") %>
+          <% else %>
+            <%= t(".showing_all_rows") %>
+          <% end %>
+        </p>
+
+        <%= f.govuk_submit(t(".confirm_upload")) %>
+      <% end %>
+  </div>
+</div>

--- a/app/views/wizards/claims/onboard_providers_wizard/_upload_errors_step.html.erb
+++ b/app/views/wizards/claims/onboard_providers_wizard/_upload_errors_step.html.erb
@@ -1,0 +1,85 @@
+<% content_for(:page_title) { sanitize title_with_error_prefix(t(".page_title"), error: true) } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= t(".caption") %></span>
+    <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+
+    <div class="govuk-error-summary" data-module="govuk-error-summary">
+      <div role="alert">
+        <h2 class="govuk-error-summary__title">
+          <%= t(".error_summary.title") %>
+        </h2>
+        <div class="govuk-error-summary__body">
+          <div class="govuk-list govuk-error-summary__list">
+              <p class="govuk-heading-s">
+                <%= t(".error_summary.errors_to_fix", count: current_step.error_count) %>
+              </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <h2 class="govuk-heading-m"><%= current_step.file_name %></h2>
+
+    <%= govuk_table do |table| %>
+      <% table.with_head do |head| %>
+        <% head.with_row do |row| %>
+          <% row.with_cell text: 1 %>
+          <% row.with_cell text: t(".csv_table.headers.first_name") %>
+          <% row.with_cell text: t(".csv_table.headers.last_name") %>
+          <% row.with_cell text: t(".csv_table.headers.provider_code") %>
+          <% row.with_cell text: t(".csv_table.headers.email") %>
+        <% end %>
+      <% end %>
+
+    <% table.with_body do |body| %>
+      <% current_step.row_indexes_with_errors.each do |csv_row_index| %>
+        <% csv_row = current_step.csv[csv_row_index] %>
+        <% body.with_row do |row| %>
+          <% row.with_cell(text: csv_row_index + 2) %>
+          <% row.with_cell do %>
+            <p>
+              <% if current_step.missing_first_name_rows.include?(csv_row_index) %>
+                <strong class="error-text"><%= t(".csv_table.errors.missing_first_name") %></strong><br>
+              <% end %>
+              <%= csv_row["first_name"] %>
+            </p>
+          <% end %>
+          <% row.with_cell do %>
+            <p>
+              <% if current_step.missing_last_name_rows.include?(csv_row_index) %>
+                <strong class="error-text"><%= t(".csv_table.errors.missing_last_name") %></strong><br>
+              <% end %>
+              <%= csv_row["last_name"] %>
+            </p>
+          <% end %>
+          <% row.with_cell do %>
+            <p>
+              <% if current_step.invalid_provider_code_rows.include?(csv_row_index) %>
+                <strong class="error-text"><%= t(".csv_table.errors.invalid_provider") %></strong><br>
+              <% end %>
+              <%= csv_row["provider_code"] %>
+            </p>
+          <% end %>
+          <% row.with_cell do %>
+            <p>
+              <% if current_step.invalid_email_rows.include?(csv_row_index) %>
+                <strong class="error-text"><%= t(".csv_table.errors.invalid_email") %></strong><br>
+              <% end %>
+              <%= csv_row["email"] %>
+            </p>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <p class="govuk_body govuk-!-text-align-centre secondary-text">
+    <%= t(".only_showing_rows_with_errors") %>
+  </p>
+
+  <%= govuk_button_link_to t(".upload_your_file_again"), step_path(:upload) %>
+
+  </div>
+</div>

--- a/app/views/wizards/claims/onboard_providers_wizard/_upload_step.html.erb
+++ b/app/views/wizards/claims/onboard_providers_wizard/_upload_step.html.erb
@@ -1,0 +1,24 @@
+<% content_for(:page_title) { sanitize title_with_error_prefix(t(".page_title"), error: current_step.errors.any?) } %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".caption") %></span>
+      <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+
+      <%= form_for(current_step, url: current_step_path, method: :put, multipart: true) do |f| %>
+        <%= f.govuk_error_summary(presenter: DetailedErrorSummaryPresenter) %>
+
+        <p class="govuk-body"><%= t(".upload_the_csv_file") %></p>
+
+        <%= f.govuk_file_field :csv_upload, label: { text: t(".upload_csv_file"), hidden: true } %>
+
+        <%= govuk_details(summary_text: t(".csv_help")) do %>
+          <%= render_markdown(t(".csv_help_details")) %>
+        <% end %>
+
+        <%= f.govuk_submit(t(".upload")) %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/wizards/claims/onboard_providers_wizard.rb
+++ b/app/wizards/claims/onboard_providers_wizard.rb
@@ -1,0 +1,51 @@
+module Claims
+  class OnboardProvidersWizard < ClaimBaseWizard
+    def define_steps
+      add_step(UploadStep)
+      if csv_inputs_valid?
+        add_step(ConfirmationStep)
+      else
+        add_step(UploadErrorsStep)
+      end
+    end
+
+    def upload_providers
+      raise "Invalid wizard state" unless valid? && csv_inputs_valid?
+
+      return if provider_user_details.blank?
+
+      Claims::ProviderUser::CreateCollectionJob.perform_later(provider_user_details:)
+    end
+
+    private
+
+    def provider_user_details
+      @provider_user_details ||= begin
+        details = []
+        csv_rows.each do |row|
+          provider = Claims::Provider.find_by(code: row["provider_code"])
+          next if provider.blank?
+          next if row["email"].blank? || URI::MailTo::EMAIL_REGEXP.match(row["email"]).nil?
+
+          details << {
+            provider_id: provider.id,
+            first_name: row["first_name"],
+            last_name: row["last_name"],
+            email: row["email"],
+          }
+        end
+        details
+      end
+    end
+
+    def csv_inputs_valid?
+      @csv_inputs_valid ||= steps.fetch(:upload).csv_inputs_valid?
+    end
+
+    def csv_rows
+      steps.fetch(:upload).csv.reject do |row|
+        row["email"].blank? || row["provider_code"].blank?
+      end
+    end
+  end
+end

--- a/app/wizards/claims/onboard_providers_wizard/confirmation_step.rb
+++ b/app/wizards/claims/onboard_providers_wizard/confirmation_step.rb
@@ -1,0 +1,13 @@
+class Claims::OnboardProvidersWizard::ConfirmationStep < BaseStep
+  delegate :file_name, :csv, to: :upload_step
+
+  def csv_headers
+    @csv_headers ||= csv.headers
+  end
+
+  private
+
+  def upload_step
+    @upload_step ||= wizard.steps.fetch(:upload)
+  end
+end

--- a/app/wizards/claims/onboard_providers_wizard/upload_errors_step.rb
+++ b/app/wizards/claims/onboard_providers_wizard/upload_errors_step.rb
@@ -1,0 +1,18 @@
+class Claims::OnboardProvidersWizard::UploadErrorsStep < BaseStep
+  delegate :file_name, :csv, :invalid_email_rows, :invalid_provider_code_rows,
+           :missing_first_name_rows, :missing_last_name_rows, to: :upload_step
+
+  def row_indexes_with_errors
+    (invalid_email_rows + invalid_provider_code_rows + missing_first_name_rows + missing_last_name_rows).uniq.sort
+  end
+
+  def error_count
+    row_indexes_with_errors.count
+  end
+
+  private
+
+  def upload_step
+    @upload_step ||= wizard.steps.fetch(:upload)
+  end
+end

--- a/app/wizards/claims/onboard_providers_wizard/upload_step.rb
+++ b/app/wizards/claims/onboard_providers_wizard/upload_step.rb
@@ -1,0 +1,112 @@
+class Claims::OnboardProvidersWizard::UploadStep < BaseStep
+  attribute :csv_upload
+  attribute :csv_content
+  attribute :file_name
+  attribute :invalid_email_rows, default: []
+  attribute :invalid_provider_code_rows, default: []
+  attribute :missing_first_name_rows, default: []
+  attribute :missing_last_name_rows, default: []
+
+  validates :csv_upload, presence: true, if: -> { csv_content.blank? }
+  validate :validate_csv_file, if: -> { csv_upload.present? }
+  validate :validate_csv_headers, if: -> { csv_content.present? }
+
+  REQUIRED_HEADERS = %w[email provider_code first_name last_name].freeze
+
+  def initialize(wizard:, attributes:)
+    super(wizard:, attributes:)
+    process_csv if csv_upload.present?
+  end
+
+  def validate_csv_file
+    errors.add(:csv_upload, :invalid) unless csv_format
+  end
+
+  def validate_csv_headers
+    csv_headers = csv.headers
+    missing_columns = REQUIRED_HEADERS - csv_headers
+    return if missing_columns.empty?
+
+    errors.add(:csv_upload,
+               :invalid_headers,
+               missing_columns: missing_columns.map { |string|
+                 "'#{string}'"
+               }.to_sentence)
+    errors.add(:csv_upload,
+               :uploaded_headers,
+               uploaded_headers: csv_headers.map { |string|
+                 "'#{string}'"
+               }.to_sentence)
+  end
+
+  def csv_inputs_valid?
+    return true if csv_content.blank?
+
+    reset_input_attributes
+
+    csv.each_with_index do |row, i|
+      next if row.all? { |_k, v| v.blank? }
+
+      validate_name_fields(row, i)
+      validate_email(row, i)
+      validate_provider_code(row, i)
+    end
+
+    invalid_email_rows.blank? &&
+      invalid_provider_code_rows.blank? &&
+      missing_first_name_rows.blank? &&
+      missing_last_name_rows.blank?
+  end
+
+  def process_csv
+    validate_csv_file
+    return if errors.present?
+
+    assign_csv_content
+    self.file_name = csv_upload.original_filename
+
+    self.csv_upload = nil
+  end
+
+  def csv
+    @csv ||= CSV.parse(read_csv, headers: true, skip_blanks: true, encoding: "iso-8859-1:utf-8")
+  end
+
+  private
+
+  def csv_format
+    csv_upload.content_type == "text/csv"
+  end
+
+  def assign_csv_content
+    self.csv_content = read_csv
+  end
+
+  def read_csv
+    @read_csv ||= csv_content || csv_upload.read
+  end
+
+  def reset_input_attributes
+    self.missing_first_name_rows = []
+    self.missing_last_name_rows = []
+    self.invalid_email_rows = []
+    self.invalid_provider_code_rows = []
+  end
+
+  def validate_name_fields(row, row_number)
+    missing_first_name_rows << row_number if row["first_name"].blank?
+    missing_last_name_rows << row_number if row["last_name"].blank?
+  end
+
+  def validate_email(row, row_number)
+    return unless URI::MailTo::EMAIL_REGEXP.match(row["email"]).nil?
+
+    invalid_email_rows << row_number
+  end
+
+  def validate_provider_code(row, row_number)
+    return if Claims::Provider.find_by(code: row["provider_code"])
+
+    invalid_provider_code_rows << row_number
+  end
+end

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -371,6 +371,15 @@ en:
                 Your file needs a column called %{missing_columns}.
               uploaded_headers:
                 Right now it has columns called %{uploaded_headers}.
+        claims/onboard_providers_wizard/upload_step:
+          attributes:
+            csv_upload:
+              blank: Select a CSV file to upload
+              invalid: The selected file must be a CSV
+              invalid_headers:
+                Your file needs a column called %{missing_columns}.
+              uploaded_headers:
+                Right now it has columns called %{uploaded_headers}.
         claims/add_organisation_wizard/name_step:
           attributes:
             name:

--- a/config/locales/en/claims/provider_user_mailer.yml
+++ b/config/locales/en/claims/provider_user_mailer.yml
@@ -1,0 +1,35 @@
+en:
+  claims:
+    provider_user_mailer:
+      user_membership_created_notification:
+        subject: Invitation to join %{service_name}
+        body: |
+          Dear %{user_name},
+
+          You have been invited to join the %{service_name} service for %{organisation_name}.
+
+          Sign in using DfE Sign-in:
+
+          [%{sign_in_url}](%{sign_in_url})
+
+          # Give feedback or report a problem
+
+          If you have any questions or feedback, please contact the team at [%{support_email}](mailto:%{support_email}).
+
+          Regards
+
+          %{service_name} team
+      user_membership_destroyed_notification:
+        subject: You have been removed from %{service_name}
+        body: |
+          Dear %{user_name},
+
+          You have been removed from the %{service_name} service for %{organisation_name}.
+
+          # Give feedback or report a problem
+
+          If you have any questions or feedback, please contact the team at [%{support_email}](mailto:%{support_email}).
+
+          Regards
+
+          %{service_name} team

--- a/config/locales/en/claims/support/settings.yml
+++ b/config/locales/en/claims/support/settings.yml
@@ -10,12 +10,12 @@ en:
           providers_not_submitted_claims: Remind providers to submit claims
           schools_not_signed_in: Remind schools to sign in
           school_has_signed_in_but_not_claimed: Remind schools that have signed in to make claims
-          export: Export
           export_users: Export users (CSV)
           emails: View email templates
           reset_database: Reset database
-          revert_claims_to_submitted: Revert all claims to 'Submitted'
+          revert_claims_to_submitted: "Revert all claims to 'Submitted'"
           onboard_users: Invite users to the service
+          onboard_providers: Invite providers to the service
           onboard_schools: Make schools eligible to submit claims
           manually_onboarded_schools: View manually onboarded schools
           service_management: Service management

--- a/config/locales/en/claims/support/settings/onboard_providers.yml
+++ b/config/locales/en/claims/support/settings/onboard_providers.yml
@@ -1,0 +1,12 @@
+en:
+  claims:
+    support:
+      settings:
+        onboard_providers:
+          edit:
+            cancel: Cancel
+          update:
+            success: Providers CSV uploaded
+            body: |
+              It may take a moment for the providers to load. 
+              Refresh the page to see newly uploaded information.

--- a/config/locales/en/wizards/claims/onboard_providers_wizard.yml
+++ b/config/locales/en/wizards/claims/onboard_providers_wizard.yml
@@ -1,0 +1,51 @@
+en:
+  wizards:
+    claims:
+      onboard_providers_wizard:
+        upload_step:
+          page_title: Upload providers - Onboard providers - Claims
+          caption: Onboard providers
+          title: Upload providers
+          upload_csv_file: Upload CSV file
+          upload: Upload
+          csv_help: Help with the CSV file
+          upload_the_csv_file: Upload the CSV file sent to you with the list of provider users.
+          csv_help_details: |
+            Use this form to upload the CSV file with provider users.
+
+            The CSV file must contain the following headers in the first row:
+
+              - email
+              - provider_code
+              - first_name
+              - last_name
+        confirmation_step:
+          page_title: Are you sure you want to upload the providers? - Onboard providers - Claims
+          caption: Onboard providers
+          title: Confirm you want to upload providers
+          preview_file_name: Preview of %{file_name}
+          confirm_upload: Confirm upload
+          only_showing_first_five_rows: Only showing the first 5 rows
+          showing_all_rows: Showing all rows
+        upload_errors_step:
+          page_title: Upload providers - Onboard providers - Claims
+          caption: Onboard providers
+          title: Upload providers
+          error_summary:
+            title: There is a problem
+            errors_to_fix:
+                one: You need to fix %{count} error related to a specific row
+                other: You need to fix %{count} errors related to specific rows
+          csv_table:
+            headers:
+              first_name: first_name
+              last_name: last_name
+              provider_code: provider_code
+              email: email
+            errors:
+              missing_first_name: Enter a first name
+              missing_last_name: Enter a last name
+              invalid_email: Enter a valid email address
+              invalid_provider: Enter a valid onboarded provider code
+          only_showing_rows_with_errors: Only showing rows with errors
+          upload_your_file_again: Upload your file again

--- a/config/routes/claims.rb
+++ b/config/routes/claims.rb
@@ -260,6 +260,10 @@ scope module: :claims, as: :claims, constraints: {
         get "onboard_users", to: "settings/onboard_users#new", as: :new_onboard_users
         get "onboard_users/:state_key/:step", to: "settings/onboard_users#edit", as: :onboard_users
         put "onboard_users/:state_key/:step", to: "settings/onboard_users#update"
+
+        get "onboard_providers", to: "settings/onboard_providers#new", as: :new_onboard_providers
+        get "onboard_providers/:state_key/:step", to: "settings/onboard_providers#edit", as: :onboard_providers
+        put "onboard_providers/:state_key/:step", to: "settings/onboard_providers#update"
       end
     end
 

--- a/spec/fixtures/claims/provider_user/invalid_headers_upload_provider_users.csv
+++ b/spec/fixtures/claims/provider_user/invalid_headers_upload_provider_users.csv
@@ -1,0 +1,2 @@
+provider_name,provider_code,first_name,last_name
+London Provider,ABC,Joe,Bloggs

--- a/spec/fixtures/claims/provider_user/invalid_upload_provider_users.csv
+++ b/spec/fixtures/claims/provider_user/invalid_upload_provider_users.csv
@@ -1,0 +1,2 @@
+provider_name,provider_code,first_name,last_name,email
+London Provider,ABC,Joe,Bloggs,not-an-email

--- a/spec/fixtures/claims/provider_user/upload_provider_users.csv
+++ b/spec/fixtures/claims/provider_user/upload_provider_users.csv
@@ -1,0 +1,4 @@
+provider_name,provider_code,first_name,last_name,email
+London Provider,ABC,Joe,Bloggs,joe_bloggs@example.com
+Guildford Provider,XYZ,Sue,Doe,sue_doe@example.com
+,,,,

--- a/spec/jobs/claims/provider_user/create_and_deliver_job_spec.rb
+++ b/spec/jobs/claims/provider_user/create_and_deliver_job_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+RSpec.describe Claims::ProviderUser::CreateAndDeliverJob, type: :job do
+  describe "#perform" do
+    let(:provider) { create(:claims_provider) }
+    let(:user_details) do
+      {
+        first_name: "Joe",
+        last_name: "Bloggs",
+        email: "joe_bloggs@example.com",
+      }
+    end
+
+    it "enqueues the job in the default queue" do
+      expect {
+        described_class.perform_later(provider_id: provider.id, user_details:)
+      }.to have_enqueued_job(described_class).on_queue("default")
+    end
+
+    context "when the user details do not match an existing user" do
+      it "creates a provider user, a membership to the provider and dispatches an email to the user" do
+        expect {
+          described_class.perform_now(provider_id: provider.id, user_details:)
+        }.to change(Claims::ProviderUser, :count).by(1)
+          .and change(UserMembership, :count).by(1)
+          .and enqueue_mail(Claims::ProviderUserMailer, :user_membership_created_notification)
+
+        user = Claims::ProviderUser.find_by!(email: "joe_bloggs@example.com")
+        expect(user.first_name).to eq("Joe")
+        expect(user.last_name).to eq("Bloggs")
+
+        expect(user.providers).to contain_exactly(provider)
+      end
+    end
+
+    context "when the user details match an existing user" do
+      let(:existing_user) do
+        create(
+          :claims_provider_user,
+          first_name: "Joe",
+          last_name: "Bloggs",
+          email: "joe_bloggs@example.com",
+        )
+      end
+
+      before { existing_user }
+
+      context "when the user is not already associated with the provider" do
+        it "does not create a user" do
+          expect {
+            described_class.perform_now(provider_id: provider.id, user_details:)
+          }.not_to change(Claims::ProviderUser, :count)
+        end
+
+        it "creates a membership to the provider and dispatches an email to the user" do
+          expect {
+            described_class.perform_now(provider_id: provider.id, user_details:)
+          }.to change(UserMembership, :count).by(1)
+            .and enqueue_mail(Claims::ProviderUserMailer, :user_membership_created_notification)
+
+          expect(existing_user.providers).to contain_exactly(provider)
+        end
+      end
+
+      context "when the user is already associated with the provider" do
+        before { create(:user_membership, user: existing_user, organisation: provider) }
+
+        it "does not create a user" do
+          expect {
+            described_class.perform_now(provider_id: provider.id, user_details:)
+          }.not_to change(Claims::ProviderUser, :count)
+        end
+
+        it "does not create a membership between the user and provider" do
+          expect {
+            described_class.perform_now(provider_id: provider.id, user_details:)
+          }.not_to change(UserMembership, :count)
+        end
+
+        it "does not dispatch an email to the user" do
+          expect {
+            described_class.perform_now(provider_id: provider.id, user_details:)
+          }.not_to enqueue_mail(Claims::ProviderUserMailer, :user_membership_created_notification)
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/claims/provider_user/create_collection_job_spec.rb
+++ b/spec/jobs/claims/provider_user/create_collection_job_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe Claims::ProviderUser::CreateCollectionJob, type: :job do
+  describe "#perform" do
+    let(:provider) { create(:claims_provider) }
+    let(:provider_user_details) do
+      [
+        {
+          provider_id: provider.id,
+          first_name: "Joe",
+          last_name: "Bloggs",
+          email: "joe_bloggs@example.com",
+        },
+        {
+          provider_id: provider.id,
+          first_name: "Sue",
+          last_name: "Doe",
+          email: "sue_doe@example.com",
+        },
+      ]
+    end
+
+    it "enqueues the job in the default queue" do
+      expect {
+        described_class.perform_later(provider_user_details:)
+      }.to have_enqueued_job(described_class).on_queue("default")
+    end
+
+    context "when the array of user details is over 500 elements" do
+      let(:provider_user_details) { 600.times.map { |_i| {} } }
+
+      it "breaks the job into smaller jobs" do
+        expect {
+          described_class.perform_now(provider_user_details:)
+        }.to have_enqueued_job(described_class).twice
+      end
+    end
+
+    context "when the array of user details is less than 500 elements" do
+      it "enqueues a Claims::ProviderUser::CreateAndDeliverJob per user details" do
+        expect {
+          described_class.perform_now(provider_user_details:)
+        }.to have_enqueued_job(Claims::ProviderUser::CreateAndDeliverJob).twice
+      end
+
+      it "rate limits Claims::ProviderUser::CreateAndDeliverJob scheduling" do
+        stub_const("Claims::ProviderUser::CreateCollectionJob::MAX_CREATE_AND_DELIVER_PER_MINUTE", 1)
+        allow(Claims::ProviderUser::CreateAndDeliverJob).to receive(:set).and_call_original
+
+        described_class.perform_now(provider_user_details:)
+
+        expect(Claims::ProviderUser::CreateAndDeliverJob).to have_received(:set).with(wait: 0.minutes)
+        expect(Claims::ProviderUser::CreateAndDeliverJob).to have_received(:set).with(wait: 1.minute)
+      end
+
+      context "when a user already exists" do
+        before do
+          create(:claims_provider_user, providers: [provider], email: "joe_bloggs@example.com")
+        end
+
+        it "does not enqueue a Claims::ProviderUser::CreateAndDeliverJob" do
+          expect {
+            described_class.perform_now(provider_user_details:)
+          }.to have_enqueued_job(Claims::ProviderUser::CreateAndDeliverJob).once
+        end
+      end
+    end
+  end
+end

--- a/spec/mailers/claims/provider_user_mailer_spec.rb
+++ b/spec/mailers/claims/provider_user_mailer_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe Claims::ProviderUserMailer, type: :mailer do
+  describe "#user_membership_created_notification" do
+    subject(:invite_email) { described_class.user_membership_created_notification(user, organisation) }
+
+    let(:user) { create(:claims_provider_user, first_name: "Joe") }
+    let(:organisation) { create(:claims_provider, name: "Best Practice Network") }
+
+    it "sends the invitation" do
+      expect(invite_email.to).to contain_exactly(user.email)
+      expect(invite_email.subject).to eq("Invitation to join Claim funding for mentor training")
+      expect(invite_email.body).to have_content <<~EMAIL
+        Dear Joe,
+
+        You have been invited to join the Claim funding for mentor training service for Best Practice Network.
+
+        Sign in using DfE Sign-in:
+
+        [http://claims.localhost/sign-in?utm_campaign=provider&utm_medium=notification&utm_source=email](http://claims.localhost/sign-in?utm_campaign=provider&utm_medium=notification&utm_source=email)
+
+        # Give feedback or report a problem
+
+        If you have any questions or feedback, please contact the team at [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk).
+
+        Regards
+
+        Claim funding for mentor training team
+      EMAIL
+    end
+  end
+
+  describe "#user_membership_destroyed_notification" do
+    subject(:removal_email) { described_class.user_membership_destroyed_notification(user, organisation) }
+
+    let(:user) { create(:claims_provider_user, first_name: "Joe") }
+    let(:organisation) { create(:claims_provider, name: "Best Practice Network") }
+
+    it "sends the removal notification" do
+      expect(removal_email.to).to contain_exactly(user.email)
+      expect(removal_email.subject).to eq("You have been removed from Claim funding for mentor training")
+      expect(removal_email.body).to have_content <<~EMAIL
+        Dear Joe,
+
+        You have been removed from the Claim funding for mentor training service for Best Practice Network.
+
+        # Give feedback or report a problem
+
+        If you have any questions or feedback, please contact the team at [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk).
+
+        Regards
+
+        Claim funding for mentor training team
+      EMAIL
+    end
+  end
+end

--- a/spec/mailers/previews/claims/provider_user_mailer_preview.rb
+++ b/spec/mailers/previews/claims/provider_user_mailer_preview.rb
@@ -1,0 +1,28 @@
+class Claims::ProviderUserMailerPreview < ActionMailer::Preview
+  def user_membership_created_notification
+    Claims::ProviderUserMailer.user_membership_created_notification(provider_user, provider)
+  end
+
+  def user_membership_destroyed_notification
+    Claims::ProviderUserMailer.user_membership_destroyed_notification(provider_user, provider)
+  end
+
+  private
+
+  def provider_user
+    Claims::ProviderUser.new(
+      id: SecureRandom.uuid,
+      first_name: "Joe",
+      last_name: "Bloggs",
+      email: "example@education.gov.uk",
+    )
+  end
+
+  def provider
+    Claims::Provider.new(
+      id: SecureRandom.uuid,
+      name: "Example Provider",
+      code: "123",
+    )
+  end
+end

--- a/spec/models/claims/provider_spec.rb
+++ b/spec/models/claims/provider_spec.rb
@@ -40,6 +40,28 @@ require "rails_helper"
 
 RSpec.describe Claims::Provider, type: :model do
   context "with associations" do
+    describe "#users" do
+      it { is_expected.to have_many(:users).through(:user_memberships) }
+
+      it "returns only Claims::ProviderUser records" do
+        claims_provider = create(:claims_provider)
+        claims_provider_user = create(:claims_provider_user)
+
+        claims_provider.users << claims_provider_user
+
+        expect(claims_provider.users).to contain_exactly(claims_provider_user)
+        expect(claims_provider.users).to all(be_a(Claims::ProviderUser))
+      end
+
+      it "does not allow non-claims provider users to be added" do
+        claims_provider = create(:claims_provider)
+
+        expect {
+          claims_provider.users << create(:placements_user)
+        }.to raise_error(ActiveRecord::AssociationTypeMismatch)
+      end
+    end
+
     it { is_expected.to have_many(:mentor_trainings) }
     it { is_expected.to have_many(:claims) }
   end

--- a/spec/models/claims/provider_user_spec.rb
+++ b/spec/models/claims/provider_user_spec.rb
@@ -50,4 +50,10 @@ RSpec.describe Claims::ProviderUser do
       expect(provider_user.organisation_count).to eq(2)
     end
   end
+
+  describe "#service" do
+    it "returns :claims" do
+      expect(described_class.new.service).to eq(:claims)
+    end
+  end
 end

--- a/spec/policies/claims/support/provider_user_policy_spec.rb
+++ b/spec/policies/claims/support/provider_user_policy_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+describe Claims::Support::ProviderUserPolicy do
+  subject(:provider_user_policy) { described_class }
+
+  let(:support_user_1) { create(:claims_support_user) }
+  let(:support_user_2) { create(:claims_support_user) }
+  let(:non_support_user) { create(:claims_user) }
+
+  %i[update? download?].each do |permission|
+    permissions permission do
+      it { is_expected.to permit(support_user_1, support_user_2) }
+      it { is_expected.to permit(non_support_user, support_user_2) }
+    end
+  end
+
+  permissions :destroy? do
+    it "denies access when current user is the provider user" do
+      expect(provider_user_policy).not_to permit(support_user_1, support_user_1)
+    end
+
+    it "grants access when current user is not the provider user" do
+      expect(provider_user_policy).to permit(support_user_1, support_user_2)
+    end
+  end
+end

--- a/spec/services/user/invite_spec.rb
+++ b/spec/services/user/invite_spec.rb
@@ -17,6 +17,15 @@ RSpec.describe User::Invite do
           expect { user_invite_service }.to have_enqueued_mail(Claims::UserMailer, :user_membership_created_notification).with(user, organisation)
         end
       end
+
+      describe "when the organisation is a provider" do
+        let(:user) { create(:claims_provider_user) }
+        let(:organisation) { create(:claims_provider) }
+
+        it "calls mailer with correct prams" do
+          expect { user_invite_service }.to have_enqueued_mail(Claims::ProviderUserMailer, :user_membership_created_notification).with(user, organisation)
+        end
+      end
     end
 
     context "when the user's service is Placements" do

--- a/spec/system/claims/support/settings/onboard_multiple_provider_users/support_user_does_not_upload_a_provider_file_spec.rb
+++ b/spec/system/claims/support/settings/onboard_multiple_provider_users/support_user_does_not_upload_a_provider_file_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe "Support user does not upload a provider file", service: :claims, type: :system do
+  scenario do
+    given_providers_exist
+    and_i_am_signed_in
+    when_i_navigate_to_the_settings_index_page
+    and_i_navigate_to_onboard_multiple_provider_users
+    then_i_see_the_upload_page
+
+    when_i_click_on_upload
+    then_i_see_the_errors_page
+  end
+
+  private
+
+  def given_providers_exist
+    create(:claims_provider, name: "London Provider", code: "ABC")
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_settings_index_page
+    within(primary_navigation) do
+      click_on "Settings"
+    end
+  end
+
+  def and_i_navigate_to_onboard_multiple_provider_users
+    click_on "Invite providers to the service"
+  end
+
+  def then_i_see_the_upload_page
+    expect(page).to have_title("Upload providers - Onboard providers")
+    expect(page).to have_element(:span, text: "Onboard providers", class: "govuk-caption-l")
+    expect(page).to have_h1("Upload providers", class: "govuk-heading-l")
+    expect(page).to have_button("Upload")
+  end
+
+  def when_i_click_on_upload
+    click_on "Upload"
+  end
+
+  def then_i_see_the_errors_page
+    expect(page).to have_title("Error: Upload providers - Onboard providers - Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_element(:span, text: "Onboard providers", class: "govuk-caption-l")
+    expect(page).to have_h1("Upload providers", class: "govuk-heading-l")
+    expect(page).to have_validation_error("Select a CSV file to upload")
+  end
+end

--- a/spec/system/claims/support/settings/onboard_multiple_provider_users/support_user_onboards_provider_users_for_an_invalid_provider_code_spec.rb
+++ b/spec/system/claims/support/settings/onboard_multiple_provider_users/support_user_onboards_provider_users_for_an_invalid_provider_code_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe "Support user onboards provider users for an invalid provider code", service: :claims, type: :system do
+  scenario do
+    given_providers_exist
+    and_i_am_signed_in
+    when_i_navigate_to_the_settings_index_page
+    and_i_navigate_to_onboard_multiple_provider_users
+    then_i_see_the_upload_page
+
+    when_i_upload_a_valid_file_with_invalid_provider_codes
+    when_i_click_on_upload
+    then_i_see_the_errors_page
+  end
+
+  private
+
+  def given_providers_exist
+    create(:claims_provider, name: "London Provider", code: "DEF")
+    create(:claims_provider, name: "Guildford Provider", code: "UVW")
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_settings_index_page
+    within(primary_navigation) do
+      click_on "Settings"
+    end
+  end
+
+  def and_i_navigate_to_onboard_multiple_provider_users
+    click_on "Invite providers to the service"
+  end
+
+  def then_i_see_the_upload_page
+    expect(page).to have_title("Upload providers - Onboard providers")
+    expect(page).to have_element(:span, text: "Onboard providers", class: "govuk-caption-l")
+    expect(page).to have_h1("Upload providers", class: "govuk-heading-l")
+    expect(page).to have_button("Upload")
+  end
+
+  def when_i_upload_a_valid_file_with_invalid_provider_codes
+    attach_file "Upload CSV file", "spec/fixtures/claims/provider_user/upload_provider_users.csv"
+  end
+
+  def when_i_click_on_upload
+    click_on "Upload"
+  end
+
+  def then_i_see_the_errors_page
+    expect(page).to have_title("Error: Upload providers - Onboard providers - Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_element(:span, text: "Onboard providers", class: "govuk-caption-l")
+    expect(page).to have_h1("Upload providers", class: "govuk-heading-l")
+    expect(page).to have_element(:h2, text: "There is a problem")
+    expect(page).to have_element(:div, text: "You need to fix 2 errors related to specific rows", class: "govuk-error-summary")
+    expect(page).to have_element(:td, text: "Enter a valid onboarded provider code", class: "govuk-table__cell", count: 2)
+    expect(page).to have_element(:p, text: "Only showing rows with errors", class: "govuk-!-text-align-centre")
+  end
+end

--- a/spec/system/claims/support/settings/onboard_multiple_provider_users/support_user_onboards_provider_users_spec.rb
+++ b/spec/system/claims/support/settings/onboard_multiple_provider_users/support_user_onboards_provider_users_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.describe "Support user onboards provider users", service: :claims, type: :system do
+  scenario do
+    given_providers_exist
+    and_i_am_signed_in
+    when_i_navigate_to_the_settings_index_page
+    and_i_navigate_to_onboard_multiple_provider_users
+    then_i_see_the_upload_page
+
+    when_i_upload_a_valid_file
+    when_i_click_on_upload
+    then_i_see_the_confirm_users_you_want_to_upload_page
+
+    when_i_click_on_confirm_upload
+    then_i_see_a_success_message
+  end
+
+  private
+
+  def given_providers_exist
+    create(:claims_provider, name: "London Provider", code: "ABC")
+    create(:claims_provider, name: "Guildford Provider", code: "XYZ")
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_settings_index_page
+    within(primary_navigation) do
+      click_on "Settings"
+    end
+  end
+
+  def and_i_navigate_to_onboard_multiple_provider_users
+    click_on "Invite providers to the service"
+  end
+
+  def then_i_see_the_upload_page
+    expect(page).to have_title("Upload providers - Onboard providers")
+    expect(page).to have_element(:span, text: "Onboard providers", class: "govuk-caption-l")
+    expect(page).to have_h1("Upload providers", class: "govuk-heading-l")
+    expect(page).to have_button("Upload")
+  end
+
+  def when_i_upload_a_valid_file
+    attach_file "Upload CSV file", "spec/fixtures/claims/provider_user/upload_provider_users.csv"
+  end
+
+  def when_i_click_on_upload
+    click_on "Upload"
+  end
+
+  def then_i_see_the_confirm_users_you_want_to_upload_page
+    expect(page).to have_title("Are you sure you want to upload the providers? - Onboard providers")
+    expect(page).to have_element(:span, text: "Onboard providers", class: "govuk-caption-l")
+    expect(page).to have_h1("Confirm you want to upload providers", class: "govuk-heading-l")
+    expect(page).to have_h2(:p, text: "Preview of upload_provider_users.csv", class: "govuk-body")
+    expect(page).to have_table_row(
+      "1" => "2",
+      "provider_name" => "London Provider",
+      "provider_code" => "ABC",
+      "first_name" => "Joe",
+      "last_name" => "Bloggs",
+      "email" => "joe_bloggs@example.com",
+    )
+    expect(page).to have_table_row(
+      "1" => "3",
+      "provider_name" => "Guildford Provider",
+      "provider_code" => "XYZ",
+      "first_name" => "Sue",
+      "last_name" => "Doe",
+      "email" => "sue_doe@example.com",
+    )
+    expect(page).to have_button("Confirm upload")
+  end
+
+  def when_i_click_on_confirm_upload
+    click_on "Confirm upload"
+  end
+
+  def then_i_see_a_success_message
+    expect(page).to have_success_banner(
+      "Providers CSV uploaded",
+      "It may take a moment for the providers to load. Refresh the page to see newly uploaded information.",
+    )
+  end
+end

--- a/spec/system/claims/support/settings/onboard_multiple_provider_users/support_user_uploads_a_provider_file_with_invalid_headers_spec.rb
+++ b/spec/system/claims/support/settings/onboard_multiple_provider_users/support_user_uploads_a_provider_file_with_invalid_headers_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe "Support user uploads a provider file with invalid headers", service: :claims, type: :system do
+  scenario do
+    given_providers_exist
+    and_i_am_signed_in
+    when_i_navigate_to_the_settings_index_page
+    and_i_navigate_to_onboard_multiple_provider_users
+    then_i_see_the_upload_page
+
+    when_i_upload_a_file_containing_invalid_headers
+    and_i_click_on_upload
+    then_i_see_the_errors_page
+  end
+
+  private
+
+  def given_providers_exist
+    create(:claims_provider, name: "London Provider", code: "ABC")
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_settings_index_page
+    within(primary_navigation) do
+      click_on "Settings"
+    end
+  end
+
+  def and_i_navigate_to_onboard_multiple_provider_users
+    click_on "Invite providers to the service"
+  end
+
+  def then_i_see_the_upload_page
+    expect(page).to have_title("Upload providers - Onboard providers")
+    expect(page).to have_element(:span, text: "Onboard providers", class: "govuk-caption-l")
+    expect(page).to have_h1("Upload providers", class: "govuk-heading-l")
+    expect(page).to have_button("Upload")
+  end
+
+  def when_i_upload_a_file_containing_invalid_headers
+    attach_file "Upload CSV file", "spec/fixtures/claims/provider_user/invalid_headers_upload_provider_users.csv"
+  end
+
+  def and_i_click_on_upload
+    click_on "Upload"
+  end
+
+  def then_i_see_the_errors_page
+    expect(page).to have_title("Error: Upload providers - Onboard providers - Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_element(:span, text: "Onboard providers", class: "govuk-caption-l")
+    expect(page).to have_h1("Upload providers", class: "govuk-heading-l")
+    expect(page).to have_element(:h2, text: "There is a problem")
+    expect(page).to have_content("Your file needs a column called 'email'.")
+  end
+end

--- a/spec/system/claims/support/settings/onboard_multiple_provider_users/support_user_uploads_a_provider_file_with_invalid_inputs_spec.rb
+++ b/spec/system/claims/support/settings/onboard_multiple_provider_users/support_user_uploads_a_provider_file_with_invalid_inputs_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe "Support user uploads a provider file with invalid inputs", service: :claims, type: :system do
+  scenario do
+    given_providers_exist
+    and_i_am_signed_in
+    when_i_navigate_to_the_settings_index_page
+    and_i_navigate_to_onboard_multiple_provider_users
+    then_i_see_the_upload_page
+
+    when_i_upload_a_file_containing_invalid_inputs
+    and_i_click_on_upload
+    then_i_see_the_errors_page
+  end
+
+  private
+
+  def given_providers_exist
+    create(:claims_provider, name: "London Provider", code: "ABC")
+  end
+
+  def and_i_am_signed_in
+    sign_in_claims_support_user
+  end
+
+  def when_i_navigate_to_the_settings_index_page
+    within(primary_navigation) do
+      click_on "Settings"
+    end
+  end
+
+  def and_i_navigate_to_onboard_multiple_provider_users
+    click_on "Invite providers to the service"
+  end
+
+  def then_i_see_the_upload_page
+    expect(page).to have_title("Upload providers - Onboard providers")
+    expect(page).to have_element(:span, text: "Onboard providers", class: "govuk-caption-l")
+    expect(page).to have_h1("Upload providers", class: "govuk-heading-l")
+    expect(page).to have_button("Upload")
+  end
+
+  def when_i_upload_a_file_containing_invalid_inputs
+    attach_file "Upload CSV file", "spec/fixtures/claims/provider_user/invalid_upload_provider_users.csv"
+  end
+
+  def and_i_click_on_upload
+    click_on "Upload"
+  end
+
+  def then_i_see_the_errors_page
+    expect(page).to have_title("Error: Upload providers - Onboard providers - Claims - Claim funding for mentor training - GOV.UK")
+    expect(page).to have_element(:span, text: "Onboard providers", class: "govuk-caption-l")
+    expect(page).to have_h1("Upload providers", class: "govuk-heading-l")
+    expect(page).to have_element(:h2, text: "There is a problem")
+    expect(page).to have_element(:div, text: "You need to fix 1 error related to a specific row", class: "govuk-error-summary")
+    expect(page).to have_element(:td, text: "Enter a valid email address", class: "govuk-table__cell", count: 1)
+    expect(page).to have_element(:p, text: "Only showing rows with errors", class: "govuk-!-text-align-centre")
+  end
+end

--- a/spec/wizards/claims/onboard_providers_wizard/confirmation_step_spec.rb
+++ b/spec/wizards/claims/onboard_providers_wizard/confirmation_step_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe Claims::OnboardProvidersWizard::ConfirmationStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Claims::OnboardProvidersWizard).tap do |mock_wizard|
+      allow(mock_wizard).to receive_messages(steps: { upload: mock_upload_step })
+    end
+  end
+  let(:mock_upload_step) do
+    instance_double(Claims::OnboardProvidersWizard::UploadStep).tap do |mock_upload_step|
+      allow(mock_upload_step).to receive_messages(
+        file_name:,
+        csv:,
+      )
+    end
+  end
+  let(:attributes) { nil }
+  let(:file_name) { "uploaded.csv" }
+  let(:csv) { CSV.parse(csv_content, headers: true, skip_blanks: true) }
+  let(:csv_content) do
+    "provider_name,provider_code,first_name,last_name,email\r\n" \
+    "London Provider,ABC,John,Smith,john_smith@example.com"
+  end
+
+  describe "delegations" do
+    it { is_expected.to delegate_method(:csv).to(:upload_step) }
+    it { is_expected.to delegate_method(:file_name).to(:upload_step) }
+  end
+
+  describe "#csv_headers" do
+    it "returns CSV headers" do
+      expect(step.csv_headers).to match_array(
+        %w[provider_name provider_code first_name last_name email],
+      )
+    end
+  end
+end

--- a/spec/wizards/claims/onboard_providers_wizard/upload_errors_step_spec.rb
+++ b/spec/wizards/claims/onboard_providers_wizard/upload_errors_step_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe Claims::OnboardProvidersWizard::UploadErrorsStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) do
+    instance_double(Claims::OnboardProvidersWizard).tap do |mock_wizard|
+      allow(mock_wizard).to receive_messages(steps: { upload: mock_upload_step })
+    end
+  end
+  let(:mock_upload_step) do
+    instance_double(Claims::OnboardProvidersWizard::UploadStep).tap do |mock_upload_step|
+      allow(mock_upload_step).to receive_messages(
+        file_name:,
+        invalid_email_rows:,
+        invalid_provider_code_rows:,
+        missing_first_name_rows:,
+        missing_last_name_rows:,
+      )
+    end
+  end
+  let(:attributes) { nil }
+  let(:file_name) { nil }
+  let(:invalid_email_rows) { [] }
+  let(:invalid_provider_code_rows) { [] }
+  let(:missing_first_name_rows) { [] }
+  let(:missing_last_name_rows) { [] }
+
+  describe "delegations" do
+    it { is_expected.to delegate_method(:invalid_email_rows).to(:upload_step) }
+    it { is_expected.to delegate_method(:invalid_provider_code_rows).to(:upload_step) }
+    it { is_expected.to delegate_method(:missing_first_name_rows).to(:upload_step) }
+    it { is_expected.to delegate_method(:missing_last_name_rows).to(:upload_step) }
+    it { is_expected.to delegate_method(:file_name).to(:upload_step) }
+    it { is_expected.to delegate_method(:csv).to(:upload_step) }
+  end
+
+  describe "#row_indexes_with_errors" do
+    subject(:row_indexes_with_errors) { step.row_indexes_with_errors }
+
+    let(:invalid_email_rows) { [1] }
+    let(:invalid_provider_code_rows) { [1, 2, 3] }
+    let(:missing_first_name_rows) { [3, 4] }
+    let(:missing_last_name_rows) { [4, 5] }
+
+    it "merges all row numbers and removes duplicates" do
+      expect(row_indexes_with_errors).to contain_exactly(1, 2, 3, 4, 5)
+    end
+  end
+
+  describe "#error_count" do
+    subject(:error_count) { step.error_count }
+
+    let(:invalid_email_rows) { [1] }
+    let(:invalid_provider_code_rows) { [1, 2, 3, 4] }
+    let(:missing_first_name_rows) { [3, 4] }
+    let(:missing_last_name_rows) { [3, 4] }
+
+    it "returns the unique row count with errors" do
+      expect(error_count).to eq(4)
+    end
+  end
+end

--- a/spec/wizards/claims/onboard_providers_wizard/upload_step_spec.rb
+++ b/spec/wizards/claims/onboard_providers_wizard/upload_step_spec.rb
@@ -1,0 +1,229 @@
+require "rails_helper"
+
+RSpec.describe Claims::OnboardProvidersWizard::UploadStep, type: :model do
+  subject(:step) { described_class.new(wizard: mock_wizard, attributes:) }
+
+  let(:mock_wizard) { instance_double(Claims::OnboardProvidersWizard) }
+  let(:attributes) { nil }
+
+  describe "attributes" do
+    it {
+      expect(step).to have_attributes(
+        csv_upload: nil,
+        csv_content: nil,
+        file_name: nil,
+        missing_first_name_rows: [],
+        missing_last_name_rows: [],
+        invalid_email_rows: [],
+        invalid_provider_code_rows: [],
+      )
+    }
+  end
+
+  describe "validations" do
+    describe "#csv_upload" do
+      context "when csv_content is blank" do
+        it { is_expected.to validate_presence_of(:csv_upload) }
+      end
+
+      context "when csv_content is present" do
+        let(:csv_content) do
+          "provider_code,first_name,last_name,email\r\n" \
+          "ABC,John,Smith,john_smith@example.com"
+        end
+        let(:attributes) { { csv_content: } }
+
+        it { is_expected.not_to validate_presence_of(:csv_upload) }
+      end
+    end
+
+    describe "#validate_csv_headers" do
+      context "when csv_content is missing required headers" do
+        let(:csv_content) do
+          "something_random\r\n" \
+          "blah"
+        end
+        let(:attributes) { { csv_content: } }
+
+        it "returns errors for missing headers" do
+          expect(step.valid?).to be(false)
+          expect(step.errors.messages[:csv_upload]).to include(
+            "Your file needs a column called 'email', 'provider_code', 'first_name', and 'last_name'.",
+          )
+          expect(step.errors.messages[:csv_upload]).to include(
+            "Right now it has columns called 'something_random'.",
+          )
+        end
+      end
+    end
+
+    describe "#validate_csv_file" do
+      context "when csv_upload is not a CSV" do
+        let(:attributes) { { csv_upload: invalid_file } }
+        let(:invalid_file) do
+          ActionDispatch::Http::UploadedFile.new({
+            filename: "invalid.jpg",
+            type: "image/jpeg",
+            tempfile: Tempfile.new("invalid.jpg"),
+          })
+        end
+
+        it "adds an invalid file error" do
+          expect(step.valid?).to be(false)
+          expect(step.errors.messages[:csv_upload]).to include("The selected file must be a CSV")
+        end
+
+        it "does not process and persist file content" do
+          expect(step.csv_content).to be_nil
+          expect(step.file_name).to be_nil
+          expect(step.csv_upload).to eq(invalid_file)
+        end
+      end
+
+      context "when csv_upload is a CSV" do
+        let(:attributes) { { csv_upload: valid_file } }
+        let(:valid_file) do
+          ActionDispatch::Http::UploadedFile.new({
+            filename: "valid.csv",
+            type: "text/csv",
+            tempfile: File.open(
+              "spec/fixtures/claims/provider_user/upload_provider_users.csv",
+            ),
+          })
+        end
+
+        it "is valid" do
+          expect(step.valid?).to be(true)
+        end
+      end
+    end
+  end
+
+  describe "#csv_inputs_valid?" do
+    subject(:csv_inputs_valid) { step.csv_inputs_valid? }
+
+    before { create(:claims_provider, name: "London Provider", code: "ABC") }
+
+    context "when csv_content is blank" do
+      it "returns true" do
+        expect(csv_inputs_valid).to be(true)
+      end
+    end
+
+    context "when csv_content contains invalid provider code" do
+      let(:csv_content) do
+        "provider_code,first_name,last_name,email\r\n" \
+        "ZZZ,John,Smith,john_smith@example.com"
+      end
+      let(:attributes) { { csv_content: } }
+
+      it "returns false and assigns invalid provider code rows" do
+        expect(csv_inputs_valid).to be(false)
+        expect(step.invalid_provider_code_rows).to contain_exactly(0)
+      end
+    end
+
+    context "when csv_content contains invalid email" do
+      let(:csv_content) do
+        "provider_code,first_name,last_name,email\r\n" \
+        "ABC,John,Smith,invalid_email"
+      end
+      let(:attributes) { { csv_content: } }
+
+      it "returns false and assigns invalid email rows" do
+        expect(csv_inputs_valid).to be(false)
+        expect(step.invalid_email_rows).to contain_exactly(0)
+      end
+    end
+
+    context "when csv_content contains missing first_name" do
+      let(:csv_content) do
+        "provider_code,first_name,last_name,email\r\n" \
+        "ABC,James,Samson,test@sample.com\r\n" \
+        "ABC,,Smith,test@sample.com"
+      end
+      let(:attributes) { { csv_content: } }
+
+      it "returns false and assigns missing first_name rows" do
+        expect(csv_inputs_valid).to be(false)
+        expect(step.missing_first_name_rows).to contain_exactly(1)
+      end
+    end
+
+    context "when csv_content contains missing last_name" do
+      let(:csv_content) do
+        "provider_code,first_name,last_name,email\r\n" \
+        "ABC,James,,test@sample.com\r\n" \
+        "ABC,James,Samson,test@sample.com"
+      end
+      let(:attributes) { { csv_content: } }
+
+      it "returns false and assigns missing last_name rows" do
+        expect(csv_inputs_valid).to be(false)
+        expect(step.missing_last_name_rows).to contain_exactly(0)
+      end
+    end
+
+    context "when csv_content is valid" do
+      let(:csv_content) do
+        "provider_code,first_name,last_name,email\r\n" \
+        "ABC,John,Smith,john_smith@example.com\r\n" \
+        ",,,,"
+      end
+      let(:attributes) { { csv_content: } }
+
+      it "returns true" do
+        expect(csv_inputs_valid).to be(true)
+      end
+    end
+  end
+
+  describe "#process_csv" do
+    let(:attributes) { { csv_upload: valid_file } }
+    let(:valid_file) do
+      ActionDispatch::Http::UploadedFile.new({
+        filename: "valid.csv",
+        type: "text/csv",
+        tempfile: File.open(
+          "spec/fixtures/claims/provider_user/upload_provider_users.csv",
+        ),
+      })
+    end
+
+    it "reads a given CSV and assigns the content to csv_content" do
+      expect(step.csv_content).to eq(
+        "provider_name,provider_code,first_name,last_name,email\n" \
+        "London Provider,ABC,Joe,Bloggs,joe_bloggs@example.com\n" \
+        "Guildford Provider,XYZ,Sue,Doe,sue_doe@example.com\n" \
+        ",,,,\n",
+      )
+    end
+  end
+
+  describe "#csv" do
+    subject(:csv) { step.csv }
+
+    let(:csv_content) do
+      "provider_name,provider_code,first_name,last_name,email\n" \
+      "London Provider,ABC,Joe,Bloggs,joe_bloggs@example.com\n" \
+      "Guildford Provider,XYZ,Sue,Doe,sue_doe@example.com\n"
+    end
+    let(:attributes) { { csv_content: } }
+
+    it "converts csv content into a CSV record" do
+      expect(csv).to be_a(CSV::Table)
+      expect(csv.headers).to match_array(
+        %w[provider_name provider_code first_name last_name email],
+      )
+      expect(csv.count).to eq(2)
+
+      expect(csv[0].to_h).to eq({
+        "provider_name" => "London Provider",
+        "provider_code" => "ABC",
+        "first_name" => "Joe",
+        "last_name" => "Bloggs",
+        "email" => "joe_bloggs@example.com",
+      })
+    end
+  end
+end

--- a/spec/wizards/claims/onboard_providers_wizard_spec.rb
+++ b/spec/wizards/claims/onboard_providers_wizard_spec.rb
@@ -1,0 +1,136 @@
+require "rails_helper"
+
+RSpec.describe Claims::OnboardProvidersWizard do
+  subject(:wizard) { described_class.new(state:, params:, current_step: nil) }
+
+  let(:state) { {} }
+  let(:params_data) { {} }
+  let(:params) { ActionController::Parameters.new(params_data) }
+  let(:provider) { create(:claims_provider, name: "London Provider", code: "ABC") }
+
+  before { provider }
+
+  describe "#steps" do
+    subject { wizard.steps.keys }
+
+    context "when there are no errors in the upload step" do
+      it { is_expected.to eq(%i[upload confirmation]) }
+    end
+
+    context "when there are errors in the upload step" do
+      let(:csv_content) do
+        "provider_code,first_name,last_name,email\r\n" \
+        "ABC,John,Smith,invalid_email"
+      end
+      let(:state) do
+        {
+          "upload" => {
+            "csv_upload" => nil,
+            "csv_content" => csv_content,
+          },
+        }
+      end
+
+      it { is_expected.to eq(%i[upload upload_errors]) }
+    end
+  end
+
+  describe "#upload_providers" do
+    subject(:upload_providers) { wizard.upload_providers }
+
+    let(:csv_content) do
+      "provider_code,first_name,last_name,email\r\n" \
+      "ABC,John,Smith,john_smith@example.com"
+    end
+
+    let(:state) do
+      {
+        "upload" => {
+          "csv_upload" => nil,
+          "csv_content" => csv_content,
+        },
+      }
+    end
+
+    context "when the steps are valid" do
+      let(:csv_content) do
+        "provider_code,first_name,last_name,email\r\n" \
+        "ABC,John,Smith,john_smith@example.com"
+      end
+
+      it "queues a job to create provider users" do
+        expect { upload_providers }.to have_enqueued_job(
+          Claims::ProviderUser::CreateCollectionJob,
+        ).exactly(:once)
+      end
+    end
+
+    context "when an email is invalid" do
+      let(:csv_content) do
+        "provider_code,first_name,last_name,email\r\n" \
+        "ABC,John,Smith,invalid_email"
+      end
+
+      it "raises an invalid wizard state error" do
+        expect { upload_providers }.to raise_error("Invalid wizard state")
+      end
+    end
+
+    context "when a provider code is invalid" do
+      let(:csv_content) do
+        "provider_code,first_name,last_name,email\r\n" \
+        "ZZZ,John,Smith,john_smith@example.com"
+      end
+
+      it "raises an invalid wizard state error" do
+        expect { upload_providers }.to raise_error("Invalid wizard state")
+      end
+    end
+
+    context "when provider user details are blank" do
+      let(:csv_content) { "provider_code,first_name,last_name,email\r\n,,," }
+
+      it "does not enqueue a provider user collection job" do
+        expect { upload_providers }.not_to have_enqueued_job(
+          Claims::ProviderUser::CreateCollectionJob,
+        )
+      end
+    end
+  end
+
+  describe "#provider_user_details" do
+    subject(:provider_user_details) { wizard.send(:provider_user_details) }
+
+    let(:other_provider) { create(:claims_provider, name: "Guildford Provider", code: "XYZ") }
+    let(:state) do
+      {
+        "upload" => {
+          "csv_upload" => nil,
+          "csv_content" => csv_content,
+        },
+      }
+    end
+    let(:csv_content) do
+      "provider_code,first_name,last_name,email\r\n" \
+      "ZZZ,No,Provider,missing@example.com\r\n" \
+      "ABC,Bad,Email,invalid_email\r\n" \
+      "XYZ,Sue,Doe,sue_doe@example.com"
+    end
+
+    before do
+      provider
+      other_provider
+    end
+
+    it "returns only valid rows for existing providers with valid emails" do
+      expect(provider_user_details).to eq([
+        {
+          provider_id: other_provider.id,
+          first_name: "Sue",
+          last_name: "Doe",
+          email: "sue_doe@example.com",
+        },
+      ])
+    end
+  end
+end


### PR DESCRIPTION
## Context

Now that provider are going to be invited to the service we need a way to onboard them.

## Changes proposed in this pull request

- Add provider onboarding wizard
- Add provider mailer

## Guidance to review

- Log in as Colin
- Navigate to "Settings"
- Click on "Invite providers to the service"
- Navigate through the wizard
- Confirm the success

## Link to Trello card

https://trello.com/c/YdpLJy5c/450-create-onboarding-service-job-for-provider-users

## Screenshots

<img width="1012" height="403" alt="image" src="https://github.com/user-attachments/assets/04420543-1bb1-4201-85e5-3a78825765c1" />
<img width="1011" height="882" alt="image" src="https://github.com/user-attachments/assets/adbfd69d-9568-4978-84d2-fbd44af80528" />
<img width="1064" height="685" alt="image" src="https://github.com/user-attachments/assets/f03ba5a6-6e8c-45ab-869f-e407b0869d49" />
<img width="1025" height="417" alt="image" src="https://github.com/user-attachments/assets/11d7224b-8256-4e42-855f-84bc3471b5d1" />

