### PR TITLE
Add provider card component

### DIFF
--- a/app/components/claim/provider_card_component.html.erb
+++ b/app/components/claim/provider_card_component.html.erb
@@ -1,0 +1,27 @@
+<div class="claim-card">
+  <div class="claim-card__header">
+    <div class="claim-card__header__name govuk-heading-s">
+      <%= govuk_link_to href, no_visited_state: true do %>
+        <%= school.urn %>,
+        <%= school.name %>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="claim-card__body">
+    <div class="claim-card__body__details">
+      <div class="govuk-body-s"><%= school.address %></div>
+    </div>
+
+    <div class="claim-card__body__right">
+      <div class="govuk-body-s govuk-!-margin-bottom-2">
+        <%= render Claim::ProviderStatusTagComponent.new(claim:, classes: %w[govuk-body-s]) %>
+      </div>
+      <% if claim.created_at.present? %>
+        <div class="govuk-body-s"><%= t(".date_submitted", date: l(claim.created_at.to_date, format: :long)) %></div>
+      <% end %>
+      <div class="govuk-body-s"><%= t(".claim_reference", reference: claim.reference) %></div>
+      <div class="govuk-body-s"><%= t(".claim_amount", amount: humanized_money_with_symbol(claim.amount)) %></div>
+    </div>
+  </div>
+</div>

--- a/app/components/claim/provider_card_component.rb
+++ b/app/components/claim/provider_card_component.rb
@@ -1,0 +1,14 @@
+class Claim::ProviderCardComponent < ApplicationComponent
+  def initialize(claim:, href:, current_user:, classes: [], html_attributes: {})
+    super(classes:, html_attributes:)
+
+    @claim = claim.decorate
+    @href = href
+    @current_user = current_user
+    @school = claim.school.decorate
+  end
+
+  private
+
+  attr_reader :claim, :school, :href, :current_user
+end

--- a/app/components/claim/provider_status_tag_component.rb
+++ b/app/components/claim/provider_status_tag_component.rb
@@ -1,0 +1,42 @@
+class Claim::ProviderStatusTagComponent < ApplicationComponent
+  attr_reader :claim
+
+  STATUS_TEXT_OVERRIDES = {
+    sampling_provider_not_approved: "Amended",
+    paid: "Approved",
+  }.freeze
+
+  def initialize(claim:, classes: [], html_attributes: {})
+    super(classes:, html_attributes:)
+
+    @claim = claim
+  end
+
+  def call
+    govuk_tag(text: status_text, colour:)
+  end
+
+  private
+
+  def default_attributes
+    super.merge!(class: super.class)
+  end
+
+  def status_text
+    STATUS_TEXT_OVERRIDES.fetch(claim.status.to_sym) do
+      Claims::Claim.human_attribute_name("status.#{claim.status}")
+    end
+  end
+
+  def colour
+    status_colours.fetch(claim.status)
+  end
+
+  def status_colours
+    {
+      sampling_in_progress: "yellow",
+      sampling_provider_not_approved: "turquoise",
+      paid: "blue",
+    }.with_indifferent_access
+  end
+end

--- a/config/locales/en/components/claim/provider_card_component.yml
+++ b/config/locales/en/components/claim/provider_card_component.yml
@@ -1,0 +1,7 @@
+en:
+  components:
+    claim:
+      provider_card_component:
+        claim_reference: "Claim reference: %{reference}"
+        claim_amount: "Claim amount: %{amount}"
+        date_submitted: "Date submitted: %{date}"

--- a/config/locales/en/layouts/component_preview.yml
+++ b/config/locales/en/layouts/component_preview.yml
@@ -1,0 +1,4 @@
+en:
+  layouts:
+    component_preview:
+      service_name: "Component Preview"

--- a/spec/components/claim/provider_card_component_spec.rb
+++ b/spec/components/claim/provider_card_component_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe Claim::ProviderCardComponent, type: :component do
+  subject(:component) { described_class.new(claim:, href:, current_user:) }
+
+  let(:school) do
+    create(
+      :claims_school,
+      region: regions(:inner_london),
+      address1: "1 High Street",
+      town: "London",
+      postcode: "SW1A 1AA",
+    )
+  end
+  let(:support_user) { create(:claims_support_user, first_name: "John", last_name: "Smith") }
+  let(:claim) do
+    create(
+      :claim,
+      :submitted,
+      status:,
+      submitted_at: "2024/04/08",
+      created_at: "2024/04/08",
+      school:,
+      support_user:,
+    ) do |claim|
+      claim.mentor_trainings << create(:mentor_training, hours_completed: 20)
+    end
+  end
+  let(:href) { "/claims/#{claim.id}" }
+  let(:current_user) { create(:claims_user) }
+  let(:status) { :sampling_provider_not_approved }
+
+  it "renders the provider claim card content" do
+    render_inline(component)
+
+    expect(page).to have_content("#{claim.school_urn},")
+    expect(page).to have_link(claim.school_name, href:)
+    expect(page).to have_content("Amended")
+    expect(page).to have_content("1 High Street")
+    expect(page).to have_content("Date submitted: 8 April 2024")
+    expect(page).to have_content("Claim reference: #{claim.reference}")
+    expect(page).to have_content("£1,072.00")
+  end
+
+  context "when the claim has been approved" do
+    let(:status) { :paid }
+
+    it "renders the provider status text as approved" do
+      render_inline(component)
+
+      expect(page).to have_content("Approved")
+    end
+  end
+end

--- a/spec/components/claim/provider_status_tag_component_spec.rb
+++ b/spec/components/claim/provider_status_tag_component_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe Claim::ProviderStatusTagComponent, type: :component do
+  it "renders the provider-specific status text for amended claims" do
+    claim = create(:claim, :submitted, status: :sampling_provider_not_approved)
+
+    render_inline(described_class.new(claim:))
+
+    expect(page).to have_content("Amended")
+  end
+
+  it "renders the provider-specific status text for approved claims" do
+    claim = create(:claim, :submitted, status: :paid)
+
+    render_inline(described_class.new(claim:))
+
+    expect(page).to have_content("Approved")
+  end
+
+  it "renders the audit requested status text" do
+    claim = create(:claim, :audit_requested)
+
+    render_inline(described_class.new(claim:))
+
+    expect(page).to have_content("Audit requested")
+  end
+end

--- a/spec/components/previews/claim/provider_card_component_preview.rb
+++ b/spec/components/previews/claim/provider_card_component_preview.rb
@@ -1,0 +1,85 @@
+class Claim::ProviderCardComponentPreview < ApplicationComponentPreview
+  def default
+    render Claim::ProviderCardComponent.new(claim: build_claim(status: :sampling_in_progress), href: "", current_user:)
+  end
+
+  def amended
+    render Claim::ProviderCardComponent.new(claim: build_claim(status: :sampling_provider_not_approved), href: "", current_user:)
+  end
+
+  def paid
+    render Claim::ProviderCardComponent.new(claim: build_claim(status: :paid), href: "", current_user:)
+  end
+
+  private
+
+  def current_user
+    @current_user ||= FactoryBot.build_stubbed(:claims_provider_user)
+  end
+
+  def build_claim(status:)
+    school = FactoryBot.create(
+      :claims_school,
+      urn: next_urn,
+      name: "Riverbank Primary School",
+      address1: "12 Orchard Lane",
+      address2: "Westminster",
+      town: "London",
+      postcode: "SW1A 2AA",
+      region: region,
+    )
+
+    claim = FactoryBot.create(
+      :claim,
+      :submitted,
+      status:,
+      school:,
+      provider:,
+      created_by: preview_user,
+      submitted_by: preview_user,
+      reference: next_reference,
+      created_at: Time.zone.local(2025, 9, 5, 9, 0, 0),
+    )
+
+    mentor_one = FactoryBot.create(:claims_mentor, schools: [school])
+    mentor_two = FactoryBot.create(:claims_mentor, schools: [school])
+
+    FactoryBot.create(:mentor_training, claim:, provider:, mentor: mentor_one, hours_completed: 10)
+    FactoryBot.create(:mentor_training, claim:, provider:, mentor: mentor_two, hours_completed: 8)
+
+    claim
+  end
+
+  def region
+    @region ||= Region.find_or_create_by!(name: "Inner London") do |record|
+      record.claims_funding_available_per_hour_pence = 5_360
+      record.claims_funding_available_per_hour_currency = "GBP"
+    end
+  end
+
+  def provider
+    @provider ||= FactoryBot.create(:claims_provider, code: "P#{SecureRandom.hex(3).upcase}")
+  end
+
+  def preview_user
+    @preview_user ||= Claims::User.find_or_create_by!(email: "preview-claims-user@example.com") do |user|
+      user.first_name = "Preview"
+      user.last_name = "User"
+      user.dfe_sign_in_uid = "preview-claims-user"
+    end
+  end
+
+  def next_urn
+    loop do
+      urn = sprintf("%06d", SecureRandom.random_number(1_000_000))
+      return urn unless School.exists?(urn:)
+    end
+  end
+
+  def next_reference
+    loop do
+      reference = (9_000_000 + SecureRandom.random_number(999_999)).to_s
+      return reference unless Claims::Claim.exists?(reference:)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Adds the provider index page card component to facilitate the provider extension to the service.

## Changes proposed in this pull request

- Adds the provider card component and preview

## Link to Trello card

https://trello.com/c/hcvzeJHV/456-create-the-provider-claims-card-component

## Screenshots

<img width="1001" height="206" alt="image" src="https://github.com/user-attachments/assets/c0b610ab-280c-492a-9676-2edaeadaa42c" />
<img width="998" height="199" alt="image" src="https://github.com/user-attachments/assets/5f896020-c8aa-477d-a7e8-78ada899e0e0" />
<img width="1009" height="211" alt="image" src="https://github.com/user-attachments/assets/d08d12c9-1811-43b3-9e93-b0d57b0de410" />

